### PR TITLE
Remove extraneous slash for path

### DIFF
--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -5,7 +5,7 @@
     <% organization = story.organization %>
     <% if organization && !@organization_article_index %>
       <div class="article-organization-headline">
-        <a href="/<%= organization.slug %>" class="article-organization-headline-inner"><img src="<%= organization.profile_image_90 %>"><%= organization.name %></a><a class="org-headline-filler" href="/<%= story.path %>">&nbsp;</a></div>
+        <a href="/<%= organization.slug %>" class="article-organization-headline-inner"><img src="<%= organization.profile_image_90 %>"><%= organization.name %></a><a class="org-headline-filler" href="<%= story.path %>">&nbsp;</a></div>
     <% end %>
     <a href="<%=story.user.path%>" class="small-pic-link-wrapper">
       <div class="small-pic" >


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [ ] Documentation Update

## Description
Removes an extra slash for `org-headline-filler` links. Apparently, this isn't an issue with macOS but is an issue for Windows. 🤔 

Resolves #1488 

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![A Windows logo looks around suspiciously...](https://media.giphy.com/media/cCvz3zQzhDgbu/giphy.gif)
