### PR TITLE
Add unique indexes to articles - part 5

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -568,15 +568,7 @@ class Article < ApplicationRecord
   def canonical_url_must_not_have_spaces
     return unless canonical_url.to_s.match?(/[[:space:]]/)
 
-<<<<<<< HEAD
     errors.add(:canonical_url, "must not have spaces")
-=======
-  # Admin only beta tags etc.
-  def validate_liquid_tag_permissions
-    return unless liquid_tags_used.include?(PollTag) && !(user.has_role?(:super_admin) || user.has_role?(:admin))
-
-    errors.add(:body_markdown, "must only use permitted tags")
->>>>>>> f431b8ee2... Add unique indexes to articles - part 5
   end
 
   def create_slug

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -49,30 +49,31 @@ class Article < ApplicationRecord
            inverse_of: :commentable,
            class_name: "Comment"
 
-  validates :slug, presence: { if: :published? }, format: /\A[0-9a-z\-_]*\z/,
-                   uniqueness: { scope: :user_id }
-  validates :title, presence: true,
-                    length: { maximum: 128 }
-  validates :user_id, presence: true
-  validates :feed_source_url, uniqueness: { allow_blank: true }
-  validates :canonical_url,
-            url: { allow_blank: true, no_local: true, schemes: %w[https http] },
-            uniqueness: { allow_blank: true }
-  validates :body_markdown, length: { minimum: 0, allow_nil: false }, uniqueness: { scope: %i[user_id title] }
-  validate :validate_tag
-  validate :validate_video
-  validate :validate_collection_permission
-  validate :past_or_present_date
-  validate :canonical_url_must_not_have_spaces
-  validates :video_state, inclusion: { in: %w[PROGRESSING COMPLETED] }, allow_nil: true
+  validates :body_markdown, length: { minimum: 0, allow_nil: false }
+  validates :body_markdown, uniqueness: { scope: %i[user_id title] }
   validates :cached_tag_list, length: { maximum: 126 }
+  validates :canonical_url, uniqueness: { allow_nil: true }
+  validates :canonical_url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
+  validates :feed_source_url, uniqueness: { allow_nil: true }
   validates :main_image, url: { allow_blank: true, schemes: %w[https http] }
   validates :main_image_background_hex_color, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/
+  validates :slug, presence: { if: :published? }, format: /\A[0-9a-z\-_]*\z/
+  validates :slug, uniqueness: { scope: :user_id }
+  validates :title, presence: true, length: { maximum: 128 }
+  validates :user_id, presence: true
   validates :video, url: { allow_blank: true, schemes: %w[https http] }
-  validates :video_source_url, url: { allow_blank: true, schemes: ["https"] }
-  validates :video_thumbnail_url, url: { allow_blank: true, schemes: %w[https http] }
   validates :video_closed_caption_track_url, url: { allow_blank: true, schemes: ["https"] }
   validates :video_source_url, url: { allow_blank: true, schemes: ["https"] }
+  validates :video_source_url, url: { allow_blank: true, schemes: ["https"] }
+  validates :video_state, inclusion: { in: %w[PROGRESSING COMPLETED] }, allow_nil: true
+  validates :video_thumbnail_url, url: { allow_blank: true, schemes: %w[https http] }
+
+  validate :canonical_url_must_not_have_spaces
+  validate :past_or_present_date
+  validate :validate_collection_permission
+  validate :validate_liquid_tag_permissions
+  validate :validate_tag
+  validate :validate_video
 
   before_validation :evaluate_markdown, :create_slug
   before_save :update_cached_user
@@ -567,7 +568,15 @@ class Article < ApplicationRecord
   def canonical_url_must_not_have_spaces
     return unless canonical_url.to_s.match?(/[[:space:]]/)
 
+<<<<<<< HEAD
     errors.add(:canonical_url, "must not have spaces")
+=======
+  # Admin only beta tags etc.
+  def validate_liquid_tag_permissions
+    return unless liquid_tags_used.include?(PollTag) && !(user.has_role?(:super_admin) || user.has_role?(:admin))
+
+    errors.add(:body_markdown, "must only use permitted tags")
+>>>>>>> f431b8ee2... Add unique indexes to articles - part 5
   end
 
   def create_slug

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -71,7 +71,6 @@ class Article < ApplicationRecord
   validate :canonical_url_must_not_have_spaces
   validate :past_or_present_date
   validate :validate_collection_permission
-  validate :validate_liquid_tag_permissions
   validate :validate_tag
   validate :validate_video
 

--- a/db/migrate/20200527101013_add_unique_indexes_to_articles_slug_feed_source_url_canonical_url_body_markdown.rb
+++ b/db/migrate/20200527101013_add_unique_indexes_to_articles_slug_feed_source_url_canonical_url_body_markdown.rb
@@ -6,16 +6,35 @@ class AddUniqueIndexesToArticlesSlugFeedSourceUrlCanonicalUrlBodyMarkdown < Acti
       remove_index :articles, column: :feed_source_url, algorithm: :concurrently
     end
 
+    # needed for the digest() function, checks if the extension already exists
+    ActiveRecord::Base.connection.enable_extension("pgcrypto")
+
     add_index :articles, %i[slug user_id], unique: true, algorithm: :concurrently
     add_index :articles, :feed_source_url, unique: true, algorithm: :concurrently
     add_index :articles, :canonical_url, unique: true, algorithm: :concurrently
-    add_index :articles, %i[body_markdown user_id title], unique: true, algorithm: :concurrently
+
+    # to avoid the error "Values larger than 1/3 of a buffer page cannot be indexed."
+    # due to the fact that large text column cannot be indexed by btree indexes
+    # we are going to need to build an index on the hash of the `body_markdown` column.
+    # We also cannot use a `HASH` index as it's not supported by unique columns.
+    # I don't recommend using GiN or GiST as well
+    # See <https://www.postgresql.org/message-id/AANLkTin3p6VS1Z=TtqUV-5cG4TZpTjUMfuPNzWJFgnr5@mail.gmail.com>,
+    # <https://www.postgresql.org/docs/11/pgcrypto.html#id-1.11.7.34.5> and
+    # <https://www.postgresql.org/docs/11/indexes-types.html>
+    # NOTE: using SQL as I couldn't find a way to have Rails generate it correctly
+    ActiveRecord::Base.connection.execute(
+      <<~SQL
+        CREATE UNIQUE INDEX CONCURRENTLY "index_articles_on_digest_body_markdown_and_user_id_and_title"
+        ON "articles"
+        USING btree (digest("body_markdown", 'sha512'::text), "user_id", "title");
+      SQL
+    )
   end
 
   def down
     remove_index :articles, column: %i[slug user_id], algorithm: :concurrently
     remove_index :articles, column: :feed_source_url, algorithm: :concurrently
     remove_index :articles, column: :canonical_url, algorithm: :concurrently
-    remove_index :articles, column: %i[body_markdown user_id title], algorithm: :concurrently
+    remove_index :articles, name: :index_articles_on_digest_body_markdown_and_user_id_and_title, algorithm: :concurrently
   end
 end

--- a/db/migrate/20200527101013_add_unique_indexes_to_articles_slug_feed_source_url_canonical_url_body_markdown.rb
+++ b/db/migrate/20200527101013_add_unique_indexes_to_articles_slug_feed_source_url_canonical_url_body_markdown.rb
@@ -1,0 +1,21 @@
+class AddUniqueIndexesToArticlesSlugFeedSourceUrlCanonicalUrlBodyMarkdown < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    if index_exists?(:articles, :feed_source_url)
+      remove_index :articles, column: :feed_source_url, algorithm: :concurrently
+    end
+
+    add_index :articles, %i[slug user_id], unique: true, algorithm: :concurrently
+    add_index :articles, :feed_source_url, unique: true, algorithm: :concurrently
+    add_index :articles, :canonical_url, unique: true, algorithm: :concurrently
+    add_index :articles, %i[body_markdown user_id title], unique: true, algorithm: :concurrently
+  end
+
+  def down
+    remove_index :articles, column: %i[slug user_id], algorithm: :concurrently
+    remove_index :articles, column: :feed_source_url, algorithm: :concurrently
+    remove_index :articles, column: :canonical_url, algorithm: :concurrently
+    remove_index :articles, column: %i[body_markdown user_id title], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -152,7 +152,7 @@ ActiveRecord::Schema.define(version: 2020_08_28_032013) do
     t.string "video_source_url"
     t.string "video_state"
     t.string "video_thumbnail_url"
-    t.index ["body_markdown", "user_id", "title"], name: "index_articles_on_body_markdown_and_user_id_and_title", unique: true
+    t.index "digest(body_markdown, 'sha512'::text), user_id, title", name: "index_articles_on_digest_body_markdown_and_user_id_and_title", unique: true
     t.index ["boost_states"], name: "index_articles_on_boost_states", using: :gin
     t.index ["canonical_url"], name: "index_articles_on_canonical_url", unique: true
     t.index ["comment_score"], name: "index_articles_on_comment_score"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -152,15 +152,18 @@ ActiveRecord::Schema.define(version: 2020_08_28_032013) do
     t.string "video_source_url"
     t.string "video_state"
     t.string "video_thumbnail_url"
+    t.index ["body_markdown", "user_id", "title"], name: "index_articles_on_body_markdown_and_user_id_and_title", unique: true
     t.index ["boost_states"], name: "index_articles_on_boost_states", using: :gin
+    t.index ["canonical_url"], name: "index_articles_on_canonical_url", unique: true
     t.index ["comment_score"], name: "index_articles_on_comment_score"
     t.index ["featured_number"], name: "index_articles_on_featured_number"
-    t.index ["feed_source_url"], name: "index_articles_on_feed_source_url"
+    t.index ["feed_source_url"], name: "index_articles_on_feed_source_url", unique: true
     t.index ["hotness_score"], name: "index_articles_on_hotness_score"
     t.index ["path"], name: "index_articles_on_path"
     t.index ["public_reactions_count"], name: "index_articles_on_public_reactions_count", order: :desc
     t.index ["published"], name: "index_articles_on_published"
     t.index ["published_at"], name: "index_articles_on_published_at"
+    t.index ["slug", "user_id"], name: "index_articles_on_slug_and_user_id", unique: true
     t.index ["slug"], name: "index_articles_on_slug"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe Article, type: :model do
 
     it { is_expected.not_to allow_value("foo").for(:main_image_background_hex_color) }
 
+    describe "#body_markdown" do
+      it "is unique scoped for user_id and title" do
+        art2 = build(:article, body_markdown: article.body_markdown, user: article.user, title: article.title)
+        expect(art2).not_to be_valid
+        expect(art2.errors.full_messages.to_sentence).to match("markdown has already been taken")
+      end
+    end
+
     describe "#after_commit" do
       it "on update enqueues job to index article to elasticsearch" do
         article.save

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_length_of(:title).is_at_most(128) }
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:user_id) }
-    it { is_expected.to validate_uniqueness_of(:canonical_url).allow_blank }
-    it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_blank }
+    it { is_expected.to validate_uniqueness_of(:canonical_url).allow_nil }
+    it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_nil }
     it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:user_id) }
 
     it { is_expected.not_to allow_value("foo").for(:main_image_background_hex_color) }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Follow up to https://github.com/thepracticaldev/dev.to/pull/8059

This only adds missing unique indexes to the `articles` table:

- `slug`+ `user_id` - https://dev.to/admin/blazer/queries/78-duplicate-articles-by-slug-and-user_id
- `feed_source_url` - https://dev.to/admin/blazer/queries/79-duplicate-articles-feed_source_url
- `canonical_url` - https://dev.to/admin/blazer/queries/80-duplicate-articles-canonical_url
- `body_markdown` + `user_id` + `title` - https://dev.to/admin/blazer/queries/81-duplicate-articles-by-body_markdown-user_id-title


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

**pre deployment**: unfortunately we have duplicates in each of the indexes. It's a bit odd we have duplicates on canonical URL and duplicated articles for the same user 😞 


- `slug`+ `user_id`:

```sql
select slug, user_id, count(*)
from articles
group by slug, user_id
having count(*) > 1
```

- `feed_source_url`:

```sql
select feed_source_url, count(*)
from articles
group by feed_source_url
having count(*) > 1
```

- `canonical_url`:

```sql
select canonical_url, count(*)
from articles
group by canonical_url
having count(*) > 1
```

- `body_markdown` + `user_id` + `title` (this times out at time but when it doesn't, it yields results)

```sql
select body_markdown, user_id, title, count(*)
from articles
group by body_markdown, user_id, title
having count(*) > 1
```
