### PR TITLE
Added regex to check possible xss attempts

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -138,9 +138,12 @@ class MarkdownParser
   end
 
   def catch_xss_attempts(markdown)
-    bad_xss = ['src="data', "src='data", "src='&", 'src="&', "data:text/html"]
-    bad_xss.each do |xss_attempt|
-      raise ArgumentError, "Invalid markdown detected" if markdown.include?(xss_attempt)
+    bad_xss_regex = [
+      Regexp.new("src=[\"'](data|&)", Regexp::IGNORECASE),
+      Regexp.new("data:text/html[,;][\sa-z0-9]*", Regexp::IGNORECASE),
+    ]
+    bad_xss_regex.each do |xss_attempt|
+      raise ArgumentError, "Invalid markdown detected" if xss_attempt.match(markdown)
     end
   end
 

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe MarkdownParser, type: :labor do
     expect(generate_and_parse_markdown(inline_code)).to include(inline_code[1..-2])
   end
 
-  context "when checking XSS attempt in markdown conten" do
+  context "when checking XSS attempt in markdown content" do
     it "raises an error if XSS attempt detected" do
       expect {
         generate_and_parse_markdown("src='DatA:text/html;base64:xxxx'")

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -167,8 +167,22 @@ RSpec.describe MarkdownParser, type: :labor do
     expect(generate_and_parse_markdown(inline_code)).to include(inline_code[1..-2])
   end
 
-  it "raises an error if it detects a XSS attempt" do
-    expect { generate_and_parse_markdown("data:text/html") }.to raise_error(ArgumentError)
+  context "when checking XSS attempt in markdown conten" do
+    it "raises an error if XSS attempt detected" do
+      expect {
+        generate_and_parse_markdown("src='DatA:text/html;base64:xxxx'")
+      }.to raise_error(ArgumentError)
+
+      expect {
+        generate_and_parse_markdown("src=\"&\"")
+      }.to raise_error(ArgumentError)
+    end
+
+    it "does not raise error if no XSS attempt detected" do
+       expect {
+        generate_and_parse_markdown("```const data = 'data:text/html';```")
+      }.not_to raise_error(ArgumentError)
+    end
   end
 
   context "when provided with an @username" do


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds regex expressions to check possible XSS attempts in markdown content.
Regex also prevents bypassing checks by using capital letters or blank spaces.
Note: as mentioned on the ticket, this regex will check if `data:text/html` is followed by `,` or `;` and text. Example of a possible attack
```
data:text/html;base64,PHNjcmlwdD5hbGVydCgndGVzdDMnKTwvc2NyaXB0Pg
```

## Related Tickets & Documents
Closes #7905
## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Note
Hello guys! This is my first contribution to this awesome community. After reading the contribution guide I decided to give it a try. Unfortunately I wasn't able to run the local env because of
```
The following environment variables should be set: ALGOLIASEARCH_API_KEY, ALGOLIASEARCH_APPLICATION_ID, ALGOLIASEARCH_SEARCH_ONLY_KEY.
```
and I didn't find docs about those env variables.

## What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/B0vFTrb0ZGDf2/giphy.gif)
