### PR TITLE
expand hover radius with before element

### DIFF
--- a/app/assets/stylesheets/top-bar.scss
+++ b/app/assets/stylesheets/top-bar.scss
@@ -113,6 +113,7 @@
   display: flex;
   align-items: center;
   z-index: 20;
+  position: relative;
   &__trigger {
     all: unset;
     padding: var(--su-1);
@@ -125,6 +126,17 @@
   &__dropdown {
     display: var(--dropdown-display);
     top: var(--header-height);
+  }
+
+  &:before {
+    content: '';
+    position: absolute;
+    --menu-width: 150%;
+    --menu-height: 110%;
+    width: var(--menu-width);
+    height: var(--menu-height);
+    top: calc((100% - var(--menu-height)) / 2);
+    left: calc((100% - var(--menu-width)) / 2);
   }
 
   &.showing,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Closes #7606.

In brief, the drop-down under user profile disappears when the cursor is moved diagonally because the hover area of the top bar menu is insufficient. The solution is to use a pseudo element such as `:before` to keep the original element size but make the hover area bigger. Now the user can move the cursor diagonally and access the user profile without issue.

![Screenshot from 2020-06-07 00-16-08](https://user-images.githubusercontent.com/60417145/83960219-21711600-a854-11ea-9415-cb523ed5538c.png)

## Related Tickets & Documents

Issue #7606.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed