### PR TITLE
Fix erblint errors on the `app/views/internal` folder

### DIFF
--- a/app/views/internal/articles/index.html.erb
+++ b/app/views/internal/articles/index.html.erb
@@ -35,7 +35,6 @@
       <li class="nav-item">
         <a href="/internal/articles?state=satellite-not-buffered" class="nav-link <%= "active" if params[:state] == "satellite-not-buffered" %>">Satellite</a>
       </li>
-      
     </ul>
     <% if params[:state] && params[:state].include?("top-") && params[:state] != "top-3" && params[:state] != "top-6" %>
       <h1 style="color:red">

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -202,7 +202,7 @@
            <div class="form-group">
              <div>
               <label for="site_config_email_addresses_default">Default</label>
-              <input type="text" value="<%= ApplicationConfig['DEFAULT_EMAIL'] %>" class="form-control" readonly>
+              <input type="text" value="<%= ApplicationConfig["DEFAULT_EMAIL"] %>" class="form-control" readonly>
               <div class="alert alert-info">Default (set via DEFAULT_EMAIL environment variable)</div>
              </div>
              <%= f.fields_for :email_addresses do |email_field| %>

--- a/app/views/internal/feedback_messages/index.html.erb
+++ b/app/views/internal/feedback_messages/index.html.erb
@@ -16,12 +16,7 @@
   <%= f.label :reporter_username_cont, "Reporter", class: "sr-only" %>
   <%= f.search_field :reporter_username_cont, placeholder: "Reporter", class: "form-control mx-3" %>
 
-  <%= f.select(
-    :status_eq,
-    options_for_select(["Open", "Invalid", "Resolved"], @q.status_eq),
-    { include_blank: true },
-    class: "custom-select mx-3",
-  ) %>
+  <%= f.select(:status_eq, options_for_select(%w[Open Invalid Resolved], @q.status_eq), { include_blank: true }, class: "custom-select mx-3") %>
 
   <%= f.submit "Search", class: "btn btn-secondary" %>
 <% end %>

--- a/app/views/internal/organizations/show.html.erb
+++ b/app/views/internal/organizations/show.html.erb
@@ -36,7 +36,7 @@
     <%= form_tag update_org_credits_internal_organization_path(@organization), method: :patch, class: "form-inline justify-content-between mb-2" do %>
       <div class="form-group">
         <%= hidden_field_tag :credit_action, :add %>
-        <%= number_field_tag :credits, nil, in: 1...100000, required: true, class: "form-control mr-3", size: 5 %>
+        <%= number_field_tag :credits, nil, in: 1...100_000, required: true, class: "form-control mr-3", size: 5 %>
         <%= text_field_tag :note, "", placeholder: "Why are you adding these credits?", size: 50, required: true, class: "form-control mr-3" %>
       </div>
       <%= submit_tag "Add Org Credits", class: "btn btn-primary" %>

--- a/app/views/internal/pages/_form.html.erb
+++ b/app/views/internal/pages/_form.html.erb
@@ -57,7 +57,6 @@
             <%= link_to "here", "/internal/feature_flags/features/" %>
           <% end %>
           </br>
-          
         </p>
       </div>
       <%= form.submit class: "btn btn-primary float-right" %>
@@ -66,7 +65,6 @@
 </div>
 
 <script>
-
 function showBodyFields() {
     // hide all optional elements
     $('.optional').css('display','none');
@@ -79,8 +77,6 @@ function showBodyFields() {
       }
     });
   };
-
-
 
 window.addEventListener('load', function() {
   document.getElementById("page_template").onchange = function() {

--- a/app/views/internal/response_templates/_form.html.erb
+++ b/app/views/internal/response_templates/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: [:internal, response_template], local: true, html: { class: "mb-5" }) do |f| %>
   <div class="form-group">
     <%= f.label :type_of, "Type of Response Template" %>
-    <% type_of_options = [["Mod Comment", "mod_comment"], ["Personal Comment", "personal_comment"], ["Email", "email_reply"], ["Abuse Report Email", "abuse_report_email_reply"]] %>
+    <% type_of_options = [["Mod Comment", "mod_comment"], ["Personal Comment", "personal_comment"], %w[Email email_reply], ["Abuse Report Email", "abuse_report_email_reply"]] %>
     <%= f.select :type_of, options_for_select(type_of_options, response_template.type_of), html: { required: true }, class: "form-control" %>
   </div>
   <div class="form-group">
@@ -14,7 +14,7 @@
   </div>
   <div class="form-group">
     <%= f.label :content_type, "Content Type (for ex. Markdown)", value: response_template.content %>
-    <% content_type_options = [["Markdown", "body_markdown"], ["Plain Text", "plain_text"], ["HTML", "html"]] %>
+    <% content_type_options = [%w[Markdown body_markdown], ["Plain Text", "plain_text"], %w[HTML html]] %>
     <%= f.select :content_type, options_for_select(content_type_options, response_template.content_type || "plain_text"), class: "form-control" %>
   </div>
   <div class="form-group">

--- a/app/views/internal/tools/index.html.erb
+++ b/app/views/internal/tools/index.html.erb
@@ -1,6 +1,6 @@
 <h2>General Purpose URL Purge</h2>
 <p>For a page that should 404. This will purge the page via Fastly.</p>
-<p>Use the full path (<%= app_url('xyz') %>) or the relative path: (/xyz)</p>
+<p>Use the full path (<%= app_url("xyz") %>) or the relative path: (/xyz)</p>
 <div class="row m-3">
   <%= form_tag bust_cache_internal_tools_path do %>
     <div class="form-row">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR fixes the errors resulting from running `bundle exec erblint app/views/internal`. There's still something I haven't figured, see the attached log.

<details>
<summary>`bundle exec erblint app/views/internal` output</summary>

```ruby
Linting 60 files with 12 linters...

Exception occured when processing: app/views/internal/listings/index.html.erb
If this file cannot be processed by erb-lint, you can exclude it in your configuration file.
Parser::Source::Range: end_pos must not be less than begin_pos
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/parser-2.7.1.3/lib/parser/source/range.rb:39:in `initialize'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/better_html-1.0.15/lib/better_html/tokenizer/location.rb:12:in `initialize'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/better_html-1.0.15/lib/better_html/parser.rb:204:in `new'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/better_html-1.0.15/lib/better_html/parser.rb:204:in `build_location'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/better_html-1.0.15/lib/better_html/parser.rb:197:in `build_node'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/better_html-1.0.15/lib/better_html/parser.rb:171:in `build_attribute_node'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/better_html-1.0.15/lib/better_html/parser.rb:145:in `build_tag_attributes_node'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/better_html-1.0.15/lib/better_html/parser.rb:128:in `build_tag_node'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/better_html-1.0.15/lib/better_html/parser.rb:75:in `build_document_node'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/better_html-1.0.15/lib/better_html/parser.rb:45:in `ast'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/processed_source.rb:14:in `ast'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/linters/right_trim.rb:16:in `run'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/runner.rb:25:in `block in run'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/runner.rb:24:in `each'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/runner.rb:24:in `run'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/cli.rb:113:in `block in run_with_corrections'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/cli.rb:111:in `times'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/cli.rb:111:in `run_with_corrections'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/cli.rb:63:in `block in run'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/cli.rb:60:in `each'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/lib/erb_lint/cli.rb:60:in `run'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/erb_lint-0.0.33/exe/erblint:9:in `<top (required)>'
/home/apdrf/.rbenv/versions/2.7.1/bin/erblint:23:in `load'
/home/apdrf/.rbenv/versions/2.7.1/bin/erblint:23:in `<top (required)>'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli/exec.rb:63:in `load'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli/exec.rb:63:in `kernel_load'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli/exec.rb:28:in `run'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:476:in `exec'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:30:in `dispatch'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/cli.rb:24:in `start'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/site_ruby/2.7.0/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/home/apdrf/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
/home/apdrf/.rbenv/versions/2.7.1/bin/bundle:23:in `load'
/home/apdrf/.rbenv/versions/2.7.1/bin/bundle:23:in `<main>'

No errors were found in ERB files
```
</details>

## Related Tickets & Documents

This PR is part of #8370.

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Thinking gif](https://media.giphy.com/media/BBkKEBJkmFbTG/giphy.gif)
