### PR TITLE
Create profile image generator

### DIFF
--- a/app/services/users/profile_image_generator.rb
+++ b/app/services/users/profile_image_generator.rb
@@ -1,0 +1,33 @@
+# rubocop:disable MixinUsage
+include CloudinaryHelper
+
+module Users
+  module ProfileImageGenerator
+    EMOJI_IMAGES =
+      %w[dog-face_1f436.png
+         monkey-face_1f435.png
+         unicorn_1f984.png
+         mouse-face_1f42d.png
+         hamster_1f439.png
+         koala_1f428.png
+         bear_1f43b.png
+         panda_1f43c.png
+         penguin_1f427.png
+         spouting-whale_1f433.png
+         honeybee_1f41d.png
+         lion_1f981.png
+         tiger-face_1f42f.png
+         fox_1f98a.png
+         wolf_1f43a.png].freeze
+    BACKGROUND_HEXES = %w[#f68d8e #fce289 #f3f096 #55c1ae #88aedc #f8b4d0].freeze
+    def self.call
+      source = "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/240/twitter/248/" + EMOJI_IMAGES.sample
+      cl_image_path(
+        source,
+        type: "fetch",
+        background: BACKGROUND_HEXES.sample,
+        sign_url: true,
+      )
+    end
+  end
+end

--- a/app/services/users/profile_image_generator.rb
+++ b/app/services/users/profile_image_generator.rb
@@ -1,6 +1,3 @@
-# rubocop:disable MixinUsage
-include CloudinaryHelper
-
 module Users
   module ProfileImageGenerator
     EMOJI_IMAGES =
@@ -21,13 +18,9 @@ module Users
          wolf_1f43a.png].freeze
     BACKGROUND_HEXES = %w[#f68d8e #fce289 #f3f096 #55c1ae #88aedc #f8b4d0].freeze
     def self.call
-      source = "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/240/twitter/248/" + EMOJI_IMAGES.sample
-      cl_image_path(
-        source,
-        type: "fetch",
-        background: BACKGROUND_HEXES.sample,
-        sign_url: true,
-      )
+      # This pulls from emojipedia source for the liberally open source twemoji lib.
+      # TODO: Make this much more interesting than just emojis.
+      "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/240/twitter/248/" + EMOJI_IMAGES.sample
     end
   end
 end

--- a/spec/services/users/profile_image_generator_spec.rb
+++ b/spec/services/users/profile_image_generator_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe Users::ProfileImageGenerator, type: :service do
+  it "returns a cloudinary url" do
+    expect(described_class.call).to start_with("https://res.cloudinary.com/")
+  end
+end

--- a/spec/services/users/profile_image_generator_spec.rb
+++ b/spec/services/users/profile_image_generator_spec.rb
@@ -1,5 +1,9 @@
 require "rails_helper"
 
+RSpec.configure do |c|
+  include CloudinaryHelper
+end
+
 RSpec.describe Users::ProfileImageGenerator, type: :service do
   it "returns a cloudinary url" do
     expect(described_class.call).to start_with("https://res.cloudinary.com/")

--- a/spec/services/users/profile_image_generator_spec.rb
+++ b/spec/services/users/profile_image_generator_spec.rb
@@ -1,11 +1,7 @@
 require "rails_helper"
 
-RSpec.configure do |c|
-  include CloudinaryHelper
-end
-
 RSpec.describe Users::ProfileImageGenerator, type: :service do
-  it "returns a cloudinary url" do
-    expect(described_class.call).to start_with("https://res.cloudinary.com/")
+  it "returns an emoji url" do
+    expect(described_class.call).to start_with("https://emojipedia-us.s3")
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a quick and dirty way to create a profile image generator to help push `Sign in with Apple` over the line.

#7952 

The idea is that this helps us have default profile images on sign ups that don't come with avatars.

Usage...

In the GitHub auth we have this...

```ruby
  remote_profile_image_url: info.image.to_s
```

So in Apple and elsewhere we can have this...

```ruby
  remote_profile_image_url: Users::AvatarGenerator.call
```

And this will create a random profile image from Twemoji and colors from our pastel rainbow.

I don't know if this is the final solution, but I think it's a decent quick way to get this working. I chose Twemoji because it's liberally open source.

I'd love to replace this with something delightful and unique, but I think this is a good starter place for that in the future, and at least it's one less blocker on Apple.

![](https://res.cloudinary.com/practicaldev/image/fetch/s--zr2F1_1V--/b_rgb:55c1ae/https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/240/twitter/248/panda_1f43c.png)