### PR TITLE
set level=0 when generating boxes for .crayons-notice

### DIFF
--- a/app/assets/stylesheets/components/notices.scss
+++ b/app/assets/stylesheets/components/notices.scss
@@ -3,7 +3,7 @@
 .crayons-notice {
   padding: var(--su-4);
   @include generate-box(
-    $level: 1,
+    $level: 0,
     $bg: var(--card-bg),
     $border: var(--card-color),
     $color: var(--card-color)
@@ -11,7 +11,7 @@
 
   &--danger {
     @include generate-box(
-      $level: 1,
+      $level: 0,
       $bg: var(--accent-danger-a10),
       $border: var(--accent-danger),
       $color: var(--card-color)
@@ -20,7 +20,7 @@
 
   &--warning {
     @include generate-box(
-      $level: 1,
+      $level: 0,
       $bg: var(--accent-warning-a10),
       $border: var(--accent-warning),
       $color: var(--card-color)
@@ -29,7 +29,7 @@
 
   &--success {
     @include generate-box(
-      $level: 1,
+      $level: 0,
       $bg: var(--accent-success-a10),
       $border: var(--accent-success),
       $color: var(--card-color)
@@ -38,7 +38,7 @@
 
   &--info {
     @include generate-box(
-      $level: 1,
+      $level: 0,
       $bg: var(--accent-brand-a10),
       $border: var(--accent-brand),
       $color: var(--card-color)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
shadow of crayons-notice class feels out-of-place in flat design

## Related Tickets & Documents
#8969

## QA Instructions, Screenshots, Recordings

- check out the shadow of the red box that says "Unpublished Post. This URL is public but secret, ..." when looking at an unpublished post.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed (only design is affected)
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![alt_text](gif_link)
