### PR TITLE
Fix archived readinglist reactions affecting count

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -124,7 +124,7 @@ class ReactionsController < ApplicationController
       reactable_type: params[:reactable_type],
       category: category
     }
-    if NEGATIVE_CATEGORIES.include?(category) && current_user&.any_admin?
+    if current_user&.any_admin? && NEGATIVE_CATEGORIES.include?(category)
       create_params[:status] = "confirmed"
     end
     Reaction.new(create_params)

--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -124,7 +124,9 @@ class ReactionsController < ApplicationController
       reactable_type: params[:reactable_type],
       category: category
     }
-    create_params[:status] = "confirmed" if current_user&.any_admin?
+    if NEGATIVE_CATEGORIES.include?(category) && current_user&.any_admin?
+      create_params[:status] = "confirmed"
+    end
     Reaction.new(create_params)
   end
 

--- a/app/labor/reading_list.rb
+++ b/app/labor/reading_list.rb
@@ -20,7 +20,7 @@ class ReadingList
   end
 
   def ids_of_articles
-    Reaction.where(reaction_criteria).order(created_at: :desc).pluck(:reactable_id)
+    Reaction.where(reaction_criteria).where.not(status: "archived").order(created_at: :desc).pluck(:reactable_id)
   end
 
   def count
@@ -28,6 +28,6 @@ class ReadingList
   end
 
   def reaction_criteria
-    { user_id: user.id, reactable_type: "Article", category: "readinglist", status: "valid" }
+    { user_id: user.id, reactable_type: "Article", category: "readinglist" }
   end
 end

--- a/app/labor/reading_list.rb
+++ b/app/labor/reading_list.rb
@@ -28,6 +28,6 @@ class ReadingList
   end
 
   def reaction_criteria
-    { user_id: user.id, reactable_type: "Article", category: "readinglist" }
+    { user_id: user.id, reactable_type: "Article", category: "readinglist", status: "valid" }
   end
 end

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe "Reactions", type: :request do
         sign_in admin
       end
 
-      it "automatically approves vomits on users" do
+      it "automatically confirms vomits on users" do
         post "/reactions", params: user_params
 
         reaction = Reaction.find_by(reactable_id: user.id)
@@ -283,12 +283,20 @@ RSpec.describe "Reactions", type: :request do
         expect(reaction.status).to eq("confirmed")
       end
 
-      it "automatically approves vomits on articles" do
+      it "automatically confirms vomits on articles" do
         post "/reactions", params: article_params.merge(category: "vomit")
 
         reaction = Reaction.find_by(reactable_id: article.id)
         expect(reaction.category).to eq("vomit")
         expect(reaction.status).to eq("confirmed")
+      end
+
+      it "does not automatically confirm positive reactions" do
+        post "/reactions", params: article_params
+
+        reaction = Reaction.find_by(reactable_id: article.id)
+        expect(reaction.category).to eq("like")
+        expect(reaction.status).to eq("valid")
       end
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I've seen at least two issues pertaining to this bug, so I went ahead and fixed it. 

~However, I found another bug while doing so... Admin reactions have probably been created with a status of `confirmed` in production instead of the expected `valid`. Which means that this proposed change will cause admin users who have saved articles before this point to have an incorrect readinglist count badge going forward, _but_ it will not affect admins from this point forward~

~If that's considered unacceptable, we can come up with a workaround or change those reaction records in production :sweat:~

~The reading list count badge on the home page currently takes all
readinglist reactions into account, but we shouldn't be including those
that are marked "archived."~

~Secondarily this fixes a bug that affects only admin users: all
reactions created by admins were given the status "confirmed."
Essentially this means that all admin users who saved articles to their
reading list might see an odd behavior here...~

The above concern is no longer an issue thanks to @mstruve's suggestion. I will modify the commit message on merge.

## Related Tickets & Documents

Closes #8164

## QA Instructions, Screenshots, Recordings

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

If we are concerned about a slight cosmetic bug (incorrect reading list badge count) that affects only admins, we will need to go update all of the `readinglist` reactions that admins have made while this bug existed. Their status is most likely currently `confirmed` rather than the default `valid`.