### PR TITLE
Accept "slug" in front matter for titles not in the Latin alphabet (#6942)

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -454,6 +454,13 @@ class Article < ApplicationRecord
     self.title = front_matter["title"] if front_matter["title"].present?
     set_tag_list(front_matter["tags"]) if front_matter["tags"].present?
     self.published = front_matter["published"] if %w[true false].include?(front_matter["published"].to_s)
+    if front_matter["slug"].present? && self.slug.blank? && self.title.present?
+      if self.published
+        self.slug = front_matter["slug"]
+      else
+        self.slug = front_matter["slug"] + "-temp-slug-#{rand(10_000_000)}"
+      end
+    end
     self.published_at = parse_date(front_matter["date"]) if published
     self.main_image = determine_image(front_matter)
     self.canonical_url = front_matter["canonical_url"] if front_matter["canonical_url"].present?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Accept setting the "slug" directly from the front matter, not only converted from the title.

## Related Tickets & Documents

#6942.

## QA Instructions, Screenshots, Recordings

* Add `slug` in the front matter, which is different from `title`.
* Add `slug` in the front matter, which is invalid as a slug, to see what error happens.

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
- (Still draft. To be added.)

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [ ] no documentation needed
- (Still draft. To be added.)
