### PR TITLE
decreased the color of crayons-btn-ghost-sucess by 10% for more visibility

### DIFF
--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -46,10 +46,10 @@
   --accent-brand-a10: #{rgba(#3b49df, 0.1)};
 
   // Success
-  --accent-success: #26d9ca;
-  --accent-success-darker: #1ab3a6;
-  --accent-success-lighter: #79ece2;
-  --accent-success-a10: #{rgba(#26d9ca, 0.1)};
+  --accent-success: #1fada2;
+  --accent-success-darker: #13867c;
+  --accent-success-lighter: #4de6d9;
+  --accent-success-a10: #{rgba(#1fada2, 0.1)};
 
   // Warning
   --accent-warning: #ffcf4c;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Request to improve the visual legibility of the `crayons-btn--ghost-success' button due to the fact that the teal color was a little too bright. The solution given decreased the brightness of the colors by scaling it down 10%, making it more visible.

## Related Tickets & Documents
References issue #8897
https://github.com/thepracticaldev/dev.to/issues/8898

## QA Instructions, Screenshots, Recordings
The top features the original color, the bottom features a darker more visible color.
![change 2](https://user-images.githubusercontent.com/35935438/86628943-a1e07f00-bf98-11ea-8b91-0401e86ea34a.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media2.giphy.com/media/3ohzdFHDBEG32PmWJO/giphy.gif)
