### PR TITLE
Make sidebar sponsor headline configurable

### DIFF
--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -34,6 +34,7 @@ module Internal
         payment_pointer
         health_check_token
         feed_style
+        sponsor_headline
       ]
 
       allowed_params = allowed_params |

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -125,6 +125,9 @@ class SiteConfig < RailsSettings::Base
   }
   field :twitter_hashtag, type: :string
 
+  # Sponsors
+  field :sponsor_headline, default: "Community Sponsors"
+
   # Tags
   field :sidebar_tags, type: :array, default: %w[]
 

--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -8,7 +8,7 @@
       <% if @sponsorships.present? %>
         <div class="<%= "hidden" if user_signed_in? %> px-1" id="sponsorship-widget">
           <h4 class="flex align-center fs-s ff-accent fw-bold tt-uppercase mb-4">
-            Community Sponsors
+            <%= SiteConfig.sponsor_headline %>
             <%= inline_svg_tag("twemoji/heart.svg", aria: true, class: "crayons-icon crayons-icon--default ml-1", title: "Love") %>
           </h4>
             <div class="grid grid-cols-1 gap-6">

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -682,6 +682,26 @@
         <div class="card mt-3">
           <%= render partial: "card_header",
                      locals: {
+                       header: "Sponsors",
+                       state: "collapse",
+                       target: "sponsorsContainer",
+                       expanded: "false"
+                     } %>
+          <div id="sponsorsContainer" class="card-body collapse hide" aria-labelledby="sponsorsContainer">
+            <div class="form-group">
+              <%= f.label :sponsor_headline %>
+              <%= f.text_field :sponsor_headline,
+                               class: "form-control",
+                               value: SiteConfig.sponsor_headline,
+                               placeholder: "Community Sponsors" %>
+              <div class="alert alert-info">Determines the heading text of the main sponsors sidebar above the list of sponsors.</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card mt-3">
+          <%= render partial: "card_header",
+                     locals: {
                        header: "Tags",
                        state: "collapse",
                        target: "tagsBodyContainer",

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe "/internal/config", type: :request do
       describe "Sponsors" do
         it "updates the sponsor_headline" do
           headline = "basic"
-          post "/internal/config", params: { site_config: { mascot_user_id: sponsor_headline },
+          post "/internal/config", params: { site_config: { sponsor_headline: healine },
                                              confirmation: confirmation_message }
           expect(SiteConfig.sponsor_headline).to eq(headline)
         end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "/internal/config", type: :request do
     "My username is @#{admin_plus_config.username} and this action is 100% safe and appropriate."
   end
 
-  describe "POST internal/events as a user" do
+  describe "POST internal/config as a user" do
     before do
       sign_in(user)
     end
@@ -19,7 +19,7 @@ RSpec.describe "/internal/config", type: :request do
   end
 
   # rubocop:disable RSpec/NestedGroups
-  describe "POST internal/events" do
+  describe "POST internal/config" do
     context "when admin has typical admin permissions but not single resource" do
       before do
         sign_in(admin)
@@ -471,7 +471,7 @@ RSpec.describe "/internal/config", type: :request do
       describe "Sponsors" do
         it "updates the sponsor_headline" do
           headline = "basic"
-          post "/internal/config", params: { site_config: { sponsor_headline: healine },
+          post "/internal/config", params: { site_config: { sponsor_headline: headline },
                                              confirmation: confirmation_message }
           expect(SiteConfig.sponsor_headline).to eq(headline)
         end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -468,6 +468,15 @@ RSpec.describe "/internal/config", type: :request do
         end
       end
 
+      describe "Sponsors" do
+        it "updates the sponsor_headline" do
+          headline = "basic"
+          post "/internal/config", params: { site_config: { mascot_user_id: sponsor_headline },
+                                             confirmation: confirmation_message }
+          expect(SiteConfig.sponsor_headline).to eq(headline)
+        end
+      end
+
       describe "Tags" do
         it "removes space sidebar_tags" do
           post "/internal/config", params: { site_config: { sidebar_tags: "hey, haha,hoho, bobo fofo" },


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This makes the "headline" of the gold sponsor area configurable, in case a community wants to list things differently there, such as describing "partners" or "supporters".

<img width="280" alt="Screen Shot 2020-07-10 at 12 33 12 PM" src="https://user-images.githubusercontent.com/3102842/87177371-8aabd500-c2a9-11ea-856c-16cd3336b6e7.png">
