### PR TITLE
Fix TypeError: Cannot set property 'innerHTML' of null

### DIFF
--- a/app/views/articles/_search.html.erb
+++ b/app/views/articles/_search.html.erb
@@ -16,13 +16,13 @@
 
   var params = getQueryParams(document.location.search);
 
-  function searchMain() {
+  function searchMain(substories) {
     var query = filterXSS(params.q);
     var filters = filterXSS(params.filters || "");
     var sortBy = filterXSS(params.sort_by || "");
     var sortDirection = filterXSS(params.sort_direction || "");
 
-    document.getElementById("substories").innerHTML = '<div class="query-results-nothing"><div class="query-results-loader"></div><br/></div>'
+    substories.innerHTML = '<div class="query-results-nothing"><div class="query-results-loader"></div><br/></div>';
     if (document.getElementById("query-wrapper")) {
       search(query, filters, sortBy, sortDirection);
       initializeFilters(query, filters);
@@ -189,8 +189,9 @@
   var waitingOnSearch = setInterval(function () {
     if (typeof search == 'function' && typeof filterXSS == 'function' && typeof buildArticleHTML == 'function') {
       clearInterval(waitingOnSearch);
-      if (document.querySelectorAll('.search-results-loaded').length == 0) {
-        searchMain();
+      const substories = document.getElementById("substories");
+      if (document.querySelectorAll('.search-results-loaded').length == 0 && substories) {
+        searchMain(substories);
       }
     }
   }, 1);


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
As [this Honeybadger error](https://app.honeybadger.io/fault/67192/f79e24dfb4e4364da09dda6380e9d2ff) shows, we sometimes try to set `innerHTML` as a property on a "substories" element (`document.getElementById("substories")`), which can occasionally be `null`.

From what I can tell, we don't even want to _call_ on the `searchMain` function if we don't have a `substories` element loaded, since this will throw a TypeError. In the rest of the `searchMain` function, we have guard clauses to make sure that elements exist before we try to do anything to them:

```javascript
if (document.getElementById("query-wrapper")) {
    search(query, filters, sortBy, sortDirection);
    initializeFilters(query, filters);
    initializeSortingTabs(query);
}
```

Given these checks, I think it similarly makes sense to not even invoke `searchMain` unless we know we have a substories element:

```javascript
const substories = document.getElementById("substories");
if (document.querySelectorAll('.search-results-loaded').length == 0 && substories) {
    searchMain(substories);
}
```

Since `searchMain` isn't being used anywhere else, I figured it made sense to find the element, check that it exists, and then invoke `searchMain`, while passing in the "found" `substories` element into it :)

This particular error happens rather frequently, as you can see in the [Honeybadger dashboard](https://app.honeybadger.io/projects/67192/faults?sort=last_seen_desc&q=-is%3Aresolved%E2%80%81-is%3Aignored%E2%80%81Cannot+set+property+%27innerHTML%27+of+null).

## Related Tickets & Documents
Should fix https://app.honeybadger.io/fault/67192/f79e24dfb4e4364da09dda6380e9d2ff.

## QA Instructions, Screenshots, Recordings

Not a great way to test this other than seeing if the Honeybadger error re-occurs after this guard clause (it _shouldn't_).🤞 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
Once this PR is merged, I'll mark the Honeybadger error as resolved, and see if it happens again.

## What gif best describes this PR or how it makes you feel?

![tired cat](https://media2.giphy.com/media/QAIB3wwvcS5RvmwZI4/giphy.webp?cid=5a38a5a233114f3f03cf80e7640b915194167949ff6b024c&rid=giphy.webp)
