### PR TITLE
Remove outdated comment

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -1,9 +1,6 @@
 # Site configuration based on RailsSettings models,
 # see <https://github.com/huacnlee/rails-settings-cached> for further info
 
-# Defaults are currently very DEV-oriented.
-# Should change to more truly generic values in future.
-
 class SiteConfig < RailsSettings::Base
   self.table_name = "site_configs"
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Documentation Update

## Description

In our recent effort to generalize the `SiteConfig` we forgot to remove this comment. Removing it now since it's misleading.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

n/a

## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed
