### PR TITLE
Make credit pricing configurable

### DIFF
--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -99,14 +99,17 @@ class CreditsController < ApplicationController
   end
 
   def cost_per_credit
-    if @number_to_purchase < 10
-      500
-    elsif @number_to_purchase < 100
-      400
-    elsif @number_to_purchase < 1000
-      300
+    prices = SiteConfig.credit_prices_in_cents
+
+    case @number_to_purchase
+    when ..9
+      prices[:small]
+    when 10..99
+      prices[:medium]
+    when 100..999
+      prices[:large]
     else
-      250
+      prices[:xlarge]
     end
   end
 end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -55,6 +55,7 @@ module Internal
         social_media_handles: SiteConfig.social_media_handles.keys,
         email_addresses: SiteConfig.email_addresses.keys,
         meta_keywords: SiteConfig.meta_keywords.keys,
+        credit_prices_in_cents: SiteConfig.credit_prices_in_cents.keys,
       )
     end
 

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -70,6 +70,7 @@ module Internal
       %i[sidebar_tags suggested_tags suggested_users].each do |param|
         config[param] = config[param].downcase.delete(" ") if config[param]
       end
+      config[:credit_prices_in_cents]&.transform_values!(&:to_i)
     end
 
     def bust_relevant_caches

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -138,4 +138,12 @@ class SiteConfig < RailsSettings::Base
 
   # Broadcast
   field :welcome_notifications_live_at, type: :date
+
+  # Credits
+  field :credit_prices_in_cents, type: :hash, default: {
+    small: 500,
+    medium: 400,
+    large: 300,
+    xlarge: 250
+  }
 end

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -184,6 +184,49 @@
         <div class="card mt-3">
           <%= render partial: "card_header",
                      locals: {
+                       header: "Credits",
+                       state: "collapse",
+                       target: "creditsBodyContainer",
+                       expanded: "false"
+                     } %>
+
+          <div id="creditsBodyContainer" class="card-body collapse hide" aria-labelledby="creditsBodyContainer">
+            <%= f.fields_for :credit_prices_in_cents do |price_field| %>
+              <div class="form-group">
+                <%= price_field.label "Credit price in cents (S)" %>
+                <%= price_field.number_field :small,
+                                             class: "form-control",
+                                             value: SiteConfig.credit_prices_in_cents[:small] %>
+                <div class="alert alert-info">Price for small credit purchase (< 10 credits).</div>
+              </div>
+              <div class="form-group">
+                <%= price_field.label "Credit price in cents (M)" %>
+                <%= price_field.number_field :medium,
+                                             class: "form-control",
+                                            value: SiteConfig.credit_prices_in_cents[:medium] %>
+                <div class="alert alert-info">Price for medium credit purchase (10 - 99 credits).</div>
+              </div>
+              <div class="form-group">
+                <%= price_field.label "Credit price in cents (L)" %>
+                <%= price_field.number_field :large,
+                                             class: "form-control",
+                                             value: SiteConfig.credit_prices_in_cents[:large] %>
+                <div class="alert alert-info">Price for large credit purchase (100 - 999 credits).</div>
+              </div>
+              <div class="form-group">
+                <%= price_field.label "Credit price in cents (XL)" %>
+                <%= price_field.number_field :xlarge,
+                                             class: "form-control",
+                                             value: SiteConfig.credit_prices_in_cents[:xlarge] %>
+                <div class="alert alert-info">Price for extra large credit purchase (1000 credits or more).</div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+ 
+        <div class="card mt-3">
+          <%= render partial: "card_header",
+                     locals: {
                        header: "Emails",
                        state: "collapse",
                        target: "emailBodyContainer",

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -499,6 +499,15 @@ RSpec.describe "/internal/config", type: :request do
           expect(SiteConfig.feed_style).to eq(feed_style)
         end
       end
+
+      describe "Credits" do
+        it "updates the credit prices", :aggregate_failures do
+          SiteConfig.credit_prices_in_cents.each_key do |size|
+            post "/internal/config", params: { site_config: { credit_prices_in_cents: { size => 1000 } } }
+            expect(SiteConfig.credit_prices_in_cents[size]).to eq 1000
+          end
+        end
+      end
     end
   end
   # rubocop:enable RSpec/NestedGroups

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -502,9 +502,20 @@ RSpec.describe "/internal/config", type: :request do
 
       describe "Credits" do
         it "updates the credit prices", :aggregate_failures do
+          original_prices = {
+            small: 500,
+            medium: 400,
+            large: 300,
+            xlarge: 250
+          }
+          SiteConfig.credit_prices_in_cents = original_prices
+
           SiteConfig.credit_prices_in_cents.each_key do |size|
-            post "/internal/config", params: { site_config: { credit_prices_in_cents: { size => 1000 } } }
-            expect(SiteConfig.credit_prices_in_cents[size]).to eq 1000
+            new_prices = original_prices.merge(size => 123)
+            expect do
+              post "/internal/config", params: { site_config: { credit_prices_in_cents: new_prices },
+                                                 confirmation: confirmation_message }
+            end.to change { SiteConfig.credit_prices_in_cents[size] }.from(original_prices[size.to_sym]).to(123)
           end
         end
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

Our credit prices so far were hardcoded (in cents). This PR makes the values configurable. I went with T-shirt sizing for the names of the limits, i.e. small, medium, large, xlarge (these is the number of credits purchased in a transaction). Note that I set the default in `SiteConfig` to the values currently used by DEV. They seem sensible and I don't want new Forem admins to feel forced to configure this.

Not in scope: making the limits themselves configurable, i.e. setting the limits for small, medium, etc. I'm not sure if we even want to do this, but if we do I'd rather make that follow-up PR.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

<img width="1127" alt="Screen Shot 2020-07-17 at 11 34 15" src="https://user-images.githubusercontent.com/47985/87750788-9a399980-c826-11ea-8c33-748bd7b982a1.png">

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed
