### PR TITLE
Fixes javascript folder typo in webpacker documentation

### DIFF
--- a/docs/frontend/webpacker.md
+++ b/docs/frontend/webpacker.md
@@ -10,7 +10,7 @@ One contains plain JavaScript,
 [which you can read more about in this guide](/frontend/plain-js).
 
 The other one is managed by [Webpacker](https://github.com/rails/webpacker), and
-it's located inside `/app/javascripts`, written using ES6+.
+it's located inside `/app/javascript`, written using ES6+.
 
 Currently, it's mainly used for Preact components, served via `webpack` which is
 integrated into the Rails app using `Webpacker`.
@@ -27,8 +27,7 @@ For example:
 <%= javascript_packs_with_chunks_tag "webShare", defer: true %>
 ```
 
-The include statement corresponds to the pack
-`app/javascripts/packs/webShare.js`
+The include statement corresponds to the pack `app/javascript/packs/webShare.js`
 
 If you have more than one webpacker pack on the page, you need to include it in
 the same `javascript_packs_with_chunks_tag` call. The reason being is it avoids


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
folder path typo `app/javascripts` -> `app/javascript`

## Related Tickets & Documents
Fixes #9328

## QA Instructions, Screenshots, Recordings
made use of gitpods could not get the gitdocs to serve docs page.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

gif link didn't work 🤦‍♂️ (it was a cat with a fidget spinner)
