### PR TITLE
[MERGE AFTER INVITATION PR] Add registered_at data script

### DIFF
--- a/lib/data_update_scripts/20200715140848_backfill_user_registered_at.rb
+++ b/lib/data_update_scripts/20200715140848_backfill_user_registered_at.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class BackfillUserRegisteredAt
+    def run
+      User.where(registered_at: nil).find_each do |user|
+        user.update_column(:registered_at, user.created_at)
+      end
+    end
+  end
+end

--- a/lib/data_update_scripts/20200715140848_backfill_user_registered_at.rb
+++ b/lib/data_update_scripts/20200715140848_backfill_user_registered_at.rb
@@ -1,7 +1,7 @@
 module DataUpdateScripts
   class BackfillUserRegisteredAt
     def run
-      User.where(registered_at: nil).find_each do |user|
+      User.where(registered_at: nil, registered: true).find_each do |user|
         user.update_column(:registered_at, user.created_at)
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This backfills the `registered_at` value which we now want to use since we have the capacity to create non-registered users.

Merge after #9294 