### PR TITLE
Enable public or private forem config

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   skip_before_action :track_ahoy_visit
+  before_action :verify_private_forem
   protect_from_forgery with: :exception, prepend: true
 
   include SessionCurrentUser
@@ -13,6 +14,13 @@ class ApplicationController < ActionController::Base
 
   rescue_from RateLimitChecker::LimitReached do |exc|
     error_too_many_requests(exc)
+  end
+
+  def verify_private_forem
+    if SiteConfig.access == "private"
+      render template: "devise/registrations/new"
+      return
+    end
   end
 
   def not_found

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,9 +17,13 @@ class ApplicationController < ActionController::Base
   end
 
   def verify_private_forem
-    if SiteConfig.access == "private"
+    return if %w[shell async_info ga_events].include?(controller_name)
+    return if user_signed_in? || SiteConfig.public
+
+    if api_action?
+      authenticate!
+    else
       render template: "devise/registrations/new"
-      return
     end
   end
 
@@ -114,5 +118,9 @@ class ApplicationController < ActionController::Base
 
   def anonymous_user
     User.new(ip_address: request.env["HTTP_FASTLY_CLIENT_IP"])
+  end
+
+  def api_action?
+    self.class.to_s.start_with?("Api::")
   end
 end

--- a/app/controllers/internal/configs_controller.rb
+++ b/app/controllers/internal/configs_controller.rb
@@ -35,6 +35,7 @@ module Internal
         health_check_token
         feed_style
         sponsor_headline
+        public
       ]
 
       allowed_params = allowed_params |

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -136,7 +136,6 @@ class SiteConfig < RailsSettings::Base
   # a public forem could have more fine-grained authentication (listings ar private etc.) in future
   field :public, type: :boolean, default: 1
 
-
   # Broadcast
   field :welcome_notifications_live_at, type: :date
 end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -132,7 +132,10 @@ class SiteConfig < RailsSettings::Base
   # These are the default UX settings, which can be overridded by individual user preferences.
   # basic (current default), rich (cover image on all posts), compact (more minimal)
   field :feed_style, type: :string, default: "basic"
-  field :access, type: :string, default: "public"
+  # a non-public forem will redirect all unauthenticated pages to the registration page.
+  # a public forem could have more fine-grained authentication (listings ar private etc.) in future
+  field :public, type: :boolean, default: 1
+
 
   # Broadcast
   field :welcome_notifications_live_at, type: :date

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -132,6 +132,7 @@ class SiteConfig < RailsSettings::Base
   # These are the default UX settings, which can be overridded by individual user preferences.
   # basic (current default), rich (cover image on all posts), compact (more minimal)
   field :feed_style, type: :string, default: "basic"
+  field :access, type: :string, default: "public"
 
   # Broadcast
   field :welcome_notifications_live_at, type: :date

--- a/app/views/internal/configs/show.html.erb
+++ b/app/views/internal/configs/show.html.erb
@@ -736,6 +736,11 @@
                                placeholder: "basic, rich, or compact" %>
               <div class="alert alert-info">Determines which default feed the users sees (rich content, more minimal, etc.)</div>
             </div>
+            <div class="form-group">
+              <%= internal_config_label :public %>
+              <%= f.check_box :public, checked: SiteConfig.public %>
+              <div class="alert alert-info">Are most of the site pages (posts, profiles, etc. public?) — BE VERY CAUTIOUS IN CHANGING THIS</div>
+            </div>
           </div>
         </div>
 

--- a/spec/requests/api/v0/users_spec.rb
+++ b/spec/requests/api/v0/users_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe "Api::V0::Users", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it "returns unauthenticated if no authentication and site config is set to private" do
+      SiteConfig.public = false
+      get api_user_path("by_username"), params: { url: user.username }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
     it "returns the correct json representation of the user", :aggregate_failures do
       get api_user_path(user.id)
 
@@ -55,6 +61,24 @@ RSpec.describe "Api::V0::Users", type: :request do
       let_it_be(:access_token) { create(:doorkeeper_access_token, resource_owner: user, scopes: "public") }
 
       it "returns the correct json representation of the user", :aggregate_failures do
+        get me_api_users_path, params: { access_token: access_token.token }
+
+        response_user = response.parsed_body
+
+        expect(response_user["type_of"]).to eq("user")
+
+        %w[
+          id username name summary twitter_username github_username website_url location
+        ].each do |attr|
+          expect(response_user[attr]).to eq(user.public_send(attr))
+        end
+
+        expect(response_user["joined_at"]).to eq(user.created_at.strftime("%b %e, %Y"))
+        expect(response_user["profile_image"]).to eq(ProfileImage.new(user).get(width: 320))
+      end
+
+      it "returns 200 if no authentication and site config is set to private but user is authenticated" do
+        SiteConfig.public = false
         get me_api_users_path, params: { access_token: access_token.token }
 
         response_user = response.parsed_body

--- a/spec/requests/async_info_spec.rb
+++ b/spec/requests/async_info_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe "AsyncInfo", type: :request do
         get "/async_info/base_data"
         expect(response.parsed_body.keys).to match_array(%w[broadcast param token])
       end
+
+      it "renders normal response even if site config is private" do
+        SiteConfig.public = false
+        get "/async_info/base_data"
+        expect(response.parsed_body.keys).to match_array(%w[broadcast param token])
+      end
     end
 
     context "when logged in" do

--- a/spec/requests/ga_events_spec.rb
+++ b/spec/requests/ga_events_spec.rb
@@ -13,5 +13,13 @@ RSpec.describe "GaEvents", type: :request, vcr: vcr_option do
       }.to_json
       expect(response.body).to eq("")
     end
+
+    it "renders normal response even if site config is private" do
+      SiteConfig.public = false
+      post "/fallback_activity_recorder", params: {
+        path: "/ben", user_language: "en"
+      }.to_json
+      expect(response.body).to eq("")
+    end
   end
 end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -500,17 +500,17 @@ RSpec.describe "/internal/config", type: :request do
         end
 
         it "updates public to true" do
-          is_private = true
-          post "/internal/config", params: { site_config: { private: is_private },
+          is_public = true
+          post "/internal/config", params: { site_config: { private: is_public },
                                              confirmation: confirmation_message }
-          expect(SiteConfig.private).to eq(is_private)
+          expect(SiteConfig.public).to eq(is_public)
         end
 
         it "updates public to false" do
-          is_private = false
-          post "/internal/config", params: { site_config: { private: is_private },
+          is_public = false
+          post "/internal/config", params: { site_config: { private: is_public },
                                              confirmation: confirmation_message }
-          expect(SiteConfig.private).to eq(is_private)
+          expect(SiteConfig.public).to eq(is_public)
         end
       end
     end

--- a/spec/requests/internal/configs_spec.rb
+++ b/spec/requests/internal/configs_spec.rb
@@ -498,6 +498,20 @@ RSpec.describe "/internal/config", type: :request do
                                              confirmation: confirmation_message }
           expect(SiteConfig.feed_style).to eq(feed_style)
         end
+
+        it "updates public to true" do
+          is_private = true
+          post "/internal/config", params: { site_config: { private: is_private },
+                                             confirmation: confirmation_message }
+          expect(SiteConfig.private).to eq(is_private)
+        end
+
+        it "updates public to false" do
+          is_private = false
+          post "/internal/config", params: { site_config: { private: is_private },
+                                             confirmation: confirmation_message }
+          expect(SiteConfig.private).to eq(is_private)
+        end
       end
     end
   end

--- a/spec/requests/shells_spec.rb
+++ b/spec/requests/shells_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe "Shells", type: :request do
       get "/shell_top"
       expect(response.header["Surrogate-Key"]).to include("shell-top")
     end
+
+    it "renders normal response even if site config is private" do
+      SiteConfig.public = false
+      get "/shell_top"
+      expect(response.body).to include("user-signed-in")
+    end
   end
 
   describe "GET /shell_bottom" do
@@ -23,5 +29,12 @@ RSpec.describe "Shells", type: :request do
       get "/shell_bottom"
       expect(response.header["Surrogate-Key"]).to include("shell-bottom")
     end
+
+    it "renders normal response even if site config is private" do
+      SiteConfig.public = false
+      get "/shell_bottom"
+      expect(response.body).to include("footer-container")
+    end
+
   end
 end

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.body).to include(CGI.escapeHTML(article.title))
     end
 
+    it "renders registration page if site config is private" do
+      SiteConfig.public = false
+      get "/"
+      expect(response.body).to include("Great to have you")
+    end
+
     it "renders proper description" do
       get "/"
       expect(response.body).to include(SiteConfig.community_description)
@@ -330,6 +336,12 @@ RSpec.describe "StoriesIndex", type: :request do
       end
 
       it "shows tags to signed-in users" do
+        get "/t/#{tag.name}"
+        expect(response.body).to include("crayons-tabs__item crayons-tabs__item--current")
+      end
+
+      it "renders properly even if site config is private" do
+        SiteConfig.public = false
         get "/t/#{tag.name}"
         expect(response.body).to include("crayons-tabs__item crayons-tabs__item--current")
       end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This feature allows admins to create entirely private forems— where all requests are returned with the sign up page.

There's some more nuance to other stuff that should go along with this— like whether the footer should display a bunch of pages like `about` etc.

We also need to ensure edge caching is configured in such away to ensure true privacy. This will require some additional configuration alignment. It won't matter for DEV because we won't use this, but we need to ensure in a future PR that we wouldn't be leaking private info via any caches.