### PR TITLE
Bug Fix: Refresh Hypershield after db:prepare if Enabled

### DIFF
--- a/lib/tasks/app_initializer.rake
+++ b/lib/tasks/app_initializer.rake
@@ -13,3 +13,7 @@ namespace :app_initializer do
     SiteConfig.health_check_token ||= SecureRandom.hex(10)
   end
 end
+
+if ENV["ENABLE_HYPERSHIELD"].present?
+  Rake::Task["db:prepare"].enhance(["hypershield:refresh"])
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When we switched to using `db:prepare` for our pre-deploy tasks we broke refreshing Hypershield. The reason is because [hypershield hooks into the migrate rake task](https://github.com/ankane/hypershield/blob/master/lib/tasks/hypershield.rake#L19) to trigger the refresh. When using [`db:prepare`, migrate](https://github.com/rails/rails/blob/98754de1412870d7dae9eba1c7bac944b9b90093/activerecord/lib/active_record/railties/databases.rake#L306) is not triggered through rake but rather through the [ActiveRecord::Tasks::DatabaseTasks](https://github.com/rails/rails/blob/98754de1412870d7dae9eba1c7bac944b9b90093/activerecord/lib/active_record/tasks/database_tasks.rb#L224) class.

## Related Tickets & Documents
https://github.com/forem/forem/projects/9#card-41787287


![alt_text](https://media2.giphy.com/media/12haGO61oFZ28w/giphy.gif)
