### PR TITLE
Update NoiseCancellingSampler to make it more self-documenting

### DIFF
--- a/spec/lib/honeycomb/noise_cancelling_sampler_spec.rb
+++ b/spec/lib/honeycomb/noise_cancelling_sampler_spec.rb
@@ -11,40 +11,45 @@ RSpec.describe Honeycomb::NoiseCancellingSampler do
   end
 
   context "with a redis command" do
-    before { allow(described_class).to receive(:should_sample) }
-
-    it "samples if its a NOISY_COMMANDS" do
-      described_class.sample({ "redis.command" => "TIME", "trace.trace_id" => trace_id })
-      expect(described_class).to have_received(:should_sample).with(100, trace_id)
+    it "samples if its in NOISY_REDIS_COMMANDS" do
+      is_sampled, rate = described_class.sample({ "redis.command" => "TIME", "trace.trace_id" => trace_id })
+      expect(is_sampled).to be_in [true, false]
+      expect(rate).to match(100)
     end
 
     it "samples if the command is BRPOP" do
-      described_class.sample({ "redis.command" => "BRPOP", "trace.trace_id" => trace_id })
-      expect(described_class).to have_received(:should_sample).with(1000, trace_id)
+      is_sampled, rate = described_class.sample({ "redis.command" => "BRPOP", "trace.trace_id" => trace_id })
+      expect(is_sampled).to be_in [true, false]
+      expect(rate).to match(1000)
     end
 
     it "samples if the command starts with TTL" do
-      described_class.sample({ "redis.command" => "TTL this and that", "trace.trace_id" => trace_id })
-      expect(described_class).to have_received(:should_sample).with(100, trace_id)
+      is_sampled, rate = described_class.sample({ "redis.command" => "TTL this and that",
+                                                  "trace.trace_id" => trace_id })
+      expect(is_sampled).to be_in [true, false]
+      expect(rate).to match(100)
     end
 
     it "samples if the command starts with GET rack:" do
-      described_class.sample({ "redis.command" => "GET rack::something", "trace.trace_id" => trace_id })
-      expect(described_class).to have_received(:should_sample).with(100, trace_id)
+      is_sampled, rate = described_class.sample({ "redis.command" => "GET rack::something",
+                                                  "trace.trace_id" => trace_id })
+      expect(is_sampled).to be_in [true, false]
+      expect(rate).to match(100)
     end
 
     it "samples if the command starts with SET rack:" do
-      described_class.sample({ "redis.command" => "SET rack::something", "trace.trace_id" => trace_id })
-      expect(described_class).to have_received(:should_sample).with(100, trace_id)
+      is_sampled, rate = described_class.sample({ "redis.command" => "SET rack::something",
+                                                  "trace.trace_id" => trace_id })
+      expect(is_sampled).to be_in [true, false]
+      expect(rate).to match(100)
     end
   end
 
   context "with a active_record SQL command" do
-    before { allow(described_class).to receive(:should_sample) }
-
-    it "samples if its a NOISY_COMMANDS" do
-      described_class.sample({ "sql.active_record.sql" => "COMMIT", "trace.trace_id" => trace_id })
-      expect(described_class).to have_received(:should_sample).with(100, trace_id)
+    it "samples if its in NOISY_SQL_COMMANDS" do
+      is_sampled, rate = described_class.sample({ "sql.active_record.sql" => "COMMIT", "trace.trace_id" => trace_id })
+      expect(is_sampled).to be_in [true, false]
+      expect(rate).to match(100)
     end
   end
 end

--- a/spec/lib/honeycomb/noise_cancelling_sampler_spec.rb
+++ b/spec/lib/honeycomb/noise_cancelling_sampler_spec.rb
@@ -3,17 +3,16 @@ require "rails_helper"
 RSpec.describe Honeycomb::NoiseCancellingSampler do
   let(:trace_id) { "TRACE_ID" }
 
-  before { allow(described_class).to receive(:should_sample) }
-
   context "without a noisy command" do
     it "does not sample" do
       result = described_class.sample({ "request.path" => "/me", "trace.trace_id" => trace_id })
-      expect(described_class).not_to have_received(:should_sample)
       expect(result).to eq([true, 1])
     end
   end
 
   context "with a redis command" do
+    before { allow(described_class).to receive(:should_sample) }
+
     it "samples if its a NOISY_COMMANDS" do
       described_class.sample({ "redis.command" => "TIME", "trace.trace_id" => trace_id })
       expect(described_class).to have_received(:should_sample).with(100, trace_id)
@@ -41,6 +40,8 @@ RSpec.describe Honeycomb::NoiseCancellingSampler do
   end
 
   context "with a active_record SQL command" do
+    before { allow(described_class).to receive(:should_sample) }
+
     it "samples if its a NOISY_COMMANDS" do
       described_class.sample({ "sql.active_record.sql" => "COMMIT", "trace.trace_id" => trace_id })
       expect(described_class).to have_received(:should_sample).with(100, trace_id)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Not technically a refactor since it broke tests, but the functionality is the same.

Refactor `NoiseCancellingSampler`
- break up Redis and SQL commands lists and conditional block
- update conditional statements to use ActiveSupport `.in?` to be a bit more idiomatic Rails
- add default value for `rate` up front
- call `should_sample` at the end on everything to reduce number of conditional paths
- add some comments to explain reasoning for different sample rates

Update spec
- remove stub, so now we're calling `Honeycomb::DeterministicSampler.should_sample` every time
- break up return values into `is_sampled` (boolean) and `rate` (integer) for downsampled test cases

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Should be able to just run the test suite. We can check in Honeycomb to make sure the sample rates are the same before and after.

## Added tests?

- [x] yes (updated)
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed (added comments)

## [optional] Are there any post deployment tasks we need to perform?

Observe in Honeycomb! 👀 🍯 🐝 

## [optional] What gif best describes this PR or how it makes you feel?

![A person working at a free sample booth, eating the samples as people walk by](https://media1.tenor.com/images/1d62f8fdc37a5a5952d7aa5addaf7446/tenor.gif)
