### PR TITLE
Attempt to turn off Flipper UI CSRF protections

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,8 @@ Rails.application.routes.draw do
       mount Blazer::Engine, at: "blazer"
 
       flipper_ui = Flipper::UI.app(Flipper,
-                                   { rack_protection: { except: %i[authenticity_token form_token json_csrf] } })
+                                   { rack_protection: { except: %i[authenticity_token form_token json_csrf
+                                                                   remote_token http_origin session_hijacking] } })
       mount flipper_ui, at: "feature_flags"
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,13 +44,8 @@ Rails.application.routes.draw do
     authenticate :user, ->(user) { user.has_role?(:tech_admin) } do
       mount Blazer::Engine, at: "blazer"
 
-      flipper_ui = Flipper::UI.app(Flipper) do |builder|
-        builder.use Rack::Protection, origin_whitelist: [URL.url]
-        # Requires redis-store > 1.9: https://github.com/redis-store/redis-store/pull/333
-        builder.use Rack::Session::Cookie,
-                    secret: Rails.application.secrets[:secret_key_base]
-        builder.use Rack::CommonLogger, STDOUT
-      end
+      flipper_ui = Flipper::UI.app(Flipper,
+                                   { rack_protection: { except: %i[authenticity_token form_token json_csrf] } })
       mount flipper_ui, at: "feature_flags"
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

One last attempt to get the Flipper UI working before I just write me own (grr). _Something_ is happening in the bowels of the rack app served by Flipper UI and session, CSRF tokens, etc. Based on my reading of the source code (https://github.com/jnunemaker/flipper/blob/master/lib/flipper/ui.rb), Rack::Protect's code (https://github.com/sinatra/sinatra/blob/master/rack-protection/lib/rack/protection.rb), I believe this will turn off some CSRF protections just within the mounted Flipper UI.

(Logging was also removed as...it didn't log in production for some reason. Grr).

## Related Tickets & Documents

https://github.com/forem/forem/pull/9355
https://github.com/thepracticaldev/tech-private/issues/450


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed


