### PR TITLE
Fix reading list rendering multiple times

### DIFF
--- a/app/javascript/packs/readingList.jsx
+++ b/app/javascript/packs/readingList.jsx
@@ -4,7 +4,9 @@ import { ReadingList } from '../readingList/readingList';
 
 function loadElement() {
   getUserDataAndCsrfToken().then(({ currentUser }) => {
-    const followedTagNames = JSON.parse(currentUser.followed_tags).map(t => t.name);
+    const followedTagNames = JSON.parse(currentUser.followed_tags).map(
+      (t) => t.name,
+    );
     const root = document.getElementById('reading-list');
     if (root) {
       render(
@@ -13,7 +15,6 @@ function loadElement() {
           statusView={root.dataset.view}
         />,
         root,
-        root.firstElementChild,
       );
     }
   });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Should fix reading list rendering multiple times when navigating from home to reading-list pages.

I ran into issues trying to set up a development environment locally and via Gitpod (see #9195), so I wasn't able to test if this actually fixes this issue.

Note: The precommit hook reformatted the `followedTagNames` code; lmk if you want me to remove that.

## Related Tickets & Documents
fixes #9342

## QA Instructions, Screenshots, Recordings

See bug reproduction steps in issue.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed