### PR TITLE
Optimization:Change Broadcast and GithubIssue PKs to Bigint

### DIFF
--- a/db/migrate/20200717220654_change_broadcast_and_github_issue_pks_to_bigint.rb
+++ b/db/migrate/20200717220654_change_broadcast_and_github_issue_pks_to_bigint.rb
@@ -1,0 +1,15 @@
+class ChangeBroadcastAndGithubIssuePksToBigint < ActiveRecord::Migration[6.0]
+  def up
+    safety_assured {
+      change_column :broadcasts, :id, :bigint
+      change_column :github_issues, :id, :bigint
+    }
+  end
+
+  def down
+    safety_assured {
+      change_column :broadcasts, :id, :int
+      change_column :github_issues, :id, :int
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_17_203432) do
+ActiveRecord::Schema.define(version: 2020_07_17_220654) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -273,7 +273,7 @@ ActiveRecord::Schema.define(version: 2020_07_17_203432) do
     t.index ["creator_id"], name: "index_blazer_queries_on_creator_id"
   end
 
-  create_table "broadcasts", id: :serial, force: :cascade do |t|
+  create_table "broadcasts", force: :cascade do |t|
     t.boolean "active", default: false
     t.datetime "active_status_updated_at"
     t.string "banner_style"
@@ -559,7 +559,7 @@ ActiveRecord::Schema.define(version: 2020_07_17_203432) do
     t.index ["follower_id", "follower_type"], name: "fk_follows"
   end
 
-  create_table "github_issues", id: :serial, force: :cascade do |t|
+  create_table "github_issues", force: :cascade do |t|
     t.string "category"
     t.datetime "created_at", null: false
     t.string "issue_serialized", default: "--- {}\n"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Switching from Int to Bigint PKs(Primary Keys) for Broadcasts and GithubIssues. Both these tables are small and don't get a lot of writes so I think doing them in place is the way to go. 
Tables Sizes
```
irb(main):022:0> GithubIssue.count
=> 1010
irb(main):023:0> Broadcast.count
=> 11
```
Migration on my computer with 1000 GithubIssues
```
mollystruve$ migrate
== 20200717202342 ChangeBroadcastAndGithubIssuePksToBigint: migrating =========
-- change_column(:broadcasts, :id, :bigint)
   -> 0.0624s
-- change_column(:github_issues, :id, :bigint)
   -> 0.2294s
== 20200717202342 ChangeBroadcastAndGithubIssuePksToBigint: migrated (0.2920s)
```

## Related Tickets & Documents
https://github.com/forem/forem/projects/9#card-37704279


![alt_text](https://media3.giphy.com/media/lluj1cauAlO2vQEm8A/giphy.gif)
