### PR TITLE
Use Enumerable#filter_map in more places

### DIFF
--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -47,7 +47,7 @@ class GlitchTag < LiquidTagBase
 
   def build_options(options)
     # Convert options to query param pairs
-    params = options.map { |option| OPTIONS_TO_QUERY_PAIR[option] }.compact
+    params = options.filter_map { |option| OPTIONS_TO_QUERY_PAIR[option] }
 
     # Deal with the file option if present or use default
     file_option = options.detect { |option| option.start_with?("file=") }

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -128,9 +128,9 @@ module Broadcasts
       end
 
       def find_auth_broadcast
-        missing_identities = SiteConfig.authentication_providers.map do |provider|
+        missing_identities = SiteConfig.authentication_providers.filter_map do |provider|
           identities.exists?(provider: provider) ? nil : "#{provider}_connect"
-        end.compact
+        end
         Broadcast.active.find_by!(title: "Welcome Notification: #{missing_identities.first}")
       end
 

--- a/app/services/credits/ledger.rb
+++ b/app/services/credits/ledger.rb
@@ -49,7 +49,7 @@ module Credits
 
       if credits_purchases_with_purchase.present?
         # to avoid N+1 on purchases, we load them by type separately
-        purchase_types = credits_purchases_with_purchase.map(&:purchase_type).uniq.compact
+        purchase_types = credits_purchases_with_purchase.filter_map(&:purchase_type).uniq
         purchase_types.each do |purchase_type|
           credits_purchases_by_type = credits_purchases_with_purchase.select do |row|
             row.purchase_type == purchase_type

--- a/app/services/search/query_builders/chat_channel_membership.rb
+++ b/app/services/search/query_builders/chat_channel_membership.rb
@@ -38,7 +38,7 @@ module Search
       end
 
       def filter_conditions
-        FILTER_KEYS.map do |filter_key|
+        FILTER_KEYS.filter_map do |filter_key|
           next if @params[filter_key].blank? || @params[filter_key] == "all"
 
           if %i[viewable_by status].include? filter_key
@@ -46,7 +46,7 @@ module Search
           else
             { term: { filter_key => @params[filter_key] } }
           end
-        end.compact
+        end
       end
     end
   end

--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -126,19 +126,19 @@ module Search
       end
 
       def term_keys
-        TERM_KEYS.map do |term_key, search_key|
+        TERM_KEYS.filter_map do |term_key, search_key|
           next unless @params.key? term_key
 
           { terms: { search_key => Array.wrap(@params[term_key]) } }
-        end.compact
+        end
       end
 
       def range_keys
-        RANGE_KEYS.map do |range_key|
+        RANGE_KEYS.filter_map do |range_key|
           next unless @params.key? range_key
 
           { range: { range_key => @params[range_key] } }
-        end.compact
+        end
       end
 
       def query_hash(key, fields)

--- a/app/services/search/query_builders/listing.rb
+++ b/app/services/search/query_builders/listing.rb
@@ -74,11 +74,11 @@ module Search
       end
 
       def range_keys
-        RANGE_KEYS.map do |range_key|
+        RANGE_KEYS.filter_map do |range_key|
           next unless @params.key? range_key
 
           { range: { range_key => @params[range_key] } }
-        end.compact
+        end
       end
 
       def range_keys_present?

--- a/app/services/search/query_builders/query_base.rb
+++ b/app/services/search/query_builders/query_base.rb
@@ -40,13 +40,13 @@ module Search
       end
 
       def query_conditions
-        self.class::QUERY_KEYS.map do |query_key, query_fields|
+        self.class::QUERY_KEYS.filter_map do |query_key, query_fields|
           next if @params[query_key].blank?
 
           fields = query_fields.presence || [query_key]
 
           query_hash(@params[query_key], fields)
-        end.compact
+        end
       end
 
       def query_hash(key, fields)

--- a/app/services/search/query_builders/user.rb
+++ b/app/services/search/query_builders/user.rb
@@ -38,11 +38,11 @@ module Search
       end
 
       def excluded_term_keys
-        EXCLUDED_TERM_KEYS.map do |term_key, search_key|
+        EXCLUDED_TERM_KEYS.filter_map do |term_key, search_key|
           next unless @params.key? term_key
 
           { terms: { search_key => Array.wrap(@params[term_key]) } }
-        end.compact
+        end
       end
     end
   end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -449,7 +449,7 @@ RSpec.describe "NotificationsIndex", type: :request do
 
         get notifications_path(filter: :org)
         notifications = controller.instance_variable_get(:@notifications)
-        expect(notifications.map(&:organization_id).compact.size).to eq(0)
+        expect(notifications.filter_map(&:organization_id).size).to eq(0)
       end
 
       it "does not render notifications belonging to other orgs" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this?

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

[Ruby 2.7 adds Enumerable#filter_map](https://blog.mavenhive.in/ruby-2-7-adds-enumerable-filter-map-d84aad03b6d4) which can replace `map { ... }.compact` in most of cases and it's a bit faster.
## Related Tickets & Documents

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
