### PR TITLE
Optimization:Change Primary Keys on Mentions and Notes to Bigint

### DIFF
--- a/db/migrate/20200719205123_change_mentions_and_notes_pks_to_bigint.rb
+++ b/db/migrate/20200719205123_change_mentions_and_notes_pks_to_bigint.rb
@@ -1,0 +1,15 @@
+class ChangeMentionsAndNotesPksToBigint < ActiveRecord::Migration[6.0]
+  def up
+    safety_assured {
+      change_column :mentions, :id, :bigint
+      change_column :notes, :id, :bigint
+    }
+  end
+
+  def down
+    safety_assured {
+      change_column :mentions, :id, :int
+      change_column :notes, :id, :int
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_17_220654) do
+ActiveRecord::Schema.define(version: 2020_07_19_205123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -633,7 +633,7 @@ ActiveRecord::Schema.define(version: 2020_07_17_220654) do
     t.index ["provider", "user_id"], name: "index_identities_on_provider_and_user_id", unique: true
   end
 
-  create_table "mentions", id: :serial, force: :cascade do |t|
+  create_table "mentions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "mentionable_id"
     t.string "mentionable_type"
@@ -655,7 +655,7 @@ ActiveRecord::Schema.define(version: 2020_07_17_220654) do
     t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
-  create_table "notes", id: :serial, force: :cascade do |t|
+  create_table "notes", force: :cascade do |t|
     t.integer "author_id"
     t.text "content"
     t.datetime "created_at", null: false


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Production Data:
- Notes: 10k
- Mentions: 6.5k
With 10k notes and mentions in my local environment I ran this migration and it was super speedy so this is another I believe is plenty safe to do in place. 
```
== 20200719205123 ChangeMentionsAndNotesPksToBigint: migrating ================
-- change_column(:mentions, :id, :bigint)
   -> 0.0262s
-- change_column(:notes, :id, :bigint)
   -> 0.0171s
== 20200719205123 ChangeMentionsAndNotesPksToBigint: migrated (0.0439s) =======
```
## Related Tickets & Documents
https://github.com/forem/forem/projects/9#card-37704279


![alt_text](https://media.giphy.com/media/h2f0hypLAESFjFw6Gb/giphy-downsized-medium.gif)
