### PR TITLE
Standardize ActiveRecord order clauses

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -175,7 +175,7 @@ class ChatChannelsController < ApplicationController
                                      .where(show_global_badge_notification: true)
                                      .where.not(status: %w[removed_from_channel left_channel])
                                      .includes(%i[chat_channel user])
-                                     .order("chat_channel_memberships.updated_at DESC")
+                                     .order("chat_channel_memberships.updated_at" => :desc)
                                  else
                                    []
                                  end
@@ -187,7 +187,7 @@ class ChatChannelsController < ApplicationController
                                    current_user
                                      .chat_channel_memberships.includes(:chat_channel)
                                      .where(status: "pending")
-                                     .order("chat_channel_memberships.updated_at DESC")
+                                     .order("chat_channel_memberships.updated_at" => :desc)
                                  else
                                    []
                                  end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -36,27 +36,27 @@ class DashboardsController < ApplicationController
 
   def following_tags
     @followed_tags = @user.follows_by_type("ActsAsTaggableOn::Tag")
-      .order("points DESC").includes(:followable).limit(@follows_limit)
+      .order(points: :desc).includes(:followable).limit(@follows_limit)
   end
 
   def following_users
     @follows = @user.follows_by_type("User")
-      .order("created_at DESC").includes(:followable).limit(@follows_limit)
+      .order(created_at: :desc).includes(:followable).limit(@follows_limit)
   end
 
   def following_organizations
     @followed_organizations = @user.follows_by_type("Organization")
-      .order("created_at DESC").includes(:followable).limit(@follows_limit)
+      .order(created_at: :desc).includes(:followable).limit(@follows_limit)
   end
 
   def following_podcasts
     @followed_podcasts = @user.follows_by_type("Podcast")
-      .order("created_at DESC").includes(:followable).limit(@follows_limit)
+      .order(created_at: :desc).includes(:followable).limit(@follows_limit)
   end
 
   def followers
     @follows = Follow.followable_user(@user.id)
-      .includes(:follower).order("created_at DESC").limit(@follows_limit)
+      .includes(:follower).order(created_at: :desc).limit(@follows_limit)
   end
 
   def pro

--- a/app/controllers/email_authorizations_controller.rb
+++ b/app/controllers/email_authorizations_controller.rb
@@ -5,7 +5,7 @@ class EmailAuthorizationsController < ApplicationController
     user = User.find_by(username: params[:username])
     raise ActionController::RoutingError, "Not Found" unless current_user == user
 
-    email_authorization = user.email_authorizations.order("created_at DESC").first
+    email_authorization = user.email_authorizations.order(created_at: :desc).first
     correct_token = email_authorization.confirmation_token == params[:confirmation_token]
     raise ActionController::RoutingError, "Not Found" unless correct_token
 

--- a/app/controllers/internal/articles_controller.rb
+++ b/app/controllers/internal/articles_controller.rb
@@ -57,7 +57,7 @@ module Internal
         .where("published_at > ? OR crossposted_at > ?", days_ago.days.ago, days_ago.days.ago)
         .includes(:user)
         .limited_columns_internal_select
-        .order("public_reactions_count DESC")
+        .order(public_reactions_count: :desc)
         .page(params[:page])
         .per(50)
     end
@@ -67,7 +67,7 @@ module Internal
         .where("published_at > ?", months_ago)
         .includes(user: [:notes])
         .limited_columns_internal_select
-        .order("public_reactions_count DESC")
+        .order(public_reactions_count: :desc)
         .page(params[:page])
         .per(50)
     end
@@ -77,7 +77,7 @@ module Internal
         .includes(:user, :buffer_updates)
         .tagged_with(Tag.bufferized_tags, any: true)
         .limited_columns_internal_select
-        .order("hotness_score DESC")
+        .order(hotness_score: :desc)
         .page(params[:page])
         .per(60)
     end
@@ -86,7 +86,7 @@ module Internal
       Article.boosted_via_additional_articles
         .includes(:user, :buffer_updates)
         .limited_columns_internal_select
-        .order("published_at DESC")
+        .order(published_at: :desc)
         .page(params[:page])
         .per(100)
     end
@@ -95,7 +95,7 @@ module Internal
       Article.published
         .includes(user: [:notes])
         .limited_columns_internal_select
-        .order("published_at DESC")
+        .order(published_at: :desc)
         .page(params[:page])
         .per(50)
     end
@@ -104,7 +104,7 @@ module Internal
       Article.published
         .includes(user: [:notes])
         .limited_columns_internal_select
-        .order("hotness_score DESC")
+        .order(hotness_score: :desc)
         .page(params[:page])
         .per(30)
     end
@@ -115,7 +115,7 @@ module Internal
         .where("featured_number > ?", Time.current.to_i)
         .includes(:user, :buffer_updates)
         .limited_columns_internal_select
-        .order("featured_number DESC")
+        .order(featured_number: :desc)
     end
 
     def article_params

--- a/app/controllers/internal/comments_controller.rb
+++ b/app/controllers/internal/comments_controller.rb
@@ -7,14 +7,14 @@ module Internal
                     Comment
                       .includes(:user)
                       .includes(:commentable)
-                      .order("public_reactions_count DESC")
+                      .order(public_reactions_count: :desc)
                       .where("created_at > ?", params[:state].split("-").last.to_i.days.ago)
                       .page(params[:page] || 1).per(50)
                   else
                     Comment
                       .includes(:user)
                       .includes(:commentable)
-                      .order("created_at DESC")
+                      .order(created_at: :desc)
                       .page(params[:page] || 1).per(50)
                   end
     end

--- a/app/controllers/internal/events_controller.rb
+++ b/app/controllers/internal/events_controller.rb
@@ -9,12 +9,12 @@ module Internal
         location_url: app_url,
         description_markdown: "*Description* *Pre-requisites:* *Bio*",
       )
-      @events = Event.order("starts_at DESC")
+      @events = Event.order(starts_at: :desc)
     end
 
     def create
       @event = Event.new(event_params)
-      @events = Event.order("starts_at DESC")
+      @events = Event.order(starts_at: :desc)
       if @event.save
         flash[:success] = "Successfully created event: #{@event.title}"
         redirect_to(action: :index)
@@ -26,7 +26,7 @@ module Internal
 
     def update
       @event = Event.find(params[:id])
-      @events = Event.order("starts_at DESC")
+      @events = Event.order(starts_at: :desc)
       if @event.update(event_params)
         flash[:success] = "#{@event.title} was successfully updated"
         redirect_to "/internal/events"

--- a/app/controllers/internal/listings_controller.rb
+++ b/app/controllers/internal/listings_controller.rb
@@ -9,7 +9,7 @@ module Internal
     def index
       @listings =
         Listing.includes(%i[user listing_category])
-          .page(params[:page]).order("bumped_at DESC").per(50)
+          .page(params[:page]).order(bumped_at: :desc).per(50)
 
       @listings = @listings.published unless include_unpublished?
       @listings = @listings.in_category(params[:filter]) if params[:filter].present?

--- a/app/controllers/internal/podcasts_controller.rb
+++ b/app/controllers/internal/podcasts_controller.rb
@@ -8,7 +8,7 @@ module Internal
     def index
       @podcasts = Podcast.left_outer_joins(:podcast_episodes)
         .select("podcasts.*, count(podcast_episodes) as episodes_count")
-        .group("podcasts.id").order("podcasts.created_at DESC")
+        .group("podcasts.id").order("podcasts.created_at" => :desc)
         .page(params[:page]).per(50)
 
       return if params[:search].blank?

--- a/app/controllers/internal/privileged_reactions_controller.rb
+++ b/app/controllers/internal/privileged_reactions_controller.rb
@@ -9,7 +9,7 @@ module Internal
         .includes(:user,
                   :reactable)
         .where("category IN (?)", PRIVILEGED_REACTION_CATEGORIES)
-        .order("reactions.created_at DESC")
+        .order("reactions.created_at" => :desc)
         .ransack(params[:q])
       @privileged_reactions = @q.result.page(params[:page] || 1).per(25)
     end

--- a/app/controllers/internal/sponsorships_controller.rb
+++ b/app/controllers/internal/sponsorships_controller.rb
@@ -3,7 +3,7 @@ module Internal
     layout "internal"
 
     def index
-      @sponsorships = Sponsorship.includes(:organization, :user).order("created_at desc").page(params[:page]).per(50)
+      @sponsorships = Sponsorship.includes(:organization, :user).order(created_at: :desc).page(params[:page]).per(50)
     end
 
     def edit

--- a/app/controllers/internal/tags_controller.rb
+++ b/app/controllers/internal/tags_controller.rb
@@ -9,11 +9,11 @@ module Internal
     def index
       @tags = case params[:state]
               when "supported"
-                Tag.where(supported: true).order("taggings_count DESC").page(params[:page]).per(50)
+                Tag.where(supported: true).order(taggings_count: :desc).page(params[:page]).per(50)
               when "unsupported"
-                Tag.where(supported: false).order("taggings_count DESC").page(params[:page]).per(50)
+                Tag.where(supported: false).order(taggings_count: :desc).page(params[:page]).per(50)
               else
-                Tag.order("taggings_count DESC").page(params[:page]).per(50)
+                Tag.order(taggings_count: :desc).page(params[:page]).per(50)
               end
       @tags = @tags.where("tags.name ILIKE :search", search: "%#{params[:search]}%") if params[:search].present?
     end

--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -23,7 +23,7 @@ module Internal
       @notes = @user.notes.order(created_at: :desc).limit(10)
       @organization_memberships = @user.organization_memberships
         .joins(:organization)
-        .order("organizations.name ASC")
+        .order("organizations.name" => :asc)
         .includes(:organization)
       @last_email_verification_date = @user.email_authorizations
         .where.not(verified_at: nil)

--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -27,7 +27,7 @@ module Internal
         .includes(:organization)
       @last_email_verification_date = @user.email_authorizations
         .where.not(verified_at: nil)
-        .order("created_at DESC").first&.verified_at || "Never"
+        .order(created_at: :desc).first&.verified_at || "Never"
     end
 
     def update

--- a/app/controllers/internal/webhook_endpoints_controller.rb
+++ b/app/controllers/internal/webhook_endpoints_controller.rb
@@ -5,7 +5,7 @@ module Internal
     def index
       @endpoints = Webhook::Endpoint.includes(:user)
         .page(params[:page]).per(50)
-        .order("created_at desc")
+        .order(created_at: :desc)
     end
   end
 end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -39,7 +39,7 @@ class ListingsController < ApplicationController
     @listings =
       if params[:category].blank?
         published_listings
-          .order("bumped_at DESC")
+          .order(bumped_at: :desc)
           .includes(:user, :organization, :taggings)
           .limit(12)
       else

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -14,7 +14,7 @@ class ModerationsController < ApplicationController
 
     articles = Article.published
       .where("score > -5 AND score < 5")
-      .order("published_at DESC").limit(70)
+      .order(published_at: :desc).limit(70)
     articles = articles.cached_tagged_with(params[:tag]) if params[:tag].present?
     if params[:state] == "new-authors"
       articles = articles.where("nth_published_by_author > 0 AND nth_published_by_author < 4 AND published_at > ?",

--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -19,7 +19,7 @@ class PageViewsController < ApplicationMetalController
 
   def update
     if session_current_user_id
-      page_view = PageView.order("created_at DESC").find_or_create_by(article_id: params[:id],
+      page_view = PageView.order(created_at: :desc).find_or_create_by(article_id: params[:id],
                                                                       user_id: session_current_user_id)
       unless page_view.new_record?
         page_view.update_column(:time_tracked_in_seconds, page_view.time_tracked_in_seconds + 15)

--- a/app/controllers/podcast_episodes_controller.rb
+++ b/app/controllers/podcast_episodes_controller.rb
@@ -5,10 +5,10 @@ class PodcastEpisodesController < ApplicationController
   def index
     @podcast_index = true
 
-    @podcasts = Podcast.available.order("title asc")
+    @podcasts = Podcast.available.order(title: :asc)
     @podcast_episodes = PodcastEpisodeDecorator.decorate_collection(PodcastEpisode
       .available
-      .includes(:podcast).order("published_at desc").first(20))
+      .includes(:podcast).order(published_at: :desc).first(20))
 
     if params[:q].blank?
       surrogate_keys = ["podcast_episodes_all"] + @podcast_episodes.map(&:record_key)

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -9,7 +9,7 @@ class PodcastsController < ApplicationController
 
   def new
     @podcast = Podcast.new
-    @podcasts = Podcast.available.order("title asc")
+    @podcasts = Podcast.available.order(title: :asc)
     @podcast_index = true
   end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -71,7 +71,7 @@ class StoriesController < ApplicationController
   def get_latest_campaign_articles
     campaign_articles_scope = Article.tagged_with(SiteConfig.campaign_featured_tags, any: true)
       .where("published_at > ? AND score > ?", 4.weeks.ago, 0)
-      .order("hotness_score DESC")
+      .order(hotness_score: :desc)
 
     requires_approval = SiteConfig.campaign_articles_require_approval?
     campaign_articles_scope = campaign_articles_scope.where(approved: true) if requires_approval
@@ -195,7 +195,7 @@ class StoriesController < ApplicationController
     @podcast_index = true
     @list_of = "podcast-episodes"
     @podcast_episodes = @podcast.podcast_episodes
-      .reachable.order("published_at DESC").limit(30).decorate
+      .reachable.order(published_at: :desc).limit(30).decorate
     set_surrogate_key_header "podcast_episodes"
     render template: "podcast_episodes/index"
   end
@@ -204,7 +204,7 @@ class StoriesController < ApplicationController
     @user = @organization
     @stories = ArticleDecorator.decorate_collection(@organization.articles.published
       .limited_column_select
-      .order("published_at DESC").page(@page).per(8))
+      .order(published_at: :desc).page(@page).per(8))
     @organization_article_index = true
     set_organization_json_ld
     set_surrogate_key_header "articles-org-#{@organization.id}"
@@ -314,7 +314,7 @@ class StoriesController < ApplicationController
     comment_count = params[:view] == "comments" ? 250 : 8
     @comments = if @user.comments_count.positive?
                   @user.comments.where(deleted: false)
-                    .order("created_at DESC").includes(:commentable).limit(comment_count)
+                    .order(created_at: :desc).includes(:commentable).limit(comment_count)
                 else
                   []
                 end
@@ -323,11 +323,11 @@ class StoriesController < ApplicationController
   def assign_user_stories
     @pinned_stories = Article.published.where(id: @user.profile_pins.select(:pinnable_id))
       .limited_column_select
-      .order("published_at DESC").decorate
+      .order(published_at: :desc).decorate
     @stories = ArticleDecorator.decorate_collection(@user.articles.published
       .limited_column_select
       .where.not(id: @pinned_stories.pluck(:id))
-      .order("published_at DESC").page(@page).per(user_signed_in? ? 2 : SIGNED_OUT_RECORD_COUNT))
+      .order(published_at: :desc).page(@page).per(user_signed_in? ? 2 : SIGNED_OUT_RECORD_COUNT))
   end
 
   def assign_user_github_repositories
@@ -337,11 +337,11 @@ class StoriesController < ApplicationController
   def stories_by_timeframe
     if %w[week month year infinity].include?(params[:timeframe])
       @stories.where("published_at > ?", Timeframer.new(params[:timeframe]).datetime)
-        .order("public_reactions_count DESC")
+        .order(public_reactions_count: :desc)
     elsif params[:timeframe] == "latest"
-      @stories.where("score > ?", -20).order("published_at DESC")
+      @stories.where("score > ?", -20).order(published_at: :desc)
     else
-      @stories.order("hotness_score DESC").where("score > 2")
+      @stories.order(hotness_score: :desc).where("score > 2")
     end
   end
 
@@ -351,7 +351,7 @@ class StoriesController < ApplicationController
     num_hours = Rails.env.production? ? 24 : 2400
     @podcast_episodes = PodcastEpisode
       .includes(:podcast)
-      .order("published_at desc")
+      .order(published_at: :desc)
       .where("published_at > ?", num_hours.hours.ago)
       .select(:slug, :title, :podcast_id, :image)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -304,7 +304,7 @@ class UsersController < ApplicationController
   end
 
   def handle_organization_tab
-    @organizations = @current_user.organizations.order("name ASC")
+    @organizations = @current_user.organizations.order(name: :asc)
     if params[:org_id] == "new" || params[:org_id].blank? && @organizations.size.zero?
       @organization = Organization.new
     elsif params[:org_id].blank? || params[:org_id].match?(/\d/)

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -9,7 +9,7 @@ class VideosController < ApplicationController
     @video_articles = Article.with_video
       .includes([:user])
       .select(:id, :video, :path, :title, :video_thumbnail_url, :user_id, :video_duration_in_seconds)
-      .order("hotness_score DESC")
+      .order(hotness_score: :desc)
       .page(params[:page].to_i).per(24)
 
     set_surrogate_key_header "videos", Article.table_key, @video_articles.map(&:record_key)

--- a/app/labor/article_suggester.rb
+++ b/app/labor/article_suggester.rb
@@ -31,7 +31,7 @@ class ArticleSuggester
     Article.published
       .where.not(id: ids_to_ignore)
       .where.not(user_id: article.user_id)
-      .order("hotness_score DESC")
+      .order(hotness_score: :desc)
       .offset(rand(0..offset))
       .first(max)
   end
@@ -40,7 +40,7 @@ class ArticleSuggester
     Article.published.tagged_with(cached_tag_list_array, any: true)
       .where.not(user_id: article.user_id)
       .where("organic_page_views_past_month_count > 5")
-      .order("hotness_score DESC")
+      .order(hotness_score: :desc)
       .offset(rand(0..offset))
       .first(max)
   end

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -77,7 +77,7 @@ module CacheBuster
     end
     TIMEFRAMES.each do |timestamp, interval|
       if Article.published.where("published_at > ?", timestamp)
-          .order("public_reactions_count DESC").limit(3).pluck(:id).include?(article.id)
+          .order(public_reactions_count: :desc).limit(3).pluck(:id).include?(article.id)
         bust("/top/#{interval}")
         bust("/top/#{interval}?i=i")
         bust("/top/#{interval}/?i=i")
@@ -87,7 +87,7 @@ module CacheBuster
       bust("/latest")
       bust("/latest?i=i")
     end
-    bust("/") if Article.published.order("hotness_score DESC").limit(4).pluck(:id).include?(article.id)
+    bust("/") if Article.published.order(hotness_score: :desc).limit(4).pluck(:id).include?(article.id)
   end
 
   def self.bust_tag_pages(article)
@@ -100,7 +100,7 @@ module CacheBuster
       end
       TIMEFRAMES.each do |timestamp, interval|
         if Article.published.where("published_at > ?", timestamp).tagged_with(tag)
-            .order("public_reactions_count DESC").limit(3).pluck(:id).include?(article.id)
+            .order(public_reactions_count: :desc).limit(3).pluck(:id).include?(article.id)
           bust("/top/#{interval}")
           bust("/top/#{interval}?i=i")
           bust("/top/#{interval}/?i=i")
@@ -111,7 +111,7 @@ module CacheBuster
       end
       if rand(2) == 1 &&
           Article.published.tagged_with(tag)
-              .order("hotness_score DESC").limit(2).pluck(:id).include?(article.id)
+              .order(hotness_score: :desc).limit(2).pluck(:id).include?(article.id)
         bust("/t/#{tag}")
         bust("/t/#{tag}?i=i")
       end
@@ -195,7 +195,7 @@ module CacheBuster
 
   # bust commentable if it's an article
   def self.bust_article_comment(commentable)
-    bust("/") if Article.published.order("hotness_score DESC").limit(3).pluck(:id).include?(commentable.id)
+    bust("/") if Article.published.order(hotness_score: :desc).limit(3).pluck(:id).include?(commentable.id)
     if commentable.decorate.cached_tag_list_array.include?("discuss") &&
         commentable.featured_number.to_i > 35.hours.ago.to_i
       bust("/")

--- a/app/labor/email_logic.rb
+++ b/app/labor/email_logic.rb
@@ -40,7 +40,7 @@ class EmailLogic
                    .where("score > ?", 12)
                    .where("experience_level_rating > ? AND experience_level_rating < ?",
                           experience_level_rating_min, experience_level_rating_max)
-                   .order("score DESC")
+                   .order(score: :desc)
                    .limit(8)
                else
                  Article.published
@@ -48,7 +48,7 @@ class EmailLogic
                    .where(featured: true, email_digest_eligible: true)
                    .where.not(user_id: @user.id)
                    .where("score > ?", 25)
-                   .order("score DESC")
+                   .order(score: :desc)
                    .limit(8)
                end
 

--- a/app/labor/reading_list.rb
+++ b/app/labor/reading_list.rb
@@ -20,7 +20,7 @@ class ReadingList
   end
 
   def ids_of_articles
-    Reaction.where(reaction_criteria).order("created_at DESC").pluck(:reactable_id)
+    Reaction.where(reaction_criteria).order(created_at: :desc).pluck(:reactable_id)
   end
 
   def count

--- a/app/labor/reading_list.rb
+++ b/app/labor/reading_list.rb
@@ -10,7 +10,7 @@ class ReadingList
       .joins(:reactions)
       .includes(:user)
       .where(reactions: reaction_criteria)
-      .order("reactions.created_at DESC")
+      .order("reactions.created_at" => :desc)
   end
 
   def cached_ids_of_articles

--- a/app/labor/sticky_article_collection.rb
+++ b/app/labor/sticky_article_collection.rb
@@ -12,7 +12,7 @@ class StickyArticleCollection
     author.articles.published
       .limited_column_select
       .tagged_with(article_tags, any: true)
-      .where.not(id: article.id).order("published_at DESC")
+      .where.not(id: article.id).order(published_at: :desc)
       .limit(3)
   end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -34,7 +34,7 @@ class Article < ApplicationRecord
              where(
                "comments.score > ? AND ancestry IS NULL and hidden_by_commentable_user is FALSE and deleted is FALSE",
                10,
-             ).order("comments.score DESC")
+             ).order("comments.score" => :desc)
            },
            as: :commentable,
            inverse_of: :commentable,

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -199,12 +199,12 @@ class Article < ApplicationRecord
   def self.active_threads(tags = ["discuss"], time_ago = nil, number = 10)
     stories = published.limit(number)
     stories = if time_ago == "latest"
-                stories.order("published_at DESC").where("score > ?", -5)
+                stories.order(published_at: :desc).where("score > ?", -5)
               elsif time_ago
-                stories.order("comments_count DESC")
+                stories.order(comments_count: :desc)
                   .where("published_at > ? AND score > ?", time_ago, -5)
               else
-                stories.order("last_comment_at DESC")
+                stories.order(last_comment_at: :desc)
                   .where("published_at > ? AND score > ?", (tags.present? ? 5 : 2).days.ago, -5)
               end
     stories = tags.size == 1 ? stories.cached_tagged_with(tags.first) : stories.tagged_with(tags)

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -180,7 +180,7 @@ class ChatChannel < ApplicationRecord
 
   def channel_human_names
     active_memberships
-      .order("last_opened_at DESC").limit(5).includes(:user).map do |membership|
+      .order(last_opened_at: :desc).limit(5).includes(:user).map do |membership|
         membership.user.name
       end
   end

--- a/app/models/html_variant.rb
+++ b/app/models/html_variant.rb
@@ -37,7 +37,7 @@ class HtmlVariant < ApplicationRecord
 
     def find_top_for_test(tags_array, group)
       where(group: group, approved: true, published: true, target_tag: tags_array)
-        .order("success_rate DESC").limit(rand(1..20)).sample
+        .order(success_rate: :desc).limit(rand(1..20)).sample
     end
 
     def find_random_for_test(tags_array, group)

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -224,7 +224,7 @@ class Message < ApplicationRecord
     recipient = direct_receiver
     return if !chat_channel.direct? ||
       recipient.updated_at > 1.hour.ago ||
-      recipient.chat_channel_memberships.order("last_opened_at DESC")
+      recipient.chat_channel_memberships.order(last_opened_at: :desc)
         .first.last_opened_at > 15.hours.ago ||
       chat_channel.last_message_at > 30.minutes.ago ||
       recipient.email_connect_messages == false

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -53,7 +53,7 @@ class Tag < ActsAsTaggableOn::Tag
   end
 
   def tag_moderator_ids
-    User.with_role(:tag_moderator, self).order("id ASC").pluck(:id)
+    User.with_role(:tag_moderator, self).order(id: :asc).pluck(:id)
   end
 
   def self.bufferized_tags

--- a/app/queries/internal/moderators_query.rb
+++ b/app/queries/internal/moderators_query.rb
@@ -12,7 +12,7 @@ module Internal
                    relation.where(
                      "id NOT IN (SELECT user_id FROM users_roles WHERE role_id = ?)",
                      role_id_for(:trusted),
-                   ).order("users.comments_count DESC")
+                   ).order("users.comments_count" => :desc)
                  else
                    relation.joins(:roles)
                      .where(users_roles: { role_id: role_id_for(state) })

--- a/app/queries/internal/users_query.rb
+++ b/app/queries/internal/users_query.rb
@@ -6,7 +6,7 @@ module Internal
       relation = relation.with_role(role, :any) if role.presence
       relation = search_relation(relation, search) if search.presence
 
-      relation.order("created_at DESC")
+      relation.order(created_at: :desc)
     end
 
     def self.search_relation(relation, search)

--- a/app/services/article_api_index_service.rb
+++ b/app/services/article_api_index_service.rb
@@ -42,13 +42,13 @@ class ArticleApiIndexService
     if (user = User.find_by(username: username))
       user.articles.published
         .includes(:organization)
-        .order("published_at DESC")
+        .order(published_at: :desc)
         .page(page)
         .per(per_page || num)
     elsif (organization = Organization.find_by(slug: username))
       organization.articles.published
         .includes(:user)
-        .order("published_at DESC")
+        .order(published_at: :desc)
         .page(page)
         .per(per_page || num)
     else
@@ -60,12 +60,12 @@ class ArticleApiIndexService
     articles = Article.published.cached_tagged_with(tag).includes(:user, :organization)
 
     articles = if Tag.find_by(name: tag)&.requires_approval
-                 articles.where(approved: true).order("featured_number DESC")
+                 articles.where(approved: true).order(featured_number: :desc)
                elsif top.present?
                  articles.where("published_at > ?", top.to_i.days.ago)
-                   .order("public_reactions_count DESC")
+                   .order(public_reactions_count: :desc)
                else
-                 articles.order("hotness_score DESC")
+                 articles.order(hotness_score: :desc)
                end
 
     articles.page(page).per(per_page || DEFAULT_PER_PAGE)
@@ -74,7 +74,7 @@ class ArticleApiIndexService
   def top_articles
     Article.published.includes(:user, :organization)
       .where("published_at > ?", top.to_i.days.ago)
-      .order("public_reactions_count DESC")
+      .order(public_reactions_count: :desc)
       .page(page).per(per_page || DEFAULT_PER_PAGE)
   end
 
@@ -102,7 +102,7 @@ class ArticleApiIndexService
     Article.published
       .where(collection_id: collection_id)
       .includes(:user, :organization)
-      .order("published_at")
+      .order(:published_at)
       .page(page)
       .per(per_page || DEFAULT_PER_PAGE)
   end
@@ -111,7 +111,7 @@ class ArticleApiIndexService
     Article.published
       .where(featured: true)
       .includes(:user, :organization)
-      .order("hotness_score DESC")
+      .order(hotness_score: :desc)
       .page(page)
       .per(per_page || DEFAULT_PER_PAGE)
   end

--- a/app/services/articles/feed.rb
+++ b/app/services/articles/feed.rb
@@ -37,11 +37,11 @@ module Articles
     # Timeframe values from Timeframer::DATETIMES
     def top_articles_by_timeframe(timeframe:)
       published_articles_by_tag.where("published_at > ?", Timeframer.new(timeframe).datetime)
-        .order("score DESC").page(@page).per(@number_of_articles)
+        .order(score: :desc).page(@page).per(@number_of_articles)
     end
 
     def latest_feed
-      published_articles_by_tag.order("published_at DESC")
+      published_articles_by_tag.order(published_at: :desc)
         .where("featured_number > ? AND score > ?", 1_449_999_999, -20)
         .page(@page).per(@number_of_articles)
     end
@@ -238,7 +238,7 @@ module Articles
     def globally_hot_articles(user_signed_in)
       hot_stories = published_articles_by_tag
         .where("score > ? OR featured = ?", 7, true)
-        .order("hotness_score DESC")
+        .order(hotness_score: :desc)
       featured_story = hot_stories.where.not(main_image: nil).first
       if user_signed_in
         hot_story_count = hot_stories.count
@@ -248,7 +248,7 @@ module Articles
         hot_stories = hot_stories.offset(offset)
         new_stories = Article.published
           .where("score > ?", -15)
-          .limited_column_select.includes(top_comments: :user).order("published_at DESC").limit(rand(15..80))
+          .limited_column_select.includes(top_comments: :user).order(published_at: :desc).limit(rand(15..80))
         hot_stories = hot_stories.to_a + new_stories.to_a
       end
       [featured_story, hot_stories.to_a]

--- a/app/services/notifications/new_follower/send.rb
+++ b/app/services/notifications/new_follower/send.rb
@@ -25,7 +25,7 @@ module Notifications
 
       def call
         recent_follows = Follow.where(followable_type: followable_type, followable_id: followable_id)
-          .where("created_at > ?", 24.hours.ago).order("created_at DESC")
+          .where("created_at > ?", 24.hours.ago).order(created_at: :desc)
 
         notification_params = { action: "Follow" }
         case followable_type

--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -26,7 +26,7 @@ module Notifications
                                                            reactable_type: reaction.reactable_type)
           .where.not(reactions: { user_id: reaction.reactable_user_id })
           .preload(:reactable).includes(:user).where.not(users: { id: nil })
-          .order("reactions.created_at DESC")
+          .order("reactions.created_at" => :desc)
 
         aggregated_reaction_siblings = reaction_siblings.map do |reaction|
           { category: reaction.category, created_at: reaction.created_at, user: user_data(reaction.user) }

--- a/app/services/suggester/users/recent.rb
+++ b/app/services/suggester/users/recent.rb
@@ -34,7 +34,7 @@ module Suggester
         relation = User.where(id: tagged_article_user_ids(num_weeks))
         relation = relation.select(attributes_to_select) if attributes_to_select
 
-        relation.order("updated_at DESC").limit(80).to_a
+        relation.order(updated_at: :desc).limit(80).to_a
       end
 
       def recent_top_producers
@@ -44,14 +44,14 @@ module Suggester
         )
         relation = relation.select(attributes_to_select) if attributes_to_select
 
-        relation.order("updated_at DESC").limit(50).to_a
+        relation.order(updated_at: :desc).limit(50).to_a
       end
 
       def recent_commenters(num_comments = 2, limit = 8)
         relation = User.where("comments_count > ?", num_comments)
         relation = relation.select(attributes_to_select) if attributes_to_select
 
-        relation.order("updated_at DESC").limit(limit).to_a
+        relation.order(updated_at: :desc).limit(limit).to_a
       end
 
       def established_user_article_count

--- a/app/services/suggester/users/sidebar.rb
+++ b/app/services/suggester/users/sidebar.rb
@@ -32,7 +32,7 @@ module Suggester
       end
 
       def reputable_user_ids
-        User.where(id: active_authors_for_given_tags).order("reputation_modifier DESC").limit(20).pluck(:id)
+        User.where(id: active_authors_for_given_tags).order(reputation_modifier: :desc).limit(20).pluck(:id)
       end
 
       def random_user_ids

--- a/app/views/articles/_badges_area.html.erb
+++ b/app/views/articles/_badges_area.html.erb
@@ -40,7 +40,7 @@
   </style>
   <div style="overflow: visible;padding-top:20px;">
     <div class="widget-body badge-widget">
-      <% @user.badge_achievements.order("id DESC").includes(:badge).each do |achievement| %>
+      <% @user.badge_achievements.order(id: :desc).includes(:badge).each do |achievement| %>
         <a class="badge-achievement" href="/badge/<%= achievement.badge.slug %>">
           <img
             src="<%= cloudinary achievement.badge.badge_image_url, 180 %>"

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -31,7 +31,7 @@
           </header>
 
           <div>
-            <% @listings.order("bumped_at DESC").limit(5).each do |listing| %>
+            <% @listings.order(bumped_at: :desc).limit(5).each do |listing| %>
               <a class="crayons-link crayons-link--contentful" href="<%= listing.path %>">
                 <div><%= listing.title %></div>
                 <div class="crayons-link__secondary"><%= listing.category %></div>

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -99,7 +99,7 @@
         DESIGN YOUR EXPERIENCE
       <% end %>
     </header>
-    <% Tag.where(supported: true).order("hotness_score DESC").limit(30).pluck(:id, :name).each do |tag_array| %>
+    <% Tag.where(supported: true).order(hotness_score: :desc).limit(30).pluck(:id, :name).each do |tag_array| %>
       <div class="sidebar-nav-element" id="default-sidebar-element-<%= tag_array.second %>">
         <a class="crayons-link crayons-link--block" href="<%= tag_path(tag_array.second) %>">
           #<%= tag_array.second %>

--- a/app/views/internal/articles/_individual_article.html.erb
+++ b/app/views/internal/articles/_individual_article.html.erb
@@ -115,7 +115,7 @@
     <% if article.last_buffered %>
     <div class="mt-5">
       <em>Last Buffered <%= article.last_buffered %></em>
-      <% article.buffer_updates.order("created_at ASC").each do |buffer_update| %>
+      <% article.buffer_updates.order(created_at: :asc).each do |buffer_update| %>
       <h5>
         <a href="https://buffer.com/app/profile/<%= buffer_update.buffer_profile_id_code %>/buffer/queue/list">
           <%= buffer_update.social_service_name %>

--- a/app/views/internal/feedback_messages/_feedback_message.html.erb
+++ b/app/views/internal/feedback_messages/_feedback_message.html.erb
@@ -132,7 +132,7 @@
           <div class="col-12">
             <h3>Notes:</h3>
             <div class="notes__container" id="notes__<%= feedback_message.id %>">
-              <% feedback_message.notes&.order("created_at")&.each do |note| %>
+              <% feedback_message.notes&.order(:created_at)&.each do |note| %>
                 <div class="border border-info bg-light rounded my-2 p-2">
                   <span class="badge badge-info float-right">
                     <%= time_ago_in_words note.created_at %> ago

--- a/app/views/internal/users/_email_tools.html.erb
+++ b/app/views/internal/users/_email_tools.html.erb
@@ -24,7 +24,7 @@
   <div class="col-12">
     <h3>Recent Emails</h3>
     <div class="list-group-flush">
-      <% @user.email_messages.order("sent_at DESC").limit(50).each do |email| %>
+      <% @user.email_messages.order(sent_at: :desc).limit(50).each do |email| %>
         <a href="/admin/email_messages/<%= email.id %>" class="list-group-item list-group-item-action">
           <%= email.subject %>
           <em> - <%= email.sent_at&.strftime("%b %e '%y") %></em>

--- a/app/workers/reactions/bust_homepage_cache_worker.rb
+++ b/app/workers/reactions/bust_homepage_cache_worker.rb
@@ -9,7 +9,7 @@ module Reactions
       reaction = Reaction.find_by(id: reaction_id, reactable_type: "Article")
       return unless reaction&.reactable
 
-      featured_articles_ids = Article.where(featured: true).order("hotness_score DESC").limit(3).pluck(:id)
+      featured_articles_ids = Article.where(featured: true).order(hotness_score: :desc).limit(3).pluck(:id)
       return unless featured_articles_ids.include?(reaction.reactable_id)
 
       reaction.reactable.touch

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -20,11 +20,11 @@ SitemapGenerator::Sitemap.create do
     add article.path, lastmod: article.last_comment_at, changefreq: "daily"
   end
 
-  User.order("comments_count DESC").where("updated_at > ?", 5.days.ago).limit(8000).find_each do |user|
+  User.order(comments_count: :desc).where("updated_at > ?", 5.days.ago).limit(8000).find_each do |user|
     add "/#{user.username}", changefreq: "daily"
   end
 
-  Tag.order("hotness_score DESC").limit(250).find_each do |tag|
+  Tag.order(hotness_score: :desc).limit(250).find_each do |tag|
     add "/t/#{tag.name}", changefreq: "daily"
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] OCD

## Description

The use of ActiveRecord `order` clauses throughout our codebase was very inconsistent. We used both the hash and string form, didn't always user uppercase keywords in string clauses, etc.

This PR standardizes on the following style:

1. Simple cases are now of the form `order(attribute: direction)`. No more string clauses, no more relying on "ASC" being the default.
2. Nested cases are now consistently of the form `order("other_table.attribute" => direction)`. We previously used a mix of this form and the string form.

Reason: the hash version is slightly smarter/more robust than the string version. It automatically prefixes the table name to the columns, adds an explicit direction of "ASC" when it's missing (we don't do this anymore), etc. It also reads better (IMHO of course) and I think consistency matters.

*checks microphone*
"Is this on? I want to thank ripgrep and Vim's macro system, without whom this PR would not have been possible. This succuess is as much theirs as it is mine."

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

If Travis is happy, we are happy.

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
