### PR TITLE
Fixed a Typo at "A Published article by path"

### DIFF
--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -1996,7 +1996,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl https://dev.to/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
+            curl https://dev.to/api/articles/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
 
   /articles/me:
     get:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
I have changed a little typo in API docs. 

#### from 
```ssh
curl https://dev.to/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
```
#### to
```ssh
curl https://dev.to/api/articles/bytesized/byte-sized-episode-2-the-creation-of-graph-theory-34g1
```
## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
