### PR TITLE
Add regex to check for possible XSS attempts

### DIFF
--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -138,9 +138,12 @@ class MarkdownParser
   end
 
   def catch_xss_attempts(markdown)
-    bad_xss = ['src="data', "src='data", "src='&", 'src="&', "data:text/html"]
-    bad_xss.each do |xss_attempt|
-      raise ArgumentError, "Invalid markdown detected" if markdown.include?(xss_attempt)
+    bad_xss_regex = [
+      Regexp.new("src=[\"'](data|&)", Regexp::IGNORECASE),
+      Regexp.new("data:text/html[,;][\sa-z0-9]*", Regexp::IGNORECASE),
+    ]
+    bad_xss_regex.each do |xss_attempt|
+      raise ArgumentError, "Invalid markdown detected" if xss_attempt.match(markdown)
     end
   end
 

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe MarkdownParser, type: :labor do
     expect(generate_and_parse_markdown(inline_code)).to include(inline_code[1..-2])
   end
 
-  context "when checking XSS attempt in markdown conten" do
+  context "when checking XSS attempt in markdown content" do
     it "raises an error if XSS attempt detected" do
       expect {
         generate_and_parse_markdown("src='DatA:text/html;base64:xxxx'")

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -167,8 +167,22 @@ RSpec.describe MarkdownParser, type: :labor do
     expect(generate_and_parse_markdown(inline_code)).to include(inline_code[1..-2])
   end
 
-  it "raises an error if it detects a XSS attempt" do
-    expect { generate_and_parse_markdown("data:text/html") }.to raise_error(ArgumentError)
+  context "when checking XSS attempt in markdown conten" do
+    it "raises an error if XSS attempt detected" do
+      expect {
+        generate_and_parse_markdown("src='DatA:text/html;base64:xxxx'")
+      }.to raise_error(ArgumentError)
+
+      expect {
+        generate_and_parse_markdown("src=\"&\"")
+      }.to raise_error(ArgumentError)
+    end
+
+    it "does not raise error if no XSS attempt detected" do
+       expect {
+        generate_and_parse_markdown("```const data = 'data:text/html';```")
+      }.not_to raise_error(ArgumentError)
+    end
   end
 
   context "when provided with an @username" do


### PR DESCRIPTION
_Note: All credit for this PR goes to @protium-dev. I just took over the closed PR and incorporated the last few pieces of feedback._

## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

This PR adds two regex to check for possible XSS attempts in Markdown content. They also prevent bypassing checks by using capital letters or blank spaces.

**Note:** as mentioned in the issue, this regex will check if `data:text/html` is followed by `,` or `;` and text. Example of a possible attack:

```
data:text/html;base64,PHNjcmlwdD5hbGVydCgndGVzdDMnKTwvc2NyaXB0Pg
```

## Related Tickets & Documents

Closes #7905

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [X] yes

## Added to documentation?
- [X] no documentation needed
