### PR TITLE
Change from presence to private pusher channels

### DIFF
--- a/app/controllers/pusher_controller.rb
+++ b/app/controllers/pusher_controller.rb
@@ -10,17 +10,17 @@ class PusherController < ApplicationController
   end
 
   def valid_channel
-    valid_private_channel || valid_presence_channel
+    valid_private_dm_channel || valid_private_group_channel
   end
 
-  def valid_private_channel
+  def valid_private_dm_channel
     current_user && params[:channel_name] == "private-message-notifications-#{current_user.id}"
   end
 
-  def valid_presence_channel
-    return false unless params[:channel_name].include?("presence-channel-")
+  def valid_private_group_channel
+    return false unless params[:channel_name].include?("private-channel-")
 
-    id = params[:channel_name].split("presence-channel-")[1].split("-")[0]
+    id = params[:channel_name].split("private-channel-")[1].split("-")[0]
     channel = ChatChannel.find(id)
     channel.has_member?(current_user)
   end

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -273,7 +273,7 @@ export default class Chat extends Component {
     );
     this.subscribeChannelsToPusher(
       channels.filter(this.channelTypeFilterFn('invite_only')),
-      (channel) => `presence-channel-${channel.chat_channel_id}`,
+      (channel) => `private-channel-${channel.chat_channel_id}`,
     );
     const chatChannelsList = document.getElementById(
       'chatchannels__channelslist',
@@ -352,7 +352,7 @@ export default class Chat extends Component {
       if (activeChannel.channel_type === 'open')
         this.subscribePusher(`open-channel-${channelId}`);
     }
-    this.subscribePusher(`presence-channel-${channelId}`);
+    this.subscribePusher(`private-channel-${channelId}`);
   };
 
   setOpenChannelUsers = (res) => {

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -155,7 +155,7 @@ class ChatChannel < ApplicationRecord
 
   def pusher_channels
     if invite_only?
-      "presence-channel-#{id}"
+      "private-channel-#{id}"
     elsif open?
       "open-channel-#{id}"
     else


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We've been using Pusher's "presence" channels, which actually have a max occupancy. So in order to create bigger group channels, we need to move to "private", which is fine. As far as I know we aren't using any of the features of presence anyway. (I think we _may_ have in a prior implementation of some features.

Correct me if I'm wrong about this idea.

Here is the info about presence channels:

https://pusher.com/docs/channels/using_channels/presence-channels

> Presence channels have some limits associated with them: 100 members maximum, 1KB limit for user object, and maximum 128 characters for user id. If you use a numeric user id, remember that the maximum size integer that is representable in JavaScript is 2^53.

And FWIW, here is an article about how one might implement some of the features of "presence" for "large" channels.

https://support.pusher.com/hc/en-us/articles/360019620253-How-can-I-implement-large-presence-channels-on-Channels-

We may want to legit use presence channels or these concepts in the future, but the most likely outcome should be us moving from Pusher to something we can containerize and ship on commodity clouds. So this is probably a step towards that pattern by using less complicated Pusher features.