### PR TITLE
Flaky Spec Fix:Clear Elasticsearch FeedContent to avoid trying to load missing data

### DIFF
--- a/spec/system/comments/user_delete_a_comment_spec.rb
+++ b/spec/system/comments/user_delete_a_comment_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Deleting Comment", type: :system, js: true do
+RSpec.describe "Deleting Comment", type: :system, js: true, elasticsearch: "FeedContent" do
   let(:user) { create(:user) }
   let(:raw_comment) { Faker::Lorem.paragraph }
   let(:article) do


### PR DESCRIPTION


## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Same as #8388 we need to clear Elasticsearch data here to avoid trying to load missing user images

> With some logging I confirmed that those users had no images but we were still seeing user profile images on the page. Turns out those were coming from left over Elasticsearch data. The only reason it affects the js: true specs is bc the js runs on the page and loads elasticsearch data.


![alt_text](https://media3.giphy.com/media/WqLtlPiYbyPWvDkCjE/giphy.gif)
