### PR TITLE
Change from url to path in form

### DIFF
--- a/app/views/chat_channel_memberships/join_channel_invitation.html.erb
+++ b/app/views/chat_channel_memberships/join_channel_invitation.html.erb
@@ -3,12 +3,12 @@
     <h1>This Invitation link is expired. Please contact the channel mod for new Invitation link</h1>
   <% else %>
     <h1 class="mt-5">Would you like to join the <%= @chat_channel.channel_name %> channel</h1>
-    <%= form_with(url: joining_invitation_response_url, html: { class: "align-center" }) do |f| %>
+    <%= form_with(url: joining_invitation_response_path, html: { class: "align-center" }) do |f| %>
       <%= f.hidden_field :user_action, value: "accept" %>
       <%= f.hidden_field :chat_channel_id, value: @chat_channel.id %>
       <%= f.submit "Accept", class: "crayons-btn crayons-btn--s" %>
     <% end %>
-    <%= form_with(url: joining_invitation_response_url, html: { class: "align-center" }) do |f| %>
+    <%= form_with(url: joining_invitation_response_path, html: { class: "align-center" }) do |f| %>
       <%= f.hidden_field :user_action, value: "decline" %>
       <%= f.hidden_field :chat_channel_id, value: @chat_channel.id %>
       <%= f.submit "Decline", class: "crayons-btn crayons-btn--danger mb-5 crayons-btn--s" %>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Changes the use of `_url` in favor of `_path` in Connect Invitation links flow.

Using `_url` worked well when testing locally but in production seems to be changing the protocol to `http` possibly introducing the bug seen in production.

## Related Tickets & Documents

Invitation links introduced in membership management component #8945

## QA Instructions, Screenshots, Recordings

If looking into testing this locally:

1. Create channel (`/internal/chat_channels`)
1. Copy invite link from membership management component
1. Open the link using a different user

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
