### PR TITLE
Rubocop: fix Rails/HasManyOrHasOneDependent by specifying it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -524,16 +524,6 @@ Performance/StringInclude:
 Rails/FilePath:
   EnforcedStyle: slashes
 
-Rails/HasManyOrHasOneDependent:
-  Description: 'Define the dependent option to the has_many and has_one associations.'
-  StyleGuide: 'https://rails.rubystyle.guide#has_many-has_one-dependent-option'
-  Enabled: false
-
-Rails/SaveBang:
-  Description: 'Identifies possible cases where Active Record save! or related should be used.'
-  StyleGuide: 'https://rails.rubystyle.guide#save-bang'
-  Enabled: false
-
 Rails/SkipsModelValidations:
   Description: >-
                  Use methods that skips model validations with caution.

--- a/app/models/ahoy/visit.rb
+++ b/app/models/ahoy/visit.rb
@@ -2,7 +2,7 @@ module Ahoy
   class Visit < ApplicationRecord
     self.table_name = "ahoy_visits"
 
-    has_many :events, class_name: "Ahoy::Event"
+    has_many :events, class_name: "Ahoy::Event", dependent: :destroy
     belongs_to :user, optional: true
   end
 end

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -2,8 +2,8 @@ class Badge < ApplicationRecord
   mount_uploader :badge_image, BadgeUploader
   resourcify
 
-  has_many :badge_achievements
-  has_many :tags
+  has_many :badge_achievements, dependent: :destroy
+  has_many :tags, dependent: :nullify
   has_many :users, through: :badge_achievements
 
   validates :badge_image, presence: true

--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -2,7 +2,7 @@ class Broadcast < ApplicationRecord
   VALID_BANNER_STYLES = %w[default brand success warning error].freeze
   resourcify
 
-  has_many :notifications, as: :notifiable, inverse_of: :notifiable
+  has_many :notifications, as: :notifiable, inverse_of: :notifiable, dependent: :destroy
 
   validates :title, uniqueness: { scope: :type_of }, presence: true
   validates :type_of, :processed_html, presence: true

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,5 +1,5 @@
 class Collection < ApplicationRecord
-  has_many :articles
+  has_many :articles, dependent: :nullify
   belongs_to :user
   belongs_to :organization, optional: true
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -25,8 +25,13 @@ class Comment < ApplicationRecord
   validate :permissions, if: :commentable
   validates :body_markdown, presence: true, length: { in: BODY_MARKDOWN_SIZE_RANGE }
   validates :body_markdown, uniqueness: { scope: %i[user_id ancestry commentable_id commentable_type] }
-  validates :commentable_id, presence: true
-  validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }
+
+  # As commentable is declared optional (a comment survives the destruction of the commentable it once belonged to),
+  # we should check commentable_id for the presence only with commentable_type, as a comment can be orphaned in time and
+  # we should allow commentable_type to be nil as it's going to be set to nil when the commentable is destroyed
+  validates :commentable_id, presence: true, allow_nil: true
+  validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }, allow_nil: true
+
   validates :user_id, presence: true
 
   before_create :adjust_comment_parent_based_on_depth

--- a/app/models/concerns/user_subscription_sourceable.rb
+++ b/app/models/concerns/user_subscription_sourceable.rb
@@ -4,7 +4,7 @@ module UserSubscriptionSourceable
   # This all assumes there's an association with User under the column user_id.
 
   included do
-    has_many :user_subscriptions, as: :user_subscription_sourceable
+    has_many :user_subscriptions, as: :user_subscription_sourceable, dependent: :destroy
     has_many :sourced_subscribers,
              class_name: "User",
              through: :user_subscriptions,

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -1,6 +1,6 @@
 class DisplayAd < ApplicationRecord
   belongs_to :organization
-  has_many :display_ad_events
+  has_many :display_ad_events, dependent: :destroy
 
   validates :organization_id, presence: true
   validates :placement_area, presence: true,

--- a/app/models/html_variant.rb
+++ b/app/models/html_variant.rb
@@ -10,8 +10,8 @@ class HtmlVariant < ApplicationRecord
   validate  :no_edits
 
   belongs_to :user, optional: true
-  has_many :html_variant_trials
-  has_many :html_variant_successes
+  has_many :html_variant_trials, dependent: :destroy
+  has_many :html_variant_successes, dependent: :destroy
 
   before_save :prefix_all_images
 

--- a/app/models/listing_category.rb
+++ b/app/models/listing_category.rb
@@ -3,7 +3,7 @@ class ListingCategory < ApplicationRecord
   # We standardized on the latter, but keeping the table name was easier.
   self.table_name = "classified_listing_categories"
 
-  has_many :listings, inverse_of: :listing_category
+  has_many :listings, inverse_of: :listing_category, dependent: :nullify
 
   before_validation :normalize_social_preview_color
 

--- a/app/models/listing_category.rb
+++ b/app/models/listing_category.rb
@@ -3,7 +3,7 @@ class ListingCategory < ApplicationRecord
   # We standardized on the latter, but keeping the table name was easier.
   self.table_name = "classified_listing_categories"
 
-  has_many :listings, inverse_of: :listing_category, dependent: :nullify
+  has_many :listings, inverse_of: :listing_category, dependent: :restrict_with_exception
 
   before_validation :normalize_social_preview_color
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,15 +12,14 @@ class Organization < ApplicationRecord
   acts_as_followable
 
   has_many :api_secrets, through: :users
-  has_many :articles
-  has_many :listings
-  has_many :collections
-  has_many :credits
-  has_many :display_ads
-  has_many :notifications
+  has_many :articles, dependent: :nullify
+  has_many :listings, dependent: :nullify
+  has_many :collections, dependent: :nullify
+  has_many :credits, dependent: :restrict_with_exception
+  has_many :display_ads, dependent: :destroy
+  has_many :notifications, dependent: :destroy
   has_many :organization_memberships, dependent: :delete_all
-  has_many :profile_pins, as: :profile, inverse_of: :profile
-  has_many :sponsorships
+  has_many :sponsorships, dependent: :nullify
   has_many :unspent_credits, -> { where spent: false }, class_name: "Credit", inverse_of: :organization
   has_many :users, through: :organization_memberships
 

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -1,8 +1,8 @@
 class Podcast < ApplicationRecord
   resourcify
 
-  has_many :podcast_episodes
   belongs_to :creator, class_name: "User", inverse_of: :created_podcasts, optional: true
+  has_many :podcast_episodes, dependent: :destroy
 
   mount_uploader :image, ProfileImageUploader
   mount_uploader :pattern_image, ProfileImageUploader

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -15,7 +15,7 @@ class PodcastEpisode < ApplicationRecord
   delegate :published, to: :podcast
 
   belongs_to :podcast
-  has_many :comments, as: :commentable, inverse_of: :commentable
+  has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :nullify
 
   mount_uploader :image, ProfileImageUploader
   mount_uploader :social_image, ProfileImageUploader

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -4,9 +4,9 @@ class Poll < ApplicationRecord
   serialize :voting_data
 
   belongs_to :article
-  has_many :poll_options
-  has_many :poll_skips
-  has_many :poll_votes
+  has_many :poll_options, dependent: :destroy
+  has_many :poll_skips, dependent: :destroy
+  has_many :poll_votes, dependent: :destroy
 
   validates :prompt_markdown, presence: true,
                               length: { maximum: 128 }

--- a/app/models/poll_option.rb
+++ b/app/models/poll_option.rb
@@ -1,9 +1,8 @@
 class PollOption < ApplicationRecord
   belongs_to :poll
-  has_many :poll_votes
+  has_many :poll_votes, dependent: :destroy
 
-  validates :markdown, presence: true,
-                       length: { maximum: 128 }
+  validates :markdown, presence: true, length: { maximum: 128 }
 
   before_save :evaluate_markdown
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < ApplicationRecord
   has_many :identities_enabled, -> { enabled }, class_name: "Identity", inverse_of: false
   has_many :mentions, dependent: :destroy
   has_many :messages, dependent: :destroy
-  has_many :notes, as: :noteable, inverse_of: :noteable, dependent: :destroy
+  has_many :notes, as: :noteable, inverse_of: :noteable, dependent: :nullify
   has_many :notification_subscriptions, dependent: :destroy
   has_many :user_optional_fields, dependent: :destroy
   has_many :notifications, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,7 +90,7 @@ class User < ApplicationRecord
   has_many :identities_enabled, -> { enabled }, class_name: "Identity", inverse_of: false
   has_many :mentions, dependent: :destroy
   has_many :messages, dependent: :destroy
-  has_many :notes, as: :noteable, inverse_of: :noteable
+  has_many :notes, as: :noteable, inverse_of: :noteable, dependent: :destroy
   has_many :notification_subscriptions, dependent: :destroy
   has_many :user_optional_fields, dependent: :destroy
   has_many :notifications, dependent: :destroy

--- a/app/services/articles/destroyer.rb
+++ b/app/services/articles/destroyer.rb
@@ -3,12 +3,14 @@ module Articles
     module_function
 
     def call(article, event_dispatcher = Webhook::DispatchEvent)
-      article.destroy!
       Notification.remove_all_without_delay(notifiable_ids: article.id, notifiable_type: "Article")
+
       if article.comments.exists?
-        Notification.remove_all(notifiable_ids: article.comments.pluck(:id),
-                                notifiable_type: "Comment")
+        Notification.remove_all(notifiable_ids: article.comments.pluck(:id), notifiable_type: "Comment")
       end
+
+      article.destroy!
+
       event_dispatcher.call("article_destroyed", article) if article.published?
     end
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -66,6 +66,8 @@ test:
   <<: *default
   url: <%= ENV['DATABASE_URL_TEST'] || ENV['DATABASE_URL'] || ''%>
   database: PracticalDeveloper_test<%= ENV['TEST_ENV_NUMBER'] %>
+  variables:
+      statement_timeout: <%= ENV['STATEMENT_TIMEOUT'] || 10_000 %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/spec/models/ahoy/visit_spec.rb
+++ b/spec/models/ahoy/visit_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Ahoy::Visit, type: :model do
+  let(:visit) { create(:ahoy_visit) }
+
+  describe "validations" do
+    describe "builtin validations" do
+      subject { visit }
+
+      it { is_expected.to have_many(:events).class_name("Ahoy::Event").dependent(:destroy) }
+      it { is_expected.to belong_to(:user).optional }
+    end
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -14,21 +14,29 @@ RSpec.describe Article, type: :model do
   it_behaves_like "UserSubscriptionSourceable"
 
   describe "validations" do
-    it { is_expected.to validate_uniqueness_of(:canonical_url).allow_blank }
-    it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:user_id) }
-    it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_blank }
-    it { is_expected.to validate_presence_of(:title) }
-    it { is_expected.to validate_length_of(:title).is_at_most(128) }
-    it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(126) }
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:organization).optional }
-    it { is_expected.to belong_to(:collection).optional }
-    it { is_expected.to have_many(:comments) }
-    it { is_expected.to have_many(:reactions).dependent(:destroy) }
-    it { is_expected.to have_many(:notifications).dependent(:delete_all) }
-    it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
-    it { is_expected.to validate_presence_of(:user_id) }
-    it { is_expected.not_to allow_value("foo").for(:main_image_background_hex_color) }
+    describe "builtin validations" do
+      it { is_expected.to belong_to(:collection).optional }
+      it { is_expected.to belong_to(:organization).optional }
+      it { is_expected.to belong_to(:user) }
+
+      it { is_expected.to have_many(:buffer_updates).dependent(:destroy) }
+      it { is_expected.to have_many(:comments).dependent(:nullify) }
+      it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
+      it { is_expected.to have_many(:notifications).dependent(:delete_all) }
+      it { is_expected.to have_many(:page_views).dependent(:destroy) }
+      it { is_expected.to have_many(:profile_pins).dependent(:destroy) }
+      it { is_expected.to have_many(:rating_votes).dependent(:destroy) }
+
+      it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(126) }
+      it { is_expected.to validate_length_of(:title).is_at_most(128) }
+      it { is_expected.to validate_presence_of(:title) }
+      it { is_expected.to validate_presence_of(:user_id) }
+      it { is_expected.to validate_uniqueness_of(:canonical_url).allow_blank }
+      it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_blank }
+      it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:user_id) }
+
+      it { is_expected.not_to allow_value("foo").for(:main_image_background_hex_color) }
+    end
 
     describe "#after_commit" do
       it "on update enqueues job to index article to elasticsearch" do

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Badge, type: :model do
     describe "builtin validations" do
       subject { badge }
 
-      it { is_expected.to have_many(:badge_achievements) }
-      it { is_expected.to have_many(:tags) }
+      it { is_expected.to have_many(:badge_achievements).dependent(:destroy) }
+      it { is_expected.to have_many(:tags).dependent(:nullify) }
       it { is_expected.to have_many(:users).through(:badge_achievements) }
 
       it { is_expected.to validate_presence_of(:title) }

--- a/spec/models/broadcast_spec.rb
+++ b/spec/models/broadcast_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Broadcast, type: :model do
   it { is_expected.to validate_inclusion_of(:banner_style).in_array(%w[default brand success warning error]) }
   it { is_expected.to validate_uniqueness_of(:title).scoped_to(:type_of) }
 
-  it { is_expected.to have_many(:notifications) }
+  it { is_expected.to have_many(:notifications).dependent(:destroy) }
 
   it "validates that only one Broadcast with a type_of Announcement can be active" do
     create(:announcement_broadcast)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Collection, type: :model do
   describe "validations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:organization).optional }
-    it { is_expected.to have_many(:articles) }
+    it { is_expected.to have_many(:articles).dependent(:nullify) }
 
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:slug) }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Comment, type: :model do
     it { is_expected.to have_many(:mentions).dependent(:destroy) }
     it { is_expected.to have_many(:notifications).dependent(:delete_all) }
     it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
-    it { is_expected.to validate_presence_of(:commentable_id) }
+    it { is_expected.to validate_presence_of(:commentable_id).allow_nil }
     it { is_expected.to validate_presence_of(:body_markdown) }
 
     it do
@@ -28,7 +28,7 @@ RSpec.describe Comment, type: :model do
     end
 
     it { is_expected.to validate_length_of(:body_markdown).is_at_least(1).is_at_most(25_000) }
-    it { is_expected.to validate_inclusion_of(:commentable_type).in_array(%w[Article PodcastEpisode]) }
+    it { is_expected.to validate_inclusion_of(:commentable_type).in_array(%w[Article PodcastEpisode]).allow_nil }
 
     it "is invalid if commentable is unpublished article" do
       # rubocop:disable RSpec/NamedSubject

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -4,11 +4,18 @@ RSpec.describe DisplayAd, type: :model do
   let_it_be(:organization) { create(:organization) }
   let_it_be(:display_ad) { create(:display_ad, organization_id: organization.id) }
 
-  it { is_expected.to validate_presence_of(:organization_id) }
-  it { is_expected.to validate_presence_of(:placement_area) }
-  it { is_expected.to validate_presence_of(:body_markdown) }
-
   describe "validations" do
+    describe "builtin validations" do
+      subject { display_ad }
+
+      it { is_expected.to belong_to(:organization) }
+      it { is_expected.to have_many(:display_ad_events).dependent(:destroy) }
+
+      it { is_expected.to validate_presence_of(:organization_id) }
+      it { is_expected.to validate_presence_of(:placement_area) }
+      it { is_expected.to validate_presence_of(:body_markdown) }
+    end
+
     it "allows sidebar_right" do
       display_ad.placement_area = "sidebar_right"
       expect(display_ad).to be_valid

--- a/spec/models/html_variant_spec.rb
+++ b/spec/models/html_variant_spec.rb
@@ -3,9 +3,18 @@ require "rails_helper"
 RSpec.describe HtmlVariant, type: :model do
   let(:html_variant) { create(:html_variant, approved: true, published: true) }
 
-  it { is_expected.to validate_uniqueness_of(:name) }
-  it { is_expected.to validate_presence_of(:html) }
-  it { is_expected.to belong_to(:user).optional }
+  describe "validations" do
+    describe "builtin validations" do
+      subject { html_variant }
+
+      it { is_expected.to belong_to(:user).optional }
+      it { is_expected.to have_many(:html_variant_trials).dependent(:destroy) }
+      it { is_expected.to have_many(:html_variant_successes).dependent(:destroy) }
+
+      it { is_expected.to validate_uniqueness_of(:name) }
+      it { is_expected.to validate_presence_of(:html) }
+    end
+  end
 
   it "calculates success rate" do
     4.times { HtmlVariantTrial.create!(html_variant_id: html_variant.id) }

--- a/spec/models/listing_category_spec.rb
+++ b/spec/models/listing_category_spec.rb
@@ -2,16 +2,20 @@ require "rails_helper"
 
 RSpec.describe ListingCategory, type: :model do
   describe "validations" do
-    # The uniqueness validation didn't work without this, see section "Caveat" at
-    # https://www.rubydoc.info/github/thoughtbot/shoulda-matchers/Shoulda%2FMatchers%2FActiveRecord:validate_uniqueness_of
-    subject { create(:listing_category) }
+    describe "builtin validations" do
+      # The uniqueness validation didn't work without this, see section "Caveat" at
+      # https://www.rubydoc.info/github/thoughtbot/shoulda-matchers/Shoulda%2FMatchers%2FActiveRecord:validate_uniqueness_of
+      subject { create(:listing_category) }
 
-    it { is_expected.to validate_presence_of(:name) }
-    it { is_expected.to validate_presence_of(:cost) }
-    it { is_expected.to validate_presence_of(:rules) }
-    it { is_expected.to validate_presence_of(:slug) }
-    it { is_expected.to validate_uniqueness_of(:name) }
-    it { is_expected.to validate_uniqueness_of(:slug) }
+      it { is_expected.to have_many(:listings).dependent(:restrict_with_exception) }
+
+      it { is_expected.to validate_presence_of(:name) }
+      it { is_expected.to validate_presence_of(:cost) }
+      it { is_expected.to validate_presence_of(:rules) }
+      it { is_expected.to validate_presence_of(:slug) }
+      it { is_expected.to validate_uniqueness_of(:name) }
+      it { is_expected.to validate_uniqueness_of(:slug) }
+    end
 
     context "when validating social preview colors" do
       let(:category) { build(:listing_category) }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -8,15 +8,14 @@ RSpec.describe Organization, type: :model do
       subject { organization }
 
       it { is_expected.to have_many(:api_secrets).through(:users) }
-      it { is_expected.to have_many(:articles) }
-      it { is_expected.to have_many(:listings) }
-      it { is_expected.to have_many(:collections) }
-      it { is_expected.to have_many(:credits) }
-      it { is_expected.to have_many(:display_ads) }
-      it { is_expected.to have_many(:notifications) }
+      it { is_expected.to have_many(:articles).dependent(:nullify) }
+      it { is_expected.to have_many(:listings).dependent(:nullify) }
+      it { is_expected.to have_many(:collections).dependent(:nullify) }
+      it { is_expected.to have_many(:credits).dependent(:restrict_with_exception) }
+      it { is_expected.to have_many(:display_ads).dependent(:destroy) }
+      it { is_expected.to have_many(:notifications).dependent(:destroy) }
       it { is_expected.to have_many(:organization_memberships).dependent(:delete_all) }
-      it { is_expected.to have_many(:profile_pins) }
-      it { is_expected.to have_many(:sponsorships) }
+      it { is_expected.to have_many(:sponsorships).dependent(:nullify) }
       it { is_expected.to have_many(:unspent_credits).class_name("Credit") }
       it { is_expected.to have_many(:users).through(:organization_memberships) }
 

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -3,12 +3,19 @@ require "rails_helper"
 RSpec.describe PodcastEpisode, type: :model do
   let(:podcast_episode) { create(:podcast_episode) }
 
-  it { is_expected.to validate_presence_of(:title) }
-  it { is_expected.to validate_presence_of(:slug) }
-  it { is_expected.to validate_presence_of(:media_url) }
-  it { is_expected.to validate_presence_of(:guid) }
-
   describe "validations" do
+    describe "builtin validations" do
+      subject { podcast_episode }
+
+      it { is_expected.to belong_to(:podcast) }
+      it { is_expected.to have_many(:comments).dependent(:nullify) }
+
+      it { is_expected.to validate_presence_of(:title) }
+      it { is_expected.to validate_presence_of(:slug) }
+      it { is_expected.to validate_presence_of(:media_url) }
+      it { is_expected.to validate_presence_of(:guid) }
+    end
+
     # Couldn't use shoulda matchers for these tests because:
     # Shoulda uses `save(validate: false)` which skips validations, but runs callbacks
     # So an invalid record is saved and the elasticsearch callback fails because there's no associated podcast

--- a/spec/models/podcast_spec.rb
+++ b/spec/models/podcast_spec.rb
@@ -3,12 +3,6 @@ require "rails_helper"
 RSpec.describe Podcast, type: :model do
   let(:podcast) { create(:podcast) }
 
-  it { is_expected.to validate_presence_of(:image) }
-  it { is_expected.to validate_presence_of(:slug) }
-  it { is_expected.to validate_presence_of(:title) }
-  it { is_expected.to validate_presence_of(:main_color_hex) }
-  it { is_expected.to validate_presence_of(:feed_url) }
-
   it "has a creator" do
     user = build(:user)
     pod = create(:podcast, creator: user)
@@ -24,6 +18,19 @@ RSpec.describe Podcast, type: :model do
   end
 
   describe "validations" do
+    describe "builtin validations" do
+      subject { podcast }
+
+      it { is_expected.to belong_to(:creator).class_name("User").optional }
+      it { is_expected.to have_many(:podcast_episodes).dependent(:destroy) }
+
+      it { is_expected.to validate_presence_of(:image) }
+      it { is_expected.to validate_presence_of(:slug) }
+      it { is_expected.to validate_presence_of(:title) }
+      it { is_expected.to validate_presence_of(:main_color_hex) }
+      it { is_expected.to validate_presence_of(:feed_url) }
+    end
+
     # Couldn't use shoulda uniqueness matchers for these tests because:
     # Shoulda uses `save(validate: false)` which skips validations
     # So an invalid record is trying to be saved but fails because of the db constraints

--- a/spec/models/poll_option_spec.rb
+++ b/spec/models/poll_option_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe PollOption, type: :model do
   let_it_be(:poll_option) { build(:poll_option, poll: poll) }
 
   describe "validations" do
+    describe "builtin validations" do
+      subject { poll_option }
+
+      it { is_expected.to belong_to(:poll) }
+      it { is_expected.to have_many(:poll_votes).dependent(:destroy) }
+
+      it { is_expected.to validate_presence_of(:markdown) }
+    end
+
     it "allows up to 128 markdown characters" do
       poll_option.markdown = "0" * 128
       expect(poll_option).to be_valid

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -4,7 +4,19 @@ RSpec.describe Poll, type: :model do
   let_it_be(:article) { create(:article, featured: true) }
 
   describe "validations" do
-    let_it_be(:poll) { build(:poll, article: article) }
+    let(:poll) { build(:poll, article: article) }
+
+    describe "builtin validations" do
+      subject { poll }
+
+      it { is_expected.to belong_to(:article) }
+      it { is_expected.to have_many(:poll_options).dependent(:destroy) }
+      it { is_expected.to have_many(:poll_skips).dependent(:destroy) }
+      it { is_expected.to have_many(:poll_votes).dependent(:destroy) }
+
+      it { is_expected.to validate_presence_of(:prompt_markdown) }
+      it { is_expected.to validate_presence_of(:poll_options_input_array) }
+    end
 
     describe "#prompt_markdown" do
       it "is valid up to 128 chars" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe User, type: :model do
       it { is_expected.to have_many(:identities).dependent(:destroy) }
       it { is_expected.to have_many(:mentions).dependent(:destroy) }
       it { is_expected.to have_many(:messages).dependent(:destroy) }
-      it { is_expected.to have_many(:notes) }
+      it { is_expected.to have_many(:notes).dependent(:destroy) }
       it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
       it { is_expected.to have_many(:notifications).dependent(:destroy) }
       it { is_expected.to have_many(:organization_memberships).dependent(:destroy) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe User, type: :model do
       it { is_expected.to have_many(:identities).dependent(:destroy) }
       it { is_expected.to have_many(:mentions).dependent(:destroy) }
       it { is_expected.to have_many(:messages).dependent(:destroy) }
-      it { is_expected.to have_many(:notes).dependent(:destroy) }
+      it { is_expected.to have_many(:notes).dependent(:nullify) }
       it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
       it { is_expected.to have_many(:notifications).dependent(:destroy) }
       it { is_expected.to have_many(:organization_memberships).dependent(:destroy) }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x]  Optimization
- [ ] Documentation Update

## Description

We have a few `has_many` that have no explicit `dependent` clause, and those should be as explicit as possible. I left some comments to each of them to make it easier for reviewer to comment.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
