### PR TITLE
API: add nullable to nullable fields in documentation

### DIFF
--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -942,6 +942,7 @@ components:
           nullable: true          
         location:
           type: string
+          nullable: true
         joined_at:
           description: Date of joining (formatted with strftime `"%b %e, %Y"`)
           type: string

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -852,6 +852,7 @@ components:
           nullable: true          
         github_username:
           type: string
+          nullable: true
         website_url:
           type: string
           format: url
@@ -932,6 +933,7 @@ components:
           nullable: true
         github_username:
           type: string
+          nullable: true
         website_url:
           type: string
           format: url

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -209,6 +209,7 @@ components:
         edited_at:
           type: string
           format: date-time
+          nullable: true          
         crossposted_at:
           type: string
           format: date-time
@@ -304,6 +305,7 @@ components:
         edited_at:
           type: string
           format: date-time
+          nullable: true
         crossposted_at:
           type: string
           format: date-time

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -849,6 +849,7 @@ components:
           type: string
         twitter_username:
           type: string
+          nullable: true          
         github_username:
           type: string
         website_url:
@@ -928,6 +929,7 @@ components:
           type: string
         twitter_username:
           type: string
+          nullable: true
         github_username:
           type: string
         website_url:

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -929,6 +929,7 @@ components:
           type: string
         summary:
           type: string
+          nullable: true
         twitter_username:
           type: string
           nullable: true

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -212,6 +212,7 @@ components:
         crossposted_at:
           type: string
           format: date-time
+          nullable: true          
         published_at:
           type: string
           format: date-time
@@ -306,6 +307,7 @@ components:
         crossposted_at:
           type: string
           format: date-time
+          nullable: true          
         published_at:
           type: string
           format: date-time

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -856,6 +856,7 @@ components:
         website_url:
           type: string
           format: url
+          nullable: true          
         profile_image:
           description: Profile image (640x640)
           type: string
@@ -937,6 +938,7 @@ components:
         website_url:
           type: string
           format: url
+          nullable: true          
         location:
           type: string
         joined_at:

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -175,6 +175,7 @@ components:
         cover_image:
           type: string
           format: url
+          nullable: true
         readable_publish_date:
           type: string
         social_image:
@@ -271,6 +272,7 @@ components:
         cover_image:
           type: string
           format: url
+          nullable: true
         readable_publish_date:
           type: string
         social_image:
@@ -497,6 +499,7 @@ components:
         cover_image:
           type: string
           format: url
+          nullable: true
         published:
           type: boolean
         published_at:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
Added 'nullable' to fields which may return a null value in API documentation
issue #9061

## QA Instructions, Screenshots, Recordings

Currently in the documentation it is listed data to be returned in the response, but does not offer the possibility that it can return null as a value.

For instance, with respect to articles:
![before: nullable not included in article](https://i.imgur.com/wiKVenI.png)

Changed so any data which may have a null value is documented accordingly
![after: nullable included in article](https://i.imgur.com/YTj0QQy.png)

With users, a user may or may not have a website url, github, or twitter linked to their profile. In these cases where they do not, the API will return null for those fields. The documentation is updated to account for this
![changed user fields to include nullable](https://i.imgur.com/Hj2S4v1.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed
