### PR TITLE
Update broadcast styling

### DIFF
--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -67,10 +67,8 @@ function renderBroadcast(broadcastElement, data) {
     }
   }
 
-  const closeButton = `<button class="close-announcement-button">
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M6.99974 5.58623L11.9497 0.63623L13.3637 2.05023L8.41374 7.00023L13.3637 11.9502L11.9497 13.3642L6.99974 8.41423L2.04974 13.3642L0.635742 11.9502L5.58574 7.00023L0.635742 2.05023L2.04974 0.63623L6.99974 5.58623Z" fill="white" />
-    </svg>
+  const closeButton = `<button class="close-announcement-button crayons-btn crayons-btn--icon-rounded crayons-btn--inverted crayons-btn--ghost">
+    <svg class="crayons-icon" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 10.586l4.95-4.95 1.414 1.414-4.95 4.95 4.95 4.95-1.414 1.414-4.95-4.95-4.95 4.95-1.414-1.414 4.95-4.95-4.95-4.95L7.05 5.636l4.95 4.95z" /></svg>
   </button>`;
 
   broadcastElement.insertAdjacentHTML(

--- a/app/assets/stylesheets/components/banners.scss
+++ b/app/assets/stylesheets/components/banners.scss
@@ -8,24 +8,50 @@
   background: var(--base-90);
   color: var(--base-0);
 
+  a {
+    color: var(--body-color-inverted);
+  }
+
   &--brand {
     background: var(--accent-brand);
     border-bottom-color: var(--accent-brand-darker);
+
+    a {
+      color: var(--body-color-inverted);
+    }
   }
 
   &--success {
     background: var(--accent-success);
     border-bottom-color: var(--accent-success-darker);
+    color: var(--body-color);
+
+    a {
+      color: var(--body-color);
+    }
   }
 
   &--warning {
     background: var(--accent-warning);
     border-bottom-color: var(--accent-warning-darker);
+    color: var(--body-color);
+
+    a {
+      color: var(--body-color);
+    }
   }
 
   &--error {
     background: var(--accent-danger);
     border-bottom-color: var(--accent-danger-darker);
     color: var(--body-color-inverted);
+
+    a {
+      color: var(--body-color-inverted);
+    }
+  }
+
+  a {
+    text-decoration: underline;
   }
 }

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -155,14 +155,13 @@ body.ten-x-hacker-theme {
 }
 
 .broadcast-wrapper {
+  box-sizing: border-box;
   display: none;
-  width: 100%;
-  font-size: 20px;
-  text-align: center;
-  padding: 0;
-  min-height: 45px;
-  z-index: 101; // Must be higher than the z-index of the sticky-nav.
+  padding: var(--su-2) var(--su-4);
   position: fixed;
+  text-align: center;
+  width: 100%;
+  z-index: 101; // Must be higher than the z-index of the sticky-nav.
 }
 
 .broadcast-visible {
@@ -171,12 +170,7 @@ body.ten-x-hacker-theme {
 
 .broadcast-data {
   flex-grow: 1;
-  padding: var(--su-2);
-}
-
-.close-announcement-button {
-  background-color: transparent;
-  border: none;
+  align-self: center;
 }
 
 body.static-navbar-config {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Update `broadcast` & `crayons-banner` to:
- use `crayons-btn` styles for close button
- support `a` styles

This task will require follow-up considerations & support for the close buttons' colors across the different banner colors.

## QA Instructions, Screenshots, Recordings

![Screen Shot 2020-07-20 at 4 19 49 PM](https://user-images.githubusercontent.com/816402/87995831-63bd8200-caa5-11ea-8193-3dfcda9c1c0b.png)
![Screen Shot 2020-07-20 at 4 20 08 PM](https://user-images.githubusercontent.com/816402/87995832-64561880-caa5-11ea-8dad-7b35cd5be2c9.png)


_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![yay](https://media.giphy.com/media/vFKqnCdLPNOKc/giphy.gif)
