### PR TITLE
Add audit logs for credit card actions

### DIFF
--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -1,6 +1,9 @@
 class StripeActiveCardsController < ApplicationController
   before_action :authenticate_user!
 
+  AUDIT_LOG_CATEGORY = "user.creditcard.modification".freeze
+  private_constant :AUDIT_LOG_CATEGORY
+
   def create
     authorize :stripe_active_card
 
@@ -8,6 +11,7 @@ class StripeActiveCardsController < ApplicationController
 
     if Payments::Customer.create_source(customer.id, stripe_params[:stripe_token])
       flash[:settings_notice] = "Your billing information has been updated"
+      audit_log("add")
     else
       DatadogStatsClient.increment("stripe.errors", tags: ["action:create_card", "user_id:#{current_user.id}"])
 
@@ -29,6 +33,7 @@ class StripeActiveCardsController < ApplicationController
 
     if Payments::Customer.save(customer)
       flash[:settings_notice] = "Your billing information has been updated"
+      audit_log("update")
     else
       DatadogStatsClient.increment("stripe.errors", tags: ["action:update_card", "user_id:#{current_user.id}"])
       flash[:error] = "There was a problem updating your billing info."
@@ -54,6 +59,7 @@ class StripeActiveCardsController < ApplicationController
       Payments::Customer.save(customer)
 
       flash[:settings_notice] = "Your card has been successfully removed."
+      audit_log("remove")
     end
 
     redirect_to user_settings_path(:billing)
@@ -81,5 +87,19 @@ class StripeActiveCardsController < ApplicationController
 
   def stripe_params
     params.permit(%i[stripe_token])
+  end
+
+  def audit_log(user_action)
+    AuditLog.create(
+      category: AUDIT_LOG_CATEGORY,
+      user: current_user,
+      roles: current_user.roles_name,
+      slug: "creditcard_#{user_action}",
+      data: {
+        action: action_name,
+        controller: controller_name,
+        user_action: user_action
+      },
+    )
   end
 end

--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -1,7 +1,7 @@
 class StripeActiveCardsController < ApplicationController
   before_action :authenticate_user!
 
-  AUDIT_LOG_CATEGORY = "user.creditcard.modification".freeze
+  AUDIT_LOG_CATEGORY = "user.credit_card.edit".freeze
   private_constant :AUDIT_LOG_CATEGORY
 
   def create
@@ -94,7 +94,7 @@ class StripeActiveCardsController < ApplicationController
       category: AUDIT_LOG_CATEGORY,
       user: current_user,
       roles: current_user.roles_name,
-      slug: "creditcard_#{user_action}",
+      slug: "credit_card_#{user_action}",
       data: {
         action: action_name,
         controller: controller_name,

--- a/docs/backend/audit-log.md
+++ b/docs/backend/audit-log.md
@@ -43,3 +43,23 @@ the internal controller.
 
 It's a good idea to add a similar `after_action` to any controller action that
 might benefit from increased transparency.
+
+Additionally, the `AuditLog` is used to track important actions performed on a
+user's account, e.g. adding or removing a credit card:
+
+```ruby
+#<AuditLog:0x00000001193ce348> {
+    category: "user.creditcard.modification",
+  created_at: Tue, 21 Jul 2020 06:35:13 +03 +03:00,
+        data: {
+         "action" => "create",
+     "controller" => "stripe_active_cards",
+    "user_action" => "add"
+  },
+          id: 4,
+       roles: [],
+        slug: "creditcard_add",
+  updated_at: Tue, 21 Jul 2020 06:35:13 +03 +03:00,
+     user_id: 53
+}
+```

--- a/docs/backend/audit-log.md
+++ b/docs/backend/audit-log.md
@@ -49,7 +49,7 @@ user's account, e.g. adding or removing a credit card:
 
 ```ruby
 #<AuditLog:0x00000001193ce348> {
-    category: "user.creditcard.modification",
+    category: "user.credit_card.edit",
   created_at: Tue, 21 Jul 2020 06:35:13 +03 +03:00,
         data: {
          "action" => "create",
@@ -58,7 +58,7 @@ user's account, e.g. adding or removing a credit card:
   },
           id: 4,
        roles: [],
-        slug: "creditcard_add",
+        slug: "credit_card_add",
   updated_at: Tue, 21 Jul 2020 06:35:13 +03 +03:00,
      user_id: 53
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

During a [discussion on a previous PR](https://github.com/forem/forem/pull/7924#pullrequestreview-414059201) we talked about maybe adding more logging around important user events, like adding or removing a credit card:

<img width="963" alt="Screen Shot 2020-07-21 at 11 20 16" src="https://user-images.githubusercontent.com/47985/88012472-28be5b80-cb44-11ea-9c2e-4a3c362525e4.png">

In a Slack discussion with @rhymes we agreed to reuse the existing `AuditLog` model for this. 

This PR introduces basic logging for credit card CRUD events. There's no interface for looking at them yet.

The created log entries currently look like this:

```ruby
#<AuditLog:0x00000001193ce348> {
    category: "user.creditcard.modification",
  created_at: Tue, 21 Jul 2020 06:35:13 +03 +03:00,
        data: {
         "action" => "create",
     "controller" => "stripe_active_cards",
    "user_action" => "add"
  },
          id: 4,
       roles: [],
        slug: "creditcard_add",
  updated_at: Tue, 21 Jul 2020 06:35:13 +03 +03:00,
     user_id: 53
}
```


## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Add, remove or update credit cards and inspect the log entries created.

## Added tests?

- [X] yes

## Added to documentation?

- [X] docs.dev.to

## What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/47985/88012604-894d9880-cb44-11ea-93bc-06f38d582737.png)

