### PR TITLE
Rubocop: re-activate Style/RegexpLiteral and fix violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -414,11 +414,6 @@ Style/RedundantRegexpEscape:
   Description: 'Checks for redundant escapes in Regexps.'
   Enabled: true
 
-Style/RegexpLiteral:
-  Description: 'Use / or %r around regular expressions.'
-  StyleGuide: '#percent-r'
-  Enabled: false
-
 Style/ReturnNil:
   Description: 'Use return instead of return nil.'
   Enabled: true

--- a/app/controllers/concerns/valid_request.rb
+++ b/app/controllers/concerns/valid_request.rb
@@ -25,7 +25,7 @@ module ValidRequest
     # In this case we make sure the redirect ends in the app protocol.
     # This is the same as the base Rails method except URL.protocol
     # is used instead of request.protocol.
-    when /\A([a-z][a-z\d\-+.]*:|\/\/).*/i
+    when %r{\A([a-z][a-z\d\-+.]*:|//).*}i
       options
     when String
       "#{(URL.protocol || request.protocol)}#{request.host_with_port}#{options}"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,7 +106,7 @@ module ApplicationHelper
   end
 
   def beautified_url(url)
-    url.sub(/\A((https?|ftp):\/)?\//, "").sub(/\?.*/, "").chomp("/")
+    url.sub(%r{\A((https?|ftp):/)?/}, "").sub(/\?.*/, "").chomp("/")
   rescue StandardError
     url
   end

--- a/app/lib/redcarpet/render/html_rouge.rb
+++ b/app/lib/redcarpet/render/html_rouge.rb
@@ -15,13 +15,13 @@ module Redcarpet
       def link(link, _title, content)
         # Probably not the best fix but it does it's job of preventing
         # a nested links.
-        return if /<a\s.+\/a>/.match?(content)
+        return if %r{<a\s.+/a>}.match?(content)
 
         link_attributes = ""
         @options[:link_attributes]&.each do |attribute, value|
           link_attributes += %( #{attribute}="#{value}")
         end
-        if (/https?:\/\/\S+/.match? link) || link.nil?
+        if (%r{https?://\S+}.match? link) || link.nil?
           %(<a href="#{link}"#{link_attributes}>#{content}</a>)
         elsif /\.{1}/.match? link
           %(<a href="//#{link}"#{link_attributes}>#{content}</a>)

--- a/app/liquid_tags/codepen_tag.rb
+++ b/app/liquid_tags/codepen_tag.rb
@@ -1,7 +1,7 @@
 class CodepenTag < LiquidTagBase
   PARTIAL = "liquids/codepen".freeze
   URL_REGEXP =
-    /\A(http|https):\/\/(codepen\.io|codepen\.io\/team)\/[a-zA-Z0-9_\-]{1,30}\/pen\/([a-zA-Z]{5,7})\/{0,1}\z/
+    %r{\A(http|https)://(codepen\.io|codepen\.io/team)/[a-zA-Z0-9_\-]{1,30}/pen/([a-zA-Z]{5,7})/{0,1}\z}
       .freeze
 
   def initialize(_tag_name, link, _parse_context)

--- a/app/liquid_tags/codesandbox_tag.rb
+++ b/app/liquid_tags/codesandbox_tag.rb
@@ -1,10 +1,10 @@
 class CodesandboxTag < LiquidTagBase
   PARTIAL = "liquids/codesandbox".freeze
   OPTIONS_REGEXP =
-    /\A(initialpath=([a-zA-Z0-9\-_\/.@%])+)\Z|
-      \A(module=([a-zA-Z0-9\-_\/.@%])+)\Z|
+    %r{\A(initialpath=([a-zA-Z0-9\-_/.@%])+)\Z|
+      \A(module=([a-zA-Z0-9\-_/.@%])+)\Z|
       \A(runonclick=((0|1){1}))\Z|
-      \Aview=(editor|split|preview)\Z/x
+      \Aview=(editor|split|preview)\Z}x
       .freeze
 
   def initialize(_tag_name, id, _parse_context)

--- a/app/liquid_tags/gist_tag.rb
+++ b/app/liquid_tags/gist_tag.rb
@@ -1,7 +1,7 @@
 class GistTag < LiquidTagBase
   PARTIAL = "liquids/gist".freeze
   VALID_LINK_REGEXP =
-    /\Ahttps:\/\/gist\.github\.com\/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})\/([a-zA-Z0-9]){1,32}(\/[a-zA-Z0-9]+)?\Z/
+    %r{\Ahttps://gist\.github\.com/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})/([a-zA-Z0-9]){1,32}(/[a-zA-Z0-9]+)?\Z}
       .freeze
 
   def initialize(_tag_name, link, _parse_context)

--- a/app/liquid_tags/git_pitch_tag.rb
+++ b/app/liquid_tags/git_pitch_tag.rb
@@ -1,6 +1,6 @@
 class GitPitchTag < LiquidTagBase
   PARTIAL = "liquids/gitpitch".freeze
-  URL_REGEXP = /(http|https):\/\/gitpitch.com\/[a-zA-Z0-9\-\/]*/.freeze
+  URL_REGEXP = %r{(http|https)://gitpitch.com/[a-zA-Z0-9\-/]*}.freeze
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/github_tag/github_issue_tag.rb
+++ b/app/liquid_tags/github_tag/github_issue_tag.rb
@@ -79,9 +79,9 @@ class GithubTag
     end
 
     def valid_link?(link)
-      link_without_domain = link.gsub(/.*github\.com\//, "").split("/")
+      link_without_domain = link.gsub(%r{.*github\.com/}, "").split("/")
       validations = [
-        /.*github\.com\//.match?(link),
+        %r{.*github\.com/}.match?(link),
         link_without_domain.length == 4,
         link_without_domain[3].to_i.positive?,
       ]

--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -82,7 +82,7 @@ class GithubTag
         attribute = element.name == "img" ? "src" : "href"
         element["href"] = "" if attribute == "href" && element.attributes[attribute].blank?
         path = element.attributes[attribute].value
-        element.attributes[attribute].value = url.gsub(/\/README.md/, "") + "/" + path if path[0, 4] != "http"
+        element.attributes[attribute].value = url.gsub(%r{/README.md}, "") + "/" + path if path[0, 4] != "http"
       end
       readme.to_html
     end

--- a/app/liquid_tags/js_fiddle_tag.rb
+++ b/app/liquid_tags/js_fiddle_tag.rb
@@ -1,7 +1,7 @@
 class JsFiddleTag < LiquidTagBase
   PARTIAL = "liquids/jsfiddle".freeze
   OPTION_REGEXP = /\A(js|html|css|result|,)*\z/.freeze
-  LINK_REGEXP = /\A(http|https):\/\/(jsfiddle\.net)\/[a-zA-Z0-9\-\/]*\z/.freeze
+  LINK_REGEXP = %r{\A(http|https)://(jsfiddle\.net)/[a-zA-Z0-9\-/]*\z}.freeze
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/jsitor_tag.rb
+++ b/app/liquid_tags/jsitor_tag.rb
@@ -1,6 +1,6 @@
 class JsitorTag < LiquidTagBase
   PARTIAL = "liquids/jsitor".freeze
-  URL_REGEXP = /\A(https|http):\/\/jsitor\.com\/embed\/\w+[-?a-zA-Z&]*\Z/.freeze
+  URL_REGEXP = %r{\A(https|http)://jsitor\.com/embed/\w+[-?a-zA-Z&]*\Z}.freeze
   ID_REGEXP = /\A[\w&?-]+\Z/.freeze
 
   def initialize(_tag_name, link, _parse_context)

--- a/app/liquid_tags/next_tech_tag.rb
+++ b/app/liquid_tags/next_tech_tag.rb
@@ -30,7 +30,7 @@ class NextTechTag < LiquidTagBase
   #   - http://nt.dev/s/123456abcdef/
   #   - nt.dev/s/123456abcdef
   def valid_share_url?(share_url)
-    (share_url =~ /^(?:(?:http|https):\/\/)?nt\.dev\/s\/[a-z0-9]{12}\/{0,1}$/)&.zero?
+    (share_url =~ %r{^(?:(?:http|https)://)?nt\.dev/s/[a-z0-9]{12}/{0,1}$})&.zero?
   end
 end
 

--- a/app/liquid_tags/parler_tag.rb
+++ b/app/liquid_tags/parler_tag.rb
@@ -21,14 +21,14 @@ class ParlerTag < LiquidTagBase
 
   def parse_id(input)
     input_no_space = input.delete(" ")
-    input_no_space = input_no_space.scan(/\bhttps?:\/\/[a-z.\/0-9-]+\b/).first
+    input_no_space = input_no_space.scan(%r{\bhttps?://[a-z./0-9-]+\b}).first
     raise StandardError, "Invalid Parler URL" unless valid_id?(input_no_space)
 
     input_no_space
   end
 
   def valid_id?(id)
-    id =~ /\A(https:\/\/www.parler.io\/audio\/\d{1,11}\/[a-zA-Z0-9]{11,40}.[0-9a-zA-Z-]{11,36}.mp3)\Z/
+    id =~ %r{\A(https://www.parler.io/audio/\d{1,11}/[a-zA-Z0-9]{11,40}.[0-9a-zA-Z-]{11,36}.mp3)\Z}
   end
 end
 

--- a/app/liquid_tags/reddit_tag.rb
+++ b/app/liquid_tags/reddit_tag.rb
@@ -2,7 +2,7 @@ class RedditTag < LiquidTagBase
   include ActionView::Helpers::SanitizeHelper
 
   PARTIAL = "liquids/reddit".freeze
-  URL_REGEXP = /\Ahttps:\/\/(www.)?reddit.com/.freeze
+  URL_REGEXP = %r{\Ahttps://(www.)?reddit.com}.freeze
 
   def initialize(_tag_name, url, _parse_context)
     super

--- a/app/liquid_tags/replit_tag.rb
+++ b/app/liquid_tags/replit_tag.rb
@@ -24,7 +24,7 @@ class ReplitTag < LiquidTagBase
   end
 
   def valid_id?(id)
-    id =~ /\A@\w{2,15}\/[a-zA-Z0-9\-]{0,60}\Z/
+    id =~ %r{\A@\w{2,15}/[a-zA-Z0-9\-]{0,60}\Z}
   end
 end
 

--- a/app/liquid_tags/soundcloud_tag.rb
+++ b/app/liquid_tags/soundcloud_tag.rb
@@ -31,7 +31,7 @@ class SoundcloudTag < LiquidTagBase
   end
 
   def valid_link?(link)
-    (link =~ /\Ahttps:\/\/soundcloud\.com\/([a-zA-Z0-9_\-]){3,25}\/(sets\/)?([a-zA-Z0-9_\-]){3,255}\Z/)
+    (link =~ %r{\Ahttps://soundcloud\.com/([a-zA-Z0-9_\-]){3,25}/(sets/)?([a-zA-Z0-9_\-]){3,255}\Z})
       &.zero?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,27 +5,27 @@ class User < ApplicationRecord
   include Searchable
   include Storext.model
 
-  BEHANCE_URL_REGEXP = /\A(http(s)?:\/\/)?(www.behance.net|behance.net)\/.*\z/.freeze
+  BEHANCE_URL_REGEXP = %r{\A(http(s)?://)?(www.behance.net|behance.net)/.*\z}.freeze
   COLOR_HEX_REGEXP = /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/.freeze
-  DRIBBBLE_URL_REGEXP = /\A(http(s)?:\/\/)?(www.dribbble.com|dribbble.com)\/.*\z/.freeze
+  DRIBBBLE_URL_REGEXP = %r{\A(http(s)?://)?(www.dribbble.com|dribbble.com)/.*\z}.freeze
   EDITORS = %w[v1 v2].freeze
-  FACEBOOK_URL_REGEXP = /\A(http(s)?:\/\/)?(www.facebook.com|facebook.com)\/.*\z/.freeze
+  FACEBOOK_URL_REGEXP = %r{\A(http(s)?://)?(www.facebook.com|facebook.com)/.*\z}.freeze
   FONTS = %w[default sans_serif monospace comic_sans open_dyslexic].freeze
-  GITLAB_URL_REGEXP = /\A(http(s)?:\/\/)?(www.gitlab.com|gitlab.com)\/.*\z/.freeze
+  GITLAB_URL_REGEXP = %r{\A(http(s)?://)?(www.gitlab.com|gitlab.com)/.*\z}.freeze
   INBOXES = %w[open private].freeze
   INSTAGRAM_URL_REGEXP =
-    /\A(http(s)?:\/\/)?(?:www.)?instagram.com\/(?=.{1,30}\/?$)([a-zA-Z\d_]\.?)*[a-zA-Z\d_]+\/?\z/.freeze
+    %r{\A(http(s)?://)?(?:www.)?instagram.com/(?=.{1,30}/?$)([a-zA-Z\d_]\.?)*[a-zA-Z\d_]+/?\z}.freeze
 
-  LINKEDIN_URL_REGEXP = /\A(http(s)?:\/\/)?(www.linkedin.com|linkedin.com|[A-Za-z]{2}.linkedin.com)\/.*\z/.freeze
-  MEDIUM_URL_REGEXP = /\A(http(s)?:\/\/)?(www.medium.com|medium.com)\/.*\z/.freeze
+  LINKEDIN_URL_REGEXP = %r{\A(http(s)?://)?(www.linkedin.com|linkedin.com|[A-Za-z]{2}.linkedin.com)/.*\z}.freeze
+  MEDIUM_URL_REGEXP = %r{\A(http(s)?://)?(www.medium.com|medium.com)/.*\z}.freeze
   NAVBARS = %w[default static].freeze
   STACKOVERFLOW_URL_REGEXP =
-    /\A(http(s)?:\/\/)?(((www|pt|ru|es|ja).)?stackoverflow.com|(www.)?stackexchange.com)\/.*\z/.freeze
+    %r{\A(http(s)?://)?(((www|pt|ru|es|ja).)?stackoverflow.com|(www.)?stackexchange.com)/.*\z}.freeze
 
-  YOUTUBE_URL_REGEXP = /\A(http(s)?:\/\/)?(www.youtube.com|youtube.com)\/.*\z/.freeze
+  YOUTUBE_URL_REGEXP = %r{\A(http(s)?://)?(www.youtube.com|youtube.com)/.*\z}.freeze
   STREAMING_PLATFORMS = %w[twitch].freeze
   THEMES = %w[default night_theme pink_theme minimal_light_theme ten_x_hacker_theme].freeze
-  TWITCH_URL_REGEXP = /\A(http(s)?:\/\/)?(www.twitch.tv|twitch.tv)\/.*\z/.freeze
+  TWITCH_URL_REGEXP = %r{\A(http(s)?://)?(www.twitch.tv|twitch.tv)/.*\z}.freeze
   USERNAME_MAX_LENGTH = 30
   USERNAME_REGEXP = /\A[a-zA-Z0-9_]+\z/.freeze
   MESSAGES = {

--- a/app/services/rss_reader/assembler.rb
+++ b/app/services/rss_reader/assembler.rb
@@ -77,7 +77,7 @@ class RssReader
         next if a_tag.empty?
 
         possible_link = a_tag[0].inner_html
-        next unless /medium\.com\/media\/.+\/href/.match?(possible_link)
+        next unless %r{medium\.com/media/.+/href}.match?(possible_link)
 
         real_link = HTTParty.head(possible_link).request.last_uri.to_s
         return nil unless real_link.include?("gist.github.com")

--- a/config/database.yml
+++ b/config/database.yml
@@ -66,6 +66,8 @@ test:
   <<: *default
   url: <%= ENV['DATABASE_URL_TEST'] || ENV['DATABASE_URL'] || ''%>
   database: PracticalDeveloper_test<%= ENV['TEST_ENV_NUMBER'] %>
+  variables:
+      statement_timeout: <%= ENV['STATEMENT_TIMEOUT'] || 10_000 %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/initializers/timber.rb
+++ b/config/initializers/timber.rb
@@ -16,7 +16,7 @@ config.integrations.active_record.silence = !Rails.env.development?
 config.integrations.rack.http_events.collapse_into_single_event = true
 
 config.integrations.rack.http_events.silence_request = lambda do |_rack_env, rack_request|
-  rack_request.path.match?(/^\/page_views\/\d{1,9}/)
+  rack_request.path.match?(%r{^/page_views/\d{1,9}})
 end
 
 config.integrations.rack.user_context.custom_user_hash = lambda do |rack_env|

--- a/spec/requests/videos_spec.rb
+++ b/spec/requests/videos_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Videos", type: :request do
       end
 
       it "redirects to the article's edit page for the logged in user" do
-        stub_request(:get, /dw71fyauz7yz9\.cloudfront\.net\//).to_return(status: 200, body: "", headers: {})
+        stub_request(:get, %r{dw71fyauz7yz9\.cloudfront\.net/}).to_return(status: 200, body: "", headers: {})
         post "/videos", params: { article: { video: "https://www.something.com/something.mp4" } }
         expect(response.status).to eq(302)
       end

--- a/spec/support/initializers/vcr.rb
+++ b/spec/support/initializers/vcr.rb
@@ -29,6 +29,6 @@ VCR.configure do |config|
     i.request.headers.delete("Authorization")
 
     u = URI.parse(i.request.uri)
-    i.request.uri.sub!(/:\/\/.*#{Regexp.escape(u.host)}/, "://#{u.host}")
+    i.request.uri.sub!(%r{://.*#{Regexp.escape(u.host)}}, "://#{u.host}")
   end
 end

--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Using the editor", type: :system do
 
     it "fills out form with rich content and click preview" do
       article_body = find("div.crayons-article__body")["innerHTML"]
-      article_body.gsub!(/"https:\/\/res\.cloudinary\.com\/.{1,}"/, "cloudinary_link")
+      article_body.gsub!(%r{"https://res\.cloudinary\.com/.{1,}"}, "cloudinary_link")
 
       Approvals.verify(article_body, name: "user_preview_article_body", format: :html)
     end
@@ -46,7 +46,7 @@ RSpec.describe "Using the editor", type: :system do
       fill_markdown_with(read_from_file(raw_text))
       find("button", text: /\ASave changes\z/).click
       article_body = find(:xpath, "//div[@id='article-body']")["innerHTML"]
-      article_body.gsub!(/"https:\/\/res\.cloudinary\.com\/.{1,}"/, "cloudinary_link")
+      article_body.gsub!(%r{"https://res\.cloudinary\.com/.{1,}"}, "cloudinary_link")
 
       Approvals.verify(article_body, name: "user_preview_article_body", format: :html)
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

`Style/RegexpLiteral` is activated by default on Rubocop, we should activate it as well:

https://github.com/rubocop-hq/rubocop/blob/343f62e4555be0470326f47af219689e21c61a37/config/default.yml#L3780-L3783

```yaml
Style/RegexpLiteral:
  Description: 'Use / or %r around regular expressions.'
  StyleGuide: '#percent-r'
  Enabled: true
```

The raw syntax is also very handy because, in addition on not requiring escapes, it allows regexp to be split in multiple lines and inline comments can be used.

For example:

```ruby
regexp = %r{
  start         # some text
  \s            # white space char
  (group)       # first group
  (?:alt1|alt2) # some alternation
  end
}x
```

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
