### PR TITLE
Rubocop: Move from OpenStruct to Struct in Notifications::Reactions::Send

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,7 +17,6 @@ Performance/OpenStruct:
   Exclude:
     - 'app/models/article.rb'
     - 'app/models/organization.rb'
-    - 'app/services/notifications/reactions/send.rb'
     - 'spec/models/github_repo_spec.rb'
     - 'spec/requests/github_repos_spec.rb'
 

--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -2,6 +2,8 @@
 module Notifications
   module Reactions
     class Send
+      Response = Struct.new(:action, :notification_id)
+
       # @param reaction_data [Hash]
       #   * :reactable_id [Integer] - article or comment id
       #   * :reactable_type [String] - "Article" or "Comment"
@@ -46,7 +48,7 @@ module Notifications
 
         if aggregated_reaction_siblings.size.zero?
           Notification.where(notification_params).delete_all
-          OpenStruct.new(action: :deleted)
+          Response.new(:deleted)
         else
           recent_reaction = reaction_siblings.first
 
@@ -64,7 +66,7 @@ module Notifications
 
           notification_id = save_notification(notification_params, notification)
 
-          OpenStruct.new(action: :saved, notification_id: notification_id)
+          Response.new(:saved, notification_id)
         end
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This was one of the remaining Rubocop todos. I decided to do this file by file, so it's easier to notice/rollback when something goes wrong as I seem to remember there previously were issues when we attempted to move from `OpenStruct` to `Struct`.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
