### PR TITLE
Add ability to turn off reaction notifications in notification settings

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,5 +1,6 @@
 class UserPolicy < ApplicationPolicy
   PERMITTED_ATTRIBUTES = %i[
+    article_reaction_notifications
     available_for
     behance_url
     bg_color_hex

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -57,6 +57,16 @@
 
   <div class="crayons-card mb-6 grid gap-6 p-6">
     <header>
+      <h3 class="mb-2">General Notification Settings</h3>
+    </header>
+    <div class="crayons-field crayons-field--checkbox">
+      <%= f.check_box :article_reaction_notifications, class: "crayons-checkbox" %>
+      <%= f.label :article_reaction_notifications, "Send notifications when someone reacts to my comments or posts", class: "crayons-field__label" %>
+    </div>
+  </div>
+
+  <div class="crayons-card mb-6 grid gap-6 p-6">
+    <header>
       <h3 class="mb-2">Mobile Notification Settings (Beta)</h3>
       <p>Additional settings will be rolled out as new notification features are made available.</p>
     </header>

--- a/app/workers/notifications/new_reaction_worker.rb
+++ b/app/workers/notifications/new_reaction_worker.rb
@@ -13,7 +13,14 @@ module Notifications
       return unless %w[User Organization].include?(receiver_klass)
 
       receiver = receiver_klass.constantize.find_by(id: receiver_data.fetch(:id))
-      Notifications::Reactions::Send.call(reaction_data, receiver) if receiver
+      Notifications::Reactions::Send.call(reaction_data, receiver) if should_send?(receiver, receiver_klass)
+    end
+
+    def should_send?(receiver, receiver_klass)
+      return false unless receiver
+      return true if receiver_klass == "Organization"
+
+      !receiver.article_reaction_notifications
     end
   end
 end

--- a/db/migrate/20200720110041_add_article_reaction_notifications.rb
+++ b/db/migrate/20200720110041_add_article_reaction_notifications.rb
@@ -1,0 +1,5 @@
+class AddArticleReactionNotifications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :article_reaction_notifications, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_17_203432) do
+ActiveRecord::Schema.define(version: 2020_07_20_110041) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1146,6 +1146,7 @@ ActiveRecord::Schema.define(version: 2020_07_17_203432) do
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
+    t.boolean "article_reaction_notifications", default: true
     t.integer "articles_count", default: 0, null: false
     t.string "available_for"
     t.integer "badge_achievements_count", default: 0, null: false

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -188,6 +188,11 @@ RSpec.describe "UserSettings", type: :request do
       expect(user.reload.profile_updated_at).to be > 2.minutes.ago
     end
 
+    it "disables article reaction notifications" do
+      put "/users/#{user.id}", params: { user: { tab: "notifications", article_reaction_notifications: 0 } }
+      expect(user.reload.article_reaction_notifications).to be(false)
+    end
+
     it "enables community-success notifications" do
       put "/users/#{user.id}", params: { user: { tab: "notifications", mod_roundrobin_notifications: 1 } }
       expect(user.reload.mod_roundrobin_notifications).to be(true)

--- a/spec/workers/notifications/new_reaction_worker_spec.rb
+++ b/spec/workers/notifications/new_reaction_worker_spec.rb
@@ -3,7 +3,10 @@ require "rails_helper"
 RSpec.describe Notifications::NewReactionWorker, type: :worker do
   let(:reaction_data) { { reactable_type: "Comment", reactable_id: 1, reactable_user_id: 2 } }
   let(:org) { create(:organization) }
-  let(:receiver_data) { { klass: "Organization", id: org.id } }
+  let(:user) { create(:user) }
+  let(:receiver_data_org) { { klass: "Organization", id: org.id } }
+  let(:receiver_data_user) { { klass: "User", id: user.id } }
+  let(:receiver_data_user_disabled) { { klass: "User", id: user.id, article_reaction_notifications: false } }
   let(:worker) { subject }
 
   include_examples "#enqueues_on_correct_queue", "medium_priority", [{}, {}]
@@ -13,9 +16,19 @@ RSpec.describe Notifications::NewReactionWorker, type: :worker do
 
     before { allow(reaction_service).to receive(:call) }
 
-    it "calls the service" do
-      worker.perform(reaction_data, receiver_data)
+    it "calls the service if receiver is an organization" do
+      worker.perform(reaction_data, receiver_data_org)
       allow(reaction_service).to receive(:call).with(reaction_data, org).once
+    end
+
+    it "calls the service if receiver is a user" do
+      worker.perform(reaction_data, receiver_data_user)
+      allow(reaction_service).to receive(:call).with(reaction_data, user).once
+    end
+
+    it "doesn't call if reaction notifications are turned off for user" do
+      worker.perform(reaction_data, receiver_data_user_disabled)
+      expect(reaction_service).not_to have_received(:call)
     end
 
     it "doesn't call if is a receiver is of a wrong class" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Adds new "General Notification Settings" section to UI, with option to turn off reaction notifications. It will be on by default.

When this checkbox is unchecked, users will no longer receive notifications for reactions.

## Related Tickets & Documents

#3244 

## QA Instructions, Screenshots, Recordings

<img width="600" alt="image" src="https://user-images.githubusercontent.com/33337378/88173723-687d6400-cc66-11ea-94c8-6495ad49415c.png">

Open to changing the UI / location of the checkbox, of course!

Are notifications batched? I signed in on two separate DEV accounts on separate browsers, however I couldn't get this react notifications reliably working. i.e. I "react" to a comment and then jump onto my other browser and refresh the page, the notification doesn't always show up. Not sure if this is expected behaviour, or something is wrong with the code that I wrote!

## Added tests?

- [x] yes

## Added to documentation?

- [x] no documentation needed