### PR TITLE
Don't show badge when reading list is left empty

### DIFF
--- a/app/assets/javascripts/initializers/initializeReadingListIcons.js
+++ b/app/assets/javascripts/initializers/initializeReadingListIcons.js
@@ -91,7 +91,8 @@ function renderNewSidebarCount(button, json) {
     newCount = count - 1;
   }
   document.getElementById('reading-list-count').dataset.count = newCount;
-  document.getElementById('reading-list-count').innerHTML = newCount;
+  document.getElementById('reading-list-count').innerHTML =
+    newCount > 0 ? newCount : '';
 }
 
 function buttonFormData(button) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes a bug where the badge of the reading list navigation item on the left sidebar won't disappear when the list is left empty.

## Related Tickets & Documents

Fixes #8900.

## QA Instructions, Screenshots, Recordings

On the homepage, with an empty reading list:

1. Click on the "Save" button of an article and notice how the badge appears
2. Click on the "Unsave" button of that same article and notice how the badge disappears

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

No.

## [optional] What gif best describes this PR or how it makes you feel?

![Fix GIF](https://media.giphy.com/media/RHK6nGK6mBFIR216pg/giphy.gif)
