### PR TITLE
Fix double render of home feed

### DIFF
--- a/app/javascript/articles/Feed.jsx
+++ b/app/javascript/articles/Feed.jsx
@@ -146,6 +146,7 @@ export class Feed extends Component {
 
     return (
       <div
+        id='rendered-article-feed'
         ref={(element) => {
           this.feedContainer = element;
         }}

--- a/app/javascript/packs/homePage.jsx
+++ b/app/javascript/packs/homePage.jsx
@@ -89,7 +89,9 @@ if (!document.getElementById('featured-story-marker')) {
 
     if (userStatus === 'logged-in' && user !== null) {
       clearInterval(waitingForDataLoad);
-
+      if (document.getElementById('rendered-article-feed')) {
+        return;
+      }
       import('./homePageFeed').then(({ renderFeed }) => {
         // We have user data, render followed tags.
         renderFeed(feedTimeFrame);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I think there's a better "preacty" way of dealing with this, but this is something we've had on the site for a while.

I don't think people notice it unless they're sensitive but I think it hurts UX and also leads to an extra call to an endpoint and lower performance overall.

Described here, but confirmed locally that we are, in fact, running some code multiple times in a way that is inappropriate.
#9079

This is a pretty straightforward fix in that it is self evident not to proceed with the following step if the element is already on the page.

Fixes #9079