### PR TITLE
Update slideshare embed code length limit

### DIFF
--- a/app/liquid_tags/slideshare_tag.rb
+++ b/app/liquid_tags/slideshare_tag.rb
@@ -19,7 +19,7 @@ class SlideshareTag < LiquidTagBase
   private
 
   def validate(key)
-    raise StandardError, "Invalid Slideshare Key" unless key.match?(/\A[a-zA-Z0-9]{14}\Z/)
+    raise StandardError, "Invalid Slideshare Key" unless key.match?(/\A[a-zA-Z0-9]{12,14}\Z/)
 
     key
   end

--- a/spec/liquid_tags/slideshare_tag_spec.rb
+++ b/spec/liquid_tags/slideshare_tag_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SlideshareTag, type: :liquid_tag do
   describe "#key" do
-    let(:valid_key) { "rdOzN9kr1yK5eE" }
+    let(:valid_keys) { %w[rdOzN9kr1yK5eE NM9EY9oYslwfE] }
 
     def generate_tag(key)
       Liquid::Template.register_tag("slideshare", SlideshareTag)
@@ -10,7 +10,9 @@ RSpec.describe SlideshareTag, type: :liquid_tag do
     end
 
     it "accepts a valid key" do
-      expect { generate_tag(valid_key) }.not_to raise_error
+      valid_keys.each do |key|
+        expect { generate_tag(key) }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Slideshare codes can be 13 characters long as well as 14. This updates the regex length validation to 12-14 characters long.

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed