### PR TITLE
Default to adding users as members to a chat channel and not mods

### DIFF
--- a/app/controllers/internal/chat_channels_controller.rb
+++ b/app/controllers/internal/chat_channels_controller.rb
@@ -19,7 +19,7 @@ module Internal
 
     def update
       @chat_channel = ChatChannel.find(params[:id])
-      @chat_channel.invite_users(users: users_by_param, membership_role: "mod")
+      @chat_channel.invite_users(users: users_by_param)
       redirect_back(fallback_location: "/internal/chat_channels")
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a bug where users were being added to chat channels as mods of that channel, when they should just be regular members.

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed