### PR TITLE
Bug Fix:Validate User Password Length is Between 8-100 characters

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -61,7 +61,13 @@ class UsersController < ApplicationController
     else
       Honeycomb.add_field("error", @user.errors.messages.reject { |_, v| v.empty? })
       Honeycomb.add_field("errored", true)
-      render :edit, status: :bad_request
+
+      if @tab
+        render :edit, status: :bad_request
+      else
+        flash[:error] = @user.errors.full_messages.join(", ")
+        redirect_to "/settings"
+      end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,6 +140,7 @@ class User < ApplicationRecord
   validates :medium_url, length: { maximum: 200 }, allow_blank: true, format: MEDIUM_URL_REGEXP
   validates :mostly_work_with, :currently_learning, :currently_hacking_on, :available_for, length: { maximum: 500 }
   validates :name, length: { in: 1..100 }
+  validates :password, length: { in: 8..100 }, allow_nil: true
   validates :stackoverflow_url, length: { maximum: 150 }, allow_blank: true, format: STACKOVERFLOW_URL_REGEXP
   validates :summary, length: { maximum: 1300 }, allow_nil: true
   validates :text_color_hex, format: COLOR_HEX_REGEXP, allow_blank: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe User, type: :model do
       it { is_expected.to validate_length_of(:location).is_at_most(100).allow_nil }
       it { is_expected.to validate_length_of(:mostly_work_with).is_at_most(500).allow_nil }
       it { is_expected.to validate_length_of(:name).is_at_most(100).is_at_least(1) }
+      it { is_expected.to validate_length_of(:password).is_at_most(100).is_at_least(8) }
       it { is_expected.to validate_length_of(:summary).is_at_most(1300).allow_nil }
       it { is_expected.to validate_length_of(:username).is_at_most(30).is_at_least(2) }
       it { is_expected.to validate_uniqueness_of(:github_username).allow_nil }

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -239,6 +239,12 @@ RSpec.describe "UserSettings", type: :request do
       expect(response).to have_http_status(:bad_request)
     end
 
+    it "returns error message if user can't be saved" do
+      put "/users/#{user.id}", params: { user: { password: "1", password_confirmation: "1" } }
+
+      expect(flash[:error]).to include("Password is too short")
+    end
+
     context "when requesting an export of the articles" do
       def send_request(flag = true)
         put "/users/#{user.id}", params: {


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Validate that a user's password is between 8 and 100 characters long. While setting this up I noticed that submitting an invalid input on the account page of settings would cause a 500 since `@tab` is not set on that page. Rather than try to dig into why I just put in a little workaround. 

## Added tests?
- [x] yes

![alt_text](https://media.tenor.com/images/ddbf150b50821327ab41303fb820752f/tenor.gif)
