### PR TITLE
Validate password confirmation when updating password

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,6 +160,7 @@ class User < ApplicationRecord
   validate :validate_mastodon_url
   validate :can_send_confirmation_email
   validate :update_rate_limit
+  validate :password_matches_confirmation, if: :encrypted_password_changed?
 
   alias_attribute :public_reactions_count, :reactions_count
   alias_attribute :subscribed_to_welcome_notifications?, :welcome_notifications
@@ -644,5 +645,11 @@ class User < ApplicationRecord
     rate_limiter.check_limit!(:user_update)
   rescue RateLimitChecker::LimitReached => e
     errors.add(:base, "User could not be saved. #{e.message}")
+  end
+
+  def password_matches_confirmation
+    return true if password == password_confirmation
+
+    errors.add(:password, "doesn't match password confirmation")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,6 +160,8 @@ class User < ApplicationRecord
   validate :validate_mastodon_url
   validate :can_send_confirmation_email
   validate :update_rate_limit
+  # NOTE: when updating the password on a Devise enabled model, the :encrypted_password
+  # field will be marked as dirty, not :password.
   validate :password_matches_confirmation, if: :encrypted_password_changed?
 
   alias_attribute :public_reactions_count, :reactions_count

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -113,8 +113,10 @@ module Authentication
     end
 
     def default_user_fields
+      password = Devise.friendly_token(20)
       {
-        password: Devise.friendly_token(20),
+        password: password,
+        password_confirmation: password,
         signup_cta_variant: cta_variant,
         registered: true,
         registered_at: Time.current,

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -245,6 +245,12 @@ RSpec.describe "UserSettings", type: :request do
       expect(flash[:error]).to include("Password is too short")
     end
 
+    it "returns an error message if the passwords do not match" do
+      put "/users/#{user.id}", params: { user: { password: "asdfghjk", password_confirmation: "qwertyui" } }
+
+      expect(flash[:error]).to include("Password doesn't match password confirmation")
+    end
+
     context "when requesting an export of the articles" do
       def send_request(flag = true)
         put "/users/#{user.id}", params: {


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

We recently added passwords to our `User` model. However, we never validated the password confirmation when updating the password, so users could accidentally set them to unexpected values:

```ruby
user.reset_password("newpassword", "nupassword")
#=> true
```

This PR fixes this by adding a validation:

```ruby
user.reset_password("newpassword", "nupassword")
#=> false
user.errors_as_sentence
#=> "Password doesn't match password confirmation"
```

Note: I originally tried to use `Devise::Models::Validatable`, however, this expects the password to be non-blank, despite the following:

```ruby
  validates :password, length: { in: 8..100 }, allow_nil: true
```

I thought we can fix this by overriding `password_required?`, but as [the documentation states](https://rubydoc.info/github/plataformatec/devise/master/Devise%2FModels%2FValidatable:password_required%3F):

> Passwords are always required if it's a new record, or if the password or confirmation are being set somewhere.

## QA Instructions, Screenshots, Recordings

1. Go to `/settings/account` in your local dev environment.
2. Set the password and confirmation to different values and submit the form.
3. You should see the following error:
    <img width="1421" alt="Screen Shot 2020-07-23 at 11 20 14" src="https://user-images.githubusercontent.com/47985/88251897-7cf94500-ccd6-11ea-97d8-091de51d3459.png">
4. Now set the passwords to the same value and submit the form again.
5. You should see a success message:
    <img width="1430" alt="Screen Shot 2020-07-23 at 11 21 09" src="https://user-images.githubusercontent.com/47985/88251950-b29e2e00-ccd6-11ea-8612-79b811962583.png">

## Added tests?

- [x] yes

## Added to documentation?

- [x] no documentation needed

## What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/47985/88252000-df524580-ccd6-11ea-93e0-ad46610586a2.png)

