### PR TITLE
Update /ban for Connect

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -94,22 +94,23 @@ class ChatChannelsController < ApplicationController
         user.messages.where(chat_channel: chat_channel).delete_all
         membership.update(status: "removed_from_channel")
         Pusher.trigger(chat_channel.pusher_channels, "user-banned", { userId: user.id }.to_json)
-        render json: { status: "success", message: "suspended!" }, status: :ok
+        render json: { status: "moderation-success", message: "#{username} was suspended.", userId: user.id,
+                       chatChannelId: chat_channel.id }, status: :ok
       else
         render json: {
           status: "error",
-          message: "Ban failed. user with username '#{username}' not found."
+          message: "Ban failed. user with username '#{username}' not found in this channel."
         }, status: :bad_request
       end
     when "/unban"
       user = User.find_by(username: username)
       if user
         user.remove_role :banned
-        render json: { status: "success", message: "unsuspended!" }, status: :ok
+        render json: { status: "moderation-success", message: "#{username} was unsuspended." }, status: :ok
       else
         render json: {
           status: "error",
-          message: "Unban failed. User with username '#{username}' not found"
+          message: "Unban failed. User with username '#{username}' not found in this channel."
         }, status: :bad_request
       end
     when "/clearchannel"

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -882,6 +882,8 @@ export default class Chat extends Component {
           return { messages: newMessages };
         });
       }
+    } else if (response.status === 'moderation-success') {
+      addSnackbarItem({ message: response.message, addCloseButton: true });
     } else if (response.status === 'error') {
       addSnackbarItem({ message: response.message, addCloseButton: true });
     }

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -883,7 +883,7 @@ export default class Chat extends Component {
         });
       }
     } else if (response.status === 'error') {
-      addSnackbarItem({ message: response.message });
+      addSnackbarItem({ message: response.message, addCloseButton: true });
     }
   };
 
@@ -1071,6 +1071,7 @@ export default class Chat extends Component {
   handleFailure = (err) => {
     // eslint-disable-next-line no-console
     console.error(err);
+    addSnackbarItem({ message: err, addCloseButton: true });
   };
 
   renderMessages = () => {

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -8,6 +8,7 @@ import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 import { setupPusher } from '../utilities/connect';
 import debounceAction from '../utilities/debounceAction';
+import { addSnackbarItem } from '../Snackbar';
 import {
   conductModeration,
   getAllMessages,
@@ -737,6 +738,13 @@ export default class Chat extends Component {
         path: `/search?q=${message.replace('/s ', '')}`,
         type_of: 'article',
       });
+    } else if (message.startsWith('/ban ')) {
+      conductModeration(
+        activeChannelId,
+        message,
+        this.handleSuccess,
+        this.handleFailure,
+      );
     } else if (message.startsWith('/')) {
       this.setActiveContentState(activeChannelId, {
         type_of: 'loading-post',
@@ -748,13 +756,6 @@ export default class Chat extends Component {
     } else if (message.startsWith('/github')) {
       const args = message.split('/github ')[1].trim();
       this.setActiveContentState(activeChannelId, { type_of: 'github', args });
-    } else if (message[0] === '/') {
-      conductModeration(
-        activeChannelId,
-        message,
-        this.handleSuccess,
-        this.handleFailure,
-      );
     } else {
       const messageObject = {
         activeChannelId,
@@ -882,7 +883,7 @@ export default class Chat extends Component {
         });
       }
     } else if (response.status === 'error') {
-      this.receiveNewMessage(response.message);
+      addSnackbarItem({ message: response.message });
     }
   };
 

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -738,7 +738,7 @@ export default class Chat extends Component {
         path: `/search?q=${message.replace('/s ', '')}`,
         type_of: 'article',
       });
-    } else if (message.startsWith('/ban ')) {
+    } else if (message.startsWith('/ban ') || message.startsWith('/unban ')) {
       conductModeration(
         activeChannelId,
         message,

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -3,6 +3,7 @@ class Role < ApplicationRecord
     admin
     banned
     chatroom_beta_tester
+    codeland_admin
     comment_banned
     podcast_admin
     pro

--- a/app/policies/chat_channel_policy.rb
+++ b/app/policies/chat_channel_policy.rb
@@ -12,7 +12,7 @@ class ChatChannelPolicy < ApplicationPolicy
   end
 
   def moderate?
-    !user_is_banned? && user_admin?
+    !user_is_banned? && codeland_admin?
   end
 
   def show?
@@ -69,5 +69,9 @@ class ChatChannelPolicy < ApplicationPolicy
 
   def channel_is_direct
     record.channel_type == "direct"
+  end
+
+  def codeland_admin?
+    user.has_role?(:codeland_admin)
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Role, type: :model do
   describe "::ROLES" do
     it "contains the correct values" do
       expected_roles = %w[
-        admin banned chatroom_beta_tester comment_banned podcast_admin pro restricted_liquid_tag
+        admin banned chatroom_beta_tester codeland_admin comment_banned podcast_admin pro restricted_liquid_tag
         single_resource_admin super_admin tag_moderator mod_relations_admin tech_admin trusted
         warned workshop_pass
       ]

--- a/spec/policies/chat_channel_policy_spec.rb
+++ b/spec/policies/chat_channel_policy_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ChatChannelPolicy, type: :policy do
   context "when user is an admin but not part of channel" do
     before { user.add_role(:super_admin) }
 
-    it { is_expected.to permit_actions(%i[index moderate update]) }
+    it { is_expected.to permit_actions(%i[index update]) }
     it { is_expected.to forbid_actions(%i[show open]) }
   end
 end

--- a/spec/requests/chat_channels_spec.rb
+++ b/spec/requests/chat_channels_spec.rb
@@ -251,7 +251,8 @@ RSpec.describe "ChatChannels", type: :request do
 
     context "when user is logged-in and authorized" do
       before do
-        user.add_role :super_admin
+        user.add_role :codeland_admin
+        chat_channel.add_users([user, test_subject])
         sign_in user
         allow(Pusher).to receive(:trigger).and_return(true)
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature
- [x] Bug Fix

## Description
This is the WIP for getting `/ban` working again in Connect. Ideally, we get it with these specifications:
- remove the user from the channel
- ban them, and therefore preventing them from messaging in other channels
- delete all their messages in that specific channel — delete because Pusher already is configured to handle the messages
- can only `/ban andy` if `andy` is in that channel
- will be limited to a new role `codeland-admin`

The current version in this PR makes `/ban` somewhat

## QA Instructions, Screenshots, Recordings
The video shows the sad path (user not found) and then the happy path (banning a user):
https://share.getcloudapp.com/6qu26APe

This PR assumes you have Pusher setup locally. Unfortunately it's been too long since I last set it up 😬 

```ruby
# make a connect channel
cc = ChatChannel.create(channel_name: 'group test', status: 'active', channel_type: 'open', slug: 'group-test')

# add yourself and another account
me = User.last # or whoever you are
cc.add_users([me, User.first])

# allow auth with User.first if you don't have any extra accounts
User.first.update_columns(email: 'test@dev.to', password: 'test')

# add the codeland_admin role
me.add_role :codeland_admin
```

Then:
1. Sign in with the `User.first`
2. Go to the connect channel on both accounts: localhost:3000/connect/group-test
3. Type a couple messages
4. Ban the first user: `/ban first_users_username`
5. See that the messages disappear
6. Try to ban some fake username `/ban blahblahblah`

## Added tests?
- [x] not yet
- [x] no, because I need help

## Added to documentation?

- [x] not yet :(

## [optional] Are there any post deployment tasks we need to perform?
Give the correct users the `codeland_admin` role.
