### PR TITLE
Update CODEOWNERS and team names in TODO comments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,36 +2,36 @@
 # see https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 # for further details
 
-/*.md                                               @thepracticaldev/oss
-/app/assets/stylesheets/internal/                   @thepracticaldev/snackcase
-/app/controllers/articles_controller.rb             @thepracticaldev/hells-bells
-/app/controllers/internal/                          @thepracticaldev/snackcase
-/app/services/notifications/                        @thepracticaldev/delightful
-/app/controllers/notifications/                     @thepracticaldev/delightful
-/app/workers/notifications/                         @thepracticaldev/delightful
-/app/controllers/internal/broadcasts_controller.rb  @thepracticaldev/delightful
-/app/controllers/async_info_controller.rb           @thepracticaldev/sre
-/app/controllers/pages_controller.rb                @thepracticaldev/cool
-/app/controllers/stories_controller.rb              @thepracticaldev/hells-bells
-/app/services/search/                               @thepracticaldev/sre
-/app/views/articles/                                @thepracticaldev/hells-bells
-/app/views/internal/                                @thepracticaldev/snackcase
-/app/views/moderation/                              @thepracticaldev/snackcase
-/app/views/notifications/                           @thepracticaldev/delightful
-/app/views/partnerships/                            @thepracticaldev/cool
-/app/views/stories/                                 @thepracticaldev/hells-bells
-/app/workers/                                       @thepracticaldev/sre
-/config/                                            @thepracticaldev/sre
-/db/                                                @thepracticaldev/sre
-/docs/                                              @thepracticaldev/oss    @jacobherrington
-/lib/data_update_scripts/                           @thepracticaldev/sre
-/lib/sidekiq/                                       @thepracticaldev/sre
-/spec/rails_helper.rb                               @thepracticaldev/sre
-/spec/requests/internal/                            @thepracticaldev/snackcase
-/spec/support/                                      @thepracticaldev/sre
-/spec/system/internal/                              @thepracticaldev/snackcase
-Gemfile                                             @thepracticaldev/sre    @thepracticaldev/oss
-Gemfile.lock                                        @thepracticaldev/sre    @thepracticaldev/oss
-package.json                                        @thepracticaldev/oss    @nickytonline
-yarn.lock                                           @thepracticaldev/oss    @nickytonline
-.travis.yml                                         @thepracticaldev/sre
+/*.md                                               @forem/oss
+/app/assets/stylesheets/internal/                   @forem/snackcase
+/app/controllers/articles_controller.rb             @forem/hells-bells
+/app/controllers/internal/                          @forem/snackcase
+/app/services/notifications/                        @forem/delightful
+/app/controllers/notifications/                     @forem/delightful
+/app/workers/notifications/                         @forem/delightful
+/app/controllers/internal/broadcasts_controller.rb  @forem/delightful
+/app/controllers/async_info_controller.rb           @forem/sre
+/app/controllers/pages_controller.rb                @forem/cool
+/app/controllers/stories_controller.rb              @forem/hells-bells
+/app/services/search/                               @forem/sre
+/app/views/articles/                                @forem/hells-bells
+/app/views/internal/                                @forem/snackcase
+/app/views/moderation/                              @forem/snackcase
+/app/views/notifications/                           @forem/delightful
+/app/views/partnerships/                            @forem/cool
+/app/views/stories/                                 @forem/hells-bells
+/app/workers/                                       @forem/sre
+/config/                                            @forem/sre
+/db/                                                @forem/sre
+/docs/                                              @forem/oss    @jacobherrington
+/lib/data_update_scripts/                           @forem/sre
+/lib/sidekiq/                                       @forem/sre
+/spec/rails_helper.rb                               @forem/sre
+/spec/requests/internal/                            @forem/snackcase
+/spec/support/                                      @forem/sre
+/spec/system/internal/                              @forem/snackcase
+Gemfile                                             @forem/sre    @forem/oss
+Gemfile.lock                                        @forem/sre    @forem/oss
+package.json                                        @forem/oss    @nickytonline
+yarn.lock                                           @forem/oss    @nickytonline
+.travis.yml                                         @forem/sre

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,14 +11,12 @@
 /app/workers/notifications/                         @forem/delightful
 /app/controllers/internal/broadcasts_controller.rb  @forem/delightful
 /app/controllers/async_info_controller.rb           @forem/sre
-/app/controllers/pages_controller.rb                @forem/cool
 /app/controllers/stories_controller.rb              @forem/hells-bells
 /app/services/search/                               @forem/sre
 /app/views/articles/                                @forem/hells-bells
 /app/views/internal/                                @forem/snackcase
 /app/views/moderation/                              @forem/snackcase
 /app/views/notifications/                           @forem/delightful
-/app/views/partnerships/                            @forem/cool
 /app/views/stories/                                 @forem/hells-bells
 /app/workers/                                       @forem/sre
 /config/                                            @forem/sre

--- a/app/assets/stylesheets/notifications-welcome-broadcast.scss
+++ b/app/assets/stylesheets/notifications-welcome-broadcast.scss
@@ -1,4 +1,4 @@
-// TODO: [@thepracticaldev/delightful]: Refactor nesting in this file
+// TODO: [@forem/delightful]: Refactor nesting in this file
 // in addition to notifications.scss so that the nesting is
 // not as deep as it currently is
 .notifications-index {

--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -28,7 +28,7 @@
           }
         }
       }
-      // TODO: [@thepracticaldev/delightful]: Remove .signup-cue-advanced and .sloan
+      // TODO: [@forem/delightful]: Remove .signup-cue-advanced and .sloan
       // from stylesheet since it does not appear to be used anywhere
       .signup-cue-advanced {
         text-align: left;

--- a/app/controllers/concerns/listings_toolkit.rb
+++ b/app/controllers/concerns/listings_toolkit.rb
@@ -12,7 +12,7 @@ module ListingsToolkit
   end
 
   def update_listing_details
-    # [thepracticaldev/oss] Not entirely sure what the intention behind the
+    # [@forem/oss] Not entirely sure what the intention behind the
     # original code was, but at least this is more compact.
     filtered_params = listing_params.reject { |_k, v| v.nil? }
     @listing.update(filtered_params)

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -27,7 +27,7 @@ class DisplayAd < ApplicationRecord
     markdown = Redcarpet::Markdown.new(renderer)
     initial_html = markdown.render(body_markdown)
     # Temporarily disable the sanitisation in order to launch the SheCoded Campaign.
-    # TODO: [@forem/cool] find an alternate solution.
+    # TODO: find an alternate solution.
 
     # stripped_html = ActionController::Base.helpers.sanitize initial_html,
     #                                                         tags: %w[a em i b u br img h1 h2 h3 h4 div style],

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -27,7 +27,7 @@ class DisplayAd < ApplicationRecord
     markdown = Redcarpet::Markdown.new(renderer)
     initial_html = markdown.render(body_markdown)
     # Temporarily disable the sanitisation in order to launch the SheCoded Campaign.
-    # TODO: [@thepracticaldev/cool] find an alternate solution.
+    # TODO: [@forem/cool] find an alternate solution.
 
     # stripped_html = ActionController::Base.helpers.sanitize initial_html,
     #                                                         tags: %w[a em i b u br img h1 h2 h3 h4 div style],

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -18,7 +18,7 @@ class Identity < ApplicationRecord
                                                               identity.user_id_changed? || identity.provider_changed?
                                                             }
 
-  # TODO: [thepracticaldev/oss] should this be transitioned to JSON?
+  # TODO: [@forem/oss] should this be transitioned to JSON?
   serialize :auth_data_dump
 
   # Builds an identity from OmniAuth's authentication payload

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -1,5 +1,5 @@
 module Authentication
-  # TODO: [thepracticaldev/oss] use strategy pattern for the three cases
+  # TODO: [@forem/oss] use strategy pattern for the three cases
   #   described below.
   #   Make the decision early which one of the 3 cases we're dealing with
   #   and then call either NewUserStrategy, UpdateUserStrategy or

--- a/app/services/authentication/providers.rb
+++ b/app/services/authentication/providers.rb
@@ -32,7 +32,7 @@ module Authentication
     end
 
     # Returns enabled providers
-    # TODO: [thepracticaldev/oss] ideally this should be "available - disabled"
+    # TODO: [@forem/oss] ideally this should be "available - disabled"
     # we can get there once we have feature flags
     def self.enabled
       SiteConfig.authentication_providers.map(&:to_sym).sort

--- a/app/services/user_subscriptions/create_from_controller_params.rb
+++ b/app/services/user_subscriptions/create_from_controller_params.rb
@@ -16,7 +16,7 @@ module UserSubscriptions
       @source_id = user_subscription_params[:source_id]
       @response = Response.new(success: false)
 
-      # TODO: [@thepracticaldev/delightful]: uncomment this once email confirmation is re-enabled
+      # TODO: [@forem/delightful]: uncomment this once email confirmation is re-enabled
       # @subscriber_email = user_subscription_params[:subscriber_email]
     end
 
@@ -26,7 +26,7 @@ module UserSubscriptions
       source = source_type.constantize.find_by(id: source_id)
       return response if invalid_source?(source)
 
-      # TODO: [@thepracticaldev/delightful]: uncomment this once email confirmation is re-enabled
+      # TODO: [@forem/delightful]: uncomment this once email confirmation is re-enabled
       # return response if subscriber_email_mismatch?
 
       user_subscription = source.build_user_subscription(user)

--- a/app/views/dashboards/subscriptions.html.erb
+++ b/app/views/dashboards/subscriptions.html.erb
@@ -9,7 +9,7 @@
         <a href=<%= @source.path %>><%= @source.title %></a>
       </h2>
     </div>
-    <%#TODO: [@thepracticaldev/delightful]: uncomment this when ready to implement CSV exports%>
+    <%#TODO: [@forem/delightful]: uncomment this when ready to implement CSV exports%>
     <%#<button type="button" class="crayons-btn crayons-btn--secondary">Export CSV</button>%>
   </header>
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -29,7 +29,7 @@
     const target = event.target;
     const { parentElement: { id: title }, text } = target;
 
-    // TODO: [@thepracticaldev/delightful]: This event doesn't appear to be firing on Honeybadger.
+    // TODO: [@forem/delightful]: This event doesn't appear to be firing on Honeybadger.
     // We probably want to remove it eventually if we continually don't see it being triggered.
     if (!title) {
       Honeybadger.notify(`Could not find parentElement.id when clicking on event target text: ${text}`);

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
     end
   end
 
-  # TODO: [@thepracticaldev/delightful]: re-enable this once email confirmation
+  # TODO: [@forem/delightful]: re-enable this once email confirmation
   # is re-enabled and confirm it isn't flaky.
   xcontext "when a user has an Apple private relay email address", type: :system, js: true do
     it "prompts the user to update their email address" do

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -518,7 +518,7 @@ RSpec.describe "/listings", type: :request do
   end
 end
 
-# TODO: [thepracticaldev/oss] We used to have 2 request spec files, listing_spec.rb
+# TODO: [@forem/oss] We used to have 2 request spec files, listing_spec.rb
 # and classified_listing_spec.rb. This context contains the specs of the former,
 # but we should eventually unify them into one set to remove some redundancy.
 context "when running the specs that were previously in another file" do

--- a/spec/requests/user_subscriptions_spec.rb
+++ b/spec/requests/user_subscriptions_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "UserSubscriptions", type: :request do
       expect(response.parsed_body["error"]).to include("Subscriber has already been taken")
     end
 
-    # TODO: [@thepracticaldev/delightful]: re-enable this once email confirmation is re-enabled
+    # TODO: [@forem/delightful]: re-enable this once email confirmation is re-enabled
     xit "returns an error for an email mismatch" do
       article = create(:article, :with_user_subscription_tag_role_user, with_user_subscription_tag: true)
       invalid_source_attributes = { source_type: article.class_name, source_id: article.id,

--- a/spec/services/user_subscriptions/create_from_controller_params_spec.rb
+++ b/spec/services/user_subscriptions/create_from_controller_params_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe UserSubscriptions::CreateFromControllerParams, type: :service do
     expect(user_subscription.error).to eq "Source not found."
   end
 
-  # TODO: [@thepracticaldev/delightful]: re-enable this once email confirmation is re-enabled
+  # TODO: [@forem/delightful]: re-enable this once email confirmation is re-enabled
   xit "returns an error for an email mismatch" do
     source = create(:article, :with_user_subscription_tag_role_user, with_user_subscription_tag: true)
     user_subscription_params = { source_type: source.class.name, source_id: source.id,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Documentation Update

## Description

This PR

1. updates the `CODEOWNERS`  file to reflect the move to `forem/forem`,
2. changes all TODO comments to the new team names and
3. standardizes the TODO comment format to `@forem/teamname`.
,
It seems we no longer have a "Team Cool", please advice who the `CODEOWNERS` entries and TODO comment should be assigned to.

## Related Tickets & Documents\

n/a

## Added tests?

- [X] no, because they aren't needed

## Added to documentation?

- [X] no documentation needed
