### PR TITLE
Optimization:Recreate Comments Index with Digest Hash

### DIFF
--- a/db/migrate/20200723180841_create_new_comments_body_markdown_index.rb
+++ b/db/migrate/20200723180841_create_new_comments_body_markdown_index.rb
@@ -1,0 +1,58 @@
+class CreateNewCommentsBodyMarkdownIndex < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    if index_exists?(
+      :comments,
+      %i[body_markdown user_id ancestry commentable_id commentable_type],
+      name: :index_comments_on_body_markdown_user_id_ancestry_commentable
+    )
+      remove_index(
+        :comments,
+        name: :index_comments_on_body_markdown_user_id_ancestry_commentable,
+        algorithm: :concurrently
+      )
+    end
+
+    # needed for the digest() function, checks if the extension already exists
+    ActiveRecord::Base.connection.enable_extension("pgcrypto")
+
+    # to avoid the error "Values larger than 1/3 of a buffer page cannot be indexed."
+    # due to the fact that large text column cannot be indexed by btree indexes
+    # we are going to need to build an index on the hash of the `body_markdown` column.
+    # We also cannot use a `HASH` index as it's not supported by unique columns.
+    # I don't recommend using GiN or GiST as well
+    # See <https://www.postgresql.org/message-id/AANLkTin3p6VS1Z=TtqUV-5cG4TZpTjUMfuPNzWJFgnr5@mail.gmail.com>,
+    # <https://www.postgresql.org/docs/11/pgcrypto.html#id-1.11.7.34.5> and
+    # <https://www.postgresql.org/docs/11/indexes-types.html>
+    ActiveRecord::Base.connection.execute(
+      <<~SQL
+        CREATE UNIQUE INDEX CONCURRENTLY "index_comments_on_body_markdown_user_ancestry_commentable"
+        ON "comments"
+        USING btree (digest("body_markdown", 'sha512'::text), "user_id", "ancestry", "commentable_id", "commentable_type");
+      SQL
+    )
+  end
+
+  def down
+    ActiveRecord::Base.connection.execute(
+      <<~SQL
+        DROP INDEX CONCURRENTLY "index_comments_on_body_markdown_user_ancestry_commentable"
+      SQL
+    )
+
+    unless index_exists?(
+      :comments,
+      %i[body_markdown user_id ancestry commentable_id commentable_type],
+      name: :index_comments_on_body_markdown_user_id_ancestry_commentable
+    )
+      add_index(
+        :comments,
+        %i[body_markdown user_id ancestry commentable_id commentable_type],
+        unique: true,
+        algorithm: :concurrently,
+        name: :index_comments_on_body_markdown_user_id_ancestry_commentable
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_21_213341) do
+ActiveRecord::Schema.define(version: 2020_07_23_180841) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "ahoy_events", force: :cascade do |t|
@@ -406,8 +407,8 @@ ActiveRecord::Schema.define(version: 2020_07_21_213341) do
     t.integer "spaminess_rating", default: 0
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.index "digest(body_markdown, 'sha512'::text), user_id, ancestry, commentable_id, commentable_type", name: "index_comments_on_body_markdown_user_ancestry_commentable", unique: true
     t.index ["ancestry"], name: "index_comments_on_ancestry"
-    t.index ["body_markdown", "user_id", "ancestry", "commentable_id", "commentable_type"], name: "index_comments_on_body_markdown_user_id_ancestry_commentable", unique: true
     t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type"
     t.index ["created_at"], name: "index_comments_on_created_at"
     t.index ["score"], name: "index_comments_on_score"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
In order to transition our comment ID fields to bigints, we first have to update this index, `index_comments_on_body_markdown_user_ancestry_commentable` to use a digest for the body markdown to ensure that the index does not get too large for our database. 

## Related Tickets & Documents
https://github.com/forem/forem/projects/9#card-37704279

![alt_text](https://media3.giphy.com/media/MBmD4BKKXyZ9wPAe9S/giphy.gif)
