### PR TITLE
Optimization: Change Large Table Primary Keys to Bigints

### DIFF
--- a/db/migrate/20200806193438_large_table_primary_keys_to_bigints.rb
+++ b/db/migrate/20200806193438_large_table_primary_keys_to_bigints.rb
@@ -1,6 +1,6 @@
 class LargeTablePrimaryKeysToBigints < ActiveRecord::Migration[6.0]
   def up
-    puts "ahoy_messages"
+    puts "migrating ahoy_message PKs to bigints"
     ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.ahoy_messages")
     ActiveRecord::Base.connection.execute(
       <<-SQL
@@ -11,7 +11,7 @@ class LargeTablePrimaryKeysToBigints < ActiveRecord::Migration[6.0]
       SQL
     )
 
-    puts "articles"
+    puts "migrating article PKs to bigints"
     ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.articles")
     ActiveRecord::Base.connection.execute(
       <<-SQL
@@ -25,7 +25,7 @@ class LargeTablePrimaryKeysToBigints < ActiveRecord::Migration[6.0]
       SQL
     )
 
-    puts "notifications"
+    puts "migrating notification PKs to bigints"
     ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.notifications")
     ActiveRecord::Base.connection.execute(
       <<-SQL

--- a/db/migrate/20200806193438_large_table_primary_keys_to_bigints.rb
+++ b/db/migrate/20200806193438_large_table_primary_keys_to_bigints.rb
@@ -1,0 +1,74 @@
+class LargeTablePrimaryKeysToBigints < ActiveRecord::Migration[6.0]
+  def up
+    puts "ahoy_messages"
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.ahoy_messages")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE ahoy_messages
+          ALTER COLUMN id TYPE bigint,
+          ALTER COLUMN user_id TYPE bigint,
+          ALTER COLUMN feedback_message_id TYPE bigint
+      SQL
+    )
+
+    puts "articles"
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.articles")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE articles
+          ALTER COLUMN id TYPE bigint,
+          ALTER COLUMN user_id TYPE bigint,
+          ALTER COLUMN second_user_id TYPE bigint,
+          ALTER COLUMN third_user_id TYPE bigint,
+          ALTER COLUMN organization_id TYPE bigint,
+          ALTER COLUMN collection_id TYPE bigint
+      SQL
+    )
+
+    puts "notifications"
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.notifications")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE notifications
+          ALTER COLUMN id TYPE bigint,
+          ALTER COLUMN notifiable_id TYPE bigint,
+          ALTER COLUMN user_id TYPE bigint
+      SQL
+    )
+  end
+
+  def down
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.ahoy_messages")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE ahoy_messages
+          ALTER COLUMN id TYPE int,
+          ALTER COLUMN user_id TYPE int,
+          ALTER COLUMN feedback_message_id TYPE int
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.articles")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE articles
+          ALTER COLUMN id TYPE int,
+          ALTER COLUMN user_id TYPE int,
+          ALTER COLUMN second_user_id TYPE int,
+          ALTER COLUMN third_user_id TYPE int,
+          ALTER COLUMN organization_id TYPE int,
+          ALTER COLUMN collection_id TYPE int
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.notifications")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE notifications
+          ALTER COLUMN id TYPE int,
+          ALTER COLUMN notifiable_id TYPE int,
+          ALTER COLUMN user_id TYPE int
+      SQL
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_05_050048) do
+ActiveRecord::Schema.define(version: 2020_08_06_193438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -29,17 +29,17 @@ ActiveRecord::Schema.define(version: 2020_08_05_050048) do
     t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
   end
 
-  create_table "ahoy_messages", id: :serial, force: :cascade do |t|
+  create_table "ahoy_messages", force: :cascade do |t|
     t.datetime "clicked_at"
     t.text "content"
-    t.integer "feedback_message_id"
+    t.bigint "feedback_message_id"
     t.string "mailer"
     t.datetime "opened_at"
     t.datetime "sent_at"
     t.text "subject"
     t.text "to"
     t.string "token"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.string "user_type"
     t.string "utm_campaign"
     t.string "utm_content"
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2020_08_05_050048) do
     t.index ["user_id"], name: "index_api_secrets_on_user_id"
   end
 
-  create_table "articles", id: :serial, force: :cascade do |t|
+  create_table "articles", force: :cascade do |t|
     t.boolean "any_comments_hidden", default: false
     t.boolean "approved", default: false
     t.boolean "archived", default: false
@@ -89,7 +89,7 @@ ActiveRecord::Schema.define(version: 2020_08_05_050048) do
     t.string "cached_user_name"
     t.string "cached_user_username"
     t.string "canonical_url"
-    t.integer "collection_id"
+    t.bigint "collection_id"
     t.integer "comment_score", default: 0
     t.string "comment_template"
     t.integer "comments_count", default: 0, null: false
@@ -115,7 +115,7 @@ ActiveRecord::Schema.define(version: 2020_08_05_050048) do
     t.integer "organic_page_views_count", default: 0
     t.integer "organic_page_views_past_month_count", default: 0
     t.integer "organic_page_views_past_week_count", default: 0
-    t.integer "organization_id"
+    t.bigint "organization_id"
     t.datetime "originally_published_at"
     t.integer "page_views_count", default: 0
     t.string "password"
@@ -135,15 +135,15 @@ ActiveRecord::Schema.define(version: 2020_08_05_050048) do
     t.integer "score", default: 0
     t.string "search_optimized_description_replacement"
     t.string "search_optimized_title_preamble"
-    t.integer "second_user_id"
+    t.bigint "second_user_id"
     t.boolean "show_comments", default: true
     t.text "slug"
     t.string "social_image"
     t.integer "spaminess_rating", default: 0
-    t.integer "third_user_id"
+    t.bigint "third_user_id"
     t.string "title"
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.bigint "user_id"
     t.integer "user_subscriptions_count", default: 0, null: false
     t.string "video"
     t.string "video_closed_caption_track_url"
@@ -678,17 +678,17 @@ ActiveRecord::Schema.define(version: 2020_08_05_050048) do
     t.index ["user_id", "notifiable_type", "notifiable_id"], name: "idx_notification_subs_on_user_id_notifiable_type_notifiable_id", unique: true
   end
 
-  create_table "notifications", id: :serial, force: :cascade do |t|
+  create_table "notifications", force: :cascade do |t|
     t.string "action"
     t.datetime "created_at", null: false
     t.jsonb "json_data"
-    t.integer "notifiable_id"
+    t.bigint "notifiable_id"
     t.string "notifiable_type"
     t.datetime "notified_at"
     t.bigint "organization_id"
     t.boolean "read", default: false
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.bigint "user_id"
     t.index ["created_at"], name: "index_notifications_on_created_at"
     t.index ["json_data"], name: "index_notifications_on_json_data", using: :gin
     t.index ["notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_notifiable_id_notifiable_type_and_action"

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -16,6 +16,6 @@ set -Eex
 
 # runs migration for Postgres, setups/updates Elasticsearch
 # and boots the app to check there are no errors
-STATEMENT_TIMEOUT=3600000 bundle exec rails app_initializer:setup
+STATEMENT_TIMEOUT=4500000 bundle exec rails app_initializer:setup
 bundle exec rake fastly:update_configs
 bundle exec rails runner "puts 'app load success'"

--- a/release-tasks.sh
+++ b/release-tasks.sh
@@ -16,6 +16,6 @@ set -Eex
 
 # runs migration for Postgres, setups/updates Elasticsearch
 # and boots the app to check there are no errors
-STATEMENT_TIMEOUT=180000 bundle exec rails app_initializer:setup
+STATEMENT_TIMEOUT=3600000 bundle exec rails app_initializer:setup
 bundle exec rake fastly:update_configs
 bundle exec rails runner "puts 'app load success'"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Plan:
After running all of these migrations one by one and [gathering timing information](https://gist.github.com/mstruve/1600b29a30b39b9f4edc0c8d79d9ba91) we have decided to run them all during a low traffic period and display a banner on the site notifying users that they may experience degraded performance for specific parts of the application. Here is the timing breakdown with performance implications
```
# ahoy_messages
# seconds: 1385.38
# Nothing in the UI seemed to break

# articles
# seconds: 201.74
# everything breaks except connect and notifications pages still work. Can still see banner! 

# notifications
# seconds: 2295.07
# Comments created but submitting breaks so it looks like it was not created
# notification pages break
```
Example Banner that we used for another set of migrations except we will explicitly call out for example when notifications are going that people should expect the notification page to be offline. 

<img width="1153" alt="Screen Shot 2020-08-06 at 6 41 22 PM" src="https://user-images.githubusercontent.com/1813380/89595821-2bdf6a00-d81b-11ea-8244-99de949742f7.png">

You will also notice I am removing the hypershield views before running the migrations! I have noticed in the past and while doing some of the manual migrations(without the change_column helper) that the additional views caused the migrations to fail or timeout. When the migration is complete hypershield will be refreshed anyways so those views will get added back.

## Related Tickets & Documents
https://github.com/forem/forem/projects/9#card-37704279

## QA/Review

PLEASE double check that I did not miss any integer columns on these large tables bc I would hate to have to do this twice! I actually missed the feedback_message_id on ahoy messages on my first pass. During my last pass through the schema I noticed I missed a few other integer IDs but all are for small tables that I can easily pick off in another PR. Here are what will remain after this PR
```
"api_secrets" - "user_id"
"badge_achievements" - "rewarder_id"
"broadcasts" - "broadcastable_id"
"display_ads" - "organization_id"
"feedback_messages" - "affected_id", "offender_id", "reporter_id"
"html_variant_successes" - "article_id", "html_variant_id"
"html_variant_trials" - "article_id", "html_variant_id"=
"users_roles" - "id", "user_id"
```

![alt_text](https://media1.tenor.com/images/78f2dc75355a64311f4a6f896be5d4ff/tenor.gif?itemid=15687163)
