### PR TITLE
Optimization:Change Mentions, Notes, Podcasts, Roles Related Ids To Bigints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,10 +15,6 @@ AllCops:
     - node_modules/**/*
     - tmp/**/*
     - vendor/**/*
-    - app/views/dashboards/subscriptions.html.erb
-    - app/views/internal/configs/show.html.erb
-    - app/views/moderations/_mod_sidebar_left.html.erb
-    - app/views/notifications/index.html.erb
   DisplayStyleGuide: true
   ExtraDetails: true
   TargetRubyVersion: 2.7

--- a/db/migrate/20200723203155_change_mentions_notes_podcasts_roles_related_ids_to_bigints.rb
+++ b/db/migrate/20200723203155_change_mentions_notes_podcasts_roles_related_ids_to_bigints.rb
@@ -1,0 +1,41 @@
+class ChangeMentionsNotesPodcastsRolesRelatedIdsToBigints < ActiveRecord::Migration[6.0]
+  def up
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.mentions")
+    safety_assured { change_column :mentions, :user_id, :bigint }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.notes")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE notes
+          ALTER COLUMN author_id TYPE bigint,
+          ALTER COLUMN noteable_id TYPE bigint
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.podcasts")
+    safety_assured { change_column :podcasts, :creator_id, :bigint }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.roles")
+    safety_assured { change_column :roles, :resource_id, :bigint }
+  end
+
+  def down
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.mentions")
+    safety_assured { change_column :mentions, :user_id, :int }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.notes")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE notes
+          ALTER COLUMN author_id TYPE int,
+          ALTER COLUMN noteable_id TYPE int
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.podcasts")
+    safety_assured { change_column :podcasts, :creator_id, :int }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.roles")
+    safety_assured { change_column :roles, :resource_id, :int }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_21_213341) do
+ActiveRecord::Schema.define(version: 2020_07_23_203155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -638,7 +638,7 @@ ActiveRecord::Schema.define(version: 2020_07_21_213341) do
     t.integer "mentionable_id"
     t.string "mentionable_type"
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.bigint "user_id"
     t.index ["user_id", "mentionable_id", "mentionable_type"], name: "index_mentions_on_user_id_and_mentionable_id_mentionable_type", unique: true
   end
 
@@ -656,10 +656,10 @@ ActiveRecord::Schema.define(version: 2020_07_21_213341) do
   end
 
   create_table "notes", force: :cascade do |t|
-    t.integer "author_id"
+    t.bigint "author_id"
     t.text "content"
     t.datetime "created_at", null: false
-    t.integer "noteable_id"
+    t.bigint "noteable_id"
     t.string "noteable_type"
     t.string "reason"
     t.datetime "updated_at", null: false
@@ -858,7 +858,7 @@ ActiveRecord::Schema.define(version: 2020_07_21_213341) do
   create_table "podcasts", force: :cascade do |t|
     t.string "android_url"
     t.datetime "created_at", null: false
-    t.integer "creator_id"
+    t.bigint "creator_id"
     t.text "description"
     t.string "feed_url", null: false
     t.string "image", null: false
@@ -980,7 +980,7 @@ ActiveRecord::Schema.define(version: 2020_07_21_213341) do
   create_table "roles", force: :cascade do |t|
     t.datetime "created_at"
     t.string "name"
-    t.integer "resource_id"
+    t.bigint "resource_id"
     t.string "resource_type"
     t.datetime "updated_at"
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Update a few more keys on these smaller tables to bigints. All of these tables have 10k or fewer rows which we have seen can be updated very quickly inline. 

You will also notice I am removing the hypershield views before running the migrations! I have noticed in the past and while doing some of the manual migrations(without the `change_column` helper) that the additional views caused the migrations to fail or timeout. When the migration is complete hypershield will be refreshed anyways so those views will get added back. 

## Related Tickets & Documents
https://github.com/forem/forem/projects/9#card-37704279


![alt_text](https://media2.giphy.com/media/Q8Zf8nybTQA7W1bIXB/200.gif)
