### PR TITLE
Make UX settings save button sticky when modified

### DIFF
--- a/app/javascript/packs/stickySaveFooter.js
+++ b/app/javascript/packs/stickySaveFooter.js
@@ -1,4 +1,4 @@
-const form = document.querySelector('.edit_user');
+const form = document.querySelector('.sticky-footer-form');
 
 form.addEventListener('change', () => {
     const saveFooter = document.getElementsByClassName('save-footer');

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -11,7 +11,7 @@
   </div>
 </div>
 
-<%= form_for @user, html: {class: "sticky-footer-form"} do |f| %>
+<%= form_for @user, html: { class: "sticky-footer-form" } do |f| %>
   <div class="crayons-card mb-6 grid grid-flow-row gap-6 p-6">
     <div class="crayons-field">
       <%= f.label :email, class: "crayons-field__label" %>

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -11,7 +11,7 @@
   </div>
 </div>
 
-<%= form_for @user do |f| %>
+<%= form_for @user, html: {class: "sticky-footer-form"} do |f| %>
   <div class="crayons-card mb-6 grid grid-flow-row gap-6 p-6">
     <div class="crayons-field">
       <%= f.label :email, class: "crayons-field__label" %>

--- a/app/views/users/_ux.html.erb
+++ b/app/views/users/_ux.html.erb
@@ -1,4 +1,6 @@
-<%= form_for @user, html: { id: "ux-customization-form", class: "grid gap-6" } do |f| %>
+<%= javascript_packs_with_chunks_tag "stickySaveFooter", defer: true %>
+
+<%= form_for @user, html: { id: "ux-customization-form", class: "sticky-footer-form grid gap-6" } do |f| %>
   <div class="crayons-card grid gap-6 p-6">
     <h2>Style Customization</h2>
 
@@ -55,7 +57,7 @@
     </div>
   </div>
 
-  <div class="mb-6 grid gap-6 p-6">
+  <div class="save-footer crayons-card mb-6 grid gap-6 p-6">
   <%= f.hidden_field :tab, value: @tab, id: nil %>
     <div>
       <button class="crayons-btn" type="submit">Save</button>

--- a/spec/system/user/user_edits_ux_spec.rb
+++ b/spec/system/user/user_edits_ux_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "User edits their UX settings", type: :system do
+  let(:user) { create(:user, saw_onboarding: true) }
+
+  before do
+    sign_in user
+    visit "/settings/ux"
+  end
+
+  describe "visiting /settings/ux" do
+    it "makes the 'Save Button' footer sticky once a theme is selected", js: true do
+      expect(page).not_to have_css(".sticky-save-footer")
+
+      choose "Ten X Hacker Theme"
+
+      expect(page).to have_css(".sticky-save-footer")
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description
When a user modifies a field on the UX settings page, the save button footer will become "sticky" along the bottom of the screen (see GIF below).

I re-used the `stickySaveFooter` that we used for profile settings. I modified/added some extra classnames so that this will work for both.

## Related Tickets & Documents
#9240 
#9378 

## QA Instructions, Screenshots, Recordings

![sticky-ux](https://user-images.githubusercontent.com/33337378/88339243-0bc09d00-cd7d-11ea-8744-92bab4690bab.gif)

## Added tests?

- [x] yes

## Added to documentation?

- [x] no documentation needed