### PR TITLE
Optimization:Index Chat Channel Memberships Async on Message Creation

### DIFF
--- a/app/workers/chat_channels/indexes_memberships_worker.rb
+++ b/app/workers/chat_channels/indexes_memberships_worker.rb
@@ -1,0 +1,12 @@
+module ChatChannels
+  class IndexesMembershipsWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority, lock: :until_executing
+
+    def perform(chat_channel_id)
+      chat_channel = ChatChannel.find(chat_channel_id)
+      chat_channel.chat_channel_memberships.each(&:index_to_elasticsearch)
+    end
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -143,4 +143,15 @@ RSpec.describe Message, type: :model do
       end.to change(EmailMessage, :count).by(0)
     end
   end
+
+  describe "#after_create" do
+    it "enqueues ChatChannels::IndexesMembershipsWorker" do
+      chat_channel.add_users([user])
+      allow(ChatChannels::IndexesMembershipsWorker).to receive(:perform_async)
+
+      create(:message, chat_channel: chat_channel, user: user)
+
+      expect(ChatChannels::IndexesMembershipsWorker).to have_received(:perform_async)
+    end
+  end
 end

--- a/spec/workers/chat_channels/indexes_memberships_worker_spec.rb
+++ b/spec/workers/chat_channels/indexes_memberships_worker_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe ChatChannels::IndexesMembershipsWorker, type: :worker do
+  describe "#perform" do
+    let(:chat_channel) { create(:chat_channel) }
+    let(:chat_channel_membership) { create(:chat_channel_membership) }
+
+    it "indexes chat channel memberships" do
+      allow(ChatChannel).to receive(:find).and_return(chat_channel)
+      allow(chat_channel).to receive(:chat_channel_memberships).and_return([chat_channel_membership])
+      allow(chat_channel_membership).to receive(:index_to_elasticsearch)
+
+      described_class.new.perform(chat_channel.id)
+
+      expect(chat_channel_membership).to have_received(:index_to_elasticsearch)
+    end
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
When a message is sent to a channel that has a very large number of members it can take us seconds to loop through all of those and enqueue indexing jobs for them which means it takes seconds for us to complete creating the message. The only thing being updated for the memberships is the last message sent at. This value on the memberships helps us order the chat channels in connect and I don't think we need it updated in realtime which is why I created a job to update those records asynchronously. 


## Added tests?
- [x] yes

![alt_text](https://media3.giphy.com/media/l1KtYs7ZpeBskCQus/giphy.gif)
