### PR TITLE
Optimization:Create message JSON once when Notifying Users

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -107,8 +107,9 @@ class MessagesController < ApplicationController
   def notify_users(user_ids, type)
     return unless user_ids
 
+    message_json = create_pusher_payload(@message, @temp_message_id)
+
     user_ids.each do |id|
-      message_json = create_pusher_payload(@message, @temp_message_id)
       if type == "mention"
         Pusher.trigger("private-message-notifications-#{id}", "mentioned", message_json)
       else


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Let's not waste time building the same message JSON for every single user that needs to be notified in a chat channel.

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/f9f627d0f52b7b315a91fd5fbfda2efe/tenor.gif?itemid=15387379)
