### PR TITLE
Add more sign in options button to home sidebar

### DIFF
--- a/app/views/shared/authentication/_providers_sidebar.html.erb
+++ b/app/views/shared/authentication/_providers_sidebar.html.erb
@@ -7,3 +7,8 @@
     Sign In with <%= provider.official_name %>
   </a>
 <% end %>
+  <a
+    href="/enter"
+    class="crayons-btn crayons-btn--secondary crayons-btn--l">
+    More Sign In Options
+  </a>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds a button to the home page sidebar for "more sign in options" to make it consistent with the site-wide navigation.

<img width="351" alt="Screen Shot 2020-07-24 at 2 28 14 PM" src="https://user-images.githubusercontent.com/3102842/88423540-ea31d680-cdb9-11ea-8c6d-3c277817f6e6.png">

Closes #9346