### PR TITLE
Fix showing unpublished article edit link

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -92,7 +92,7 @@
 
   <main class="crayons-layout__content grid gap-4">
     <div class="article-wrapper">
-      <% if !@article.published %>
+      <% if !@article.published && user_signed_in? && @article.user_id == current_user.id %>
         <div class="crayons-notice crayons-notice--danger mb-4">
           <strong>Unpublished Post.</strong> This URL is public but secret, so share at your own discretion.
           <a href="<%= @article.path %>/edit" class="fw-bold">Click to edit</a>.

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -92,10 +92,12 @@
 
   <main class="crayons-layout__content grid gap-4">
     <div class="article-wrapper">
-      <% if !@article.published && user_signed_in? && @article.user_id == current_user.id %>
+      <% if !@article.published %>
         <div class="crayons-notice crayons-notice--danger mb-4">
           <strong>Unpublished Post.</strong> This URL is public but secret, so share at your own discretion.
-          <a href="<%= @article.path %>/edit" class="fw-bold">Click to edit</a>.
+          <% if user_signed_in? && @article.user_id == current_user.id %>
+            <a href="<%= @article.path %>/edit" class="fw-bold">Click to edit</a>.
+          <% end %>
         </div>
       <% end %>
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -95,7 +95,7 @@
       <% if !@article.published %>
         <div class="crayons-notice crayons-notice--danger mb-4">
           <strong>Unpublished Post.</strong> This URL is public but secret, so share at your own discretion.
-          <% if user_signed_in? && @article.user_id == current_user.id %>
+          <% if user_signed_in? && policy(@article.object).update? %>
             <a href="<%= @article.path %>/edit" class="fw-bold">Click to edit</a>.
           <% end %>
         </div>

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -121,17 +121,17 @@ RSpec.describe "Views an article", type: :system do
 
   describe "when an article is not published" do
     let(:article) { create(:article, user: article_user, published: false) }
-    let(:article_path) { article.path << query_params }
-    let(:selector) { ".article-wrapper .crayons-notice--danger strong" }
-    let(:text) { "Unpublished Post." }
+    let(:article_path) { article.path + query_params }
+    let(:href) { "#{article.path}/edit" }
+    let(:link_text) { "Click to edit" }
 
     context "with the article password, and the logged-in user is the article author" do
       let(:query_params) { "?preview=#{article.password}" }
       let(:article_user) { user }
 
-      it "shows the message" do
+      it "shows the article edit link" do
         visit article_path
-        expect(page).to have_selector(selector, text: text)
+        expect(page).to have_link(link_text, href: href)
       end
     end
 
@@ -139,20 +139,20 @@ RSpec.describe "Views an article", type: :system do
       let(:query_params) { "?preview=#{article.password}" }
       let(:article_user) { create(:user) }
 
-      it "does not show the message" do
+      it "does not the article edit link" do
         visit article_path
-        expect(page).not_to have_selector(selector, text: text)
+        expect(page).not_to have_link(link_text, href: href)
       end
     end
 
-    context "with the article password, and the user does not log in" do
+    context "with the article password, and the user is not logged-in" do
       let(:query_params) { "?preview=#{article.password}" }
       let(:article_user) { user }
 
-      it "does not show the message" do
+      it "does not the article edit link" do
         sign_out user
         visit article_path
-        expect(page).not_to have_selector(selector, text: text)
+        expect(page).not_to have_link(link_text, href: href)
       end
     end
 

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Views an article", type: :system do
     let(:href) { "#{article.path}/edit" }
     let(:link_text) { "Click to edit" }
 
-    context "with the article password, and the logged-in user is the article author" do
+    context "with the article password, and the logged-in user is authorized to update the article" do
       let(:query_params) { "?preview=#{article.password}" }
       let(:article_user) { user }
 
@@ -135,7 +135,7 @@ RSpec.describe "Views an article", type: :system do
       end
     end
 
-    context "with the article password, and the logged-in user is not the article author" do
+    context "with the article password, and the logged-in user is not authorized to update the article" do
       let(:query_params) { "?preview=#{article.password}" }
       let(:article_user) { create(:user) }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- show edit link when
  - logged-in user is the article author

- does not show edit link when
  - logged-in user is not the article author
  - user does not log in

## Related Tickets & Documents

Closes #6998

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed