### PR TITLE
Flaky Spec Fix:Remove let_it_be To Prevent Bad Database State Failing Specs

### DIFF
--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "ArticlesShow", type: :request do
-  let_it_be(:user) { create(:user) }
-  let_it_be(:article, reload: true) { create(:article, user: user, published: true, organization: organization) }
-  let_it_be(:organization) { create(:organization) }
+  let(:user) { create(:user) }
+  let(:article) { create(:article, user: user, published: true, organization: organization) }
+  let(:organization) { create(:organization) }
   let(:doc) { Nokogiri::HTML(response.body) }
   let(:text) { doc.at('script[type="application/ld+json"]').text }
   let(:response_json) { JSON.parse(text) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
For the notification spec I was able to successfully recreate the errors locally by running the following set of specs.
```
be rspec "spec/labor/email_logic_spec.rb" "spec/requests/notification_subscriptions_spec.rb" "spec/services/search/reaction_spec.rb" "spec/services/search/listing_spec.rb" "spec/system/internal/admin_awards_badges_spec.rb" "spec/services/notifications/new_comment/send_spec.rb" "spec/requests/articles/articles_update_spec.rb" "spec/requests/tag_adjustments_spec.rb" "spec/requests/credits_spec.rb" "spec/system/comments/user_delete_a_comment_spec.rb" "spec/models/notification_spec.rb"
```
What appears to happen is before the first spec failure, the `let_it_be` data gets removed from the database and since the rest of the spec rely on it, the rest of the specs for that class fail. Whatever causes the `let_it_be` data to be removed then also seems to mess with the database state bc it also causes timeout errors down the line in other specs. I played around with logging and such to try and figure out exactly WHY this was happening. After a few hours, I decided the easiest solution was to remove the `let_it_be` statements. Thanks to parallelization and Knapsack our suite can still run in 9m so I think any small performance loss we might get is worth it to save time rerunning entire builds over and over.

The articles show spec was another one that failed on a recent PR of mine (#9477) that I decided to throw in here as well. Given its a small spec I dont think the time difference is even noticeable on it.  

We honestly could probably remove all the `let_it_be` stuff but I stuck with the two files that I have recently seen fail, the notifications one has been particularly bad, and then maybe @snackattas could figure out the reason and we could use it. But honestly, depending on the time it takes might be worth it to just remove the added complexity. Open to thoughts on that but at least this will get the spec in a better working state

Lets `let_it_be` go! 
![alt_text](https://media.tenor.com/images/1d3b2f7d6837cc66df2a74c5d646ddc7/tenor.gif)
