### PR TITLE
Optimization:Change Multiple Small Table Column IDs to Bigints

### DIFF
--- a/db/migrate/20200725215546_change_small_table_related_ids_to_bigints.rb
+++ b/db/migrate/20200725215546_change_small_table_related_ids_to_bigints.rb
@@ -1,0 +1,77 @@
+class ChangeSmallTableRelatedIdsToBigints < ActiveRecord::Migration[6.0]
+  def up
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.buffer_updates")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE buffer_updates
+          ALTER COLUMN article_id TYPE bigint,
+          ALTER COLUMN approver_user_id TYPE bigint,
+          ALTER COLUMN composer_user_id TYPE bigint,
+          ALTER COLUMN tag_id TYPE bigint
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.collections")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE collections
+          ALTER COLUMN id TYPE bigint,
+          ALTER COLUMN organization_id TYPE bigint,
+          ALTER COLUMN user_id TYPE bigint
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.github_repos")
+    safety_assured { change_column :github_repos, :user_id, :bigint }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.html_variants")
+    safety_assured { change_column :html_variants, :user_id, :bigint }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.mentions")
+    safety_assured { change_column :mentions, :mentionable_id, :bigint }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.organizations")
+    safety_assured { change_column :organizations, :id, :bigint }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.tweets")
+    safety_assured { change_column :tweets, :user_id, :bigint }
+  end
+
+  def down
+        ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.buffer_updates")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE buffer_updates
+          ALTER COLUMN article_id TYPE int,
+          ALTER COLUMN approver_user_id TYPE int,
+          ALTER COLUMN composer_user_id TYPE int,
+          ALTER COLUMN tag_id TYPE int
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.collections")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE collections
+          ALTER COLUMN id TYPE int,
+          ALTER COLUMN organization_id TYPE int,
+          ALTER COLUMN user_id TYPE int
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.github_repos")
+    safety_assured { change_column :github_repos, :user_id, :int }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.html_variants")
+    safety_assured { change_column :html_variants, :user_id, :int }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.mentions")
+    safety_assured { change_column :mentions, :mentionable_id, :int }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.organizations")
+    safety_assured { change_column :organizations, :id, :int }
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.tweets")
+    safety_assured { change_column :tweets, :user_id, :int }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_23_203155) do
+ActiveRecord::Schema.define(version: 2020_07_25_215546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -291,17 +291,17 @@ ActiveRecord::Schema.define(version: 2020_07_23_203155) do
   end
 
   create_table "buffer_updates", force: :cascade do |t|
-    t.integer "approver_user_id"
-    t.integer "article_id", null: false
+    t.bigint "approver_user_id"
+    t.bigint "article_id", null: false
     t.text "body_text"
     t.string "buffer_id_code"
     t.string "buffer_profile_id_code"
     t.text "buffer_response", default: "--- {}\n"
-    t.integer "composer_user_id"
+    t.bigint "composer_user_id"
     t.datetime "created_at", null: false
     t.string "social_service_name"
     t.string "status", default: "pending"
-    t.integer "tag_id"
+    t.bigint "tag_id"
     t.datetime "updated_at", null: false
   end
 
@@ -369,17 +369,17 @@ ActiveRecord::Schema.define(version: 2020_07_23_203155) do
     t.index ["user_id"], name: "index_classified_listings_on_user_id"
   end
 
-  create_table "collections", id: :serial, force: :cascade do |t|
+  create_table "collections", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "description"
     t.string "main_image"
-    t.integer "organization_id"
+    t.bigint "organization_id"
     t.boolean "published", default: false
     t.string "slug"
     t.string "social_image"
     t.string "title"
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.bigint "user_id"
     t.index ["organization_id"], name: "index_collections_on_organization_id"
     t.index ["slug", "user_id"], name: "index_collections_on_slug_and_user_id", unique: true
     t.index ["user_id"], name: "index_collections_on_user_id"
@@ -585,7 +585,7 @@ ActiveRecord::Schema.define(version: 2020_07_23_203155) do
     t.integer "stargazers_count"
     t.datetime "updated_at", null: false
     t.string "url"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.integer "watchers_count"
     t.index ["github_id_code"], name: "index_github_repos_on_github_id_code", unique: true
     t.index ["url"], name: "index_github_repos_on_url", unique: true
@@ -617,7 +617,7 @@ ActiveRecord::Schema.define(version: 2020_07_23_203155) do
     t.float "success_rate", default: 0.0
     t.string "target_tag"
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.bigint "user_id"
     t.index ["name"], name: "index_html_variants_on_name", unique: true
   end
 
@@ -636,7 +636,7 @@ ActiveRecord::Schema.define(version: 2020_07_23_203155) do
 
   create_table "mentions", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.integer "mentionable_id"
+    t.bigint "mentionable_id"
     t.string "mentionable_type"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
@@ -754,7 +754,7 @@ ActiveRecord::Schema.define(version: 2020_07_23_203155) do
     t.index ["user_id", "organization_id"], name: "index_organization_memberships_on_user_id_and_organization_id", unique: true
   end
 
-  create_table "organizations", id: :serial, force: :cascade do |t|
+  create_table "organizations", force: :cascade do |t|
     t.integer "articles_count", default: 0, null: false
     t.string "bg_color_hex"
     t.string "company_size"
@@ -1108,7 +1108,7 @@ ActiveRecord::Schema.define(version: 2020_07_23_203155) do
     t.string "twitter_username"
     t.datetime "updated_at", null: false
     t.text "urls_serialized", default: "--- []\n"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.boolean "user_is_verified"
   end
 

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Views an article", type: :system do
-  let_it_be(:user) { create(:user) }
-  let_it_be_changeable(:article) do
+  let(:user) { create(:user) }
+  let(:article) do
     create(:article, :with_notification_subscription, user: user)
   end
   let(:timestamp) { "2019-03-04T10:00:00Z" }
@@ -67,7 +67,7 @@ RSpec.describe "Views an article", type: :system do
   end
 
   describe "when articles belong to a collection" do
-    let_it_be_readonly(:collection) { create(:collection) }
+    let(:collection) { create(:collection) }
     let(:articles_selector) { "//div[@class='article-collection']//a" }
 
     context "with regular articles" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Changing the last of the small table keys from ints to Bigints. All of these tables when I ran these migrations on a copy of prod ran in a second or under. The last few small table migrations I have to run beyond these are around 5-10 second migrations. Then last but not least we have long migrations(#9476)  which I plan to schedule downtime for. 
Prod Data Sizes:
collections - 7k
buffer_updates - 55k ([1 second to update id, .5 seconds to update the other columns](https://gist.github.com/mstruve/1600b29a30b39b9f4edc0c8d79d9ba91))
github_repos - 35k
html_variants - 128
mentions - 6k
organizations - 2k
tweets - 11k

For more information on the spec fix checkout #9512 

## Related Tickets & Documents
https://github.com/forem/forem/projects/9#card-37704279


![alt_text](https://media1.tenor.com/images/d223cbd8a1ba44ea98cf9f18d2d3b312/tenor.gif?itemid=9764034)
