### PR TITLE
fix actions/checkout to v2 for rebase workflow

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.comment.author_association == 'OWNER')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Automatic Rebase


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes the `Automatic Rebase` workflow file's `actions/checkout` action to `v2`. I chose `v2` over `main` in order to avoid breaking changes which might get pushed to it, like what happened with `master` being switched to `main`. `v2` fixates it to the version `2.x.x` which will still allow to get critical security patches. More information can be found at [Workflow Syntax for GitHub Actions - jobs.<job_id>.steps.uses](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses).

## Related Tickets & Documents
Issue:
- #9510

Demo PR:
- https://github.com/Amorpheuz/forem/pull/2

Run Logs:
- https://github.com/Amorpheuz/forem/actions/runs/183020180
- https://github.com/Amorpheuz/forem/actions/runs/183020457 

## QA Instructions, Screenshots, Recordings

- Requires to be merged into master for testing.
- Comment on a PR in order to generate a Run file after the merge.
- No warning similar to one indicated in the issue should appear under the `Annotations` tab.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Fix it to the version](https://media.giphy.com/media/VeSvZhPrqgZxx2KpOA/giphy.gif)
