### PR TITLE
homepageFeed: Add null checks in cases where there's no featured story present

### DIFF
--- a/app/javascript/packs/homePageFeed.jsx
+++ b/app/javascript/packs/homePageFeed.jsx
@@ -82,21 +82,23 @@ export const renderFeed = (timeFrame) => {
 
         const [featuredStory, ...subStories] = feedItems;
         const feedStyle = JSON.parse(document.body.dataset.user).feed_style;
-
-        sendFeaturedArticleAnalytics(featuredStory.id);
+        if(featuredStory) {
+          sendFeaturedArticleAnalytics(featuredStory.id);
+        }
 
         // 1. Show the featured story first
         // 2. Podcast episodes out today
         // 3. Rest of the stories for the feed
         return (
           <div>
+            {featuredStory && 
             <Article
               {...commonProps}
               article={featuredStory}
               isFeatured
               feedStyle={feedStyle}
               isBookmarked={bookmarkedFeedItems.has(featuredStory.id)}
-            />
+            />}
             {podcastEpisodes.length > 0 && (
               <PodcastEpisodes episodes={podcastEpisodes} />
             )}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

During the initial setup, if there are no featuredArticles, the UI breaks. so to avoid this particular scenario I'm adding null checks at appropriate places.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Try setting up a brand new dev environment without any featured article, to reproduce this particular bug

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?

N/A

##  What gif best describes this PR or how it makes you feel?

![Undefined error](https://media.tenor.com/images/12af966a977d9aa80599854ea656b30e/tenor.gif)
