### PR TITLE
Flaky Spec Fix:Remove let_it_be usage from Comment Model Spec

### DIFF
--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  let_it_be(:user) { create(:user) }
-  let_it_be(:article) { create(:article, user: user) }
-  let_it_be_changeable(:comment) { create(:comment, user: user, commentable: article) }
+  let(:user) { create(:user) }
+  let(:article) { create(:article, user: user) }
+  let(:comment) { create(:comment, user: user, commentable: article) }
 
   include_examples "#sync_reactions_count", :article_comment
 
@@ -255,8 +255,8 @@ RSpec.describe Comment, type: :model do
   end
 
   describe ".tree_for" do
-    let_it_be(:other_comment) { create(:comment, commentable: article, user: user) }
-    let_it_be(:child_comment) { create(:comment, commentable: article, parent: comment, user: user) }
+    let!(:other_comment) { create(:comment, commentable: article, user: user) }
+    let!(:child_comment) { create(:comment, commentable: article, parent: comment, user: user) }
 
     before { comment.update_column(:score, 1) }
 
@@ -326,6 +326,8 @@ RSpec.describe Comment, type: :model do
       let!(:user) { create(:user) }
 
       before do
+        article
+        comment
         # making sure there are no other enqueued jobs from other tests
         sidekiq_perform_enqueued_jobs(only: Slack::Messengers::Worker)
       end

--- a/spec/requests/api/v0/webhooks_spec.rb
+++ b/spec/requests/api/v0/webhooks_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 RSpec.describe "Api::V0::Webhooks", type: :request do
-  let_it_be_changeable(:user) { create(:user) }
-  let_it_be_changeable(:webhook) do
+  let(:user) { create(:user) }
+  let!(:webhook) do
     create(:webhook_endpoint, user: user, target_url: "https://api.example.com/go")
   end
 
   describe "GET /api/v0/webhooks" do
-    let_it_be_readonly(:webhook2) do
+    let(:webhook2) do
       create(:webhook_endpoint, user: user, target_url: "https://api.example.com/webhook")
     end
 
@@ -55,6 +55,7 @@ RSpec.describe "Api::V0::Webhooks", type: :request do
       end
 
       it "returns json on success" do
+        webhook2
         get api_webhooks_path
 
         expect(response.parsed_body).to include(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Flaky Spec Fix

## Description
These specs I saw fail a couple of times in the dependabot update branches so I went ahead and removed the problematic `let_it_be` statements. For more information checkout #9512 

I think one of the dependabot updates must have missed vendoring a gem since after updating with master and bundling I seem to have an extra file. 

![alt_text](https://media.tenor.com/images/5a7c95c3fb03deeedbf1c35791e99422/tenor.gif)
