### PR TITLE
Fix contributing guide link to point to docs.forem.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,4 @@ We are all humans trying to work together to improve the community. Always be
 kind and appreciate the need for trade-offs. ❤️
 
 Before making your first pull request or issue, give our full
-[Contributor's Guide](https://docs.dev.to/contributing/forem) a read.
+[Contributor's Guide](https://docs.forem.com/contributing/forem/) a read.


### PR DESCRIPTION
Replacing https://docs.dev.to/contributing/forem/ new forem docs link per issue #9505.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ X] Documentation Update

## Description
Replacing https://docs.dev.to/contributing/forem/ new forem docs link per issue #9505.
## Related Tickets & Documents
Closes #9505 

## Added tests?

- [ ] yes
- [ X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ X] readme
- [ ] no documentation needed

