### PR TITLE
Replace getting started links to point to docs.forem.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ proceed.
 
 This section provides a high-level quick start guide. If you're looking for the
 [installation guide](https://docs.dev.to/installation/), you'll want to refer to
-our complete [Developer Documentation](https://docs.dev.to).
+our complete [Developer Documentation](https://docs.forem.com/).
 
 We run on a [Rails](https://rubyonrails.org/) backend, and we are currently
 transitioning to a [Preact](https://preactjs.com/)-first frontend.
 
 A more complete overview of our stack is available in
-[our docs](https://docs.dev.to/technical-overview/).
+[our docs](https://docs.forem.com/technical-overview/).
 
 ### Prerequisites
 


### PR DESCRIPTION
Replacing links to https://docs.dev.to in the Getting Started section with links to the newer https://docs.forem.com/ instead

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ X] Documentation Update

## Description
Replacing links to https://docs.dev.to in the Getting Started section with links to the newer https://docs.forem.com/ instead

## Related Tickets & Documents
Closes #9505 

## Added tests?

- [ ] yes
- [X ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ X] readme
- [ ] no documentation needed
