### PR TITLE
Activate Devise::Lockable

### DIFF
--- a/app/controllers/internal/users_controller.rb
+++ b/app/controllers/internal/users_controller.rb
@@ -122,6 +122,13 @@ module Internal
       end
     end
 
+    def unlock_access
+      @user = User.find(params[:id])
+      @user.unlock_access!
+      flash[:success] = "Unlocked User account!"
+      redirect_to internal_user_path(@user)
+    end
+
     private
 
     def manage_credits

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,7 +112,8 @@ class User < ApplicationRecord
 
   mount_uploader :profile_image, ProfileImageUploader
 
-  devise :invitable, :omniauthable, :registerable, :database_authenticatable, :confirmable, :rememberable, :recoverable
+  devise :invitable, :omniauthable, :registerable, :database_authenticatable, :confirmable, :rememberable,
+         :recoverable, :lockable
 
   validates :behance_url, length: { maximum: 100 }, allow_blank: true, format: BEHANCE_URL_REGEXP
   validates :bg_color_hex, format: COLOR_HEX_REGEXP, allow_blank: true

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -127,6 +127,7 @@ module Authentication
 
     def update_user(user)
       user.tap do |model|
+        user.unlock_access! if user.access_locked?
         user.assign_attributes(provider.existing_user_data)
 
         update_profile_updated_at(model)

--- a/app/views/internal/users/edit.html.erb
+++ b/app/views/internal/users/edit.html.erb
@@ -3,13 +3,18 @@
     <h2 class="d-inline">
       <%= @user.name %><%= link_to "@#{@user.username}", @user.path, class: "ml-2", target: "_blank", rel: "noopener" %>
     </h2>
+
+    <% if @user.access_locked? %>
+      <div>
+        <%= link_to "Unlock access", unlock_access_internal_user_path(@user), method: :patch, class: "btn btn-success" %>
+      </div>
+    <% end %>
     <a href="<%= internal_user_path(@user) %>" class="btn btn-primary float-right">Internal Profile</a>
     <p class="font-italic">Member since <%= @user.created_at.strftime("%b %e '%y") %></p>
   </div>
 </div>
 
 <%= render "activity" %>
-
 <div class="row">
   <div class="col-12">
     <h2 class="d-inline">User Status</h2>

--- a/app/views/internal/users/show.html.erb
+++ b/app/views/internal/users/show.html.erb
@@ -17,6 +17,8 @@
       <dd><%= @user.name %></dd>
       <dt>Email:</dt>
       <dd><%= @user.email %></dd>
+      <dt>Access Locked:</dt>
+      <dd><%= @user.access_locked? %></dd>
       <dt>Twitter:</dt>
       <% if @user.twitter_username %>
         <dd><%= link_to @user.twitter_username, "https://twitter.com/#{@user.twitter_username}" %></dd>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -206,7 +206,7 @@ Devise.setup do |config|
   # Defines which strategy will be used to lock an account.
   # :failed_attempts = Locks an account after a number of failed attempts to sign in.
   # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
+  config.lock_strategy = :failed_attempts
 
   # Defines which key will be used when locking and unlocking an account
   # config.unlock_keys = [:email]
@@ -216,14 +216,14 @@ Devise.setup do |config|
   # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
   # :both  = Enables both strategies
   # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
+  config.unlock_strategy = :both
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 3
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
+  config.unlock_in = 1.hour
 
   # Warn on the last attempt before the account is locked.
   # config.last_attempt_warning = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -220,7 +220,7 @@ Devise.setup do |config|
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  config.maximum_attempts = 3
+  config.maximum_attempts = 5
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
   config.unlock_in = 1.hour

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
         post "recover_identity"
         post "send_email"
         post "verify_email_ownership"
+        patch "unlock_access"
       end
     end
     resources :organization_memberships, only: %i[update destroy create]

--- a/db/migrate/20200727052235_add_lockable_to_devise.rb
+++ b/db/migrate/20200727052235_add_lockable_to_devise.rb
@@ -1,0 +1,7 @@
+class AddLockableToDevise < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :failed_attempts, :integer, default: 0
+    add_column :users, :unlock_token, :string
+    add_column :users, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -472,6 +472,7 @@ ActiveRecord::Schema.define(version: 2020_07_27_163200) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.datetime "verified_at"
+    t.index ["user_id"], name: "index_email_authorizations_on_user_id"
   end
 
   create_table "events", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -472,7 +472,6 @@ ActiveRecord::Schema.define(version: 2020_07_27_163200) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.datetime "verified_at"
-    t.index ["user_id"], name: "index_email_authorizations_on_user_id"
   end
 
   create_table "events", force: :cascade do |t|
@@ -1197,6 +1196,7 @@ ActiveRecord::Schema.define(version: 2020_07_27_163200) do
     t.boolean "export_requested", default: false
     t.datetime "exported_at"
     t.string "facebook_url"
+    t.integer "failed_attempts", default: 0
     t.boolean "feed_admin_publish_permission", default: true
     t.datetime "feed_fetched_at", default: "2017-01-01 05:00:00"
     t.boolean "feed_mark_canonical", default: false
@@ -1231,6 +1231,7 @@ ActiveRecord::Schema.define(version: 2020_07_27_163200) do
     t.inet "last_sign_in_ip"
     t.string "linkedin_url"
     t.string "location"
+    t.datetime "locked_at"
     t.boolean "looking_for_work", default: false
     t.boolean "looking_for_work_publicly", default: false
     t.string "mastodon_url"
@@ -1275,6 +1276,7 @@ ActiveRecord::Schema.define(version: 2020_07_27_163200) do
     t.integer "twitter_following_count"
     t.string "twitter_username"
     t.string "unconfirmed_email"
+    t.string "unlock_token"
     t.integer "unspent_credits_count", default: 0, null: false
     t.datetime "updated_at", null: false
     t.string "username"

--- a/spec/requests/internal/users_spec.rb
+++ b/spec/requests/internal/users_spec.rb
@@ -105,4 +105,13 @@ RSpec.describe "internal/users", type: :request do
       expect { backup.reload }.to raise_error ActiveRecord::RecordNotFound
     end
   end
+
+  describe "PATCH internal/users/:id/unlock_access" do
+    it "unlocks a locked user account" do
+      user.lock_access!
+      expect do
+        patch unlock_access_internal_user_path(user)
+      end.to change { user.reload.access_locked? }.from(true).to(false)
+    end 
+  end
 end

--- a/spec/system/user_logs_in_with_password_spec.rb
+++ b/spec/system/user_logs_in_with_password_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Authenticating with a password" do
+  let(:password) { "p4assw0rd" }
+  let!(:user) { create(:user, password: password, password_confirmation: password) }
+
+  before do
+    visit sign_up_path
+  end
+
+  def submit_login_form(email, password)
+    fill_in "Email", with: email
+    fill_in "Password", with: password
+    click_button "Log in"
+  end
+
+  context "when logging in with incorrect credentials" do
+    it "displays an error when the email address is wrong" do
+      submit_login_form("wrong@example.com", password)
+      expect(page).to have_text("Invalid Email or password.")
+    end
+
+    it "displays an error when the password is wrong" do
+      submit_login_form(user.email, "wr0ng")
+      expect(page).to have_text("Invalid Email or password.")
+    end
+
+    it "displays a message when the user got locked out" do
+      allow(User).to receive(:maximum_attempts).and_return(1)
+
+      submit_login_form(user.email, "wr0ng")
+      expect(page).to have_text("Your account is locked.")
+    end
+  end
+
+  context "when logging in with the correct credentials" do
+    it "allows the user to sign in with the correct password" do
+      submit_login_form(user.email, password)
+      expect(page).to have_current_path("/dashboard?signin=true")
+    end
+  end
+end

--- a/spec/system/user_logs_in_with_password_spec.rb
+++ b/spec/system/user_logs_in_with_password_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe "Authenticating with a password" do
       expect(page).to have_text("Invalid Email or password.")
     end
 
+    it "displays a message on the last login attempt" do
+      allow(User).to receive(:maximum_attempts).and_return(2)
+
+      submit_login_form(user.email, "wr0ng")
+      expect(page).to have_text("You have one more attempt before your account is locked.")
+    end
+
     it "displays a message when the user got locked out" do
       allow(User).to receive(:maximum_attempts).and_return(1)
 

--- a/spec/system/user_logs_in_with_password_spec.rb
+++ b/spec/system/user_logs_in_with_password_spec.rb
@@ -1,17 +1,17 @@
 require "rails_helper"
 
 RSpec.describe "Authenticating with a password" do
+  def submit_login_form(email, password)
+    fill_in "Email", with: email
+    fill_in "Password", with: password
+    click_button "Log in"
+  end
+
   let(:password) { "p4assw0rd" }
   let!(:user) { create(:user, password: password, password_confirmation: password) }
 
   before do
     visit sign_up_path
-  end
-
-  def submit_login_form(email, password)
-    fill_in "Email", with: email
-    fill_in "Password", with: password
-    click_button "Log in"
   end
 
   context "when logging in with incorrect credentials" do

--- a/spec/system/user_logs_in_with_password_spec.rb
+++ b/spec/system/user_logs_in_with_password_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe "Authenticating with a password" do
       submit_login_form(user.email, "wr0ng")
       expect(page).to have_text("Your account is locked.")
     end
+
+    it "sends an email with the unlock link if the uset gets locked out" do
+      allow(User).to receive(:maximum_attempts).and_return(1)
+
+      expect do
+        submit_login_form(user.email, "wr0ng")
+      end.to change { Devise.mailer.deliveries.count }.by(1)
+    end
   end
 
   context "when logging in with the correct credentials" do

--- a/spec/system/user_logs_in_with_password_spec.rb
+++ b/spec/system/user_logs_in_with_password_spec.rb
@@ -48,6 +48,22 @@ RSpec.describe "Authenticating with a password" do
     end
   end
 
+  context "when the user's account is locked" do
+    it "allows the user to unlock their account via social logins" do
+      omniauth_mock_github_payload
+      auth_payload = OmniAuth.config.mock_auth[:github]
+      create(:user, :with_identity, identities: [:github])
+      auth_payload.info.email = user.email
+      user.lock_access!
+
+      visit root_path
+      click_link("Sign In with GitHub", match: :first)
+
+      expect(page).to have_current_path("/dashboard?signin=true")
+      expect(page).not_to have_text("Your account is locked.")
+    end
+  end
+
   context "when logging in with the correct credentials" do
     it "allows the user to sign in with the correct password" do
       submit_login_form(user.email, password)

--- a/spec/system/user_logs_in_with_password_spec.rb
+++ b/spec/system/user_logs_in_with_password_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Authenticating with a password" do
       visit root_path
       click_link("Sign In with GitHub", match: :first)
 
-      expect(page).to have_current_path("/dashboard?signin=true")
+      expect(page).to have_current_path("/?signin=true")
       expect(page).not_to have_text("Your account is locked.")
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

It was recently brought to our attention that we're not locking out users who attempt to conduct dictionary and brute force attacks against user accounts. This PR activates `Devise::Lockable` to address this.

## QA Instructions, Screenshots, Recordings

1. Make sure your user has a password that you know:
    ```ruby
    user.update(password: "...", password_confirmation: "...")
   ```
2. Go to `/users/sign_in` or `/enter` in your local environment.
3. Enter the wrong password a couple of times and see your account get locked out.
4. You can unlock it in the console with `user.unlock_access!`.

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed
