### PR TITLE
Removes intrusive mobile video autoplay & adds ahoy for visibility

### DIFF
--- a/app/assets/javascripts/initializers/initializeVideoPlayback.js
+++ b/app/assets/javascripts/initializers/initializeVideoPlayback.js
@@ -13,10 +13,12 @@
 /* eslint no-param-reassign: 0 */
 /* eslint no-useless-escape: 0 */
 /* global jwplayer */
+/* global ahoy */
 
 function initializeVideoPlayback() {
   var nativeBridgeMessage;
   var currentTime = '0';
+  var deviceType = 'web';
 
   function getById(name) {
     return document.getElementById(name);
@@ -116,6 +118,9 @@ function initializeVideoPlayback() {
       url: metadata.video_source_url,
       seconds: currentTime,
     });
+
+    var properties = { article: metadata.id, deviceType: deviceType };
+    ahoy.track('Article video play', properties);
   }
 
   function handleVideoMessages(mutation) {
@@ -145,6 +150,7 @@ function initializeVideoPlayback() {
     var metadata = videoMetadata(videoSource);
 
     if (isNativeIOS()) {
+      deviceType = 'iOS';
       nativeBridgeMessage = function (message) {
         try {
           window.webkit.messageHandlers.video.postMessage(message);
@@ -153,6 +159,7 @@ function initializeVideoPlayback() {
         }
       };
     } else if (isNativeAndroid()) {
+      deviceType = 'Android';
       nativeBridgeMessage = function (message) {
         try {
           AndroidBridge.videoMessage(JSON.stringify(message));
@@ -170,7 +177,7 @@ function initializeVideoPlayback() {
     playerElement.addEventListener('click', requestFocus);
 
     playerElement.classList.add('native');
-    getById('pause-butt').classList.add('active');
+    getById('play-butt').classList.add('active');
 
     var mutationObserver = new MutationObserver(function (mutations) {
       mutations.forEach(function (mutation) {
@@ -180,11 +187,6 @@ function initializeVideoPlayback() {
     mutationObserver.observe(videoSource, { attributes: true });
 
     currentTime = `${seconds}`;
-    nativeBridgeMessage({
-      action: 'play',
-      url: metadata.video_source_url,
-      seconds: currentTime,
-    });
   }
 
   // If an video player element is found initialize it

--- a/app/assets/javascripts/initializers/initializeVideoPlayback.js
+++ b/app/assets/javascripts/initializers/initializeVideoPlayback.js
@@ -170,6 +170,8 @@ function initializeVideoPlayback() {
     } else {
       // jwplayer is initialized and no further interaction is needed
       initWebPlayer(seconds, metadata);
+      var properties = { article: metadata.id, deviceType: deviceType };
+      ahoy.track('Article video play', properties);
       return;
     }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Autoplay can be a little intrusive on mobile because it does not let the user read the article associated, which can even be a Series like [BaseCS](https://dev.to/devteam/basecs-intro-to-binary-2j09).

So instead of having the video take over we let the user choose to play. For visibility also added an Ahoy event

## QA Instructions, Screenshots, Recordings

Using iOS app in production or Android beta release we can see the videos are played automatically. The web video should not be affected at all.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![play pause](https://media.giphy.com/media/phE6OuPs2IyXK/giphy.gif)
