### PR TITLE
Remove banner_style from Broadcasts (Part 3 of Polymorphic Broadcasts)

### DIFF
--- a/app/controllers/internal/broadcasts_controller.rb
+++ b/app/controllers/internal/broadcasts_controller.rb
@@ -61,7 +61,7 @@ module Internal
     private
 
     def broadcast_params
-      params.permit(:title, :processed_html, :type_of, :banner_style, :active)
+      params.permit(:title, :processed_html, :type_of, :active)
     end
 
     def authorize_admin

--- a/app/views/internal/broadcasts/_form.html.erb
+++ b/app/views/internal/broadcasts/_form.html.erb
@@ -11,7 +11,7 @@
 </div>
 <div class="form-group">
   <%= label_tag :banner_style, "Banner Style:" %>
-  <%= select_tag "banner_style", options_for_select(%w[default brand success warning error], selected: @broadcast.banner_style), include_blank: true %>
+  <%= select_tag "banner_style", options_for_select(%w[default brand success warning error], selected: @broadcast.broadcastable.banner_style), include_blank: true %>
 </div>
 <div class="form-group">
   <%= label_tag :active, "Active:" %>

--- a/db/migrate/20200720232446_remove_banner_style_from_broadcasts.rb
+++ b/db/migrate/20200720232446_remove_banner_style_from_broadcasts.rb
@@ -1,0 +1,5 @@
+class RemoveBannerStyleFromBroadcasts < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured { remove_column :broadcasts, :banner_style, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -277,17 +277,15 @@ ActiveRecord::Schema.define(version: 2020_07_26_215928) do
   create_table "broadcasts", force: :cascade do |t|
     t.boolean "active", default: false
     t.datetime "active_status_updated_at"
-    t.string "banner_style"
     t.text "body_markdown"
     t.integer "broadcastable_id"
     t.string "broadcastable_type"
     t.datetime "created_at"
     t.text "processed_html"
     t.string "title"
-    t.string "type_of"
     t.datetime "updated_at"
     t.index ["broadcastable_type", "broadcastable_id"], name: "index_broadcasts_on_broadcastable_type_and_broadcastable_id", unique: true
-    t.index ["title", "type_of"], name: "index_broadcasts_on_title_and_type_of", unique: true
+    t.index ["title", "broadcastable_type"], name: "index_broadcasts_on_title_and_broadcastable_type", unique: true
   end
 
   create_table "buffer_updates", force: :cascade do |t|
@@ -1224,7 +1222,7 @@ ActiveRecord::Schema.define(version: 2020_07_26_215928) do
     t.datetime "last_article_at", default: "2017-01-01 05:00:00"
     t.datetime "last_comment_at", default: "2017-01-01 05:00:00"
     t.datetime "last_followed_at"
-    t.datetime "last_moderation_notification", default: "2017-01-01 05:00:00"
+    t.datetime "last_moderation_notification", default: "2017-01-01 07:00:00"
     t.datetime "last_notification_activity"
     t.string "last_onboarding_page"
     t.datetime "last_sign_in_at"
@@ -1293,6 +1291,7 @@ ActiveRecord::Schema.define(version: 2020_07_26_215928) do
     t.index ["language_settings"], name: "index_users_on_language_settings", using: :gin
     t.index ["old_old_username"], name: "index_users_on_old_old_username"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["twitch_username"], name: "index_users_on_twitch_username"
     t.index ["twitter_username"], name: "index_users_on_twitter_username", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR removes `banner_style` from the `Broadcasts` table and from the `broadcast_params` in the `Broadcasts::Controller`. Additionally, this PR refactors code that currently uses `banner_style` to work with the newly added polymorphic association--it ensures that `banner_style` is properly called in the Broadcast-related views.

## Related Tickets & Documents
Related to [Add Polymorphism to Broadcasts (Part 1)](https://github.com/forem/forem/pull/9231)
Related to [Add Polymorphism to Broadcasts (Part 2)](https://github.com/forem/forem/pull/9410)
Reason for changes are due to [#7169](https://github.com/forem/forem/issues/7169) and [#8861](https://github.com/forem/forem/issues/8861)

## QA Instructions, Screenshots, Recordings
To QA these changes, make sure that the Travis build passes. Additionally, you can test that you are still able to successfully create Announcement broadcasts with banners:

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Seinfeld](https://media.giphy.com/media/KPTCBr8piZ51m/giphy.gif)
