### PR TITLE
Bug Fix:Run Hypershield Refresh AFTER db:prepare

### DIFF
--- a/lib/tasks/app_initializer.rake
+++ b/lib/tasks/app_initializer.rake
@@ -15,5 +15,7 @@ namespace :app_initializer do
 end
 
 if ENV["ENABLE_HYPERSHIELD"].present?
-  Rake::Task["db:prepare"].enhance(["hypershield:refresh"])
+  Rake::Task["db:prepare"].enhance do
+    Rake::Task["hypershield:refresh"]
+  end
 end

--- a/lib/tasks/app_initializer.rake
+++ b/lib/tasks/app_initializer.rake
@@ -15,6 +15,9 @@ namespace :app_initializer do
 end
 
 if ENV["ENABLE_HYPERSHIELD"].present?
+  # enhance must be passed a block here to ensure that our hypershield task
+  # runs AFTER db:prepare. Passing it as an argument will cause it to run BEFORE
+  # https://ruby-doc.org/stdlib-2.0.0/libdoc/rake/rdoc/Rake/Task.html#method-i-enhance
   Rake::Task["db:prepare"].enhance do
     Rake::Task["hypershield:refresh"]
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Recently I noticed that our hypershield refresh task was running before our migrations which is a problem bc then our views are not getting updated with new migrations.
```
[hypershield] Refreshing schemas
[hypershield] Success!
== 20200726215928 ChangeTagIdsToBigints: migrating ============================
== 20200726215928 ChangeTagIdsToBigints: migrated (4.9509s) ===================
```
Now, who is ready to get their mind blown? The reason is bc of the way we were invoking/using `enhance`. 
Turns out when you use [`enhance`](https://ruby-doc.org/stdlib-2.0.0/libdoc/rake/rdoc/Rake/Task.html#method-i-enhance) like this and pass it an argument
```ruby
Rake::Task["db:prepare"].enhance(["hypershield:refresh"])
```
The task that is your argument becomes a **prerequisite** and is run **BEFORE** the rake task you are enhancing. This is a problem for us bc we want our hypershield views updated AFTER we run migrations.

If you pass a block to `enhance` like this
```ruby
Rake::Task["db:prepare"].enhance do
  Rake::Task["hypershield:refresh"]
end
```
It will run the rake task in the block **AFTER** the Rake task that is being enhanced. 🤯 

## Related Tickets & Documents
https://github.com/forem/forem/projects/9#card-42626051


![alt_text](https://media1.giphy.com/media/SJX3gbZ2dbaEhU92Pu/giphy.gif)
