### PR TITLE
Show article year if article published last year

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -317,7 +317,7 @@ class Article < ApplicationRecord
   end
 
   def readable_publish_date
-    relevant_date = crossposted_at.presence || published_at
+    relevant_date = displayable_published_at
     if relevant_date && relevant_date.year == Time.current.year
       relevant_date&.strftime("%b %e")
     else
@@ -329,7 +329,11 @@ class Article < ApplicationRecord
     return "" unless published
     return "" unless crossposted_at || published_at
 
-    (crossposted_at || published_at).utc.iso8601
+    displayable_published_at.utc.iso8601
+  end
+
+  def displayable_published_at
+    crossposted_at.presence || published_at
   end
 
   def series

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -150,7 +150,7 @@
 
               <span class="fs-s mb-4 s:mb-0">
                 <% if @article.published_timestamp.present? %>
-                  <%= local_date(@article.published_timestamp, show_year: false) %>
+                  <%= local_date(@article.published_timestamp, show_year: @article.displayable_published_at.year != Time.current.year) %>
                 <% end %>
                 <% if @second_user.present? %>
                   <em>with <b><a href="<%= @second_user.path %>"><%= @second_user.name %></a></b></em>

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -75,6 +75,18 @@ RSpec.describe "StoriesShow", type: :request do
       expect(response.body).not_to include("<span class=\"fs-xl color-base-70 block\">Hey this is a test</span>")
     end
 
+    ###
+
+    it "renders date-no-year if article published this year" do
+      expect(response.body).to include "date-no-year"
+    end
+
+    it "renders date with year if article published last year" do
+      article.update_column(:published_at, 1.year.ago)
+      expect(response.body).not_to include "date-no-year"
+    end
+
+
     it "renders user payment pointer if set" do
       article.user.update_column(:payment_pointer, "this-is-a-pointer")
       get article.path

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -78,11 +78,13 @@ RSpec.describe "StoriesShow", type: :request do
     ###
 
     it "renders date-no-year if article published this year" do
+      get article.path
       expect(response.body).to include "date-no-year"
     end
 
     it "renders date with year if article published last year" do
       article.update_column(:published_at, 1.year.ago)
+      get article.path
       expect(response.body).not_to include "date-no-year"
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently we're not showing the date year when articles were published last year, when we should be.

<img width="338" alt="Screen Shot 2020-07-27 at 6 32 43 PM" src="https://user-images.githubusercontent.com/3102842/88598573-93393500-d037-11ea-99f5-4b951e6f46a2.png">
