### PR TITLE
change default height to 420 as the editor guide suggest  (#9550)

### DIFF
--- a/app/view_objects/articles/social_image.rb
+++ b/app/view_objects/articles/social_image.rb
@@ -7,7 +7,7 @@ module Articles
 
     def initialize(article, **options)
       @article = article
-      @height = options[:height] || 500
+      @height = options[:height] || 420
       @width = options[:width] || 1000
     end
 
@@ -43,7 +43,7 @@ module Articles
         cl_image_path(src,
                       type: "fetch",
                       width: "1000",
-                      height: "500",
+                      height: "420",
                       crop: "imagga_scale",
                       quality: "auto",
                       flags: "progressive",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Following the [Editor Guide](https://dev.to/p/editor_guide) the size for the correct image is:

>cover_image: cover image for post, accepts a URL.
> The best size is 1000 x 420.

This PR helps avoid social preview image to get cropped.

## Related Tickets & Documents
Fixes #9550 

## QA Instructions, Screenshots, Recordings

I think it can be tested by uploading a cover image to an article with `1000x420` and check the  cloudinary transformation url

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

![alt_text](gif_link)
