### PR TITLE
Search: replace replaceState with pushState to fix the back button

### DIFF
--- a/app/views/articles/_search.html.erb
+++ b/app/views/articles/_search.html.erb
@@ -48,10 +48,10 @@
         var sortString = buildSortString(sortBy, sortDirection);
 
         if (filters) {
-          window.history.replaceState(null, null, "/search?q=" + query + "&filters=" + filters + sortString);
+          window.history.requestState(null, null, "/search?q=" + query + "&filters=" + filters + sortString);
           search(query, filters, sortBy, sortDirection);
         } else {
-          window.history.replaceState(null, null, "/search?q=" + query + sortString);
+          window.history.requestState(null, null, "/search?q=" + query + sortString);
           search(query, "", sortBy, sortDirection);
         }
 
@@ -83,7 +83,7 @@
           return;
         }
         var filters = e.target.dataset.filter;
-        window.history.replaceState(null, null, "/search?q=" + query + "&filters=" + filters + sortString);
+        window.history.pushState(null, null, "/search?q=" + query + "&filters=" + filters + sortString);
         var className = e.target.className;
         for (var i = 0; i < filterButts.length; i++) {
           filterButts[i].classList.remove("selected");

--- a/app/views/articles/_search.html.erb
+++ b/app/views/articles/_search.html.erb
@@ -48,10 +48,10 @@
         var sortString = buildSortString(sortBy, sortDirection);
 
         if (filters) {
-          window.history.requestState(null, null, "/search?q=" + query + "&filters=" + filters + sortString);
+          window.history.pushState(null, null, "/search?q=" + query + "&filters=" + filters + sortString);
           search(query, filters, sortBy, sortDirection);
         } else {
-          window.history.requestState(null, null, "/search?q=" + query + sortString);
+          window.history.pushState(null, null, "/search?q=" + query + sortString);
           search(query, "", sortBy, sortDirection);
         }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Made changes such that user is now able to click through filters in the search bar while clicking the back button does not immediately take them to the home page, but to the previous search filter. Fixes #9433.

## QA Instructions, Screenshots, Recordings

![FilterBackButton](https://user-images.githubusercontent.com/35935438/88686678-51ef6680-d0c5-11ea-9bdb-47f57d6c3a5f.gif)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed
