### PR TITLE
Feature:Boost Scores For Adjacent Words

### DIFF
--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -101,7 +101,13 @@ module Search
       def build_queries
         @body[:query] = { bool: {} }
         @body[:query][:bool][:filter] = filter_conditions if filter_keys_present?
-        @body[:query][:bool][:must] = query_conditions if query_keys_present?
+        return unless query_keys_present?
+
+        @body[:query][:bool][:must] = query_conditions
+        # Boost the score of queries that match these conditions but if they dont match any,
+        # minimum_should_match: 0, then that is OK
+        @body[:query][:bool][:should] = match_phrase_conditions
+        @body[:query][:bool][:minimum_should_match] = 0
       end
 
       def filter_conditions

--- a/app/services/search/query_builders/query_base.rb
+++ b/app/services/search/query_builders/query_base.rb
@@ -49,6 +49,22 @@ module Search
         end
       end
 
+      def match_phrase_conditions
+        self.class::QUERY_KEYS.filter_map do |query_key, _fields|
+          next if @params[query_key].blank?
+
+          match_phrase(@params[query_key], query_key)
+        end
+      end
+
+      def match_phrase(phrase, query_key)
+        {
+          match_phrase: {
+            query_key => { query: phrase, slop: 0 }
+          }
+        }
+      end
+
       def query_hash(key, fields)
         {
           simple_query_string: {

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe Search::FeedContent, type: :service do
         doc_ids = feed_docs.map { |t| t.dig("id") }
         expect(doc_ids).to include(article1.id, article2.id)
       end
+
+      it "bumps scores for words closer together" do
+        allow(article1).to receive(:body_text).and_return("Ruby I dont know maybe is cool")
+        allow(article2).to receive(:body_text).and_return("Ruby is cool")
+        index_documents([article1, article2])
+        query_params = { size: 5, search_fields: "ruby is cool" }
+
+        feed_docs = described_class.search_documents(params: query_params)
+        expect(feed_docs.count).to eq(2)
+        doc_ids = feed_docs.map { |t| t.dig("id") }
+        expect(doc_ids).to include(article2.id, article1.id)
+      end
     end
 
     context "with a filter term" do

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -91,14 +91,14 @@ RSpec.describe Search::FeedContent, type: :service do
 
       it "bumps scores for words closer together" do
         allow(article1).to receive(:body_text).and_return("Ruby I dont know maybe is cool")
-        allow(article2).to receive(:body_text).and_return("Ruby is cool")
+        allow(article2).to receive(:body_text).and_return("Ruby is cool I dont know maybe")
         index_documents([article1, article2])
         query_params = { size: 5, search_fields: "ruby is cool" }
 
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(2)
         doc_ids = feed_docs.map { |t| t.dig("id") }
-        expect(doc_ids).to include(article2.id, article1.id)
+        expect(doc_ids).to eq([article2.id, article1.id])
       end
     end
 

--- a/spec/services/search/query_builders/feed_content_spec.rb
+++ b/spec/services/search/query_builders/feed_content_spec.rb
@@ -26,11 +26,8 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
 
   describe "#as_hash" do
     let(:query_fields) { described_class::QUERY_KEYS[:search_fields] }
-
-    it "applies QUERY_KEYS from params" do
-      params = { search_fields: "test" }
-      filter = described_class.new(params: params)
-      expected_query = [{
+    let(:expected_query) do
+      [{
         "simple_query_string" => {
           "query" => "test",
           "fields" => query_fields,
@@ -39,7 +36,24 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
           "minimum_should_match" => 2
         }
       }]
+    end
+    let(:expected_match_phrase) do
+      [{
+        "match_phrase" => {
+          "search_fields" => {
+            "query" => "test",
+            "slop" => 0
+          }
+        }
+      }]
+    end
+
+    it "applies QUERY_KEYS from params" do
+      params = { search_fields: "test" }
+      filter = described_class.new(params: params)
       expect(search_bool_clause(filter)["must"]).to match_array(expected_query)
+      expect(search_bool_clause(filter)["should"]).to match_array(expected_match_phrase)
+      expect(search_bool_clause(filter)["minimum_should_match"]).to eq(0)
     end
 
     it "applies TERM_KEYS from params" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
I found a "workaround" for boosting the search scores for articles with words that are adjacent by using a `should` clause in our [`bool` query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html#query-dsl-bool-query). The way this works is I have added a [`match_phrase`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html) query which focuses on matching phrases. How well you want the phrase matched depends on your `slop` value. A value of 0 means you want to match the phrase exactly. We are using a value of 0. A greater slop value means you are ok with some words in between the words of the phrase you searched. Adding this query ensures that any time we find the exact phrase we are looking for, the article with the phrase will get scored higher by Elasticsearch. 

However, we don't want to eliminate articles that have all the words even if they are not all next to each other. That is where the `should` part comes in. `should` in a bool clause means we want some combination of the queries in that should block to match. How many of them we want to match depends on our [`minimum_should_match`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html) parameter. We have set that to 0, which means, if a phrase matches, the article's score gets bumped. If a phrase does not match, it won't count against the article in any way. 

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/7408


## Added tests?
- [x] yes


![alt_text](https://media0.giphy.com/media/RK9udF1XhY9L7IZRaZ/200.gif)
