### PR TITLE
Add new Golang liquid tag support

### DIFF
--- a/app/liquid_tags/golang_tag.rb
+++ b/app/liquid_tags/golang_tag.rb
@@ -1,10 +1,12 @@
 class GolangTag < LiquidTagBase
   PARTIAL = "liquids/golang".freeze
-  URL_REGEXP = %r{(http|https)://play.golang.com/p/[a-zA-Z0-9\-/]*}.freeze
+  URL_REGEXP = %r{\Ahttps?://play.golang.org/p/[a-zA-Z0-9\-/]+\z}.freeze
 
   def initialize(_tag_name, link, _parse_context)
     super
-    @link = parse_link(link)
+    stripped_link = ActionController::Base.helpers.strip_tags(link)
+    the_link = stripped_link.split(" ").first
+    @embedded_url = valid_link?(the_link)
   end
 
   def render(_context)
@@ -18,20 +20,9 @@ class GolangTag < LiquidTagBase
 
   private
 
-  def parse_link(link)
-    stripped_link = ActionController::Base.helpers.strip_tags(link)
-    the_link = stripped_link.split(" ").first
-    raise_error unless valid_link?(the_link)
-    the_link
-  end
-
   def valid_link?(link)
     link_no_space = link.delete(" ")
-    (link_no_space =~ URL_REGEXP)&.zero?
-  end
-
-  def raise_error
-    raise StandardError, "Invalid Golang Playground URL"
+    link_no_space.match?(URL_REGEXP)
   end
 end
 

--- a/app/liquid_tags/golang_tag.rb
+++ b/app/liquid_tags/golang_tag.rb
@@ -1,10 +1,10 @@
 class GolangTag < LiquidTagBase
   PARTIAL = "liquids/golang".freeze
+  URL_REGEXP = %r{(http|https)://play.golang.com/p/[a-zA-Z0-9\-/]*}.freeze
 
   def initialize(_tag_name, link, _parse_context)
     super
-    stripped_link = ActionController::Base.helpers.strip_tags(link)
-    @embedded_url = stripped_link.split(" ").first
+    @link = parse_link(link)
   end
 
   def render(_context)
@@ -14,6 +14,24 @@ class GolangTag < LiquidTagBase
         url: @embedded_url
       },
     )
+  end
+
+  private
+
+  def parse_link(link)
+    stripped_link = ActionController::Base.helpers.strip_tags(link)
+    the_link = stripped_link.split(" ").first
+    raise_error unless valid_link?(the_link)
+    the_link
+  end
+
+  def valid_link?(link)
+    link_no_space = link.delete(" ")
+    (link_no_space =~ URL_REGEXP)&.zero?
+  end
+
+  def raise_error
+    raise StandardError, "Invalid Golang Playground URL"
   end
 end
 

--- a/app/liquid_tags/golang_tag.rb
+++ b/app/liquid_tags/golang_tag.rb
@@ -1,0 +1,20 @@
+class GolangTag < LiquidTagBase
+  PARTIAL = "liquids/golang".freeze
+
+  def initialize(_tag_name, link, _parse_context)
+    super
+    stripped_link = ActionController::Base.helpers.strip_tags(link)
+    @embedded_url = stripped_link.split(" ").first
+  end
+
+  def render(_context)
+    ActionController::Base.new.render_to_string(
+      partial: PARTIAL,
+      locals: {
+        url: @embedded_url
+      },
+    )
+  end
+end
+
+Liquid::Template.register_tag("golang", GolangTag)

--- a/app/liquid_tags/golang_tag.rb
+++ b/app/liquid_tags/golang_tag.rb
@@ -6,7 +6,8 @@ class GolangTag < LiquidTagBase
     super
     stripped_link = ActionController::Base.helpers.strip_tags(link)
     the_link = stripped_link.split(" ").first
-    @embedded_url = valid_link?(the_link)
+    raise "Invalid URL" valid_link?(the_link)
+    @embedded_url = the_link
   end
 
   def render(_context)

--- a/app/liquid_tags/golang_tag.rb
+++ b/app/liquid_tags/golang_tag.rb
@@ -6,7 +6,7 @@ class GolangTag < LiquidTagBase
     super
     stripped_link = ActionController::Base.helpers.strip_tags(link)
     the_link = stripped_link.split(" ").first
-    raise "Invalid URL" valid_link?(the_link)
+    raise "Invalid URL" unless valid_link?(the_link)
     @embedded_url = the_link
   end
 

--- a/app/views/liquids/_golang.html.erb
+++ b/app/views/liquids/_golang.html.erb
@@ -3,5 +3,6 @@
   src="<%= url %>"
   height="400"
   frameborder="0"
+  loading="lazy"
 >
 </iframe>

--- a/app/views/liquids/_golang.html.erb
+++ b/app/views/liquids/_golang.html.erb
@@ -1,0 +1,7 @@
+<iframe
+  title="golang editor"
+  src="<%= url %>"
+  height="400"
+  frameborder="0"
+>
+</iframe>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -358,6 +358,11 @@
 {% reddit https://www.reddit.com/r/aww/comments/ag3s4b/ive_waited_28_years_to_finally_havr_my_first_pet %}
         </pre>
 
+        <h3><strong>Golang Embed</strong></h3>
+        <p>Visualize your Golang Playground code <a href="https://play.golang.org/">Golang's</a> visualizer embed</p>
+        <p>All you need is the share URL to embed the playground</p>
+        <code>{% golang https://play.golang.org/p/HmnNoBf0p1z %}</code>
+
         <h3><strong>Parsing Liquid Tags as a Code Example</strong></h3>
         <p>To parse Liquid tags as code, simply wrap it with a single backtick or triple backticks.</p>
         <p><code>`{% mytag %}{{ site.SOMETHING }}{% endmytag %}`</code></p>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -297,5 +297,9 @@
     <p>One specific edge case is with using the <code>raw</code> tag. To properly escape it, use this format:
     </p>
     <p><code>`{% raw %}{{site.SOMETHING }} {% ``endraw`` %}`</code></p>
+    <h3><strong>Golang Embed</strong></h3>
+    <p>Visualize your Golang Playground code <a href="https://play.golang.org/">Golang's</a> visualizer embed</p>
+    <p>All you need is the share URL to embed the playground</p>
+    <code>{% golang https://play.golang.org/p/HmnNoBf0p1z %}</code>
   </div>
 </div>

--- a/docs/frontend/liquid-tags.md
+++ b/docs/frontend/liquid-tags.md
@@ -56,6 +56,7 @@ Here is a bunch of liquid tags supported on Forem:
 {% kotlin https://pl.kotl.in/owreUFFUG %}
 {% wikipedia https://en.wikipedia.org/wiki/Wikipedia %}
 {% reddit https://www.reddit.com/r/aww/comments/ag3s4b/ive_waited_28_years_to_finally_havr_my_first_pet %}
+{% golang https://play.golang.org/p/HmnNoBf0p1z %}
 ```
 
 ## How liquid tags are developed

--- a/spec/liquid_tags/golang_tag_spec.rb
+++ b/spec/liquid_tags/golang_tag_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe GolangTag, type: :liquid_tag do
   describe "#link" do
     let(:valid_link) { "https://play.golang.org/p/HmnNoBf0p1z" }
-    let(:missing_link) { "https://play.golang.org/p/HmnNoBf0p1z" }
 
     def generate_tag(link)
       Liquid::Template.register_tag("golang", GolangTag)
@@ -16,11 +15,11 @@ RSpec.describe GolangTag, type: :liquid_tag do
 
     it "renders valid input" do
       template = generate_tag(valid_link)
-      expected = 'src="https://play.golang.org/p/HmnNoBf0p1z"'
-      expect(template.render(nil)).to include(expected)
+      expected = 'src="true"'
+      expect(template.render).to include(expected)
     end
 
-    it "accepts only Kotlin Playground links" do
+    it "accepts only Golang Playground links" do
       badurl = "https://example.com"
       expect do
         generate_new_liquid(badurl)

--- a/spec/liquid_tags/golang_tag_spec.rb
+++ b/spec/liquid_tags/golang_tag_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe GolangTag, type: :liquid_tag do
       expect do
         generate_new_liquid(badurl)
       end.to raise_error(StandardError)
+    end
 
+    it "invalid URL format" do
       badurl = "not even an URL"
       expect do
         generate_new_liquid(badurl)

--- a/spec/liquid_tags/golang_tag_spec.rb
+++ b/spec/liquid_tags/golang_tag_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe GolangTag, type: :liquid_tag do
       badurl = "not even an URL"
       expect do
         generate_new_liquid(badurl)
-      end.to raise_error(StandardError)
+      end.to raise_error(RuntimeError)
     end
 
     it "renders iframe" do

--- a/spec/liquid_tags/golang_tag_spec.rb
+++ b/spec/liquid_tags/golang_tag_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GolangTag, type: :liquid_tag do
       badurl = "https://example.com"
       expect do
         generate_new_liquid(badurl)
-      end.to raise_error(StandardError)
+      end.to raise_error(RuntimeError)
     end
 
     it "invalid URL format" do

--- a/spec/liquid_tags/golang_tag_spec.rb
+++ b/spec/liquid_tags/golang_tag_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GolangTag, type: :liquid_tag do
 
     it "renders valid input" do
       template = generate_tag(valid_link)
-      expected = 'src="true"'
+      expected = 'src="#{valid_link}"'
       expect(template.render).to include(expected)
     end
 

--- a/spec/liquid_tags/golang_tag_spec.rb
+++ b/spec/liquid_tags/golang_tag_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe GolangTag, type: :liquid_tag do
+  describe "#link" do
+    let(:valid_link) { "https://play.golang.org/p/HmnNoBf0p1z" }
+    let(:missing_link) { "https://play.golang.org/p/HmnNoBf0p1z" }
+
+    def generate_tag(link)
+      Liquid::Template.register_tag("golang", GolangTag)
+      Liquid::Template.parse("{% golang #{link} %}")
+    end
+
+    it "accepts valid input" do
+      expect { generate_tag(valid_link) }.not_to raise_error
+    end
+
+    it "renders valid input" do
+      template = generate_tag(valid_link)
+      expected = 'src="https://play.golang.org/p/HmnNoBf0p1z"'
+      expect(template.render(nil)).to include(expected)
+    end
+
+    it "accepts only Kotlin Playground links" do
+      badurl = "https://example.com"
+      expect do
+        generate_new_liquid(badurl)
+      end.to raise_error(StandardError)
+
+      badurl = "not even an URL"
+      expect do
+        generate_new_liquid(badurl)
+      end.to raise_error(StandardError)
+    end
+
+    it "renders iframe" do
+      liquid = generate_tag(valid_link)
+      expect(liquid.render).to include("<iframe")
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
This PR will add a feature to liquid tags for Golang Playground support. The user will supply a Golang Playground URL:
`{% golang https://play.golang.org/p/HmnNoBf0p1z %}`

## Related Tickets & Documents
#8923 

## QA Instructions, Screenshots, Recordings

This is a Draft and there is some outstanding tasks left to do:
- [x] Add documentation to `app/views/pages/_editor_liquid_help.html.erb` DONE
- [x] Add documentation to `app/views/pages/_editor_guide_text.html.erb` DONE
- [x] Add feature to validate the user inputted url string as valid. 

## Added tests?
- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.dev.to
- [ ] readme
- [ ] no documentation needed

## What gif best describes this PR or how it makes you feel?

![Hello HI](https://media.giphy.com/media/Xev2JdopBxGj1LuGvt/giphy.gif)
