### PR TITLE
Add ProfileField model

### DIFF
--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -1,0 +1,12 @@
+class ProfileField < ApplicationRecord
+  # Key names follow the Rails form helpers
+  enum input_type: {
+    text_field: 0,
+    text_area: 1,
+    check_box: 2,
+    color_field: 3
+  }
+
+  validates :label, presence: true, uniqueness: { case_sensitive: false }
+  validates :active, presence: true
+end

--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -8,5 +8,5 @@ class ProfileField < ApplicationRecord
   }
 
   validates :label, presence: true, uniqueness: { case_sensitive: false }
-  validates :active, presence: true
+  validates :active, inclusion: { in: [true, false] }
 end

--- a/db/migrate/20200731041554_create_profile_fields.rb
+++ b/db/migrate/20200731041554_create_profile_fields.rb
@@ -1,0 +1,14 @@
+class CreateProfileFields < ActiveRecord::Migration[6.0]
+  def change
+    create_table :profile_fields do |t|
+      enable_extension("citext")
+
+      t.citext :label, null: false, index: { unique: true }
+      t.integer :input_type, null: false, default: 0
+      t.string :placeholder_text
+      t.boolean :active, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_31_033002) do
+ActiveRecord::Schema.define(version: 2020_07_31_041554) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
@@ -918,6 +919,16 @@ ActiveRecord::Schema.define(version: 2020_07_31_033002) do
     t.string "prompt_html"
     t.string "prompt_markdown"
     t.datetime "updated_at", null: false
+  end
+
+  create_table "profile_fields", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.integer "input_type", default: 0, null: false
+    t.citext "label", null: false
+    t.string "placeholder_text"
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["label"], name: "index_profile_fields_on_label", unique: true
   end
 
   create_table "profile_pins", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1132,6 +1132,16 @@ ActiveRecord::Schema.define(version: 2020_07_31_041554) do
     t.index ["blocked_id", "blocker_id"], name: "index_user_blocks_on_blocked_id_and_blocker_id", unique: true
   end
 
+  create_table "user_optional_fields", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "label", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.string "value", null: false
+    t.index ["label", "user_id"], name: "index_user_optional_fields_on_label_and_user_id", unique: true
+    t.index ["user_id"], name: "index_user_optional_fields_on_user_id"
+  end
+
   create_table "user_subscriptions", force: :cascade do |t|
     t.bigint "author_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -1353,6 +1363,7 @@ ActiveRecord::Schema.define(version: 2020_07_31_041554) do
   add_foreign_key "tag_adjustments", "users", on_delete: :cascade
   add_foreign_key "user_blocks", "users", column: "blocked_id"
   add_foreign_key "user_blocks", "users", column: "blocker_id"
+  add_foreign_key "user_optional_fields", "users"
   add_foreign_key "user_subscriptions", "users", column: "author_id"
   add_foreign_key "user_subscriptions", "users", column: "subscriber_id"
   add_foreign_key "users_roles", "users", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1132,16 +1132,6 @@ ActiveRecord::Schema.define(version: 2020_07_31_041554) do
     t.index ["blocked_id", "blocker_id"], name: "index_user_blocks_on_blocked_id_and_blocker_id", unique: true
   end
 
-  create_table "user_optional_fields", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "label", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.string "value", null: false
-    t.index ["label", "user_id"], name: "index_user_optional_fields_on_label_and_user_id", unique: true
-    t.index ["user_id"], name: "index_user_optional_fields_on_user_id"
-  end
-
   create_table "user_subscriptions", force: :cascade do |t|
     t.bigint "author_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -1363,7 +1353,6 @@ ActiveRecord::Schema.define(version: 2020_07_31_041554) do
   add_foreign_key "tag_adjustments", "users", on_delete: :cascade
   add_foreign_key "user_blocks", "users", column: "blocked_id"
   add_foreign_key "user_blocks", "users", column: "blocker_id"
-  add_foreign_key "user_optional_fields", "users"
   add_foreign_key "user_subscriptions", "users", column: "author_id"
   add_foreign_key "user_subscriptions", "users", column: "subscriber_id"
   add_foreign_key "users_roles", "users", on_delete: :cascade

--- a/spec/factories/profile_fields.rb
+++ b/spec/factories/profile_fields.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :profile_field do
+    label { "Email" }
+    input_type { :text_field }
+    placeholder_text { "john.doe@example.com" }
+    active { true }
+  end
+end

--- a/spec/factories/profile_fields.rb
+++ b/spec/factories/profile_fields.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :profile_field do
-    label { "Email" }
+    sequence(:label) { |n| "Email #{n}" }
     input_type { :text_field }
     placeholder_text { "john.doe@example.com" }
     active { true }

--- a/spec/models/profile_field_spec.rb
+++ b/spec/models/profile_field_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe ProfileField, type: :model do
+  let(:profile_field) { create(:profile_field) }
+
+  describe "validations" do
+    describe "builtin validations" do
+      subject { profile_field }
+
+      it { is_expected.to validate_presence_of(:label) }
+      it { is_expected.to validate_uniqueness_of(:label).case_insensitive }
+      it { is_expected.to validate_presence_of(:active) }
+    end
+  end
+end

--- a/spec/models/profile_field_spec.rb
+++ b/spec/models/profile_field_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ProfileField, type: :model do
 
       it { is_expected.to validate_presence_of(:label) }
       it { is_expected.to validate_uniqueness_of(:label).case_insensitive }
-      it { is_expected.to validate_presence_of(:active) }
+      it { is_expected.to validate_inclusion_of(:active).in_array([true, false]) }
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR introduces a new `ProfileField` model which will be used to store the list of available profile fields.

Notes:

* The list of columns is most likely not complete yet, so this table may get updated in future PRs.
* Integers should be fine as primary keys for this model since I don't expect any Forem to have more than 2 billion profile fields (2,147,483,647 is the max for int IDs).
* For the same reason, there are no indexes apart from the unique index on `label`. Fields numbers should be low enough that the query planner would use a seq scan over an index scan anyway.

## Related Tickets & Documents

Part of #6994

## QA Instructions, Screenshots, Recordings

Not much to QA yet, this just adds the model.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [X] no documentation needed
