### PR TITLE
Award badges asynchronously in internal

### DIFF
--- a/app/controllers/internal/badges_controller.rb
+++ b/app/controllers/internal/badges_controller.rb
@@ -11,8 +11,9 @@ module Internal
 
       usernames = permitted_params[:usernames].split(/\s*,\s*/)
       message = permitted_params[:message_markdown].presence || "Congrats!"
-      BadgeRewarder.award_badges(usernames, permitted_params[:badge], message)
-      flash[:success] = "BadgeRewarder task ran!"
+      BadgeAchievements::BadgeAwardWorker.perform_async(usernames, permitted_params[:badge], message)
+
+      flash[:success] = "Badges are being rewarded. The task will finish shortly."
       redirect_to internal_badges_url
     rescue ArgumentError => e
       flash[:danger] = e.message

--- a/app/workers/badge_achievements/badge_award_worker.rb
+++ b/app/workers/badge_achievements/badge_award_worker.rb
@@ -1,0 +1,11 @@
+module BadgeAchievements
+  class BadgeAwardWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority, retry: 10
+
+    def perform(usernames, badge_slug, message)
+      BadgeRewarder.award_badges(usernames, badge_slug, message)
+    end
+  end
+end

--- a/spec/requests/internal/badges_spec.rb
+++ b/spec/requests/internal/badges_spec.rb
@@ -17,32 +17,33 @@ RSpec.describe "/internal/badges", type: :request do
     end
 
     it "awards badges" do
-      expect do
-        post internal_badges_award_badges_path, params: {
-          badge: badge.slug,
-          usernames: "#{user.username}, #{user2.username}",
-          message_markdown: "Hinder me? Thou fool. No living man may hinder me!"
-        }
-      end.to change { user.badges.count }.by(1).and change { user2.badges.count }.by(1)
+      allow(BadgeAchievements::BadgeAwardWorker).to receive(:perform_async)
+      post internal_badges_award_badges_path, params: {
+        badge: badge.slug,
+        usernames: "#{user.username}, #{user2.username}",
+        message_markdown: "Hinder me? Thou fool. No living man may hinder me!"
+      }
+      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(badge.slug, "#{user.username}, #{user2.username}", "Hinder me? Thou fool. No living man may hinder me!")
+      expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
     it "awards badges without a message" do
-      expect do
-        post internal_badges_award_badges_path, params: {
-          badge: badge.slug,
-          usernames: "#{user.username}, #{user2.username}",
-          message_markdown: ""
-        }
-      end.to change { user.badges.count }.by(1).and change { user2.badges.count }.by(1)
+      allow(BadgeAchievements::BadgeAwardWorker).to receive(:perform_async)
+      post internal_badges_award_badges_path, params: {
+        badge: badge.slug,
+        usernames: "#{user.username}, #{user2.username}",
+        message_markdown: ""
+      }
+      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(badge.slug, "#{user.username}, #{user2.username}", "")
+      expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
     it "does not award a badge and raises an error if a badge is not specified" do
-      expect do
-        post internal_badges_award_badges_path, params: {
-          usernames: "#{user.username}, #{user2.username}",
-          message_markdown: ""
-        }
-      end.to change { user.badges.count }.by(0)
+      post internal_badges_award_badges_path, params: {
+        usernames: "#{user.username}, #{user2.username}",
+        message_markdown: ""
+      }
+      expect(BadgeAchievements::BadgeAwardWorker).not_to have_received(:perform_async).with(badge.slug, "#{user.username}, #{user2.username}", "")
     end
   end
 end

--- a/spec/requests/internal/badges_spec.rb
+++ b/spec/requests/internal/badges_spec.rb
@@ -11,39 +11,46 @@ RSpec.describe "/internal/badges", type: :request do
     let(:user) { create(:user) }
     let(:user2) { create(:user) }
     let(:badge) { create(:badge) }
+    let(:usernames_string) { "#{user.username}, #{user2.username}" }
+    let(:usernames_array) { [user.username, user2.username] }
 
     before do
       sign_in admin
+      allow(BadgeAchievements::BadgeAwardWorker).to receive(:perform_async)
     end
 
     it "awards badges" do
       allow(BadgeAchievements::BadgeAwardWorker).to receive(:perform_async)
       post internal_badges_award_badges_path, params: {
         badge: badge.slug,
-        usernames: "#{user.username}, #{user2.username}",
+        usernames: usernames_string,
         message_markdown: "Hinder me? Thou fool. No living man may hinder me!"
       }
-      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(badge.slug, "#{user.username}, #{user2.username}", "Hinder me? Thou fool. No living man may hinder me!")
+      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(
+        usernames_array, badge.slug, "Hinder me? Thou fool. No living man may hinder me!"
+      )
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
-    it "awards badges without a message" do
+    it "awards badges with default a message" do
       allow(BadgeAchievements::BadgeAwardWorker).to receive(:perform_async)
       post internal_badges_award_badges_path, params: {
         badge: badge.slug,
-        usernames: "#{user.username}, #{user2.username}",
+        usernames: usernames_string,
         message_markdown: ""
       }
-      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(badge.slug, "#{user.username}, #{user2.username}", "")
+      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(usernames_array, badge.slug,
+                                                                                        "Congrats!")
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
     it "does not award a badge and raises an error if a badge is not specified" do
       post internal_badges_award_badges_path, params: {
-        usernames: "#{user.username}, #{user2.username}",
+        usernames: usernames_string,
         message_markdown: ""
       }
-      expect(BadgeAchievements::BadgeAwardWorker).not_to have_received(:perform_async).with(badge.slug, "#{user.username}, #{user2.username}", "")
+      expect(BadgeAchievements::BadgeAwardWorker).not_to have_received(:perform_async).with(usernames_array,
+                                                                                            badge.slug, "")
     end
   end
 end

--- a/spec/workers/badge_achievements/badge_award_worker_spec.rb
+++ b/spec/workers/badge_achievements/badge_award_worker_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe BadgeAchievements::BadgeAwardWorker, type: :worker do
+  let(:worker) { subject }
+  let(:badge_rewarder) { BadgeRewarder }
+
+  # passing in a random badge_achievement_id argument since the worker itself won't be executed
+  include_examples "#enqueues_on_correct_queue", "high_priority", [456]
+
+  describe "#perform_now" do
+    before do
+      allow(badge_rewarder).to receive(:award_badges)
+    end
+
+    context "with badge achievement" do
+      it "sends badge email" do
+        worker.perform("jess", "test", "yo")
+
+        expect(badge_rewarder).to have_received(:award_badges).with("jess", "test", "yo")
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we reward badges via `/internal/badges` it can time out with too many usernames. This is a fairly common occurrence. This pull request moves the job to the background so the request will not time out.