### PR TITLE
Prevent signing up with no email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -123,6 +123,7 @@ class User < ApplicationRecord
   validates :dribbble_url, length: { maximum: 100 }, allow_blank: true, format: DRIBBBLE_URL_REGEXP
   validates :editor_version, inclusion: { in: EDITORS, message: MESSAGES[:invalid_editor_version] }
   validates :email, length: { maximum: 50 }, email: true, allow_nil: true
+  validates :email, presence: true, unless: :persisted?
   validates :email, uniqueness: { allow_nil: true, case_sensitive: false }, if: :email_changed?
   validates :employer_name, :employer_url, length: { maximum: 100 }
   validates :employment_title, :education, :location, length: { maximum: 100 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,8 @@ class User < ApplicationRecord
     invalid_config_navbar: "%<value>s is not a valid navbar value",
     invalid_config_theme: "%<value>s is not a valid theme",
     invalid_editor_version: "%<value>s must be either v1 or v2",
-    reserved_username: "username is reserved"
+    reserved_username: "username is reserved",
+    blank_email: "can't be blank. Your social account must have an email associated with it."
   }.freeze
 
   attr_accessor :scholar_email, :new_note, :note_for_current_role, :user_status, :pro, :merge_user_id,
@@ -123,7 +124,7 @@ class User < ApplicationRecord
   validates :dribbble_url, length: { maximum: 100 }, allow_blank: true, format: DRIBBBLE_URL_REGEXP
   validates :editor_version, inclusion: { in: EDITORS, message: MESSAGES[:invalid_editor_version] }
   validates :email, length: { maximum: 50 }, email: true, allow_nil: true
-  validates :email, presence: true, unless: :persisted?
+  validates :email, presence: { message: MESSAGES[:blank_email] }, unless: :persisted?
   validates :email, uniqueness: { allow_nil: true, case_sensitive: false }, if: :email_changed?
   validates :employer_name, :employer_url, length: { maximum: 100 }
   validates :employment_title, :education, :location, length: { maximum: 100 }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -284,6 +284,7 @@ RSpec.describe User, type: :model do
 
     describe "#email" do
       it "sets email to nil if empty" do
+        user.save
         user.email = ""
         user.validate!
         expect(user.email).to eq(nil)
@@ -599,8 +600,6 @@ RSpec.describe User, type: :model do
   end
 
   context "when callbacks are triggered before and after create" do
-    let(:user) { create(:user, email: nil) }
-
     describe "#language_settings" do
       it "sets correct language_settings by default" do
         expect(user.language_settings).to eq("preferred_languages" => %w[en])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -165,6 +165,15 @@ RSpec.describe User, type: :model do
       it { is_expected.to validate_url_of(:website_url) }
     end
 
+    it "validates the presence of the email if the user has not persisted" do
+      user = build(:user, email: "")
+      user.valid?
+      expect(user.errors[:email]).to include("can't be blank")
+      user.email = nil
+      user.valid?
+      expect(user.errors[:email]).to include("can't be blank")
+    end
+
     it "validates username against reserved words" do
       user = build(:user, username: "readinglist")
       expect(user).not_to be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -168,10 +168,10 @@ RSpec.describe User, type: :model do
     it "validates the presence of the email if the user has not persisted" do
       user = build(:user, email: "")
       user.valid?
-      expect(user.errors[:email]).to include("can't be blank")
+      expect(user.errors[:email][0]).to include("can't be blank")
       user.email = nil
       user.valid?
-      expect(user.errors[:email]).to include("can't be blank")
+      expect(user.errors[:email][0]).to include("can't be blank")
     end
 
     it "validates username against reserved words" do

--- a/spec/requests/user/user_destroy_spec.rb
+++ b/spec/requests/user/user_destroy_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "UserDestroy", type: :request do
     end
 
     it "offers to set an email when user doesn't have an email" do
-      shallow_user = create(:user, email: nil)
+      shallow_user = create(:user)
+      shallow_user.update(email: nil)
       sign_in shallow_user
       get "/settings/account"
       expect(response.body).not_to include("Deleting your account will")
@@ -44,10 +45,11 @@ RSpec.describe "UserDestroy", type: :request do
     end
 
     context "when user doesn't have an email" do
-      let!(:shallow_user) { create(:user, email: nil) }
+      let!(:shallow_user) { create(:user) }
 
       before do
         sign_in shallow_user
+        shallow_user.update(email: nil)
       end
 
       it "redirects to account page" do
@@ -97,9 +99,10 @@ RSpec.describe "UserDestroy", type: :request do
     end
 
     context "when user doesn't have an email" do
-      let!(:shallow_user) { create(:user, email: nil) }
+      let!(:shallow_user) { create(:user) }
 
       before do
+        shallow_user.update(email: nil)
         sign_in shallow_user
       end
 

--- a/spec/services/users/estimate_default_language_spec.rb
+++ b/spec/services/users/estimate_default_language_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe Users::EstimateDefaultLanguage, type: :service do
   it "estimates default language when the email is nil" do
-    no_email_user = create(:user, email: nil)
+    no_email_user = create(:user)
+    no_email_user.update(email: nil)
     described_class.call(no_email_user)
     no_email_user.reload
     expect(no_email_user.estimated_default_language).to eq(nil)
@@ -60,7 +61,8 @@ RSpec.describe Users::EstimateDefaultLanguage, type: :service do
   end
 
   it "sets correct language_settings for no lang" do
-    user = create(:user, email: nil)
+    user = create(:user)
+    user.update(email: nil)
     described_class.call(user)
     expect(user.language_settings).to eq("preferred_languages" => %w[en], "estimated_default_language" => nil)
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We have a bug where a user might be able to create an account but their email doesn't come through. This adds a validation to prevent that, and lets the user know what the issue is.

## QA Instructions, Screenshots, Recordings
1. Go to rails console
2. Instantiate a user: `user = User.new(email: "")`
3. See if the user is valid `user.valid?`
4. Should return false

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![A man asks a horse, "Are you the gatekeeper?"](https://media.giphy.com/media/xT8qBmNrpCOTWvkQi4/giphy.gif)
