### PR TITLE
Bug Fix:Rename Listing Search Field in Elasticsearch to Fix Searching

### DIFF
--- a/app/services/search/query_builders/listing.rb
+++ b/app/services/search/query_builders/listing.rb
@@ -18,7 +18,7 @@ module Search
       ].freeze
 
       QUERY_KEYS = %i[
-        classified_listing_search
+        listing_search
       ].freeze
 
       DEFAULT_PARAMS = {

--- a/config/elasticsearch/mappings/listings.json
+++ b/config/elasticsearch/mappings/listings.json
@@ -20,7 +20,7 @@
     },
     "body_markdown": {
       "type": "text",
-      "copy_to": "classified_listing_search"
+      "copy_to": "listing_search"
     },
     "bumped_at": {
       "type": "date"
@@ -28,7 +28,7 @@
     "category": {
       "type": "keyword"
     },
-    "classified_listing_search": {
+    "listing_search": {
       "type": "text"
     },
     "contact_via_connect": {
@@ -42,7 +42,7 @@
     },
     "location": {
       "type": "text",
-      "copy_to": "classified_listing_search",
+      "copy_to": "listing_search",
       "fields": {
         "raw": {
           "type": "keyword"
@@ -57,7 +57,7 @@
     },
     "slug": {
       "type": "text",
-      "copy_to": "classified_listing_search",
+      "copy_to": "listing_search",
       "fields": {
         "raw": {
           "type": "keyword"
@@ -66,11 +66,11 @@
     },
     "tags": {
       "type": "keyword",
-      "copy_to": "classified_listing_search"
+      "copy_to": "listing_search"
     },
     "title": {
       "type": "text",
-      "copy_to": "classified_listing_search",
+      "copy_to": "listing_search",
       "fields": {
         "raw": {
           "type": "keyword"

--- a/lib/data_update_scripts/20200803142830_reindex_listing_search_column.rb
+++ b/lib/data_update_scripts/20200803142830_reindex_listing_search_column.rb
@@ -1,9 +1,9 @@
 module DataUpdateScripts
-  class IndexListingsToElasticsearch
+  class ReindexListingSearchColumn
     def run
       # Choose to do inline so development envs are ready immediately after
       # this is run
-      # Listing.find_each(&:index_to_elasticsearch_inline)
+      Listing.find_each(&:index_to_elasticsearch_inline)
     end
   end
 end

--- a/spec/lib/data_update_scripts/reindex_listing_search_column_spec.rb
+++ b/spec/lib/data_update_scripts/reindex_listing_search_column_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
-require Rails.root.join("lib/data_update_scripts/20200217215802_index_listings_to_elasticsearch.rb")
+require Rails.root.join("lib/data_update_scripts/20200803142830_reindex_listing_search_column.rb")
 
-describe DataUpdateScripts::IndexListingsToElasticsearch, elasticsearch: "Listing" do
+describe DataUpdateScripts::ReindexListingSearchColumn, elasticsearch: "Listing" do
   it "indexes listings to Elasticsearch" do
     listing = create(:listing)
     expect { listing.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)

--- a/spec/services/search/query_builders/listing_spec.rb
+++ b/spec/services/search/query_builders/listing_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe Search::QueryBuilders::Listing, type: :service do
     end
 
     it "applies QUERY_KEYS from params" do
-      params = { classified_listing_search: "test" }
+      params = { listing_search: "test" }
       filter = described_class.new(params: params)
       expected_query = [{
         "simple_query_string" => {
           "query" => "test*",
-          "fields" => [:classified_listing_search],
+          "fields" => [:listing_search],
           "lenient" => true,
           "analyze_wildcard" => true
         }
@@ -71,10 +71,10 @@ RSpec.describe Search::QueryBuilders::Listing, type: :service do
 
     it "applies QUERY_KEYS, TERM_KEYS, and RANGE_KEYS from params" do
       Timecop.freeze(Time.current) do
-        params = { classified_listing_search: "test", bumped_at: Time.current, category: "cfp" }
+        params = { listing_search: "test", bumped_at: Time.current, category: "cfp" }
         filter = described_class.new(params: params)
         expected_query = [{
-          "simple_query_string" => { "query" => "test*", "fields" => [:classified_listing_search], "lenient" => true,
+          "simple_query_string" => { "query" => "test*", "fields" => [:listing_search], "lenient" => true,
                                      "analyze_wildcard" => true }
         }]
         expected_filters = [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Listing search is currently broken because the field in Elasticsearch that we want to query against is `classified_listing_search` but the field we are searching in the view is `listing_search` thanks to simplifying the naming a little while back. This PR updates the Elasticsearch field to match what we are searching in the view. 

## Related Tickets & Documents
closes #9583 

## QA Instructions, Screenshots, Recordings
- pull down branch
- run `bin/setup`
- Searching listings

## Added tests?
- [x] yes


![alt_text](https://media2.giphy.com/media/aWxbEGCqkiZFK/giphy.gif?cid=ecf05e47k204lpd8mjws7zpdfi9izv21e72xu55lafpa9cmm&rid=giphy.gif)
