### PR TITLE
Update Users, Follows, Identities, and Reaction Pks to Bigints

### DIFF
--- a/db/migrate/20200803193841_update_user_follow_identity_reaction_pks_to_bigints.rb
+++ b/db/migrate/20200803193841_update_user_follow_identity_reaction_pks_to_bigints.rb
@@ -1,0 +1,70 @@
+class UpdateUserFollowIdentityReactionPksToBigints < ActiveRecord::Migration[6.0]
+  def up
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.follows")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE follows
+          ALTER COLUMN id TYPE bigint,
+          ALTER COLUMN followable_id TYPE bigint,
+          ALTER COLUMN follower_id TYPE bigint
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.identities")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE identities
+          ALTER COLUMN id TYPE bigint,
+          ALTER COLUMN user_id TYPE bigint
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.reactions")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE reactions
+          ALTER COLUMN id TYPE bigint,
+          ALTER COLUMN reactable_id TYPE bigint,
+          ALTER COLUMN user_id TYPE bigint
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.users")
+    safety_assured { change_column :users, :id, :bigint }
+  end
+
+  def down
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.follows")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE follows
+          ALTER COLUMN id TYPE int,
+          ALTER COLUMN followable_id TYPE int,
+          ALTER COLUMN follower_id TYPE int
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.identities")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE identities
+          ALTER COLUMN id TYPE int,
+          ALTER COLUMN user_id TYPE int
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.reactions")
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        ALTER TABLE reactions
+          ALTER COLUMN id TYPE int,
+          ALTER COLUMN reactable_id TYPE int,
+          ALTER COLUMN user_id TYPE int
+      SQL
+    )
+
+    ActiveRecord::Base.connection.execute("DROP VIEW IF EXISTS hypershield.users")
+    safety_assured { change_column :users, :id, :int }
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_31_033002) do
+ActiveRecord::Schema.define(version: 2020_08_03_193841) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -544,12 +544,12 @@ ActiveRecord::Schema.define(version: 2020_07_31_033002) do
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
-  create_table "follows", id: :serial, force: :cascade do |t|
+  create_table "follows", force: :cascade do |t|
     t.boolean "blocked", default: false, null: false
     t.datetime "created_at"
-    t.integer "followable_id", null: false
+    t.bigint "followable_id", null: false
     t.string "followable_type", null: false
-    t.integer "follower_id", null: false
+    t.bigint "follower_id", null: false
     t.string "follower_type", null: false
     t.float "points", default: 1.0
     t.string "subscription_status", default: "all_articles", null: false
@@ -621,7 +621,7 @@ ActiveRecord::Schema.define(version: 2020_07_31_033002) do
     t.index ["name"], name: "index_html_variants_on_name", unique: true
   end
 
-  create_table "identities", id: :serial, force: :cascade do |t|
+  create_table "identities", force: :cascade do |t|
     t.text "auth_data_dump"
     t.datetime "created_at", null: false
     t.string "provider"
@@ -629,7 +629,7 @@ ActiveRecord::Schema.define(version: 2020_07_31_033002) do
     t.string "token"
     t.string "uid"
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.bigint "user_id"
     t.index ["provider", "uid"], name: "index_identities_on_provider_and_uid", unique: true
     t.index ["provider", "user_id"], name: "index_identities_on_provider_and_user_id", unique: true
   end
@@ -945,15 +945,15 @@ ActiveRecord::Schema.define(version: 2020_07_31_033002) do
     t.index ["user_id"], name: "index_rating_votes_on_user_id"
   end
 
-  create_table "reactions", id: :serial, force: :cascade do |t|
+  create_table "reactions", force: :cascade do |t|
     t.string "category"
     t.datetime "created_at", null: false
     t.float "points", default: 1.0
-    t.integer "reactable_id"
+    t.bigint "reactable_id"
     t.string "reactable_type"
     t.string "status", default: "valid"
     t.datetime "updated_at", null: false
-    t.integer "user_id"
+    t.bigint "user_id"
     t.index ["category"], name: "index_reactions_on_category"
     t.index ["created_at"], name: "index_reactions_on_created_at"
     t.index ["points"], name: "index_reactions_on_points"
@@ -1136,7 +1136,7 @@ ActiveRecord::Schema.define(version: 2020_07_31_033002) do
     t.index ["user_subscription_sourceable_type", "user_subscription_sourceable_id"], name: "index_on_user_subscription_sourcebable_type_and_id"
   end
 
-  create_table "users", id: :serial, force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.integer "articles_count", default: 0, null: false
     t.string "available_for"
     t.integer "badge_achievements_count", default: 0, null: false


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Below is the timing data for each of the migration update statements. Since these migrations are relatively fast I am proposing we just run them and take the brief outage hit. Then the longer table migrations (notifications, ahoy_messages, and articles) we pair with a warning broadcast banner about what exactly is happening. For this group of migrations, since they are so short, I think we could use a single banner stating service might be degraded for a couple of minutes.
```
# follows
# seconds:65.44
# follow buttons break
# User dashboard breaks

# identities
# seconds:27.37964816301246
# Can't log in

# reactions
# seconds:30.13
# Ability to react and see counts breaks

# users
# seconds:19.704
# everything breaks
```
## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43004918


![alt_text](https://media.tenor.com/images/14b636b53adb4f65f99ff7d42a86672b/tenor.gif)
