### PR TITLE
Bug Fix:Redirect to Direct User Channel for Org Listings

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -7,7 +7,8 @@ class ListingsController < ApplicationController
       title processed_html tag_list category id user_id slug contact_via_connect location
     ],
     include: {
-      author: { only: %i[username name], methods: %i[username profile_image_90] }
+      author: { only: %i[username name], methods: %i[username profile_image_90] },
+      user: { only: %i[username], methods: %i[username] }
     }
   }.freeze
 

--- a/app/javascript/listings/__tests__/AllListings.test.jsx
+++ b/app/javascript/listings/__tests__/AllListings.test.jsx
@@ -14,10 +14,13 @@ const firstListing = {
   tags: ['go', 'git'],
   user_id: 1,
   author: {
-    name: 'Mrs. Yoko Christiansen',
-    username: 'mrschristiansenyoko',
+    name: 'Evil Corp Org',
+    username: 'evil_corp_org',
     profile_image_90:
       '/uploads/user/profile_image/7/4b1c980a-beb0-4a5f-b3f2-acc91adc503c.png',
+  },
+  user: {
+    username: 'mrschristiansenyoko',
   },
 };
 
@@ -37,6 +40,9 @@ const secondListing = {
     profile_image_90:
       '/uploads/user/profile_image/7/4b1c980a-beb0-4a5f-b3f2-acc91adc503c.png',
   },
+  user: {
+    username: 'fred',
+  },
 };
 
 const thirdListing = {
@@ -54,6 +60,9 @@ const thirdListing = {
     username: 'mrsjohnmack',
     profile_image_90:
       '/uploads/user/profile_image/7/4b1c980a-beb0-4a5f-b3f2-acc91adc503c.png',
+  },
+  user: {
+    username: 'mrsjohnmack',
   },
 };
 
@@ -121,11 +130,11 @@ describe('<AllListings />', () => {
     expect(gitTag.getAttribute('href')).toEqual('/listings?t=git');
 
     // listing author
-    const listing1Author = getByText('Mrs. Yoko Christiansen', {
+    const listing1Author = getByText('Evil Corp Org', {
       selector: '[data-testid="single-listing-20"] a',
     });
 
-    expect(listing1Author.getAttribute('href')).toEqual('/mrschristiansenyoko');
+    expect(listing1Author.getAttribute('href')).toEqual('/evil_corp_org');
 
     // 2nd listing
     getByTestId('single-listing-21');

--- a/app/javascript/listings/listings.jsx
+++ b/app/javascript/listings/listings.jsx
@@ -178,7 +178,7 @@ export class Listings extends Component {
     formData.append('message', `**re: ${openedListing.title}** ${message}`);
     formData.append('controller', 'chat_channels');
 
-    const destination = `/connect/@${openedListing.author.username}`;
+    const destination = `/connect/@${openedListing.user.username}`;
     const metaTag = document.querySelector("meta[name='csrf-token']");
     window
       .fetch('/chat_channels/create_chat', {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This bug has been around for a long time but I never really felt the urgency to dig into it since it didn't occur that often. Finally while testing another branch I hit a 500 that caused me to zero in on the cause of this bug.  The issue here is that when a listing is owned by an organization then the org is considered the author. This means we try to search for the org's slug when trying to find the chat channel created from the message which is incorrect. What we really want is the username for the user who created the listing, not the org's slug. 

https://app.honeybadger.io/fault/66984/e8a80728dc5294c09fc37ca2d0c8f5f2
```
NoMethodError: undefined method `chat_channel_memberships' for nil:NilClass
 chat_channels_controller.rb  241 render_channels_html(...)
[PROJECT_ROOT]/app/controllers/chat_channels_controller.rb:241:in `render_channels_html'
239            end
240     chat_channel = ChatChannel.find_by(slug: slug)
241     membership = chat_channel.chat_channel_memberships.find_by(user_id: current_user.id)
242     @active_channel = membership&.status == "active" ? chat_channel : nil
```

## Added tests?

- [x] kinda, I updated a test to ensure we handled orgs correctly but I did not know how to write a test to specifically look at that connect URL after submit was hit. Suggestions welcome! 


![alt_text](https://media.tenor.com/images/29b7b302bc95e5f7a99198097c46cd24/tenor.gif)
