### PR TITLE
Add redirects from docs.dev.to to docs.forem.com

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -7,3 +7,22 @@
 
 [build]
   command = "make"
+[[redirects]]
+from = "http://docs.dev.to"
+to = "http://docs.forem.com"
+status = 301
+
+[[redirects]]
+from = "https://docs.dev.to"
+to = "https://docs.forem.com"
+status = 301
+
+[[redirects]]
+from = "http://docs.dev.to/*"
+to = "http://docs.forem.com/*"
+status = 301
+
+[[redirects]]
+from = "https://docs.dev.to/*"
+to = "https://docs.forem.com/*"
+status = 301


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This redirects docs.dev.to to docs.forem.com properly. Will update for Storybook too if the deploy preview works.

## QA Instructions, Screenshots, Recordings

1. Will update once deploy preview is available