### PR TITLE
Spec Optimization:Remove Travis Cruft and Bundle Locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ env:
 branches:
   only:
     - master
+install: true
 script:
   - date --rfc-3339=seconds
   - nvm install
@@ -56,6 +57,7 @@ script:
   - sudo systemctl start elasticsearch
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
+  - gem update --system
   - bundle config set path 'vendor/bundle'
   - bundle install --local --jobs=2
   - yarn install --frozen-lockfile

--- a/bin/travis-bundle-install
+++ b/bin/travis-bundle-install
@@ -1,0 +1,3 @@
+#!/bin/bash
+bundle config set --path 'vendor/cache'
+bundle install --local --jobs=3


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
I noticed recently that we are running bundle install twice in our builds and the first time we are not doing it locally. Travis kicks off a bundle on its own. To get it to bundle locally we have to add a `before_install` step to ensure that our Gemfile vendor path is set before that command runs.


![alt_text](gif_link)
