### PR TITLE
Add in a VOLUME directive in the Container file.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -49,6 +49,8 @@ RUN mkdir -p "${APP_HOME}"/public/{assets,images,packs,podcasts,uploads}
 
 COPY . "${APP_HOME}"
 
+VOLUME "${APP_HOME}"/public/
+
 ENTRYPOINT ["./scripts/entrypoint.sh"]
 
 CMD ["bundle", "exec", "rails","server","-b","0.0.0.0","-p","3000"]


### PR DESCRIPTION
This lets other containers like nginx/Openresty  mount the `/opt/apps/forem/public`
directory to get at static files like 500.html.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://giffiles.alphacoders.com/205/205915.gif)
