### PR TITLE
Conditionally remove `no-cache` from Fastly headers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   include SessionCurrentUser
   include ValidRequest
   include Pundit
-  include FastlyHeaders
+  include CachingHeaders
   include ImageUploads
   include VerifySetupCompleted
 

--- a/app/controllers/concerns/caching_headers.rb
+++ b/app/controllers/concerns/caching_headers.rb
@@ -18,7 +18,8 @@ module CachingHeaders
 
     # TODO: [@forem/delightful]: Once we've tested that removing `no-cache` from the Cache-Control headers
     # does not adversely affect fastly, we should remove this specific check entirely.
-    article_requested = request.env["REQUEST_PATH"].include?("the-3-biggest-misconceptions-about-diversity-3hkm")
+    article_requested = request.env["REQUEST_PATH"].present? &&
+      request.env["REQUEST_PATH"].include?("the-3-biggest-misconceptions-about-diversity-3hkm")
     cache_control = if article_requested
                       "public, max-age=86400"
                     else

--- a/app/controllers/concerns/caching_headers.rb
+++ b/app/controllers/concerns/caching_headers.rb
@@ -1,4 +1,4 @@
-module FastlyHeaders
+module CachingHeaders
   extend ActiveSupport::Concern
 
   # The following is from the now deprecated fastly-rails gem
@@ -12,11 +12,20 @@ module FastlyHeaders
   # custom config example:
   #  {cache_control: 'public, no-cache, maxage=xyz', surrogate_control: 'max-age: 100'}
   def set_cache_control_headers(
-    max_age = 1.day.to_i, cache_control: "public, no-cache",
+    max_age = 1.day.to_i,
     surrogate_control: nil, stale_while_revalidate: nil, stale_if_error: 26_400
   )
-    request.session_options[:skip] = true # no cookies
 
+    # TODO: [@forem/delightful]: Once we've tested that removing `no-cache` from the Cache-Control headers
+    # does not adversely affect fastly, we should remove this specific check entirely.
+    article_requested = request.env["REQUEST_PATH"].include?("the-3-biggest-misconceptions-about-diversity-3hkm")
+    cache_control = if article_requested
+                      "public, max-age=86400"
+                    else
+                      "public, no-cache"
+                    end
+
+    request.session_options[:skip] = true # no cookies
     response.headers["Cache-Control"] = cache_control
 
     response.headers["Surrogate-Control"] = surrogate_control.presence || build_surrogate_control(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Experiment

## Description

As we work to moving away from our strict dependency on Fastly, we want to be able to support Nginx as an alternate mode for caching. We have done work to set this up in our [LFSS repo](https://github.com/forem/lfss) and we also have figured out how to property cache on Nginx by relying on Rails' `Cache-Control` headers.

At first, we thought that we needed to create two separate code paths to handle the two different types of headers: one code path for Fastly-specific headers, and another for Nginx-specific headers:

```ruby
cache_control_headers = if fastly_enabled?
                                             "public, no-cache"
                                           else
                                             # Default to Nginx headers if Fastly is not enabled
                                             "public, max-age=86400"
                                           end
```

As the code snippet above shows, the difference between Nginx and Fastly is `no-cache` existing in one, and `max-age` existing in another. After doing some further investigation, we think that it actually might be possible to use the _same_ exact headers for both. The `max-age` option should be able to be used for both Nginx and Fastly, because we send `max-age` along in [the `Surrogate-Control` header](https://github.com/forem/forem/blob/master/app/controllers/concerns/fastly_headers.rb#L36-L42) to Fastly. The Fastly docs [explain](https://docs.fastly.com/en/guides/configuring-caching#applying-different-cache-rules-for-fastly-and-browsers) that:
> Except for when the Cache-Control header is set to private, the Surrogate-Control header takes priority over Cache-Control, but unlike Cache-Control it is stripped so the browsers don't see it.

Which should mean that it should be safe to send `max-age` along to Fastly, since Fastly will just use the `max_age` that we send in the `Surrogate-Control` header anyways.

This leaves just the difference of `no-cache`. Fastly's [documentation](https://docs.fastly.com/en/guides/configuring-caching#do-not-cache) suggests that `no-cache` isn't even used:
> Fastly does not currently respect no-store or no-cache directives. Including either or both of these in a Cache-Control header has no effect on Fastly's caching decision, unless you alter this behavior using custom VCL.

Which _should_ mean that it should be safe to remove! But we want to test that this is actually true and that it will not cause any unintended consequences that inadvertently affects all of our static content caching 😬.

Our approach here is to send the "Nginx" configured header to Fastly _for just one single article_, and see how it behaves. We've chosen one of @atsmith813's [old articles](https://dev.to/atsmith813/the-3-biggest-misconceptions-about-diversity-3hkm) that is stale enough/doesn't have have high activity currently. Once we deploy this, we'll use [Fastly Fiddle](https://fiddle.fastlydemo.net) to bust the cache for this article, and then request it again. We'll check to see if we get a cache `MISS` followed by a cache `HIT`, which will prove to us that it is safe to use the same header for _both_ caching strategies (Fastly _and_ Nginx). Ultimately, this experiement should allow us to send exactly one header to both services:

```ruby
response.headers["Cache-Control"] = "public, max-age=86400"
```

Another benefit here is that, if our hypothesis here is confirmed, we won't need to do a bunch of checks and have divergent code paths for Fastly-specific headers versus Nginx-specific ones! 🎉 

You'll also notice that we've renamed the concern for this file from `FastlyHeaders` to `CachingHeaders`, since ultimately, we will be handling the headers for _both_ Fastly and Nginx here.

## Related Tickets & Documents

See a bit more over in our "loosely" scoped caching [project board](https://github.com/orgs/forem/projects/4).

## QA Instructions, Screenshots, Recordings

Make sure the pre-existing tests pass!

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] inline documentation
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

Once we deploy this, we'll use [Fastly Fiddle](https://fiddle.fastlydemo.net) to bust the cache for this article, and then request it again. We'll check to see if we get a cache `MISS` followed by a cache `HIT`, which will prove to us that it is safe to use the same header for _both_ caching strategies (Fastly _and_ Nginx).
