### PR TITLE
CI Optimization:Remove unused ENV variables and Skip install Step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ env:
     # Dummy values needed to verify the app boots via "rails runner"
     - APP_PROTOCOL=http://
     - APP_DOMAIN=localhost:3000
-    - TIMBER=dummy
-    - SEND_LOGS_TO_TIMBER=false
     - SENDGRID_USERNAME_ACCEL=dummy
     - SENDGRID_PASSWORD_ACCEL=dummy
     - HEROKU_APP_URL=practicaldev.herokuapp.com
@@ -43,6 +41,7 @@ env:
 branches:
   only:
     - master
+install: true
 script:
   - date --rfc-3339=seconds
   - nvm install


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
I noticed recently that we are running bundle install twice in our builds. (I also noticed we are not serving gems from the local vendor/cache also, that fix will be a separate PR.) Travis kicks off a bundle on its own during the install step. To skip this I set `install:true` in our yml file. I also removed 2 unused ENV variables



![alt_text](https://media2.giphy.com/media/l2YWxy11DtoOAiSKk/200.gif)
