### PR TITLE
Cleanup preferred_languages language_settings for users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -245,21 +245,10 @@ class User < ApplicationRecord
     end
   end
 
-  # handles both old (prefer_language_*) and new (Array of language codes) formats
   def preferred_languages_array
     return @preferred_languages_array if defined?(@preferred_languages_array)
 
-    if language_settings["preferred_languages"].present?
-      @preferred_languages_array = language_settings["preferred_languages"].to_a
-    else
-      languages = []
-      language_settings.each_key do |setting|
-        to_split = language_settings[setting] && setting.include?("prefer_language_")
-        languages << setting.split("prefer_language_")[1] if to_split
-      end
-      @preferred_languages_array = languages
-    end
-    @preferred_languages_array
+    @preferred_languages_array = language_settings["preferred_languages"]
   end
 
   def processed_website_url

--- a/app/views/users/_language_settings.html.erb
+++ b/app/views/users/_language_settings.html.erb
@@ -12,7 +12,7 @@
   <%= form_tag users_update_language_settings_path, class: "grid gap-4"  do |f| %>
     <% Languages::LIST.each do |code, name| %>
       <label class="crayons-field crayons-field--checkbox">
-        <%= check_box_tag "user[preferred_languages][]", code, @user.preferred_languages_array.include?(code), class: "crayons-checkbox" %>
+        <%= check_box_tag "user[preferred_languages][]", code, @user.preferred_languages_array&.include?(code), class: "crayons-checkbox" %>
         <div class="crayons-field__label"><%= name %></div>
       </label>
     <% end %>

--- a/lib/data_update_scripts/20200805171911_clean_up_language_settings.rb
+++ b/lib/data_update_scripts/20200805171911_clean_up_language_settings.rb
@@ -1,0 +1,19 @@
+module DataUpdateScripts
+  class CleanUpLanguageSettings
+    def run
+      User.where("(language_settings->'preferred_languages') IS null").find_each do |user|
+        language_settings = user.language_settings
+        language_settings["preferred_languages"] = []
+
+        language_settings["preferred_languages"] << "en" if language_settings["prefer_language_en"]
+        language_settings["preferred_languages"] << "es" if language_settings["prefer_language_es"]
+        language_settings["preferred_languages"] << "fr" if language_settings["prefer_language_fr"]
+        language_settings["preferred_languages"] << "it" if language_settings["prefer_language_it"]
+        language_settings["preferred_languages"] << "ja" if language_settings["prefer_language_ja"]
+        language_settings["preferred_languages"] << "pt" if language_settings["prefer_language_pt"]
+
+        user.update(language_settings: language_settings)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -670,21 +670,10 @@ RSpec.describe User, type: :model do
         expect(user.reload.preferred_languages_array).to eq(%w[en ja])
       end
 
-      it "returns a correct array when language settings are in a new format" do
+      it "returns a correct array for language settings" do
         language_settings = { estimated_default_language: "en", preferred_languages: %w[en ru it] }
         user = build(:user, language_settings: language_settings)
         expect(user.preferred_languages_array).to eq(%w[en ru it])
-      end
-
-      it "returns a correct array when language settings are in the old format" do
-        language_settings = {
-          estimated_default_language: "en",
-          prefer_language_en: true,
-          prefer_language_ja: false,
-          prefer_language_es: true
-        }
-        user = build(:user, language_settings: language_settings)
-        expect(user.preferred_languages_array).to eq(%w[en es])
       end
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Currently, in production, we store a user's `language_settings` in different ways. This PR consolidates the preferred languages piece into a single format - a single `preferred_languages` Array. This will affect ~150k records.

## Related Tickets & Documents
https://github.com/orgs/forem/projects/3#card-42702165
https://github.com/orgs/forem/projects/3#card-42702170

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Double-check the data looks good via Blazer.

![now_you_are_talking_my_language_gif](https://media.giphy.com/media/PVNRZxTcTzz1u/giphy.gif)
