### PR TITLE
Update "/internal/badges" route to "/internal/badge_achievements"

### DIFF
--- a/app/controllers/internal/badges_controller.rb
+++ b/app/controllers/internal/badges_controller.rb
@@ -17,7 +17,7 @@ module Internal
       redirect_to internal_badges_url
     rescue ArgumentError => e
       flash[:danger] = e.message
-      redirect_to "/internal/badges/award"
+      redirect_to "/internal/badge_achievements"
     end
 
     private

--- a/app/controllers/internal/badges_controller.rb
+++ b/app/controllers/internal/badges_controller.rb
@@ -17,7 +17,7 @@ module Internal
       redirect_to internal_badges_url
     rescue ArgumentError => e
       flash[:danger] = e.message
-      redirect_to "/internal/badges"
+      redirect_to "/internal/badges/award"
     end
 
     private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,7 +114,8 @@ Rails.application.routes.draw do
     end
     resources :webhook_endpoints, only: :index
     resource :config
-    resources :badges, only: :index
+    resources :badges, only: %i[index], path: "/badges/award"
+    get "/badges", to: redirect("/internal/badges/award")
     post "badges/award_badges", to: "badges#award_badges"
     resources :secrets, only: %i[index]
     put "secrets", to: "secrets#update"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,8 +114,8 @@ Rails.application.routes.draw do
     end
     resources :webhook_endpoints, only: :index
     resource :config
-    resources :badges, only: %i[index], path: "/badges/award"
-    get "/badges", to: redirect("/internal/badges/award")
+    resources :badges, only: %i[index], path: "/badge_achievements"
+    get "/badges", to: redirect("/internal/badge_achievements")
     post "badges/award_badges", to: "badges#award_badges"
     resources :secrets, only: %i[index]
     put "secrets", to: "secrets#update"

--- a/spec/requests/internal/badges_spec.rb
+++ b/spec/requests/internal/badges_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 require "requests/shared_examples/internal_policy_dependant_request"
 
-RSpec.describe "/internal/badges/award", type: :request do
+RSpec.describe "/internal/badge_achievements", type: :request do
   it_behaves_like "an InternalPolicy dependant request", Badge do
-    let(:request) { get "/internal/badges/award" }
+    let(:request) { get "/internal/badge_achievements" }
   end
 
   describe "POST /internal/badges/award_badges" do

--- a/spec/requests/internal/badges_spec.rb
+++ b/spec/requests/internal/badges_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 require "requests/shared_examples/internal_policy_dependant_request"
 
-RSpec.describe "/internal/badges", type: :request do
+RSpec.describe "/internal/badges/award", type: :request do
   it_behaves_like "an InternalPolicy dependant request", Badge do
-    let(:request) { get "/internal/badges" }
+    let(:request) { get "/internal/badges/award" }
   end
 
   describe "POST /internal/badges/award_badges" do

--- a/spec/system/internal/admin_awards_badges_spec.rb
+++ b/spec/system/internal/admin_awards_badges_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Admin awards badges", type: :system do
   before do
     create_list :badge, 5
     sign_in admin
-    visit "/internal/badges/award"
+    visit "/internal/badge_achievements"
   end
 
   it "loads the view" do

--- a/spec/system/internal/admin_awards_badges_spec.rb
+++ b/spec/system/internal/admin_awards_badges_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Admin awards badges", type: :system do
   before do
     create_list :badge, 5
     sign_in admin
-    visit "/internal/badges"
+    visit "/internal/badges/award"
   end
 
   it "loads the view" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR updates the `/internal/badges` route to `/internal/badge_achievements`. Additionally, it ensures that `/internal/badges` is redirected to `/internal/badge_achievements` in `routes.rb` as well as in the `#award_badges` method in the `Internal::Badges::Controller`. 

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings
**To QA this PR, please do the following:** 

- Visit `/internal/badges` locally (make sure you have `admin` credentials first!) and observe that it redirects to its new route, `/internal/badge_achievements`:
![Screen Shot 2020-08-05 at 3 04 03 PM (2)](https://user-images.githubusercontent.com/32834804/89464060-0a07b980-d72d-11ea-8696-30a4c27ddf47.png)

- Award yourself (or any user) a badge by filling out the below form:
![Screen Shot 2020-08-05 at 3 05 37 PM (2)](https://user-images.githubusercontent.com/32834804/89464184-40453900-d72d-11ea-901f-ba0ed28ccc8b.png)

- Observe that after successfully creating a new badge, you are redirected back to the new route, `/internal/badge_achievements`:
![Screen Shot 2020-08-05 at 3 05 51 PM (2)](https://user-images.githubusercontent.com/32834804/89464226-5521cc80-d72d-11ea-92ab-1548185f7e52.png)

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
- [x] Updated `admin_awards_badges_spec.rb` and `badges_spec.rb` to use the correct routes

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![award](https://media.giphy.com/media/TeyUcgdeGYVoc/giphy.gif)
