### PR TITLE
Hypershield: use per column table hide for specificity

### DIFF
--- a/config/initializers/hypershield.rb
+++ b/config/initializers/hypershield.rb
@@ -14,25 +14,25 @@ if Rails.env.production?
         hypershield: {
           # columns to hide
           # matches table.column
-          hide: %w[
-            auth_data_dump
-            content
-            email
-            encrypted
-            encrypted_password
-            message_html
-            message_markdown
-            password
-            previous_refresh_token
-            refresh_token
-            secret
-            to
-            token
-            current_sign_in_ip
-            last_sign_in_ip
-            reset_password_token
-            remember_token
-            unconfirmed_email
+          hide: [
+            "ahoy_messages.content",
+            "ahoy_messages.to",
+            "email",
+            "encrypted",
+            "encrypted_password",
+            "identities.auth_data_dump",
+            "messages.message_html",
+            "messages.message_markdown",
+            "oauth_access_tokens.previous_refresh_token",
+            "oauth_access_tokens.refresh_token",
+            "password",
+            "secret",
+            "token",
+            "users.current_sign_in_ip",
+            "users.last_sign_in_ip",
+            "users.remember_token",
+            "users.reset_password_token",
+            "users.unconfirmed_email",
           ]
         }
       }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Introducing per table hiding for specificity. Mostly kickstarted by the need to hide `ahoy_messages.content` in Blazer but not `notes.content` nor `response_templates.content`

I've added a few table qualifiers and sorted the entries.

See also https://github.com/ankane/hypershield#configuration and https://github.com/ankane/hypershield/issues/8

## QA Instructions, Screenshots, Recordings

How do I QA this? I also noticed that at the present moment `content` is still accessible in Blazer, probably because the views haven't been refreshed when https://github.com/forem/forem/pull/9634 was merged?

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
