### PR TITLE
Add X-Accel-Expires header to support Nginx caching

### DIFF
--- a/app/controllers/concerns/caching_headers.rb
+++ b/app/controllers/concerns/caching_headers.rb
@@ -13,29 +13,20 @@ module CachingHeaders
   #  {cache_control: 'public, no-cache, maxage=xyz', surrogate_control: 'max-age: 100'}
   def set_cache_control_headers(
     max_age = 1.day.to_i,
-    surrogate_control: nil, stale_while_revalidate: nil, stale_if_error: 26_400
+    surrogate_control: nil,
+    stale_while_revalidate: nil,
+    stale_if_error: 26_400
   )
-
-    # TODO: [@forem/delightful]: Once we've tested that removing `no-cache` from the Cache-Control headers
-    # does not adversely affect fastly, we should remove this specific check entirely.
-    article_requested = request.env["REQUEST_PATH"].present? &&
-      request.env["REQUEST_PATH"].include?("the-3-biggest-misconceptions-about-diversity-3hkm")
-    cache_control = if article_requested
-                      "public, max-age=86400"
-                    else
-                      "public, no-cache"
-                    end
-
     request.session_options[:skip] = true # no cookies
-    response.headers["Cache-Control"] = cache_control
 
+    response.headers["Cache-Control"] = "public, max-age=#{max_age}"
     response.headers["Surrogate-Control"] = surrogate_control.presence || build_surrogate_control(
       max_age, stale_while_revalidate: stale_while_revalidate, stale_if_error: stale_if_error
     )
   end
 
   # Sets Surrogate-Key HTTP header with one or more keys strips session data
-  # from the request
+  # from the request.
   def set_surrogate_key_header(*surrogate_keys)
     request.session_options[:skip] = true # No Set-Cookie
     response.headers["Surrogate-Key"] = surrogate_keys.join(" ")

--- a/app/controllers/concerns/caching_headers.rb
+++ b/app/controllers/concerns/caching_headers.rb
@@ -19,7 +19,8 @@ module CachingHeaders
   )
     request.session_options[:skip] = true # no cookies
 
-    response.headers["Cache-Control"] = "public, max-age=#{max_age}"
+    response.headers["Cache-Control"] = "public, no-cache"
+    response.headers["X-Accel-Expires"] = max_age.to_s
     response.headers["Surrogate-Control"] = surrogate_control.presence || build_surrogate_control(
       max_age, stale_while_revalidate: stale_while_revalidate, stale_if_error: stale_if_error
     )

--- a/app/controllers/concerns/caching_headers.rb
+++ b/app/controllers/concerns/caching_headers.rb
@@ -19,8 +19,8 @@ module CachingHeaders
   )
     request.session_options[:skip] = true # no cookies
 
-    response.headers["Cache-Control"] = "public, no-cache"
-    response.headers["X-Accel-Expires"] = max_age.to_s
+    response.headers["Cache-Control"] = "public, no-cache" # Used only by Fastly.
+    response.headers["X-Accel-Expires"] = max_age.to_s # Used only by Nginx.
     response.headers["Surrogate-Control"] = surrogate_control.presence || build_surrogate_control(
       max_age, stale_while_revalidate: stale_while_revalidate, stale_if_error: stale_if_error
     )

--- a/spec/requests/api/v0/listings_spec.rb
+++ b/spec/requests/api/v0/listings_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe "Api::V0::Listings", type: :request do
       get api_listings_path
 
       expect(response.headers["cache-control"]).to be_present
+      expect(response.headers["x-accel-expires"]).to be_present
       expect(response.headers["surrogate-control"]).to match(/max-age/).and(match(/stale-if-error/))
     end
 
@@ -214,6 +215,7 @@ RSpec.describe "Api::V0::Listings", type: :request do
       get api_listing_path(listing.id)
 
       expect(response.headers["cache-control"]).to be_present
+      expect(response.headers["x-accel-expires"]).to be_present
       expect(response.headers["surrogate-control"]).to match(/max-age/).and(match(/stale-if-error/))
     end
 

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Articles", type: :request do
       get "/feed"
       expect(response.status).to eq(200)
 
-      expected_cache_control_headers = %w[public no-cache]
+      expected_cache_control_headers = %w[max-age=600 public]
       expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
     end
 

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -26,31 +26,37 @@ RSpec.describe "Articles", type: :request do
       expect { get "/feed/#{tag.name}" }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    it "sets Fastly Cache-Control headers" do
-      create(:article, featured: true)
-      get "/feed"
-      expect(response.status).to eq(200)
+    context "with caching headers" do
+      before do
+        create(:article, featured: true)
+        get "/feed"
+      end
 
-      expected_cache_control_headers = %w[no-cache public]
-      expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
-    end
+      it "sets Fastly Cache-Control headers" do
+        expect(response.status).to eq(200)
 
-    it "sets Fastly Surrogate-Control headers" do
-      create(:article, featured: true)
-      get "/feed"
-      expect(response.status).to eq(200)
+        expected_cache_control_headers = %w[public no-cache]
+        expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
+      end
 
-      expected_surrogate_control_headers = %w[max-age=600 stale-while-revalidate=30 stale-if-error=86400]
-      expect(response.headers["Surrogate-Control"].split(", ")).to match_array(expected_surrogate_control_headers)
-    end
+      it "sets Fastly Surrogate-Control headers" do
+        expect(response.status).to eq(200)
 
-    it "sets Fastly Surrogate-Key headers" do
-      create(:article, featured: true)
-      get "/feed"
-      expect(response.status).to eq(200)
+        expected_surrogate_control_headers = %w[max-age=600 stale-while-revalidate=30 stale-if-error=86400]
+        expect(response.headers["Surrogate-Control"].split(", ")).to match_array(expected_surrogate_control_headers)
+      end
 
-      expected_surrogate_key_headers = %w[feed]
-      expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
+      it "sets Fastly Surrogate-Key headers" do
+        expect(response.status).to eq(200)
+
+        expected_surrogate_key_headers = %w[feed]
+        expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
+      end
+
+      it "sets Nginx X-Accel-Expires headers" do
+        expect(response.status).to eq(200)
+        expect(response.headers["X-Accel-Expires"]).to eq("600")
+      end
     end
 
     context "when :username param is not given" do

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Articles", type: :request do
       get "/feed"
       expect(response.status).to eq(200)
 
-      expected_cache_control_headers = %w[max-age=600 public]
+      expected_cache_control_headers = %w[no-cache public]
       expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
     end
 

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -33,8 +33,12 @@ RSpec.describe "Reactions", type: :request do
         expect(result["reactions"].to_json).to eq(user.reactions.where(reactable: article).to_json)
       end
 
-      it "does not set cache control headers" do
+      it "does not set Surrogate-Key cache control headers" do
         expect(response.headers["Surrogate-Key"]).to eq(nil)
+      end
+
+      it "does not set X-Accel-Expires headers" do
+        expect(response.headers["X-Accel-Expires"]).to eq(nil)
       end
 
       it "does not set Fastly cache control and surrogate control headers" do
@@ -63,6 +67,10 @@ RSpec.describe "Reactions", type: :request do
 
       it "sets the surrogate key header equal to params for article" do
         expect(response.headers["Surrogate-Key"]).to eq(controller.params.to_s)
+      end
+
+      it "sets the x-accel-expires header equal to max-age for article" do
+        expect(response.headers["X-Accel-Expires"]).to eq(max_age.to_s)
       end
 
       it "sets Fastly cache control and surrogate control headers" do
@@ -98,6 +106,10 @@ RSpec.describe "Reactions", type: :request do
         expect(response.headers["surrogate-key"]).to be_nil
       end
 
+      it "does not set x-accel-expires headers" do
+        expect(response.headers["x-accel-expires"]).to be_nil
+      end
+
       it "does not set Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).not_to include(
           "Cache-Control" => "public, no-cache",
@@ -119,6 +131,10 @@ RSpec.describe "Reactions", type: :request do
 
       it "sets the surrogate key header equal to params" do
         expect(response.headers["Surrogate-Key"]).to eq(controller.params.to_s)
+      end
+
+      it "sets the x-accel-expires header equal to max-age for article" do
+        expect(response.headers["X-Accel-Expires"]).to eq(max_age.to_s)
       end
 
       it "sets Fastly cache control and surrogate control headers" do

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Reactions", type: :request do
 
       it "does not set Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).not_to include(
-          "Cache-Control" => "public, no-cache",
+          "Cache-Control" => "max-age=86400, public",
           "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end
@@ -67,7 +67,7 @@ RSpec.describe "Reactions", type: :request do
 
       it "sets Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).to include(
-          "Cache-Control" => "public, no-cache",
+          "Cache-Control" => "max-age=86400, public",
           "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end
@@ -100,7 +100,7 @@ RSpec.describe "Reactions", type: :request do
 
       it "does not set Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).not_to include(
-          "Cache-Control" => "public, no-cache",
+          "Cache-Control" => "max-age=86400, public",
           "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end
@@ -123,7 +123,7 @@ RSpec.describe "Reactions", type: :request do
 
       it "sets Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).to include(
-          "Cache-Control" => "public, no-cache",
+          "Cache-Control" => "max-age=86400, public",
           "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Reactions", type: :request do
 
       it "sets Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).to include(
-          "Cache-Control" => "max-age=86400, public",
+          "Cache-Control" => "public, no-cache",
           "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end
@@ -123,7 +123,7 @@ RSpec.describe "Reactions", type: :request do
 
       it "sets Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).to include(
-          "Cache-Control" => "max-age=86400, public",
+          "Cache-Control" => "public, no-cache",
           "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Reactions", type: :request do
 
       it "does not set Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).not_to include(
-          "Cache-Control" => "max-age=86400, public",
+          "Cache-Control" => "public, no-cache",
           "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end
@@ -100,7 +100,7 @@ RSpec.describe "Reactions", type: :request do
 
       it "does not set Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).not_to include(
-          "Cache-Control" => "max-age=86400, public",
+          "Cache-Control" => "public, no-cache",
           "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe "StoriesIndex", type: :request do
       get "/t/#{tag.name}"
       expect(response.status).to eq(200)
 
-      expected_cache_control_headers = %w[public no-cache]
+      expected_cache_control_headers = %w[max-age=600 public]
       expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
     end
 

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe "StoriesIndex", type: :request do
       get "/t/#{tag.name}"
       expect(response.status).to eq(200)
 
-      expected_cache_control_headers = %w[max-age=600 public]
+      expected_cache_control_headers = %w[no-cache public]
       expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
     end
 

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -106,6 +106,13 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
     end
 
+    it "sets Nginx X-Accel-Expires headers" do
+      get "/"
+      expect(response.status).to eq(200)
+
+      expect(response.headers["X-Accel-Expires"]).to eq("600")
+    end
+
     it "shows default meta keywords" do
       SiteConfig.meta_keywords = { default: "cool developers, civil engineers" }
       get "/"
@@ -263,33 +270,41 @@ RSpec.describe "StoriesIndex", type: :request do
       )
     end
 
-    it "renders page with proper header" do
-      get "/t/#{tag.name}"
-      expect(response.body).to include(tag.name)
-    end
+    context "with caching headers" do
+      before do
+        get "/t/#{tag.name}"
+      end
 
-    it "sets Fastly Cache-Control headers" do
-      get "/t/#{tag.name}"
-      expect(response.status).to eq(200)
+      it "renders page with proper header" do
+        expect(response.body).to include(tag.name)
+      end
 
-      expected_cache_control_headers = %w[no-cache public]
-      expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
-    end
+      it "sets Fastly Cache-Control headers" do
+        expect(response.status).to eq(200)
 
-    it "sets Fastly Surrogate-Control headers" do
-      get "/t/#{tag.name}"
-      expect(response.status).to eq(200)
+        expected_cache_control_headers = %w[public no-cache]
+        expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
+      end
 
-      expected_surrogate_control_headers = %w[max-age=600 stale-while-revalidate=30 stale-if-error=86400]
-      expect(response.headers["Surrogate-Control"].split(", ")).to match_array(expected_surrogate_control_headers)
-    end
+      it "sets Fastly Surrogate-Control headers" do
+        expect(response.status).to eq(200)
 
-    it "sets Fastly Surrogate-Key headers" do
-      get "/t/#{tag.name}"
-      expect(response.status).to eq(200)
+        expected_surrogate_control_headers = %w[max-age=600 stale-while-revalidate=30 stale-if-error=86400]
+        expect(response.headers["Surrogate-Control"].split(", ")).to match_array(expected_surrogate_control_headers)
+      end
 
-      expected_surrogate_key_headers = %W[articles-#{tag}]
-      expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
+      it "sets Fastly Surrogate-Key headers" do
+        expect(response.status).to eq(200)
+
+        expected_surrogate_key_headers = %W[articles-#{tag}]
+        expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
+      end
+
+      it "sets Nginx X-Accel-Expires headers" do
+        expect(response.status).to eq(200)
+
+        expect(response.headers["X-Accel-Expires"]).to eq("600")
+      end
     end
 
     it "renders page with top/week etc." do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

**PLEASE READ UPDATED DESCRIPTION AT THE BOTTOM OF THIS PR**

~In https://github.com/forem/forem/pull/9631, we conditionally removed the `no-cache` option from the `Cache-Control` headers that are sent along to Fastly + Nginx via our `CachingHeaders` concern, as a way of experimenting to see if Fastly still caches the same way. We did some experiments, and saw that Fastly still picked up on our change, and still caches the way that we'd expect.~

~You can play with our [Fastly fiddle snippet](https://fiddle.fastlydemo.net/fiddle/62626efe) if you'd like, but the TL;DR can be summed up by these specific headers/response from Fastly:~
```bash
HTTP/2 200

cache-control: max-age=86400, public
x-cache-hits: 0, 1, 1
x-cache: MISS, HIT, HIT
x-served-by: cache-den19627-DEN, cache-wdc5547-WDC, cache-wdc5562-WDC
```

~Now that we've confirmed that this _doesn't_ break Fastly caching, this PR uses the same exactly Cache-Control headers for _both_ Fastly **and** Nginx:~
```ruby
response.headers["Cache-Control"] = "public, max-age=#{max_age}"
```

## Related Tickets & Documents

Once https://github.com/forem/lfss/pull/1 is merged, we expect that [forem.dev](https://forem.dev/) should Just Work™️  with Nginx caching enabled.

## QA Instructions, Screenshots, Recordings

Make sure the tests pass! If you are set up with the LFSS repo, you can pull this branch down and QA it to test out whether caching really _does_ work without the explicitly set headers in the `nginx.conf`, which https://github.com/forem/lfss/pull/1 removes :)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

We need to keep an eye on this PR when it deploys and watch to make sure we're not seeing a bunch of busted caches; ideally, caching should work as normal and we shouldn't see any impacts.

## What gif best describes this PR or how it makes you feel?

![slowly smiling sloth](https://media3.giphy.com/media/NEPy1nvpxnKjS/giphy.webp?cid=5a38a5a2fas42vdgpgfoioyqy9p17qmsf9nbg5a6xqm57ehp&rid=giphy.webp)
