### PR TITLE
Rubocop: Fix Rails/HasManyOrHasOneDependent for Broadcast and Collection

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,8 +24,6 @@ Performance/OpenStruct:
 Rails/HasManyOrHasOneDependent:
   Exclude:
     - 'app/models/article.rb'
-    - 'app/models/broadcast.rb'
-    - 'app/models/collection.rb'
     - 'app/models/concerns/user_subscription_sourceable.rb'
     - 'app/models/display_ad.rb'
     - 'app/models/html_variant.rb'

--- a/app/models/broadcast.rb
+++ b/app/models/broadcast.rb
@@ -2,7 +2,7 @@ class Broadcast < ApplicationRecord
   VALID_BANNER_STYLES = %w[default brand success warning error].freeze
   resourcify
 
-  has_many :notifications, as: :notifiable, inverse_of: :notifiable
+  has_many :notifications, as: :notifiable, inverse_of: :notifiable, dependent: :destroy
 
   validates :title, uniqueness: { scope: :type_of }, presence: true
   validates :type_of, :processed_html, presence: true

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,5 +1,6 @@
 class Collection < ApplicationRecord
-  has_many :articles
+  has_many :articles, dependent: :nullify
+
   belongs_to :user
   belongs_to :organization, optional: true
 

--- a/spec/models/broadcast_spec.rb
+++ b/spec/models/broadcast_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Broadcast, type: :model do
   it { is_expected.to validate_inclusion_of(:banner_style).in_array(%w[default brand success warning error]) }
   it { is_expected.to validate_uniqueness_of(:title).scoped_to(:type_of) }
 
-  it { is_expected.to have_many(:notifications) }
+  it { is_expected.to have_many(:notifications).dependent(:destroy) }
 
   it "validates that only one Broadcast with a type_of Announcement can be active" do
     create(:announcement_broadcast)

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Collection, type: :model do
   describe "validations" do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:organization).optional }
-    it { is_expected.to have_many(:articles) }
+    it { is_expected.to have_many(:articles).dependent(:nullify) }
 
     it { is_expected.to validate_presence_of(:user_id) }
     it { is_expected.to validate_presence_of(:slug) }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Follow up to https://github.com/forem/forem/pull/9565

I've decided to split #9405 in multiple PR with a smaller scope/surface.

This PR tackles `Rails/HasManyOrHasOneDependent` for `Broadcast` and `Collection`.

I could neither find any orphaned notification belonging to non existing broadcasts (mostly because we don't delete broadcasts, we just deactivate them) nor I could find any article attached to a collection that doesn't exist (mostly because we don't allow people to delete collections yet ;-)).

Thus I didn't add a data update script

## Related Tickets & Documents

#9405 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
