### PR TITLE
Remove Forward Slashes from <br> Tags in Pages Partial

### DIFF
--- a/app/views/admin/pages/_form.html.erb
+++ b/app/views/admin/pages/_form.html.erb
@@ -48,7 +48,7 @@
           <span class="badge badge-<%= FeatureFlag.exist?(@page.feature_flag_name) ? "success" : "warning" %>">
             <%= FeatureFlag.exist?(@page.feature_flag_name) ? "Present" : "Not Present" %>
           </span>
-          </br>
+          <br>
           <% if FeatureFlag.exist?(@page.feature_flag_name) %>
             Access to this page is being guarded by the feature flag <code><%= @page.feature_flag_name %></code>.
             <%= link_to "Modify flag here", "/admin/feature_flags/features/#{@page.feature_flag_name}" %>
@@ -56,7 +56,7 @@
             Everyone has access. Optionally guard access to this page by creating feature <code><%= @page.feature_flag_name %></code>
             <%= link_to "here", "/admin/feature_flags/features" %>
           <% end %>
-          </br>
+          <br>
         </p>
       </div>
       <%= form.submit class: "btn btn-primary float-right" %>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR removes two unnecessary forward slashes from the line breaks in the Pages partial, `_form.html.erb`, that I came across while working in `/admin`. 😄 

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings
Make sure the Travis build passes.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![spongebob cleaning](https://media.giphy.com/media/LLR3cBvqxpamY/giphy.gif)
