### PR TITLE
Migration Optimization: Async Handle Notifications for Comments When Saved

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -65,10 +65,8 @@ class CommentsController < ApplicationController
       checked_code_of_conduct = params[:checked_code_of_conduct].present? && !current_user.checked_code_of_conduct
       current_user.update(checked_code_of_conduct: true) if checked_code_of_conduct
 
-      NotificationSubscription.create(
-        user: current_user, notifiable_id: @comment.id, notifiable_type: "Comment", config: "all_comments",
-      )
-      Notification.send_new_comment_notifications_without_delay(@comment)
+      Comments::CreateNotificationSubscriptionWorker.perform_async(current_user.id, @comment.id)
+      Notification.send_new_comment_notifications(@comment)
       Mention.create_all(@comment)
 
       if @comment.invalid?

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -85,7 +85,7 @@ class Article < ApplicationRecord
   after_save :notify_slack_channel_about_publication
 
   after_update_commit :update_notifications, if: proc { |article|
-                                                   article.notifications.any? && !article.saved_changes.empty?
+                                                   !article.saved_changes.empty? && article.notifications.any?
                                                  }
   after_commit :async_score_calc, :update_main_image_background_hex, :touch_collection, on: %i[create update]
   after_commit :index_to_elasticsearch, on: %i[create update]

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -51,6 +51,13 @@ class Notification < ApplicationRecord
       Notifications::NewComment::Send.call(comment)
     end
 
+    def send_new_comment_notifications(comment)
+      return if comment.commentable_type == "PodcastEpisode"
+      return if UserBlock.blocking?(comment.commentable.user_id, comment.user_id)
+
+      Comments::SendNewCommentNotificationsWorker.perform_async(comment.id)
+    end
+
     def send_new_badge_achievement_notification(badge_achievement)
       Notifications::NewBadgeAchievementWorker.perform_async(badge_achievement.id)
     end

--- a/app/workers/comments/create_notification_subscription_worker.rb
+++ b/app/workers/comments/create_notification_subscription_worker.rb
@@ -1,0 +1,15 @@
+module Comments
+  class CreateNotificationSubscriptionWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority
+
+    def perform(user_id, comment_id)
+      comment = Comment.find(comment_id)
+      user = User.find(user_id)
+      NotificationSubscription.create(
+        user: user, notifiable_id: comment.id, notifiable_type: "Comment", config: "all_comments",
+      )
+    end
+  end
+end

--- a/app/workers/comments/send_new_comment_notifications_worker.rb
+++ b/app/workers/comments/send_new_comment_notifications_worker.rb
@@ -1,0 +1,12 @@
+module Comments
+  class SendNewCommentNotificationsWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority
+
+    def perform(comment_id)
+      comment = Comment.find_by(id: comment_id)
+      Notifications::NewComment::Send.call(comment) if comment
+    end
+  end
+end

--- a/app/workers/comments/update_commentable_last_comment_at_worker.rb
+++ b/app/workers/comments/update_commentable_last_comment_at_worker.rb
@@ -1,0 +1,12 @@
+module Comments
+  class UpdateCommentableLastCommentAtWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :high_priority
+
+    def perform(commentable_id, commentable_type)
+      commentable = commentable_type.constantize.find(commentable_id)
+      commentable.touch(:last_comment_at) if commentable.respond_to?(:last_comment_at)
+    end
+  end
+end

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "CommentsCreate", type: :request do
 
   it "creates NotificationSubscription for comment" do
     post comments_path, params: comment_params
+    sidekiq_perform_enqueued_jobs
 
     expect(NotificationSubscription.last.notifiable).to eq(Comment.last)
   end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -265,11 +265,12 @@ RSpec.describe "Comments", type: :request do
       it "updates body markdown" do
         article = create(:article, user: user)
         comment = create(:comment, commentable: article, user: user)
-
+        sidekiq_perform_enqueued_jobs
         article.destroy
 
         params = { comment: { body_markdown: "{edited comment}" } }
         put "/comments/#{comment.id}", params: params
+        sidekiq_perform_enqueued_jobs
 
         comment.reload
         expect(comment.processed_html).to include("edited comment")

--- a/spec/workers/comments/create_notification_subscription_worker_spec.rb
+++ b/spec/workers/comments/create_notification_subscription_worker_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe Comments::CreateNotificationSubscriptionWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "high_priority", 1
+
+  describe "#perform_now" do
+    let(:worker) { subject }
+
+    it "creates NotificationSubscription for comment" do
+      comment = create(:comment)
+      worker.perform(comment.user_id, comment.id)
+
+      expect(NotificationSubscription.last.notifiable).to eq(comment)
+    end
+  end
+end

--- a/spec/workers/comments/send_new_comment_notifications_worker_spec.rb
+++ b/spec/workers/comments/send_new_comment_notifications_worker_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Comments::SendNewCommentNotificationsWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "high_priority", 1
+
+  describe "#perform_now" do
+    let(:worker) { subject }
+
+    it "sends new comment notification" do
+      allow(Notifications::NewComment::Send).to receive(:call)
+      comment = create(:comment)
+      worker.perform(comment.id)
+
+      expect(Notifications::NewComment::Send).to have_received(:call)
+    end
+  end
+end

--- a/spec/workers/comments/update_commentable_last_comment_at_worker_spec.rb
+++ b/spec/workers/comments/update_commentable_last_comment_at_worker_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Comments::UpdateCommentableLastCommentAtWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "high_priority", 1
+
+  describe "#perform_now" do
+    let(:worker) { subject }
+
+    it "updates commentable last_comment_at" do
+      comment = create(:comment)
+      commentable = comment.commentable
+      Timecop.freeze do
+        old_time = 1.week.ago
+        commentable.update(last_comment_at: old_time)
+        worker.perform(commentable.id, commentable.class.name)
+
+        expect(commentable.reload.last_comment_at).not_to eq(old_time)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
**FWIW my plan would be deploy this, deploy and run the migrations, then roll this back. I think there are some good pieces here that might help performance but I also am not a fan of all the additional sidekiq jobs it creates. I would rather consolidate them.**

When we migrate the notifications table to convert ints to bigints, it is going to take us 35-40 min. The notifications table will be locked during that whole time. Because of this, if a user tries to create a comment with the code as is they will see an error message

<img width="455" alt="Screen Shot 2020-08-07 at 7 19 54 PM" src="https://user-images.githubusercontent.com/1813380/89697757-39602700-d8e3-11ea-99f4-4c8593903450.png">

However, the comment will get created and if they refresh the page they will see their comment. It's a bit confusing. With this change, users can create comments and all the notification updates will be kicked to the background workers. Those will then fail but eventually will be able to retry and succeed once the table has been migrated and unlocked. 

## Related Tickets & Documents
https://github.com/forem/forem/pull/9476

## Added tests?
Codeclimate can be ignored.

- [x] yes

![alt_text](https://media1.giphy.com/media/3oeSAzOknAcW4ttStW/200.gif)
