### PR TITLE
Add new support admin role

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -12,6 +12,7 @@ class Role < ApplicationRecord
     super_admin
     tag_moderator
     mod_relations_admin
+    support_admin
     tech_admin
     trusted
     warned

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -67,6 +67,10 @@ class ApplicationPolicy
     user.has_role?(:super_admin)
   end
 
+  def support_admin?
+    user.has_role?(:support_admin)
+  end
+
   def user_is_banned?
     user.banned
   end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -129,9 +129,9 @@
       <%= form_for(@user, url: banish_admin_user_path(@user), html: { method: :post, onsubmit: "return confirm('Are you sure? This is extremely destructive and irreversible. Banishing will delete all articles and turn their username into @spam_###')" }) do %>
         <button class="btn btn-danger float-right">🚫 Banish User for Spam 🚫</button>
       <% end %>
-    <% elsif current_user.has_role?(:super_admin) %>
+    <% elsif current_user.has_role?(:super_admin) || current_user.has_role?(:support_admin) %>
       <p><strong>This is not a new user.</strong> You are only allowed to take this action because you are a
-        <strong>super admin.</strong></p>
+        <strong>super admin or a support admin.</strong></p>
       <p>
         <em>This is extremely destructive. Banishing will delete all the user's existing content and change their username to @spam_###.</em>
       </p>
@@ -140,7 +140,7 @@
         <button class="btn btn-danger float-right">Banish User for Spam!</button>
       <% end %>
     <% else %>
-      <p><em>This is not a new user so you'll need to contact a super admin to banish this user.</em></p>
+      <p><em>This is not a new user. Only super admins or support admins are allowed to banish this user.</em></p>
     <% end %>
   </div>
 

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Role, type: :model do
     it "contains the correct values" do
       expected_roles = %w[
         admin banned chatroom_beta_tester codeland_admin comment_banned podcast_admin pro restricted_liquid_tag
-        single_resource_admin super_admin tag_moderator mod_relations_admin tech_admin support_admin trusted
+        single_resource_admin super_admin tag_moderator mod_relations_admin support_admin tech_admin trusted
         warned workshop_pass
       ]
       expect(described_class::ROLES).to eq(expected_roles)

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Role, type: :model do
     it "contains the correct values" do
       expected_roles = %w[
         admin banned chatroom_beta_tester codeland_admin comment_banned podcast_admin pro restricted_liquid_tag
-        single_resource_admin super_admin tag_moderator mod_relations_admin tech_admin trusted
+        single_resource_admin super_admin tag_moderator mod_relations_admin tech_admin support_admin trusted
         warned workshop_pass
       ]
       expect(described_class::ROLES).to eq(expected_roles)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This adds a new support admin role to handle a specific DEV use-case. Ideally we have a better solution for this in the context of Forem, but for now this should do.

This allows anyone with the `support_admin` and `single_resource_admin, User` roles to banish users.

## Added tests?
- [x] no, because they aren't needed. This is a quick fix that should be replaced by a longer term solution.

## Added to documentation?
- [x] no documentation needed