### PR TITLE
Optimization:Set Honeybadger send_data_at_exit to False

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -16,6 +16,7 @@ Honeybadger.configure do |config|
   config.env = "#{ApplicationConfig['APP_DOMAIN']}-#{Rails.env}"
   config.api_key = ApplicationConfig["HONEYBADGER_API_KEY"]
   config.revision = ApplicationConfig["HEROKU_SLUG_COMMIT"]
+  config.send_data_at_exit = false
   config.exceptions.ignore += [
     Pundit::NotAuthorizedError,
     ActiveRecord::RecordNotFound,

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -12,11 +12,18 @@ COMPONENT_FINGERPRINTS = {
   "internal" => "internal"
 }.freeze
 
+# https://docs.honeybadger.io/lib/ruby/gem-reference/configuration.html
 Honeybadger.configure do |config|
   config.env = "#{ApplicationConfig['APP_DOMAIN']}-#{Rails.env}"
   config.api_key = ApplicationConfig["HONEYBADGER_API_KEY"]
   config.revision = ApplicationConfig["HEROKU_SLUG_COMMIT"]
+
+  # Prevent Ruby from exiting until all queued notices have been delivered to Honeybadger.
+  # When set to true(default), it can lead to a large number of errors causing a process to get stuck.
+  # To prevent this we set it to false ensuring that a process can exit quickly regardless of errors.
+  # Logging allows us to fill in gaps if we need to when errors get discarded.
   config.send_data_at_exit = false
+
   config.exceptions.ignore += [
     Pundit::NotAuthorizedError,
     ActiveRecord::RecordNotFound,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
This PR is in response to the outage we had that was caused by migrating our notifications table. While the site should have still worked, the overwhelming number of errors caused our servers to crash. Here is the explanation:

> Given the very low number of logs that came into Honeybadger during the outage time I am 90% sure I know what happened and it is exactly the same scenario we saw once at Kenna that I talk about in this post https://dev.to/molly_struve/10-tips-for-debugging-in-production-ko1
> 
> We poll the app for notification counts when a user is on a page. Locally when I tested this it was no big deal, I saw the timeout errors in my logs but the app worked fine minus an updating notification count bubble. In production however every single one of those timeout's triggered a Honeybadger. If you trigger a lot of Honeybadger's in a very short amount of time they will pile up. By default Honeybadger will attempt to send ALL of these errors before it allows a process to exit
 Honeybadger would not allow a program to exit until it had sent all of its enqueued data.
This means you end up with a ton of hung processes trying to send data to Honeybadger and refusing to exit until they do.

By setting [`send_data_at_exit` to false for Honeybadger](https://docs.honeybadger.io/lib/ruby/gem-reference/configuration.html) it will allow processes to exit even if they have not sent all of their enqueued errors. In my experience when you have an onslaught of errors they are a ton of duplicates so throwing some out so a process can exit is not a big deal. Plus we always have the logs we can refer to if we feel like we missed something. 


![alt_text](https://media0.giphy.com/media/v6gi2yGhoM4HC/source.gif)
