### PR TITLE
Bug Fix:Dont Set Active Channel if ChatChannel Does Not Exist

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -242,6 +242,8 @@ class ChatChannelsController < ApplicationController
              params[:slug]
            end
     chat_channel = ChatChannel.find_by(slug: slug)
+    return unless chat_channel
+
     membership = chat_channel.chat_channel_memberships.find_by(user_id: current_user.id)
     @active_channel = membership&.status == "active" ? chat_channel : nil
   end

--- a/spec/requests/chat_channels_spec.rb
+++ b/spec/requests/chat_channels_spec.rb
@@ -54,6 +54,15 @@ RSpec.describe "ChatChannels", type: :request do
         expect(response.body).not_to include(invite_channel.slug)
       end
     end
+
+    context "when logged in and chat channel doesnt exist" do
+      it "renders chat page" do
+        sign_in user
+        get "/connect/@#{user.username}"
+        expect(response.status).to eq(200)
+        expect(response.body).to include("chat-page-wrapper")
+      end
+    end
   end
 
   describe "get /chat_channels?state=unopened" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
There are times when a user can click on a chat link in the app that has a link with their own username in it. When this happens, we cannot find a chat channel between the user and themselves so we end up with the following error. This exits early without setting active_channel if the chat channel does not exist. 

Honeybadger: https://app.honeybadger.io/fault/66984/e8a80728dc5294c09fc37ca2d0c8f5f2
```
NoMethodError: undefined method `chat_channel_memberships' for nil:NilClass
chat_channels_controller.rb  241 render_channels_html(...)
[PROJECT_ROOT]/app/controllers/chat_channels_controller.rb:241:in `render_channels_html'
239            end
240     chat_channel = ChatChannel.find_by(slug: slug)
241     membership = chat_channel.chat_channel_memberships.find_by(user_id: current_user.id)
242     @active_channel = membership&.status == "active" ? chat_channel : nil
243   end
```
## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
One way to test this is to create a Listing then try to send a message to that listing when you are logged in. 

## Added tests?
- [x] yes


![alt_text](https://media2.giphy.com/media/JoVb15GA3t6vdmrKD6/giphy.gif)
