### PR TITLE
Travis Optimization:Bundle from Bash File to Use Cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - bundle config set path 'vendor/bundle'
-  - bundle install --local --jobs=2
+  - bin/ci-bundle
   - yarn install --frozen-lockfile
   - bundle exec rails db:create
   - bundle exec rails webpacker:compile

--- a/bin/ci-bundle
+++ b/bin/ci-bundle
@@ -1,0 +1,2 @@
+#!/bin/bash
+bundle install --local --jobs 3


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
I noticed recently that our first builds on branches were taking much longer bc they were installing all of the gems instead of using the gem cache. I am not sure why it behaves this way on travis but adding a bash file to run the bundle install seems to have fixed the issue. 


![alt_text](https://media3.giphy.com/media/RKZ25EH1junlFIUjza/200.gif)
