### PR TITLE
Flaky Spec Fix:HTML Escape Special Characters in Assertion like Template

### DIFF
--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Dashboards", type: :request do
         sign_in pro_user
         get dashboard_path
 
-        expect(response.body).to include("Pro Analytics for #{organization.name}")
+        expect(response.body).to include("Pro Analytics for #{CGI.escapeHTML(organization.name)}")
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When we display the org name in a dashboard the template will HMTL escape the special characters. This means if we have a name with those special characters in this test, comparing it without escaping it causes the test to fail.
```
1) Dashboards GET /dashboard when logged in as a pro user renders a link to pro analytics for the org
     Failure/Error: expect(response.body).to include("Pro Analytics for #{organization.name}")
       expected "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <meta charset=\"utf-8\">\n    <title>Dashboard - ...ba8488d21cd8ee1fee097b8410db9deaa41d0ca30b004c0c63de0a479114156f.svg\" />\n  </body>\n  </html>\n\n" to include "Pro Analytics for O'Kon and Sons"
       Diff:
       @@ -1,2 +1,420 @@
       -Pro Analytics for O'Kon and Sons
       +<!DOCTYPE html>
       +<html lang="en">
```


![alt_text](https://media.tenor.com/images/961044341e3bf6d800670e0514f3ce0d/tenor.gif)
