### PR TITLE
Fixed bug in [user-metadata-details], top portion clipped when scrollbar is visible

### DIFF
--- a/app/assets/stylesheets/user-profile-header.scss
+++ b/app/assets/stylesheets/user-profile-header.scss
@@ -231,10 +231,12 @@
         padding: 15px 0px;
       }
       @media screen and (min-width: 1100px) {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
         position: absolute;
-        top: 45%;
-        transform: translateY(-45%);
         padding: 15px 0px;
+        min-height: 90%;
       }
       .row {
         padding: calc(5px + 0.2vw) 0px;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This RP fixes the problem in the user profile page, where the top of the **user-metadata-details** section gets clipped and goes off bounds.

## QA Instructions, Screenshots, Recordings
<img src="https://user-images.githubusercontent.com/25284536/89768992-aa852180-db11-11ea-9718-3c9426ab9ecd.png" width="200"><img src="https://user-images.githubusercontent.com/25284536/89769025-b8d33d80-db11-11ea-8476-e8f9a4bf25d3.png" width="200">

As you can see in the first screenshot, the label **EMAIL** is barely visible and there is no way you can scroll there, this will cause scrolling problems as the height of the **user-metadata-details** grows and obviously more part of it is becomes hidden.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
