### PR TITLE
Redirect /internal to /admin

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -430,6 +430,11 @@ Style/ClassAndModuleChildren:
   Enabled: true
   SafeAutoCorrect: true
 
+Style/FormatStringToken:
+  Description: 'Use a consistent style for format string tokens.'
+  Exclude:
+    - 'config/routes.rb'
+
 Style/OptionalBooleanParameter:
   Description: 'Use keyword arguments when defining method with boolean argument.'
   StyleGuide: '#boolean-keyword-arguments'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -298,6 +298,8 @@ Rails.application.routes.draw do
   delete "/messages/:id" => "messages#destroy"
   patch "/messages/:id" => "messages#update"
   get "/live/:username" => "twitch_live_streams#show"
+  get "/internal", to: redirect("/admin")
+  get "/internal/:path", to: redirect("/admin/%{path}")
 
   post "/pusher/auth" => "pusher#auth"
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed how a bunch of my bookmarks to Blazer queries are broken because they point to `/internal` which is now called `/admin`. Prompted also by @michael-tharrington's post [here on forem.dev](https://forem.dev/michaelmadcat/renaming-things-and-broken-links-48j1) I added redirections for the old `/internal` links.

## QA Instructions, Screenshots, Recordings

- Fire up the branch
- point it to http://localhost:3000/internal/blazer which should redirect to http://localhost:3000/admin/blazer or http://localhost:3000/internal which will redirect to http://localhost:3000/admin which will redirect to http://localhost:3000/admin/articles :)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
