### PR TITLE
Fix Netlify catch all redirections

### DIFF
--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -7,6 +7,8 @@
 
 [build]
   command = "make"
+
+# See <https://docs.netlify.com/routing/redirects/redirect-options/> for more options
 [[redirects]]
 from = "http://docs.dev.to"
 to = "http://docs.forem.com"
@@ -14,19 +16,7 @@ status = 301
 force = true
 
 [[redirects]]
-from = "https://docs.dev.to"
-to = "https://docs.forem.com"
-status = 301
-force = true
-
-[[redirects]]
 from = "http://docs.dev.to/*"
-to = "http://docs.forem.com/*"
-status = 301
-force = true
-
-[[redirects]]
-from = "https://docs.dev.to/*"
-to = "https://docs.forem.com/*"
+to = "http://docs.forem.com/:splat"
 status = 301
 force = true


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

http://docs.dev.to/api and anything else like http://docs.dev.to/ruby-doc all redirect to http://docs.forem.com/* instead of capturing the path.

See https://docs.netlify.com/routing/redirects/redirect-options/#splats for the correct syntax

