### PR TITLE
Start using profile model

### DIFF
--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -1,4 +1,8 @@
 class ProfileField < ApplicationRecord
+  before_create :generate_attribute_name
+
+  WORD_REGEX = /\w+/.freeze
+
   # Key names follow the Rails form helpers
   enum input_type: {
     text_field: 0,
@@ -9,16 +13,19 @@ class ProfileField < ApplicationRecord
 
   validates :label, presence: true, uniqueness: { case_sensitive: false }
   validates :active, inclusion: { in: [true, false] }
+  validates :attribute_name, presence: true, on: :update
 
   scope :active, -> { where(active: true) }
-
-  def attribute_name
-    label.titleize.delete(" ").underscore
-  end
 
   def type
     return :boolean if check_box?
 
     :string
+  end
+
+  private
+
+  def generate_attribute_name
+    self.attribute_name = label.titleize.scan(WORD_REGEX).join.underscore
   end
 end

--- a/app/services/profile_fields/add_link_fields.rb
+++ b/app/services/profile_fields/add_link_fields.rb
@@ -3,17 +3,17 @@ module ProfileFields
     include FieldDefinition
 
     group "Links" do
-      field "Facebook profile URL", :text_field, placeholder: "https://facebook.com/..."
+      field "Facebook URL", :text_field, placeholder: "https://facebook.com/..."
       field "Youtube URL", :text_field, placeholder: "https://www.youtube.com/channel/..."
-      field "StackOverflow profile URL", :text_field, placeholder: "https://stackoverflow.com/users/..."
-      field "LinkedIn profile URL", :text_field, placeholder: "https://www.linkedin.com/in/..."
-      field "Behance profile URL", :text_field, placeholder: "https://..."
-      field "Dribble profile URL", :text_field, placeholder: "https://dribble.com/..."
-      field "Medium profile URL", :text_field, placeholder: "https://..."
-      field "GitLab profile URL", :text_field, placeholder: "https://..."
-      field "Instagram profile URL", :text_field, placeholder: "https://..."
-      field "Mastodon profile URL", :text_field, placeholder: "https://..."
-      field "Twitch profile URL", :text_field, placeholder: "https://..."
+      field "StackOverflow URL", :text_field, placeholder: "https://stackoverflow.com/users/..."
+      field "LinkedIn URL", :text_field, placeholder: "https://www.linkedin.com/in/..."
+      field "Behance URL", :text_field, placeholder: "https://www.behance.net/..."
+      field "Dribble URL", :text_field, placeholder: "https://dribble.com/..."
+      field "Medium URL", :text_field, placeholder: "https://medium.com/@..."
+      field "GitLab URL", :text_field, placeholder: "https://gitlab.com/..."
+      field "Instagram URL", :text_field, placeholder: "https://www.instagram.com/..."
+      field "Mastodon URL", :text_field, placeholder: "https://..."
+      field "Twitch URL", :text_field, placeholder: "https://www.twitch.tv/..."
     end
   end
 end

--- a/db/migrate/20200811044202_add_attribute_name_to_profile_field.rb
+++ b/db/migrate/20200811044202_add_attribute_name_to_profile_field.rb
@@ -1,0 +1,5 @@
+class AddAttributeNameToProfileField < ActiveRecord::Migration[6.0]
+  def change
+    add_column :profile_fields, :attribute_name, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_09_200631) do
+ActiveRecord::Schema.define(version: 2020_08_11_044202) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -923,6 +923,7 @@ ActiveRecord::Schema.define(version: 2020_08_09_200631) do
 
   create_table "profile_fields", force: :cascade do |t|
     t.boolean "active", default: true, null: false
+    t.string "attribute_name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.string "description"
     t.string "group"

--- a/lib/data/coding_profile_fields.csv
+++ b/lib/data/coding_profile_fields.csv
@@ -1,4 +1,4 @@
 Skills/Languages,text_area,,What tools and languages are you most experienced with? Are you specialized or more of a generalist?,Coding
-I'm getting into,text_area,,What are you learning right now? What are the new tools and languages you're picking up right now?,Coding
-My projects and hacks,text_area,,What projects are currently occupying most of your time?,Coding
+Currently learning,text_area,,What are you learning right now? What are the new tools and languages you're picking up right now?,Coding
+Currently hacking on,text_area,,What projects are currently occupying most of your time?,Coding
 Available for,text_area,,What kinds of collaborations or discussions are you available for? What's a good reason to say Hey! to you these days?,Coding

--- a/lib/data/dev_profile_fields.csv
+++ b/lib/data/dev_profile_fields.csv
@@ -1,0 +1,29 @@
+Display email on profile,check_box,,,Basic
+Name,text_field,John Doe,,Basic
+Website URL,text_field,https://yoursite.com,,Basic
+Summary,text_area,A short bio...,,Basic
+Location,text_field,"Halifax, Nova Scotia",,Basic
+Facebook URL,text_field,https://facebook.com/...,,Links
+Youtube URL,text_field,https://www.youtube.com/channel/...,,Links
+StackOverflow URL,text_field,https://stackoverflow.com/users/...,,Links
+LinkedIn URL,text_field,https://www.linkedin.com/in/...,,Links
+Behance URL,text_field,https://www.behance.net/...,,Links
+Dribble URL,text_field,https://dribble.com/...,,Links
+Medium URL,text_field,https://medium.com/@...,,Links
+GitLab URL,text_field,https://gitlab.com/...,,Links
+Instagram URL,text_field,https://www.instagram.com/...,,Links
+Mastodon URL,text_field,https://...,,Links
+Twitch URL,text_field,https://www.twitch.tv/...,,Links
+Education,text_field,,,Work
+Employer name,text_field,Acme Inc.,,Work
+Employer URL,text_field,https://dev.com,,Work
+Employment title,text_field,Junior Frontend Engineer,,Work
+Looking for work,check_box,,,Work
+"Display ""looking for work"" on profile",check_box,,,Work
+Recruiters can contact me about job opportunities,check_box,,,Work
+Skills/Languages,text_area,,What tools and languages are you most experienced with? Are you specialized or more of a generalist?,Coding
+Currently learning,text_area,,"What are you learning right now? What are the new tools and languages you're picking up right now?",Coding
+Currently hacking on,text_area,,What projects are currently occupying most of your time?,Coding
+Available for,text_area,,"What kinds of collaborations or discussions are you available for? What's a good reason to say Hey! to you these days?",Coding
+Brand color 1,color_field,#000000,"Used for backgrounds, borders etc.",Branding
+Brand color 2,color_field,#000000,Used for texts (usually put on Brand color 1).,Branding

--- a/lib/tasks/temporary/create_profile_fields.rake
+++ b/lib/tasks/temporary/create_profile_fields.rake
@@ -4,3 +4,4 @@ namespace :temporary do
     csv = Rails.root.join("lib/data/dev_profile_fields.csv")
     ProfileFields::ImportFromCsv.call(csv)
   end
+end

--- a/lib/tasks/temporary/migrate_profiles.rake
+++ b/lib/tasks/temporary/migrate_profiles.rake
@@ -1,0 +1,6 @@
+namespace :temporary do
+  desc "Create profile fields based on DEV profile" 
+  task create_profile_fields: :environment do
+    csv = Rails.root.join("lib/data/dev_profile_fields.csv")
+    ProfileFields::ImportFromCsv.call(csv)
+  end

--- a/spec/models/profile_field_spec.rb
+++ b/spec/models/profile_field_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe ProfileField, type: :model do
       it { is_expected.to validate_presence_of(:label) }
       it { is_expected.to validate_uniqueness_of(:label).case_insensitive }
       it { is_expected.to validate_inclusion_of(:active).in_array([true, false]) }
+      it { is_expected.to validate_presence_of(:attribute_name).on(:update) }
+    end
+  end
+
+  describe "callbacks" do
+    it "automatically generates an attribute name" do
+      pf = create(:profile_field, label: "Is this a test? This is a test! 1")
+      expect(pf.attribute_name).to eq "is_this_a_test_this_is_a_test1"
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature

## Description

This PR

* refactors `ProfileField` (attribute names are now generated differently and persisted),
* updates some field labels and placeholders and
* adds a Rake task for creating the existing DEV profile fields.

Note to whoever it may concern (but cc @benhalpern and @ludwiczakpawel so someone feels responsible): This introduces some slight copy changes to `/settings/profile`:

* "Dribble profile URL", "Behance profile URL", etc. will lose the word "profile" in the middle. It was a bit redundant anyway.
*  "I'm getting into" -> "Currently learning" (better reflects the DB column we store this in)
* "My projects and hacks" -> "Currently hacking on" (better reflects the DB column we store this in)
 
## Related Tickets & Documents

Part of #6994

## QA Instructions, Screenshots, Recordings

1. Run `bundle exec rails db:migrate`
1. Run `rails temporary:create_profile_fields` 
1. Verify that `ProfileField.count == 29`.
1. Sanity check the generated profile fields.
1. Take a few minutes to calm down after this thrilling ride.

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed

## Are there any post deployment tasks we need to perform?

* [ ] Run `rails temporary:create_profile_fields` 
