### PR TITLE
Create option for calculating score without external black box

### DIFF
--- a/app/black_box/black_box.rb
+++ b/app/black_box/black_box.rb
@@ -35,7 +35,8 @@ class BlackBox
     def calculate_spaminess(story, function_caller = FunctionCaller)
       # accepts comment or article as story
       return 100 unless story.user
-      return 100 unless ENV["AWS_SDK_KEY"].present? # Skip this if we don't have a private spam score for now
+      return 100 if ENV["AWS_SDK_KEY"].blank? # Skip this if we don't have a private spam score for now
+      return 100 if ENV["AWS_SDK_KEY"] == "foobarbaz" # Also skip if placeholder
 
       function_caller.call("blackbox-production-spamScore",
                            { story: story, user: story.user }.to_json).to_i

--- a/app/black_box/black_box.rb
+++ b/app/black_box/black_box.rb
@@ -16,7 +16,7 @@ class BlackBox
         reaction_points = (reaction_points * 0.8).to_i # watercooler posts shouldn't get as much love in feed
       end
 
-      article_hotness = last_mile_hotness_calc(function_caller)
+      article_hotness = last_mile_hotness_calc(article, function_caller)
 
       (
         article_hotness + reaction_points + recency_bonus + super_recent_bonus +
@@ -50,7 +50,7 @@ class BlackBox
       size_bonus + code_bonus
     end
 
-    def last_mile_hotness_calc(function_caller)
+    def last_mile_hotness_calc(article, function_caller)
       if ENV["AWS_SDK_KEY"].present? && ENV["AWS_SDK_KEY"] != "foobarbaz"
         function_caller.call(
           "blackbox-production-articleHotness",

--- a/app/black_box/black_box.rb
+++ b/app/black_box/black_box.rb
@@ -35,8 +35,8 @@ class BlackBox
     def calculate_spaminess(story, function_caller = FunctionCaller)
       # accepts comment or article as story
       return 100 unless story.user
-      return 100 if ENV["AWS_SDK_KEY"].blank? # Skip this if we don't have a private spam score for now
-      return 100 if ENV["AWS_SDK_KEY"] == "foobarbaz" # Also skip if placeholder
+      return 0 if ENV["AWS_SDK_KEY"].blank? # Skip this if we don't have a private spam score for now
+      return 0 if ENV["AWS_SDK_KEY"] == "foobarbaz" # Also skip if placeholder
 
       function_caller.call("blackbox-production-spamScore",
                            { story: story, user: story.user }.to_json).to_i
@@ -60,9 +60,9 @@ class BlackBox
         # Simple calculation that takes in published at time and scores
         # Same order of magnitude calculation as existing private function
         # Gives credit to new articles and articles which score well from users and mods
-        article.published_at.to_i/10000 +
-        (article.score * 5000) +
-        (article.comment_score * 5000)
+        article.published_at.to_i / 10_000 +
+          (article.score * 5000) +
+          (article.comment_score * 5000)
       end
     end
   end

--- a/spec/black_box/black_box_spec.rb
+++ b/spec/black_box/black_box_spec.rb
@@ -95,9 +95,18 @@ RSpec.describe BlackBox, type: :black_box do
       ENV["AWS_SDK_KEY"] = nil
     end
 
-    it "returns the value that the caller returns" do
+    it "returns the function_caller spaminess if AWS_SDK_KEY present" do
+      ENV["AWS_SDK_KEY"] = "valid_key"
       spaminess = described_class.calculate_spaminess(comment, function_caller)
       expect(spaminess).to eq(1)
+      ENV["AWS_SDK_KEY"] = nil
+    end
+
+    it "returns the default retrun value if AWS_SDK_KEY is placeholder" do
+      ENV["AWS_SDK_KEY"] = "foobarbaz"
+      spaminess = described_class.calculate_spaminess(comment, function_caller)
+      expect(spaminess).to eq(0)
+      ENV["AWS_SDK_KEY"] = nil
     end
   end
 end

--- a/spec/black_box/black_box_spec.rb
+++ b/spec/black_box/black_box_spec.rb
@@ -6,10 +6,18 @@ RSpec.describe BlackBox, type: :black_box do
   describe "#article_hotness_score" do
     let!(:article) { build_stubbed(:article, published_at: Time.current) }
 
-    it "calls function caller" do
+    it "calls function caller if AWS_SDK_KEY present" do
+      ENV["AWS_SDK_KEY"] = "valid_key"
       allow(function_caller).to receive(:call).and_return(5)
       described_class.article_hotness_score(article, function_caller)
       expect(function_caller).to have_received(:call).once
+      ENV["AWS_SDK_KEY"] = nil
+    end
+
+    it "does not call function caller if AWS_SDK_KEY is placeholder" do
+      ENV["AWS_SDK_KEY"] = "foobarbaz"
+      allow(function_caller).not_to receive(:call)
+      ENV["AWS_SDK_KEY"] = nil
     end
 
     it "doesn't fail when function caller returns nil" do

--- a/spec/black_box/black_box_spec.rb
+++ b/spec/black_box/black_box_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe BlackBox, type: :black_box do
 
     it "does not call function caller if AWS_SDK_KEY is placeholder" do
       ENV["AWS_SDK_KEY"] = "foobarbaz"
+      allow(function_caller).to receive(:call).and_return(5)
+      described_class.article_hotness_score(article, function_caller)
       expect(function_caller).not_to have_received(:call)
       ENV["AWS_SDK_KEY"] = nil
     end
@@ -89,7 +91,7 @@ RSpec.describe BlackBox, type: :black_box do
       ENV["AWS_SDK_KEY"] = "foobarbaz"
       described_class.calculate_spaminess(comment, function_caller)
       expect(function_caller).not_to have_received(:call).with("blackbox-production-spamScore",
-                                                               { story: comment, user: user }.to_json).once
+                                                               { story: comment, user: user }.to_json)
       ENV["AWS_SDK_KEY"] = nil
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We presently use a "private/external endpoint" for calculating score, using AWS Lambda. As we get up and running, this is not entirely necessary. I think inserting a basic "is this post good?" calc if the SDK keys are not present should be fine and we can revisit the functionality down the road.