### PR TITLE
Account deletion email: serialize only user's details

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -104,11 +104,10 @@ class NotifyMailer < ApplicationMailer
   end
 
   def account_deleted_email
-    user = params[:user]
-    @name = user.name
+    @name = params[:name]
 
     subject = "#{ApplicationConfig['COMMUNITY_NAME']} - Account Deletion Confirmation"
-    mail(to: user.email, subject: subject)
+    mail(to: params[:email], subject: subject)
   end
 
   def account_deletion_requested_email

--- a/app/workers/users/delete_worker.rb
+++ b/app/workers/users/delete_worker.rb
@@ -11,7 +11,10 @@ module Users
       Users::Delete.call(user)
       return if admin_delete || user.email.blank?
 
-      NotifyMailer.with(user: user).account_deleted_email.deliver_now
+      # at this point the user object is already destroyed on the DB,
+      # thus we pass the data we need to render to deliver the email, not the
+      # whole object
+      NotifyMailer.with(name: user.name, email: user.email).account_deleted_email.deliver_now
     rescue StandardError => e
       DatadogStatsClient.count("users.delete", 1, tags: ["action:failed", "user_id:#{user.id}"])
       Honeybadger.context({ user_id: user.id })

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#account_deleted_email" do
-    let(:email) { described_class.with(user: user).account_deleted_email }
+    let(:email) { described_class.with(name: user.name, email: user.email).account_deleted_email }
 
     it "renders proper subject" do
       expect(email.subject).to eq("#{ApplicationConfig['COMMUNITY_NAME']} - Account Deletion Confirmation")

--- a/spec/mailers/previews/notify_mailer_preview.rb
+++ b/spec/mailers/previews/notify_mailer_preview.rb
@@ -77,7 +77,8 @@ class NotifyMailerPreview < ActionMailer::Preview
   end
 
   def account_deleted_email
-    NotifyMailer.with(user: User.last).account_deleted_email
+    user = User.last
+    NotifyMailer.with(name: user.name, email: user.email).account_deleted_email
   end
 
   def export_email

--- a/spec/workers/users/delete_worker_spec.rb
+++ b/spec/workers/users/delete_worker_spec.rb
@@ -7,15 +7,18 @@ RSpec.describe Users::DeleteWorker, type: :worker do
   let(:message_delivery) { double }
 
   describe "#perform" do
-    let(:user) { create(:user) }
+    let!(:user) { create(:user) }
     let(:delete) { Users::Delete }
 
-    before do
-      allow(delete).to receive(:call)
-    end
-
     context "when user is found" do
+      it "deletes the user correctly" do
+        worker.perform(user.id)
+
+        expect(User.exists?(id: user.id)).to be(false)
+      end
+
       it "calls the service when a user is found" do
+        allow(delete).to receive(:call)
         worker.perform(user.id)
         expect(delete).to have_received(:call).with(user)
       end
@@ -39,7 +42,7 @@ RSpec.describe Users::DeleteWorker, type: :worker do
 
         worker.perform(user.id)
 
-        expect(mailer_class).to have_received(:with).with(user: user)
+        expect(mailer_class).to have_received(:with).with(name: user.name, email: user.email)
         expect(mailer).to have_received(:account_deleted_email)
         expect(message_delivery).to have_received(:deliver_now)
       end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After we merged #9636 a [logic error popped up in Honeybadger](https://app.honeybadger.io/fault/66984/8d581ecec8834ef75034edb89f27593a).

Basically what happens is that the email message is sent after the user and its data is removed from the DB, this message is serialized with the user object and its ID, that user ID doesn't exist anymore in the `users` table, thus PostgreSQL foreign key checks complain that the given ID doesn't exist.

The solution is to pass along only the needed data to register the email message, not the user itself. See also https://github.com/ankane/ahoy_email/blob/5d103b925763648c7b56527dd2318cb96a8b1f9c/lib/ahoy_email.rb#L44

I also made it so that the tests actually delete the object, as with the mocks until now the tests weren't failing (which is why we haven't caught this during the PR review process)

## Related Tickets & Documents

#9636 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
