### PR TITLE
Fix dotenv migration script and set pusher beams keys as optional

### DIFF
--- a/config/initializers/pusher.rb
+++ b/config/initializers/pusher.rb
@@ -8,8 +8,10 @@ if ApplicationConfig["PUSHER_APP_ID"].present?
   Pusher.logger = Rails.logger
   Pusher.encrypted = true
 
-  Pusher::PushNotifications.configure do |config|
-    config.instance_id = ApplicationConfig["PUSHER_BEAMS_ID"]
-    config.secret_key = ApplicationConfig["PUSHER_BEAMS_KEY"]
+  if ApplicationConfig["PUSHER_BEAMS_ID"].present? && ApplicationConfig["PUSHER_BEAMS_KEY"].present?
+    Pusher::PushNotifications.configure do |config|
+      config.instance_id = ApplicationConfig["PUSHER_BEAMS_ID"]
+      config.secret_key = ApplicationConfig["PUSHER_BEAMS_KEY"]
+    end
   end
 end

--- a/lib/tasks/temporary/env_variables.rake
+++ b/lib/tasks/temporary/env_variables.rake
@@ -1,11 +1,11 @@
 # Create a .env file from your application.yml file
 task create_dot_env_file: :environment do
-  exit unless File.file?("config/application.yml")
+  exit if File.file?(".env")
 
   File.open(".env", "w") do |env_file|
     File.open("config/application.yml", 'r') do |file|
       file.each_line do |line|
-        new_line = line.gsub(": ", "=")
+        new_line = line.gsub(%r{\:\s?}, "=")
         unless new_line.blank? || new_line.starts_with?("#")
           new_line.prepend("export ")
         end
@@ -13,6 +13,4 @@ task create_dot_env_file: :environment do
       end
     end
   end
-
-  File.delete("config/application.yml")
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the DEV Contributing Guide: https://github.com/thepracticaldev/dev.to/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the DEV Code of Conduct: https://github.com/thepracticaldev/dev.to/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As I ran the script locally I was left with neither of the file files (`.env` or `config/application.yml`) after running `bin/setup`.

I also had empty keys in my previous one which lead to a parsing error from dotenv.

The script now bails if `.env` is already there and doesn't delete `config/application.yml` so a person can manually check if the keys are migrated. As the file is ignored by our `.gitignore`, it's not going to be a big deal if we leave it there.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Please make a copy of your `config/application.yml` somewhere safe, test the script and make sure all the keys are migrated and then start the webserver to see if stuff works.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
