### PR TITLE
Remove orphaned DisplayAdEvent rows

### DIFF
--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -1,6 +1,6 @@
 class DisplayAd < ApplicationRecord
   belongs_to :organization
-  has_many :display_ad_events
+  has_many :display_ad_events, dependent: :destroy
 
   validates :organization_id, presence: true
   validates :placement_area, presence: true,

--- a/lib/data_update_scripts/20200813072205_remove_orphaned_display_ad_events.rb
+++ b/lib/data_update_scripts/20200813072205_remove_orphaned_display_ad_events.rb
@@ -1,0 +1,21 @@
+module DataUpdateScripts
+  class RemoveOrphanedDisplayAdEvents
+    def run
+      # Delete all DisplayAdEvents belonging to DisplayAds that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM display_ad_events
+          WHERE display_ad_id NOT IN (SELECT id FROM display_ads);
+        SQL
+      )
+
+      # Delete all DisplayAdEvents belonging to Users that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM display_ad_events
+          WHERE user_id NOT IN (SELECT id FROM users);
+        SQL
+      )
+    end
+  end
+end

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -4,11 +4,18 @@ RSpec.describe DisplayAd, type: :model do
   let(:organization) { create(:organization) }
   let(:display_ad) { create(:display_ad, organization_id: organization.id) }
 
-  it { is_expected.to validate_presence_of(:organization_id) }
-  it { is_expected.to validate_presence_of(:placement_area) }
-  it { is_expected.to validate_presence_of(:body_markdown) }
-
   describe "validations" do
+    describe "builtin validations" do
+      subject { display_ad }
+
+      it { is_expected.to belong_to(:organization) }
+      it { is_expected.to have_many(:display_ad_events).dependent(:destroy) }
+
+      it { is_expected.to validate_presence_of(:organization_id) }
+      it { is_expected.to validate_presence_of(:placement_area) }
+      it { is_expected.to validate_presence_of(:body_markdown) }
+    end
+
     it "allows sidebar_right" do
       display_ad.placement_area = "sidebar_right"
       expect(display_ad).to be_valid


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Before we add the foreign keys between relations, we need to cleanup the the DB.

This PR assumes that by removing an ad we want to remove its rows of events as well. Let me know if that's not the case.

As we did for ahoy models with [cleanup](https://github.com/forem/forem/pull/9710) and then [adding FKs](https://github.com/forem/forem/pull/9636) we need to do the same here.

Please make sure the query is correct :-D 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## [optional] Are there any post deployment tasks we need to perform?

We have around 310+ thousand orphan rows in the DB:

https://dev.to/admin/blazer/queries/153-display_ad_events-orphan-rows
