### PR TITLE
Remove flash message from article show page

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,11 +1,5 @@
 <% title @article.title_with_query_preamble(user_signed_in?) %>
 
-<% if flash[:success].present? %>
-  <div class="crayons-banner">
-    <%= flash[:success] %>
-  </div>
-<% end %>
-
 <%= render "shared/payment_pointer", user: @article.user %>
 
 <style>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This removes the flash message from the article show page, because the article show page is cached, and the flash would be cached too.
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] should probably add