### PR TITLE
Generalize liquid tag docs

### DIFF
--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -55,11 +55,11 @@
     </p>
     <h3><strong><%= community_name %> Article/Post Embed</strong></h3>
     <p>All you need is the full link of the article:</p>
-    <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <code><%= "{% link #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/kazz/boost-your-productivity-using-markdown-1be %}" %></code>
     <p>You can also use the slug like this:</p>
     <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the alias post instead of link like this:</p>
-    <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <code><%= "{% post #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/kazz/boost-your-productivity-using-markdown-1be %}" %>"</code>
     <p>or this:</p>
     <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
     <h3><strong><%= community_name %> User Embed</strong></h3>
@@ -75,10 +75,10 @@
     <code>{% comment 2d1a %}</code>
     <h3><strong><%= community_name %> Podcast Episode Embed</strong></h3>
     <p>All you need is the full link of the podcast episode:</p>
-    <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
+    <code><%= "{% podcast #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/basecspodcast/s2e2--queues-irl %}" %></code>
     <h3><strong><%= community_name %> Listing Embed</strong></h3>
     <p>All you need is the full link of the listing:</p>
-    <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
+    <code><%= "{% listing #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/listings/collabs/dev-is-open-source-823 %}" %></code>
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -55,11 +55,11 @@
     </p>
     <h3><strong><%= community_name %> Article/Post Embed</strong></h3>
     <p>All you need is the full link of the article:</p>
-    <code><%= "{% link #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/kazz/boost-your-productivity-using-markdown-1be %}" %></code>
+    <code>{% link <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
     <p>You can also use the slug like this:</p>
     <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the alias post instead of link like this:</p>
-    <code><%= "{% post #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/kazz/boost-your-productivity-using-markdown-1be %}" %>"</code>
+    <code>{% post <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
     <p>or this:</p>
     <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
     <h3><strong><%= community_name %> User Embed</strong></h3>
@@ -75,10 +75,10 @@
     <code>{% comment 2d1a %}</code>
     <h3><strong><%= community_name %> Podcast Episode Embed</strong></h3>
     <p>All you need is the full link of the podcast episode:</p>
-    <code><%= "{% podcast #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/basecspodcast/s2e2--queues-irl %}" %></code>
+    <code>{% podcast <%= app_url("/basecspodcast/s2e2--queues-irl") %> %}</code>
     <h3><strong><%= community_name %> Listing Embed</strong></h3>
     <p>All you need is the full link of the listing:</p>
-    <code><%= "{% listing #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/listings/collabs/dev-is-open-source-823 %}" %></code>
+    <code>{% listing <%= app_url("/listings/collabs/dev-is-open-source-823") %> %}</code>
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -3,11 +3,11 @@
     <p>We support native <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:</p>
     <h3><%= community_name %> Article/Post Embed</h3>
     <p>All you need is the full link of the article:</p>
-    <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <code><%= "{% link #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/kazz/boost-your-productivity-using-markdown-1be %}" %></code>
     <p>You can also use the slug like this:</p>
     <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the alias post instead of link like this:</p>
-    <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <code><%= "{% post #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/kazz/boost-your-productivity-using-markdown-1be %}" %>"</code>
     <p>or this:</p>
     <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
     <h3><%= community_name %> User Embed</h3>
@@ -20,7 +20,7 @@
     <p>All you need is the
       <code>ID</code> at the end of a comment URL. To get the comment link, click either the timestamp or the menu button in the top right corner on a comment and then click "Permalink". Here's an example:
     </p>
-    <code>{% devcomment 2d1a %}</code>
+    <code>{% comment 2d1a %}</code>
     <% if @user_approved_liquid_tags.include? UserSubscriptionTag %>
       <h3><%= community_name %> User Subscriptions</h3>
       <p class="fs-s fw-bold">This tag can only be used in articles.</p>
@@ -34,10 +34,10 @@
     <% end %>
     <h3><%= community_name %> Podcast Episode Embed</h3>
     <p>All you need is the full link of the podcast episode:</p>
-    <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
+    <code><%= "{% podcast #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/basecspodcast/s2e2--queues-irl %}" %></code>
     <h3><%= community_name %> Listing Embed</h3>
     <p>All you need is the full link of the listing:</p>
-    <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
+    <code><%= "{% listing #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/listings/collabs/dev-is-open-source-823 %}" %></code>
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -3,11 +3,11 @@
     <p>We support native <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:</p>
     <h3><%= community_name %> Article/Post Embed</h3>
     <p>All you need is the full link of the article:</p>
-    <code><%= "{% link #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/kazz/boost-your-productivity-using-markdown-1be %}" %></code>
+    <code>{% link <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
     <p>You can also use the slug like this:</p>
     <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the alias post instead of link like this:</p>
-    <code><%= "{% post #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/kazz/boost-your-productivity-using-markdown-1be %}" %>"</code>
+    <code>{% post <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
     <p>or this:</p>
     <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
     <h3><%= community_name %> User Embed</h3>
@@ -34,10 +34,10 @@
     <% end %>
     <h3><%= community_name %> Podcast Episode Embed</h3>
     <p>All you need is the full link of the podcast episode:</p>
-    <code><%= "{% podcast #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/basecspodcast/s2e2--queues-irl %}" %></code>
+    <code>{% podcast <%= app_url("/basecspodcast/s2e2--queues-irl") %> %}</code>
     <h3><%= community_name %> Listing Embed</h3>
     <p>All you need is the full link of the listing:</p>
-    <code><%= "{% listing #{ApplicationConfig['APP_PROTOCOL']}#{ApplicationConfig['APP_DOMAIN']}/listings/collabs/dev-is-open-source-823 %}" %></code>
+    <code>{% listing <%= app_url("/listings/collabs/dev-is-open-source-823") %> %}</code>
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
This PR further generalizes liquid tag documentation by replacing hardcoded `https://dev.to` URLs in examples to be dynamic based on the current domain. I also quickly updated the documentation to show the the `comment` alias instead of `devcomment` - both still work.

## Related Tickets & Documents
Closes #9730 

## QA Instructions, Screenshots, Recordings
1. Fire up the app locally.
2. Go to `/new`, focus "body" field, and click "liquid tags" link in the right sidebar. You should _not_ see URLs in the examples that include `https://dev.to`.
3. Go to http://localhost:3000/p/editor_guide. The same thing, you should _not_ see URLs in the examples that include `https://dev.to`.

![Screen Shot 2020-08-13 at 12 33 33 PM](https://user-images.githubusercontent.com/15987080/90161650-72741d80-dd61-11ea-9364-2ee392232e5a.png)
![Screen Shot 2020-08-13 at 12 34 33 PM](https://user-images.githubusercontent.com/15987080/90161659-743de100-dd61-11ea-985d-019188e31a89.png)

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

![dancing_gif](https://media.giphy.com/media/YAzwUqQwQbxzq/giphy.gif)
