### PR TITLE
Use .errors_as_sentece in Admin::Badges::Controller

### DIFF
--- a/app/controllers/admin/badges_controller.rb
+++ b/app/controllers/admin/badges_controller.rb
@@ -21,7 +21,7 @@ module Admin
         flash[:success] = "Badge has been created!"
         redirect_to admin_badges_path
       else
-        flash[:danger] = @badge.errors.full_messages.to_sentence
+        flash[:danger] = @badge.errors_as_sentence
         render new_admin_badge_path
       end
     end
@@ -33,7 +33,7 @@ module Admin
         flash[:success] = "Badge has been updated!"
         redirect_to admin_badges_path
       else
-        flash[:danger] = @badge.errors.full_messages.to_sentence
+        flash[:danger] = @badge.errors_as_sentence
         render :edit
       end
     end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR makes the switch to using the error message shortcut, `.errors_as_sentence`, in place of the verbose `.errors.full_messages.to_sentence` in the `Admin::Badges::Controller` per @rhymes' suggestion!

## Related Tickets & Documents
This PR relates to #9721 

## QA Instructions, Screenshots, Recordings
Make sure the Travis build passes.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![sleeping cat](https://media.giphy.com/media/3o6Zt6ML6BklcajjsA/giphy.gif)
