### PR TITLE
Create details liquid tag

### DIFF
--- a/app/liquid_tags/details_tag.rb
+++ b/app/liquid_tags/details_tag.rb
@@ -1,0 +1,25 @@
+class DetailsTag < Liquid::Block
+  PARTIAL = "liquids/details".freeze
+
+  def initialize(_tag_name, summary, _parse_context)
+    super
+    @summary = summary.strip
+  end
+
+  def render(_context)
+    content = Nokogiri::HTML.parse(super)
+    parsed_content = content.xpath("//html/body").text.strip
+
+    ActionController::Base.new.render_to_string(
+      partial: PARTIAL,
+      locals: {
+        summary: @summary,
+        parsed_content: parsed_content
+      },
+    )
+  end
+end
+
+Liquid::Template.register_tag("collapsible", DetailsTag)
+Liquid::Template.register_tag("details", DetailsTag)
+Liquid::Template.register_tag("spoiler", DetailsTag)

--- a/app/liquid_tags/details_tag.rb
+++ b/app/liquid_tags/details_tag.rb
@@ -1,14 +1,16 @@
 class DetailsTag < Liquid::Block
+  include ActionView::Helpers::SanitizeHelper
+
   PARTIAL = "liquids/details".freeze
 
   def initialize(_tag_name, summary, _parse_context)
     super
-    @summary = summary.strip
+    @summary = sanitize(summary.strip)
   end
 
   def render(_context)
     content = Nokogiri::HTML.parse(super)
-    parsed_content = content.xpath("//html/body").text.strip
+    parsed_content = sanitize(content.xpath("//html/body").inner_html)
 
     ActionController::Base.new.render_to_string(
       partial: PARTIAL,

--- a/app/views/liquids/_details.html.erb
+++ b/app/views/liquids/_details.html.erb
@@ -1,0 +1,4 @@
+<details>
+  <summary><%= summary %></summary>
+  <%= parsed_content %>
+</details>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -55,11 +55,11 @@
     </p>
     <h3><strong><%= community_name %> Article/Post Embed</strong></h3>
     <p>All you need is the full link of the article:</p>
-    <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <code>{% link <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
     <p>You can also use the slug like this:</p>
     <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the alias post instead of link like this:</p>
-    <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <code>{% post <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
     <p>or this:</p>
     <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
     <h3><strong><%= community_name %> User Embed</strong></h3>
@@ -75,10 +75,10 @@
     <code>{% comment 2d1a %}</code>
     <h3><strong><%= community_name %> Podcast Episode Embed</strong></h3>
     <p>All you need is the full link of the podcast episode:</p>
-    <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
+    <code>{% podcast <%= app_url("/basecspodcast/s2e2--queues-irl") %> %}</code>
     <h3><strong><%= community_name %> Listing Embed</strong></h3>
     <p>All you need is the full link of the listing:</p>
-    <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
+    <code>{% listing <%= app_url("/listings/collabs/dev-is-open-source-823") %> %}</code>
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -82,6 +82,15 @@
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
+    <h3><strong>Details Embed</strong></h3>
+    <p>You can embed a details HTML element by using details, spoiler, or
+    collapsible. The <em>summary</em> will be what the dropdown title displays.
+    The <em>content</em> will be the text hidden behind the dropdown. This is
+    great for when you want to hide text (i.e. answers to questions) behind a
+    user action/intent (i.e. a click)</p>
+    <p><code>{% details summary %} content {% enddetails %}</code></p>
+    <p><code>{% spoiler summary %} content {% endspoiler %}</code></p>
+    <p><code>{% collapsible summary %} content {% endcollapsible %}</code></p>
     <h3><strong>Twitter Embed</strong></h3>
     <p>Using the Twitter Liquid tag will allow the tweet to pre-render from the server, providing your reader with a better experience. All you need is the tweet
       <code>id</code> from the url.</p>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -55,11 +55,11 @@
     </p>
     <h3><strong><%= community_name %> Article/Post Embed</strong></h3>
     <p>All you need is the full link of the article:</p>
-    <code>{% link <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
+    <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the slug like this:</p>
     <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the alias post instead of link like this:</p>
-    <code>{% post <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
+    <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>or this:</p>
     <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
     <h3><strong><%= community_name %> User Embed</strong></h3>
@@ -75,10 +75,10 @@
     <code>{% comment 2d1a %}</code>
     <h3><strong><%= community_name %> Podcast Episode Embed</strong></h3>
     <p>All you need is the full link of the podcast episode:</p>
-    <code>{% podcast <%= app_url("/basecspodcast/s2e2--queues-irl") %> %}</code>
+    <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
     <h3><strong><%= community_name %> Listing Embed</strong></h3>
     <p>All you need is the full link of the listing:</p>
-    <code>{% listing <%= app_url("/listings/collabs/dev-is-open-source-823") %> %}</code>
+    <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
@@ -87,7 +87,7 @@
     collapsible. The <em>summary</em> will be what the dropdown title displays.
     The <em>content</em> will be the text hidden behind the dropdown. This is
     great for when you want to hide text (i.e. answers to questions) behind a
-    user action/intent (i.e. a click)</p>
+    user action/intent (i.e. a click).</p>
     <p><code>{% details summary %} content {% enddetails %}</code></p>
     <p><code>{% spoiler summary %} content {% endspoiler %}</code></p>
     <p><code>{% collapsible summary %} content {% endcollapsible %}</code></p>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -3,11 +3,11 @@
     <p>We support native <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:</p>
     <h3><%= community_name %> Article/Post Embed</h3>
     <p>All you need is the full link of the article:</p>
-    <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <code>{% link <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
     <p>You can also use the slug like this:</p>
     <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the alias post instead of link like this:</p>
-    <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
+    <code>{% post <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
     <p>or this:</p>
     <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
     <h3><%= community_name %> User Embed</h3>
@@ -34,10 +34,10 @@
     <% end %>
     <h3><%= community_name %> Podcast Episode Embed</h3>
     <p>All you need is the full link of the podcast episode:</p>
-    <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
+    <code>{% podcast <%= app_url("/basecspodcast/s2e2--queues-irl") %> %}</code>
     <h3><%= community_name %> Listing Embed</h3>
     <p>All you need is the full link of the listing:</p>
-    <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
+    <code>{% listing <%= app_url("/listings/collabs/dev-is-open-source-823") %> %}</code>
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -20,7 +20,7 @@
     <p>All you need is the
       <code>ID</code> at the end of a comment URL. To get the comment link, click either the timestamp or the menu button in the top right corner on a comment and then click "Permalink". Here's an example:
     </p>
-    <code>{% devcomment 2d1a %}</code>
+    <code>{% comment 2d1a %}</code>
     <% if @user_approved_liquid_tags.include? UserSubscriptionTag %>
       <h3><%= community_name %> User Subscriptions</h3>
       <p class="fs-s fw-bold">This tag can only be used in articles.</p>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -3,11 +3,11 @@
     <p>We support native <a href="https://shopify.github.io/liquid" target="_blank" rel="noopener">Liquid tags</a> in our editor, but have created our own custom tags listed below:</p>
     <h3><%= community_name %> Article/Post Embed</h3>
     <p>All you need is the full link of the article:</p>
-    <code>{% link <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
+    <code>{% link https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the slug like this:</p>
     <code>{% link kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>You can also use the alias post instead of link like this:</p>
-    <code>{% post <%= app_url("/kazz/boost-your-productivity-using-markdown-1be") %> %}</code>
+    <code>{% post https://dev.to/kazz/boost-your-productivity-using-markdown-1be %}</code>
     <p>or this:</p>
     <code>{% post kazz/boost-your-productivity-using-markdown-1be %}</code>
     <h3><%= community_name %> User Embed</h3>
@@ -20,7 +20,7 @@
     <p>All you need is the
       <code>ID</code> at the end of a comment URL. To get the comment link, click either the timestamp or the menu button in the top right corner on a comment and then click "Permalink". Here's an example:
     </p>
-    <code>{% comment 2d1a %}</code>
+    <code>{% devcomment 2d1a %}</code>
     <% if @user_approved_liquid_tags.include? UserSubscriptionTag %>
       <h3><%= community_name %> User Subscriptions</h3>
       <p class="fs-s fw-bold">This tag can only be used in articles.</p>
@@ -34,10 +34,10 @@
     <% end %>
     <h3><%= community_name %> Podcast Episode Embed</h3>
     <p>All you need is the full link of the podcast episode:</p>
-    <code>{% podcast <%= app_url("/basecspodcast/s2e2--queues-irl") %> %}</code>
+    <code>{% podcast https://dev.to/basecspodcast/s2e2--queues-irl %}</code>
     <h3><%= community_name %> Listing Embed</h3>
     <p>All you need is the full link of the listing:</p>
-    <code>{% listing <%= app_url("/listings/collabs/dev-is-open-source-823") %> %}</code>
+    <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
@@ -46,7 +46,7 @@
     collapsible. The <em>summary</em> will be what the dropdown title displays.
     The <em>content</em> will be the text hidden behind the dropdown. This is
     great for when you want to hide text (i.e. answers to questions) behind a
-    user action/intent (i.e. a click)</p>
+    user action/intent (i.e. a click).</p>
     <p><code>{% details summary %} content {% enddetails %}</code></p>
     <p><code>{% spoiler summary %} content {% endspoiler %}</code></p>
     <p><code>{% collapsible summary %} content {% endcollapsible %}</code></p>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -50,12 +50,6 @@
     <p><code>{% details summary %} content {% enddetails %}</code></p>
     <p><code>{% spoiler summary %} content {% endspoiler %}</code></p>
     <p><code>{% collapsible summary %} content {% endcollapsible %}</code></p>
-    <h3><%= community_name %> Listing Embed</h3>
-    <p>All you need is the full link of the listing:</p>
-    <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
-    <p>You can also use the category and slug like this:</p>
-    <code>{% listing collabs/dev-is-open-source-823 %}</code>
-    <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
     <h3>Twitter Embed</h3>
     <p>Using the Twitter Liquid tag will allow the tweet to pre-render from the server, providing your reader with a better experience. All you need is the tweet
       <code>id</code> from the url.</p>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -41,6 +41,21 @@
     <p>You can also use the category and slug like this:</p>
     <code>{% listing collabs/dev-is-open-source-823 %}</code>
     <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
+    <h3>Details Embed</h3>
+    <p>You can embed a details HTML element by using details, spoiler, or
+    collapsible. The <em>summary</em> will be what the dropdown title displays.
+    The <em>content</em> will be the text hidden behind the dropdown. This is
+    great for when you want to hide text (i.e. answers to questions) behind a
+    user action/intent (i.e. a click)</p>
+    <p><code>{% details summary %} content {% enddetails %}</code></p>
+    <p><code>{% spoiler summary %} content {% endspoiler %}</code></p>
+    <p><code>{% collapsible summary %} content {% endcollapsible %}</code></p>
+    <h3><%= community_name %> Listing Embed</h3>
+    <p>All you need is the full link of the listing:</p>
+    <code>{% listing https://dev.to/listings/collabs/dev-is-open-source-823 %}</code>
+    <p>You can also use the category and slug like this:</p>
+    <code>{% listing collabs/dev-is-open-source-823 %}</code>
+    <p>Note: Expired listings will raise an error. Make sure the listing is published or recently bumped.</p>
     <h3>Twitter Embed</h3>
     <p>Using the Twitter Liquid tag will allow the tweet to pre-render from the server, providing your reader with a better experience. All you need is the tweet
       <code>id</code> from the url.</p>

--- a/spec/liquid_tags/details_tag_spec.rb
+++ b/spec/liquid_tags/details_tag_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe DetailsTag, type: :liquid_tag do
+  describe "#render" do
+    let(:summary) { "Click to see the answer!" }
+    let(:content) { "The answer is Forem!" }
+
+    def generate_details_liquid(summary, content)
+      Liquid::Template.register_tag("details", described_class)
+      Liquid::Template.parse("{% details #{summary} %} #{content} {% enddetails %}")
+    end
+
+    it "generates proper details div with summary" do
+      rendered = generate_details_liquid(summary, content).render
+      Approvals.verify(rendered, name: "details_liquid_tag_spec", format: :html)
+    end
+  end
+end

--- a/spec/support/fixtures/approvals/details_liquid_tag_spec.approved.html
+++ b/spec/support/fixtures/approvals/details_liquid_tag_spec.approved.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
   <body>
-    <details><summary>Click to see the answer!</summary>
-  The answer is Forem!
+    <details><summary>Click to see the answer!</summary><p>The answer is Forem! </p>
 </details>
   </body>
 </html>

--- a/spec/support/fixtures/approvals/details_liquid_tag_spec.approved.html
+++ b/spec/support/fixtures/approvals/details_liquid_tag_spec.approved.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <body>
+    <details><summary>Click to see the answer!</summary>
+  The answer is Forem!
+</details>
+  </body>
+</html>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR creates a new liquid tag that enables an author to include a `details` HTML element which helps to hide content behind a click.

This concept has been discussed in a few places and I started by registering the tag under `details`, `collapsible`, and `spoiler` so that any/all of these would work and do the same thing. If we want to separate the functionality, like make `spoiler` behave similarly to how [Reddit handles it](https://www.reddit.com/wiki/commenting#wiki_posting), let's decide that now so we can avoid having to re-save a bunch of articles in the future.

I figured since the default styling looks okay we can start there, see some real use cases in the wild, and then update the styling with the design team later.

While this liquid tag is bare-bones by putting text into a `details` and `summary` element, one of the advantages of implementing this functionality as a liquid tag is it gives the option to expand on it later (add custom JavaScript, styles, etc.) with less restriction. We could update this tag to be a fully custom implementation of hiding/showing content on click with crazy JavaScript animations. It would require a re-save to any existing articles using the tag and then it would "just work" :trollface:.

## Related Tickets & Documents
Closes https://github.com/forem/forem/issues/9719
Closes https://github.com/forem/forem/issues/947

## QA Instructions, Screenshots, Recordings
1. Fire up the app locally.
2. Go to `/new` (aka **Write a post**).
3. Use the new liquid tag.
4. Click preview and/or publish to see it in action 🎉 .

```
{% details What is the best community platform? %}
Forem 🎉 
{% enddetails %}
```
**Documentation**
![Screen Shot 2020-08-13 at 4 49 08 PM](https://user-images.githubusercontent.com/15987080/90186199-cb55ad00-dd85-11ea-8df3-d9d4ad1f5bb1.png)

**Using the liquid tag**
![Screen Shot 2020-08-13 at 4 51 49 PM](https://user-images.githubusercontent.com/15987080/90186200-cc86da00-dd85-11ea-8f7b-d881e59c4730.png)

**How it renders in an article by default**
![Screen Shot 2020-08-13 at 4 51 54 PM](https://user-images.githubusercontent.com/15987080/90186202-cc86da00-dd85-11ea-8ae9-4527aa0d8a22.png)

**How it looks when clicked**
![Screen Shot 2020-08-13 at 4 52 05 PM](https://user-images.githubusercontent.com/15987080/90186203-cd1f7080-dd85-11ea-8ad9-7bde5eca4cbb.png)


_Note: this feature uses [the `details` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) and is not supported by Internet Explorer._
## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed - updated liquid tag documentation which could _definitely_ use some feedback to make it more concise 🙈 

![details_gif](https://media.giphy.com/media/fefZ2NUMZmIjWNokVi/giphy.gif)
