### PR TITLE
Allow canonical urls that have not been taken by a published article

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -52,10 +52,9 @@ class Article < ApplicationRecord
                     length: { maximum: 128 }
   validates :user_id, presence: true
   validates :feed_source_url, uniqueness: { allow_blank: true }
-  validates :canonical_url,
-            url: { allow_blank: true, no_local: true, schemes: %w[https http] }
-  # uniqueness: { scope: :published, allow_blank: true }
-  validate :canonical_url_must_be_unique
+  validates :canonical_url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
+  validates :canonical_url, uniqueness: { allow_blank: true },
+                            if: -> { Article.published.exists?(canonical_url: canonical_url) }
   validates :body_markdown, length: { minimum: 0, allow_nil: false }, uniqueness: { scope: %i[user_id title] }
   validate :validate_tag
   validate :validate_video
@@ -566,12 +565,6 @@ class Article < ApplicationRecord
     return unless canonical_url.to_s.match?(/[[:space:]]/)
 
     errors.add(:canonical_url, "must not have spaces")
-  end
-
-  def canonical_url_must_be_unique
-    return unless canonical_url && Article.published.exists?(canonical_url: canonical_url)
-
-    errors.add(:canonical_url, "has already been taken")
   end
 
   def create_slug

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Article, type: :model do
   it_behaves_like "UserSubscriptionSourceable"
 
   describe "validations" do
-    it { is_expected.to validate_uniqueness_of(:canonical_url).allow_blank }
     it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:user_id) }
     it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_blank }
     it { is_expected.to validate_presence_of(:title) }
@@ -145,17 +144,18 @@ RSpec.describe Article, type: :model do
         expect(another_article).to be_valid
       end
 
-      it "is not valid when the url has been taken by a published article" do
-        article.update(canonical_url: url)
-        another_article = build(:article)
-        another_article.canonical_url = url
+      it "is not valid" do
+        body_markdown = "---\ntitle: Title\ncanonical_url: #{url}\npublished: true\n---\n\n"
+        create(:article, body_markdown: body_markdown)
+        another_article = build(:article, body_markdown: body_markdown)
 
         expect(another_article).not_to be_valid
       end
 
-      it "is valid when the url has been taken by a draft article" do
-        another_article = build(:article)
-        another_article.canonical_url = url
+      it "is valid" do
+        body_markdown = "---\ntitle: Title\ncanonical_url: #{url}\npublished: false\n---\n\n"
+        create(:article, body_markdown: body_markdown)
+        another_article = build(:article, body_markdown: body_markdown)
 
         expect(another_article).to be_valid
       end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -136,6 +136,25 @@ RSpec.describe Article, type: :model do
       end
     end
 
+    describe "#canonical_url_must_be_unique" do
+      let(:url) { "http://example.com" }
+
+      it "is not valid when the url has been taken by a published article" do
+        article.update(canonical_url: url)
+        another_article = build(:article)
+        another_article.canonical_url = url
+
+        expect(another_article).not_to be_valid
+      end
+
+      it "is valid when the url has been taken by a draft article" do
+        another_article = build(:article)
+        another_article.canonical_url = url
+
+        expect(another_article).to be_valid
+      end
+    end
+
     describe "#main_image" do
       it "must have url for main image if present" do
         article.main_image = "hello"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -139,6 +139,12 @@ RSpec.describe Article, type: :model do
     describe "#canonical_url_must_be_unique" do
       let(:url) { "http://example.com" }
 
+      it "is valid when the canonical url is nil" do
+        another_article = build(:article)
+
+        expect(another_article).to be_valid
+      end
+
       it "is not valid when the url has been taken by a published article" do
         article.update(canonical_url: url)
         another_article = build(:article)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Replace uniqueness validation with custom method to only check published articles for the uniqueness of a new article canonical url

## Related Tickets & Documents
Closes #9759 

## QA Instructions, Screenshots, Recordings

1. Create a draft article with a canonical url
2. Create another article with the same canonical url
3. The second article should update without any errors
4. Update the first article to be published.
5. Make any update to the second article. Now it should show the error "Canonical url has already been taken"

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)

Note: A potential disadvantage of this change is that draft  articles that were valid when saved can become invalid once another article is published using the same canonical url.
