### PR TITLE
Add "autofocus" and "required" attributes to the email field

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -6,7 +6,7 @@
 
     <div class="crayons-field">
       <%= f.label :email, class: "crayons-field__label" %>
-      <%= f.email_field :email, class: "crayons-textfield", placeholder: "you@email.com", autofocus: true %>
+      <%= f.email_field :email, class: "crayons-textfield", placeholder: "you@email.com", autofocus: true, required: true %>
     </div>
 
     <div class="crayons-field pt-6">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -6,7 +6,7 @@
 
     <div class="crayons-field">
       <%= f.label :email, class: "crayons-field__label" %>
-      <%= f.email_field :email, class: "crayons-textfield", placeholder: "you@email.com" %>
+      <%= f.email_field :email, class: "crayons-textfield", placeholder: "you@email.com", autofocus: true %>
     </div>
 
     <div class="crayons-field pt-6">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Currently, on [the password reset page](https://dev.to/users/password/new), I can submit the form without enter an email.

![image](https://user-images.githubusercontent.com/5250117/90283337-3ee8de80-de9a-11ea-8bb6-c569bbab3c99.png)


So I added the attribute `required` to make sure the user will enter something before submitting.

![image](https://user-images.githubusercontent.com/5250117/90283401-5de77080-de9a-11ea-97bb-b22ed2c6e014.png)


In addition, adding `autofocus` also improves user experience.

## QA Instructions, Screenshots, Recordings

![new-attributes](https://user-images.githubusercontent.com/5250117/90283725-d6e6c800-de9a-11ea-8311-640bd48cf1d2.PNG)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
