### PR TITLE
Add missing `.call`

### DIFF
--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -13,7 +13,7 @@
 
       <% if decorated_comment.low_quality %>
         <div class="low-quality-comment-marker">
-          <%= image_tag(Images::Optimizer(SiteConfig.mascot_image_url, width: 50, height: 50, crop: "imagga_scale"), class: "sloan", alt: "Sloan, the sloth mascot", loading: "lazy") %>
+          <%= image_tag(Images::Optimizer.call(SiteConfig.mascot_image_url, width: 50, height: 50, crop: "imagga_scale"), class: "sloan", alt: "Sloan, the sloth mascot", loading: "lazy") %>
           Comment marked as low quality/non-constructive by the community
           <a href="/code-of-conduct">View code of conduct</a>
         </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
1. line 14 of `app/views/comments/_comment_proper.html.erb`, change that to  `<% if true %>`
2. Start the server up locally and navigate to an article with at least a comment.
3. You should be able to browse normally.

## Added tests?
- [x] no, there's no time!

## Added to documentation?
- [x] no documentation needed
