### PR TITLE
Bug Fix:Increase look back time for Cron jobs to 120 seconds

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,7 +8,7 @@ module Sidekiq
         # sidekiq workers, we need to ensure any job scheduled during that down time
         # is run once Sidekiq boots back up
         # https://github.com/ondrejbartas/sidekiq-cron/blob/074a87546f16122c1f508bb2805b9951588f2510/lib/sidekiq/cron/job.rb#L593
-        return false if (current_time.to_i - last_cron_time.to_i) > 120
+        return false if (current_time.to_i - last_cron_time.to_i) > (ENV["CRON_LOOKBACK_TIME"] || 60).to_i
 
         true
       end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,21 @@
+module Sidekiq
+  module Cron
+    class Job
+      def not_past_scheduled_time?(current_time)
+        last_cron_time = parsed_cron.previous_time(current_time).utc
+        # @mstruve/@sre: method monkey patched to increase time we look back for
+        # unrun scheduled jobs from 60 to 120. Heroku takes 60 seconds to restart
+        # sidekiq workers, we need to ensure any job scheduled during that down time
+        # is run once Sidekiq boots back up
+        # https://github.com/ondrejbartas/sidekiq-cron/blob/074a87546f16122c1f508bb2805b9951588f2510/lib/sidekiq/cron/job.rb#L593
+        return false if (current_time.to_i - last_cron_time.to_i) > 120
+
+        true
+      end
+    end
+  end
+end
+
 Rails.application.config.to_prepare do
   Dir.glob(Rails.root.join("lib/sidekiq/*.rb")).sort.each do |filename|
     require_dependency filename
@@ -6,9 +24,15 @@ end
 
 Sidekiq.configure_server do |config|
   schedule_file = "config/schedule.yml"
+  # @mstruve/@sre: sidekiq-cron still uses the removed poll_interval
+  # to determine how often to poll for jobs so we should manually set it
+  # https://github.com/ondrejbartas/sidekiq-cron/issues/254
+  # Sidekiq default is 5, we don't need it quite that often but would like it more than
+  # every 30 seconds which the gem defaults to
+  Sidekiq.options[:poll_interval] = 10
 
   if File.exist?(schedule_file)
-    Sidekiq::Cron::Job.load_from_hash(YAML.load_file(schedule_file))
+    Sidekiq::Cron::Job.load_from_hash!(YAML.load_file(schedule_file))
   end
 
   sidekiq_url = ApplicationConfig["REDIS_SIDEKIQ_URL"] || ApplicationConfig["REDIS_URL"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
It takes us a little over 60 seconds to restart Sidekiq workers on Heroku. Our [sidekiq-cron gem however only looks back 60 seconds](https://github.com/ondrejbartas/sidekiq-cron/blob/074a87546f16122c1f508bb2805b9951588f2510/lib/sidekiq/cron/job.rb#L597) to see if it missed any jobs that need to be run. This means that would inadvertently miss some jobs during a deploy. To fix this I increased the time we look back to 120 seconds. This should give us more than enough cushion for the restart and ensure we get all unrun past jobs. 

My plan is to open up some PRs on the gem to fix this issue by making the "look back" time configurable. If I really wanted to get flashy(which I might) I could set a time in Redis for each Sidekiq poll then check for the last poll time and make sure to check for any unrun jobs between that poll time and the current time. Regardless though I wanted to get this patch in our codebase so we could hop over to Sidekiq quickly and save @jdoss some infrastructure hassle.

## QA
- Stop the app right before any 10 min interval (1:00, 1:10, 1:20, 1:30 etc) 
- Restart the app at 90 seconds after shutting it down. 
- After 10 seconds you should see a log indicating that the stats worker ran
```
17:01:05 sidekiq.1   | 2020-08-14T22:01:05.848Z pid=78846 tid=kbq class=Metrics::RecordBackgroundQueueStatsWorker jid=1eaadd8c8acd369f5d03e3b7 INFO: start
``` 

![alt_text](https://media3.giphy.com/media/3rrn8f3oVnzASClZ86/giphy-downsized.gif)
