### PR TITLE
🐞Bug Fix: Chat doesn't extend to its frame on Firefox iOS [ Fixes #4024 ]

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -297,7 +297,7 @@
   @media screen and (max-width: 426px) {
     padding: 10px;
     min-width: 50%;
-    width: calc(100% - 16px);
+    width: calc(100%);
     position: fixed;
     height: 100%;
     margin-left: 0;

--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -12,13 +12,7 @@
 }
 
 .live-chat {
-  height: calc(100vh - 56px);
-
-  &.live-chat--iossafari {
-    height: calc(100vh - 190px);
-  }
-
-  overflow-y: hidden;
+  height: calc(100 * var(--vh) - var(--header-height));
 }
 
 .live-chat {
@@ -28,14 +22,10 @@
 
 .chat {
   display: flex;
-  height: calc(100vh - var(--header-height));
+  height: calc(100 * var(--vh) - var(--header-height));
   position: relative;
   overflow-x: hidden;
   overflow-y: hidden;
-
-  &.chat--iossafari {
-    height: calc(100vh - 201px);
-  }
 }
 
 .chat__channels {

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -1830,11 +1830,6 @@ export default class Chat extends Component {
 
   render() {
     const { state } = this;
-    const detectIOSSafariClass =
-      navigator.userAgent.match(/iPhone/i) &&
-      !navigator.userAgent.match('CriOS')
-        ? ' chat--iossafari'
-        : '';
     let channelHeader = <div className="active-channel__header">&nbsp;</div>;
     if (state.activeChannel) {
       channelHeader = (
@@ -1855,9 +1850,9 @@ export default class Chat extends Component {
       <div
         data-testid="chat"
         className={`chat chat--expanded
-        ${detectIOSSafariClass} chat--${
-          state.videoPath ? 'video-visible' : 'video-not-visible'
-        } chat--${
+         chat--${
+           state.videoPath ? 'video-visible' : 'video-not-visible'
+         } chat--${
           state.activeContent[state.activeChannelId]
             ? 'content-visible'
             : 'content-not-visible'

--- a/app/views/chat_channels/index.html.erb
+++ b/app/views/chat_channels/index.html.erb
@@ -36,3 +36,9 @@
     display: none
   }
 </style>
+<script>
+    // First we get the viewport height and we multiple it by 1% to get a value for a vh unit
+  let vh = window.innerHeight * 0.01;
+  // Then we set the value in the --vh custom property to the root of the document
+  document.documentElement.style.setProperty('--vh', `${vh}px`);
+</script>

--- a/app/views/chat_channels/index.html.erb
+++ b/app/views/chat_channels/index.html.erb
@@ -36,8 +36,3 @@
     display: none
   }
 </style>
-<script>
-  if (navigator.userAgent.match(/iPhone/i) && !navigator.userAgent.match('CriOS')) {
-    document.getElementById("chat").classList.add("live-chat--iossafari")
-  }
-</script>

--- a/app/views/chat_channels/index.html.erb
+++ b/app/views/chat_channels/index.html.erb
@@ -41,4 +41,5 @@
   let vh = window.innerHeight * 0.01;
   // Then we set the value in the --vh custom property to the root of the document
   document.documentElement.style.setProperty('--vh', `${vh}px`);
+  document.body.style.setProperty('min-height','-webkit-fill-available')
 </script>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
So after doing more research into it. I found few things, `navigator.userAgent.match(/iPhone/i) && !navigator.userAgent.match('CriOS')` this logic as added for IOS app which have this tabs
<img width="381" alt="image" src="https://user-images.githubusercontent.com/3650216/90310773-63809d00-df12-11ea-96d4-00fb6f96526d.png">

But user agent in case of iOS app is custom and equal to "DEV-Native-ios" that's how I discover that this request never fulfill and classes never got added. So When I removed it everything as working fine.  
## Related Tickets & Documents
Fixes [#4024](https://github.com/forem/forem/issues/4024)
## QA Instructions, Screenshots, Recordings
![Screen Recording 2020-08-15 at 04 08 PM gif](https://user-images.githubusercontent.com/3650216/90310982-20bfc480-df14-11ea-80d0-f461b2d86d40.gif)
<img width="475" alt="image" src="https://user-images.githubusercontent.com/3650216/90310988-32a16780-df14-11ea-9dfd-79be4027555f.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/l0HlNcircjaT2VT2M/giphy.gif)
