### PR TITLE
Fixing broken link to dynamic imports in docs

### DIFF
--- a/docs/technical-overview/architecture.md
+++ b/docs/technical-overview/architecture.md
@@ -34,7 +34,7 @@ rule, you should avoid relying on JavaScript for layout when working on Forem.
 
 We use [PreactJS](/frontend/preact), a lightweight alternative to ReactJS, and
 we try to reduce our bundle size with
-[dynamic imports](frontend/dynamic-imports).
+[dynamic imports](/frontend/dynamic-imports).
 
 ## Service workers and shell architecture
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
It fixes broken link to **dynamic imports** section  in the docs

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.forem.com
- [ ] readme
- [ ] no documentation needed

