### PR TITLE
🐞Bug Fix: Room that has been left still shows up in URL [Fixes: #9501]

### DIFF
--- a/app/helpers/chat_channel_memberships_helper.rb
+++ b/app/helpers/chat_channel_memberships_helper.rb
@@ -10,7 +10,8 @@ module ChatChannelMembershipsHelper
         status: membership.status,
         image: ProfileImage.new(membership.user).get(width: 90),
         chat_channel_name: membership.chat_channel.channel_name,
-        chat_channel_id: membership.chat_channel.id
+        chat_channel_id: membership.chat_channel.id,
+        slug: membership.chat_channel.slug
       }
     end
   end

--- a/app/javascript/chat/ChatChannelSettings/ChatChannelSettings.jsx
+++ b/app/javascript/chat/ChatChannelSettings/ChatChannelSettings.jsx
@@ -18,6 +18,7 @@ import ChatChannelSettingsSection from './ChatChannelSettingsSection';
 
 export default class ChatChannelSettings extends Component {
   static propTypes = {
+    handleLeavingChannel: PropTypes.func.isRequired,
     activeMembershipId: PropTypes.number.isRequired,
   };
 
@@ -308,7 +309,7 @@ export default class ChatChannelSettings extends Component {
     if (actionStatus) {
       const response = await leaveChatChannelMembership(currentMembership.id);
       if (response.success) {
-        this.updateChannelDetails();
+        this.props.handleLeavingChannel(currentMembership.id);
       } else {
         this.setState({
           successMessages: null,

--- a/app/javascript/chat/RequestManager/PersonalInvitationListItem.jsx
+++ b/app/javascript/chat/RequestManager/PersonalInvitationListItem.jsx
@@ -17,7 +17,7 @@ const RequestListItem = ({ request, updateMembership }) => (
           onClick={updateMembership}
           data-channel-id={request.chat_channel_id}
           data-membership-id={request.membership_id}
-          data-channel-slug={request.channel_modified_slug}
+          data-channel-slug={request.slug}
           data-user-action="reject"
         >
           {' '}
@@ -29,7 +29,7 @@ const RequestListItem = ({ request, updateMembership }) => (
           onClick={updateMembership}
           data-channel-id={request.chat_channel_id}
           data-membership-id={request.membership_id}
-          data-channel-slug={request.channel_modified_slug}
+          data-channel-slug={request.slug}
           data-user-action="accept"
         >
           {' '}

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -339,12 +339,7 @@ export default class Chat extends Component {
   };
 
   setupChannel = (channelId) => {
-    const {
-      messages,
-      messageOffset,
-      activeChannel,
-      activeChannelId,
-    } = this.state;
+    const { messages, messageOffset, activeChannel } = this.state;
     if (
       !messages[channelId] ||
       messages[channelId].length === 0 ||
@@ -354,7 +349,7 @@ export default class Chat extends Component {
     }
     if (activeChannel && activeChannel.channel_type !== 'direct') {
       getContent(
-        `/chat_channels/${activeChannelId}/channel_info`,
+        `/chat_channels/${channelId}/channel_info`,
         this.setOpenChannelUsers,
         null,
       );
@@ -372,7 +367,7 @@ export default class Chat extends Component {
       res.channel_users,
       ([username]) => username !== window.currentUser.username,
     );
-    if (activeChannel.channel_type === 'open') {
+    if (activeChannel && activeChannel.channel_type === 'open') {
       this.setState({
         channelUsers: {
           [activeChannelId]: leftUser,
@@ -915,10 +910,12 @@ export default class Chat extends Component {
         searchType: '',
         paginationNumber: 0,
       };
+      console.log(acceptedInfo);
       getChannels(searchParams, 'all', this.loadChannels);
       this.triggerSwitchChannel(
         parseInt(acceptedInfo.channelId, 10),
         acceptedInfo.channelSlug,
+        this.state.chatChannels,
       );
     }
 
@@ -1022,6 +1019,7 @@ export default class Chat extends Component {
           data: {},
           type_of: 'chat-channel-setting',
           activeMembershipId: activeChannel.id,
+          handleLeavingChannel: this.handleLeavingChannel,
         });
       }
     }
@@ -1060,6 +1058,21 @@ export default class Chat extends Component {
       });
       return { chatChannels: newChannelsObj };
     });
+  };
+
+  handleLeavingChannel = (leftChannelId) => {
+    const { chatChannels } = this.state;
+    this.triggerSwitchChannel(
+      chatChannels[1].chat_channel_id,
+      chatChannels[1].channel_modified_slug,
+      chatChannels,
+    );
+    this.setState((prevState) => ({
+      chatChannels: prevState.chatChannels.filter(
+        (channel) => channel.id !== leftChannelId,
+      ),
+    }));
+    this.setActiveContentState(chatChannels[1].chat_channel_id, null);
   };
 
   triggerChannelTypeFilter = (e) => {

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -910,7 +910,6 @@ export default class Chat extends Component {
         searchType: '',
         paginationNumber: 0,
       };
-      console.log(acceptedInfo);
       getChannels(searchParams, 'all', this.loadChannels);
       this.triggerSwitchChannel(
         parseInt(acceptedInfo.channelId, 10),

--- a/app/javascript/chat/content.jsx
+++ b/app/javascript/chat/content.jsx
@@ -109,6 +109,7 @@ const Display = ({ resource }) => {
         <ChatChannelSettings
           resource={resource.data}
           activeMembershipId={resource.activeMembershipId}
+          handleLeavingChannel={resource.handleLeavingChannel}
         />
       );
     default:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After leaving a room and then navigating to the /connect view, the room that was left still shows up in the URL.
Also did some fixes in case of Joining a channel.

## Related Tickets & Documents
Fixes: #9501 

## QA Instructions, Screenshots, Recordings
![Screen Recording 2020-08-15 at 08 32 PM gif](https://user-images.githubusercontent.com/3650216/90315138-9c326d80-df36-11ea-9450-b2b3eb3da022.gif)


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/anY8RifJ0lgdy/giphy.gif)
