### PR TITLE
Deleting hidden comment notification using after_update

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -206,10 +206,6 @@ class CommentsController < ApplicationController
     @comment.hidden_by_commentable_user = true
     @comment&.commentable&.update_column(:any_comments_hidden, true)
 
-    Notification.destroy_by(user_id: current_user.id,
-                            notifiable_type: "Comment",
-                            notifiable_id: params[:comment_id])
-
     if @comment.save
       render json: { hidden: "true" }, status: :ok
     else

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -28,8 +28,8 @@ class Comment < ApplicationRecord
   before_create :adjust_comment_parent_based_on_depth
   after_create :after_create_checks
   after_create :notify_slack_channel_about_warned_users
-  after_update :remove_notifications, if: :deleted
   after_update :update_descendant_notifications, if: :deleted
+  after_update :remove_notifications, if: :hidden_by_commentable_user
   before_destroy :before_destroy_actions
   after_destroy :after_destroy_actions
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -29,7 +29,7 @@ class Comment < ApplicationRecord
   after_create :after_create_checks
   after_create :notify_slack_channel_about_warned_users
   after_update :update_descendant_notifications, if: :deleted
-  after_update :remove_notifications, if: :hidden_by_commentable_user
+  after_update :remove_notifications, if: :remove_notifications?
   before_destroy :before_destroy_actions
   after_destroy :after_destroy_actions
 
@@ -133,6 +133,10 @@ class Comment < ApplicationRecord
   end
 
   private
+
+  def remove_notifications?
+    deleted? || hidden_by_commentable_user?
+  end
 
   def update_notifications
     Notification.update_notifications(self)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -417,6 +417,14 @@ RSpec.describe Comment, type: :model do
       expect(comment.notifications).to be_empty
     end
 
+    it "deletes the comment's notifications when hidden_by_commentable_user is set to true" do
+      create(:notification, notifiable: comment, user: user)
+      sidekiq_perform_enqueued_jobs do
+        comment.update(hidden_by_commentable_user: true)
+      end
+      expect(comment.notifications).to be_empty
+    end
+
     it "updates the notifications of the descendants with [deleted]" do
       comment = create(:comment, commentable: article)
       child_comment = create(:comment, parent: comment, commentable: article, user: user)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Deleting notification when the comment is hidden using after_update method

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/9807

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

The test is already there for this.

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
