### PR TITLE
Add PUBLIC_CONTROLLERS constant

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,8 +16,11 @@ class ApplicationController < ActionController::Base
     error_too_many_requests(exc)
   end
 
+  PUBLIC_CONTROLLERS = %w[shell async_info ga_events].freeze
+  private_constant :PUBLIC_CONTROLLERS
+
   def verify_private_forem
-    return if %w[shell async_info ga_events].include?(controller_name)
+    return if controller_name.in?(PUBLIC_CONTROLLERS)
     return if user_signed_in? || SiteConfig.public
 
     if api_action?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

While working on something unrelated in `ApplicationController` I noticed that we have a constant array inside a method. Normally I'd leave this as a little cleanup task during downtime, but it's an unconditional `before_action` called `verify_private_forem` so we'll create a garbage array on every request.

## Related Tickets & Documents

Only related to my OCD.

## QA Instructions, Screenshots, Recordings

Everything should work exactly like before.

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
