### PR TITLE
API: add created_at datetime to comments

### DIFF
--- a/app/controllers/api/v0/comments_controller.rb
+++ b/app/controllers/api/v0/comments_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :set_cache_control_headers, only: %i[index show]
 
       ATTRIBUTES_FOR_SERIALIZATION = %i[
-        id processed_html user_id ancestry deleted hidden_by_commentable_user
+        id processed_html user_id ancestry deleted hidden_by_commentable_user created_at
       ].freeze
       private_constant :ATTRIBUTES_FOR_SERIALIZATION
 

--- a/app/views/api/v0/comments/_comment.json.jbuilder
+++ b/app/views/api/v0/comments/_comment.json.jbuilder
@@ -1,5 +1,6 @@
 json.type_of "comment"
 json.id_code comment.id_code_generated
+json.created_at utc_iso_timestamp(comment.created_at)
 
 if comment.deleted?
   json.body_html "<p>#{Comment::TITLE_DELETED}</p>"

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -607,6 +607,7 @@ components:
       required:
         - type_of
         - id_code
+        - created_at
         - body_html
         - user
         - children
@@ -615,6 +616,9 @@ components:
           type: string
         id_code:
           type: string
+        created_at:
+          type: string
+          format: date-time
         body_html:
           description: HTML formatted comment
           type: string
@@ -1204,6 +1208,7 @@ components:
       value:
         - type_of: comment
           id_code: m3m0
+          created_at: 2020-07-01T17:59:43Z
           body_html: |
             <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
             <html><body>
@@ -1221,6 +1226,7 @@ components:
           children: []
         - type_of: comment
           id_code: m357
+          created_at: 2020-07-02T17:19:40Z          
           body_html: |
             <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
             <html><body>
@@ -1240,6 +1246,7 @@ components:
           children:
           - type_of: comment
             id_code: m35m
+            created_at: 2020-08-01T11:59:40Z          
             body_html: |
               <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
               <html><body>
@@ -1310,6 +1317,7 @@ components:
       value:
         type_of: comment
         id_code: m357
+        created_at: 2020-08-02T17:19:40Z          
         body_html: |
           <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
           <html><body>
@@ -1329,6 +1337,7 @@ components:
         children:
         - type_of: comment
           id_code: m35m
+          created_at: 2020-07-02T17:19:40Z          
           body_html: |
             <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
             <html><body>

--- a/spec/requests/api/v0/comments_spec.rb
+++ b/spec/requests/api/v0/comments_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe "Api::V0::Comments", type: :request do
     it "returns date created" do
       get api_comments_path(a_id: article.id)
       expect(find_root_comment(response)).to include(
-        "created_at" => article.created_at.utc.iso8601
+        "created_at" => article.created_at.utc.iso8601,
       )
     end
-    
+
     context "when a comment is deleted" do
       before do
         child_comment.update(deleted: true)
@@ -173,6 +173,7 @@ RSpec.describe "Api::V0::Comments", type: :request do
         get api_comments_path(p_id: "asdfghjkl")
         expect(response).to have_http_status(:not_found)
       end
+
       it "returns comment if good podcast episode id" do
         get api_comments_path(p_id: podcast_episode.id)
         expect(response).to have_http_status(:ok)

--- a/spec/requests/api/v0/comments_spec.rb
+++ b/spec/requests/api/v0/comments_spec.rb
@@ -97,6 +97,13 @@ RSpec.describe "Api::V0::Comments", type: :request do
       expect(response.headers["surrogate-key"].split.to_set).to eq(expected_key)
     end
 
+    it "returns date created" do
+      get api_comments_path(a_id: article.id)
+      expect(find_root_comment(response)).to include(
+        "created_at" => article.created_at.utc.iso8601
+      )
+    end
+    
     context "when a comment is deleted" do
       before do
         child_comment.update(deleted: true)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Added created_at field for comments in api response

## Related Tickets & Documents
Fixes #6095 

## QA Instructions, Screenshots, Recordings
Currently when user requests api/comment they do not see when each comment was created

![before](https://i.imgur.com/ADkaQfO.png)


Now that information is included:

![after](https://i.imgur.com/yO0ofgp.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.forem.com
- [ ] readme
- [ ] no documentation needed

