### PR TITLE
Refactor:Remove User Roles From Elasticsearch Returned Data

### DIFF
--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -25,7 +25,6 @@ module Search
           "comments_count" => source["comments_count"],
           "badge_achievements_count" => source["badge_achievements_count"],
           "last_comment_at" => source["last_comment_at"],
-          "roles" => source["roles"],
           "user_id" => source["id"]
         }
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
I could not find anywhere in the codebase where we were using a user's role data on the frontend from Elasticsearch. For this reason, I have gone ahead and removed it from the data returned to the view. I could go ahead and remove it completely from Elasticsearch and stop serializing it but I could see it being really handy for filtering at some point so I left it in there. 

![alt_text](https://media0.giphy.com/media/4TcVFG7EYvp3Yvbu9j/giphy.gif)
