### PR TITLE
Documenation: Update API Article Update Rate Limit Value to 30

### DIFF
--- a/app/helpers/rate_limit_checker_helper.rb
+++ b/app/helpers/rate_limit_checker_helper.rb
@@ -3,7 +3,7 @@ module RateLimitCheckerHelper
     rate_limit_article_update: {
       min: 1,
       placeholder: 30,
-      description: "The number of article updates a user can make in 30 seconds"
+      description: "The number of article updates a user can make in 30 seconds. Please update API docs when changed."
     },
     rate_limit_user_update: {
       min: 1,

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -7,7 +7,7 @@ openapi: "3.0.3"
 info:
   title: DEV API (beta)
   description: |
- 
+
     Access Forem articles, users and other resources via API.
 
     For a real-world example of Forem in action, check out [DEV](https://www.dev.to).
@@ -16,7 +16,7 @@ info:
 
     Dates and date times, unless otherwise specified, must be in
     the [RFC 3339](https://tools.ietf.org/html/rfc3339) format.
-    
+
   version: "0.7.0"
   termsOfService: https://dev.to/terms
   contact:
@@ -214,11 +214,11 @@ components:
         edited_at:
           type: string
           format: date-time
-          nullable: true          
+          nullable: true
         crossposted_at:
           type: string
           format: date-time
-          nullable: true          
+          nullable: true
         published_at:
           type: string
           format: date-time
@@ -315,7 +315,7 @@ components:
         crossposted_at:
           type: string
           format: date-time
-          nullable: true          
+          nullable: true
         published_at:
           type: string
           format: date-time
@@ -853,14 +853,14 @@ components:
           type: string
         twitter_username:
           type: string
-          nullable: true          
+          nullable: true
         github_username:
           type: string
           nullable: true
         website_url:
           type: string
           format: url
-          nullable: true          
+          nullable: true
         profile_image:
           description: Profile image (640x640)
           type: string
@@ -943,7 +943,7 @@ components:
         website_url:
           type: string
           format: url
-          nullable: true          
+          nullable: true
         location:
           type: string
           nullable: true
@@ -1869,7 +1869,7 @@ paths:
 
         ### Rate limiting
 
-        There is a limit of 150 requests per 30 seconds.
+        There is a limit of 30 requests per 30 seconds.
 
         ### Additional resources
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Documentation Update

## Description
Quick Fix: Update documentation to reflect Rate Limit for article updates. Also update SiteConfig notes to let the user know to update the API docs when that value is changed. 

Long term here we probably need an API or something for the Rate Limit values so we can change them on the fly without having to open a PR every time. And then we should document the rate limit endpoints and remove all rate limit values from the docs since different Forem's will likely have different values. 

## Related Issue
https://github.com/forem/forem/issues/9674

![alt_text](https://www.itglue.com/wp-content/uploads/2019/05/copy-of-features-list-optimized.gif)
