### PR TITLE
Flaky Spec Fix:Ensure We Find Articles With Tags and Dont Cache Count for Class Method

### DIFF
--- a/app/labor/article_suggester.rb
+++ b/app/labor/article_suggester.rb
@@ -1,7 +1,7 @@
 class ArticleSuggester
   def initialize(article)
     @article = article
-    @total_articles_count = self.class.memoized_articles_count
+    @total_articles_count = self.class.articles_count
   end
 
   def articles(max: 4)
@@ -23,7 +23,7 @@ class ArticleSuggester
     end
   end
 
-  def self.memoized_articles_count
+  def self.articles_count
     Article.published.estimated_count
   end
 

--- a/app/labor/article_suggester.rb
+++ b/app/labor/article_suggester.rb
@@ -24,7 +24,7 @@ class ArticleSuggester
   end
 
   def self.memoized_articles_count
-    @memoized_articles_count ||= Article.published.estimated_count
+    Article.published.estimated_count
   end
 
   private

--- a/spec/labor/article_suggester_spec.rb
+++ b/spec/labor/article_suggester_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 
 RSpec.describe ArticleSuggester, type: :labor do
   it "returns proper number of articles with post with the same tags" do
-    create_list(:article, 4, featured: true, tags: ["discuss"])
+    create_list(:article, 4, featured: true, tags: ["discuss"], score: 10)
     article = create(:article, featured: true, tags: ["discuss"])
     expect(described_class.new(article).articles.size).to eq(4)
   end
 
   it "returns proper number of articles with post with different tags" do
-    create_list(:article, 2, featured: true, tags: ["discuss"])
+    create_list(:article, 2, featured: true, tags: ["discuss"], score: 10)
     create_list(:article, 2, featured: true, tags: ["javascript"])
     article = create(:article, featured: true, tags: ["discuss"])
     expect(described_class.new(article).articles.size).to eq(4)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
Found a couple issues with the Article Suggester class from some recent changes we made.
1) We added [a score filter](https://github.com/forem/forem/pull/9833/files#diff-13b25834b581265292d484e25c446ffdR60) which caused our spec to no longer be able to pull back articles with the same tag. This caused the spec to have to fallback on `other_suggestions` which is not what we wanted to be testing so I updated that.
2) We changed the way we do offsets. One of the changes we made was to use the total number of published articles divided by 10 to help us get that number. However, we were caching that article count in a class method rather than an instance method which I think was what the intention was. I removed the class level caching. I think this may have gotten set during spec runs and we ended up with an unexpected value causing us to return 0 results when we expected some. 

Fixes: 
```
Failures:
  1) ArticleSuggester returns proper number of articles with post with the same tags
     Failure/Error: expect(described_class.new(article).articles.size).to eq(4)
       expected: 4
            got: 1
       (compared using ==)
     # ./spec/labor/article_suggester_spec.rb:7:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
  2) ArticleSuggester returns proper number of articles with post with different tags
     Failure/Error: expect(described_class.new(article).articles.size).to eq(4)
       expected: 4
            got: 0
       (compared using ==)
     # ./spec/labor/article_suggester_spec.rb:14:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
  3) ArticleSuggester returns proper number of articles with post without tags
     Failure/Error: expect(described_class.new(article).articles.size).to eq(4)
       expected: 4
            got: 0
       (compared using ==)
     # ./spec/labor/article_suggester_spec.rb:20:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
  4) ArticleSuggester returns the number of articles requested
     Failure/Error: expect(described_class.new(articles.first).articles(max: 2).size).to eq(2)
       expected: 2
            got: 0
       (compared using ==)
     # ./spec/labor/article_suggester_spec.rb:25:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
```

![alt_text](https://media1.tenor.com/images/2cce4553dfb708a58ab8c41efee46e1a/tenor.gif?itemid=16948427)
