### PR TITLE
Comments out the USER directive due to issues with podman-compose.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -31,7 +31,9 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/"${DOCKERIZE_VER
 
 WORKDIR "${APP_HOME}"
 
-USER "${APP_USER}"
+# Comment out running as the forem user due to this issue with podman-compose:
+# https://github.com/containers/podman-compose/issues/166
+# USER "${APP_USER}"
 
 COPY ./.ruby-version "${APP_HOME}"
 COPY ./Gemfile ./Gemfile.lock "${APP_HOME}"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This post on https://forem.dev/avalerionv/difficulty-installing-forem-on-ubuntu-18-04-tls-4eh6

talks about issues running Forem on Linux. Digging into the issue it seems that
podman-compose does not pass the `--userns=keep-id` flag correctly to podman so
files and directories mounted as root and not as the user. This causes permission
denied errors.

`podman rmi localhost/forem-rails:latest` might be needed to rebuild the container with the change.

## Related Tickets & Documents

https://forem.dev/avalerionv/difficulty-installing-forem-on-ubuntu-18-04-tls-4eh6

## [optional] What gif best describes this PR or how it makes you feel?

![containers were a mistake](https://media.giphy.com/media/x2ifyKU82zY4g/giphy.gif)
