### PR TITLE
Refactor:Move Yearly Badge Awarder to Sidekiq Cron

### DIFF
--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -1,5 +1,5 @@
 module BadgeRewarder
-  YEARS = { 1 => "one", 2 => "two", 3 => "three" }.freeze
+  YEARS = { 1 => "one", 2 => "two", 3 => "three", 4 => "four", 5 => "five", 6 => "six", 7 => "seven" }.freeze
   REPOSITORIES = ["thepracticaldev/dev.to", "thepracticaldev/DEV-ios", "thepracticaldev/DEV-Android"].freeze
 
   LONGEST_STREAK_WEEKS = 16
@@ -10,7 +10,8 @@ module BadgeRewarder
   MINIMUM_QUALITY = -25
 
   def self.award_yearly_club_badges
-    (1..3).each do |i|
+    total_years = Time.current.year - ApplicationConfig["COMMUNITY_COPYRIGHT_START_YEAR"].to_i
+    (1..total_years).each do |i|
       message = "Happy #{ApplicationConfig['COMMUNITY_NAME']} birthday! " \
         "Can you believe it's been #{i} #{'year'.pluralize(i)} already?!"
       badge = Badge.find_by!(slug: "#{YEARS[i]}-year-club")

--- a/app/workers/badge_achievements/badge_award_worker.rb
+++ b/app/workers/badge_achievements/badge_award_worker.rb
@@ -5,7 +5,11 @@ module BadgeAchievements
     sidekiq_options queue: :high_priority, retry: 10
 
     def perform(usernames, badge_slug, message)
-      BadgeRewarder.award_badges(usernames, badge_slug, message)
+      if BadgeRewarder.respond_to?(badge_slug)
+        BadgeRewarder.public_send(badge_slug)
+      else
+        BadgeRewarder.award_badges(usernames, badge_slug, message)
+      end
     end
   end
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -10,3 +10,10 @@ record_daily_notifications:
 record_data_counts:
   cron: "10 * * * *" # every hour, 10 min after the hour
   class: "Metrics::RecordDataCountsWorker"
+award_yearly_club_badges:
+  cron: "0 0 * * *" # daily at 12 am UTC
+  class: "BadgeAchievements::BadgeAwardWorker"
+  args:
+    - ""
+    - award_yearly_club_badges
+    - ""

--- a/lib/tasks/badges.rake
+++ b/lib/tasks/badges.rake
@@ -1,5 +1,4 @@
 task award_badges: :environment do
-  BadgeRewarder.award_yearly_club_badges
   BadgeRewarder.award_beloved_comment_badges
   BadgeRewarder.award_streak_badge(4)
   BadgeRewarder.award_streak_badge(8)

--- a/spec/labor/badge_rewarder_spec.rb
+++ b/spec/labor/badge_rewarder_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 RSpec.describe BadgeRewarder, type: :labor do
   describe "::award_yearly_club_badges" do
     before do
+      stub_const("#{described_class}::YEARS", BadgeRewarder::YEARS.slice(1, 2, 3))
+      allow(ApplicationConfig).to receive(:[])
+      allow(ApplicationConfig).to receive(:[]).with("COMMUNITY_COPYRIGHT_START_YEAR").and_return(3.years.ago.year)
       create(:badge, title: "one-year-club")
       create(:badge, title: "two-year-club")
       create(:badge, title: "three-year-club")

--- a/spec/workers/badge_achievements/badge_award_worker_spec.rb
+++ b/spec/workers/badge_achievements/badge_award_worker_spec.rb
@@ -19,5 +19,15 @@ RSpec.describe BadgeAchievements::BadgeAwardWorker, type: :worker do
         expect(badge_rewarder).to have_received(:award_badges).with("jess", "test", "yo")
       end
     end
+
+    context "with predefined badge_slug" do
+      it "sends badge email" do
+        allow(badge_rewarder).to receive(:award_yearly_club_badges)
+        worker.perform("", "award_yearly_club_badges", "")
+
+        expect(badge_rewarder).to have_received(:award_yearly_club_badges)
+        expect(badge_rewarder).not_to have_received(:award_badges)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
This moves the yearly badge awarding method into a Sidekiq Cron job using the already existing `BadgeAchievements::BadgeAwardWorker` which I tweaked. I could make a separate worker for each badge or a different worker for "predefined" badges but I was not sure what to call it and keeping all the badge rewarding in one place seemed like a better idea. 

Rather than doing all badge awarding in a single cron I decided to split them out. This will make the jobs run faster which is what Sidekiq is really made for and it will make them more resilient. If we break something for one badge the rest won't fail bc of it. 

Let me know what you all think of this approach! If you approve then I will continue with the rest of the badges. If not we can discuss and tweak things. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43687049

## QA Instructions, Screenshots, Recordings
- Pull down branch
- Restart app
- visit http://localhost:3000/sidekiq/cron and you should see the new job
- If you want to run it create a One Year Club badge then click "Enqueue Now" on the Sidekiq Cron dashboard and you should see the work run in your logs. You will also see it fail on the two year club badge.  

## Added tests?

- [x] yes


![alt_text](https://media2.giphy.com/media/h5jKG9a4oTJtDYMnBH/giphy.gif?cid=6c09b95278aaae75dc058121b498a7e908b98ffa8a3a142e&rid=giphy.gif)
