### PR TITLE
Rubocop: Enable and fix Style/SingleArgumentDig

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -486,7 +486,7 @@ Style/Send:
 
 Style/SingleArgumentDig:
   Description: 'Avoid using single argument dig method.'
-  Enabled: pending
+  Enabled: true
 
 Style/SingleLineBlockParams:
   Description: 'Enforces the names of some block params.'

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -128,7 +128,7 @@ module Api
       end
 
       def validate_article_param_is_hash
-        return if params.to_unsafe_h.dig(:article).is_a?(Hash)
+        return if params.to_unsafe_h[:article].is_a?(Hash)
 
         message = "article param must be a JSON object. You provided article as a #{params[:article].class.name}"
         render json: { error: message, status: 422 }, status: :unprocessable_entity

--- a/app/controllers/image_uploads_controller.rb
+++ b/app/controllers/image_uploads_controller.rb
@@ -55,7 +55,7 @@ class ImageUploadsController < ApplicationController
   end
 
   def validate_image
-    images = Array.wrap(params.dig("image"))
+    images = Array.wrap(params["image"])
     return if images.blank?
     return IS_NOT_FILE_MESSAGE unless valid_image_files?(images)
     return FILENAME_TOO_LONG_MESSAGE unless valid_filenames?(images)

--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -54,7 +54,7 @@ module Search
       end
 
       def document_count
-        Search::Client.count(index: self::INDEX_ALIAS).dig("count")
+        Search::Client.count(index: self::INDEX_ALIAS)["count"]
       end
 
       def search_documents(params:)
@@ -69,7 +69,7 @@ module Search
       private
 
       def prepare_doc(hit)
-        hit.dig("_source")
+        hit["_source"]
       end
 
       def search(body:)

--- a/app/services/search/feed_content.rb
+++ b/app/services/search/feed_content.rb
@@ -13,14 +13,14 @@ module Search
         define_method("#{class_name.underscore.pluralize}_document_count") do
           Search::Client.count(
             index: self::INDEX_ALIAS, body: count_filter(class_name),
-          ).dig("count")
+          )["count"]
         end
       end
 
       private
 
       def prepare_doc(hit)
-        source = hit.dig("_source")
+        source = hit["_source"]
         source["tag_list"] = hit["tags"]&.map { |t| t["name"] } || []
         source["id"] = source["id"].split("_").last.to_i
         source["tag_list"] = source["tags"]&.map { |t| t["name"] } || []

--- a/app/services/search/tag.rb
+++ b/app/services/search/tag.rb
@@ -7,7 +7,7 @@ module Search
     class << self
       def search_documents(query_string)
         results = search(body: query(query_string))
-        results.dig("hits", "hits").map { |tag_doc| tag_doc.dig("_source") }
+        results.dig("hits", "hits").map { |tag_doc| tag_doc["_source"] }
       end
 
       private

--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -10,7 +10,7 @@ module Search
       private
 
       def prepare_doc(hit)
-        source = hit.dig("_source")
+        source = hit["_source"]
         {
           "user" => {
             "username" => source["username"],

--- a/spec/serializers/search/reaction_serializer_spec.rb
+++ b/spec/serializers/search/reaction_serializer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Search::ReactionSerializer do
     data_hash = described_class.new(article_reaction).serializable_hash.dig(:data, :attributes)
     user_data = Search::NestedUserSerializer.new(user).serializable_hash.dig(:data, :attributes)
     expect(data_hash.dig(:reactable, :user)).to eq(user_data)
-    expect(data_hash.dig(:reactable).keys).to include(:id, :body_text, :class_name, :path, :tags, :title)
+    expect(data_hash[:reactable].keys).to include(:id, :body_text, :class_name, :path, :tags, :title)
     expect(data_hash.keys).to include(:id, :category, :status, :user_id)
   end
 
@@ -20,7 +20,7 @@ RSpec.describe Search::ReactionSerializer do
     data_hash = described_class.new(comment_reaction).serializable_hash.dig(:data, :attributes)
     user_data = Search::NestedUserSerializer.new(user).serializable_hash.dig(:data, :attributes)
     expect(data_hash.dig(:reactable, :user)).to eq(user_data)
-    expect(data_hash.dig(:reactable).keys).to include(:id, :body_text, :class_name, :path, :tags, :title)
+    expect(data_hash[:reactable].keys).to include(:id, :body_text, :class_name, :path, :tags, :title)
     expect(data_hash.keys).to include(:id, :category, :status, :user_id)
   end
 

--- a/spec/services/search/chat_channel_membership_spec.rb
+++ b/spec/services/search/chat_channel_membership_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Search::ChatChannelMembership, type: :service do
 
         chat_channel_membership_docs = described_class.search_documents(params: name_params)
         expect(chat_channel_membership_docs.count).to eq(2)
-        doc_ids = chat_channel_membership_docs.map { |t| t.dig("id") }
+        doc_ids = chat_channel_membership_docs.map { |t| t["id"] }
         expect(doc_ids).to include(chat_channel_membership1.id, chat_channel_membership2.id)
       end
     end
@@ -82,7 +82,7 @@ RSpec.describe Search::ChatChannelMembership, type: :service do
 
         chat_channel_membership_docs = described_class.search_documents(params: name_params)
         expect(chat_channel_membership_docs.count).to eq(1)
-        doc_ids = chat_channel_membership_docs.map { |t| t.dig("id") }
+        doc_ids = chat_channel_membership_docs.map { |t| t["id"] }
         expect(doc_ids).to include(chat_channel_membership1.id)
       end
     end

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Search::FeedContent, type: :service do
 
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(2)
-        doc_ids = feed_docs.map { |t| t.dig("id") }
+        doc_ids = feed_docs.map { |t| t["id"] }
         expect(doc_ids).to include(article1.id, article2.id)
       end
 
@@ -98,7 +98,7 @@ RSpec.describe Search::FeedContent, type: :service do
 
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(2)
-        doc_ids = feed_docs.map { |t| t.dig("id") }
+        doc_ids = feed_docs.map { |t| t["id"] }
         expect(doc_ids).to eq([article2.id, article1.id])
       end
     end
@@ -112,7 +112,7 @@ RSpec.describe Search::FeedContent, type: :service do
 
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(1)
-        doc_ids = feed_docs.map { |t| t.dig("id") }
+        doc_ids = feed_docs.map { |t| t["id"] }
         expect(doc_ids).to include(article1.id)
       end
 
@@ -122,7 +122,7 @@ RSpec.describe Search::FeedContent, type: :service do
 
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(1)
-        doc_ids = feed_docs.map { |t| t.dig("id") }
+        doc_ids = feed_docs.map { |t| t["id"] }
         expect(doc_ids).to include(article1.id)
       end
 
@@ -134,7 +134,7 @@ RSpec.describe Search::FeedContent, type: :service do
 
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(1)
-        doc_ids = feed_docs.map { |t| t.dig("id") }
+        doc_ids = feed_docs.map { |t| t["id"] }
         expect(doc_ids).to include(article2.id)
       end
 
@@ -145,7 +145,7 @@ RSpec.describe Search::FeedContent, type: :service do
 
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(1)
-        doc_ids = feed_docs.map { |t| t.dig("id") }
+        doc_ids = feed_docs.map { |t| t["id"] }
         expect(doc_ids).to include(pde.id)
       end
     end
@@ -159,7 +159,7 @@ RSpec.describe Search::FeedContent, type: :service do
 
         feed_docs = described_class.search_documents(params: query_params)
         expect(feed_docs.count).to eq(1)
-        doc_ids = feed_docs.map { |t| t.dig("id") }
+        doc_ids = feed_docs.map { |t| t["id"] }
         expect(doc_ids).to include(article2.id)
       end
     end
@@ -175,7 +175,7 @@ RSpec.describe Search::FeedContent, type: :service do
         query_params = { size: 5, search_fields: "ruby" }
 
         feed_docs = described_class.search_documents(params: query_params)
-        doc_ids = feed_docs.map { |t| t.dig("id") }
+        doc_ids = feed_docs.map { |t| t["id"] }
         expect(doc_ids).to eq([article2.id, article1.id])
       end
     end

--- a/spec/services/search/listing_spec.rb
+++ b/spec/services/search/listing_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Search::Listing, type: :service do
 
         listing_docs = described_class.search_documents(params: { size: 5, listing_search: "test" })
         expect(listing_docs.count).to eq(5)
-        expect(listing_docs.map { |t| t.dig("id") }).to match_array(listings.map(&:id))
+        expect(listing_docs.map { |t| t["id"] }).to match_array(listings.map(&:id))
       end
     end
 

--- a/spec/services/search/query_builders/chat_channel_membership_spec.rb
+++ b/spec/services/search/query_builders/chat_channel_membership_spec.rb
@@ -87,15 +87,15 @@ RSpec.describe Search::QueryBuilders::ChatChannelMembership, type: :service do
 
     it "sets default params when not present" do
       filter = described_class.new(params: {})
-      expect(filter.as_hash.dig("sort")).to eq("channel_last_message_at" => "desc")
-      expect(filter.as_hash.dig("size")).to eq(0)
+      expect(filter.as_hash["sort"]).to eq("channel_last_message_at" => "desc")
+      expect(filter.as_hash["size"]).to eq(0)
     end
 
     it "allows default params to be overriden" do
       params = { sort_by: "status", sort_direction: "asc", size: 20 }
       filter = described_class.new(params: params)
-      expect(filter.as_hash.dig("sort")).to eq("status" => "asc")
-      expect(filter.as_hash.dig("size")).to eq(20)
+      expect(filter.as_hash["sort"]).to eq("status" => "asc")
+      expect(filter.as_hash["size"]).to eq(20)
     end
   end
 end

--- a/spec/services/search/query_builders/feed_content_spec.rb
+++ b/spec/services/search/query_builders/feed_content_spec.rb
@@ -114,13 +114,13 @@ RSpec.describe Search::QueryBuilders::FeedContent, type: :service do
     it "allows default params to be overriden" do
       params = { sort_by: "published_at", sort_direction: "asc", size: 20 }
       filter = described_class.new(params: params).as_hash
-      expect(filter.dig("sort")).to eq("published_at" => "asc")
-      expect(filter.dig("size")).to eq(20)
+      expect(filter["sort"]).to eq("published_at" => "asc")
+      expect(filter["size"]).to eq(20)
     end
 
     it "correctly sets default sort" do
       filter = described_class.new(params: {}).as_hash
-      expect(filter.dig("sort")).to eq(described_class::DEFAULT_PARAMS[:sort])
+      expect(filter["sort"]).to eq(described_class::DEFAULT_PARAMS[:sort])
     end
   end
 

--- a/spec/services/search/query_builders/listing_spec.rb
+++ b/spec/services/search/query_builders/listing_spec.rb
@@ -99,16 +99,16 @@ RSpec.describe Search::QueryBuilders::Listing, type: :service do
 
     it "sets default params when not present" do
       filter = described_class.new(params: {}).as_hash
-      expect(filter.dig("sort")).to eq("bumped_at" => "desc")
-      expect(filter.dig("size")).to eq(0)
+      expect(filter["sort"]).to eq("bumped_at" => "desc")
+      expect(filter["size"]).to eq(0)
       expect(filter.dig("query", "bool", "filter")).to match_array([{ "terms" => { "published" => [true] } }])
     end
 
     it "allows default params to be overriden" do
       params = { sort_by: "category", sort_direction: "asc", size: 20 }
       filter = described_class.new(params: params).as_hash
-      expect(filter.dig("sort")).to eq("category" => "asc")
-      expect(filter.dig("size")).to eq(20)
+      expect(filter["sort"]).to eq("category" => "asc")
+      expect(filter["size"]).to eq(20)
     end
   end
 end

--- a/spec/services/search/query_builders/reaction_spec.rb
+++ b/spec/services/search/query_builders/reaction_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe Search::QueryBuilders::Reaction, type: :service do
     it "allows default params to be overriden" do
       params = { sort_by: "status", sort_direction: "asc", size: 20 }
       filter = described_class.new(params: params).as_hash
-      expect(filter.dig("sort")).to eq("status" => "asc")
-      expect(filter.dig("size")).to eq(20)
+      expect(filter["sort"]).to eq("status" => "asc")
+      expect(filter["size"]).to eq(20)
     end
   end
 

--- a/spec/services/search/query_builders/user_spec.rb
+++ b/spec/services/search/query_builders/user_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe Search::QueryBuilders::User, type: :service do
     it "allows default params to be overriden" do
       params = { sort_by: "name", sort_direction: "asc", size: 20 }
       filter = described_class.new(params: params).as_hash
-      expect(filter.dig("sort")).to eq("name" => "asc")
-      expect(filter.dig("size")).to eq(20)
+      expect(filter["sort"]).to eq("name" => "asc")
+      expect(filter["size"]).to eq(20)
     end
   end
 end

--- a/spec/services/search/reaction_spec.rb
+++ b/spec/services/search/reaction_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Search::Reaction, type: :service do
 
         reaction_docs = described_class.search_documents(params: query_params)["reactions"]
         expect(reaction_docs.count).to eq(2)
-        doc_ids = reaction_docs.map { |t| t.dig("id") }
+        doc_ids = reaction_docs.map { |t| t["id"] }
         expect(doc_ids).to include(reaction1.id, reaction2.id)
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe Search::Reaction, type: :service do
 
         reaction_docs = described_class.search_documents(params: query_params)["reactions"]
         expect(reaction_docs.count).to eq(1)
-        doc_ids = reaction_docs.map { |t| t.dig("id") }
+        doc_ids = reaction_docs.map { |t| t["id"] }
         expect(doc_ids).to include(reaction1.id)
       end
 
@@ -75,7 +75,7 @@ RSpec.describe Search::Reaction, type: :service do
 
         reaction_docs = described_class.search_documents(params: query_params)["reactions"]
         expect(reaction_docs.count).to eq(1)
-        doc_ids = reaction_docs.map { |t| t.dig("id") }
+        doc_ids = reaction_docs.map { |t| t["id"] }
         expect(doc_ids).to include(reaction2.id)
       end
 
@@ -85,7 +85,7 @@ RSpec.describe Search::Reaction, type: :service do
 
         reaction_docs = described_class.search_documents(params: query_params)["reactions"]
         expect(reaction_docs.count).to eq(1)
-        doc_ids = reaction_docs.map { |t| t.dig("id") }
+        doc_ids = reaction_docs.map { |t| t["id"] }
         expect(doc_ids).to include(reaction1.id)
       end
 
@@ -96,7 +96,7 @@ RSpec.describe Search::Reaction, type: :service do
 
         reaction_docs = described_class.search_documents(params: query_params)["reactions"]
         expect(reaction_docs.count).to eq(1)
-        doc_ids = reaction_docs.map { |t| t.dig("id") }
+        doc_ids = reaction_docs.map { |t| t["id"] }
         expect(doc_ids).to include(reaction2.id)
       end
 
@@ -106,7 +106,7 @@ RSpec.describe Search::Reaction, type: :service do
 
         reaction_docs = described_class.search_documents(params: query_params)["reactions"]
         expect(reaction_docs.count).to eq(1)
-        doc_ids = reaction_docs.map { |t| t.dig("id") }
+        doc_ids = reaction_docs.map { |t| t["id"] }
         expect(doc_ids).to include(reaction2.id)
       end
     end
@@ -116,7 +116,7 @@ RSpec.describe Search::Reaction, type: :service do
         index_documents([reaction1, reaction2])
 
         reaction_docs = described_class.search_documents(params: query_params)["reactions"]
-        doc_ids = reaction_docs.map { |t| t.dig("id") }
+        doc_ids = reaction_docs.map { |t| t["id"] }
         expect(doc_ids).to eq([reaction2.id, reaction1.id])
       end
     end

--- a/spec/services/search/user_spec.rb
+++ b/spec/services/search/user_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Search::User, type: :service do
 
         user_docs = described_class.search_documents(params: query_params)
         expect(user_docs.count).to eq(2)
-        doc_ids = user_docs.map { |t| t.dig("id") }
+        doc_ids = user_docs.map { |t| t["id"] }
         expect(doc_ids).to include(user1.id, user2.id)
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe Search::User, type: :service do
 
         user_docs = described_class.search_documents(params: query_params)
         expect(user_docs.count).to eq(1)
-        doc_ids = user_docs.map { |t| t.dig("id") }
+        doc_ids = user_docs.map { |t| t["id"] }
         expect(doc_ids).to match_array([user1.id])
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Enabling Rubocop 0.89's `Style/SingleArgumentDig` to replace `hash.dig(:foo)` with `hash[:foo]` which is the most common syntax for single key access

## Related Tickets & Documents

- #9699
- #9709

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
