### PR TITLE
Rubocop: Enable and fix Style/StringConcatenation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -499,7 +499,7 @@ Style/SlicingWithRange:
 Style/StringConcatenation:
   Description: 'Checks for places where string concatenation can be replaced with string interpolation.'
   StyleGuide: '#string-interpolation'
-  Enabled: pending
+  Enabled: true
 
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'

--- a/app/controllers/admin/welcome_controller.rb
+++ b/app/controllers/admin/welcome_controller.rb
@@ -11,7 +11,7 @@ module Admin
         body_markdown: welcome_thread_content,
         user: User.dev_account,
       )
-      redirect_to URI.parse(welcome_thread.path).path + "/edit"
+      redirect_to "#{URI.parse(welcome_thread.path).path}/edit"
     end
 
     private

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -148,7 +148,7 @@ class ArticlesController < ApplicationController
           return
         end
         if params[:article][:video_thumbnail_url]
-          redirect_to(@article.path + "/edit")
+          redirect_to("#{@article.path}/edit")
           return
         end
         render json: { status: 200 }

--- a/app/controllers/video_chats_controller.rb
+++ b/app/controllers/video_chats_controller.rb
@@ -31,7 +31,7 @@ class VideoChatsController < ApplicationController
   def display_username
     return "@#{params[:username]}" if params[:username] && Rails.env.development? # simpler solo testing in dev
 
-    "@" + current_user.username
+    "@#{current_user.username}"
   end
 
   def video_type

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -18,7 +18,7 @@ class VideosController < ApplicationController
   def create
     @article = ArticleWithVideoCreationService.new(article_params, current_user).create!
 
-    redirect_to @article.path + "/edit"
+    redirect_to "#{@article.path}/edit"
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -124,7 +124,7 @@ module ApplicationHelper
     return if followable == DELETED_USER
 
     tag :button, # Yikes
-        class: "crayons-btn follow-action-button " + classes,
+        class: "crayons-btn follow-action-button #{classes}",
         data: {
           :info => { id: followable.id, className: followable.class.name, style: style }.to_json,
           "follow-action-button" => true

--- a/app/labor/bufferizer.rb
+++ b/app/labor/bufferizer.rb
@@ -57,7 +57,8 @@ class Bufferizer
 
   def social_tags
     # for linkedin's followable tags
-    " #programming #softwareengineering " + (@article.tag_list.map { |tag| "#" + tag }).join(" ")
+    tags = @article.tag_list.map { |tag| "##{tag}" }.join(" ")
+    " #programming #softwareengineering #{tags}"
   end
 
   def listings_twitter_text

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -142,7 +142,7 @@ module CacheBuster
   end
 
   def self.bust_podcast(path)
-    bust("/" + path)
+    bust("/#{path}")
   end
 
   def self.bust_organization(organization, slug)
@@ -161,7 +161,7 @@ module CacheBuster
     podcast_episode.purge_all
     begin
       bust(path)
-      bust("/" + podcast_slug)
+      bust("/#{podcast_slug}")
       bust("/pod")
       bust(path)
     rescue StandardError => e

--- a/app/labor/language_detector.rb
+++ b/app/labor/language_detector.rb
@@ -15,7 +15,6 @@ class LanguageDetector
   end
 
   def text
-    @article.title + ". " +
-      FrontMatterParser::Parser.new(:md).call(@article.body_markdown).content.split("`")[0]
+    "#{@article.title}. #{FrontMatterParser::Parser.new(:md).call(@article.body_markdown).content.split('`')[0]}"
   end
 end

--- a/app/labor/markdown_parser.rb
+++ b/app/labor/markdown_parser.rb
@@ -168,9 +168,9 @@ class MarkdownParser
       codeblock.gsub!("{% endraw %}", "{----% endraw %----}")
       codeblock.gsub!("{% raw %}", "{----% raw %----}")
       if codeblock.match?(/[[:space:]]*`{3}/)
-        "\n{% raw %}\n" + codeblock + "\n{% endraw %}\n"
+        "\n{% raw %}\n#{codeblock}\n{% endraw %}\n"
       else
-        "{% raw %}" + codeblock + "{% endraw %}"
+        "{% raw %}#{codeblock}{% endraw %}"
       end
     end
   end

--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -82,7 +82,7 @@ class GithubTag
         attribute = element.name == "img" ? "src" : "href"
         element["href"] = "" if attribute == "href" && element.attributes[attribute].blank?
         path = element.attributes[attribute].value
-        element.attributes[attribute].value = url.gsub(%r{/README.md}, "") + "/" + path if path[0, 4] != "http"
+        element.attributes[attribute].value = "#{url.gsub(%r{/README.md}, '')}/#{path}" if path[0, 4] != "http"
       end
       readme.to_html
     end

--- a/app/liquid_tags/kotlin_tag.rb
+++ b/app/liquid_tags/kotlin_tag.rb
@@ -19,7 +19,7 @@ class KotlinTag < LiquidTagBase
   end
 
   def self.embedded_url(link)
-    "https://play.kotlinlang.org/embed?" + URI.encode_www_form(parse_link(link))
+    "https://play.kotlinlang.org/embed?#{URI.encode_www_form(parse_link(link))}"
   end
 
   def self.parse_link(link)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -251,7 +251,7 @@ class Article < ApplicationRecord
 
   def processed_description
     text_portion = body_text.present? ? body_text[0..100].tr("\n", " ").strip.to_s : ""
-    text_portion = text_portion.strip + "..." if body_text.size > 100
+    text_portion = "#{text_portion.strip}..." if body_text.size > 100
     return "A post by #{user.name}" if text_portion.blank?
 
     text_portion.strip
@@ -634,7 +634,7 @@ class Article < ApplicationRecord
   end
 
   def title_to_slug
-    title.to_s.downcase.parameterize.tr("_", "") + "-" + rand(100_000).to_s(26)
+    "#{title.to_s.downcase.parameterize.tr('_', '')}-#{rand(100_000).to_s(26)}"
   end
 
   def clean_data

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -125,9 +125,10 @@ class ChatChannel < ApplicationRecord
   def adjusted_slug(user = nil, caller_type = "receiver")
     user ||= current_user
     if direct? && caller_type == "receiver"
-      "@" + slug.gsub("/#{user.username}", "").gsub("#{user.username}/", "")
+      cleaned_slug = slug.gsub("/#{user.username}", "").gsub("#{user.username}/", "")
+      "@#{cleaned_slug}"
     elsif caller_type == "sender"
-      "@" + user.username
+      "@#{user.username}"
     else
       slug
     end

--- a/app/models/chat_channel_membership.rb
+++ b/app/models/chat_channel_membership.rb
@@ -66,7 +66,7 @@ class ChatChannelMembership < ApplicationRecord
 
   def channel_modified_slug
     if chat_channel.channel_type == "direct"
-      "@" + other_user&.username
+      "@#{other_user&.username}"
     else
       chat_channel.slug
     end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -107,7 +107,7 @@ class Message < ApplicationRecord
         html += "<a href='#{article.current_state_path}'
         class='chatchannels__richlink'
           target='_blank' rel='noopener' data-content='sidecar-article'>
-            #{"<div class='chatchannels__richlinkmainimage' style='background-image:url(" + cl_path(article.main_image) + ")' data-content='sidecar-article' ></div>" if article.main_image.present?}
+            #{"<div class='chatchannels__richlinkmainimage' style='background-image:url(#{cl_path(article.main_image)})' data-content='sidecar-article' ></div>" if article.main_image.present?}
           <h1 data-content='sidecar-article'>#{article.title}</h1>
           <h4 data-content='sidecar-article'><img src='#{ProfileImage.new(article.cached_user).get(width: 90)}' /> #{article.cached_user.name}・#{article.readable_publish_date || 'Draft Post'}</h4>
           </a>".html_safe
@@ -116,7 +116,7 @@ class Message < ApplicationRecord
         class='chatchannels__richlink'
           target='_blank' rel='noopener' data-content='sidecar-tag'>
           <h1 data-content='sidecar-tag'>
-            #{"<img src='" + cl_path(tag.badge.badge_image_url) + "' data-content='sidecar-tag' style='transform:rotate(-5deg)' />" if tag.badge_id.present?}
+            #{"<img src='#{cl_path(tag.badge.badge_image_url)}' data-content='sidecar-tag' style='transform:rotate(-5deg)' />" if tag.badge_id.present?}
             ##{tag.name}
           </h1>
           </a>".html_safe

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -19,12 +19,12 @@ class Tweet < ApplicationRecord
     end
     mentioned_usernames_serialized.each do |username|
       uname = username["screen_name"]
-      text.gsub!("@" + uname, "<a href='https://twitter.com/#{uname}'>#{'@' + uname}</a>")
+      text.gsub!("@#{uname}", "<a href='https://twitter.com/#{uname}'>#{"@#{uname}"}</a>")
     end
     hashtags_serialized.each do |tag|
       tag_text = tag[:text]
-      text.gsub!("#" + tag_text,
-                 "<a href='https://twitter.com/hashtag/#{tag_text}'>#{'#' + tag_text}</a>")
+      text.gsub!("##{tag_text}",
+                 "<a href='https://twitter.com/hashtag/#{tag_text}'>#{"##{tag_text}"}</a>")
     end
 
     if extended_entities_serialized && extended_entities_serialized[:media]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -226,7 +226,7 @@ class User < ApplicationRecord
   end
 
   def path
-    "/" + username.to_s
+    "/#{username}"
   end
 
   def followed_articles
@@ -515,7 +515,7 @@ class User < ApplicationRecord
 
   def set_temp_username
     self.username = if temp_name_exists?
-                      temp_username + "_" + rand(100).to_s
+                      "#{temp_username}_#{rand(100)}"
                     else
                       temp_username
                     end

--- a/app/services/chat_channels/create_with_users.rb
+++ b/app/services/chat_channels/create_with_users.rb
@@ -39,7 +39,7 @@ module ChatChannels
     end
 
     def verify_contrived_name(usernames)
-      channel_type == "direct" ? "Direct chat between " + usernames.join(" and ") : contrived_name
+      channel_type == "direct" ? "Direct chat between #{usernames.join(' and ')}" : contrived_name
     end
   end
 end

--- a/app/services/users/profile_image_generator.rb
+++ b/app/services/users/profile_image_generator.rb
@@ -20,7 +20,7 @@ module Users
     def self.call
       # This pulls from emojipedia source for the liberally open source twemoji lib.
       # TODO: Make this much more interesting than just emojis.
-      "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/240/twitter/248/" + EMOJI_IMAGES.sample
+      "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/240/twitter/248/#{EMOJI_IMAGES.sample}"
     end
   end
 end

--- a/config/initializers/sprockets_uglifier_with_source_maps_compressor.rb
+++ b/config/initializers/sprockets_uglifier_with_source_maps_compressor.rb
@@ -12,7 +12,7 @@ module Sprockets
 
       # Update source map according to the version 3 spec: https://sourcemaps.info/spec.html
       sourcemap                   = JSON.parse(sourcemap_json)
-      sourcemap["sources"]        = [name + ".js"]
+      sourcemap["sources"]        = ["#{name}.js"]
       sourcemap["sourceRoot"]     = ::Rails.application.config.assets.prefix
       sourcemap["sourcesContent"] = [data]
       sourcemap_json              = sourcemap.to_json

--- a/spec/labor/bufferizer_spec.rb
+++ b/spec/labor/bufferizer_spec.rb
@@ -42,6 +42,6 @@ RSpec.describe Bufferizer, type: :labor do
     post = "test facebook post"
     described_class.new("article", article, post).facebook_post!
     expect(BufferUpdate.last.body_text).to include(" #programming")
-    expect(BufferUpdate.last.body_text).to include(" #" + article.tag_list.first)
+    expect(BufferUpdate.last.body_text).to include(" ##{article.tag_list.first}")
   end
 end

--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -66,20 +66,20 @@ RSpec.describe MarkdownParser, type: :labor do
 
   it "wraps figcaptions with figures" do
     code_span = "<p>Statement</p>\n<figcaption>A fig</figcaption>"
-    test = generate_and_parse_markdown("<p>case: </p>" + code_span)
-    expect(test).to eq("<p>case: </p>\n<figure>" + code_span + "</figure>\n\n\n\n")
+    test = generate_and_parse_markdown("<p>case: </p>#{code_span}")
+    expect(test).to eq("<p>case: </p>\n<figure>#{code_span}</figure>\n\n\n\n")
   end
 
   it "does not wrap figcaptions already in figures" do
     code_span = "<figure><p>Statement</p>\n<figcaption>A fig</figcaption></figure>"
     test = generate_and_parse_markdown(code_span)
-    expect(test).to eq(code_span + "\n\n\n\n")
+    expect(test).to eq("#{code_span}\n\n\n\n")
   end
 
   it "does not wrap figcaptions without predecessors" do
     code_span = "<figcaption>A fig</figcaption>"
     test = generate_and_parse_markdown(code_span)
-    expect(test).to eq(code_span + "\n\n")
+    expect(test).to eq("#{code_span}\n\n")
   end
 
   context "when rendering links markdown" do

--- a/spec/liquid_tags/glitch_tag_spec.rb
+++ b/spec/liquid_tags/glitch_tag_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 require "uri"
 
-base_uri = "https://glitch.com/embed/#!/embed/"
-
 RSpec.describe GlitchTag, type: :liquid_tag do
+  let(:base_uri) { "https://glitch.com/embed/#!/embed/" }
+
   describe "#id" do
     let(:valid_id) { "BXgGcAUjM39" }
     let(:id_with_quotes) { 'some-id" onload="alert(42)"' }
@@ -31,50 +31,49 @@ RSpec.describe GlitchTag, type: :liquid_tag do
 
     it "handles 'app' option" do
       template = generate_tag(id_with_app_option)
-      expected = "src=\"" + base_uri + "some-id?previewSize=100&amp;path=index.html"
+      expected = "src=\"#{base_uri}some-id?previewSize=100&amp;path=index.html"
       expect(template.render(nil)).to include(expected)
     end
 
     it "handles 'code' option" do
       template = generate_tag(id_with_code_option)
-      expected = "src=\"" + base_uri + "some-id?previewSize=0&amp;path=index.html"
+      expected = "src=\"#{base_uri}some-id?previewSize=0&amp;path=index.html"
       expect(template.render(nil)).to include(expected)
     end
 
     it "handles 'no-files' option" do
       template = generate_tag(id_with_no_files_option)
-      expected = "src=\"" + base_uri + "some-id?sidebarCollapsed=true&amp;path=index.html"
+      expected = "src=\"#{base_uri}some-id?sidebarCollapsed=true&amp;path=index.html"
       expect(template.render(nil)).to include(expected)
     end
 
     it "handles 'preview-first' option" do
       template = generate_tag(id_with_preview_first_option)
-      expected = "src=\"" + base_uri + "some-id?previewFirst=true&amp;path=index.html"
+      expected = "src=\"#{base_uri}some-id?previewFirst=true&amp;path=index.html"
       expect(template.render(nil)).to include(expected)
     end
 
     it "handles 'no-attribution' option" do
       template = generate_tag(id_with_no_attribution_option)
-      expected = "src=\"" + base_uri + "some-id?attributionHidden=true&amp;path=index.html"
+      expected = "src=\"#{base_uri}some-id?attributionHidden=true&amp;path=index.html"
       expect(template.render(nil)).to include(expected)
     end
 
     it "handles 'file' option" do
       template = generate_tag(id_with_file_option)
-      expected = "src=\"" + base_uri + "some-id?path=script.js"
+      expected = "src=\"#{base_uri}some-id?path=script.js"
       expect(template.render(nil)).to include(expected)
     end
 
     it "handles complex case" do
       template = generate_tag(id_with_many_options)
-      expected = "src=\"" + base_uri +
-        "some-id?previewSize=100&amp;attributionHidden=true&amp;sidebarCollapsed=true&amp;path=script.js"
+      expected = "src=\"#{base_uri}some-id?previewSize=100&amp;attributionHidden=true&amp;sidebarCollapsed=true&amp;path=script.js" # rubocop:disable Layout/LineLength
       expect(template.render(nil)).to include(expected)
     end
 
     it "'app' and 'code' cancel each other" do
       template = generate_tag(id_with_app_and_code_option)
-      expected = "src=\"" + base_uri + "some-id?path=index.html"
+      expected = "src=\"#{base_uri}some-id?path=index.html"
       expect(template.render(nil)).to include(expected)
     end
   end

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe LinkTag, type: :liquid_tag do
   end
 
   def correct_link_html(article)
-    tags = article.tag_list.map { |t| "<span class='ltag__link__tag'>##{t}</span>" }.join("\n" + "\s" * 8)
+    tags = article.tag_list.map { |t| "<span class='ltag__link__tag'>##{t}</span>" }.join("\n#{"\s" * 8}")
     <<~HTML
       <div class='ltag__link'>
         <a href='#{article.user.path}' class='ltag__link__link'>

--- a/spec/liquid_tags/next_tech_tag_spec.rb
+++ b/spec/liquid_tags/next_tech_tag_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe NextTechTag, type: :liquid_template do
 
     it "accepts nexttech link with a / at the end" do
       expect do
-        generate_new_liquid(nexttech_link + "/")
+        generate_new_liquid("#{nexttech_link}/")
       end.not_to raise_error
     end
 

--- a/spec/liquid_tags/podcast_tag_spec.rb
+++ b/spec/liquid_tags/podcast_tag_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PodcastTag, type: :liquid_tag do
 
     it "raises error if podcast does not exist" do
       expect do
-        generate_podcast_liquid_tag(valid_long_slug + "1")
+        generate_podcast_liquid_tag("#{valid_long_slug}1")
       end.to raise_error(StandardError)
     end
   end

--- a/spec/liquid_tags/youtube_tag_spec.rb
+++ b/spec/liquid_tags/youtube_tag_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe YoutubeTag, type: :liquid_tag do
     end
 
     it "accepts YouTube ID with no start time and an empty space" do
-      liquid = generate_new_liquid(valid_id_no_time + " ").render
+      liquid = generate_new_liquid("#{valid_id_no_time} ").render
       Approvals.verify(liquid, name: "youtube_liquid_tag_no_time_trailing_space", format: :html)
     end
 
     it "accepts YouTube ID with start times and one empty space" do
-      liquid = generate_new_liquid(valid_ids_with_time + " ").render
+      liquid = generate_new_liquid("#{valid_ids_with_time} ").render
       Approvals.verify(liquid, name: "youtube_liquid_tag_with_time", format: :html)
     end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -446,7 +446,7 @@ RSpec.describe Article, type: :model do
       article.update(body_markdown: body, approved: true)
 
       Timecop.travel(1.second.from_now) do
-        article.update(body_markdown: body + "s")
+        article.update(body_markdown: "#{body}s")
       end
 
       expect(article.featured_number).not_to eq(article.updated_at.to_i)

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -795,7 +795,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
           )
           expect(response).to have_http_status(:created)
         end.to change(Article, :count).by(1)
-        expect(Article.find(response.parsed_body["id"]).description).to eq("yoooo" * 20 + "y...")
+        expect(Article.find(response.parsed_body["id"]).description).to eq("#{'yoooo' * 20}y...")
       end
 
       it "does not raise an error if article params are missing" do

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "ArticlesShow", type: :request do
 
   context "when user not signed in but internal nav triggered" do
     before do
-      get article.path + "?i=i"
+      get "#{article.path}?i=i"
     end
 
     describe "GET /:slug (user)" do

--- a/spec/requests/comments_destroy_spec.rb
+++ b/spec/requests/comments_destroy_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "CommentsDestroy", type: :request do
   describe "GET /:username/comment/:id_code/delete_confirm" do
     it "renders the confirmation message" do
       comment = create(:comment, user_id: user.id, commentable: article)
-      get comment.path + "/delete_confirm"
+      get "#{comment.path}/delete_confirm"
       expect(response.body).to include("Are you sure you want to delete this comment")
     end
   end

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -43,12 +43,12 @@ RSpec.describe "Moderations", type: :request do
     end
 
     it "grants access to comment moderation" do
-      get comment.path + "/mod"
+      get "#{comment.path}/mod"
       expect(response).to have_http_status(:ok)
     end
 
     it "grant access to article moderation" do
-      get article.path + "/mod"
+      get "#{article.path}/mod"
       expect(response).to have_http_status(:ok)
     end
 
@@ -67,7 +67,7 @@ RSpec.describe "Moderations", type: :request do
     it "grants access to /mod/:tag index with articles" do
       create(:article, published: true)
       get "/mod/#{article.tags.first}"
-      expect(response.body).to include("#" + article.tags.first.name)
+      expect(response.body).to include("##{article.tags.first.name}")
       expect(response.body).to include(CGI.escapeHTML(article.title))
     end
 

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe "StoriesIndex", type: :request do
     it "renders page with proper header" do
       podcast = create(:podcast)
       create(:podcast_episode, podcast: podcast)
-      get "/" + podcast.slug
+      get "/#{podcast.slug}"
       expect(response.body).to include(podcast.title)
     end
   end

--- a/spec/requests/user/user_organization_spec.rb
+++ b/spec/requests/user/user_organization_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "UserOrganization", type: :request do
     end
 
     it "correctly strips the secret of the org_secret param" do
-      post "/users/join_org", params: { org_secret: organization.secret + "     " }
+      post "/users/join_org", params: { org_secret: "#{organization.secret}     " }
       expect(OrganizationMembership.exists?(user: user, organization: organization)).to eq true
     end
   end

--- a/spec/requests/user/user_show_spec.rb
+++ b/spec/requests/user/user_show_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "UserShow", type: :request do
 
   context "when user not signed in but internal nav triggered" do
     before do
-      get user.path + "?i=i"
+      get "#{user.path}?i=i"
     end
 
     describe "GET /:slug (user)" do

--- a/spec/services/chat_channels/find_or_create_spec.rb
+++ b/spec/services/chat_channels/find_or_create_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ChatChannels::FindOrCreate, type: :service do
   let(:usernames) { users.map(&:username).sort }
   let(:direct_slug) { usernames.join("/") }
   let(:other_slug) { "New Channel-#{rand(100_000).to_s(26)}" }
-  let(:contrived_name) { "Direct chat between " + usernames.join(" and ") }
+  let(:contrived_name) { "Direct chat between #{usernames.join(' and ')}" }
   let(:open_slug) { "Test channel-#{rand(100_000).to_s(26)}" }
   let(:chat_channel) do
     ChatChannel.create(

--- a/spec/system/comments/user_delete_a_comment_spec.rb
+++ b/spec/system/comments/user_delete_a_comment_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Deleting Comment", type: :system, js: true, elasticsearch: "Feed
 
   it "works" do
     visit "/"
-    visit comment.path + "/delete_confirm"
+    visit "#{comment.path}/delete_confirm"
 
     wait_for_javascript
 

--- a/spec/system/dashboards/user_scrolls_down_dashboard_follows_spec.rb
+++ b/spec/system/dashboards/user_scrolls_down_dashboard_follows_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe "Infinite scroll on dashboard", type: :system, js: true do
 
     it "shows working links" do
       podcasts.each do |podcast|
-        expect(page).to have_link(nil, href: "/" + podcast.path)
+        expect(page).to have_link(nil, href: "/#{podcast.path}")
       end
     end
   end

--- a/spec/workers/articles/bust_multiple_caches_worker_spec.rb
+++ b/spec/workers/articles/bust_multiple_caches_worker_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Articles::BustMultipleCachesWorker, type: :worker do
       worker.perform([article.id])
 
       expect(CacheBuster).to have_received(:bust).with(path).once
-      expect(CacheBuster).to have_received(:bust).with(path + "?i=i").once
+      expect(CacheBuster).to have_received(:bust).with("#{path}?i=i").once
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Enabling Rubocop 0.89's `Style/StringConcatenation` to force [string interpolation](https://rubystyle.guide/#string-interpolation) over string concatenation.

I know it's a big PR but it's mostly automatic replacements done by Rubocop on a single rule

## Related Tickets & Documents

- #9699
- #9709

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
