### PR TITLE
Nullify article_id for HtmlVariantTrials linked to non existing articles

### DIFF
--- a/lib/data_update_scripts/20200818103028_nullify_orphaned_by_article_html_variant_trials.rb
+++ b/lib/data_update_scripts/20200818103028_nullify_orphaned_by_article_html_variant_trials.rb
@@ -1,0 +1,14 @@
+module DataUpdateScripts
+  class NullifyOrphanedByArticleHtmlVariantTrials
+    def run
+      # Nullify article_id for all HtmlVariantTrials linked to a non existing article
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          UPDATE html_variant_trials
+          SET article_id = NULL
+          WHERE article_id IS NOT NULL AND article_id NOT IN (SELECT id FROM articles);
+        SQL
+      )
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The effort to cleanup and fortify the tables continues. In this episode we have `HtmlVariant`, `HtmlVariantSuccess` and `HtmlVariantTrial`.

This is step 1 of 2:

- cleanup the data, this PR
- enforce relations and foreign keys on the various models

### What it contains and doesn't

- `HtmlVariantSuccess` is linked to both `HtmlVariant` and `Article` (it contains orphaned rows for neither: https://dev.to/admin/blazer/queries/188-html_variant_successes-orphan-rows)
- `HtmlVariantTrial` is linked to both `HtmlVariant` and `Article` (it contains orphaned rows for `Article`, thus this PR: https://dev.to/admin/blazer/queries/153-html_variant_trials-orphan-rows)

As the relation with the `Article` is optional, I chose to set `NULL` those IDs that do not exist anymore. Let me know if instead we should destroy them.

Please review the SQL ;-)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
