### PR TITLE
Rubocop: Fix ListingCategory has_many relation to Listing

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,7 +25,6 @@ Rails/HasManyOrHasOneDependent:
   Exclude:
     - 'app/models/article.rb'
     - 'app/models/concerns/user_subscription_sourceable.rb'
-    - 'app/models/listing_category.rb'
     - 'app/models/organization.rb'
     - 'app/models/podcast.rb'
     - 'app/models/podcast_episode.rb'

--- a/app/models/listing_category.rb
+++ b/app/models/listing_category.rb
@@ -3,7 +3,9 @@ class ListingCategory < ApplicationRecord
   # We standardized on the latter, but keeping the table name was easier.
   self.table_name = "classified_listing_categories"
 
-  has_many :listings, inverse_of: :listing_category
+  has_many :listings, inverse_of: :listing_category,
+                      foreign_key: :classified_listing_category_id,
+                      dependent: :restrict_with_error
 
   before_validation :normalize_social_preview_color
 

--- a/spec/models/listing_category_spec.rb
+++ b/spec/models/listing_category_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe ListingCategory, type: :model do
     # https://www.rubydoc.info/github/thoughtbot/shoulda-matchers/Shoulda%2FMatchers%2FActiveRecord:validate_uniqueness_of
     subject { create(:listing_category) }
 
-    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to have_many(:listings).inverse_of(:listing_category).dependent(:restrict_with_error) }
+
     it { is_expected.to validate_presence_of(:cost) }
+    it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:rules) }
     it { is_expected.to validate_presence_of(:slug) }
     it { is_expected.to validate_uniqueness_of(:name) }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Currently the relation between `ListingCategory` has two issues:

- it does not work because it's not able to infer the name of the foreign key, you can verify it this by loading the console in master:

```ruby
category = ListingCategory.first
category.listings # this doesn't return the array of listings
```

- it doesn't define a `dependent` clause. I chose `:restrict_with_error` because removing a category should fail if there are listings assigned to that category.

The foreign key is already in place so no need to add that.

## QA Instructions, Screenshots, Recordings

```ruby
category = ListingCategory.first
category.destroy
puts category.errors
```

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
