### PR TITLE
Bug Fix:Execute Hypershield Refresh Task

### DIFF
--- a/lib/tasks/app_initializer.rake
+++ b/lib/tasks/app_initializer.rake
@@ -19,6 +19,6 @@ if ENV["ENABLE_HYPERSHIELD"].present?
   # runs AFTER db:prepare. Passing it as an argument will cause it to run BEFORE
   # https://ruby-doc.org/stdlib-2.0.0/libdoc/rake/rdoc/Rake/Task.html#method-i-enhance
   Rake::Task["db:prepare"].enhance do
-    Rake::Task["hypershield:refresh"]
+    Rake::Task["hypershield:refresh"].execute
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
For realz, I fixed it this time. Turns out we actually gotta call execute on the task when using the block notation this way. 

If you use argument notation like this you don't have to call execute on your task, it just automatically does it for you.
```ruby
Rake::Task["db:prepare"].enhance(["search:setup"])
```
For block notation, you have to call execute yourself. 

![alt_text](https://media1.giphy.com/media/3oKIPlifLxdigaD2Y8/200.gif)
