### PR TITLE
Proof of concept: Set appropriate config along with Vault

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -19,6 +19,7 @@ class AsyncInfoController < ApplicationController
       remember_me(current_user)
     end
     @user = current_user.decorate
+    check_process_env_updates
     occasionally_update_analytics
     respond_to do |format|
       format.json do
@@ -97,6 +98,13 @@ class AsyncInfoController < ApplicationController
   end
 
   private
+
+  def check_process_env_updates
+    Rails.cache.fetch("config-update-shield-#{Process.pid}") do
+      Devise.omniauth :github, AppSecrets["GITHUB_KEY"], AppSecrets["GITHUB_SECRET"]
+      Devise.omniauth :twitter, AppSecrets["TWITTER_KEY"], AppSecrets["TWITTER_SECRET"]
+    end
+  end
 
   def occasionally_update_analytics
     return unless Rails.env.production? && rand(SiteConfig.ga_fetch_rate) == 1

--- a/app/lib/app_secrets.rb
+++ b/app/lib/app_secrets.rb
@@ -28,7 +28,8 @@ class AppSecrets
   end
 
   def write_to_rails_config(key, value)
-    # Bust the cache of config-update-shield-xxxx for every process running.....
+    # This is where we'd bust the cache of config-update-shield-xxxx for every process running.....
+    # Then every process would indepenently check the next time through that path.
   end
 
   def self.namespace

--- a/app/lib/app_secrets.rb
+++ b/app/lib/app_secrets.rb
@@ -3,6 +3,10 @@ class AppSecrets
     SLACK_CHANNEL
     SLACK_DEPLOY_CHANNEL
     SLACK_WEBHOOK_URL
+    GITHUB_KEY
+    GITHUB_SECRET
+    TWITTER_KEY
+    TWITTER_SECRET
   ].freeze
 
   def self.[](key)
@@ -15,11 +19,29 @@ class AppSecrets
   end
 
   def self.[]=(key, value)
+    write_to_rails_config(key, value)
     Vault.kv(namespace).write(key, value: value)
   end
 
   def self.vault_enabled?
     ENV["VAULT_TOKEN"].present?
+  end
+
+  def write_to_rails_config(key, value)
+    # Write to appropriate config after writing to vault.
+    # So that the setting is live right away instead of only on reboot
+    # For specific values where this is appropriate and safe.
+
+    case key
+    when "GITHUB_KEY"
+      Devise.omniauth :github, value, self["GITHUB_SECRET"]
+    when "GITHUB_SECRET"
+      Devise.omniauth :github, self["GITHUB_KEY"], value
+    when "TWITTER_KEY"
+      Devise.omniauth :twitter, value, self["TWITTER_SECRET"]
+    when "TWITTER_SECRET"
+      Devise.omniauth :twitter, self["TWITTER_KEY"], value
+    end
   end
 
   def self.namespace

--- a/app/lib/app_secrets.rb
+++ b/app/lib/app_secrets.rb
@@ -28,20 +28,7 @@ class AppSecrets
   end
 
   def write_to_rails_config(key, value)
-    # Write to appropriate config after writing to vault.
-    # So that the setting is live right away instead of only on reboot
-    # For specific values where this is appropriate and safe.
-
-    case key
-    when "GITHUB_KEY"
-      Devise.omniauth :github, value, self["GITHUB_SECRET"]
-    when "GITHUB_SECRET"
-      Devise.omniauth :github, self["GITHUB_KEY"], value
-    when "TWITTER_KEY"
-      Devise.omniauth :twitter, value, self["TWITTER_SECRET"]
-    when "TWITTER_SECRET"
-      Devise.omniauth :twitter, self["TWITTER_KEY"], value
-    end
+    # Bust the cache of config-update-shield-xxxx for every process running.....
   end
 
   def self.namespace

--- a/spec/lib/app_secrets_spec.rb
+++ b/spec/lib/app_secrets_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe AppSecrets, type: :lib do
       described_class[key] = "secret-value"
       expect(write_stub).to have_received(:write).with(key, value: "secret-value")
     end
+
+    it "sets appropriate config for certain keys" do
+      write_stub = instance_double("Vault::Kv", write: nil)
+      allow(Vault).to receive(:kv) { write_stub }
+
+      described_class["GITHUB_KEY"] = "secret-github-key"
+      Devise.omniauth_configs[:github].args[0].to eq("secret-github-key")
+    end
   end
 
   describe "#vault_enabled?" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a proof of concept to communicate an approach to this problem...

When we set a vault key, and we then make that available to read from for that value, a lot of the default Rails scenarios are that that value gets read during initialization, and is stored thereafter.

But if a user is setting a secret for, say, their application's oauth key, we just want that to get set like any other value. Rarely would there be a scenario where it can only be set at boot time. That's just the convention, but I doubt there's pretty much anything that can't be reassigned whenever we want.

I'm not sure this is exactly the pattern we'd want to follow, but throwing it out there as an idea for feedback. There might be more to it than what I have here, but opening it up for scrutiny.