### PR TITLE
Warning Fix: Rename Unused application.yml File to Prevent Warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ latest.dump
 
 # Ignore application configuration
 /config/application.yml
+/config/application_unused.yml
 /public/packs
 /public/packs-test
 /node_modules

--- a/bin/setup
+++ b/bin/setup
@@ -28,6 +28,9 @@ chdir APP_ROOT do
   # TEMPORARY @sre will remove before Sept 1, 2020
   puts "\n== Create .env File from application.yml =="
   system!("bin/rails create_dot_env_file")
+  if File.exist?("config/application.yml")
+    system!("mv config/application.yml config/application_unused.yml")
+  end
 
   puts "\n== Copying sample files =="
   unless File.exist?("config/database.yml")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Warning Fix

## Description
As many of you noticed, when you start using the `.env` file instead of `application.yml` you tend to see these warnings a lot.
```
WARNING: Skipping key "TWITCH_CLIENT_ID". Already set in ENV.
WARNING: Skipping key "TWITCH_CLIENT_SECRET". Already set in ENV.
WARNING: Skipping key "TWITCH_WEBHOOK_SECRET". Already set in ENV.
WARNING: Skipping key "STACK_EXCHANGE_APP_KEY". Already set in ENV.
```
This is because we are still using the Figaro gem. We need to keep that in place for a while until everyone moves over to the new `.env` setup. I was planning to give it a month since deploying the change. In the meantime, removing the `application.yml` will fix the warnings. However, in the event something goes wrong, I dont want to be programmatically removing files that might have lots of important keys for users. Instead, I came up with the idea to rename the file so that it is not found by the Figaro gem. This way users will still have their keys if something goes wrong but won't have any warnings.


![alt_text](https://media1.tenor.com/images/bbb1a23fcf766e5439b3546027f3c2b0/tenor.gif?itemid=10711703)
