### PR TITLE
Refactor: Move beloved comment Badge to Sidekiq Cron

### DIFF
--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -28,7 +28,7 @@ module BadgeRewarder
 
   def self.award_beloved_comment_badges(comment_count = 24)
     badge_id = Badge.find_by!(slug: "beloved-comment").id
-    Comment.where("public_reactions_count > ?", comment_count).find_each do |comment|
+    Comment.includes(:user).where("public_reactions_count > ?", comment_count).find_each do |comment|
       message = "You're famous! [This is the comment](#{URL.comment(comment)}) for which you are being recognized. 😄"
       achievement = BadgeAchievement.create(
         user_id: comment.user_id,

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -17,3 +17,10 @@ award_yearly_club_badges:
     - ""
     - award_yearly_club_badges
     - ""
+award_beloved_comment_badges:
+  cron: "5 0 * * *" # daily at 12:05 am UTC
+  class: "BadgeAchievements::BadgeAwardWorker"
+  args:
+    - ""
+    - award_beloved_comment_badges
+    - ""

--- a/lib/tasks/badges.rake
+++ b/lib/tasks/badges.rake
@@ -1,5 +1,4 @@
 task award_badges: :environment do
-  BadgeRewarder.award_beloved_comment_badges
   BadgeRewarder.award_streak_badge(4)
   BadgeRewarder.award_streak_badge(8)
   BadgeRewarder.award_streak_badge(16)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
Moves the award_beloved_comment_badges task to a Sidekiq Cron and runs it just after the yearly badges. Since I was here, I also added a little optimization to eager load the users.

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43687049

nothing to do with the PR but makes me laugh 😅 
![alt_text](https://media.giphy.com/media/yoJC2i270b1mQvcDdK/giphy-downsized.gif)
