### PR TITLE
Set Stripe dynamically instead of at boot

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -32,6 +32,8 @@ module Admin
         twitter_hashtag
         shop_url
         payment_pointer
+        stripe_api_key
+        stripe_publishable_key
         health_check_token
         feed_style
         default_font

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -128,10 +128,6 @@ class ApplicationController < ActionController::Base
   end
 
   def initialize_stripe
-    Rails.configuration.stripe = {
-      publishable_key: "Set dynamically instead of once at boot."
-    }
-
-    Stripe.api_key = "Also set dynamically instead of once at boot."
+    Stripe.api_key = SiteConfig.stripe_api_key
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -126,4 +126,12 @@ class ApplicationController < ActionController::Base
   def api_action?
     self.class.to_s.start_with?("Api::")
   end
+
+  def initialize_stripe
+    Rails.configuration.stripe = {
+      publishable_key: "Set dynamically instead of once at boot."
+    }
+
+    Stripe.api_key = "Also set dynamically instead of once at boot."
+  end
 end

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -1,5 +1,6 @@
 class CreditsController < ApplicationController
   before_action :authenticate_user!
+  before_action :initialize_stripe
 
   def index
     @user_unspent_credits_count = current_user.credits.unspent.size

--- a/app/controllers/stripe_active_cards_controller.rb
+++ b/app/controllers/stripe_active_cards_controller.rb
@@ -1,5 +1,6 @@
 class StripeActiveCardsController < ApplicationController
   before_action :authenticate_user!
+  before_action :initialize_stripe
 
   AUDIT_LOG_CATEGORY = "user.credit_card.edit".freeze
   private_constant :AUDIT_LOG_CATEGORY

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
   after_action :verify_authorized, except: %i[index signout_confirm add_org_admin remove_org_admin remove_from_org]
   before_action :authenticate_user!, only: %i[onboarding_update onboarding_checkbox_update]
   before_action :set_suggested_users, only: %i[index]
+  before_action :initialize_stripe, only: %i[edit]
 
   INDEX_ATTRIBUTES_FOR_SERIALIZATION = %i[id name username summary profile_image].freeze
   private_constant :INDEX_ATTRIBUTES_FOR_SERIALIZATION

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -149,7 +149,7 @@ module Constants
         placeholder: "sk_live_...."
       },
       stripe_publishable_key: {
-        description: "Public stripe key for receiving payments. " \
+        description: "Public Stripe key for receiving payments. " \
         "See: https://stripe.com/docs/keys",
         placeholder: "pk_live_...."
       },

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -131,6 +131,16 @@ module Constants
         "See: https://github.com/thepracticaldev/dev.to/pull/6345",
         placeholder: "$pay.somethinglikethis.co/value"
       },
+      stripe_api_key: {
+        description: "Secret stripe key for receiving payments. " \
+        "See: https://stripe.com/docs/keys",
+        placeholder: "sk_live_...."
+      },
+      stripe_publishable_key: {
+        description: "Public stripe key for receiving payments. " \
+        "See: https://stripe.com/docs/keys",
+        placeholder: "pk_live_...."
+      },
       mailchimp_newsletter_id: {
         description: "Main Newsletter ID",
         placeholder: ""

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -76,7 +76,9 @@ class SiteConfig < RailsSettings::Base
   }
 
   # Monetization
-  field :payment_pointer, type: :string # Experimental
+  field :payment_pointer, type: :string
+  field :stripe_api_key, type: :string, default: ApplicationConfig["STRIPE_SECRET_KEY"]
+  field :stripe_publishable_key, type: :string, default: ApplicationConfig["STRIPE_PUBLISHABLE_KEY"]
   field :shop_url, type: :string
 
   # Newsletter

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -595,6 +595,24 @@
             </div>
 
             <div class="form-group">
+              <%= admin_config_label :stripe_api_key %>
+              <%= f.text_field :stripe_api_key,
+                               class: "form-control",
+                               value: SiteConfig.stripe_api_key,
+                               placeholder: Constants::SiteConfig::DETAILS[:stripe_api_key][:placeholder] %>
+              <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:stripe_api_key][:description] %></div>
+            </div>
+
+            <div class="form-group">
+              <%= admin_config_label :stripe_publishable_key %>
+              <%= f.text_field :stripe_publishable_key,
+                               class: "form-control",
+                               value: SiteConfig.stripe_publishable_key,
+                               placeholder: Constants::SiteConfig::DETAILS[:stripe_publishable_key][:placeholder] %>
+              <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:stripe_publishable_key][:description] %></div>
+            </div>
+
+            <div class="form-group">
               <%= admin_config_label :payment_pointer %>
               <%= f.text_field :payment_pointer,
                                class: "form-control",

--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -144,7 +144,7 @@
 </div>
   <script>
 
-    var stripe = Stripe('<%= Rails.configuration.stripe[:publishable_key] %>');
+    var stripe = Stripe('<%= SiteConfig.stripe_publishable_key %>');
     var elements = stripe.elements();
 
     <% if current_user.decorate.dark_theme? %>

--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -144,7 +144,7 @@
 </div>
   <script>
 
-    var stripe = Stripe('<%= ApplicationConfig["STRIPE_PUBLISHABLE_KEY"] %>');
+    var stripe = Stripe('<%= Rails.configuration.stripe[:publishable_key] %>');
     var elements = stripe.elements();
 
     <% if current_user.decorate.dark_theme? %>

--- a/app/views/users/_billing.html.erb
+++ b/app/views/users/_billing.html.erb
@@ -46,7 +46,7 @@
   <script>
     setTimeout(function () {
       var handler = StripeCheckout.configure({
-        key: '<%= Rails.configuration.stripe[:publishable_key] %>',
+        key: '<%= SiteConfig.stripe_publishable_key %>',
         image: "https://thepracticaldev.s3.amazonaws.com/i/xoxvppfjorrnxudkzskw.jpg",
         locale: 'auto',
         token: function (token) {

--- a/config/.env_sample
+++ b/config/.env_sample
@@ -134,11 +134,6 @@ export SLACK_CHANNEL=""
 export SLACK_DEPLOY_CHANNEL=""
 export SLACK_WEBHOOK_URL=""
 
-# Stripe for payment system
-# (https://stripe.com/docs/api)
-export STRIPE_PUBLISHABLE_KEY="Optional"
-export STRIPE_SECRET_KEY="Optional"
-
 # For video calling in DEV Connect
 # (https://www.twilio.com/docs/video)
 export TWILIO_ACCOUNT_SID="Optional"

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,9 +1,3 @@
-Rails.configuration.stripe = {
-  publishable_key: ApplicationConfig["STRIPE_PUBLISHABLE_KEY"]
-}
-
-Stripe.api_key = ApplicationConfig["STRIPE_SECRET_KEY"]
-
 if Rails.env.development? && Stripe.api_key.present?
   Stripe.log_level = Stripe::LEVEL_INFO
 end

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -276,6 +276,14 @@ RSpec.describe "/admin/config", type: :request do
           expect(SiteConfig.payment_pointer).to eq("$pay.yo")
         end
 
+        it "updates stripe configs" do
+          post "/admin/config", params: { site_config: { stripe_api_key: "sk_live_yo",
+                                                         stripe_publishable_key: "pk_live_haha" },
+                                          confirmation: confirmation_message }
+          expect(SiteConfig.stripe_api_key).to eq("sk_live_yo")
+          expect(SiteConfig.stripe_publishable_key).to eq("pk_live_haha")
+        end
+
         describe "Shop" do
           it "rejects update to shop_url without proper confirmation" do
             expected_shop_url = "https://qshop.dev.to"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is an example of setting stripe from dynamically, so the keys can be pulled from a storage source instead of `ENV`.... We can do this in several other places as well in order to move away from dependency on boot-time logic which requires us to restart the app if a user were to configure it.

An admin can now go into _their own_ stripe account and put the keys into their forem.... Which really is the way things should be. If we want to modify how storage is done in the future, we could, but the way this all works for now makes sense. I think we can keep plopping more into `SiteConfig` until we're done getting stuff out of `ENV`.