### PR TITLE
Use ApplicationController for liquid render

### DIFF
--- a/app/liquid_tags/asciinema_tag.rb
+++ b/app/liquid_tags/asciinema_tag.rb
@@ -8,7 +8,7 @@ class AsciinemaTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id

--- a/app/liquid_tags/blogcast_tag.rb
+++ b/app/liquid_tags/blogcast_tag.rb
@@ -6,7 +6,7 @@ class BlogcastTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id

--- a/app/liquid_tags/codepen_tag.rb
+++ b/app/liquid_tags/codepen_tag.rb
@@ -11,7 +11,7 @@ class CodepenTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         link: @link,

--- a/app/liquid_tags/codesandbox_tag.rb
+++ b/app/liquid_tags/codesandbox_tag.rb
@@ -14,7 +14,7 @@ class CodesandboxTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id,

--- a/app/liquid_tags/comment_tag.rb
+++ b/app/liquid_tags/comment_tag.rb
@@ -7,7 +7,7 @@ class CommentTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: { comment: @comment },
     )

--- a/app/liquid_tags/details_tag.rb
+++ b/app/liquid_tags/details_tag.rb
@@ -12,7 +12,7 @@ class DetailsTag < Liquid::Block
     content = Nokogiri::HTML.parse(super)
     parsed_content = sanitize(content.xpath("//html/body").inner_html)
 
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         summary: @summary,

--- a/app/liquid_tags/gist_tag.rb
+++ b/app/liquid_tags/gist_tag.rb
@@ -10,7 +10,7 @@ class GistTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         uri: @uri

--- a/app/liquid_tags/git_pitch_tag.rb
+++ b/app/liquid_tags/git_pitch_tag.rb
@@ -8,7 +8,7 @@ class GitPitchTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         link: @link

--- a/app/liquid_tags/github_tag/github_issue_tag.rb
+++ b/app/liquid_tags/github_tag/github_issue_tag.rb
@@ -21,7 +21,7 @@ class GithubTag
     end
 
     def render
-      ActionController::Base.new.render_to_string(
+      ApplicationController.render(
         partial: PARTIAL,
         locals: {
           body: @body,

--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -16,7 +16,7 @@ class GithubTag
         readme_html = fetch_readme(repository_path)
       end
 
-      ActionController::Base.new.render_to_string(
+      ApplicationController.render(
         partial: PARTIAL,
         locals: {
           content: content,

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -19,7 +19,7 @@ class GlitchTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id,

--- a/app/liquid_tags/instagram_tag.rb
+++ b/app/liquid_tags/instagram_tag.rb
@@ -7,7 +7,7 @@ class InstagramTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id

--- a/app/liquid_tags/js_fiddle_tag.rb
+++ b/app/liquid_tags/js_fiddle_tag.rb
@@ -10,7 +10,7 @@ class JsFiddleTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         link: @link,

--- a/app/liquid_tags/jsitor_tag.rb
+++ b/app/liquid_tags/jsitor_tag.rb
@@ -9,7 +9,7 @@ class JsitorTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         link: @link,

--- a/app/liquid_tags/katex_tag.rb
+++ b/app/liquid_tags/katex_tag.rb
@@ -22,7 +22,7 @@ class KatexTag < Liquid::Block
       context[KATEX_EXISTED] = true
     end
 
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         parsed_content: parsed_content,

--- a/app/liquid_tags/kotlin_tag.rb
+++ b/app/liquid_tags/kotlin_tag.rb
@@ -10,7 +10,7 @@ class KotlinTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         url: @embedded_url

--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -9,7 +9,7 @@ class LinkTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: { article: @article, title: @title },
     )

--- a/app/liquid_tags/listing_tag.rb
+++ b/app/liquid_tags/listing_tag.rb
@@ -8,7 +8,7 @@ class ListingTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: { listing: @listing },
     )

--- a/app/liquid_tags/medium_tag.rb
+++ b/app/liquid_tags/medium_tag.rb
@@ -12,7 +12,7 @@ class MediumTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         response: @response

--- a/app/liquid_tags/next_tech_tag.rb
+++ b/app/liquid_tags/next_tech_tag.rb
@@ -7,7 +7,7 @@ class NextTechTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         token: @token

--- a/app/liquid_tags/organization_tag.rb
+++ b/app/liquid_tags/organization_tag.rb
@@ -11,7 +11,7 @@ class OrganizationTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         organization: @organization.decorate,

--- a/app/liquid_tags/parler_tag.rb
+++ b/app/liquid_tags/parler_tag.rb
@@ -7,7 +7,7 @@ class ParlerTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id,

--- a/app/liquid_tags/poll_tag.rb
+++ b/app/liquid_tags/poll_tag.rb
@@ -106,7 +106,7 @@ class PollTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         poll: @poll

--- a/app/liquid_tags/reddit_tag.rb
+++ b/app/liquid_tags/reddit_tag.rb
@@ -11,7 +11,7 @@ class RedditTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         author: @reddit_content[:author],

--- a/app/liquid_tags/replit_tag.rb
+++ b/app/liquid_tags/replit_tag.rb
@@ -6,7 +6,7 @@ class ReplitTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id

--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -74,7 +74,7 @@ class RunkitTag < Liquid::Block
   def render(context)
     content = Nokogiri::HTML.parse(super)
     parsed_content = content.xpath("//html/body").text
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         preamble: @preamble,

--- a/app/liquid_tags/slideshare_tag.rb
+++ b/app/liquid_tags/slideshare_tag.rb
@@ -7,7 +7,7 @@ class SlideshareTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         key: @key,

--- a/app/liquid_tags/soundcloud_tag.rb
+++ b/app/liquid_tags/soundcloud_tag.rb
@@ -7,7 +7,7 @@ class SoundcloudTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         link: @link,

--- a/app/liquid_tags/speakerdeck_tag.rb
+++ b/app/liquid_tags/speakerdeck_tag.rb
@@ -7,7 +7,7 @@ class SpeakerdeckTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id

--- a/app/liquid_tags/spotify_tag.rb
+++ b/app/liquid_tags/spotify_tag.rb
@@ -21,7 +21,7 @@ class SpotifyTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         embed_link: @embed_link,

--- a/app/liquid_tags/stackblitz_tag.rb
+++ b/app/liquid_tags/stackblitz_tag.rb
@@ -13,7 +13,7 @@ class StackblitzTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id,

--- a/app/liquid_tags/stackery_tag.rb
+++ b/app/liquid_tags/stackery_tag.rb
@@ -7,7 +7,7 @@ class StackeryTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         owner: @data[:owner],

--- a/app/liquid_tags/stackexchange_tag.rb
+++ b/app/liquid_tags/stackexchange_tag.rb
@@ -24,7 +24,7 @@ class StackexchangeTag < LiquidTagBase
   def render(_context)
     default_link = "https://stackoverflow.com/a/#{@json_content['answer_id'] || @json_content['question_id']}"
 
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         site: @site,

--- a/app/liquid_tags/tag_tag.rb
+++ b/app/liquid_tags/tag_tag.rb
@@ -11,7 +11,7 @@ class TagTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         tag: @tag,

--- a/app/liquid_tags/tweet_tag.rb
+++ b/app/liquid_tags/tweet_tag.rb
@@ -33,7 +33,7 @@ class TweetTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         tweet: @tweet,

--- a/app/liquid_tags/user_tag.rb
+++ b/app/liquid_tags/user_tag.rb
@@ -11,7 +11,7 @@ class UserTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         user: user_object_for_partial(@user),

--- a/app/liquid_tags/vimeo_tag.rb
+++ b/app/liquid_tags/vimeo_tag.rb
@@ -9,7 +9,7 @@ class VimeoTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id,

--- a/app/liquid_tags/wikipedia_tag.rb
+++ b/app/liquid_tags/wikipedia_tag.rb
@@ -8,7 +8,7 @@ class WikipediaTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         title: @data[:title],

--- a/app/liquid_tags/youtube_tag.rb
+++ b/app/liquid_tags/youtube_tag.rb
@@ -9,7 +9,7 @@ class YoutubeTag < LiquidTagBase
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         id: @id,

--- a/docs/frontend/liquid-tags.md
+++ b/docs/frontend/liquid-tags.md
@@ -82,7 +82,7 @@ Each liquid tag contains an `initialize` method which takes arguments and calls
   end
 
   def render(_context)
-    ActionController::Base.new.render_to_string(
+    ApplicationController.render(
       partial: PARTIAL,
       locals: {
         url: @embedded_url

--- a/spec/fixtures/approvals/katextag/render/generates_katex_output.approved.html
+++ b/spec/fixtures/approvals/katextag/render/generates_katex_output.approved.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <link rel="stylesheet" media="screen" href="/assets/katex-9b6c3867a72192e69a311ffb59803143541c5bb3af401953b55bc7fc0ad25336.css" />
+    <link rel="stylesheet" media="screen" href="/assets/katex-cee672d582a5569164f4eaa61d7b277639a5c7fef57ed48b8949f4135457c6d9.css" />
   </head>
   <body>
     <div class="katex-element">

--- a/spec/fixtures/approvals/katextag/render/generates_katex_output.approved.html
+++ b/spec/fixtures/approvals/katextag/render/generates_katex_output.approved.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <link rel="stylesheet" media="screen" href="/assets/katex-cee672d582a5569164f4eaa61d7b277639a5c7fef57ed48b8949f4135457c6d9.css" />
+    <link rel="stylesheet" media="screen" href="/assets/katex-9b6c3867a72192e69a311ffb59803143541c5bb3af401953b55bc7fc0ad25336.css" />
   </head>
   <body>
     <div class="katex-element">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
I just found out that `Application.render` is a feature introduced in Rails 5 to [render erb outside of the request-response cycle](https://evilmartians.com/chronicles/new-feature-in-rails-5-render-views-outside-of-actions). Aside from being cleaner looking, it also provides view helpers without additional tinkering.
## Related Tickets & Documents
n/a
## QA Instructions, Screenshots, Recordings
1. Start up server locally
2. Navigate to `/new`
3. Try any liquid tag and click preview/save.
4. Content should render normally.
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a