### PR TITLE
Allow staff_user_id to be modified

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -97,6 +97,7 @@ module Admin
         community_member_label
         community_action
         community_copyright_start_year
+        staff_user_id
         tagline
       ]
     end

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -45,6 +45,10 @@ module Constants
         description: "Used to mark the year this forem was started.",
         placeholder: Time.zone.today.year.to_s
       },
+      staff_user_id: {
+        description: "Account ID which acts as automated 'staff'— used principally for welcome thread.",
+        placeholder: ""
+      },
       tagline: {
         description: "Used in signup modal.",
         placeholder: "We're a place where coders share, stay up-to-date and grow their careers."

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -33,6 +33,7 @@ class SiteConfig < RailsSettings::Base
   field :community_copyright_start_year, type: :integer,
                                          default: ApplicationConfig["COMMUNITY_COPYRIGHT_START_YEAR"] ||
                                            Time.zone.today.year
+  field :staff_user_id, type: :integer, default: 1
 
   # Emails
   field :email_addresses, type: :hash, default: {
@@ -115,7 +116,6 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_user_subscription_creation, type: :integer, default: 3
 
   # Social Media
-  field :staff_user_id, type: :integer, default: 1
   field :social_media_handles, type: :hash, default: {
     twitter: nil,
     facebook: nil,

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -252,6 +252,15 @@
                                placeholder: Constants::SiteConfig::DETAILS[:community_copyright_start_year][:placeholder] %>
               <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:community_copyright_start_year][:description] %></div>
             </div>
+
+            <div class="form-group">
+              <%= admin_config_label :staff_user_id %>
+              <%= f.text_field :staff_user_id,
+                               class: "form-control",
+                               value: SiteConfig.staff_user_id,
+                               placeholder: Constants::SiteConfig::DETAILS[:staff_user_id][:placeholder] %>
+              <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:staff_user_id][:description] %></div>
+            </div>
           </div>
         </div>
 

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -108,6 +108,11 @@ RSpec.describe "/admin/config", type: :request do
           post "/admin/config", params: { site_config: { tagline: description }, confirmation: confirmation_message }
           expect(SiteConfig.tagline).to eq(description)
         end
+
+        it "updates the staff_user_id" do
+          post "/admin/config", params: { site_config: { staff_user_id: 22 }, confirmation: confirmation_message }
+          expect(SiteConfig.staff_user_id).to eq(22)
+        end
       end
 
       describe "Emails" do
@@ -445,12 +450,6 @@ RSpec.describe "/admin/config", type: :request do
       end
 
       describe "Social Media" do
-        it "does not allow the staff_user_id to be updated" do
-          expect(SiteConfig.staff_user_id).to eq(1)
-          post "/admin/config", params: { site_config: { staff_user_id: 2 }, confirmation: confirmation_message }
-          expect(SiteConfig.staff_user_id).to eq(1)
-        end
-
         it "updates social_media_handles" do
           expected_handle = { "facebook" => "tpd", "github" => "", "instagram" => "", "twitch" => "", "twitter" => "" }
           post "/admin/config", params: { site_config: { social_media_handles: expected_handle },


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We had the staff user id as a field which existed in `SiteConfig` but was not editable, based on old mental models. This updates it so this is configurable like anything else.