### PR TITLE
Fix axe warnings on admin/chat_channels

### DIFF
--- a/app/views/admin/chat_channels/index.html.erb
+++ b/app/views/admin/chat_channels/index.html.erb
@@ -1,58 +1,65 @@
-<h2>Create New Connect Channel</h2>
-<div class="row m-3">
-  <div class="col">
-    <%= form_for [:admin, ChatChannel.new], html: { class: "inline-form" } do |f| %>
-      <div class="form-row">
-        <div class="form-group">
-          <%= f.text_field :channel_name, placeholder: "Channel Name", required: true %>
-          <%= f.text_field :usernames_string, placeholder: "Usernames to add" %>
-          <%= f.submit %>
+<aside>
+  <h2>Create New Connect Channel</h2>
+  <div class="row m-3">
+    <div class="col">
+      <%= form_for [:admin, ChatChannel.new], html: { class: "inline-form" } do |f| %>
+        <div class="form-row">
+          <div class="form-group">
+            <%= f.label :channel_name, "Channel Name", class: "sr-only" %>
+            <%= f.text_field :channel_name, placeholder: "Channel Name", required: true %>
+            <%= f.label :usernames_string, "Usernames", class: "sr-only" %>
+            <%= f.text_field :usernames_string, placeholder: "Usernames to add" %>
+            <%= f.submit %>
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
-<h2>Group Connect Channels</h2>
-<div class="row m-3">
-  <div class="col">
+</aside>
+<main>
+  <h2>Group Connect Channels</h2>
+  <div class="row m-3">
+    <div class="col">
+    </div>
+    <div class="col">
+      <%= search_form_for @q, url: admin_chat_channels_path, class: "form-inline justify-content-end" do |f| %>
+        <%= f.label :channel_name_cont, "Channel Name", class: "sr-only" %>
+        <%= f.search_field :channel_name_cont, placeholder: "Channel Name", class: "form-control mx-3" %>
+        <%= f.submit "Search", class: "btn btn-secondary" %>
+      <% end %>
+    </div>
   </div>
-  <div class="col">
-    <%= search_form_for @q, url: admin_chat_channels_path, class: "form-inline justify-content-end" do |f| %>
-      <%= f.label :channel_name_cont, "Channel Name", class: "sr-only" %>
-      <%= f.search_field :channel_name_cont, placeholder: "Channel Name", class: "form-control mx-3" %>
-      <%= f.submit "Search", class: "btn btn-secondary" %>
-    <% end %>
-  </div>
-</div>
-<%= paginate @group_chat_channels %>
-<table class="table">
-  <thead>
-    <tr>
-      <th scope="col">Channel Name</th>
-      <th scope="col">Users</th>
-      <th scope="col">Add Users</th>
-      <th scope="col">Remove User</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @group_chat_channels.each do |channel| %>
+  <%= paginate @group_chat_channels %>
+  <table class="table">
+    <thead>
       <tr>
-        <td><a href="/connect/<%= channel.slug %>" target="_blank" rel="noopener"><%= channel.channel_name %></td>
-          <td><%= channel.users.pluck(:username).join(", ") %></td>
-          <td>
-            <%= form_for [:admin, channel] do |f| %>
-              <%= f.text_field :usernames_string, placeholder: "Usernames to add" %>
-              <%= f.submit %>
-            <% end %>
-          </td>
-          <td>
-            <%= form_with url: remove_user_admin_chat_channel_url(channel), model: [:admin, channel], method: :delete, local: true do |f| %>
-              <%= f.text_field :username_string, placeholder: "Username to remove" %>
-              <%= f.submit "Remove From channel", data: { confirm: "Are you sure you want to remove this user?" } %>
-            <% end %>
-          </td>
+        <th scope="col">Channel Name</th>
+        <th scope="col">Users</th>
+        <th scope="col">Add Users</th>
+        <th scope="col">Remove User</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @group_chat_channels.each do |channel| %>
+        <tr>
+          <td><a href="/connect/<%= channel.slug %>" target="_blank" rel="noopener"><%= channel.channel_name %></td>
+            <td><%= channel.users.pluck(:username).join(", ") %></td>
+            <td>
+              <%= form_for [:admin, channel] do |f| %>
+                <%= f.text_field :usernames_string, id: "usersToAddToChannel#{channel.id}", placeholder: "Usernames to add", aria: { label: "Usernames" } %>
+                <%= f.submit %>
+              <% end %>
+            </td>
+            <td>
+              <%= form_with url: remove_user_admin_chat_channel_url(channel), model: [:admin, channel], method: :delete, local: true do |f| %>
+                <%= f.label :usernames_string, "Users to Remove", class: "sr-only" %>
+                <%= f.text_field :username_string, id: "usersToRemoveFromChannel#{channel.id}", placeholder: "Username to remove", aria: { label: "Usernames" } %>
+                <%= f.submit "Remove From channel", data: { confirm: "Are you sure you want to remove this user?" } %>
+              <% end %>
+            </td>
         </tr>
       <% end %>
     </tbody>
   </table>
   <%= paginate @group_chat_channels %>
+</main>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change gets rid of a bunch of axe warnings in the admin chat_channels interface :tada: 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
