### PR TITLE
Bug Fix:Run Badge Award Job Twice a Day

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -18,28 +18,28 @@ award_yearly_club_badges:
     - award_yearly_club_badges
     - ""
 award_beloved_comment_badges:
-  cron: "5 0 * * *" # daily at 12:05 am UTC
+  cron: "5 */12 * * *" # 5 min past every 12th hour UTC
   class: "BadgeAchievements::BadgeAwardWorker"
   args:
     - ""
     - award_beloved_comment_badges
     - ""
 award_four_week_streak_badge:
-  cron: "10 0 * * *" # daily at 12:10 am UTC
+  cron: "10 */12 * * *" # 10 min past every 12th hour UTC
   class: "BadgeAchievements::BadgeAwardWorker"
   args:
     - ""
     - award_four_week_streak_badge
     - ""
 award_eight_week_streak_badge:
-  cron: "15 0 * * *" # daily at 12:15 am UTC
+  cron: "15 */12 * * *" # 15 min past every 12th hour UTC
   class: "BadgeAchievements::BadgeAwardWorker"
   args:
     - ""
     - award_eight_week_streak_badge
     - ""
 award_sixteen_week_streak_badge:
-  cron: "20 0 * * *" # daily at 12:20 am UTC
+  cron: "20 */12 * * *" # 20 min past every 12th hour UTC
   class: "BadgeAchievements::BadgeAwardWorker"
   args:
     - ""


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
After #9872 was merged I went to go and remove the rake task from Heroku. This is when I noticed we were running the rake task twice a day. 12AM UTC and 2:30PM UTC. To keep with that schedule of running it twice a day I updated the cron jobs to run every 12th hour. Not exactly the same schedule as before but it will ensure the job runs twice a day. Not sure if that was a mistake or needed but the easiest thing to do is keep the same schedule for now. 

Keeping the yearly club badge to once a day since that checks the past 2 days for created users so once a day should suffice. 

![alt_text](https://media2.giphy.com/media/Q945dVyIcEsHC/giphy.gif)
