### PR TITLE
Flaky Spec Fix:Use Comment created_at in Expectation

### DIFF
--- a/spec/requests/api/v0/comments_spec.rb
+++ b/spec/requests/api/v0/comments_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Api::V0::Comments", type: :request do
     it "returns date created" do
       get api_comments_path(a_id: article.id)
       expect(find_root_comment(response)).to include(
-        "created_at" => article.created_at.utc.iso8601,
+        "created_at" => root_comment.created_at.utc.iso8601,
       )
     end
 
@@ -167,7 +167,9 @@ RSpec.describe "Api::V0::Comments", type: :request do
     context "when getting by podcast episode id" do
       let(:podcast) { create(:podcast) }
       let(:podcast_episode) { create(:podcast_episode, podcast: podcast) }
-      let!(:comment) { create(:comment, commentable: podcast_episode) }
+      let(:comment) { create(:comment, commentable: podcast_episode) }
+
+      before { comment }
 
       it "not found if bad podcast episode id" do
         get api_comments_path(p_id: "asdfghjkl")


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Flaky Spec Fix

## Description
I noticed while reviewing https://github.com/forem/forem/pull/9841 that it had the following flaky spec. When I looked closer at the spec I realized that we were comparing the comment created_at in the response to the article created_at which is incorrect. I updated the spec with the proper root_comment created_at. 
```
       -"created_at" => "2020-08-19T15:39:53Z",
       +"body_html" => "<p>Neutra kinfolk distillery chartreuse small batch cliche. Polaroid mustache cornhole direct trade 
        ....
       +"created_at" => "2020-08-19T15:39:54Z",
```

![alt_text](https://media1.tenor.com/images/30ecee2cae85e9d02e316a3668feee19/tenor.gif?itemid=4812541)
