### PR TITLE
Optimization:Collect More Specific Data From Sidekiq Jobs

### DIFF
--- a/lib/sidekiq/honeycomb_middleware.rb
+++ b/lib/sidekiq/honeycomb_middleware.rb
@@ -10,6 +10,8 @@ module Sidekiq
         span.add_field("sidekiq.queue", queue)
         span.add_field("sidekiq.jid", job["jid"])
         span.add_field("sidekiq.args", job["args"])
+        span.add_field("sidekiq.retry", job["retry"])
+        span.add_field("sidekiq.retry_count", job["retry_count"])
         begin
           yield
           span.add_field("sidekiq.result", "success")

--- a/lib/sidekiq/worker_retries_exhausted_reporter.rb
+++ b/lib/sidekiq/worker_retries_exhausted_reporter.rb
@@ -4,7 +4,13 @@
 module Sidekiq
   class WorkerRetriesExhaustedReporter
     def self.report_final_failure(job)
-      tags = ["action:dead", "worker_name:#{job['class']}"]
+      tags = [
+        "action:dead",
+        "worker_name:#{job['class']}",
+        "jid:#{job['jid']}",
+        "retry:#{job['retry']}",
+        "retry_count:#{job['retry_count']}",
+      ]
       DatadogStatsClient.increment(
         "sidekiq.worker.retries_exhausted", tags: tags
       )

--- a/spec/lib/sidekiq/worker_retries_exhausted_reporter_spec.rb
+++ b/spec/lib/sidekiq/worker_retries_exhausted_reporter_spec.rb
@@ -1,12 +1,20 @@
 require "rails_helper"
 
 describe Sidekiq::WorkerRetriesExhaustedReporter, type: :labor do
+  let(:job_hash) { { "class" => "TempWorker", "retry" => 15, "retry_count" => 1, "jid" => "123abc" } }
+
   it "increments worker retries exhausted in Datadog" do
     allow(DatadogStatsClient).to receive(:increment)
-    described_class.report_final_failure("class" => "TempWorker")
+    described_class.report_final_failure(job_hash)
     expect(DatadogStatsClient).to have_received(:increment).with(
       "sidekiq.worker.retries_exhausted",
-      tags: ["action:dead", "worker_name:TempWorker"],
+      tags: [
+        "action:dead",
+        "worker_name:#{job_hash['class']}",
+        "jid:#{job_hash['jid']}",
+        "retry:#{job_hash['retry']}",
+        "retry_count:#{job_hash['retry_count']}",
+      ],
     )
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
We are getting a lot of false alerts in [Datadog from our WorkerRetriesExhaustedReporter.](https://app.datadoghq.com/monitors/15829532) They seem to center around the `Comments::BustCacheWorker` but I am not sure why that is. I did some testing locally but nothing seemed off, the job would fail as expected and the death handler would be triggered as expected. Seeing as we get these alerts when no jobs have died I have added some additional recording data to try and help me figure out what is happening. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43527526

## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media0.giphy.com/media/X4YqmJEl6wJoY/200.gif)
