### PR TITLE
Refactor:Move Tag Badge and Github Badge Awards to Sidekiq

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -45,3 +45,17 @@ award_sixteen_week_streak_badge:
     - ""
     - award_sixteen_week_streak_badge
     - ""
+award_weekly_tag_badges:
+  cron: "0 11 * * 4" # 11 am UTC every Thursday
+  class: "BadgeAchievements::BadgeAwardWorker"
+  args:
+    - ""
+    - award_tag_badges
+    - ""
+award_contributor_badges_from_github:
+  cron: "20 * * * *" # every hour, 20 min after the hour
+  class: "BadgeAchievements::BadgeAwardWorker"
+  args:
+    - ""
+    - award_contributor_badges_from_github
+    - ""

--- a/lib/tasks/badges.rake
+++ b/lib/tasks/badges.rake
@@ -1,11 +1,3 @@
-task award_weekly_tag_badges: :environment do
-  # Should run once per week.
-  # Scheduled "daily" on Heroku Scheduler, should only fully run on Thursday.
-  if Time.current.wday == 4
-    BadgeRewarder.award_tag_badges
-  end
-end
-
 # rake award_top_seven_badges["ben jess peter mac liana andy"]
 task :award_top_seven_badges, [:arg1] => :environment do |_t, args|
   usernames = args[:arg1].split(" ")
@@ -28,9 +20,4 @@ task :award_fab_five_badges, [:arg1] => :environment do |_t, args|
   puts "Awarding fab 5 badges to #{usernames}"
   BadgeRewarder.award_fab_five_badges(usernames)
   puts "Done!"
-end
-
-# this task is meant to be scheduled daily
-task award_contributor_badges_from_github: :environment do
-  BadgeRewarder.award_contributor_badges_from_github
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This moves the `award_contributor_badges_from_github` and `award_tag_badges` rake tasks to Sidekiq Cron jobs.
<img width="1130" alt="Screen Shot 2020-08-19 at 5 59 36 PM" src="https://user-images.githubusercontent.com/1813380/90698205-ca20f600-e245-11ea-930b-9cdce5694609.png">
<img width="1111" alt="Screen Shot 2020-08-19 at 5 59 40 PM" src="https://user-images.githubusercontent.com/1813380/90698206-cab98c80-e245-11ea-96ab-b7eb017121cc.png">


## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43687049


![alt_text](https://media.tenor.com/images/cea744330bd903e88032ad4ffa71fed5/tenor.gif)
