### PR TITLE
Add display columns to ProfileField

### DIFF
--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -11,9 +11,15 @@ class ProfileField < ApplicationRecord
     color_field: 3
   }
 
+  enum display_area: {
+    header: 0,
+    left_sidebar: 1
+  }
+
   validates :label, presence: true, uniqueness: { case_sensitive: false }
   validates :active, inclusion: { in: [true, false] }
   validates :attribute_name, presence: true, on: :update
+  validates :show_in_onboarding, inclusion: { in: [true, false] }
 
   scope :active, -> { where(active: true) }
 

--- a/db/migrate/20200820055018_add_display_colums_to_profile_fields.rb
+++ b/db/migrate/20200820055018_add_display_colums_to_profile_fields.rb
@@ -1,0 +1,6 @@
+class AddDisplayColumsToProfileFields < ActiveRecord::Migration[6.0]
+  def change
+    add_column :profile_fields, :display_area, :integer, null: false, default: true
+    add_column :profile_fields, :show_in_onboarding, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_18_163834) do
+ActiveRecord::Schema.define(version: 2020_08_20_055018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -937,10 +937,12 @@ ActiveRecord::Schema.define(version: 2020_08_18_163834) do
     t.string "attribute_name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.string "description"
+    t.integer "display_area", default: 1, null: false
     t.string "group"
     t.integer "input_type", default: 0, null: false
     t.citext "label", null: false
     t.string "placeholder_text"
+    t.boolean "show_in_onboarding", default: false, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["label"], name: "index_profile_fields_on_label", unique: true
   end

--- a/spec/factories/profile_fields.rb
+++ b/spec/factories/profile_fields.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     placeholder_text { "john.doe@example.com" }
     active { true }
     group { "Basic" }
+
+    trait :onboarding do
+      show_in_onboarding { true }
+    end
   end
 end

--- a/spec/models/profile_field_spec.rb
+++ b/spec/models/profile_field_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ProfileField, type: :model do
       it { is_expected.to validate_uniqueness_of(:label).case_insensitive }
       it { is_expected.to validate_inclusion_of(:active).in_array([true, false]) }
       it { is_expected.to validate_presence_of(:attribute_name).on(:update) }
+      it { is_expected.to validate_inclusion_of(:show_in_onboarding).in_array([true, false]) }
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds two more colums to the `ProfileField` model: 

* `display_area`: an enum that for now has 2 options, "header" or "left_sidebar".
* `show_in_onboarding`": Whether or not the profile field wil be shown during the onboarding flow.

## Related Tickets & Documents

Part of #6994

## QA Instructions, Screenshots, Recordings

Not much to test yet, this is mostly about unblocking @Ridhwana for the work on the new profile page.

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
