### PR TITLE
fix content reflow on video load

### DIFF
--- a/app/assets/stylesheets/video-player.scss
+++ b/app/assets/stylesheets/video-player.scss
@@ -5,16 +5,17 @@
   .crayons-article__video__player {
     background-position: center;
     background-size: cover;
+    padding-bottom: 56.25%;
 
     &.native {
-      height: calc(100vw * (9/16)); // Maintain 16:9 ratio
+      height: calc(100vw * (9 / 16)); // Maintain 16:9 ratio
     }
 
     img {
       display: none;
-      width: calc(100vw * (9/16) * (1/2));
-      height: calc((100vw * (9/16) * (1/2)) + (100vw * (9/16) * (1/6)));
-      padding-top: calc(100vw * (9/16) * (1/6));
+      width: calc(100vw * (9 / 16) * (1 / 2));
+      height: calc((100vw * (9 / 16) * (1 / 2)) + (100vw * (9 / 16) * (1 / 6)));
+      padding-top: calc(100vw * (9 / 16) * (1 / 6));
       margin: 0 auto;
 
       &.active {
@@ -27,13 +28,16 @@
     // calculations are based on viewport size (the columns "don't count")
     @media screen and (min-width: 640px) {
       &.native {
-        height: calc(100vw * (9/16) * (2/3));
+        height: calc(100vw * (9 / 16) * (2 / 3));
       }
 
       img {
-        width: calc(100vw * (9/16) * (1/2) * (2/3));
-        height: calc((100vw * (9/16) * (1/2) * (2/3)) + (100vw * (9/16) * (1/6) * (2/3)));
-        padding-top: calc(100vw * (9/16) * (1/6) * (2/3));
+        width: calc(100vw * (9 / 16) * (1 / 2) * (2 / 3));
+        height: calc(
+          (100vw * (9 / 16) * (1 / 2) * (2 / 3)) +
+            (100vw * (9 / 16) * (1 / 6) * (2 / 3))
+        );
+        padding-top: calc(100vw * (9 / 16) * (1 / 6) * (2 / 3));
       }
     }
   }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds padding to the video player element to prevent content reflow on video load. 

## Related Tickets & Documents
Fixes #9638 

## QA Instructions, Screenshots, Recordings

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/22113778/90794817-e480cf80-e32a-11ea-9a87-2ddfca0a1986.gif)

I had to hack the video upload a bit by directly adding its information to the database due to lack of AWS keys for the upload functionality. The thumbnail in the initial part of the gif is also missing due to missing Cloudinary keys. Highly recommend testing the fix with both present before approval.

In order to test:
1. Run Forem with AWS for video storage and Cloudinary configured.
2. Add 15 days to Account's creation date `user.update(created_at: 15.days.ago)` in rails console to see the video upload button.
3. Once the article with video gets created, open it via the User profile view.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

<!-- ## [optional] Are there any post deployment tasks we need to perform? -->

## What gif best describes this PR or how it makes you feel?

![Its time for the content to freeze](https://media1.tenor.com/images/b672f6b4619246f983490fdf670b132d/tenor.gif)
