### PR TITLE
Refactor:Move Listing and Support Tag Tasks to Sidekiq

### DIFF
--- a/app/workers/listings/expire_old_listings_worker.rb
+++ b/app/workers/listings/expire_old_listings_worker.rb
@@ -1,0 +1,16 @@
+module Listings
+  class ExpireOldListingsWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :low_priority, retry: 5
+
+    def perform
+      Listing.published.where("bumped_at < ?", 30.days.ago).each do |listing|
+        listing.update(published: false)
+      end
+      Listing.published.where("expires_at < ?", Time.zone.today).each do |listing|
+        listing.update(published: false)
+      end
+    end
+  end
+end

--- a/app/workers/tags/resave_supported_tags_worker.rb
+++ b/app/workers/tags/resave_supported_tags_worker.rb
@@ -1,0 +1,11 @@
+module Tags
+  class ResaveSupportedTagsWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :low_priority, retry: 5
+
+    def perform
+      Tag.where(supported: true).find_each(&:save)
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -59,3 +59,9 @@ award_contributor_badges_from_github:
     - ""
     - award_contributor_badges_from_github
     - ""
+resave_supported_tags:
+  cron: "25 0 * * *" # daily at 12:25 am UTC
+  class: "Tags::ResaveSupportedTagsWorker"
+expire_old_listings:
+  cron: "30 0 * * *" # daily at 12:30 am UTC
+  class: "Listings::ExpireOldListingsWorker"

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -12,20 +12,6 @@ task fetch_all_rss: :environment do
   RssReader.get_all_articles(force: false) # don't force fetch. Fetch "random" subset instead of all of them.
 end
 
-task resave_supported_tags: :environment do
-  puts "resaving supported tags"
-  Tag.where(supported: true).find_each(&:save)
-end
-
-task expire_old_listings: :environment do
-  Listing.where("bumped_at < ?", 30.days.ago).each do |listing|
-    listing.update(published: false)
-  end
-  Listing.where("expires_at = ?", Time.zone.today).each do |listing|
-    listing.update(published: false)
-  end
-end
-
 task save_nil_hotness_scores: :environment do
   Article.published.where(hotness_score: nil).find_each(&:save)
 end

--- a/spec/workers/listings/expire_old_listings_worker_spec.rb
+++ b/spec/workers/listings/expire_old_listings_worker_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Listings::ExpireOldListingsWorker, type: :worker do
+  let(:worker) { subject }
+
+  include_examples "#enqueues_on_correct_queue", "low_priority"
+
+  describe "#perform" do
+    it "expires only old listings" do
+      Timecop.freeze do
+        bumped_listing = create(:listing, bumped_at: 41.days.ago, published: true)
+        expired_listing = create(:listing, expires_at: 1.day.ago, published: true)
+        valid_listing = create(:listing, expires_at: 1.week.from_now, published: true)
+
+        worker.perform
+
+        expect(bumped_listing.reload.published).to eq(false)
+        expect(expired_listing.reload.published).to eq(false)
+        expect(valid_listing.reload.published).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/workers/tags/resave_supported_tags_worker_spec.rb
+++ b/spec/workers/tags/resave_supported_tags_worker_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Tags::ResaveSupportedTagsWorker, type: :worker do
+  let(:worker) { subject }
+
+  include_examples "#enqueues_on_correct_queue", "low_priority"
+
+  describe "#perform" do
+    it "resaves supported tags" do
+      Timecop.freeze do
+        old_update_timestamp = 1.week.ago
+        tag = create(:tag, supported: true, updated_at: old_update_timestamp)
+
+        worker.perform
+
+        expect(tag.updated_at).to be > old_update_timestamp
+      end
+    end
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
This moves the `resave_supported_tags` and `expire_old_listings` rake tasks to Sidekiq Crons. While I was here I made a little optimization to the listing task by adding published to our scope and by looking for published articles with `expires_at` less than the current day. This will ensure that listings get expired even if we run into problems and possibly skip a day for one reason or another. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43687049

## Added tests?
- [x] yes

![alt_text](https://i.pinimg.com/originals/09/d3/a9/09d3a94c119c93e920a5e01bcef89d52.gif)
