### PR TITLE
Bug Fix:Skip Busting Edge Caches if Fastly API Key is not Present

### DIFF
--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -19,7 +19,7 @@ module CacheBuster
     #
     # https://github.com/fastly/fastly-ruby#efficient-purging
     return unless Rails.env.production?
-    return unless ApplicationConfig["FASTLY_API_KEY"]
+    return if ApplicationConfig["FASTLY_API_KEY"].blank?
 
     HTTParty.post("https://api.fastly.com/purge/https://#{ApplicationConfig['APP_DOMAIN']}#{path}",
                   headers: { "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"] })

--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -19,6 +19,7 @@ module CacheBuster
     #
     # https://github.com/fastly/fastly-ruby#efficient-purging
     return unless Rails.env.production?
+    return unless ApplicationConfig["FASTLY_API_KEY"]
 
     HTTParty.post("https://api.fastly.com/purge/https://#{ApplicationConfig['APP_DOMAIN']}#{path}",
                   headers: { "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"] })


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
On Forem.dev we are not currently using any cacheing. This causes our CacheBuster to fail with the following error whenever it is run
```
Fastly::Error: {"msg":"Provided credentials are missing or invalid"}
```
To prevent this from happening I added a guard clause to ensure we dont try to hit the Fastly API unless we have credentials for it. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43527526

![alt_text](https://media1.tenor.com/images/5e1314f9fc7ac49154cfcba61f266883/tenor.gif?itemid=11144740)
