### PR TITLE
Replace HEROKU_SLUG_COMMIT with custom footprint (naive)

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -35,7 +35,7 @@ class AsyncInfoController < ApplicationController
     set_surrogate_key_header "shell-version-endpoint"
     # shell_version will change on every deploy.
     # *Technically* could be only on changes to assets and shell, but this is more fool-proof.
-    shell_version = ApplicationConfig["HEROKU_SLUG_COMMIT"]
+    shell_version = ApplicationConfig["RELEASE_FOOTPRINT"]
     render json: { version: Rails.env.production? ? shell_version : rand(1000) }.to_json
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -180,11 +180,11 @@ module ApplicationHelper
     "#{community_name} Community"
   end
 
-  def cache_key_heroku_slug(path)
-    heroku_slug_commit = ApplicationConfig["HEROKU_SLUG_COMMIT"]
-    return path if heroku_slug_commit.blank?
+  def release_adjusted_cache_key(path)
+    release_footprint = ApplicationConfig["RELEASE_FOOTPRINT"]
+    return path if release_footprint.blank?
 
-    "#{path}-#{heroku_slug_commit}"
+    "#{path}-#{release_footprint}"
   end
 
   def copyright_notice

--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left crayons-layout__sidebar-left">
   <div class="sidebar-bg" id="sidebar-bg-left"></div>
   <aside class="side-bar" aria-label="Primary sidebar">
-    <% cache(cache_key_heroku_slug("main-sidebar-nav--#{user_signed_in?}"), expires_in: 15.minutes) do %>
+    <% cache(release_adjusted_cache_key("main-sidebar-nav--#{user_signed_in?}"), expires_in: 15.minutes) do %>
       <%= render "articles/sidebar_nav" %>
       <% @sponsorships = Sponsorship.gold.live.includes(:organization).order(featured_number: :asc) %>
       <%# the pattern .present?/.each has the advantage of issuing only a single SQL query to load objects in memory %>

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -11,7 +11,7 @@
         </div>
       </section>
     <% end %>
-    <% cache(cache_key_heroku_slug("main-article-right-sidebar-discussions-#{params[:timeframe]}"), expires_in: (params[:timeframe].blank? ? 120 : 360).seconds) do %>
+    <% cache(release_adjusted_cache_key("main-article-right-sidebar-discussions-#{params[:timeframe]}"), expires_in: (params[:timeframe].blank? ? 120 : 360).seconds) do %>
       <% @sidebar_ad = DisplayAd.for_display("sidebar_right") %>
       <% if @sidebar_ad %>
         <div class="crayons-card crayons-card--secondary p-4 crayons-sponsorship-widget">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -26,7 +26,7 @@
 
 <%= javascript_packs_with_chunks_tag "homePage", defer: true %>
 
-<% cache(cache_key_heroku_slug("main-stories-index-#{params}-#{user_signed_in?}"), expires_in: 90.seconds) do %>
+<% cache(release_adjusted_cache_key("main-stories-index-#{params}-#{user_signed_in?}"), expires_in: 90.seconds) do %>
   <div class="crayons-layout crayons-layout--3-cols crayons-layout--3-cols--drop-right-left" id="index-container"
       data-params="<%= params.merge(sort_by: "hotness_score", sort_direction: "desc").to_json(only: %i[tag username q sort_by sort_direction]) %>" data-which="<%= @list_of %>"
       data-tag=""

--- a/app/views/feedback_messages/index.html.erb
+++ b/app/views/feedback_messages/index.html.erb
@@ -1,5 +1,5 @@
 <% title "Feedback" %>
-<% cache(cache_key_heroku_slug("feedback-messages-lander-styling")) do %>
+<% cache(release_adjusted_cache_key("feedback-messages-lander-styling")) do %>
   <style>
     <%= Rails.application.assets["feedback_messages.css"].to_s.html_safe %>
   </style>

--- a/app/views/layouts/_styles.html.erb
+++ b/app/views/layouts/_styles.html.erb
@@ -1,4 +1,4 @@
-<% cache "base_inline_styles_#{@story_show}_#{@article_index}_#{@home_page}_#{@article_show}_#{view_class}_#{@notifications_index}_#{@tags_index}_#{@reading_list_items_index}_#{@history_index}_#{ApplicationConfig['HEROKU_SLUG_COMMIT']}_#{user_signed_in?}_#{@shell}", expires_in: 8.hours do %>
+<% cache "base_inline_styles_#{@story_show}_#{@article_index}_#{@home_page}_#{@article_show}_#{view_class}_#{@notifications_index}_#{@tags_index}_#{@reading_list_items_index}_#{@history_index}_#{ApplicationConfig['RELEASE_FOOTPRINT']}_#{user_signed_in?}_#{@shell}", expires_in: 8.hours do %>
   <% if @shell %>
     <style>
       <% Rails.application.config.assets.compile = true %>

--- a/app/views/liquid_embeds/show.html.erb
+++ b/app/views/liquid_embeds/show.html.erb
@@ -1,5 +1,5 @@
 <base target="_parent">
-<% cache "liquid_tag_styles_#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 8.hours do #TODO: Render specific ltag class instead of everything %>
+<% cache "liquid_tag_styles_#{ApplicationConfig['RELEASE_FOOTPRINT']}", expires_in: 8.hours do #TODO: Render specific ltag class instead of everything %>
   <style><%= Rails.application.assets["ltags/LiquidTags.css"].to_s.html_safe %></style>
 <% end %>
 <% begin %>

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -1,6 +1,6 @@
 <% title "Moderating " + @moderatable.title %>
 
-<% cache(cache_key_heroku_slug("mod-styling")) do %>
+<% cache(release_adjusted_cache_key("mod-styling")) do %>
   <style>
     <%= Rails.application.assets["moderators.css"].to_s.html_safe %>
   </style>

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -2,7 +2,7 @@
 
 <%= javascript_packs_with_chunks_tag "commentModPage", defer: true %>
 
-<% cache(cache_key_heroku_slug("mod-styling")) do %>
+<% cache(release_adjusted_cache_key("mod-styling")) do %>
   <style>
     <%= Rails.application.assets["moderators.css"].to_s.html_safe %>
   </style>

--- a/app/views/onboardings/show.html.erb
+++ b/app/views/onboardings/show.html.erb
@@ -1,7 +1,7 @@
 <% title "Welcome to #{community_name}" %>
 
 <style>
-  <% cache(cache_key_heroku_slug("onboarding-css"), expires_in: 10.hours) do %>
+  <% cache(release_adjusted_cache_key("onboarding-css"), expires_in: 10.hours) do %>
     <%= Rails.application.assets["preact/onboarding-modal.css"].to_s.html_safe %>
   <% end %>
   footer {

--- a/app/views/partnerships/index.html.erb
+++ b/app/views/partnerships/index.html.erb
@@ -1,7 +1,7 @@
 <% title "Partnerships and Sponsors" %>
 
 <style>
-  <% cache(cache_key_heroku_slug("partnership-org-section-credits"), expires_in: 10.hours) do %>
+  <% cache(release_adjusted_cache_key("partnership-org-section-credits"), expires_in: 10.hours) do %>
     <%= Rails.application.assets["partnerships.css"].to_s.html_safe %>
   <% end %>
 </style>

--- a/app/views/partnerships/show.html.erb
+++ b/app/views/partnerships/show.html.erb
@@ -1,7 +1,7 @@
 <% title "#{params[:option].titleize} Overview" %>
 
 <style>
-  <% cache(cache_key_heroku_slug("partnership-org-section-credits"), expires_in: 10.hours) do %>
+  <% cache(release_adjusted_cache_key("partnership-org-section-credits"), expires_in: 10.hours) do %>
     <%= Rails.application.assets["partnerships.css"].to_s.html_safe %>
   <% end %>
 </style>

--- a/app/views/shell/_bottom.html.erb
+++ b/app/views/shell/_bottom.html.erb
@@ -1,6 +1,6 @@
 <!-- Start Bottom Shell -->
 <% unless internal_navigation? %>
-  <% cache("footer-and-signup-modal--#{user_signed_in?}--#{ApplicationConfig['HEROKU_SLUG_COMMIT']}", expires_in: 24.hours) do %>
+  <% cache("footer-and-signup-modal--#{user_signed_in?}--#{ApplicationConfig['RELEASE_FOOTPRINT']}", expires_in: 24.hours) do %>
     <%= render "layouts/footer" %>
     <%= render "layouts/signup_modal" unless user_signed_in? %>
   <% end %>

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -49,7 +49,7 @@
     <% end %>
   </head>
   <% unless internal_navigation? %>
-    <% cache(cache_key_heroku_slug("top-html-and-config--#{user_signed_in?}")) do %>
+    <% cache(release_adjusted_cache_key("top-html-and-config--#{user_signed_in?}")) do %>
       <body data-user-status="<%= user_logged_in_status %>" class="<%= SiteConfig.default_font.tr("_", "-") %>-article-body" data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>">
         <div id="body-styles"></div>
         <% if user_signed_in? %>

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -16,7 +16,7 @@ COMPONENT_FINGERPRINTS = {
 Honeybadger.configure do |config|
   config.env = "#{ApplicationConfig['APP_DOMAIN']}-#{Rails.env}"
   config.api_key = ApplicationConfig["HONEYBADGER_API_KEY"]
-  config.revision = ApplicationConfig["HEROKU_SLUG_COMMIT"]
+  config.revision = ApplicationConfig["RELEASE_FOOTPRINT"]
 
   # Prevent Ruby from exiting until all queued notices have been delivered to Honeybadger.
   # When set to true(default), it can lead to a large number of errors causing a process to get stuck.

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -27,7 +27,7 @@ else
 
       # Scrub unused data to save space in Honeycomb
       config.presend_hook do |fields|
-        fields["global.build_id"] = ApplicationConfig["HEROKU_SLUG_COMMIT"]
+        fields["global.build_id"] = ApplicationConfig["RELEASE_FOOTPRINT"]
 
         if fields.key?("redis.command")
           fields["redis.command"] = fields["redis.command"].slice(0, 300)

--- a/config/initializers/initialization_cachebust.rb
+++ b/config/initializers/initialization_cachebust.rb
@@ -4,9 +4,5 @@ CacheBuster.bust("/shell_bottom")
 CacheBuster.bust("/async_info/shell_version")
 CacheBuster.bust("/onboarding")
 
-# Date/time string ending in minute.
-# Used as part of cache key. Minute precision is fine.
-# This replaces HEROKU_SLUG_COMMIT everywhere where we don't need exact release-based-precision
-# But if anyone has a better way to automate this incrementation in the simplest way that would be consistent
-# across all processes 100% of the time, feel free to replace this value :)
-ENV["RELEASE_FOOTPRINT"] = Time.current.strftime("%y%m%d%H%M")
+# We will set RELEASE_FOOTPRINT in our Forem Cloud environment, or use HEROKU_SLUG_COMMIT if set (e.g. Heroku env)
+ENV["RELEASE_FOOTPRINT"] ||= ENV["HEROKU_SLUG_COMMIT"]

--- a/config/initializers/initialization_cachebust.rb
+++ b/config/initializers/initialization_cachebust.rb
@@ -3,3 +3,10 @@ CacheBuster.bust("/shell_top")
 CacheBuster.bust("/shell_bottom")
 CacheBuster.bust("/async_info/shell_version")
 CacheBuster.bust("/onboarding")
+
+# Date/time string ending in minute.
+# Used as part of cache key. Minute precision is fine.
+# This replaces HEROKU_SLUG_COMMIT everywhere where we don't need exact release-based-precision
+# But if anyone has a better way to automate this incrementation in the simplest way that would be consistent
+# across all processes 100% of the time, feel free to replace this value :)
+ENV["RELEASE_FOOTPRINT"] = Time.current.strftime("%y%m%d%H%M")

--- a/config/sample_application.yml
+++ b/config/sample_application.yml
@@ -12,9 +12,6 @@ DEFAULT_EMAIL: "yo@dev.to"
 RACK_TIMEOUT_WAIT_TIMEOUT: 100_000
 RACK_TIMEOUT_SERVICE_TIMEOUT: 100_000
 
-# Heroku release slug used to bust caches on deploys
-HEROKU_SLUG_COMMIT: "Optional"
-
 # Redis caching storage
 REDIS_URL: "redis://localhost:6379"
 

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -61,7 +61,7 @@ if (process.env.HONEYBADGER_API_KEY && process.env.ASSETS_URL) {
       assetsUrl: process.env.ASSETS_URL,
       silent: false,
       ignoreErrors: false,
-      revision: process.env.HEROKU_SLUG_COMMIT || 'master',
+      revision: process.env.RELEASE_FOOTPRINT || process.env.HEROKU_SLUG_COMMIT || 'master',
     }),
   );
 }

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#cache_key_heroku_slug" do
-    it "does nothing when HEROKU_SLUG_COMMIT is not set" do
-      allow(ApplicationConfig).to receive(:[]).with("HEROKU_SLUG_COMMIT").and_return(nil)
+  describe "#release_adjusted_cache_key" do
+    it "does nothing when RELEASE_FOOTPRINT is not set" do
+      allow(ApplicationConfig).to receive(:[]).with("RELEASE_FOOTPRINT").and_return(nil)
       expect(helper.cache_key_heroku_slug("cache-me")).to eq("cache-me")
     end
 
-    it "appends the HEROKU_SLUG_COMMIT if it is set" do
-      allow(ApplicationConfig).to receive(:[]).with("HEROKU_SLUG_COMMIT").and_return("abc123")
+    it "appends the RELEASE_FOOTPRINT if it is set" do
+      allow(ApplicationConfig).to receive(:[]).with("RELEASE_FOOTPRINT").and_return("abc123")
       expect(helper.cache_key_heroku_slug("cache-me")).to eq("cache-me-abc123")
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -38,12 +38,12 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "#release_adjusted_cache_key" do
     it "does nothing when RELEASE_FOOTPRINT is not set" do
       allow(ApplicationConfig).to receive(:[]).with("RELEASE_FOOTPRINT").and_return(nil)
-      expect(helper.cache_key_heroku_slug("cache-me")).to eq("cache-me")
+      expect(helper.release_adjusted_cache_key("cache-me")).to eq("cache-me")
     end
 
     it "appends the RELEASE_FOOTPRINT if it is set" do
       allow(ApplicationConfig).to receive(:[]).with("RELEASE_FOOTPRINT").and_return("abc123")
-      expect(helper.cache_key_heroku_slug("cache-me")).to eq("cache-me-abc123")
+      expect(helper.release_adjusted_cache_key("cache-me")).to eq("cache-me-abc123")
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We use `HEROKU_SLUG_COMMIT` to know when one release is later than another to bust caches and other duties.

This is a Heroku dependency we need to get rid of. This PR introduces a minute-precision timestamp which will be good enough right this moment, but it could be different on a process-by-process basis. For basic cache-busting and the such that is fine, but ideally we can computer a value here which will be more consistent.

If anybody has an idea for the most straightforward way to do that, feel free to drop an idea. Otherwise, I'd say we ship this as "good enough for right now".