### PR TITLE
Bug Fix: Dont Fail Jobs If Badge Does Not Exist

### DIFF
--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -14,7 +14,9 @@ module BadgeRewarder
     (1..total_years).each do |i|
       message = "Happy #{SiteConfig.community_name} birthday! " \
         "Can you believe it's been #{i} #{'year'.pluralize(i)} already?!"
-      badge = Badge.find_by!(slug: "#{YEARS[i]}-year-club")
+      badge = Badge.find_by(slug: "#{YEARS[i]}-year-club")
+      next unless badge
+
       User.registered.where("created_at < ? AND created_at > ?", i.year.ago, i.year.ago - 2.days).find_each do |user|
         achievement = BadgeAchievement.create(
           user_id: user.id,
@@ -27,7 +29,9 @@ module BadgeRewarder
   end
 
   def self.award_beloved_comment_badges(comment_count = 24)
-    badge_id = Badge.find_by!(slug: "beloved-comment").id
+    badge_id = Badge.find_by(slug: "beloved-comment")&.id
+    return unless badge_id
+
     Comment.includes(:user).where("public_reactions_count > ?", comment_count).find_each do |comment|
       message = "You're famous! [This is the comment](#{URL.comment(comment)}) for which you are being recognized. 😄"
       achievement = BadgeAchievement.create(
@@ -74,7 +78,8 @@ module BadgeRewarder
   end
 
   def self.award_contributor_badges_from_github(since = 1.day.ago, msg = "Thank you so much for your contributions!")
-    badge = Badge.find_by!(slug: "dev-contributor")
+    badge = Badge.find_by(slug: "dev-contributor")
+    return unless badge
 
     REPOSITORIES.each do |repo|
       commits = Github::Client.commits(repo, since: since.utc.iso8601)
@@ -126,7 +131,9 @@ module BadgeRewarder
   end
 
   def self.award_badges(usernames, slug, message_markdown)
-    badge_id = Badge.find_by!(slug: slug).id
+    badge_id = Badge.find_by(slug: slug)&.id
+    return unless badge_id
+
     User.registered.where(username: usernames).find_each do |user|
       BadgeAchievement.create(
         user_id: user.id,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In new Forem's there will likely be a time before badges are properly set up. During this window we don't want to be stacking up a bunch of job failures. We also don't want every Forem to feel the need that they are required to have all of these preset badges. This allows us to gracefully exit a badge task if the badge is not present. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44035785

## QA Instructions, Screenshots, Recordings
Badge jobs should no longer return an error if you pull this branch down, restart your server and enqueue some of the corn jobs by hand

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.tenor.com/images/ed3f5df28fed8dd7593de6fbd351a534/tenor.gif)
