### PR TITLE
Mark Buffer as legacy

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -59,6 +59,8 @@ export AWS_S3_VIDEO_ID="Optional"
 export AWS_S3_VIDEO_KEY="Optional"
 
 # Buffer for sending to buffer
+# This is legacy, as Buffer no longer supports this functionality for NEW accounts.
+# DEV is still using this for now.
 # (https://buffer.com/developers/api)
 export BUFFER_ACCESS_TOKEN="Optional"
 export BUFFER_FACEBOOK_ID="Optional"

--- a/app/views/admin/articles/index.html.erb
+++ b/app/views/admin/articles/index.html.erb
@@ -1,4 +1,10 @@
-<% if @user_buffer_updates.any? %>
+<% if ENV["BUFFER_ACCESS_TOKEN"] %>
+  <div class="alert alert-warning" role="alert">
+    <p><strong>All references to "Buffering" are legacy and social media functionality is not currently operational.</strong></p>
+    <p>Buffer, the social media scheduling tool, has discontinued its API, so send-to-buffer functionality only works for legacy clients.</p>
+    <p>We will replace this functionality in the future with a functional alternative.</p>
+  </div>
+<% elsif @user_buffer_updates.any? %>
   <div class="alert alert-primary">
     You have sent <strong><%= @user_buffer_updates.size %></strong> buffers so far in the past 24 hours. Keep it up!
   </div>

--- a/app/views/admin/articles/index.html.erb
+++ b/app/views/admin/articles/index.html.erb
@@ -1,4 +1,4 @@
-<% if ENV["BUFFER_ACCESS_TOKEN"] %>
+<% if ENV["BUFFER_ACCESS_TOKEN"].blank? %>
   <div class="alert alert-warning" role="alert">
     <p><strong>All references to "Buffering" are legacy and social media functionality is not currently operational.</strong></p>
     <p>Buffer, the social media scheduling tool, has discontinued its API, so send-to-buffer functionality only works for legacy clients.</p>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

DEV sends tweets to Buffer to offload the scheduling functionality to a third party. However, [this functionality has been discontinued by Buffer](https://buffer.com/developers/api) for new developers. DEV's functionality still works, but it will not work for the broader Forem ecosystem.

I think the best scenario is we build in this basic functionality ourselves.

Instead of _sending to Buffer_, we could mark a social media share with a timestamp and then build our own cron job to have it sent at the right time. We might not match Buffer feature-for-feature, but that would make everything much more usable as FOSS and as something without external dependencies like that.

For now, I'm marking this as legacy.