### PR TITLE
Stop using ProfileField#active Part 1

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,9 +3,9 @@ class Profile < ApplicationRecord
 
   validates :user_id, uniqueness: true
 
-  # This method generates typed accessors for all active profile fields
+  # This method generates typed accessors for all profile fields
   def self.refresh_store_accessors!
-    ProfileField.active.find_each do |field|
+    ProfileField.find_each do |field|
       store_attribute :data, field.attribute_name, field.type
     end
   end

--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -1,4 +1,6 @@
 class ProfileField < ApplicationRecord
+  self.ignored_columns = ["active"]
+
   before_create :generate_attribute_name
 
   WORD_REGEX = /\w+/.freeze
@@ -17,11 +19,8 @@ class ProfileField < ApplicationRecord
   }
 
   validates :label, presence: true, uniqueness: { case_sensitive: false }
-  validates :active, inclusion: { in: [true, false] }
   validates :attribute_name, presence: true, on: :update
   validates :show_in_onboarding, inclusion: { in: [true, false] }
-
-  scope :active, -> { where(active: true) }
 
   def type
     return :boolean if check_box?

--- a/app/views/admin/profile_fields/_form.html.erb
+++ b/app/views/admin/profile_fields/_form.html.erb
@@ -18,7 +18,3 @@
   <%= form.label :input_type %>
   <%= form.select :input_type, ProfileField.input_types.keys, class: "form-control" %>
 </div>
-<div class="form-group">
-  <%= form.label :active %>
-  <%= form.check_box :active %>
-</div>

--- a/spec/factories/profile_fields.rb
+++ b/spec/factories/profile_fields.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     input_type { :text_field }
     description { "some description" }
     placeholder_text { "john.doe@example.com" }
-    active { true }
     group { "Basic" }
 
     trait :onboarding do

--- a/spec/models/profile_field_spec.rb
+++ b/spec/models/profile_field_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ProfileField, type: :model do
 
       it { is_expected.to validate_presence_of(:label) }
       it { is_expected.to validate_uniqueness_of(:label).case_insensitive }
-      it { is_expected.to validate_inclusion_of(:active).in_array([true, false]) }
       it { is_expected.to validate_presence_of(:attribute_name).on(:update) }
       it { is_expected.to validate_inclusion_of(:show_in_onboarding).in_array([true, false]) }
     end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Profile, type: :model do
     before do
       create(:profile_field, label: "Test 1")
       create(:profile_field, label: "Test 2", input_type: :check_box)
-      create(:profile_field, label: "Test 3", active: false)
       described_class.refresh_store_accessors!
     end
 
@@ -20,7 +19,6 @@ RSpec.describe Profile, type: :model do
     it "defines accessors for active profile fields", :aggregate_failures do
       expect(profile).to respond_to(:test1)
       expect(profile).to respond_to(:test2)
-      expect(profile).not_to respond_to(:test3)
     end
 
     it "performs ActiveRecord typecasting for profile fields", :aggregate_failures do

--- a/spec/requests/admin/profile_fields_spec.rb
+++ b/spec/requests/admin/profile_fields_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe "/admin/profile_fields", type: :request do
         input_type: "text_field",
         description: "users' location",
         placeholder_text: "new york",
-        active: false,
         group: "Location"
       }
     end
@@ -53,7 +52,6 @@ RSpec.describe "/admin/profile_fields", type: :request do
       expect(last_profile_field_record.input_type).to eq(new_profile_field[:input_type])
       expect(last_profile_field_record.description).to eq(new_profile_field[:description])
       expect(last_profile_field_record.placeholder_text).to eq(new_profile_field[:placeholder_text])
-      expect(last_profile_field_record.active).to eq(new_profile_field[:active])
       expect(last_profile_field_record.group).to eq(new_profile_field[:group])
     end
   end
@@ -63,16 +61,16 @@ RSpec.describe "/admin/profile_fields", type: :request do
 
     it "redirects successfully" do
       put "#{admin_profile_fields_path}/#{profile_field.id}",
-          params: { profile_field: { active: false } }
+          params: { profile_field: { show_in_onboarding: false } }
       expect(response).to redirect_to admin_profile_fields_path
     end
 
     it "updates the profile field values" do
       put "#{admin_profile_fields_path}/#{profile_field.id}",
-          params: { profile_field: { active: false } }
+          params: { profile_field: { show_in_onboarding: false } }
 
       changed_profile_record = ProfileField.find(profile_field.id)
-      expect(changed_profile_record.active).to be(false)
+      expect(changed_profile_record.show_in_onboarding).to be(false)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When creating the new `ProfileField` model I originally added a column called `active`. My rationale was as follows: While admins experiment with setting up their Forem instance the may try out different fields and see how the profile page looks. Deleting and recreating is tiring, so I wanted to give them an option to disable it. However, after discussing this with @Ridhwana we decided that the potential confusion is not worth it and this is a case where less flexibility makes for a better product experience. 

There will be a follow-up PR to remove the column itself.

## Related Tickets & Documents

Part of #6994

## QA Instructions, Screenshots, Recordings

Nothing, if the specs are green, we should be good to go.

## Added tests?

- [x] yes (updated, not added)
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
