### PR TITLE
Stop using ProfileField#active Part 2

### DIFF
--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -1,6 +1,4 @@
 class ProfileField < ApplicationRecord
-  self.ignored_columns = ["active"]
-
   before_create :generate_attribute_name
 
   WORD_REGEX = /\w+/.freeze

--- a/db/migrate/20200821035520_remove_active_from_profile_field.rb
+++ b/db/migrate/20200821035520_remove_active_from_profile_field.rb
@@ -1,0 +1,7 @@
+class RemoveActiveFromProfileField < ActiveRecord::Migration[6.0]
+  def change
+    def change
+      safety_assured { remove_column :profile_fields, :active }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_20_093752) do
+ActiveRecord::Schema.define(version: 2020_08_21_035520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -933,7 +933,6 @@ ActiveRecord::Schema.define(version: 2020_08_20_093752) do
   end
 
   create_table "profile_fields", force: :cascade do |t|
-    t.boolean "active", default: true, null: false
     t.string "attribute_name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.string "description"


### PR DESCRIPTION
__This needs #9910 to be merged first!__

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

See #9910 for details. tl;dr: we decided against using an `active` attribute on profile fields, so we are removing. Following the practices recommended by the [`strong_migrations` gem](https://github.com/ankane/strong_migrations) we do this in 2 steps. 

**Note:** The diff here will get smaller once the other PR has been merged and we update this PR accordingly. I just wanted to prepare everything in one go.

## Related Tickets & Documents

Part of 6994.

## QA Instructions, Screenshots, Recordings

Specs green? Good to go.

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
