### PR TITLE
Refactor:Move prune_old_field_tests Rake to Sidekiq Cron

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,6 +1,9 @@
 log_worker_queue_stats:
   cron: "*/10 * * * *" # every 10 minutes
   class: "Metrics::RecordBackgroundQueueStatsWorker"
+prune_old_field_tests:
+  cron: "0 13 * * *" # daily at 1 pm UTC
+  class: "FieldTests::PruneOldExperimentsWorker"
 record_daily_usage:
   cron: "0 11 * * *" # daily at 11:00 UTC
   class: "Metrics::RecordDailyUsageWorker"

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -26,13 +26,6 @@ task send_email_digest: :environment do
   end
 end
 
-# This task is meant to be scheduled daily
-task prune_old_field_tests: :environment do
-  # For rolling ongoing experiemnts, we remove old experiment memberships
-  # So that they can be re-tested.
-  FieldTests::PruneOldExperimentsWorker.perform_async
-end
-
 task remove_old_html_variant_data: :environment do
   HtmlVariantTrial.destroy_by("created_at < ?", 2.weeks.ago)
   HtmlVariantSuccess.destroy_by("created_at < ?", 2.weeks.ago)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This was a quickie, moved the `prune_old_field_tests` rake task to Sidekiq. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43687049

![alt_text](https://media1.tenor.com/images/fe6b0f0ea7e98fe09ce4854486e08ed1/tenor.gif?itemid=4477492)
