### PR TITLE
Refactor:Move Cache Busting Rake Tasks to Sidekiq

### DIFF
--- a/app/workers/bust_cache_path_worker.rb
+++ b/app/workers/bust_cache_path_worker.rb
@@ -1,0 +1,5 @@
+class BustCachePathWorker < BustCacheBaseWorker
+  def perform(path)
+    CacheBuster.bust(path)
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -71,3 +71,18 @@ expire_old_listings:
 send_welcome_notifications:
   cron: "0 16 * * *" # daily at 4 pm UTC
   class: "Broadcasts::SendWelcomeNotificationsWorker"
+hourly_feed_cache_bust:
+  cron: "0 * * * *" # hourly on the hour
+  class: "BustCachePathWorker"
+  args:
+    - "/feed.xml"
+hourly_badge_cache_bust:
+  cron: "0 * * * *" # hourly on the hour
+  class: "BustCachePathWorker"
+  args:
+    - "/badge"
+daily_home_cache_bust:
+  cron: "0 0 * * *" # daily at 12 am UTC
+  class: "BustCachePathWorker"
+  args:
+    - "/"

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,9 +1,0 @@
-task periodic_cache_bust: :environment do
-  CacheBuster.bust("/feed.xml")
-  CacheBuster.bust("/badge")
-  CacheBuster.bust("/shecoded")
-end
-
-task hourly_bust: :environment do
-  CacheBuster.bust("/")
-end

--- a/spec/workers/bust_cache_path_worker_spec.rb
+++ b/spec/workers/bust_cache_path_worker_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe BustCachePathWorker, type: :worker do
+  let(:worker) { subject }
+
+  include_examples "#enqueues_on_correct_queue", "high_priority"
+
+  describe "#perform" do
+    it "busts cache for given path" do
+      allow(CacheBuster).to receive(:bust)
+      worker.perform("/foo")
+      expect(CacheBuster).to have_received(:bust).with("/foo")
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Move all cache-busting rake tasks to sidekiq. The only cache-busting I did not move was the `/shecoded` path. I think that is very specific to DEV and if that is something we need done in the future we should probably come up with a better way to handle that. 

Update names to match actual run times since before they were flip flopped. 
<img width="621" alt="Screen Shot 2020-08-22 at 9 03 08 AM" src="https://user-images.githubusercontent.com/1813380/90957951-79341c00-e456-11ea-8b25-29fc26e445ca.png">


## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43687049

## Added tests?
- [x] yes

![alt_text](https://media.tenor.com/images/105c6675631f557990043194f69661a2/tenor.gif)
