### PR TITLE
Add dependent clauses to relations for Organization and add cleanup scripts

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,7 +25,6 @@ Rails/HasManyOrHasOneDependent:
   Exclude:
     - 'app/models/article.rb'
     - 'app/models/concerns/user_subscription_sourceable.rb'
-    - 'app/models/organization.rb'
     - 'app/models/user.rb'
 
 # Offense count: 4

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -16,7 +16,7 @@ class Organization < ApplicationRecord
   has_many :collections, dependent: :nullify
   has_many :credits, dependent: :restrict_with_error
   has_many :display_ads, dependent: :destroy
-  has_many :listings, dependent: :nullify
+  has_many :listings, dependent: :destroy
   has_many :notifications, dependent: :destroy
   has_many :organization_memberships, dependent: :delete_all
   has_many :profile_pins, as: :profile, inverse_of: :profile, dependent: :destroy

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -17,7 +17,7 @@ class Organization < ApplicationRecord
   has_many :credits, dependent: :restrict_with_error
   has_many :display_ads, dependent: :destroy
   has_many :listings, dependent: :nullify
-  has_many :notifications, dependent: :nullify
+  has_many :notifications, dependent: :destroy
   has_many :organization_memberships, dependent: :delete_all
   has_many :profile_pins, as: :profile, inverse_of: :profile, dependent: :destroy
   has_many :sponsorships, dependent: :destroy

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,15 +12,15 @@ class Organization < ApplicationRecord
   acts_as_followable
 
   has_many :api_secrets, through: :users
-  has_many :articles
-  has_many :listings
-  has_many :collections
+  has_many :articles, dependent: :nullify
+  has_many :collections, dependent: :nullify
   has_many :credits, dependent: :restrict_with_error
-  has_many :display_ads
-  has_many :notifications
+  has_many :display_ads, dependent: :destroy
+  has_many :listings, dependent: :nullify
+  has_many :notifications, dependent: :nullify
   has_many :organization_memberships, dependent: :delete_all
-  has_many :profile_pins, as: :profile, inverse_of: :profile
-  has_many :sponsorships
+  has_many :profile_pins, as: :profile, inverse_of: :profile, dependent: :destroy
+  has_many :sponsorships, dependent: :destroy
   has_many :unspent_credits, -> { where spent: false }, class_name: "Credit", inverse_of: :organization
   has_many :users, through: :organization_memberships
 

--- a/lib/data_update_scripts/20200821103125_nullify_orphaned_articles_by_organization.rb
+++ b/lib/data_update_scripts/20200821103125_nullify_orphaned_articles_by_organization.rb
@@ -1,0 +1,15 @@
+module DataUpdateScripts
+  class NullifyOrphanedArticlesByOrganization
+    def run
+      # Nullify organization_id for all Articles linked to a non existing Organization
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          UPDATE articles
+          SET organization_id = NULL
+          WHERE organization_id IS NOT NULL
+          AND organization_id NOT IN (SELECT id FROM organizations);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200821103305_nullify_orphaned_collections_by_organization.rb
+++ b/lib/data_update_scripts/20200821103305_nullify_orphaned_collections_by_organization.rb
@@ -1,0 +1,15 @@
+module DataUpdateScripts
+  class NullifyOrphanedCollectionsByOrganization
+    def run
+      # Nullify organization_id for all Collections linked to a non existing Organization
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          UPDATE collections
+          SET organization_id = NULL
+          WHERE organization_id IS NOT NULL
+          AND organization_id NOT IN (SELECT id FROM organizations);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200821103405_remove_orphaned_credits_by_organization.rb
+++ b/lib/data_update_scripts/20200821103405_remove_orphaned_credits_by_organization.rb
@@ -1,0 +1,14 @@
+module DataUpdateScripts
+  class NullifyOrphanedCollectionsByOrganization
+    def run
+      # Delete all User less Credits belonging to Organizations that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM credits
+          WHERE user_id IS NULL
+          AND organization_id NOT IN (SELECT id FROM organizations);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200821103405_remove_orphaned_credits_by_organization.rb
+++ b/lib/data_update_scripts/20200821103405_remove_orphaned_credits_by_organization.rb
@@ -1,6 +1,15 @@
 module DataUpdateScripts
-  class NullifyOrphanedCollectionsByOrganization
+  class RemoveOrphanedCreditsByOrganization
     def run
+      # Apparently we have a bunch of Credits that don't belong to either user or org
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM credits
+          WHERE user_id IS NULL
+          AND organization_id IS NULL
+        SQL
+      )
+
       # Delete all User less Credits belonging to Organizations that don't exist anymore
       ActiveRecord::Base.connection.execute(
         <<~SQL,

--- a/lib/data_update_scripts/20200821103718_remove_orphaned_display_ads_by_organization.rb
+++ b/lib/data_update_scripts/20200821103718_remove_orphaned_display_ads_by_organization.rb
@@ -1,0 +1,13 @@
+module DataUpdateScripts
+  class RemoveOrphanedDisplayAdsByOrganization
+    def run
+      # Delete all DisplayAds belonging to Organizations that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM display_ads
+          WHERE organization_id NOT IN (SELECT id FROM organizations);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200821103834_nullify_orphaned_listings_by_organization.rb
+++ b/lib/data_update_scripts/20200821103834_nullify_orphaned_listings_by_organization.rb
@@ -1,0 +1,15 @@
+module DataUpdateScripts
+  class NullifyOrphanedListingsByOrganization
+    def run
+      # Nullify organization_id for all Listings linked to a non existing Organization
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          UPDATE listings
+          SET organization_id = NULL
+          WHERE organization_id IS NOT NULL
+          AND organization_id NOT IN (SELECT id FROM organizations);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200821103834_remove_orphaned_listings_by_organization.rb
+++ b/lib/data_update_scripts/20200821103834_remove_orphaned_listings_by_organization.rb
@@ -1,11 +1,10 @@
 module DataUpdateScripts
-  class NullifyOrphanedListingsByOrganization
+  class RemoveOrphanedListingsByOrganization
     def run
-      # Nullify organization_id for all Listings linked to a non existing Organization
+      # Delete all Listings belonging to Organizations that don't exist anymore
       ActiveRecord::Base.connection.execute(
         <<~SQL,
-          UPDATE listings
-          SET organization_id = NULL
+          DELETE FROM classified_listings
           WHERE organization_id IS NOT NULL
           AND organization_id NOT IN (SELECT id FROM organizations);
         SQL

--- a/lib/data_update_scripts/20200822082229_remove_orphaned_notifications_by_organization.rb
+++ b/lib/data_update_scripts/20200822082229_remove_orphaned_notifications_by_organization.rb
@@ -5,7 +5,7 @@ module DataUpdateScripts
       ActiveRecord::Base.connection.execute(
         <<~SQL,
           DELETE FROM notifications
-          WHERE organization_id NOT IN (SELECT id FROM organization_id);
+          WHERE organization_id NOT IN (SELECT id FROM organizations);
         SQL
       )
     end

--- a/lib/data_update_scripts/20200822082229_remove_orphaned_notifications_by_organization.rb
+++ b/lib/data_update_scripts/20200822082229_remove_orphaned_notifications_by_organization.rb
@@ -1,0 +1,13 @@
+module DataUpdateScripts
+  class RemoveOrphanedNotificationsByOrganization
+    def run
+      # Delete all Notifications belonging to Organizations that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM notifications
+          WHERE organization_id NOT IN (SELECT id FROM organization_id);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200822083050_remove_orphaned_sponsorships_by_organization.rb
+++ b/lib/data_update_scripts/20200822083050_remove_orphaned_sponsorships_by_organization.rb
@@ -1,0 +1,13 @@
+module DataUpdateScripts
+  class RemoveOrphanedSponsorshipsByOrganization
+    def run
+      # Delete all Sponsorships belonging to Organizations that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM sponsorships
+          WHERE organization_id NOT IN (SELECT id FROM organizations);
+        SQL
+      )
+    end
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Organization, type: :model do
       it { is_expected.to have_many(:credits).dependent(:restrict_with_error) }
       it { is_expected.to have_many(:display_ads).dependent(:destroy) }
       it { is_expected.to have_many(:listings).dependent(:nullify) }
-      it { is_expected.to have_many(:notifications).dependent(:nullify) }
+      it { is_expected.to have_many(:notifications).dependent(:destroy) }
       it { is_expected.to have_many(:organization_memberships).dependent(:delete_all) }
       it { is_expected.to have_many(:profile_pins).dependent(:destroy) }
       it { is_expected.to have_many(:sponsorships).dependent(:destroy) }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe Organization, type: :model do
       subject { organization }
 
       it { is_expected.to have_many(:api_secrets).through(:users) }
-      it { is_expected.to have_many(:articles) }
-      it { is_expected.to have_many(:listings) }
-      it { is_expected.to have_many(:collections) }
-      it { is_expected.to have_many(:credits) }
-      it { is_expected.to have_many(:display_ads) }
-      it { is_expected.to have_many(:notifications) }
+      it { is_expected.to have_many(:articles).dependent(:nullify) }
+      it { is_expected.to have_many(:collections).dependent(:nullify) }
+      it { is_expected.to have_many(:credits).dependent(:restrict_with_error) }
+      it { is_expected.to have_many(:display_ads).dependent(:destroy) }
+      it { is_expected.to have_many(:listings).dependent(:nullify) }
+      it { is_expected.to have_many(:notifications).dependent(:nullify) }
       it { is_expected.to have_many(:organization_memberships).dependent(:delete_all) }
-      it { is_expected.to have_many(:profile_pins) }
-      it { is_expected.to have_many(:sponsorships) }
+      it { is_expected.to have_many(:profile_pins).dependent(:destroy) }
+      it { is_expected.to have_many(:sponsorships).dependent(:destroy) }
       it { is_expected.to have_many(:unspent_credits).class_name("Credit") }
       it { is_expected.to have_many(:users).through(:organization_memberships) }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Organization, type: :model do
       it { is_expected.to have_many(:collections).dependent(:nullify) }
       it { is_expected.to have_many(:credits).dependent(:restrict_with_error) }
       it { is_expected.to have_many(:display_ads).dependent(:destroy) }
-      it { is_expected.to have_many(:listings).dependent(:nullify) }
+      it { is_expected.to have_many(:listings).dependent(:destroy) }
       it { is_expected.to have_many(:notifications).dependent(:destroy) }
       it { is_expected.to have_many(:organization_memberships).dependent(:delete_all) }
       it { is_expected.to have_many(:profile_pins).dependent(:destroy) }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR adds many missing `dependent` clauses to `has_many` relations of the `Organization` model.
It also adds 7 cleanup scripts to either delete orphaned data or nullify the `*_id` column if the organization doesn't exist. The script reflect the type of relation between the two entities.

Please double check each script while reviewing.

We do have orphaned rows in our DB (and likely in other Forems DB's), see https://dev.to/admin/blazer/queries/197-organization-counts

The following PR will add foreign keys where necessary.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
