### PR TITLE
Refactor:Move remove_old_notifications Rake Task to Sidekiq

### DIFF
--- a/app/workers/notifications/remove_old_notifications_worker.rb
+++ b/app/workers/notifications/remove_old_notifications_worker.rb
@@ -1,0 +1,11 @@
+module Notifications
+  class RemoveOldNotificationsWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform
+      Notification.fast_destroy_old_notifications
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -74,3 +74,6 @@ send_welcome_notifications:
 send_email_digest:
   cron: "30 11 * * 3,4,5,6" # 11:30 am UTC Wed, Thurs, Fri, Sat, Sun
   class: "SendEmailDigestWorker"
+remove_old_notifications:
+  cron: "0 5 * * *" # 1daily at 5 am UTC
+  class: "Notifications::RemoveOldNotificationsWorker"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -75,5 +75,5 @@ send_email_digest:
   cron: "30 11 * * 3,4,5,6" # 11:30 am UTC Wed, Thurs, Fri, Sat, Sun
   class: "SendEmailDigestWorker"
 remove_old_notifications:
-  cron: "0 5 * * *" # 1daily at 5 am UTC
+  cron: "0 5 * * *" # daily at 5 am UTC
   class: "Notifications::RemoveOldNotificationsWorker"

--- a/lib/tasks/notifications.rake
+++ b/lib/tasks/notifications.rake
@@ -1,3 +1,0 @@
-task remove_old_notifications: :environment do
-  Notification.fast_destroy_old_notifications
-end

--- a/spec/workers/notifications/remove_old_notifications_worker_spec.rb
+++ b/spec/workers/notifications/remove_old_notifications_worker_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Notifications::RemoveOldNotificationsWorker, type: :woker do
+  include_examples "#enqueues_on_correct_queue", "low_priority"
+
+  describe "#perform" do
+    let(:worker) { subject }
+
+    it "fast destroys notifications" do
+      allow(Notification).to receive(:fast_destroy_old_notifications)
+      worker.perform
+      expect(Notification).to have_received(:fast_destroy_old_notifications)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Move remove_old_notifications rake task to Sidekiq.

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43687049

## Added tests?
- [x] yes


![alt_text](https://media2.giphy.com/media/PiWeJEmqCX5SEGDTbH/200.gif)
