### PR TITLE
Add tech.lgbt to allowed Mastodon instances

### DIFF
--- a/app/lib/constants/mastodon.rb
+++ b/app/lib/constants/mastodon.rb
@@ -65,6 +65,7 @@ module Constants
       "social.targaryen.house",
       "social.tchncs.de",
       "switter.at",
+      "tech.lgbt",
       "todon.nl",
       "toot.cafe",
       "wikitetas.club",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Apparently we have a Mastodon URL in the DB that bypassed validation (or was added before validation was instituted). As it's a legit Mastodon, it's just easier to add it to the list

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/9938

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
