### PR TITLE
Display all authentication providers in mailer footer

### DIFF
--- a/app/helpers/authentication_helper.rb
+++ b/app/helpers/authentication_helper.rb
@@ -15,13 +15,7 @@ module AuthenticationHelper
     end
   end
 
-  # Returns the list of enabled providers for the given user, defaults to `current_user`
-  def authentication_enabled_providers_for_user(user = nil)
-    user ||= current_user
-
-    providers = Authentication::Providers.enabled & user.identities.pluck(:provider).map(&:to_sym)
-    providers.sort.map do |provider_name|
-      Authentication::Providers.get!(provider_name)
-    end
+  def authentication_enabled_providers_for_user(user = current_user)
+    Authentication::Providers.enabled_for_user(user)
   end
 end

--- a/app/helpers/authentication_helper.rb
+++ b/app/helpers/authentication_helper.rb
@@ -15,8 +15,11 @@ module AuthenticationHelper
     end
   end
 
-  def current_user_authentication_enabled_providers
-    providers = Authentication::Providers.enabled & current_user.identities.pluck(:provider).map(&:to_sym)
+  # Returns the list of enabled providers for the given user, defaults to `current_user`
+  def authentication_enabled_providers_for_user(user = nil)
+    user ||= current_user
+
+    providers = Authentication::Providers.enabled & user.identities.pluck(:provider).map(&:to_sym)
     providers.sort.map do |provider_name|
       Authentication::Providers.get!(provider_name)
     end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,6 +5,7 @@ class ApplicationMailer < ActionMailer::Base
   # an example is the user_url
   helper Rails.application.routes.url_helpers
   helper ApplicationHelper
+  helper AuthenticationHelper
 
   default(
     from: -> { email_from("Community") },

--- a/app/services/authentication/providers.rb
+++ b/app/services/authentication/providers.rb
@@ -38,6 +38,15 @@ module Authentication
       SiteConfig.authentication_providers.map(&:to_sym).sort
     end
 
+    def self.enabled_for_user(user)
+      return [] unless user
+
+      providers = enabled & user.identities.pluck(:provider).map(&:to_sym)
+      providers.sort.map do |provider_name|
+        get!(provider_name)
+      end
+    end
+
     def self.enabled?(provider_name)
       enabled.include?(provider_name.to_sym)
     end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -9,11 +9,9 @@
   <% if @user %>
     <tr>
       <td style="padding:3% 12% 2% 4%;font-size:18px;line-height:22px;color:#7d7d7d">
-        <% if @user.twitter_username.blank? %>
-          Reminder: You used <b>GitHub</b> to authenticate your account, so use that to sign in if prompted.
-        <% else %>
-          Reminder: You used <b>Twitter</b> to authenticate your account, so use that to sign in if prompted.
-        <% end %>
+        <% providers = authentication_enabled_providers_for_user(@user).map(&:official_name) %>
+        Reminder: You used <b><%= providers.to_sentence %></b> to authenticate your account, so use <%= providers.size == 1 ? "that" : "any of those" %> to sign in if prompted.
+
         <br /><br />
         <div style="font-size:0.78em">
           <% if @unsubscribe %>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -66,7 +66,7 @@
       </p>
     </div>
 
-    <% current_user_authentication_enabled_providers.each do |provider| %>
+    <% authentication_enabled_providers_for_user.each do |provider| %>
       <% onsubmit = "return confirm('Are you absolutely sure you want to remove your #{provider.official_name} account?');" %>
       <%= form_tag users_remove_identity_path, method: :delete, onsubmit: onsubmit do %>
         <%= hidden_field_tag :provider, provider.provider_name %>

--- a/app/views/users/_account_providers_settings.html.erb
+++ b/app/views/users/_account_providers_settings.html.erb
@@ -1,5 +1,5 @@
 <ul>
-  <% current_user_authentication_enabled_providers.each do |provider| %>
+  <% authentication_enabled_providers_for_user.each do |provider| %>
     <li><a href="<%= provider.settings_url %>"><%= provider.official_name %> profile settings</a></li>
   <% end %>
 </ul>

--- a/spec/helpers/authentication_helper_spec.rb
+++ b/spec/helpers/authentication_helper_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe AuthenticationHelper, type: :helper do
+  let(:user) { create(:user, :with_identity) }
+
+  before do
+    omniauth_mock_providers_payload
+  end
+
+  describe "#authentication_enabled_providers_for_user" do
+    it "returns an enabled provider" do
+      provider = Authentication::Providers.available.first
+      allow(Authentication::Providers).to receive(:enabled).and_return([provider])
+      allow(user).to receive(:identities).and_return(user.identities.where(provider: provider))
+
+      expected_result = Authentication::Providers.get!(provider)
+      expect(helper.authentication_enabled_providers_for_user(user)).to match_array([expected_result])
+    end
+
+    it "does not return a disabled provider" do
+      disabled_provider = %i[github]
+      providers = Authentication::Providers.available - disabled_provider
+      allow(Authentication::Providers).to receive(:enabled).and_return(providers)
+      user = create(:user, :with_identity)
+
+      provider_names = helper.authentication_enabled_providers_for_user(user).map(&:provider_name)
+      expect(provider_names).not_to include(disabled_provider)
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently we display either Twitter or GitHub in the mailer footer to nudge a person to sign in with the correct provider. There are a few problems with that:

- a person can be signed in with more than one provider, so it's arbitrary to choose one or the other in the email
- soon we'll have more than one providers
- either or all of these two providers might be disabled in future Forems

This PR makes the footer a little bit more aware

It goes from:

>  Reminder: You used Twitter to authenticate your account, so use that to sign in if prompted. 

to

> Reminder: You used <b>GitHub and Twitter</b> to authenticate your account, so use any of those to sign in if prompted

if more than one is enabled.

## QA Instructions, Screenshots, Recordings

1. start the PR
1. sign in with any of the authentication methods
1. check the footer of the following email: http://localhost:3000/rails/mailers/digest_mailer/digest_email

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
