### PR TITLE
Mod Button placement fix on mobile

### DIFF
--- a/app/assets/stylesheets/moderators.scss
+++ b/app/assets/stylesheets/moderators.scss
@@ -163,13 +163,12 @@
 }
 
 .mod-actions-menu-btn {
-  transition: 0.3s all ease;
   position: fixed;
   bottom: var(--su-7);
+  margin-bottom: env(safe-area-inset-bottom);
   right: var(--su-7);
   z-index: 201;
   cursor: pointer;
-  transition: 0.3s all ease;
   border-radius: 50px;
 
   @media (max-width: $breakpoint-m) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

This PR fixes a position of mod actions button on article view on mobile - it will no longer cover the action bar at the bottom.

## QA Instructions, Screenshots, Recordings

![image](https://user-images.githubusercontent.com/108287/91049176-10e36700-e61d-11ea-9b99-d61b3a145ac2.png)

^ left: before. right: after.

## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed
