### PR TITLE
Explicitly load dotenv first in test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "dotenv/load"
 require "simplecov"
 require "zonebie/rspec"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
With the way RSpec/test load files, Simplecov doesn't detect any env var because ApplicationConfig isn't loaded immediately. We need to explicitly load it first in `spec_helper.rb` so the content within `.simplecov` can have access to env var.

I think Dotenv will end up loading env twice but I have not notice any side-effect and it doesn't seem to slow down anything.
## Related Tickets & Documents
n/a
## QA Instructions, Screenshots, Recordings
Add `export COVERAGE='false'` to your `.env` and run the test, you should be able to disable it properly and not see test coverage slow you down.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
