### PR TITLE
Refactor:Move Credit Counter Cache Sync to Sidekiq

### DIFF
--- a/app/workers/credits/sync_counter_cache.rb
+++ b/app/workers/credits/sync_counter_cache.rb
@@ -1,0 +1,11 @@
+module Credits
+  class SyncCounterCache
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform
+      Credit.counter_culture_fix_counts only: %i[user organization]
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -95,3 +95,6 @@ send_email_digest:
 remove_old_notifications:
   cron: "0 5 * * *" # daily at 5 am UTC
   class: "Notifications::RemoveOldNotificationsWorker"
+sync_credits_counter_cache:
+  cron: "0 16 * * *" # daily at 4 pm UTC
+  class: "Credits::SyncCounterCache"

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -15,7 +15,3 @@ end
 task github_repo_fetch_all: :environment do
   GithubRepo.update_to_latest
 end
-
-task fix_credits_count_cache: :environment do
-  Credit.counter_culture_fix_counts only: %i[user organization]
-end

--- a/spec/workers/credits/sync_counter_cache_spec.rb
+++ b/spec/workers/credits/sync_counter_cache_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Credits::SyncCounterCache, type: :woker do
+  include_examples "#enqueues_on_correct_queue", "low_priority"
+
+  describe "#perform" do
+    let(:worker) { subject }
+
+    it "syncs counter cache for credits" do
+      allow(Credit).to receive(:counter_culture_fix_counts)
+      worker.perform
+      expect(Credit).to have_received(:counter_culture_fix_counts).with(only: %i[user organization])
+    end
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
I was going to dive in and see if we even still need this but decided not to waste time on it [since even the gem docs suggest running a sync periodically](https://github.com/magnusvk/counter_culture#manually-populating-counter-cache-values). To me that seems like a major weakness in the gem but one we can live with for now. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43687049

## Added tests?
- [x] yes


![alt_text](https://media2.giphy.com/media/xUNd9DLukkavmhybAs/giphy.gif)
