### PR TITLE
Refactor:Move Sitemap Refresh Rake Task to Sidekiq

### DIFF
--- a/app/workers/sitemap_refresh_worker.rb
+++ b/app/workers/sitemap_refresh_worker.rb
@@ -1,0 +1,10 @@
+class SitemapRefreshWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :low_priority, retry: 10
+
+  def perform
+    Rails.application.load_tasks
+    Rake::Task["sitemap:refresh"].invoke
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -74,6 +74,9 @@ expire_old_listings:
 send_welcome_notifications:
   cron: "0 16 * * *" # daily at 4 pm UTC
   class: "Broadcasts::SendWelcomeNotificationsWorker"
+sitemap_refresh:
+  cron: "30 * * * *" # every hour, 30 min after the hour
+  class: "SitemapRefreshWorker"
 hourly_feed_cache_bust:
   cron: "0 * * * *" # hourly on the hour
   class: "BustCachePathWorker"

--- a/spec/workers/sitemap_refresh_worker_spec.rb
+++ b/spec/workers/sitemap_refresh_worker_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe SitemapRefreshWorker, type: :woker do
+  include_examples "#enqueues_on_correct_queue", "low_priority"
+
+  describe "#perform" do
+    let(:worker) { subject }
+
+    it "runs sitemap refresh rake task" do
+      allow(Rails.application).to receive(:load_tasks)
+      mock_task = instance_double(Rake::Task, invoke: true)
+      allow(Rake::Task).to receive(:[]).and_return(mock_task)
+      worker.perform
+      expect(Rake::Task).to have_received(:[]).with("sitemap:refresh")
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Move Sitemap rake task out of Heroku scheduler and into a cron Sidekiq Worker. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43687049

## Added tests?
- [x] yes



![alt_text](https://media2.giphy.com/media/QTlL3tV0XcLPsEQKso/giphy.gif?cid=ecf05e47kdi3dbi9wc1n6h2syhuf8hmqoxecui2oabc84azm&rid=giphy.gif)
