### PR TITLE
Update Sendgrid to Use API Key if Present

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,13 +115,14 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
+  sendgrid_api_key_present = ENV["SENDGRID_API_KEY"].present?
   config.action_mailer.default_url_options = { host: protocol + config.app_domain }
   ActionMailer::Base.smtp_settings = {
     address: "smtp.sendgrid.net",
     port: "587",
     authentication: :plain,
-    user_name: ENV["SENDGRID_USERNAME_ACCEL"],
-    password: ENV["SENDGRID_PASSWORD_ACCEL"],
+    user_name: sendgrid_api_key_present ? "apikey" : ENV["SENDGRID_USERNAME_ACCEL"],
+    password: sendgrid_api_key_present ? ENV["SENDGRID_API_KEY"] : ENV["SENDGRID_PASSWORD_ACCEL"],
     domain: ENV["APP_DOMAIN"],
     enable_starttls_auto: true
   }


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactopr

## Description
Per the [Sendgrid docs](https://sendgrid.com/docs/for-developers/sending-email/rubyonrails/#configure-actionmailer-to-use-sendgrid) this is how you would set up ActionMailer if you have an API key present. I kept the old way to ensure backwards compatibility for other communities 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44219616

![alt_text](https://media1.tenor.com/images/d6613cc321b3f8eabb0e0e5fd45fc41f/tenor.gif?itemid=6073092)
