### PR TITLE
Refactor:Change Unset Var Warnings to Debug Level

### DIFF
--- a/config/initializers/0_application_config.rb
+++ b/config/initializers/0_application_config.rb
@@ -5,7 +5,7 @@ class ApplicationConfig
     if ENV.key?(key)
       ENV[key]
     else
-      Rails.logger.warn("Unset ENV variable: #{key}.")
+      Rails.logger.debug("Unset ENV variable: #{key}.")
       nil
     end
   end

--- a/spec/initializers/application_config_spec.rb
+++ b/spec/initializers/application_config_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 describe ApplicationConfig do
   it "logs warning if key is not found" do
-    allow(Rails.logger).to receive(:warn)
+    allow(Rails.logger).to receive(:debug)
     described_class["missing"]
-    expect(Rails.logger).to have_received(:warn).with("Unset ENV variable: missing.")
+    expect(Rails.logger).to have_received(:debug).with("Unset ENV variable: missing.")
   end
 
   describe ".app_domain_no_port" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
These warnings are inundating some of our production environments for variables that we never plan to set. Change the debug level for these to debug so we can access them if we need to but they are not always logged in production. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44230888

## Added tests?
- [x] updated

My feelings toward @jdoss for this PR 👇 
![alt_text](https://thumbs.gfycat.com/CalmForkedFlicker-size_restricted.gif)
