### PR TITLE
Refactor:Fetch New Github Repos From Sidekiq Cron

### DIFF
--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -27,8 +27,8 @@ class GithubRepo < ApplicationRecord
   end
 
   def self.update_to_latest
-    where("updated_at < ?", 1.day.ago).find_each do |repo|
-      user = User.find_by(id: repo.user_id)
+    where("updated_at < ?", 26.hours.ago).includes(:user).find_each do |repo|
+      user = repo.user
       next unless user
 
       client = Github::OauthClient.for_user(user)

--- a/app/workers/github_repos/update_latest_worker.rb
+++ b/app/workers/github_repos/update_latest_worker.rb
@@ -1,0 +1,11 @@
+module GithubRepos
+  class UpdateLatestWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :medium_priority, retry: 10
+
+    def perform
+      GithubRepo.update_to_latest
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -104,3 +104,7 @@ sync_credits_counter_cache:
 get_podcast_episodes:
   cron: "5 * * * *" # every hour, 5 min after the hour
   class: "Podcasts::EnqueueGetEpisodesWorker"
+update_latest_github_repos:
+  cron: "30 16 * * *" # daily at 4:30 pm UTC
+  class: "GithubRepos::UpdateLatestWorker"
+

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -5,7 +5,3 @@ task fetch_all_rss: :environment do
 
   RssReader.get_all_articles(force: false) # don't force fetch. Fetch "random" subset instead of all of them.
 end
-
-task github_repo_fetch_all: :environment do
-  GithubRepo.update_to_latest
-end

--- a/spec/workers/github_repos/update_latest_worker_spec.rb
+++ b/spec/workers/github_repos/update_latest_worker_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe GithubRepos::UpdateLatestWorker, type: :worker do
+  let(:worker) { subject }
+
+  include_examples "#enqueues_on_correct_queue", "medium_priority"
+
+  describe "#perform" do
+    it "update latest GithubRepos" do
+      allow(GithubRepo).to receive(:update_to_latest)
+      worker.perform
+      expect(GithubRepo).to have_received(:update_to_latest)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
This moves the `github_repo_fetch_all` rake task to Sidekiq. I also took the opportunity to optimize the `update_to_latest` method for GithubRepo. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43687049

## Added tests?
- [x] yes


![alt_text](https://media1.giphy.com/media/3otPoUjeyRisIDxPhK/200_d.gif)
