### PR TITLE
Export RELEASE_FOOTPRINT on container start.

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -6,6 +6,8 @@ if [ -f tmp/pids/server.pid ]; then
   rm -f tmp/pids/server.pid
 fi
 
+export RELEASE_FOOTPRINT=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
 echo "Running rake app_initializer:setup..."
 bundle exec rake app_initializer:setup
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

RELEASE_FOOTPRINT will be set to the output of `date -u +'%Y-%m-%dT%H:%M:%SZ'` (2020-08-25T02:02:21Z for example) when the container starts. This will be reset to a new date and time string every time the container starts.

Fixes #9904 

## Related Tickets & Documents

https://github.com/forem/forem/pull/9904

## [optional] What gif best describes this PR or how it makes you feel?

![video game timeeeeeeeeeee](https://i.imgur.com/CSlTwOr.gif)
