### PR TITLE
Add dependent clauses to Article and fix Comment validation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,6 @@ Performance/OpenStruct:
 # Include: app/models/**/*.rb
 Rails/HasManyOrHasOneDependent:
   Exclude:
-    - 'app/models/concerns/user_subscription_sourceable.rb'
     - 'app/models/user.rb'
 
 # Offense count: 4

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,6 @@ Performance/OpenStruct:
 # Include: app/models/**/*.rb
 Rails/HasManyOrHasOneDependent:
   Exclude:
-    - 'app/models/article.rb'
     - 'app/models/concerns/user_subscription_sourceable.rb'
     - 'app/models/user.rb'
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -28,7 +28,16 @@ class Article < ApplicationRecord
   counter_culture :user
   counter_culture :organization
 
-  has_many :comments, as: :commentable, inverse_of: :commentable
+  has_many :buffer_updates, dependent: :destroy
+  has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :nullify
+  has_many :html_variant_successes, dependent: :nullify
+  has_many :html_variant_trials, dependent: :nullify
+  has_many :notification_subscriptions, as: :notifiable, inverse_of: :notifiable, dependent: :destroy
+  has_many :notifications, as: :notifiable, inverse_of: :notifiable, dependent: :delete_all
+  has_many :page_views, dependent: :destroy
+  has_many :polls, dependent: :destroy
+  has_many :profile_pins, as: :pinnable, inverse_of: :pinnable, dependent: :destroy
+  has_many :rating_votes, dependent: :destroy
   has_many :top_comments,
            lambda {
              where(
@@ -39,15 +48,6 @@ class Article < ApplicationRecord
            as: :commentable,
            inverse_of: :commentable,
            class_name: "Comment"
-  has_many :profile_pins, as: :pinnable, inverse_of: :pinnable
-  has_many :buffer_updates, dependent: :destroy
-  has_many :html_variant_successes, dependent: :nullify
-  has_many :html_variant_trials, dependent: :nullify
-  has_many :notifications, as: :notifiable, inverse_of: :notifiable, dependent: :delete_all
-  has_many :notification_subscriptions, as: :notifiable, inverse_of: :notifiable, dependent: :destroy
-  has_many :rating_votes
-  has_many :page_views
-  has_many :polls, dependent: :destroy
 
   validates :slug, presence: { if: :published? }, format: /\A[0-9a-z\-_]*\z/,
                    uniqueness: { scope: :user_id }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -14,9 +14,11 @@ class Comment < ApplicationRecord
   TITLE_HIDDEN = "[hidden by post author]".freeze
 
   belongs_to :commentable, polymorphic: true, optional: true
-  counter_culture :commentable
   belongs_to :user
+
+  counter_culture :commentable
   counter_culture :user
+
   has_many :mentions, as: :mentionable, inverse_of: :mentionable, dependent: :destroy
   has_many :notifications, as: :notifiable, inverse_of: :notifiable, dependent: :delete_all
   has_many :notification_subscriptions, as: :notifiable, inverse_of: :notifiable, dependent: :destroy
@@ -26,17 +28,19 @@ class Comment < ApplicationRecord
   before_create :adjust_comment_parent_based_on_depth
   after_create :after_create_checks
   after_create :notify_slack_channel_about_warned_users
-  after_update :update_descendant_notifications, if: :deleted
   after_update :remove_notifications, if: :deleted
+  after_update :update_descendant_notifications, if: :deleted
   before_destroy :before_destroy_actions
   after_destroy :after_destroy_actions
+
   after_save :synchronous_bust
   after_save :bust_cache
-  validate :permissions, if: :commentable
+
+  validate :published_article, if: :commentable
   validates :body_markdown, presence: true, length: { in: BODY_MARKDOWN_SIZE_RANGE }
   validates :body_markdown, uniqueness: { scope: %i[user_id ancestry commentable_id commentable_type] }
-  validates :commentable_id, presence: true
-  validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }
+  validates :commentable_id, presence: true, if: :commentable_type
+  validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }, if: :commentable_id
   validates :user_id, presence: true
 
   after_create_commit :record_field_test_event
@@ -255,7 +259,7 @@ class Comment < ApplicationRecord
     self.markdown_character_count = body_markdown.size
   end
 
-  def permissions
+  def published_article
     errors.add(:commentable_id, "is not valid.") if commentable_type == "Article" && !commentable.published
   end
 

--- a/app/services/articles/destroyer.rb
+++ b/app/services/articles/destroyer.rb
@@ -3,12 +3,19 @@ module Articles
     module_function
 
     def call(article, event_dispatcher = Webhook::DispatchEvent)
+      # comments will automatically lose the connection to their article once `.destroy` is called,
+      # due to the `dependent: nullify` clause, so to remove their notifications,
+      # we need to cache the ids in advance
+      article_comments_ids = article.comments.ids
+
       article.destroy!
+
       Notification.remove_all_without_delay(notifiable_ids: article.id, notifiable_type: "Article")
-      if article.comments.exists?
-        Notification.remove_all(notifiable_ids: article.comments.ids,
-                                notifiable_type: "Comment")
+
+      if article_comments_ids.present?
+        Notification.remove_all(notifiable_ids: article_comments_ids, notifiable_type: "Comment")
       end
+
       event_dispatcher.call("article_destroyed", article) if article.published?
     end
   end

--- a/lib/data_update_scripts/20200825095213_remove_orphaned_buffer_updates_by_article.rb
+++ b/lib/data_update_scripts/20200825095213_remove_orphaned_buffer_updates_by_article.rb
@@ -1,0 +1,13 @@
+module DataUpdateScripts
+  class RemoveOrphanedBufferUpdatesByArticle
+    def run
+      # Delete all BufferUpdates belonging to Articles that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM buffer_updates
+          WHERE article_id NOT IN (SELECT id FROM articles);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200825095512_nullify_orphaned_comments_by_article.rb
+++ b/lib/data_update_scripts/20200825095512_nullify_orphaned_comments_by_article.rb
@@ -1,0 +1,15 @@
+module DataUpdateScripts
+  class NullifyOrphanedCommentsByArticle
+    def run
+      # Nullify article_id for all Comments linked to a non existing Article
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          UPDATE comments
+          SET commentable_id = NULL, commentable_type = NULL
+          WHERE commentable_type = 'Article'
+          AND commentable_id NOT IN (SELECT id FROM articles);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200825102635_remove_orphaned_notification_subscriptions_by_article.rb
+++ b/lib/data_update_scripts/20200825102635_remove_orphaned_notification_subscriptions_by_article.rb
@@ -1,0 +1,14 @@
+module DataUpdateScripts
+  class RemoveOrphanedNotificationSubscriptionsByArticle
+    def run
+      # Delete all NotificationSubscriptions belonging to Articles that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM notification_subscriptions
+          WHERE notifiable_type = 'Article'
+          AND notifiable_id NOT IN (SELECT id FROM articles);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200825102956_remove_orphaned_notifications_by_article.rb
+++ b/lib/data_update_scripts/20200825102956_remove_orphaned_notifications_by_article.rb
@@ -1,0 +1,14 @@
+module DataUpdateScripts
+  class RemoveOrphanedNotificationsByArticle
+    def run
+      # Delete all Notifications related to Articles that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM notifications
+          WHERE notifiable_type = 'Article'
+          AND notifiable_id NOT IN (SELECT id FROM articles);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200825103119_remove_orphaned_profile_pins_by_article.rb
+++ b/lib/data_update_scripts/20200825103119_remove_orphaned_profile_pins_by_article.rb
@@ -1,0 +1,14 @@
+module DataUpdateScripts
+  class RemoveOrphanedProfilePinsByArticle
+    def run
+      # Delete all ProfilePins belonging to Articles that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM profile_pins
+          WHERE pinnable_type = 'Article'
+          AND pinnable_id NOT IN (SELECT id FROM articles);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200825103244_remove_orphaned_rating_votes_by_article.rb
+++ b/lib/data_update_scripts/20200825103244_remove_orphaned_rating_votes_by_article.rb
@@ -1,0 +1,13 @@
+module DataUpdateScripts
+  class RemoveOrphanedRatingVotesByArticle
+    def run
+      # Delete all RatingVotes belonging to Articles that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          DELETE FROM rating_votes
+          WHERE article_id NOT IN (SELECT id FROM articles);
+        SQL
+      )
+    end
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -14,23 +14,30 @@ RSpec.describe Article, type: :model do
   it_behaves_like "UserSubscriptionSourceable"
 
   describe "validations" do
-    it { is_expected.to validate_uniqueness_of(:canonical_url).allow_blank }
-    it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:user_id) }
-    it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_blank }
-    it { is_expected.to validate_presence_of(:title) }
-    it { is_expected.to validate_length_of(:title).is_at_most(128) }
-    it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(126) }
     it { is_expected.to belong_to(:user) }
     it { is_expected.to belong_to(:organization).optional }
     it { is_expected.to belong_to(:collection).optional }
-    it { is_expected.to have_many(:comments) }
+
+    it { is_expected.to have_many(:buffer_updates).dependent(:destroy) }
+    it { is_expected.to have_many(:comments).dependent(:nullify) }
     it { is_expected.to have_many(:html_variant_successes).dependent(:nullify) }
     it { is_expected.to have_many(:html_variant_trials).dependent(:nullify) }
-    it { is_expected.to have_many(:reactions).dependent(:destroy) }
-    it { is_expected.to have_many(:notifications).dependent(:delete_all) }
     it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
+    it { is_expected.to have_many(:notifications).dependent(:delete_all) }
+    it { is_expected.to have_many(:page_views).dependent(:destroy) }
     it { is_expected.to have_many(:polls).dependent(:destroy) }
+    it { is_expected.to have_many(:profile_pins).dependent(:destroy) }
+    it { is_expected.to have_many(:rating_votes).dependent(:destroy) }
+    it { is_expected.to have_many(:reactions).dependent(:destroy) }
+
+    it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(126) }
+    it { is_expected.to validate_length_of(:title).is_at_most(128) }
+    it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_uniqueness_of(:canonical_url).allow_blank }
+    it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_blank }
+    it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:user_id) }
+
     it { is_expected.not_to allow_value("foo").for(:main_image_background_hex_color) }
 
     describe "#after_commit" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -28,9 +28,10 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_many(:polls).dependent(:destroy) }
     it { is_expected.to have_many(:profile_pins).dependent(:destroy) }
     it { is_expected.to have_many(:rating_votes).dependent(:destroy) }
+    it { is_expected.to have_many(:sourced_subscribers) }
     it { is_expected.to have_many(:reactions).dependent(:destroy) }
     it { is_expected.to have_many(:tags) }
-    it { is_expected.to have_many(:user_subscriptions).dependent(:destroy) }
+    it { is_expected.to have_many(:user_subscriptions).dependent(:nullify) }
 
     it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(126) }
     it { is_expected.to validate_length_of(:title).is_at_most(128) }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_many(:profile_pins).dependent(:destroy) }
     it { is_expected.to have_many(:rating_votes).dependent(:destroy) }
     it { is_expected.to have_many(:reactions).dependent(:destroy) }
+    it { is_expected.to have_many(:tags) }
+    it { is_expected.to have_many(:user_subscriptions).dependent(:destroy) }
 
     it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(126) }
     it { is_expected.to validate_length_of(:title).is_at_most(128) }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -8,14 +8,19 @@ RSpec.describe Comment, type: :model do
   include_examples "#sync_reactions_count", :article_comment
 
   describe "validations" do
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:commentable).optional }
-    it { is_expected.to have_many(:reactions).dependent(:destroy) }
-    it { is_expected.to have_many(:mentions).dependent(:destroy) }
-    it { is_expected.to have_many(:notifications).dependent(:delete_all) }
-    it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
-    it { is_expected.to validate_presence_of(:commentable_id) }
-    it { is_expected.to validate_presence_of(:body_markdown) }
+    subject { comment }
+
+    describe "builtin validations" do
+      it { is_expected.to belong_to(:user) }
+      it { is_expected.to belong_to(:commentable).optional }
+      it { is_expected.to have_many(:reactions).dependent(:destroy) }
+      it { is_expected.to have_many(:mentions).dependent(:destroy) }
+      it { is_expected.to have_many(:notifications).dependent(:delete_all) }
+      it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
+
+      it { is_expected.to validate_presence_of(:body_markdown) }
+      it { is_expected.to validate_presence_of(:user_id) }
+    end
 
     it do
       # rubocop:disable RSpec/NamedSubject
@@ -28,14 +33,55 @@ RSpec.describe Comment, type: :model do
     end
 
     it { is_expected.to validate_length_of(:body_markdown).is_at_least(1).is_at_most(25_000) }
-    it { is_expected.to validate_inclusion_of(:commentable_type).in_array(%w[Article PodcastEpisode]) }
 
-    it "is invalid if commentable is unpublished article" do
-      # rubocop:disable RSpec/NamedSubject
-      subject.commentable = build(:article, published: false)
-      expect(subject).not_to be_valid
-      # rubocop:enable RSpec/NamedSubject
+    # rubocop:disable RSpec/NamedSubject
+    describe "commentable" do
+      it "is invalid if commentable is an unpublished article" do
+        subject.commentable = build(:article, published: false)
+
+        expect(subject).not_to be_valid
+      end
+
+      it "is valid without a commentable" do
+        subject.commentable = nil
+
+        expect(subject).to be_valid
+      end
+
+      it "checks for commentable_id presence only if commentable_type is present" do
+        subject.commentable = nil
+        subject.commentable_type = "Article"
+
+        expect(subject).not_to be_valid
+      end
+
+      it "checks for commentable_type inclusion only if commentable_id is present" do
+        subject.commentable = nil
+        subject.commentable_id = article.id
+
+        expect(subject).not_to be_valid
+        expect(subject.errors.messages[:commentable_type].first).to match(/not included in the list/)
+      end
+
+      it "is valid with Article commentable type" do
+        subject.commentable_type = "Article"
+
+        expect(subject).to be_valid
+      end
+
+      it "is valid with PodcastEpisode commentable type" do
+        subject.commentable_type = "PodcastEpisode"
+
+        expect(subject).to be_valid
+      end
+
+      it "is not valid with Podcast commentable type" do
+        subject.commentable_type = "Podcast"
+
+        expect(subject).not_to be_valid
+      end
     end
+    # rubocop:enable RSpec/NamedSubject
 
     describe "#after_commit" do
       it "on update enqueues job to index comment to elasticsearch" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR adds a few `dependent` clauses to `has_many` and the correspondent cleanup scripts.

I also fixed `Comment` validation as we currently have 8,987 with invalid article IDs and those comments should be valid and survive even if the article doesn't exist.

As usual, the PR with the foreign keys will be submitted separately

- we have orphaned buffer updates, comments with invalid ids, orphaned notifications subscriptions, pins and rating votes https://dev.to/admin/blazer/queries/197-articles-counts
- we have orphaned notifications https://dev.to/admin/blazer/queries/201-orphan-notifications-by-article

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
