### PR TITLE
Fix a typo caused by markdown

### DIFF
--- a/docs/creators/configure-forem.md
+++ b/docs/creators/configure-forem.md
@@ -37,7 +37,7 @@ disappear.
 The following permissions are required to be able to view and/or edit the config
 page:
 
-#### Role: super_admin
+#### `Role: super_admin`
 
 When providing this role to a user they will be able to access the config page.
 However, this page will be a read only view for them. They will see the
@@ -45,7 +45,7 @@ following:
 
 ![Super Admin Permissions Role Provided](https://dev-to-uploads.s3.amazonaws.com/i/xpc8g9x46vzgi49ohc0d.png)
 
-#### Role: single_resource_admin
+#### `Role: single_resource_admin`
 
 When providing this role to a user they will be able to access the config page,
 and they will be able to edit the config variables.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

I fixed a odd typo caused by markdown.

Before:
![image](https://user-images.githubusercontent.com/11466782/91203060-47c28700-e6c8-11ea-8de4-18f16ce6fa86.png)

After:
![image](https://user-images.githubusercontent.com/11466782/91203102-5872fd00-e6c8-11ea-9210-8bbd1477cc9d.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.forem.com
- [ ] readme
- [ ] no documentation needed
