### PR TITLE
Add FOREM_BUILD_SHA and FOREM_BUILD_DATE to the container.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .dockerignore
-.git
 .gitignore
 logs/
 tmp/

--- a/Containerfile
+++ b/Containerfile
@@ -51,6 +51,10 @@ RUN mkdir -p "${APP_HOME}"/public/{assets,images,packs,podcasts,uploads}
 
 COPY . "${APP_HOME}"
 
+RUN echo $(date -u +'%Y-%m-%dT%H:%M:%SZ') >> "${APP_HOME}"/FOREM_BUILD_DATE && \
+    echo $(git rev-parse --short HEAD) >> "${APP_HOME}"/FOREM_BUILD_SHA && \
+    rm -rf "${APP_HOME}"/.git/
+
 VOLUME "${APP_HOME}"/public/
 
 ENTRYPOINT ["./scripts/entrypoint.sh"]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -7,6 +7,8 @@ if [ -f tmp/pids/server.pid ]; then
 fi
 
 export RELEASE_FOOTPRINT=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+export FOREM_BUILD_DATE=$(cat FOREM_BUILD_DATE)
+export FOREM_BUILD_SHA=$(cat FOREM_BUILD_SHA)
 
 echo "Running rake app_initializer:setup..."
 bundle exec rake app_initializer:setup


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the past it was always useful to have meta data within regards to the SHA and
build date/time. This adds in two new env vars that are written to disk as flat
files and then exported to environment variables when the container starts up.

This motivation comes from this comment:

https://github.com/forem/forem/pull/9987#discussion_r476123829

## [optional] What gif best describes this PR or how it makes you feel?

![This should do it...](https://media1.tenor.com/images/3539a57b0cafe32d5b0a1b77bdf52b08/tenor.gif)
