### PR TITLE
Bug Fix:Update Sitemap Generator to Handle IAM Profiles

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,12 +1,70 @@
+# TEMPORARY
+# Until https://github.com/kjvarga/sitemap_generator/pull/359 is merged
+# We have to monkey patch the S3Adapter to allow for the fog_public option to be set
+module SitemapGenerator
+  # https://github.com/kjvarga/sitemap_generator/blob/master/lib/sitemap_generator/adapters/s3_adapter.rb
+  class S3Adapter
+    def initialize(opts = {}) # rubocop:disable Style/OptionHash
+      @aws_access_key_id = opts[:aws_access_key_id] || ENV["AWS_ACCESS_KEY_ID"]
+      @aws_secret_access_key = opts[:aws_secret_access_key] || ENV["AWS_SECRET_ACCESS_KEY"]
+      @fog_provider = opts[:fog_provider] || ENV["FOG_PROVIDER"]
+      @fog_directory = opts[:fog_directory] || ENV["FOG_DIRECTORY"]
+      @fog_region = opts[:fog_region] || ENV["FOG_REGION"]
+      @fog_path_style = opts[:fog_path_style] || ENV["FOG_PATH_STYLE"]
+      @fog_storage_options = opts[:fog_storage_options] || {}
+      @fog_public = opts[:fog_public].to_s.present? ? opts[:fog_public] : true # additional line
+    end
+
+    # Call with a SitemapLocation and string data
+    def write(location, raw_data)
+      SitemapGenerator::FileAdapter.new.write(location, raw_data)
+
+      credentials = { provider: @fog_provider }
+
+      if @aws_access_key_id && @aws_secret_access_key
+        credentials[:aws_access_key_id] = @aws_access_key_id
+        credentials[:aws_secret_access_key] = @aws_secret_access_key
+      else
+        credentials[:use_iam_profile] = true
+      end
+
+      credentials[:region] = @fog_region if @fog_region
+      credentials[:path_style] = @fog_path_style if @fog_path_style
+
+      storage   = Fog::Storage.new(@fog_storage_options.merge(credentials))
+      directory = storage.directories.new(key: @fog_directory)
+      directory.files.create(
+        key: location.path_in_public,
+        body: File.open(location.path),
+        public: @fog_public, # additional line
+      )
+    end
+  end
+end
+
 if Rails.env.production?
   region = ApplicationConfig["AWS_UPLOAD_REGION"].presence || ApplicationConfig["AWS_DEFAULT_REGION"]
-  SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(
-    fog_provider: "AWS",
-    aws_access_key_id: ApplicationConfig["AWS_ID"],
-    aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
-    fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
-    fog_region: region,
-  )
+  config_hash = if ENV["FOREM_CONTEXT"] == "forem_cloud" # @forem/systems jdoss's special sauce.
+                  # Excluding the aws_access_key_id and aws_secret_access_key causes use_iam_profile
+                  # to be set to true by the S3Adapter
+                  # https://github.com/kjvarga/sitemap_generator/blob/0b847f1e7a544ea8ef87bb643a732e30a07a14c9/lib/sitemap_generator/adapters/s3_adapter.rb#L39
+                  {
+                    fog_provider: "AWS",
+                    fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
+                    fog_region: "us-east-2",
+                    fog_public: false
+                  }
+                else
+                  {
+                    fog_provider: "AWS",
+                    aws_access_key_id: ApplicationConfig["AWS_ID"],
+                    aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
+                    fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
+                    fog_region: region
+                  }
+                end
+
+  SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(config_hash)
   SitemapGenerator::Sitemap.sitemaps_host = "https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/"
   SitemapGenerator::Sitemap.public_path = "tmp/"
   SitemapGenerator::Sitemap.sitemaps_path = "sitemaps/"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
UPDATE: Not sure when the related PR will be merged so I went ahead and monkey patched the adapter. 

Currently, Sitemap Refresh does not work on Forems' using IAM profiles. In order to get this working, we need to set `fog_public` to false and get [this PR for sitemap_generator](https://github.com/kjvarga/sitemap_generator/pull/359) merged. But what about `use_iam_profile`? [By default `use_iam_profile` gets set to true when AWS access key and secret are missing](https://github.com/kjvarga/sitemap_generator/blob/0b847f1e7a544ea8ef87bb643a732e30a07a14c9/lib/sitemap_generator/adapters/s3_adapter.rb#L39) but I figured it would help to be more explicit 

In order to test this setup, I copy and pasted the updated `SitemapGenerator::S3Adapter` code into a Forem.dev console and was able to successfully generate a sitemap with it. Prior to the change, I was getting a 403 error
```
+ sitemaps/sitemap.xml.gz                                 26 links /  522 Bytes
Sitemap stats: 26 links / 1 sitemaps / 0m00s
```

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44242105


![alt_text](https://media1.tenor.com/images/acf3ff03d092d89dcbbd8682b980d1c1/tenor.gif?itemid=3674437)
