### PR TITLE
Allow greater flexibility for footer mascot image

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -135,6 +135,8 @@ module Admin
         mascot_image_description
         mascot_image_url
         mascot_footer_image_url
+        mascot_footer_image_width
+        mascot_footer_image_height
         mascot_user_id
       ]
     end

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -144,11 +144,11 @@ module Constants
         placeholder: "https://image.url"
       },
       mascot_footer_image_width: {
-        description: "The footer image will be resized to this value, defaults to 52",
+        description: "The footer mascot width will resized to this value, defaults to 52",
         placeholder: ""
       },
       mascot_footer_image_height: {
-        description: "The footer image will be resized to this value, defaults to 120",
+        description: "The footer mascot height will be resized to this value, defaults to 120",
         placeholder: ""
       },
       mascot_image_description: {

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -143,6 +143,14 @@ module Constants
         description: "Special cute mascot image used in the footer.",
         placeholder: "https://image.url"
       },
+      mascot_footer_image_width: {
+        description: "The footer image will be resized to this value, defaults to 52",
+        placeholder: ""
+      },
+      mascot_footer_image_height: {
+        description: "The footer image will be resized to this value, defaults to 120",
+        placeholder: ""
+      },
       mascot_image_description: {
         description: "Used as the alt text for the mascot image",
         placeholder: ""

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -75,6 +75,8 @@ class SiteConfig < RailsSettings::Base
   field :mascot_image_url, type: :string
   field :mascot_image_description, type: :string, default: "The community mascot"
   field :mascot_footer_image_url, type: :string
+  field :mascot_footer_image_width, type: :integer, default: 52
+  field :mascot_footer_image_height, type: :integer, default: 120
 
   # Meta keywords
   field :meta_keywords, type: :hash, default: {

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -590,6 +590,22 @@
             </div>
 
             <div class="form-group">
+              <%= admin_config_label :mascot_footer_image_width %>
+              <%= f.text_field :mascot_footer_image_width,
+                               class: "form-control",
+                               value: SiteConfig.mascot_footer_image_width %>
+              <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:mascot_footer_image_width][:description] %></div>
+            </div>
+
+            <div class="form-group">
+              <%= admin_config_label :mascot_footer_image_height %>
+              <%= f.text_field :mascot_footer_image_height,
+                               class: "form-control",
+                               value: SiteConfig.mascot_footer_image_height %>
+              <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:mascot_footer_image_height][:description] %></div>
+            </div>
+
+            <div class="form-group">
               <%= admin_config_label :mascot_image_description %>
               <%= f.text_field :mascot_image_description,
                                class: "form-control",

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -50,8 +50,8 @@
       <%= image_tag(SiteConfig.mascot_footer_image_url,
                     class: "crayons-footer__mascot",
                     alt: SiteConfig.mascot_image_description,
-                    width: 52,
-                    height: 120,
+                    width: SiteConfig.mascot_footer_image_width,
+                    height: SiteConfig.mascot_footer_image_height,
                     loading: "lazy") %>
     <% end %>
   </div>

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -264,6 +264,30 @@ RSpec.describe "/admin/config", type: :request do
           expect(SiteConfig.mascot_footer_image_url).to eq(expected_image_url)
         end
 
+        it "updates the mascot_footer_image_width" do
+          expected_default_mascot_footer_image_width = 52
+          expected_mascot_footer_image_width = 1002
+
+          expect(SiteConfig.mascot_footer_image_width).to eq(expected_default_mascot_footer_image_width)
+
+          post "/admin/config", params: { site_config:
+                                            { mascot_footer_image_width: expected_mascot_footer_image_width },
+                                          confirmation: confirmation_message }
+          expect(SiteConfig.mascot_footer_image_width).to eq(expected_mascot_footer_image_width)
+        end
+
+        it "updates the mascot_footer_image_height" do
+          expected_default_mascot_footer_image_height = 120
+          expected_mascot_footer_image_height = 3002
+
+          expect(SiteConfig.mascot_footer_image_height).to eq(expected_default_mascot_footer_image_height)
+
+          post "/admin/config", params: { site_config:
+                                            { mascot_footer_image_height: expected_mascot_footer_image_height },
+                                          confirmation: confirmation_message }
+          expect(SiteConfig.mascot_footer_image_height).to eq(expected_mascot_footer_image_height)
+        end
+
         it "updates mascot_image_description" do
           description = "Hey hey #{rand(100)}"
           post "/admin/config", params: { site_config: { mascot_image_description: description },


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change allows admins to use footer mascot images of any size without coercing them to the default values. They can manage the default values in site config.

I think ideally this would be removed and replaced with some sort of custom CSS/theming system down the road, but I'm not sure we should anticipate that until we are ready to dedicate resources to it. When that time comes this will be easy to yank out!

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/9994

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

![image](https://user-images.githubusercontent.com/11466782/91239584-904c6580-e705-11ea-8bf5-7ef8ea6c272e.png)

Adds these too fields!

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

*note:* adds site config values
