### PR TITLE
Make confirmation text a required field

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -67,14 +67,14 @@ module Admin
       )
     end
 
-    def confirmation_text_error
-      render json: { Error: "confirmation text did not match" }, status: :unprocessable_entity
+    def raise_confirmation_mismatch_error
+      raise ActionController::BadRequest.new, "The confirmation key does not match"
     end
 
     def extra_authorization_and_confirmation
       not_authorized unless current_user.has_role?(:single_resource_admin, Config) # Special additional permission
       confirmation_message = "My username is @#{current_user.username} and this action is 100% safe and appropriate."
-      confirmation_text_error if params[:confirmation] != confirmation_message
+      raise_confirmation_mismatch_error if params.require(:confirmation) != confirmation_message
     end
 
     def clean_up_params

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -4,6 +4,10 @@ module Admin
 
     before_action :extra_authorization_and_confirmation, only: [:create]
 
+    def show
+      @confirmation_text = confirmation_text
+    end
+
     def create
       clean_up_params
 
@@ -22,6 +26,10 @@ module Admin
     end
 
     private
+
+    def confirmation_text
+      "My username is @#{current_user.username} and this action is 100% safe and appropriate."
+    end
 
     def config_params
       allowed_params = %i[
@@ -73,8 +81,7 @@ module Admin
 
     def extra_authorization_and_confirmation
       not_authorized unless current_user.has_role?(:single_resource_admin, Config) # Special additional permission
-      confirmation_message = "My username is @#{current_user.username} and this action is 100% safe and appropriate."
-      raise_confirmation_mismatch_error if params.require(:confirmation) != confirmation_message
+      raise_confirmation_mismatch_error if params.require(:confirmation) != confirmation_text
     end
 
     def clean_up_params

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -67,10 +67,14 @@ module Admin
       )
     end
 
+    def confirmation_text_error
+      render json: { Error: "confirmation text did not match" }, status: :unprocessable_entity
+    end
+
     def extra_authorization_and_confirmation
       not_authorized unless current_user.has_role?(:single_resource_admin, Config) # Special additional permission
       confirmation_message = "My username is @#{current_user.username} and this action is 100% safe and appropriate."
-      not_authorized if params[:confirmation] != confirmation_message
+      confirmation_text_error if params[:confirmation] != confirmation_message
     end
 
     def clean_up_params

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -66,8 +66,8 @@
         <% if current_user.has_role?(:single_resource_admin, Config) %>
               <div class="form-group">
                 <%= label_tag "Please type out the sentence below to submit:" %>
-                <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off", required: true %>
-                <div class="alert alert-info">Type the sentence: My username is @your_username and this action is 100% safe and appropriate.</div>
+                <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off", required: true, pattern: @confirmation_text %>
+                <div class="alert alert-info">Type the sentence: <%= @confirmation_text %></div>
                 <%= f.submit "Update Site Configuration", class: "btn btn-danger btn-lg" %>
               </div>
         <% end %>
@@ -933,8 +933,8 @@
             <div class="card-body">
               <div class="form-group">
                 <%= label_tag :confirmation %>
-                <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off", required: true %>
-                <div class="alert alert-info">Type the sentence: My username is @your_username and this action is 100% safe and appropriate.</div>
+                <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off", required: true, pattern: @confirmation_text %>
+                <div class="alert alert-info">Type the sentence: <%= @confirmation_text %></div>
                 <%= f.submit "Update Site Configuration", class: "btn btn-danger btn-lg" %>
               </div>
             </div>

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -66,7 +66,7 @@
         <% if current_user.has_role?(:single_resource_admin, Config) %>
               <div class="form-group">
                 <%= label_tag "Please type out the sentence below to submit:" %>
-                <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off" %>
+                <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off", required: true %>
                 <div class="alert alert-info">Type the sentence: My username is @your_username and this action is 100% safe and appropriate.</div>
                 <%= f.submit "Update Site Configuration", class: "btn btn-danger btn-lg" %>
               </div>
@@ -933,7 +933,7 @@
             <div class="card-body">
               <div class="form-group">
                 <%= label_tag :confirmation %>
-                <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off" %>
+                <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off", required: true %>
                 <div class="alert alert-info">Type the sentence: My username is @your_username and this action is 100% safe and appropriate.</div>
                 <%= f.submit "Update Site Configuration", class: "btn btn-danger btn-lg" %>
               </div>

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe "/admin/config", type: :request do
           expect do
             post "/admin/config", params: { site_config: { periodic_email_digest_min: 6 },
                                             confirmation: "Incorrect yo!" }
-          end.to raise_error Pundit::NotAuthorizedError
+          end.to raise_error ActionController::BadRequest
           expect(SiteConfig.periodic_email_digest_min).not_to eq(6)
         end
       end
@@ -238,7 +238,15 @@ RSpec.describe "/admin/config", type: :request do
           expect do
             post "/admin/config", params: { site_config: { logo_svg: expected_image_url },
                                             confirmation: "Incorrect yo!" }
-          end.to raise_error Pundit::NotAuthorizedError
+          end.to raise_error ActionController::BadRequest
+        end
+
+        it "rejects update without any confirmation" do
+          expected_image_url = "https://dummyimage.com/300x300"
+          expect do
+            post "/admin/config", params: { site_config: { logo_svg: expected_image_url },
+                                            confirmation: "" }
+          end.to raise_error ActionController::ParameterMissing
         end
       end
 
@@ -305,7 +313,7 @@ RSpec.describe "/admin/config", type: :request do
             expect do
               params = { site_config: { shop_url: expected_shop_url }, confirmation: "Incorrect confirmation" }
               post "/admin/config", params: params
-            end.to raise_error(Pundit::NotAuthorizedError)
+            end.to raise_error ActionController::BadRequest
 
             expect(SiteConfig.shop_url).not_to eq(expected_shop_url)
           end
@@ -514,8 +522,8 @@ RSpec.describe "/admin/config", type: :request do
           twitter_hashtag = "#DEVCommunity"
           params = { site_config: { twitter_hashtag: twitter_hashtag }, confirmation: "Incorrect confirmation" }
 
-          it "does not update the twitter hashtag" do
-            expect { post "/admin/config", params: params }.to raise_error Pundit::NotAuthorizedError
+          it "does not update the twitter hashtag without the correct confirmation text" do
+            expect { post "/admin/config", params: params }.to raise_error ActionController::BadRequest
           end
 
           it "updates the twitter hashtag" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Right now, you can submit the config form without including the required confirmation text. When you do this, it's a bit frustrating because it's such a large form and you can lose your inputs. 

~Also, this returns an unauthorized status which isn't really true because you can hit this error with all the necessary permissions, so I changed it to return a 422 (unprocessable entity) because most accurately (imo) you're missing a required parameter.~

This change now includes both frontend validation and more specific error messaging for the backend validation.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
