### PR TITLE
Optimization:Default Production Logging to Error

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = ENV["LOG_LEVEL"] || :info
+  config.log_level = ENV["LOG_LEVEL"] || :error
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
A couple of weeks ago I flipped our logging in production to `:error` level to see how it worked. It has been working really well so I want to make that the default and then if we need more color we can lower the level through the ENV variable. 


![alt_text](https://media1.tenor.com/images/963dbf83410067b8216bf3fbeec50874/tenor.gif?itemid=5012719)
