### PR TITLE
Add facebook page to Backend Guide index

### DIFF
--- a/docs/backend/readme.md
+++ b/docs/backend/readme.md
@@ -3,6 +3,7 @@ title: Backend Guide
 items:
   - audit-log.md
   - authentication.md
+  - auth-facebook.md
   - auth-twitter.md
   - auth-github.md
   - authorization.md


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

I added developer documentation for Sign in with Facebook in https://github.com/forem/forem/pull/9922, but didn't link it up correctly in `docs/backend/readme.md`, which Gitdocs requires to build the file and actually publish it!


## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/l3q2D5bfCqm9c9cRy/giphy-downsized.gif)
