### PR TITLE
Bug Fix: Dont Kill Entire Job When User is Missing a Github Identity

### DIFF
--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -31,8 +31,8 @@ class GithubRepo < ApplicationRecord
       user = repo.user
       next unless user
 
-      client = Github::OauthClient.for_user(user)
       begin
+        client = Github::OauthClient.for_user(user)
         fetched_repo = client.repository(repo.info_hash[:full_name])
 
         repo.update!(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We have had some [`GithubRepos::UpdateLatestWorker`](https://dev.to/sidekiq/morgue)s die on us due to missing identities. When we try to create a `Github::OauthClient` for a user with a GithubRepo sometimes we can't because that user does not have a Github Identity. I'm not sure how that happens but this will allow us to continue to process the rest of the users in the job.
![Screen Shot 2020-08-26 at 6 10 55 PM](https://user-images.githubusercontent.com/1813380/91365844-b20e2100-e7c7-11ea-98cd-94660df4a912.png)

I will dig in more to why these users are missing identities and if we cant better update this flow but in the meantime this will get the job back up and running and able to finish. 


![alt_text](https://media.tenor.com/images/6d40e2a67e0bf37dd98d4662e72afe52/tenor.gif)
