### PR TITLE
Remove transferring user fields to profile related code

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   # rubocop:disable Metrics/BlockLength
   concerning :ProfileMigration do
     included do
-      PROFIE_FIELDS =
+      PROFILE_FIELDS =
         (Profiles::ExtractData::DIRECT_ATTRIBUTES + Profiles::ExtractData::MAPPED_ATTRIBUTES.values).freeze
 
       # NOTE: There are rare cases were we want to skip this callback, primarily
@@ -24,7 +24,7 @@ class User < ApplicationRecord
 
       # Keep saving changes locally for the time being, but propagate them to profiles.
       after_update_commit do
-        if (previous_changes.keys.map(&:to_sym) & User::PROFIE_FIELDS).present?
+        if (previous_changes.keys.map(&:to_sym) & User::PROFILE_FIELDS).present?
           profile.update(data: Profiles::ExtractData.call(self))
         end
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ApplicationRecord
 
   # NOTE: @citizen428 This is temporary code during profile migration and will
   # be removed.
-  # rubocop:disable Metrics/BlockLength
   concerning :ProfileMigration do
     included do
       PROFILE_FIELDS =
@@ -29,36 +28,12 @@ class User < ApplicationRecord
         end
       end
 
-      # Define wrapped getters for profile attributes. We first try to get the
-      # value from the profile and if it doesn't exist there we move retrieve it
-      # from here.
-      Profiles::ExtractData::DIRECT_ATTRIBUTES.each do |attribute|
-        define_method(attribute) do
-          if profile.respond_to?(attribute)
-            profile.public_send(attribute)
-          else
-            self[attribute]
-          end
-        end
-      end
-
-      Profiles::ExtractData::MAPPED_ATTRIBUTES.each do |profile_attribute, user_attribute|
-        define_method(user_attribute) do
-          if profile.respond_to?(profile_attribute)
-            profile.public_send(profile_attribute)
-          else
-            self[user_attribute]
-          end
-        end
-      end
-
       def create_profile
         Profile.create(user: self, data: Profiles::ExtractData.call(self))
       end
       private :create_profile
     end
   end
-  # rubocop:enable Metrics/BlockLength
 
   BEHANCE_URL_REGEXP = %r{\A(http(s)?://)?(www.behance.net|behance.net)/.*\z}.freeze
   COLOR_HEX_REGEXP = /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/.freeze


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
This PR does two things:
- remove code that is no longer necessary, as the code was intended to verify that the profile migration was successful (which it was!)
- fix a bug where users with certain `nil` fields would bypass our validations, and therefore a user could submit an invalid field. Invalid fields on a user prevent them from signing in.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
1. go to `/settings/profile`
2. try to update a field with an invalid value, like `website_url = 'test'`
3. see that it does not submit
4. try to update it with a valid value, like `website_url = 'https://dev.to'`
5. see that it submits and saves successfully

## Added tests?
- [x] no, because they aren't needed. We'll be removing validations eventually.

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
None, for now...