### PR TITLE
Optimization:Break Github Repo Updates into Individual Sidekiq Jobs

### DIFF
--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -27,31 +27,8 @@ class GithubRepo < ApplicationRecord
   end
 
   def self.update_to_latest
-    where("updated_at < ?", 26.hours.ago).includes(:user).find_each do |repo|
-      user = repo.user
-      next unless user
-
-      begin
-        client = Github::OauthClient.for_user(user)
-        fetched_repo = client.repository(repo.info_hash[:full_name])
-
-        repo.update!(
-          github_id_code: fetched_repo.id,
-          name: fetched_repo.name,
-          description: fetched_repo.description,
-          language: fetched_repo.language,
-          fork: fetched_repo.fork,
-          bytes_size: fetched_repo.size,
-          watchers_count: fetched_repo.watchers,
-          stargazers_count: fetched_repo.stargazers_count,
-          info_hash: fetched_repo.to_hash,
-        )
-        repo.user&.touch(:github_repos_updated_at)
-      rescue Github::Errors::NotFound
-        repo.destroy
-      rescue StandardError
-        next
-      end
+    where("updated_at < ?", 26.hours.ago).ids.each do |repo_id|
+      GithubRepos::RepoSyncWorker.perform_async(repo_id)
     end
   end
 

--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -1,0 +1,35 @@
+module GithubRepos
+  class RepoSyncWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform(repo_id)
+      repo = GithubRepo.find_by(id: repo_id)
+      return unless repo
+
+      user = repo.user
+      return unless user.identities.github.exists?
+
+      begin
+        client = Github::OauthClient.for_user(user)
+        fetched_repo = client.repository(repo.info_hash[:full_name])
+
+        repo.update!(
+          github_id_code: fetched_repo.id,
+          name: fetched_repo.name,
+          description: fetched_repo.description,
+          language: fetched_repo.language,
+          fork: fetched_repo.fork,
+          bytes_size: fetched_repo.size,
+          watchers_count: fetched_repo.watchers,
+          stargazers_count: fetched_repo.stargazers_count,
+          info_hash: fetched_repo.to_hash,
+        )
+        repo.user&.touch(:github_repos_updated_at)
+      rescue Github::Errors::NotFound
+        repo.destroy
+      end
+    end
+  end
+end

--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -2,7 +2,7 @@ module GithubRepos
   class RepoSyncWorker
     include Sidekiq::Worker
 
-    sidekiq_options queue: :low_priority, retry: 10
+    sidekiq_options queue: :low_priority, retry: 10, lock: :until_executing
 
     def perform(repo_id)
       repo = GithubRepo.find_by(id: repo_id)

--- a/spec/workers/github_repos/repo_sync_worker_spec.rb
+++ b/spec/workers/github_repos/repo_sync_worker_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe GithubRepos::RepoSyncWorker, type: :worker do
+  let(:worker) { subject }
+  let(:user) { create(:user, :with_identity, identities: ["github"]) }
+  let(:repo) { create(:github_repo, user: user) }
+
+  before { omniauth_mock_github_payload }
+
+  include_examples "#enqueues_on_correct_queue", "low_priority"
+
+  describe "#perform" do
+    let(:fake_github_client) do
+      Class.new(Github::OauthClient) do
+        def repository(name); end
+      end
+    end
+
+    let(:stubbed_github_repo) do
+      OpenStruct.new(repo.attributes.merge(id: repo.github_id_code, html_url: repo.url)) # rubocop:disable Performance/OpenStruct
+    end
+    let(:github_client) { instance_double(fake_github_client, repository: stubbed_github_repo) }
+
+    before do
+      allow(Github::OauthClient).to receive(:new).and_return(github_client)
+    end
+
+    it "updates all repositories" do
+      old_updated_at = repo.updated_at
+
+      Timecop.freeze(3.days.from_now) do
+        worker.perform(repo.id)
+        expect(old_updated_at).not_to eq(GithubRepo.find(repo.id).updated_at)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Currently our GithubRepo Update worker is taking over an hour to complete. This breaks up the job into individual jobs for each GithubRepo to help speed things up. 
![Screen Shot 2020-08-27 at 12 48 39 PM](https://user-images.githubusercontent.com/1813380/91477269-bf78e900-e863-11ea-8c3b-d363845c4554.png)

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44435765

## Added tests?
- [x] yes


![alt_text](https://media1.tenor.com/images/c5092ab5796f3dc9c5507c63d7abe8ed/tenor.gif?itemid=3320266)
