### PR TITLE
Optimization:Dont Send Multiple Digest Emails in a Day

### DIFF
--- a/app/labor/email_logic.rb
+++ b/app/labor/email_logic.rb
@@ -28,31 +28,36 @@ class EmailLogic
   def get_articles_to_send
     fresh_date = get_fresh_date
 
-    articles = if user_has_followings?
-                 experience_level_rating = (@user.experience_level || 5)
-                 experience_level_rating_min = experience_level_rating - 3.6
-                 experience_level_rating_max = experience_level_rating + 3.6
+    if fresh_date < 23.hours.ago
+      articles = if user_has_followings?
+                   experience_level_rating = (@user.experience_level || 5)
+                   experience_level_rating_min = experience_level_rating - 3.6
+                   experience_level_rating_max = experience_level_rating + 3.6
 
-                 @user.followed_articles
-                   .where("published_at > ?", fresh_date)
-                   .where(published: true, email_digest_eligible: true)
-                   .where.not(user_id: @user.id)
-                   .where("score > ?", 12)
-                   .where("experience_level_rating > ? AND experience_level_rating < ?",
-                          experience_level_rating_min, experience_level_rating_max)
-                   .order(score: :desc)
-                   .limit(8)
-               else
-                 Article.published
-                   .where("published_at > ?", fresh_date)
-                   .where(featured: true, email_digest_eligible: true)
-                   .where.not(user_id: @user.id)
-                   .where("score > ?", 25)
-                   .order(score: :desc)
-                   .limit(8)
-               end
+                   @user.followed_articles
+                     .where("published_at > ?", fresh_date)
+                     .where(published: true, email_digest_eligible: true)
+                     .where.not(user_id: @user.id)
+                     .where("score > ?", 12)
+                     .where("experience_level_rating > ? AND experience_level_rating < ?",
+                            experience_level_rating_min, experience_level_rating_max)
+                     .order(score: :desc)
+                     .limit(8)
+                 else
+                   Article.published
+                     .where("published_at > ?", fresh_date)
+                     .where(featured: true, email_digest_eligible: true)
+                     .where.not(user_id: @user.id)
+                     .where("score > ?", 25)
+                     .order(score: :desc)
+                     .limit(8)
+                 end
 
-    @ready_to_receive_email = false if articles.length < 3
+      @ready_to_receive_email = false if articles.length < 3
+    else
+      articles = []
+      @ready_to_receive_email = false
+    end
 
     articles
   end

--- a/app/labor/email_logic.rb
+++ b/app/labor/email_logic.rb
@@ -28,7 +28,7 @@ class EmailLogic
   def get_articles_to_send
     fresh_date = get_fresh_date
 
-    if fresh_date < 23.hours.ago
+    if fresh_date.before?(23.hours.ago)
       articles = if user_has_followings?
                    experience_level_rating = (@user.experience_level || 5)
                    experience_level_rating_min = experience_level_rating - 3.6

--- a/spec/labor/email_logic_spec.rb
+++ b/spec/labor/email_logic_spec.rb
@@ -78,5 +78,12 @@ RSpec.describe EmailLogic, type: :labor do
       h = described_class.new(user).analyze
       expect(h.should_receive_email?).to eq(true)
     end
+
+    it "returns false if fresh_date is less than 24 hours before." do
+      email_logic = described_class.new(user)
+      allow(email_logic).to receive(:get_fresh_date).and_return(Time.current)
+      h = email_logic.analyze
+      expect(h.should_receive_email?).to eq(false)
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
I am working on breaking up the SendEmailDigestWorker into individual workers for each user Digest bc the looping through all users is taking hours. Prior to that being ready, this is a small optimization that will save us some time if that long-running job restarts in the middle of its run. **This assumes we would never want to send more than 1 digest email in a day which seems pretty reasonable to me.** 

## Added tests?
- [x] yes


![alt_text](https://media1.giphy.com/media/YrYZnWUDRJs1ZBLQfv/giphy.gif)
