### PR TITLE
Remove group column from profile_fields

### DIFF
--- a/db/migrate/20200828045600_remove_group_from_profile_fields.rb
+++ b/db/migrate/20200828045600_remove_group_from_profile_fields.rb
@@ -1,0 +1,5 @@
+class RemoveGroupFromProfileFields < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured { remove_column :profile_fields, :group }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_28_032013) do
+ActiveRecord::Schema.define(version: 2020_08_28_045600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -945,7 +945,6 @@ ActiveRecord::Schema.define(version: 2020_08_28_032013) do
     t.datetime "created_at", precision: 6, null: false
     t.string "description"
     t.integer "display_area", default: 1, null: false
-    t.string "group"
     t.integer "input_type", default: 0, null: false
     t.citext "label", null: false
     t.string "placeholder_text"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR removes the `group` column from `profile_fields` that we started ignoring in #10045 which needs to be merged first.

## Related Tickets & Documents

Part of #6994.

## QA Instructions, Screenshots, Recordings

Nothing

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
