### PR TITLE
Fix seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -326,7 +326,7 @@ seeder.create_if_none(ChatChannel) do
     )
   end
 
-  direct_channel = ChatChannel.create_with_users(users: User.last(2), channel_type: "direct")
+  direct_channel = ChatChannels::CreateWithUsers.call(users: User.last(2), channel_type: "direct")
   Message.create!(
     chat_channel: direct_channel,
     user: User.last,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

During #9253 the method `ChatChannel.create_with_users` got removed. Alas, it was still used in `seeds.rb`, which raised an exception when trying to seed. This updates the seed file to use the newly introduced service object.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
