### PR TITLE
Delete cookies correctly by specifying the domain

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,9 @@
 class SessionsController < Devise::SessionsController
   def destroy
     # Let's say goodbye to all the cookies when someone signs out.
-    cookies.each do |cookie|
-      cookies.delete cookie[0]
-    end
+    domain = Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
+    cookies.delete(domain: domain)
+
     super
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Cookie deletion should specify the domain as well:

> Please note that if you specify a :domain when setting a cookie, you must also specify the domain when deleting the cookie:

```ruby
cookies[:name] = {
  value: 'a yummy cookie',
  expires: 1.year,
  domain: 'domain.com'
}

cookies.delete(:name, domain: 'domain.com')
```

from https://api.rubyonrails.org/v6.0.3.2/classes/ActionDispatch/Cookies.html

## Related Tickets & Documents

#10036 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
