### PR TITLE
Bug Fix:Destroy Repos that We No Longer Have Credentials For

### DIFF
--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -27,7 +27,7 @@ module GithubRepos
           info_hash: fetched_repo.to_hash,
         )
         repo.user&.touch(:github_repos_updated_at)
-      rescue Github::Errors::NotFound
+      rescue Github::Errors::NotFound, Github::Errors::Unauthorized
         repo.destroy
       end
     end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
After Running out Sync worker I noticed a bunch of them failed due to `Github::Errors::Unauthorized` errors. I think if we get these errors we should remove the repo. 


![alt_text](https://i.kym-cdn.com/photos/images/original/001/002/168/6b3.gif)
