### PR TITLE
Add Recent Reports to Users' Admin User Page

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -39,7 +39,6 @@ module Admin
       @user = User.find(params[:id])
       manage_credits
       add_note if user_params[:new_note]
-      add_report if user_params[:new_report]
       redirect_to "/admin/users/#{params[:id]}"
     end
 
@@ -154,19 +153,6 @@ module Admin
       )
     end
 
-    def add_report
-      FeedbackMessage.create(
-        reporter_id: current_user.id,
-        feedback_type: "abuse-reports",
-        message: user_params[:new_report],
-        category: "harassment",
-        status: "Open",
-        offender_id: @user.id,
-        affected_id: @user.id,
-        reported_url: "",
-      )
-    end
-
     def add_credits
       amount = user_params[:add_credits].to_i
       Credit.add_to(@user, amount)
@@ -202,7 +188,6 @@ module Admin
         pro merge_user_id add_credits remove_credits
         add_org_credits remove_org_credits ghostify
         organization_id identity_id backup_data_id
-        new_report
       ]
       params.require(:user).permit(allowed_params)
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -15,11 +15,7 @@ module Admin
     def edit
       @user = User.find(params[:id])
       @notes = @user.notes.order(created_at: :desc).limit(10).load
-<<<<<<< HEAD
-      set_related_reactions
-=======
       set_feedback_messages
->>>>>>> Adds #set_feedback_messages to Admin::Users::Controller and adjusts _reports.html.erb
     end
 
     def show

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -190,12 +190,10 @@ module Admin
     end
 
     def set_feedback_messages
-      offender_report_ids = @user.offender_feedback_messages.ids
-      affected_report_ids = @user.affected_feedback_messages.ids
-      reporter_report_ids = @user.reporter_feedback_messages.ids
-      @related_reports = FeedbackMessage.where(offender_id: offender_report_ids)
-        .or(FeedbackMessage.where(affected_id: affected_report_ids))
-        .or(FeedbackMessage.where(reporter_id: reporter_report_ids))
+      @related_reports = FeedbackMessage.where(id: @user.reporter_feedback_messages.ids)
+        .or(FeedbackMessage.where(id: @user.affected_feedback_messages.ids))
+        .or(FeedbackMessage.where(id: @user.offender_feedback_messages.ids))
+        .order(created_at: :desc).limit(15)
     end
 
     def user_params

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -15,18 +15,17 @@ module Admin
     def edit
       @user = User.find(params[:id])
       @notes = @user.notes.order(created_at: :desc).limit(10).load
+<<<<<<< HEAD
       set_related_reactions
+=======
+      set_feedback_messages
+>>>>>>> Adds #set_feedback_messages to Admin::Users::Controller and adjusts _reports.html.erb
     end
 
     def show
       @user = User.find(params[:id])
       @organizations = @user.organizations.order(:name)
       @notes = @user.notes.order(created_at: :desc).limit(10)
-      # @reports = FeedbackMessage.where(offender_id: @user.id)
-      # @reports = FeedbackMessage.where(offender_id: current_user.id)
-      # @reports = FeedbackMessage.where(reporter_id: current_user.id, offender_id: @user.id)
-      @reports = FeedbackMessage.where(reporter_id: @user.id).or(FeedbackMessage.where(offender_id: @user.id))
-      # binding.pry
       @organization_memberships = @user.organization_memberships
         .joins(:organization)
         .order("organizations.name" => :asc)
@@ -190,15 +189,13 @@ module Admin
       Credit.remove_from(org, amount)
     end
 
-    def set_related_reactions
-      user_article_ids = @user.articles.ids
-      user_comment_ids = @user.comments.ids
-      @related_vomit_reactions = Reaction.where(reactable_type: "Comment", reactable_id: user_comment_ids,
-                                                category: "vomit")
-        .or(Reaction.where(reactable_type: "Article", reactable_id: user_article_ids, category: "vomit"))
-        .or(Reaction.where(reactable_type: "User", user_id: @user.id, category: "vomit"))
-        .includes(:reactable)
-        .order(created_at: :desc).limit(15)
+    def set_feedback_messages
+      offender_report_ids = @user.offender_feedback_messages.ids
+      affected_report_ids = @user.affected_feedback_messages.ids
+      reporter_report_ids = @user.reporter_feedback_messages.ids
+      @related_reports = FeedbackMessage.where(offender_id: offender_report_ids)
+        .or(FeedbackMessage.where(affected_id: affected_report_ids))
+        .or(FeedbackMessage.where(reporter_id: reporter_report_ids))
     end
 
     def user_params

--- a/app/models/feedback_message.rb
+++ b/app/models/feedback_message.rb
@@ -26,4 +26,12 @@ class FeedbackMessage < ApplicationRecord
   def capitalize_status
     self.status = status.capitalize if status.present?
   end
+
+  def user_types(user_id)
+    types = []
+    types << "Affected" if user_id == affected_id
+    types << "Offender" if user_id == offender_id
+    types << "Reporter" if user_id == reporter_id
+    types
+  end
 end

--- a/app/views/admin/users/_reports.html.erb
+++ b/app/views/admin/users/_reports.html.erb
@@ -1,14 +1,14 @@
 <div class="row my-3">
   <div class="col-12">
     <h2 class="d-inline">Recent Reports</h2>
-    <button type="button" data-toggle="collapse" data-target="#reports-row" class="btn btn-secondary float-right">Toggle</button>
+    <button type="button" data-toggle="collapse" data-target="#reactions-row" class="btn btn-secondary float-right">Toggle</button>
   </div>
-  <div class="col-12 collapse" id="reports-row">
+  <div class="col-12 collapse" id="reactions-row">
     <div class="list-group-flush">
-    <% unless @reports.nil? %>
-      <% @reports.order(created_at: :desc).limit(50).each do |report| %>
-        <a href="/admin/reports/<%= report.id %>" class="list-group-item list-group-item-action">
-        <%= report.feedback_type %>
+    <% unless @related_reports.empty? %>
+      <% @related_reports.each do |report| %>
+        <a href="<%= report.path %>" class="list-group-item list-group-item-action">
+        <%= report.feedback_type %>: <%= reaction.reported_url %> (<%= report.category.capitalize %>)
         <em> - <%= report.created_at&.strftime("%b %e '%y") %></em>
         </a>
       <% end %>

--- a/app/views/admin/users/_reports.html.erb
+++ b/app/views/admin/users/_reports.html.erb
@@ -7,9 +7,11 @@
     <div class="list-group-flush">
     <% unless @related_reports.empty? %>
       <% @related_reports.each do |report| %>
-        <a href="<%= report.path %>" class="list-group-item list-group-item-action">
-        <%= report.feedback_type %>: <%= reaction.reported_url %> (<%= report.category.capitalize %>)
+        <a href="<%= report.reported_url %>" class="list-group-item list-group-item-action">
+        <%= report.feedback_type.titlecase %>: <%= report.category.capitalize %> (<%= report.status %>)
         <em> - <%= report.created_at&.strftime("%b %e '%y") %></em>
+        <br>
+        <%= report.message %>
         </a>
       <% end %>
       <% else %>

--- a/app/views/admin/users/_reports.html.erb
+++ b/app/views/admin/users/_reports.html.erb
@@ -6,7 +6,7 @@
   <div class="pt-6 collapse" id="reactions-row">
     <% unless @related_reports.empty? %>
       <% @related_reports.each do |report| %>
-        <a href="<%= report.reported_url %>" class="list-group-item list-group-item-action action px-5 d-flex justify-content-between">
+        <a href="<%= admin_feedback_messages_path %>" class="list-group-item list-group-item-action action px-5 d-flex justify-content-between">
         <span><%= report.category.capitalize %> (<%= report.status %>)</span>
         <span><strong><%= report.feedback_type.titlecase %></strong>: <%= report.message %></span>
         <em> <%= report.created_at&.strftime("%b %e '%y") %></em>

--- a/app/views/admin/users/_reports.html.erb
+++ b/app/views/admin/users/_reports.html.erb
@@ -7,11 +7,10 @@
     <div class="list-group-flush">
     <% unless @related_reports.empty? %>
       <% @related_reports.each do |report| %>
-        <a href="<%= report.reported_url %>" class="list-group-item list-group-item-action">
-        <%= report.feedback_type.titlecase %>: <%= report.category.capitalize %> (<%= report.status %>)
-        <em> - <%= report.created_at&.strftime("%b %e '%y") %></em>
-        <br>
-        <%= report.message %>
+        <a href="<%= report.reported_url %>" class="list-group-item list-group-item-action action px-5 d-flex justify-content-between">
+        <span><%= report.category.capitalize %> (<%= report.status %>)</span>
+        <span><strong><%= report.feedback_type.titlecase %></strong>: <%= report.message %></span>
+        <em> <%= report.created_at&.strftime("%b %e '%y") %></em>
         </a>
       <% end %>
       <% else %>

--- a/app/views/admin/users/_reports.html.erb
+++ b/app/views/admin/users/_reports.html.erb
@@ -8,7 +8,7 @@
       <% @related_reports.each do |report| %>
         <a href="<%= admin_report_path(report.id) %>" class="list-group-item list-group-item-action action px-5 d-flex justify-content-between">
         <span><%= report.category.capitalize %> (<%= report.status %>)</span>
-        <span><strong><%= report.feedback_type.titlecase %></strong>: <%= report.message %></span>
+        <span><strong><%= report.user_types(@user.id).to_sentence %></strong>: <%= report.message %></span>
         <em> <%= report.created_at&.strftime("%b %e '%y") %></em>
         </a>
       <% end %>

--- a/app/views/admin/users/_reports.html.erb
+++ b/app/views/admin/users/_reports.html.erb
@@ -6,7 +6,7 @@
   <div class="pt-6 collapse" id="reactions-row">
     <% unless @related_reports.empty? %>
       <% @related_reports.each do |report| %>
-        <a href="<%= admin_feedback_messages_path %>" class="list-group-item list-group-item-action action px-5 d-flex justify-content-between">
+        <a href="<%= admin_report_path(report.id) %>" class="list-group-item list-group-item-action action px-5 d-flex justify-content-between">
         <span><%= report.category.capitalize %> (<%= report.status %>)</span>
         <span><strong><%= report.feedback_type.titlecase %></strong>: <%= report.message %></span>
         <em> <%= report.created_at&.strftime("%b %e '%y") %></em>

--- a/app/views/admin/users/_reports.html.erb
+++ b/app/views/admin/users/_reports.html.erb
@@ -1,0 +1,20 @@
+<div class="row my-3">
+  <div class="col-12">
+    <h2 class="d-inline">Recent Reports</h2>
+    <button type="button" data-toggle="collapse" data-target="#reports-row" class="btn btn-secondary float-right">Toggle</button>
+  </div>
+  <div class="col-12 collapse" id="reports-row">
+    <div class="list-group-flush">
+    <% unless @feedback_messages.nil? %>
+      <% @feedback_messages.order(created_at: :desc).limit(50).each do |report| %>
+        <a href="/admin/reports/<%= report.id %>" class="list-group-item list-group-item-action">
+        <%= report.feedback_type %>
+        <em> - <%= report.created_at&.strftime("%b %e '%y") %></em>
+        </a>
+      <% end %>
+      <% else %>
+      <p><em>No reports yet!</em></p>
+    <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/_reports.html.erb
+++ b/app/views/admin/users/_reports.html.erb
@@ -15,7 +15,7 @@
         </a>
       <% end %>
       <% else %>
-      <p><em>No reports yet!</em></p>
+      <p><em>Nothing to report here! 👀</em></p>
     <% end %>
     </div>
   </div>

--- a/app/views/admin/users/_reports.html.erb
+++ b/app/views/admin/users/_reports.html.erb
@@ -1,10 +1,9 @@
-<div class="row my-3">
-  <div class="col-12">
+<div class="crayons-card p-6">
+  <div>
     <h2 class="d-inline">Recent Reports</h2>
     <button type="button" data-toggle="collapse" data-target="#reactions-row" class="btn btn-secondary float-right">Toggle</button>
   </div>
-  <div class="col-12 collapse" id="reactions-row">
-    <div class="list-group-flush">
+  <div class="pt-6 collapse" id="reactions-row">
     <% unless @related_reports.empty? %>
       <% @related_reports.each do |report| %>
         <a href="<%= report.reported_url %>" class="list-group-item list-group-item-action action px-5 d-flex justify-content-between">
@@ -16,6 +15,5 @@
       <% else %>
       <p><em>Nothing to report here! 👀</em></p>
     <% end %>
-    </div>
   </div>
 </div>

--- a/app/views/admin/users/_reports.html.erb
+++ b/app/views/admin/users/_reports.html.erb
@@ -5,8 +5,8 @@
   </div>
   <div class="col-12 collapse" id="reports-row">
     <div class="list-group-flush">
-    <% unless @feedback_messages.nil? %>
-      <% @feedback_messages.order(created_at: :desc).limit(50).each do |report| %>
+    <% unless @reports.nil? %>
+      <% @reports.order(created_at: :desc).limit(50).each do |report| %>
         <a href="/admin/reports/<%= report.id %>" class="list-group-item list-group-item-action">
         <%= report.feedback_type %>
         <em> - <%= report.created_at&.strftime("%b %e '%y") %></em>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -48,7 +48,7 @@
   </div>
 
 <%= render "notes" %>
-<%= render "negative_reactions" %>
+<%= render "reports" %>
 
   <div class="crayons-card p-6">
     <div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds a "Recent Reports" section to a User's Admin User page (`/admin/users/:id/edit`). The reports section displays a User's most recent `FeedbackMessages` with useful data (`user_types`, `category`, `status`, `created_at`, and `message`). By adding this data to the User's Admin User page, Admins now have the ability to more easily view which reports that a User has and any related detail for the reports, like if the User was Affected, the Offender, the Reporter, or all of the above, allowing Admins to refer back to this data if need be. Additionally, when a report is clicked on, the Admin will be brought to the `/admin/reports/:id`, where they will find the relevant report, giving them more context as to why the report was made in the first place. 

## Related Tickets & Documents
Relates to a private issue and relates to PR #10059 

## QA Instructions, Screenshots, Recordings
**To QA this PR, first ensure that you have seeded your DB so that you have `FeedbackMessage`s (if you don't have any `FeedbackMessage`s seeded, report some content via `/admin/reports`!) and have `super_admin` permissions, then please do the following:**
- Navigate to `/admin/users/:id/edit` in your browser:
<img width="1368" alt="Screen Shot 2020-08-31 at 11 28 29 AM" src="https://user-images.githubusercontent.com/32834804/91748489-4b00bb80-eb7d-11ea-8c37-f211988937c6.png">

- Click the "Toggle" button next to "Recent Reports" to see a list of all of the reports for the particular user:
<img width="1347" alt="Screen Shot 2020-09-03 at 11 05 20 AM" src="https://user-images.githubusercontent.com/32834804/92145394-68c85d80-edd5-11ea-9a0d-c8a13a81a5d4.png">

- The `user_type` should be displayed next to the report, displaying whether the user was the person affected, the offender, the reporter, or all of the above:
<img width="1062" alt="Screen Shot 2020-09-03 at 10 08 53 AM" src="https://user-images.githubusercontent.com/32834804/92140074-e1c3b700-edcd-11ea-88cd-9ea3c617a525.png">

- If the user does not have any reports, this message should be displayed:
<img width="1039" alt="Screen Shot 2020-08-31 at 11 29 10 AM" src="https://user-images.githubusercontent.com/32834804/91748457-3d4b3600-eb7d-11ea-978f-7b4faf483f37.png">

- Click on an individual report to navigate to `/admin/reports/:id`, where the relevant report can be found:
<img width="1334" alt="Screen Shot 2020-09-03 at 10 15 39 AM" src="https://user-images.githubusercontent.com/32834804/92147230-0e7ccc00-edd8-11ea-956b-6a80ea6b49bd.png">

- Try to break things! ⚒️ 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Kitten that wants reports](https://media.giphy.com/media/xUA7aVAw3xQ4pzYkiA/giphy.gif)
