### PR TITLE
Bug Fix:Add send_email_digest Rake Task for DEV

### DIFF
--- a/app/workers/emails/enqueue_digest_worker.rb
+++ b/app/workers/emails/enqueue_digest_worker.rb
@@ -5,6 +5,11 @@ module Emails
     sidekiq_options queue: :medium_priority, retry: 15
 
     def perform
+      # Temporary
+      # @sre:mstruve This is temporary until we have an efficient way to handle this job
+      # for our large DEV community. Smaller Forems should be able to handle it no problem
+      return if SiteConfig.community_name == "DEV"
+
       EmailDigest.send_periodic_digest_email
     end
   end

--- a/lib/tasks/fetch.rake
+++ b/lib/tasks/fetch.rake
@@ -5,3 +5,12 @@ task fetch_all_rss: :environment do
 
   RssReader.get_all_articles(force: false) # don't force fetch. Fetch "random" subset instead of all of them.
 end
+
+# Temporary
+# @sre:mstruve This is temporary until we have an efficient way to handle this task
+# in Sidekiq for our large DEV community.
+task send_email_digest: :environment do
+  if Time.current.wday >= 3
+    EmailDigest.send_periodic_digest_email
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We cannot run our EmailDigest jobs in parallel bc it is too much stress on the database. This adds back in the single file rake task for DEV to use until we can figure out an adequate Sidekiq solution. 


![alt_text](https://media1.giphy.com/media/3oEjHN4MtbSqEe4D8Q/200.gif)
