### PR TITLE
Feature:Add Ability to Run RssReader via Sidekiq Cron, Prevent for DEV

### DIFF
--- a/app/workers/articles/rss_reader_worker.rb
+++ b/app/workers/articles/rss_reader_worker.rb
@@ -1,0 +1,17 @@
+module Articles
+  class RssReaderWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :medium_priority, retry: 10
+
+    def perform
+      # Temporary
+      # @sre:mstruve This is temporary until we have an efficient way to handle this job
+      # for our large DEV community. Smaller Forems should be able to handle it no problem
+      return if SiteConfig.community_name == "DEV"
+
+      # don't force fetch. Fetch "random" subset instead of all of them.
+      RssReader.get_all_articles(force: false)
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,3 +1,6 @@
+fetch_all_rss:
+  cron: "20 * * * *" # every hour, 20 min after the hour
+  class: "Articles::RssReaderWorker"
 log_worker_queue_stats:
   cron: "*/10 * * * *" # every 10 minutes
   class: "Metrics::RecordBackgroundQueueStatsWorker"

--- a/spec/workers/articles/rss_reader_worker_spec.rb
+++ b/spec/workers/articles/rss_reader_worker_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Articles::RssReaderWorker, type: :worker do
+  let(:worker) { subject }
+
+  include_examples "#enqueues_on_correct_queue", "medium_priority"
+
+  describe "#perform" do
+    it "updates RssReader articles" do
+      allow(RssReader).to receive(:get_all_articles)
+      worker.perform
+      expect(RssReader).to have_received(:get_all_articles).with(force: false)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Similar to how we did the EmailDigest job recently (#10065) this allows all other Forems to use Sidekiq to manage and kick off their RssReader imports while keeping DEV on the old rake task. I wanted to get this out bc we currently have a lot of Forems running with no way to import RSS feeds. This will allow them to do it and take the time pressure off SRE to figure out a fix for DEV.

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44508271

## Added tests?
- [x] yes


![alt_text](https://media1.tenor.com/images/f0afe8bc45bd6ba2459834a2fb095155/tenor.gif?itemid=16847063)
