### PR TITLE
Bug Fix:Run Individual Digest Workers inline for DEV

### DIFF
--- a/app/services/email_digest.rb
+++ b/app/services/email_digest.rb
@@ -10,7 +10,14 @@ class EmailDigest
   def send_periodic_digest_email
     @users.select(:id).in_batches do |batch|
       batch.each do |user|
-        Emails::SendUserDigestWorker.perform_async(user.id)
+        # Temporary
+        # @sre:mstruve This is temporary until we have an efficient way to handle this job
+        # for our large DEV community. Smaller Forems should be able to handle it no problem
+        if SiteConfig.community_name == "DEV"
+          Emails::SendUserDigestWorker.new.perform(user.id)
+        else
+          Emails::SendUserDigestWorker.perform_async(user.id)
+        end
       end
     end
   end

--- a/spec/services/email_digest_spec.rb
+++ b/spec/services/email_digest_spec.rb
@@ -1,12 +1,24 @@
 require "rails_helper"
 
-RSpec.describe EmailDigest, type: :labor do
+RSpec.describe EmailDigest, type: :service do
   describe "::send_digest_email" do
     it "enqueues Emails::SendUserDigestWorker" do
       user = create(:user, email_digest_periodic: true)
       allow(Emails::SendUserDigestWorker).to receive(:perform_async)
       described_class.send_periodic_digest_email
       expect(Emails::SendUserDigestWorker).to have_received(:perform_async).with(user.id)
+    end
+
+    it "performs job inline if community is DEV" do
+      allow(SiteConfig).to receive(:community_name).and_return("DEV")
+      user = create(:user, email_digest_periodic: true)
+      worker = Emails::SendUserDigestWorker.new
+      allow(worker).to receive(:perform)
+      allow(Emails::SendUserDigestWorker).to receive(:new).and_return(worker)
+      allow(Emails::SendUserDigestWorker).to receive(:perform_async)
+      described_class.send_periodic_digest_email
+      expect(Emails::SendUserDigestWorker).not_to have_received(:perform_async)
+      expect(worker).to have_received(:perform).with(user.id)
     end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Followup to https://github.com/forem/forem/pull/10065, we need to also ensure the individual workers run inline and are not piling up in Sidekiq since running them in parallel is what is stressing the database.


## Added tests?
- [x] yes


![alt_text](https://media.tenor.com/images/0f253a59cd8e1c1dc481a2ebf1c07a14/tenor.gif)
