### PR TITLE
Fixes unsafe reflection warning in dashboards_controller

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -78,7 +78,7 @@ class DashboardsController < ApplicationController
   def set_source
     source_type = UserSubscription::ALLOWED_TYPES.detect { |allowed_type| allowed_type == params[:source_type] }
 
-    not_found if source_type.nil?
+    not_found unless source_type
 
     source = source_type.constantize.find_by(id: params[:source_id])
     @source = source || not_found

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -76,8 +76,9 @@ class DashboardsController < ApplicationController
   private
 
   def set_source
-    source_type = params[:source_type]
-    not_found unless UserSubscription::ALLOWED_TYPES.include? source_type
+    source_type = UserSubscription::ALLOWED_TYPES.detect { |allowed_type| allowed_type == params[:source_type] }
+
+    not_found if source_type.nil?
 
     source = source_type.constantize.find_by(id: params[:source_id])
     @source = source || not_found


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This one is purely to make CodeClimate/brakeman happy as the code that was already there is equivalent (as the parameter being `constantize`'d was validated before the reflection part kicked in).

I've switch things around and do a lookup on the `UserSubscription::ALLOWED_TYPES` for the subscription `source_type`, which makes brakeman understand that type comes from an allowed list of types (instead the user input).

## Related Tickets & Documents

#3739

## QA Instructions, Screenshots, Recordings

Guarantee that no regression was introduced (the code is indeed equivalent):

1. The `requests/dashboard_spec.rb` covers these scenarios

---

1. Visit: http://localhost:3000/dashboard/subscriptions?source_type=Article&source_id=1
1. See that the page loads the subscriptions of the correct article

---

1. Visit: http://localhost:3000/dashboard/subscriptions?source_type=Comment&source_id=1
1. See that that a 404 page is rendered

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
