### PR TITLE
Fixes brakeman open redirect warnings on PagesController

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -76,7 +76,7 @@ class PagesController < ApplicationController
   def welcome
     daily_thread = Article.admin_published_with("welcome").first
     if daily_thread
-      redirect_to daily_thread.path
+      redirect_to URI.parse(daily_thread.path).path
     else
       # fail safe if we haven't made the first welcome thread
       redirect_to "/notifications"
@@ -86,7 +86,7 @@ class PagesController < ApplicationController
   def challenge
     daily_thread = Article.admin_published_with("challenge").first
     if daily_thread
-      redirect_to daily_thread.path
+      redirect_to URI.parse(daily_thread.path).path
     else
       redirect_to "/notifications"
     end
@@ -101,7 +101,7 @@ class PagesController < ApplicationController
         .first
 
     if daily_thread
-      redirect_to daily_thread.path
+      redirect_to URI.parse(daily_thread.path).path
     else
       redirect_to "/notifications"
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When redirecting to the welcome, challenge and checkin articles, breakman was complaining about a potential open redirect vulnerability due to the fact that the redirect URL comes from a string stored in the database.

This commit silences breakman by explicitly parsing the database article path (via `URI.parse`) and explicitly stating that only the `path` portion of the URI is to be used (== in an unlikely event of an absolute URI pops up from the db record, the user-agent will still be instructed to be redirected to a page under the app's domain).

## Related Tickets & Documents

#3739

## QA Instructions, Screenshots, Recordings

1. Visit the `/welcome`, `/checkin` and `/challenge` routes
1. See that the redirect to the correct articles still stands

---

1. Find out what the welcome, checking and challenge articles are (on a Rails console):

```rb
# welcome
[12] pry(main)> Article.admin_published_with("welcome").first.id

# checkin
[13] pry(main)> Article.published.where(user: User.find_by(username: "codenewbiestaff")).order("articles.published_at" => :desc).first.id

# challenge
[14] pry(main)> Article.admin_published_with("challenge").first.id
```

1. Update the `path` of each article to an absolute URL:

```rb
article.update_column(path: 'https://google.com/x/b/')
```

1. See that visiting the corresponding page redirects to the relative path of the URL (in my example `http://localhost:3000/x/b/`)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
