### PR TITLE
Purge core edge/fragment caches on config update

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -100,7 +100,7 @@ module Admin
       CacheBuster.bust("/shell_top") # Cached at edge, sent to service worker.
       CacheBuster.bust("/shell_bottom") # Cached at edge, sent to service worker.
       CacheBuster.bust("/onboarding") # Page is cached at edge.
-      Rails.cache.delete_matched(ApplicationConfig["RELEASE_FOOTPRINT"]) # Clear relevant fragment caches tied to this key.
+      Rails.cache.delete_matched(ApplicationConfig["RELEASE_FOOTPRINT"]) # Delete all caches tied to this key.
     end
 
     def campaign_params

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -97,6 +97,9 @@ module Admin
 
     def bust_relevant_caches
       CacheBuster.bust("/tags/onboarding") # Needs to change when suggested_tags is edited.
+      CacheBuster.bust("/shell_top") # Cached at edge, sent to service worker.
+      CacheBuster.bust("/shell_bottom") # Cached at edge, sent to service worker.
+      CacheBuster.bust("/onboarding") # Page is cached at edge.
       Rails.cache.delete_matched(ApplicationConfig["RELEASE_FOOTPRINT"]) # Clear relevant fragment caches tied to this key.
     end
 

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -96,8 +96,8 @@ module Admin
     end
 
     def bust_relevant_caches
-      # Needs to change when suggested_tags is edited.
-      CacheBuster.bust("/tags/onboarding")
+      CacheBuster.bust("/tags/onboarding") # Needs to change when suggested_tags is edited.
+      Rails.cache.delete_matched(ApplicationConfig["RELEASE_FOOTPRINT"]) # Clear relevant fragment caches tied to this key.
     end
 
     def campaign_params


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Added a few cache busts which can help ensure the relevant areas of the site change as soon as config is changed. We could get more granular with this in the future, but config won't change very often, so not a big deal to not have that optimization right now.

`delete_matched` is not currently in our codebase, so I hope it works as expected with Redis. This looks for any caches that match `RELEASE_FOOTPRINT` which are the caches we expect might need to change when we push new code. This is a similar scenario of new content like logos, etc.