### PR TITLE
Bug Fix:Destroy GithubRepos with Suspended or Blocked Access

### DIFF
--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -29,6 +29,11 @@ module GithubRepos
         repo.user&.touch(:github_repos_updated_at)
       rescue Github::Errors::NotFound, Github::Errors::Unauthorized
         repo.destroy
+      rescue Github::Errors::ClientError => e
+        msg = e.message
+        raise e unless msg.include?("Your account was suspended") || msg.include?("Repository access blocked")
+
+        repo.destroy
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We have some failing `GithubRepos::RepoSyncWorker` due to the following errors. In the even that a user account is suspended or if they no longer have access to a repo we should destroy the repo. 

Fixes: https://app.honeybadger.io/fault/66984/6cb5b7e34a5b6c538664cfd6135f2c97

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44619717

## Added tests?
- [x] yes


![alt_text](https://31.media.tumblr.com/dacb3e3c5603b3df64e0b741c53f6375/tumblr_mf5v4duZxO1qko2qdo1_500.gif)
