### PR TITLE
Add logic for asking for FOREM_OWNER_SECRET to be present on first user sign up if set by system

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,7 +1,9 @@
-# App domain + Protocol setting for development
+# App core values
 export APP_DOMAIN="localhost:3000"
 export APP_PROTOCOL="http://"
 export APP_NAME="forem_local"
+export FOREM_OWNER_SECRET="secret"
+
 
 # Openresty domain + Protocol setting for development
 export OPENRESTY_DOMAIN=""

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,14 @@ class ApplicationController < ActionController::Base
     error_too_many_requests(exc)
   end
 
-  PUBLIC_CONTROLLERS = %w[shell async_info ga_events service_worker omniauth_callbacks registrations].freeze
+  PUBLIC_CONTROLLERS = %w[shell
+                          async_info
+                          ga_events
+                          service_worker
+                          omniauth_callbacks
+                          registrations
+                          confirmations
+                          passwords].freeze
   private_constant :PUBLIC_CONTROLLERS
 
   def verify_private_forem

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -13,6 +13,8 @@ class RegistrationsController < Devise::RegistrationsController
 
   def create
     not_authorized unless SiteConfig.allow_email_password_registration || SiteConfig.waiting_on_first_user
+    not_authorized if SiteConfig.waiting_on_first_user && ENV["FOREM_OWNER_SECRET"].present? &&
+      ENV["FOREM_OWNER_SECRET"] != params[:user][:forem_owner_secret]
 
     build_resource(sign_up_params)
     resource.saw_onboarding = false

--- a/app/views/shared/authentication/_email_registration_form.html.erb
+++ b/app/views/shared/authentication/_email_registration_form.html.erb
@@ -48,6 +48,12 @@
       <%= f.password_field :password_confirmation, autocomplete: "current-password", class: "crayons-textfield", required: true %>
     </div>
 
+    <% if ENV["FOREM_OWNER_SECRET"].present? && SiteConfig.waiting_on_first_user %>
+      <div class="crayons-field mt-2">
+        <%= f.label :forem_owner_secret, "Few Forem Secret", class: "crayons-field__label" %>
+        <%= f.password_field :forem_owner_secret, autocomplete: "current-password", class: "crayons-textfield", required: true, placeholder: "As provided by your Forem host" %>
+      </div>
+    <% end %>
     <div class="actions pt-3">
       <%= f.submit "Sign up", class: "crayons-btn" %>
     </div>

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "Registrations", type: :request do
         expect(User.first.has_role?(:single_resource_admin, Config)).to be true
       end
 
-      it "does not create user FOREM_OWNER_SECRET scenario if not passed correct value" do
+      it "does not authorize request in FOREM_OWNER_SECRET scenario if not passed correct value" do
         ENV["FOREM_OWNER_SECRET"] = "test"
         expect do
           post "/users", params:
@@ -165,7 +165,7 @@ RSpec.describe "Registrations", type: :request do
                       forem_owner_secret: "not_test",
                       password_confirmation: "PaSSw0rd_yo000" } }
           expect(User.first).to be nil
-        end.not_to raise_error Pundit::NotAuthorizedError
+        end.to raise_error Pundit::NotAuthorizedError
       end
     end
   end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -108,13 +108,15 @@ RSpec.describe "Registrations", type: :request do
     context "when site is in waiting_on_first_user state" do
       before do
         SiteConfig.waiting_on_first_user = true
+        ENV["FOREM_OWNER_SECRET"] = nil
       end
 
       after do
         SiteConfig.waiting_on_first_user = false
+        ENV["FOREM_OWNER_SECRET"] = nil
       end
 
-      it "does not raise disallowed if community is set to allow email" do
+      it "does not raise disallowed" do
         expect { post "/users" }.not_to raise_error Pundit::NotAuthorizedError
       end
 
@@ -137,6 +139,33 @@ RSpec.describe "Registrations", type: :request do
                     password_confirmation: "PaSSw0rd_yo000" } }
         expect(User.first.has_role?(:super_admin)).to be true
         expect(User.first.has_role?(:single_resource_admin, Config)).to be true
+      end
+
+      it "creates super admin with valid params in FOREM_OWNER_SECRET scenario" do
+        ENV["FOREM_OWNER_SECRET"] = "test"
+        post "/users", params:
+          { user: { name: "test #{rand(10)}",
+                    username: "haha_#{rand(10)}",
+                    email: "yoooo#{rand(100)}@yo.co",
+                    password: "PaSSw0rd_yo000",
+                    forem_owner_secret: "test",
+                    password_confirmation: "PaSSw0rd_yo000" } }
+        expect(User.first.has_role?(:super_admin)).to be true
+        expect(User.first.has_role?(:single_resource_admin, Config)).to be true
+      end
+
+      it "does not create user FOREM_OWNER_SECRET scenario if not passed correct value" do
+        ENV["FOREM_OWNER_SECRET"] = "test"
+        expect do
+          post "/users", params:
+            { user: { name: "test #{rand(10)}",
+                      username: "haha_#{rand(10)}",
+                      email: "yoooo#{rand(100)}@yo.co",
+                      password: "PaSSw0rd_yo000",
+                      forem_owner_secret: "not_test",
+                      password_confirmation: "PaSSw0rd_yo000" } }
+          expect(User.first).to be nil
+        end.not_to raise_error Pundit::NotAuthorizedError
       end
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds an extra field to require brand new forems to pass in a value generated by systems stack to ensure a publicly generated forem can't be coopted if someone has the URL.

<img width="642" alt="Screen Shot 2020-08-31 at 1 31 24 PM" src="https://user-images.githubusercontent.com/3102842/91748666-55778100-eb8e-11ea-96c1-3c062a2afe46.png">
