### PR TITLE
Updates "Recent Reactions" UI to Match Admin UI Changes

### DIFF
--- a/app/views/admin/users/_negative_reactions.html.erb
+++ b/app/views/admin/users/_negative_reactions.html.erb
@@ -1,10 +1,9 @@
-<div class="row my-3">
-  <div class="col-12">
+<div class="crayons-card p-6">
+  <div>
     <h2 class="d-inline">Recent Reactions</h2>
     <button type="button" data-toggle="collapse" data-target="#reactions-row" class="btn btn-secondary float-right">Toggle</button>
   </div>
-  <div class="col-12 collapse" id="reactions-row">
-    <div class="list-group-flush">
+  <div class="pt-6 collapse" id="reactions-row">
     <% unless @related_vomit_reactions.empty? %>
       <% @related_vomit_reactions.each do |reaction| %>
         <a href="<%= reaction.reactable.path %>" class="list-group-item list-group-item-action px-5 d-flex justify-content-between">
@@ -16,6 +15,5 @@
       <% else %>
       <p><em>Nothing negative to see here! 👀</em></p>
     <% end %>
-    </div>
   </div>
 </div>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Today, @ludwiczakpawel shipped some Admin UI changes that affect `/admin/users/:id/edit`. I also shipped some changes to `/admin/users/:id/edit` around the same time, so the UI changes that were made did not apply to my work. This PR applies the UI changes to the "Recent Reactions" section and updates it to use the Crayons styling to keep things consistent.

## Related Tickets & Documents
Relates to PR #10059 and to PR #10015 

## QA Instructions, Screenshots, Recordings
- To QA this PR, first make sure that you have `super_admin` privileges and then navigate to `/admin/users/:id/edit`:
<img width="1352" alt="Screen Shot 2020-08-31 at 11 46 01 AM" src="https://user-images.githubusercontent.com/32834804/91750077-b5b2f680-eb7f-11ea-97d7-36772b62387d.png">

- Finally, ensure that the updated "Recent Reactions" UI matches the rest of the page's UI, specifically the "Remove Identity" and "Destructive Actions" toggle styling:
<img width="1027" alt="Screen Shot 2020-08-31 at 11 46 15 AM" src="https://user-images.githubusercontent.com/32834804/91750084-b9467d80-eb7f-11ea-9da5-42f892cf6d29.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Waving crayons](https://media.giphy.com/media/Xc9T2HUmmmxDfPATae/giphy.gif)
