### PR TITLE
Refactor Email Digest Scopes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -295,8 +295,9 @@ class User < ApplicationRecord
 
   def followed_articles
     Article.tagged_with(cached_followed_tag_names, any: true)
-      .union(Article.where(user_id: cached_following_users_ids))
-      .where(language: preferred_languages_array, published: true)
+      .where(user_id: cached_following_users_ids)
+      .where(language: preferred_languages_array)
+      .published
   end
 
   def cached_following_users_ids

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -13,8 +13,7 @@ class EmailDigestArticleCollector
 
                  @user.followed_articles
                    .where("published_at > ?", cutoff_date)
-                   .where(published: true, email_digest_eligible: true)
-                   .where.not(user_id: @user.id)
+                   .where(email_digest_eligible: true)
                    .where("score > ?", 12)
                    .where("experience_level_rating > ? AND experience_level_rating < ?",
                           experience_level_rating_min, experience_level_rating_max)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
- Replaced the `union` statement with a simple `where` clause for followed_articles. 
- Removed redundant `published: true` and replaced with scope.
- Remove `.not` for user_id since a user cannot follow themselves and we are already filtering by followed users there should be no chance of a user getting their own article.

## Added tests?
- [x] no, because they aren't needed



![alt_text](gif_link)
