### PR TITLE
Bug Fix:Monkey Patch Sitemap Generator in lib not Config

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,46 +1,4 @@
-# TEMPORARY
-# Until https://github.com/kjvarga/sitemap_generator/pull/359 is merged
-# We have to monkey patch the S3Adapter to allow for the fog_public option to be set
-module SitemapGenerator
-  # https://github.com/kjvarga/sitemap_generator/blob/master/lib/sitemap_generator/adapters/s3_adapter.rb
-  class S3Adapter
-    def initialize(opts = {}) # rubocop:disable Style/OptionHash
-      @aws_access_key_id = opts[:aws_access_key_id] || ENV["AWS_ACCESS_KEY_ID"]
-      @aws_secret_access_key = opts[:aws_secret_access_key] || ENV["AWS_SECRET_ACCESS_KEY"]
-      @fog_provider = opts[:fog_provider] || ENV["FOG_PROVIDER"]
-      @fog_directory = opts[:fog_directory] || ENV["FOG_DIRECTORY"]
-      @fog_region = opts[:fog_region] || ENV["FOG_REGION"]
-      @fog_path_style = opts[:fog_path_style] || ENV["FOG_PATH_STYLE"]
-      @fog_storage_options = opts[:fog_storage_options] || {}
-      @fog_public = opts[:fog_public].to_s.present? ? opts[:fog_public] : true # additional line
-    end
-
-    # Call with a SitemapLocation and string data
-    def write(location, raw_data)
-      SitemapGenerator::FileAdapter.new.write(location, raw_data)
-
-      credentials = { provider: @fog_provider }
-
-      if @aws_access_key_id && @aws_secret_access_key
-        credentials[:aws_access_key_id] = @aws_access_key_id
-        credentials[:aws_secret_access_key] = @aws_secret_access_key
-      else
-        credentials[:use_iam_profile] = true
-      end
-
-      credentials[:region] = @fog_region if @fog_region
-      credentials[:path_style] = @fog_path_style if @fog_path_style
-
-      storage   = Fog::Storage.new(@fog_storage_options.merge(credentials))
-      directory = storage.directories.new(key: @fog_directory)
-      directory.files.create(
-        key: location.path_in_public,
-        body: File.open(location.path),
-        public: @fog_public, # additional line
-      )
-    end
-  end
-end
+require "sitemap_generator/s3_adapter"
 
 if Rails.env.production?
   region = ApplicationConfig["AWS_UPLOAD_REGION"].presence || ApplicationConfig["AWS_DEFAULT_REGION"]

--- a/lib/sitemap_generator/s3_adapter.rb
+++ b/lib/sitemap_generator/s3_adapter.rb
@@ -1,0 +1,43 @@
+# TEMPORARY
+# Until https://github.com/kjvarga/sitemap_generator/pull/359 is merged
+# We have to monkey patch the S3Adapter to allow for the fog_public option to be set
+module SitemapGenerator
+  # https://github.com/kjvarga/sitemap_generator/blob/master/lib/sitemap_generator/adapters/s3_adapter.rb
+  class S3Adapter
+    def initialize(opts = {}) # rubocop:disable Style/OptionHash
+      @aws_access_key_id = opts[:aws_access_key_id] || ENV["AWS_ACCESS_KEY_ID"]
+      @aws_secret_access_key = opts[:aws_secret_access_key] || ENV["AWS_SECRET_ACCESS_KEY"]
+      @fog_provider = opts[:fog_provider] || ENV["FOG_PROVIDER"]
+      @fog_directory = opts[:fog_directory] || ENV["FOG_DIRECTORY"]
+      @fog_region = opts[:fog_region] || ENV["FOG_REGION"]
+      @fog_path_style = opts[:fog_path_style] || ENV["FOG_PATH_STYLE"]
+      @fog_storage_options = opts[:fog_storage_options] || {}
+      @fog_public = opts[:fog_public].to_s.present? ? opts[:fog_public] : true # additional line
+    end
+
+    # Call with a SitemapLocation and string data
+    def write(location, raw_data)
+      SitemapGenerator::FileAdapter.new.write(location, raw_data)
+
+      credentials = { provider: @fog_provider }
+
+      if @aws_access_key_id && @aws_secret_access_key
+        credentials[:aws_access_key_id] = @aws_access_key_id
+        credentials[:aws_secret_access_key] = @aws_secret_access_key
+      else
+        credentials[:use_iam_profile] = true
+      end
+
+      credentials[:region] = @fog_region if @fog_region
+      credentials[:path_style] = @fog_path_style if @fog_path_style
+
+      storage   = Fog::Storage.new(@fog_storage_options.merge(credentials))
+      directory = storage.directories.new(key: @fog_directory)
+      directory.files.create(
+        key: location.path_in_public,
+        body: File.open(location.path),
+        public: @fog_public, # additional line
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Turns out this [config file is explicitly and evaluated when running a sitemap refresh](https://github.com/kjvarga/sitemap_generator/blob/master/lib/sitemap_generator/interpreter.rb#L78). The problem with this is then when we try to initialize the monkey patched class, we end up with this error
```
Traceback (most recent call last):
        3: from (irb):34
        2: from (irb):35:in `rescue in irb_binding'
        1: from config/sitemap.rb:67:in `run'
NameError (uninitialized constant #<Class:0x00007f251b188e08>::SitemapGenerator::Sitemap)
```
This PR moves the monkey patched code out of the config to fix this problem. I was able to uncomment out the `Rails.env.production?` statement and recreate the error locally. I was then able to move the code into the lib directory, fire up a new console and validate that the new setup ran without error AND it correctly included the monkey patched class
```ruby
[1] pry(#<SitemapGenerator::Interpreter>)> SitemapGenerator::Sitemap.adapter
=> #<SitemapGenerator::S3Adapter:0x00007fecd7228320
 @aws_access_key_id=nil,
 @aws_secret_access_key=nil,
 @fog_directory="Optional",
 @fog_path_style=nil,
 @fog_provider="AWS",
 @fog_public=false,
 @fog_region="us-east-2",
```
The presence of `@fog_public=false` is the key here.

![alt_text](https://media.tenor.com/images/04ad1e7d566d90030ffb764997ee3216/tenor.gif)
