### PR TITLE
Add cache-control to CarrierWave when using S3

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -35,6 +35,7 @@ CarrierWave.configure do |config|
         aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
         region: region
       }
+      config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" }
     else
       # Fallback on file storage if AWS creds are not present
       config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/images"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
We don't have any cache-control configuration in place for uploaded images to S3. We need to have it in place or else nginx won't cache image from s3.

## Related Tickets & Documents
https://github.com/carrierwaveuploader/carrierwave#using-amazon-s3

## QA Instructions, Screenshots, Recordings
QA on production!

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a, but ideally at somepoint we update all the images on our s3 to have a cache-control
