### PR TITLE
Add multiple /entry page options

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,7 +68,7 @@ class ApplicationController < ActionController::Base
     end
 
     respond_to do |format|
-      format.html { redirect_to "/enter" }
+      format.html { redirect_to sign_up_path }
       format.json { render json: { error: "Please sign in" }, status: :unauthorized }
     end
   end

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -20,10 +20,10 @@
               <% end %>
             </p>
             <div class="authentication-widget__actions">
-              <a href="/enter" class="crayons-btn" aria-label="Create new account">
+              <a href="<%= sign_up_path(state: "new-user") %>" class="crayons-btn" aria-label="Create new account">
                 Create new account
               </a>
-              <a href="/enter" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">
+              <a href="<%= sign_up_path %>" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">
                 Log in
               </a>
             </div>

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -9,7 +9,7 @@
     </a>
   <% end %>
   <% unless user_signed_in? %>
-    <a href="/enter" class="crayons-link crayons-link--block fw-bold">
+    <a href="<%= sign_up_path %>" class="crayons-link crayons-link--block fw-bold">
       <%= inline_svg_tag("twemoji/handshake.svg", aria: true, class: "crayons-icon crayons-icon--default", title: "Sign In/Up") %>
       Sign In/Up
     </a>

--- a/app/views/articles/tag_index.html.erb
+++ b/app/views/articles/tag_index.html.erb
@@ -68,7 +68,7 @@
           </div>
         <% else %>
           <div class="flex-1 flex items-center justify-between">
-            <div class="crayons-notice w-100">👋 <a href="/enter">Sign in</a> for the ability sort posts by <strong>top</strong> and  <strong>latest</strong>.</div>
+            <div class="crayons-notice w-100">👋 <a href="<%= sign_up_path %>">Sign in</a> for the ability sort posts by <strong>top</strong> and  <strong>latest</strong>.</div>
           </div>
         <% end %>
 

--- a/app/views/devise/registrations/_registration_form.html.erb
+++ b/app/views/devise/registrations/_registration_form.html.erb
@@ -14,42 +14,50 @@
     <div class="registration__actions">
       <%= render partial: "shared/authentication/providers_registration_form" %>
 
-      <div class="registration__actions-email" id="sign-in-password-form">
-        <%# if there are no SSO auths enabled, we don't ask the user if they have a password %>
-        <% if authentication_enabled_providers.any? %>
-          <div class="registration__hr">
-            <span class="registration__hr-label">
-              Have a password? Continue with your email address
-            </span>
-          </div>
-        <% end %>
+      <% if params[:state] == "new-user" %>
+        <div class="registration__hr">
+          <span class="registration__hr-label">
+            Already have an account? <a href="<%= sign_up_path %>">View more sign in options</a>.
+          </span>
+        </div>
+      <% else %>
+        <div class="registration__actions-email" id="sign-in-password-form">
+          <%# if there are no SSO auths enabled, we don't ask the user if they have a password %>
+          <% if authentication_enabled_providers.any? %>
+            <div class="registration__hr">
+              <span class="registration__hr-label">
+                Have a password? Continue with your email address
+              </span>
+            </div>
+          <% end %>
 
-        <%= form_for(User.new, as: :user, url: session_path(:user)) do |f| %>
-          <div class="crayons-field mb-3">
-            <%= f.label :email, class: "crayons-field__label" %>
-            <%= f.email_field :email, autocomplete: "email", class: "crayons-textfield" %>
-          </div>
+          <%= form_for(User.new, as: :user, url: session_path(:user)) do |f| %>
+            <div class="crayons-field mb-3">
+              <%= f.label :email, class: "crayons-field__label" %>
+              <%= f.email_field :email, autocomplete: "email", class: "crayons-textfield" %>
+            </div>
 
-          <div class="crayons-field mb-3">
-            <%= f.label :password, class: "crayons-field__label" %>
-            <%= f.password_field :password, autocomplete: "current-password", class: "crayons-textfield" %>
-          </div>
+            <div class="crayons-field mb-3">
+              <%= f.label :password, class: "crayons-field__label" %>
+              <%= f.password_field :password, autocomplete: "current-password", class: "crayons-textfield" %>
+            </div>
 
-          <div class="crayons-field crayons-field--checkbox inline-flex flex-row items-center">
-            <%= f.check_box :remember_me, class: "crayons-checkbox" %>
-            <%= f.label :remember_me, class: "crayons-field__label fw-normal" %>
-          </div>
+            <div class="crayons-field crayons-field--checkbox inline-flex flex-row items-center">
+              <%= f.check_box :remember_me, class: "crayons-checkbox" %>
+              <%= f.label :remember_me, class: "crayons-field__label fw-normal" %>
+            </div>
 
-          <div class="actions pt-3">
-            <%= f.submit "Continue", class: "crayons-btn crayons-btn--l w-100" %>
-          </div>
-        <% end %>
-        <p class="pt-6 fs-s align-center">
-          <a href="<%= new_password_path(:user) %>">
-            I forgot my password
-          </a>
-        </p>
-      </div>
+            <div class="actions pt-3">
+              <%= f.submit "Continue", class: "crayons-btn crayons-btn--l w-100" %>
+            </div>
+          <% end %>
+          <p class="pt-6 fs-s align-center">
+            <a href="<%= new_password_path(:user) %>">
+              I forgot my password
+            </a>
+          </p>
+        </div>
+      <% end %>
     </div>
   </div>
   <footer class="registration__footer">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,5 @@
+<% title "Welcome!" %>
+
 <% if params[:state] == "beta_email_signup" && SiteConfig.allow_email_password_registration %>
   <%= render "shared/authentication/email_registration_form" %>
 <% elsif params[:state] == "beta_email_signup" %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -21,7 +21,7 @@
         <a href="<%= videos_path %>" class="crayons-link crayons-link--block">Videos</a>
         <a href="<%= tags_path %>" class="crayons-link crayons-link--block">Tags</a>
         <% unless user_signed_in? %>
-          <a href="/enter" class="crayons-link crayons-link--block fw-bold">
+          <a href="<%= sign_up_path %>" class="crayons-link crayons-link--block fw-bold">
             Sign In/Up
           </a>
         <% else %>

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -38,10 +38,10 @@
           <% end %>
         </p>
         <div class="authentication-header__actions">
-          <a href="/enter" class="crayons-btn" aria-label="Create new account">
+          <a href="<%= sign_up_path(state: "new-user") %>" class="crayons-btn" aria-label="Create new account">
             Create new account
           </a>
-          <a href="/enter" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">
+          <a href="<%= sign_up_path %>" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">
             Log in
           </a>
         </div>

--- a/app/views/layouts/_signup_modal.html.erb
+++ b/app/views/layouts/_signup_modal.html.erb
@@ -26,10 +26,10 @@
       </div>
 
       <div class="authentication-modal__actions">
-        <a href="/enter" class="crayons-btn" aria-label="Log in" data-no-instant>
+        <a href="<%= sign_up_path %>" class="crayons-btn" aria-label="Log in" data-no-instant>
           Log in
         </a>
-        <a href="/enter" class="crayons-btn crayons-btn--ghost-brand" aria-label="Create new account" data-no-instant>
+        <a href="<%= sign_up_path(state: "new-user") %>" class="crayons-btn crayons-btn--ghost-brand" aria-label="Create new account" data-no-instant>
           Create new account
         </a>
       </div>

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -41,11 +41,11 @@
           <span class="crayons-indicator crayons-indicator--critical hidden" id="notifications-number"></span>
         </a>
       <% else %>
-        <a href="/enter" class="crayons-btn crayons-btn--ghost-brand hidden mr-2 whitespace-nowrap s:block" data-no-instant>
+        <a href="<%= sign_up_path %>" class="crayons-btn crayons-btn--ghost-brand hidden mr-2 whitespace-nowrap s:block" data-no-instant>
           Log in
         </a>
 
-        <a href="/enter" class="crayons-btn hidden mr-2 whitespace-nowrap s:block" data-no-instant>
+        <a href="<%= sign_up_path(state:"new-user") %>" class="crayons-btn hidden mr-2 whitespace-nowrap s:block" data-no-instant>
           Create account
         </a>
       <% end %>

--- a/app/views/pages/badges.html.erb
+++ b/app/views/pages/badges.html.erb
@@ -73,7 +73,7 @@
         <img src="https://d2fltix0v2e0sb.cloudfront.net/dev-badge.svg" height="30" width="30" alt="<%= community_name %> badge" class="dev-badge">
       </p>
       <h2 style="text-align:center;">
-        <a href="/enter">Log in to view your custom embed code</a>
+        <a href="<%= sign_up_path %>">Log in to view your custom embed code</a>
       </h2>
       <br /><br />
     <% end %>

--- a/app/views/partnerships/show.html.erb
+++ b/app/views/partnerships/show.html.erb
@@ -27,7 +27,7 @@
     <%= render "form", level: params[:option].split("-")[0], organizations: @organizations %>
   <% else %>
     <div class="partner-credits-explainer">
-      <a href="/enter">Sign in to get started</a>
+      <a href="<%= sign_up_path %>">Sign in to get started</a>
     </div>
   <% end %>
 </div>

--- a/app/views/shared/authentication/_providers_sidebar.html.erb
+++ b/app/views/shared/authentication/_providers_sidebar.html.erb
@@ -8,7 +8,7 @@
   </a>
 <% end %>
   <a
-    href="/enter"
+    href="<%= sign_up_path %>"
     class="crayons-btn crayons-btn--secondary crayons-btn--l">
     More Sign In Options
   </a>

--- a/app/views/shared/authentication/_providers_signup_modal.html.erb
+++ b/app/views/shared/authentication/_providers_signup_modal.html.erb
@@ -7,6 +7,6 @@
     Sign In with <%= provider.official_name %>
   </a>
 <% end %>
-<a href="/enter"
+<a href="<%= sign_up_path %>"
   class="crayons-btn crayons-btn--secondary crayons-btn--xl m-1"
   data-no-instant>More Sign In Options</a>

--- a/app/views/stories/_sign_in_invitation.html.erb
+++ b/app/views/stories/_sign_in_invitation.html.erb
@@ -20,10 +20,10 @@
   </div>
 
   <div class="authentication-feed__actions">
-    <a href="/enter" class="crayons-btn" aria-label="Create new account">
+    <a href="<%= sign_up_path %>" class="crayons-btn" aria-label="Create new account">
       Create new account
     </a>
-    <a href="/enter" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">
+    <a href="<%= sign_up_path %>" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">
       Log in
     </a>
   </div>


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Now that we have multiple paths, here's a scenario where we have different paths for sign in vs sign up...

This creates two different states for more distinct options... Also moved all the non-path-helpers for `/enter` and moved them to the Railsier way.

<img width="658" alt="Screen Shot 2020-08-31 at 6 32 24 PM" src="https://user-images.githubusercontent.com/3102842/91775133-532a1c80-ebb8-11ea-81e2-3576d3046109.png">
<img width="665" alt="Screen Shot 2020-08-31 at 6 33 05 PM" src="https://user-images.githubusercontent.com/3102842/91775169-6b9a3700-ebb8-11ea-8ef3-2d89fce08d09.png">
