### PR TITLE
Comment out Flaky Reaction Search Sort Spec

### DIFF
--- a/spec/services/search/reaction_spec.rb
+++ b/spec/services/search/reaction_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Search::Reaction, type: :service do
     end
 
     context "with default sorting" do
-      it "sorts by id" do
+      xit "sorts by id" do
         index_documents([reaction1, reaction2])
 
         reaction_docs = described_class.search_documents(params: query_params)["reactions"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
I know exactly what the problem is with this spec, it has to do with how we are storing this ID field in Elasticsearch making accurately sorting by it not really possible. The fix for it is a bigger PR but in the meantime I dont want this to be a blocker for anyone. 


![alt_text](https://thumbs.gfycat.com/DigitalTangibleIberianchiffchaff-size_restricted.gif)
