### PR TITLE
Add data update script for profile fields

### DIFF
--- a/app/services/profile_fields/import_from_csv.rb
+++ b/app/services/profile_fields/import_from_csv.rb
@@ -7,7 +7,7 @@ module ProfileFields
         row = row.to_h
         group = row.delete(:group)
         row[:profile_field_group] = ProfileFieldGroup.find_or_create_by(name: group)
-        ProfileField.create(row)
+        ProfileField.find_or_create_by(row)
       end
     end
   end

--- a/lib/data_update_scripts/20200901040521_create_profile_fields.rb
+++ b/lib/data_update_scripts/20200901040521_create_profile_fields.rb
@@ -1,0 +1,10 @@
+module DataUpdateScripts
+  class CreateProfileFields
+    def run
+      # NOTE: the CSV importer uses find_or_create_by for both fields and
+      # groups, so this operation is idempotent.
+      csv = Rails.root.join("lib/data/dev_profile_fields.csv")
+      ProfileFields::ImportFromCsv.call(csv)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/create_profile_fields_spec.rb
+++ b/spec/lib/data_update_scripts/create_profile_fields_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+require Rails.root.join("lib/data_update_scripts/20200901040521_create_profile_fields.rb")
+
+def profile_field_and_group_count
+  [ProfileField.count, ProfileFieldGroup.count]
+end
+
+describe DataUpdateScripts::CreateProfileFields do
+  context "when no profile fields or groups exist" do
+    it "creates all profile fields and groups" do
+      expect do
+        described_class.new.run
+      end.to change { profile_field_and_group_count }.from([0, 0]).to([29, 5])
+    end
+  end
+
+  context "when profile fields and/or groups already exist" do
+    before do
+      csv = Rails.root.join("lib/data/dev_profile_fields.csv")
+      ProfileFields::ImportFromCsv.call(csv)
+    end
+
+    after do
+      ProfileFieldGroup.destroy_all
+      ProfileField.destroy_all
+    end
+
+    it "works when profile fields or groups already exist", :aggregate_failures do
+      expect do
+        described_class.new.run
+      end.not_to change { profile_field_and_group_count }
+      expect(profile_field_and_group_count).to eq [29, 5]
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we added profile fields to DEV in https://github.com/forem/forem/pull/9724 we should also have added them for all other existing communities via a data update script, as they have to go through the same migration process. Alas, that slipped through the cracks in the original PR. This wasn't much of a problem so far, as the sync/backfilling code relied on a hardcoded field list. This will change when merging #9912, so we need to ensure all existing communities have the necessary profile fields in place.

A data update script seems like the best way to ensure all current communities get the fields. Once we are completely done with this migration we can turn the script into a no-op by commenting out the `run` method, as previously discussed with Molly [here](https://github.com/forem/forem/pull/10007#discussion_r477129462).

## Related Tickets & Documents

Part of #6994

## QA Instructions, Screenshots, Recordings

* Delete all profile fields and groups in a Rails console:
    ```ruby
    ProfileFieldGroup.destroy_all
    ProfileField.destroy_all
    ```
* Run `rails data_updates:run` in the terminal
*  Ensure you have 29 fields and 5 group
    ```ruby
    ProfileField.count
    ProfileFieldGroup.count
    ```
* Delete the `DataUpdateScript` entry so you can run it again:
    ```ruby
    DataUpdateScript.find_by(file_name: "20200901040521_create_profile_fields").destroy
    ```
* Run `rails data_updates:run` again and make sure it finishes without errors and that you still have 29 fields and 5 groups.

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
