### PR TITLE
Add ProfileFieldGroupsController to API

### DIFF
--- a/app/controllers/profile_field_groups_controller.rb
+++ b/app/controllers/profile_field_groups_controller.rb
@@ -1,0 +1,12 @@
+class ProfileFieldGroupsController < ApplicationController
+  def index
+    relation = ProfileFieldGroup.includes(:profile_fields)
+    @profile_field_groups = onboarding? ? relation.onboarding : relation.all
+  end
+
+  private
+
+  def onboarding?
+    params[:onboarding] == "true"
+  end
+end

--- a/app/models/profile_field_group.rb
+++ b/app/models/profile_field_group.rb
@@ -2,4 +2,8 @@ class ProfileFieldGroup < ApplicationRecord
   has_many :profile_fields, dependent: :nullify
 
   validates :name, presence: true, uniqueness: true
+
+  scope :onboarding, lambda {
+    includes(:profile_fields).where(profile_fields: { show_in_onboarding: true })
+  }
 end

--- a/app/views/profile_field_groups/index.json.jbuilder
+++ b/app/views/profile_field_groups/index.json.jbuilder
@@ -1,0 +1,21 @@
+json.profile_field_groups do
+  json.array!(@profile_field_groups) do |profile_field_group|
+    json.extract!(
+      profile_field_group,
+      :id,
+      :name,
+      :description,
+    )
+    json.profile_fields(profile_field_group.profile_fields) do |profile_field|
+      json.extract!(
+        profile_field,
+        :id,
+        :attribute_name,
+        :description,
+        :input_type,
+        :label,
+        :placeholder_text,
+      )
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -271,6 +271,7 @@ Rails.application.routes.draw do
   end
 
   resource :onboarding, only: :show
+  resources :profile_field_groups, only: %i[index], defaults: { format: :json } 
 
   get "/verify_email_ownership", to: "email_authorizations#verify", as: :verify_email_authorizations
   get "/search/tags" => "search#tags"

--- a/spec/factories/profile_fields.rb
+++ b/spec/factories/profile_fields.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     input_type { :text_field }
     description { "some description" }
     placeholder_text { "john.doe@example.com" }
+    show_in_onboarding { false }
 
     trait :onboarding do
       show_in_onboarding { true }

--- a/spec/models/profile_field_group_spec.rb
+++ b/spec/models/profile_field_group_spec.rb
@@ -1,9 +1,22 @@
 require "rails_helper"
 
 RSpec.describe ProfileFieldGroup, type: :model do
-  subject { create(:profile_field_group) }
+  let!(:group) { create(:profile_field_group) }
+  subject { group }
 
   it { is_expected.to have_many(:profile_fields).dependent(:nullify) }
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
+
+  describe ".onboarding" do
+    let!(:other_group) { create(:profile_field_group) }
+    let!(:profile_field1) { create(:profile_field, :onboarding, profile_field_group: group) }
+    let!(:profile_field2) { create(:profile_field, profile_field_group: other_group) }
+
+    it "only returns groups that have fields for onboarding" do
+      groups = described_class.onboarding
+      expect(groups).to include(group)
+      expect(groups).not_to include(other_group)
+    end
+  end
 end

--- a/spec/requests/profile_field_groups_request_spec.rb
+++ b/spec/requests/profile_field_groups_request_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "ProfileFieldGroups", type: :request do
+  describe "GET /api/profile_field_groups" do
+
+    before { sign_in(create(:user)) }
+
+    let!(:group1) { create(:profile_field_group) }
+    let!(:group2) { create(:profile_field_group) }
+    let!(:field1) { create(:profile_field, :onboarding, label: "Field 1", profile_field_group: group1) }
+    let!(:field2) { create(:profile_field, label: "Field 2", profile_field_group: group1) }
+    let!(:field3) { create(:profile_field, label: "Field 3", profile_field_group: group2) }
+
+    it "returns a successful response" do
+      get profile_field_groups_path
+      expect(response.status).to eq 200
+    end
+
+    it "returns all groups with all fields by default" do
+      get profile_field_groups_path
+      json_response = JSON.parse(response.body, symbolize_names: true)
+      expect(json_response[:profile_field_groups].size).to eq 2
+    end
+
+    it "returns only groups with onboarding fields when onboarding=true" do
+      get profile_field_groups_path, params: { onboarding: true }
+      json_response = JSON.parse(response.body, symbolize_names: true)
+      expect(json_response[:profile_field_groups].size).to eq 1
+    end
+
+    it "only returns the onboarding fields in the group", :aggregate_failures do
+      get profile_field_groups_path, params: { onboarding: true }
+      json_response = JSON.parse(response.body, symbolize_names: true)
+      group = json_response[:profile_field_groups].first
+      expect(group[:profile_fields].size).to eq 1
+      expect(group[:profile_fields].first[:id]).to eq field1.id
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds a controller for profile field groups to be used during onboarding. To make the controller more versatile (i.e. for re-use on the new profile page) the filtering is optional (controlled via `?onboarding=true`.

## Related Tickets & Documents

Part of #6994 

## QA Instructions, Screenshots, Recordings

1. Make sure you have some profile fields where `show_in_onboarding` is set to `true`.
2. Make a request and ensure you that you get a response, e.g.
    ```
    # http --print=b :3000/profile_field_groups
    {
        "profile_field_groups": [
            {
                "description": null,
                "id": 11,
                "name": "Basic",
                "profile_fields": [
                [snipped]
    }
    ```
3. Make a request for only retrieving onboarding fields. This should return only a subset of the previous request (unless all your fields are marked as onboarding fields):
    ```
    $ http --print=b :3000/profile_field_groups onboarding==true
    {
        "profile_field_groups": [
            {
                "description": null,
                "id": 15,
                "name": "Branding",
                "profile_fields": [
                [snipped]
    }
    ```
    _Note: `onboarding==true` is httpie's way of specifying query strings without worrying about shell escapes, use what's appropriate for your tool, e.g. `'http://localhost:3000/profile_field_group?onboarding=true'`_

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
