### PR TITLE
Add unique index on articles slug user_id

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -49,30 +49,29 @@ class Article < ApplicationRecord
            inverse_of: :commentable,
            class_name: "Comment"
 
-  validates :slug, presence: { if: :published? }, format: /\A[0-9a-z\-_]*\z/,
-                   uniqueness: { scope: :user_id }
-  validates :title, presence: true,
-                    length: { maximum: 128 }
-  validates :user_id, presence: true
-  validates :feed_source_url, uniqueness: { allow_blank: true }
-  validates :canonical_url,
-            url: { allow_blank: true, no_local: true, schemes: %w[https http] },
-            uniqueness: { allow_blank: true }
   validates :body_markdown, length: { minimum: 0, allow_nil: false }, uniqueness: { scope: %i[user_id title] }
-  validate :validate_tag
-  validate :validate_video
-  validate :validate_collection_permission
-  validate :past_or_present_date
-  validate :canonical_url_must_not_have_spaces
-  validates :video_state, inclusion: { in: %w[PROGRESSING COMPLETED] }, allow_nil: true
   validates :cached_tag_list, length: { maximum: 126 }
+  validates :canonical_url, url: { allow_blank: true, no_local: true,
+                                   schemes: %w[https http] }, uniqueness: { allow_blank: true }
+  validates :feed_source_url, uniqueness: { allow_blank: true }
   validates :main_image, url: { allow_blank: true, schemes: %w[https http] }
   validates :main_image_background_hex_color, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/
+  validates :slug, presence: { if: :published? }, format: /\A[0-9a-z\-_]*\z/
+  validates :slug, uniqueness: { scope: :user_id }
+  validates :title, presence: true, length: { maximum: 128 }
+  validates :user_id, presence: true
   validates :video, url: { allow_blank: true, schemes: %w[https http] }
-  validates :video_source_url, url: { allow_blank: true, schemes: ["https"] }
-  validates :video_thumbnail_url, url: { allow_blank: true, schemes: %w[https http] }
   validates :video_closed_caption_track_url, url: { allow_blank: true, schemes: ["https"] }
   validates :video_source_url, url: { allow_blank: true, schemes: ["https"] }
+  validates :video_source_url, url: { allow_blank: true, schemes: ["https"] }
+  validates :video_state, inclusion: { in: %w[PROGRESSING COMPLETED] }, allow_nil: true
+  validates :video_thumbnail_url, url: { allow_blank: true, schemes: %w[https http] }
+
+  validate :canonical_url_must_not_have_spaces
+  validate :past_or_present_date
+  validate :validate_collection_permission
+  validate :validate_tag
+  validate :validate_video
 
   before_validation :evaluate_markdown, :create_slug
   before_save :update_cached_user

--- a/db/migrate/20200901084210_add_unique_index_to_articles_slug_user_id.rb
+++ b/db/migrate/20200901084210_add_unique_index_to_articles_slug_user_id.rb
@@ -1,0 +1,15 @@
+class AddUniqueIndexToArticlesSlugUserId < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    unless index_exists?(:articles, %i[slug user_id], unique: true)
+      add_index :articles, %i[slug user_id], unique: true, algorithm: :concurrently
+    end
+  end
+
+  def down
+    if index_exists?(:articles, %i[slug user_id], unique: true)
+      remove_index :articles, column: %i[slug user_id], algorithm: :concurrently
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_28_045600) do
+ActiveRecord::Schema.define(version: 2020_09_01_084210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -161,6 +161,7 @@ ActiveRecord::Schema.define(version: 2020_08_28_045600) do
     t.index ["public_reactions_count"], name: "index_articles_on_public_reactions_count", order: :desc
     t.index ["published"], name: "index_articles_on_published"
     t.index ["published_at"], name: "index_articles_on_published_at"
+    t.index ["slug", "user_id"], name: "index_articles_on_slug_and_user_id", unique: true
     t.index ["slug"], name: "index_articles_on_slug"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

In an effort to unpack https://github.com/forem/forem/pull/8072 I'm going to start with the easy part: adding a unique index to two columns that have no duplicates in the table:

- `slug` + `user_id` to make sure that slugs are indeed unique per index, not just at the Rails level but also at the DB level

Currently there are no duplicates: https://dev.to/admin/blazer/queries/78-duplicate-articles-by-slug-and-user_id

## Related Tickets & Documents

https://github.com/forem/forem/pull/8072

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
