### PR TITLE
Rely on error types to determine when a repo should be removed on the RepoSyncWorker

### DIFF
--- a/app/services/github/errors.rb
+++ b/app/services/github/errors.rb
@@ -17,5 +17,11 @@ module Github
 
     class InvalidRepository < ArgumentError
     end
+
+    class AccountSuspended < ClientError
+    end
+
+    class RepositoryUnavailable < ClientError
+    end
   end
 end

--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -27,12 +27,10 @@ module GithubRepos
           info_hash: fetched_repo.to_hash,
         )
         repo.user&.touch(:github_repos_updated_at)
-      rescue Github::Errors::NotFound, Github::Errors::Unauthorized
-        repo.destroy
-      rescue Github::Errors::ClientError => e
-        msg = e.message
-        raise e unless msg.include?("Your account was suspended") || msg.include?("Repository access blocked")
-
+      rescue Github::Errors::NotFound,
+             Github::Errors::Unauthorized,
+             Github::Errors::AccountSuspended,
+             Github::Errors::RepositoryUnavailable
         repo.destroy
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Makes the `RepoSyncWorker` rely on the error types and not their messages, to make the decision of wether to remove the Github repository reference from the database.

## Related Tickets & Documents

#10106

## QA Instructions, Screenshots, Recordings

TBH I don't quite know how have a repository reach that state (have an account suspended or a repository deemed "unavailable"), so I wasn't able to do a proper functional test.

I tried to cover the full codepath with tests as an alternative. But beware, I'm missing a proper functional test.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
