### PR TITLE
Remove ghostify from app

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -58,9 +58,9 @@ module Admin
     def full_delete
       @user = User.find(params[:id])
       begin
-        Moderator::DeleteUser.call(admin: current_user, user: @user, user_params: user_params)
+        Moderator::DeleteUser.call(user: @user)
         message = "@#{@user.username} (email: #{@user.email.presence || 'no email'}, user_id: #{@user.id}) " \
-          "has been fully deleted. If requested, old content may have been ghostified. " \
+          "has been fully deleted." \
           "If this is a GDPR delete, delete them from Mailchimp & Google Analytics."
         flash[:success] = message
       rescue StandardError => e
@@ -186,7 +186,7 @@ module Admin
       allowed_params = %i[
         new_note note_for_current_role user_status
         pro merge_user_id add_credits remove_credits
-        add_org_credits remove_org_credits ghostify
+        add_org_credits remove_org_credits
         organization_id identity_id backup_data_id
       ]
       params.require(:user).permit(allowed_params)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -266,8 +266,6 @@ class UsersController < ApplicationController
       handle_integrations_tab
     when "billing"
       handle_billing_tab
-    when "account"
-      handle_account_tab
     when "response-templates"
       handle_response_templates_tab
     else
@@ -333,17 +331,6 @@ class UsersController < ApplicationController
     return if stripe_code == "special"
 
     @customer = Payments::Customer.get(stripe_code) if stripe_code.present?
-  end
-
-  def handle_account_tab
-    community_name = SiteConfig.community_name
-    @email_body = <<~HEREDOC
-      Hello #{community_name} Team,\n
-      I would like to delete my account.\n
-      You can keep any comments and discussion posts under the Ghost account.\n
-      Regards,
-      YOUR-#{community_name}-USERNAME-HERE
-    HEREDOC
   end
 
   def handle_response_templates_tab

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,8 +92,7 @@ class User < ApplicationRecord
   }.freeze
 
   attr_accessor :scholar_email, :new_note, :note_for_current_role, :user_status, :pro, :merge_user_id,
-                :add_credits, :remove_credits, :add_org_credits, :remove_org_credits, :ghostify,
-                :ip_address
+                :add_credits, :remove_credits, :add_org_credits, :remove_org_credits, :ip_address
 
   rolify after_add: :index_roles, after_remove: :index_roles
 

--- a/app/services/moderator/delete_user.rb
+++ b/app/services/moderator/delete_user.rb
@@ -1,47 +1,15 @@
 module Moderator
   class DeleteUser < ManageActivityAndRoles
-    attr_reader :user, :admin, :user_params
+    attr_reader :user, :user_params
 
-    def self.call(admin:, user:, user_params:)
-      if user_params[:ghostify] == "true"
-        new(user: user, admin: admin, user_params: user_params).ghostify
-      else
-        Users::DeleteWorker.perform_async(user.id, true)
-      end
-    end
-
-    def ghostify
-      @ghost = User.find_by(username: "ghost")
-      reassign_articles
-      reassign_comments
-      delete_user
-      CacheBuster.bust("/ghost")
+    def self.call(user:)
+      Users::DeleteWorker.perform_async(user.id, true)
     end
 
     private
 
     def delete_user
       Users::DeleteWorker.new.perform(user.id, true)
-    end
-
-    def reassign_comments
-      return unless user.comments.any?
-
-      user.comments.find_each do |comment|
-        comment.update(user_id: @ghost.id)
-      end
-      @ghost.touch(:last_comment_at)
-    end
-
-    def reassign_articles
-      return unless user.articles.any?
-
-      # preload associations that are going to be used during indexing
-      user.articles.preload(:organization, :tag_taggings, :tags).find_each do |article|
-        path = "/#{@ghost.username}/#{article.slug}"
-        article.update_columns(user_id: @ghost.id, path: path)
-        article.index_to_elasticsearch_inline
-      end
     end
   end
 end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -147,18 +147,6 @@
       </div>
 
       <% if current_user.has_role?(:super_admin) %>
-        <div class="mb-6">
-          <h3>Delete User & Turn Content Into Ghost</h3>
-          <p>This will
-            <strong>completely destroy the user</strong> and convert all of their articles & comments into a ghost author. This action is irreversible.
-          </p>
-          <p><strong>Do not do this lightly.</strong></p>
-          <%= form_for(@user, url: full_delete_admin_user_path(@user), html: { method: :post, onsubmit: "return confirm('Are you sure? 👻 This is extremely destructive and irreversible. The user will be deleted and their articles & comments will be converted to Ghost')" }) do |f| %>
-            <%= f.hidden_field :ghostify, value: true %>
-            <button class="btn btn-danger">👻 Fully Delete User & Ghostify 👻</button>
-          <% end %>
-        </div>
-
         <div>
           <h3>Fully Delete User</h3>
           <p>This will
@@ -166,7 +154,6 @@
           </p>
           <p><strong>Do not do this lightly.</strong></p>
           <%= form_for(@user, url: full_delete_admin_user_path(@user), html: { method: :post, onsubmit: "return confirm('Are you sure? This is extremely destructive and irreversible.')" }) do |f| %>
-            <%= f.hidden_field :ghostify, value: false %>
             <button class="btn btn-danger">☠️ Fully Delete User & All Activity ☠️</button>
           <% end %>
         </div>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -105,13 +105,6 @@
   </div>
 
   <div>
-    <% if current_user.articles_count.positive? || current_user.comments_count.positive? %>
-      <p>
-        If you would like to keep your content under the <%= link_to "@ghost", "/ghost" %> account,
-        please <%= email_link(text: "click here", additional_info: { subject: "Request Account Deletion", body: @email_body }) %>.
-      </p>
-    <% end %>
-
     <p>Feel free to contact <%= email_link %> with any questions.</p>
   </div>
 </div>

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe "UserSettings", type: :request do
     end
 
     describe ":account" do
-      let(:ghost_account_message) { "If you would like to keep your content under the" }
       let(:remove_oauth_section) { "Remove OAuth Associations" }
       let(:user) { create(:user, :with_identity) }
 
@@ -68,20 +67,6 @@ RSpec.describe "UserSettings", type: :request do
       it "allows users to visit the account page" do
         get user_settings_path(tab: "account")
         expect(response).to have_http_status(:ok)
-      end
-
-      it "does not render the ghost account email option if the user has no content" do
-        get user_settings_path(tab: "account")
-        expect(response.body).not_to include(ghost_account_message)
-      end
-
-      it "does render the ghost account email option if the user has content" do
-        create(:article, user: user)
-        user.update(articles_count: 1)
-
-        get user_settings_path(tab: "account")
-
-        expect(response.body).to include(ghost_account_message)
       end
 
       it "shows the 'Remove OAuth' section if a user has multiple enabled identities" do

--- a/spec/services/moderator/delete_user_spec.rb
+++ b/spec/services/moderator/delete_user_spec.rb
@@ -2,12 +2,11 @@ require "rails_helper"
 
 RSpec.describe Moderator::DeleteUser, type: :service do
   let(:user) { create(:user) }
-  let(:admin) { create(:user, :super_admin) }
 
   describe "delete_user" do
     it "deletes user" do
       sidekiq_perform_enqueued_jobs do
-        described_class.call(user: user, admin: admin, user_params: {})
+        described_class.call(user: user)
       end
       expect(User.find_by(id: user.id)).to be_nil
     end
@@ -18,7 +17,7 @@ RSpec.describe Moderator::DeleteUser, type: :service do
 
       expect do
         sidekiq_perform_enqueued_jobs do
-          described_class.call(user: user, admin: admin, user_params: {})
+          described_class.call(user: user)
         end
       end.to change(Follow, :count).by(-2)
     end
@@ -26,30 +25,9 @@ RSpec.describe Moderator::DeleteUser, type: :service do
     it "deletes user's articles" do
       article = create(:article, user: user)
       sidekiq_perform_enqueued_jobs do
-        described_class.call(user: user, admin: admin, user_params: {})
+        described_class.call(user: user)
       end
       expect(Article.find_by(id: article.id)).to be_nil
-    end
-  end
-
-  describe "#ghostify" do
-    let(:deleter) { described_class.new(user: user, admin: admin, user_params: { ghostify: true }) }
-
-    before do
-      user.update(username: "ghost")
-      create(:article, user: user)
-    end
-
-    it "reassigns articles" do
-      allow(deleter).to receive(:reassign_articles)
-      deleter.ghostify
-      expect(deleter).to have_received(:reassign_articles)
-    end
-
-    it "reassigns comments" do
-      allow(deleter).to receive(:reassign_comments)
-      deleter.ghostify
-      expect(deleter).to have_received(:reassign_comments)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Removal

## Description
This removes the ghostify option from the app. We really don't use this feature much, and it's more confusing to use and keep around than to make it worthwhile.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/31

## QA Instructions, Screenshots, Recordings
1. Search for `ghostify` or `ghost` or `Ghostify` in the app

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![Casper the ghost walks slowly and sadly...](https://media.giphy.com/media/Ble3c2ACXj2j6/giphy.gif)
