### PR TITLE
Index Reaction created_at Timestamp

### DIFF
--- a/app/serializers/search/reaction_serializer.rb
+++ b/app/serializers/search/reaction_serializer.rb
@@ -1,6 +1,6 @@
 module Search
   class ReactionSerializer < ApplicationSerializer
-    attributes :id, :category, :status, :user_id
+    attributes :id, :created_at, :category, :status, :user_id
 
     attribute :reactable do |reaction|
       reactable = reaction.reactable

--- a/config/elasticsearch/mappings/reactions.json
+++ b/config/elasticsearch/mappings/reactions.json
@@ -7,6 +7,9 @@
     "category": {
       "type": "keyword"
     },
+    "created_at": {
+      "type": "date"
+    },
     "last_indexed_at": {
       "type": "date"
     },

--- a/lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb
+++ b/lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb
@@ -1,11 +1,11 @@
 module DataUpdateScripts
   class IndexReadingListReactions
     def run
-      Reaction.readinglist.select(:id).in_batches do |batch|
-        Search::BulkIndexWorker.set(queue: :default).perform_async(
-          "Reaction", batch.ids
-        )
-      end
+      # Reaction.readinglist.select(:id).in_batches do |batch|
+      #   Search::BulkIndexWorker.set(queue: :default).perform_async(
+      #     "Reaction", batch.ids
+      #   )
+      # end
     end
   end
 end

--- a/lib/data_update_scripts/20200901194251_reindex_reading_list_reactions.rb
+++ b/lib/data_update_scripts/20200901194251_reindex_reading_list_reactions.rb
@@ -1,0 +1,11 @@
+module DataUpdateScripts
+  class ReindexReadingListReactions
+    def run
+      Reaction.readinglist.select(:id).in_batches do |batch|
+        Search::BulkIndexWorker.set(queue: :default).perform_async(
+          "Reaction", batch.ids
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/reindex_reading_list_reactions_spec.rb
+++ b/spec/lib/data_update_scripts/reindex_reading_list_reactions_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
-require Rails.root.join("lib/data_update_scripts/20200415200651_index_reading_list_reactions.rb")
+require Rails.root.join("lib/data_update_scripts/20200901194251_reindex_reading_list_reactions.rb")
 
-describe DataUpdateScripts::IndexReadingListReactions, elasticsearch: "Reaction" do
+describe DataUpdateScripts::ReindexReadingListReactions, elasticsearch: "Reaction" do
   it "indexes feed content(articles, comments, podcast episodes) to Elasticsearch" do
     reactions = create_list(:reaction, 3, category: "readinglist")
     Sidekiq::Worker.clear_all

--- a/spec/serializers/search/reaction_serializer_spec.rb
+++ b/spec/serializers/search/reaction_serializer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Search::ReactionSerializer do
     user_data = Search::NestedUserSerializer.new(user).serializable_hash.dig(:data, :attributes)
     expect(data_hash.dig(:reactable, :user)).to eq(user_data)
     expect(data_hash[:reactable].keys).to include(:id, :body_text, :class_name, :path, :tags, :title)
-    expect(data_hash.keys).to include(:id, :category, :status, :user_id)
+    expect(data_hash.keys).to include(:id, :created_at, :category, :status, :user_id)
   end
 
   it "serializes a comment reaction" do
@@ -21,7 +21,7 @@ RSpec.describe Search::ReactionSerializer do
     user_data = Search::NestedUserSerializer.new(user).serializable_hash.dig(:data, :attributes)
     expect(data_hash.dig(:reactable, :user)).to eq(user_data)
     expect(data_hash[:reactable].keys).to include(:id, :body_text, :class_name, :path, :tags, :title)
-    expect(data_hash.keys).to include(:id, :category, :status, :user_id)
+    expect(data_hash.keys).to include(:id, :created_at, :category, :status, :user_id)
   end
 
   it "creates valid json for Elasticsearch" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix Part 1

## Description
We store reactions in Elasticsearch and the default way we sort them is by ID desc which will give us the most recent reactions first. HOWEVER, this is not quite the case. IDs are stored in Elasticsearch as strings which means when you are doing a value comparison you end up with weird behavior such as 99 > 100. The means Reactions are not being sorted correctly all the time. This PR introduces `created_at` to Elasticsearch for reactions. Once this is merged and the data is backfilled I will then issue a PR to default sort by `created_at` 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44644200

## QA Instructions, Screenshots, Recordings
- pull down branch
- run bin/setup
- open a console
- `Reaction.readinglist.last.elasticsearch_doc` should return a document with `created_at` in it

## Added tests?
- [x] updated


![alt_text](https://media1.tenor.com/images/609296d397e52fdf91b2d9da356baa15/tenor.gif?itemid=15202452)
