### PR TITLE
Optimization:Throttle Noisy Honeycomb Events More

### DIFF
--- a/app/lib/honeycomb/noise_cancelling_sampler.rb
+++ b/app/lib/honeycomb/noise_cancelling_sampler.rb
@@ -25,14 +25,14 @@ module Honeycomb
       # should_sample is a no-op if the rate is 1
 
       if fields["redis.command"].in? NOISY_REDIS_COMMANDS
-        rate = 100
+        rate = 300
       elsif fields["sql.active_record.sql"].in? NOISY_SQL_COMMANDS
-        rate = 100
+        rate = 300
       elsif fields["redis.command"]&.start_with?("BRPOP")
         # BRPOP is disproportionately noisy and not really interesting
-        rate = 1000
+        rate = 5000
       elsif fields["redis.command"]&.start_with?(*NOISY_REDIS_PREFIXES)
-        rate = 100
+        rate = 300
       end
       [should_sample(rate, fields["trace.trace_id"]), rate]
     end

--- a/spec/lib/honeycomb/noise_cancelling_sampler_spec.rb
+++ b/spec/lib/honeycomb/noise_cancelling_sampler_spec.rb
@@ -14,34 +14,34 @@ RSpec.describe Honeycomb::NoiseCancellingSampler do
     it "samples if its in NOISY_REDIS_COMMANDS" do
       is_sampled, rate = described_class.sample({ "redis.command" => "TIME", "trace.trace_id" => trace_id })
       expect(is_sampled).to be_in [true, false]
-      expect(rate).to match(100)
+      expect(rate).to match(300)
     end
 
     it "samples if the command is BRPOP" do
       is_sampled, rate = described_class.sample({ "redis.command" => "BRPOP", "trace.trace_id" => trace_id })
       expect(is_sampled).to be_in [true, false]
-      expect(rate).to match(1000)
+      expect(rate).to match(5000)
     end
 
     it "samples if the command starts with TTL" do
       is_sampled, rate = described_class.sample({ "redis.command" => "TTL this and that",
                                                   "trace.trace_id" => trace_id })
       expect(is_sampled).to be_in [true, false]
-      expect(rate).to match(100)
+      expect(rate).to match(300)
     end
 
     it "samples if the command starts with GET rack:" do
       is_sampled, rate = described_class.sample({ "redis.command" => "GET rack::something",
                                                   "trace.trace_id" => trace_id })
       expect(is_sampled).to be_in [true, false]
-      expect(rate).to match(100)
+      expect(rate).to match(300)
     end
 
     it "samples if the command starts with SET rack:" do
       is_sampled, rate = described_class.sample({ "redis.command" => "SET rack::something",
                                                   "trace.trace_id" => trace_id })
       expect(is_sampled).to be_in [true, false]
-      expect(rate).to match(100)
+      expect(rate).to match(300)
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe Honeycomb::NoiseCancellingSampler do
     it "samples if its in NOISY_SQL_COMMANDS" do
       is_sampled, rate = described_class.sample({ "sql.active_record.sql" => "COMMIT", "trace.trace_id" => trace_id })
       expect(is_sampled).to be_in [true, false]
-      expect(rate).to match(100)
+      expect(rate).to match(300)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
We hit our monthly Honeycomb data limit on August 31st which means we need to rein it in a little bit. This PR increases our rate throttling for our noisiest and least informative events. cc @lizthegrey 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44710845


## Added tests?
- [x] yes


![alt_text](https://media1.tenor.com/images/d8cc98d4ade7e0a39bf4a5004b860368/tenor.gif?itemid=10066965)
