### PR TITLE
Flaky Spec Fix:(Attempt)Ensure Article Suggester Count is Consistent

### DIFF
--- a/spec/labor/article_suggester_spec.rb
+++ b/spec/labor/article_suggester_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ArticleSuggester, type: :labor do
   it "returns proper number of articles with post with the same tags" do
     create_list(:article, 4, featured: true, tags: ["discuss"], score: 10)
     article = create(:article, featured: true, tags: ["discuss"])
+    stub_estimated_article_count
     expect(described_class.new(article).articles.size).to eq(4)
   end
 
@@ -11,17 +12,24 @@ RSpec.describe ArticleSuggester, type: :labor do
     create_list(:article, 2, featured: true, tags: ["discuss"], score: 10)
     create_list(:article, 2, featured: true, tags: ["javascript"])
     article = create(:article, featured: true, tags: ["discuss"])
+    stub_estimated_article_count
     expect(described_class.new(article).articles.size).to eq(4)
   end
 
   it "returns proper number of articles with post without tags" do
     create_list(:article, 5, tags: [], with_tags: false, featured: true)
     article = create(:article, featured: true, tag_list: "")
+    stub_estimated_article_count
     expect(described_class.new(article).articles.size).to eq(4)
   end
 
   it "returns the number of articles requested" do
     articles = create_list(:article, 3, featured: true)
+    stub_estimated_article_count
     expect(described_class.new(articles.first).articles(max: 2).size).to eq(2)
+  end
+
+  def stub_estimated_article_count
+    allow(described_class).to receive(:articles_count).and_return(Article.published.count)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
In our `ArticleSuggester` class we will offset the articles we find by some random number that is calculated using `estimated_count` for articles. Since the estimated count uses postgres statistics from `pg_class` I am wondering if sometimes it comes back with a higher value than expected. This stubs the estimated count for the real count for the class. 
```ruby
  QUERY_ESTIMATED_COUNT = <<~SQL.squish.freeze
    SELECT (
      (reltuples / GREATEST(relpages, 1)) *
      (pg_relation_size(?) / (GREATEST(current_setting('block_size')::integer, 1)))
    )::bigint AS count
    FROM pg_class
    WHERE relname = ? AND relkind = 'r';
  SQL
``` 

Fixes (hopefully):
```
  1) ArticleSuggester returns proper number of articles with post with the same tags
     Failure/Error: expect(described_class.new(article).articles.size).to eq(4)
       expected: 4
            got: 0
       (compared using ==)
     # ./spec/labor/article_suggester_spec.rb:7:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
  2) ArticleSuggester returns proper number of articles with post without tags
     Failure/Error: expect(described_class.new(article).articles.size).to eq(4)
       expected: 4
            got: 0
       (compared using ==)
     # ./spec/labor/article_suggester_spec.rb:20:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
  3) ArticleSuggester returns the number of articles requested
     Failure/Error: expect(described_class.new(articles.first).articles(max: 2).size).to eq(2)
       expected: 2
            got: 0
       (compared using ==)
     # ./spec/labor/article_suggester_spec.rb:25:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
```

![alt_text](https://media.tenor.com/images/cb5db8b53d7ab4451c18bb900ea934e5/tenor.gif)
