### PR TITLE
Optimization:Select Article Columns for Digest Email, Limit 6, Use User Attributes

### DIFF
--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -3,7 +3,7 @@ class DigestMailer < ApplicationMailer
 
   def digest_email
     @user = params[:user]
-    @articles = params[:articles].first(6)
+    @articles = params[:articles]
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_digest_periodic)
 
     subject = generate_title

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -12,22 +12,25 @@ class EmailDigestArticleCollector
                  experience_level_rating_max = experience_level_rating + 3.6
 
                  @user.followed_articles
+                   .select(:title, :description, :path)
+                   .published
                    .where("published_at > ?", cutoff_date)
-                   .where(published: true, email_digest_eligible: true)
+                   .where(email_digest_eligible: true)
                    .where.not(user_id: @user.id)
                    .where("score > ?", 12)
                    .where("experience_level_rating > ? AND experience_level_rating < ?",
                           experience_level_rating_min, experience_level_rating_max)
                    .order(score: :desc)
-                   .limit(8)
+                   .limit(6)
                else
-                 Article.published
+                 Article.select(:title, :description, :path)
+                   .published
                    .where("published_at > ?", cutoff_date)
                    .where(featured: true, email_digest_eligible: true)
                    .where.not(user_id: @user.id)
                    .where("score > ?", 25)
                    .order(score: :desc)
-                   .limit(8)
+                   .limit(6)
                end
 
     articles.length < 3 ? [] : articles

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -77,7 +77,7 @@ class EmailDigestArticleCollector
   end
 
   def user_has_followings?
-    @user.cached_following_users_ids.any? || @user.cached_followed_tag_names.any?
+    @user.following_users_count.positive? || @user.cached_followed_tag_names.any?
   end
 
   def last_user_emails

--- a/app/views/mailers/digest_mailer/digest_email.html.erb
+++ b/app/views/mailers/digest_mailer/digest_email.html.erb
@@ -27,7 +27,7 @@
       Visit <b><a href="<%= app_url(user_settings_path(:misc)) %>" style="text-decoration: none;">your settings</a></b> to enter your experience level on a scale of 1-10.
       <br /><br />
       You can change it any time in the future. Happy <%= SiteConfig.community_action %>!
-    <% elsif @user.follows.size == 0 %>
+    <% elsif @user.following_users_count == 0 %>
       <b>
         <%= community_name %> Digest is a new periodic email featuring the best posts from our community of <%= community_members_label %>.
       </b>
@@ -45,7 +45,7 @@
       <% elsif tip_rand == 3 %>
         You're a better <%= SiteConfig.community_member_label %> today than you were yesterday.
       <% elsif tip_rand == 4 %>
-        <% if @user.articles.published.any? %>
+        <% if @user.articles_count > 0 %>
           Can't wait to see <b>your</b> next <%= community_name %> post!
         <% else %>
           Can't wait to see <b>your</b> first <%= community_name %> post!

--- a/app/workers/emails/send_user_digest_worker.rb
+++ b/app/workers/emails/send_user_digest_worker.rb
@@ -12,7 +12,7 @@ module Emails
       return unless articles.any?
 
       begin
-        DigestMailer.with(user: user, articles: articles).digest_email.deliver_now
+        DigestMailer.with(user: user, articles: articles.to_a).digest_email.deliver_now
       rescue StandardError => e
         Honeybadger.context({ user_id: user.id, article_ids: articles.map(&:id) })
         Honeybadger.notify(e)

--- a/spec/services/email_digest_article_collector_spec.rb
+++ b/spec/services/email_digest_article_collector_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe EmailDigestArticleCollector, type: :service do
       before do
         author = create(:user)
         user.follow(author)
+        user.update(following_users_count: 1)
         create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
         10.times do
           Ahoy::Message.create(mailer: "DigestMailer#digest_email",
@@ -49,6 +50,7 @@ RSpec.describe EmailDigestArticleCollector, type: :service do
                                sent_at: Time.current.utc, opened_at: Time.current.utc)
           author = create(:user)
           user.follow(author)
+          user.update(following_users_count: 1)
           create_list(:article, 3, user_id: author.id, public_reactions_count: 40, score: 40)
         end
       end

--- a/spec/workers/emails/send_user_digest_worker_spec.rb
+++ b/spec/workers/emails/send_user_digest_worker_spec.rb
@@ -20,29 +20,29 @@ RSpec.describe Emails::SendUserDigestWorker, type: :worker do
       before { user.follow(author) }
 
       it "send digest email when there are at least 3 hot articles" do
-        articles = create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
+        create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
 
         worker.perform(user.id)
 
-        expect(DigestMailer).to have_received(:with).with(user: user, articles: articles)
+        expect(DigestMailer).to have_received(:with).with(user: user, articles: Array)
         expect(mailer).to have_received(:digest_email)
         expect(message_delivery).to have_received(:deliver_now)
       end
 
       it "does not send email when user does not have email_digest_periodic" do
-        articles = create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
+        create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
         user.update_column(:email_digest_periodic, false)
         worker.perform(user.id)
 
-        expect(DigestMailer).not_to have_received(:with).with(user: user, articles: articles)
+        expect(DigestMailer).not_to have_received(:with)
       end
 
       it "does not send email when user is not registered" do
-        articles = create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
+        create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20)
         user.update_column(:registered, false)
         worker.perform(user.id)
 
-        expect(DigestMailer).not_to have_received(:with).with(user: user, articles: articles)
+        expect(DigestMailer).not_to have_received(:with)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Few improvements here to the Digest Mailer
- rather than `limit(8)` then only taking the `first(6)` in the mailer, lets just make it `limit(6)`
- Articles are big models with a lot of data, we only need title, description, and path in order to populate the body of the email so limit the columns to those. 
- Replace Redis lookup `@user.cached_following_users_ids` with reading a user attribute `@user.following_users_count`
- Replace Postgres db email hits with user attributes: `@user.follows.size` with `@user.following_users_count` and `@user.articles.published` with `@user.articles_count`. Now `follows.size` includes tags but the messaging in the email is for following users so I figured the replacement made sense using the users count.
- Refactor: replaced `published: true` with our scope. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44508249

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media.tenor.com/images/6e89fab1e7673a96afaba28119ce7512/tenor.gif)
