### PR TITLE
Fix Flaky Runkit system spec

### DIFF
--- a/spec/system/articles/user_creates_an_article_spec.rb
+++ b/spec/system/articles/user_creates_an_article_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe "Creating an article with the editor", type: :system do
   context "with Runkit tag", js: true do
     it "creates a new article with a Runkit tag" do
       visit new_path
+      fill_in "article_body_markdown", with: ""
       fill_in "article_body_markdown", with: template_with_runkit_tag
       click_button "Save changes"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Flaky spec

## Description
There are two ways this spec can fail

1. It took too long to load Runkit content
2. the article was never saved because it was invalid.

This fix scenario two. I've received the following error multiple times. You can see that the body_markdown has two sets of frontmatter. This looks like the markdown was not properly replaced so added a redundency to make sure the markdown is cleared. I ran this spec locally 50x to verify that this solves this.

![r_spec_example_groups_creating_an_article_with_the_editor_with_runkit_tag_creates_a_new_article_with_a_runkit_tag_84_2020-09-01T21:-29-00-146Z](https://user-images.githubusercontent.com/15793250/91911919-11fd3f80-ec80-11ea-967e-df256e9bc891.png)


## Added tests?
- [x] n/a

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a