### PR TITLE
Attempt to fix facebook login

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,11 +9,6 @@ GITHUB_OMNIUATH_SETUP = lambda do |env|
   env["omniauth.strategy"].options[:scope] = "user:email"
 end
 
-FACEBOOK_OMNIAUTH_SETUP = lambda do |env|
-  env["omniauth.strategy"].options[:client_id] = SiteConfig.facebook_key
-  env["omniauth.strategy"].options[:client_secret] = SiteConfig.facebook_secret
-end
-
 Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
@@ -299,9 +294,9 @@ Devise.setup do |config|
   # up on your models and hooks.
 
   # Fun fact, if this is reordered to have Twitter first, it doesn't work for some reason.
-  config.omniauth :facebook, setup: FACEBOOK_OMNIAUTH_SETUP
   config.omniauth :github, setup: GITHUB_OMNIUATH_SETUP
   config.omniauth :twitter, setup: TWITTER_OMNIAUTH_SETUP
+  config.omniauth :facebook, SiteConfig.facebook_key, SiteConfig.facebook_secret, token_params: { parse: :json }
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -9,6 +9,12 @@ GITHUB_OMNIUATH_SETUP = lambda do |env|
   env["omniauth.strategy"].options[:scope] = "user:email"
 end
 
+FACEBOOK_OMNIAUTH_SETUP = lambda do |env|
+  env["omniauth.strategy"].options[:client_id] = SiteConfig.facebook_key
+  env["omniauth.strategy"].options[:client_secret] = SiteConfig.facebook_secret
+  env["omniauth.strategy"].options[:token_params][:parse] = :json
+end
+
 Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
@@ -293,10 +299,10 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
 
-  # Fun fact, if this is reordered to have Twitter first, it doesn't work for some reason.
+  # Fun fact, unless Twitter is last, it doesn't work for some reason.
+  config.omniauth :facebook, setup: FACEBOOK_OMNIAUTH_SETUP
   config.omniauth :github, setup: GITHUB_OMNIUATH_SETUP
   config.omniauth :twitter, setup: TWITTER_OMNIAUTH_SETUP
-  config.omniauth :facebook, SiteConfig.facebook_key, SiteConfig.facebook_secret, token_params: { parse: :json }
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently in production (Forem.dev and MMALife) Facebook login fails with the error: `Could not authenticate you from Facebook because "Invalid credentials".` Based on guidance from https://github.com/heartcombo/devise/wiki/OmniAuth:-Overview, this PR adds a parsing option to the OmniAuth-Facebook setup in an attempt to fix this error.

(Of course this error doesn't occur in development...grr)

## Related Tickets & Documents

https://github.com/forem/forem/pull/9922

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
