### PR TITLE
Extracts DisplayAds from Administrate into admin

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -13,6 +13,7 @@ module Admin
       { name: "chat_channels",         controller: "chat_channels" },
       { name: "comments",              controller: "comments" },
       { name: "config",                controller: "config" },
+      { name: "display_ads",           controller: "display_ads" },
       { name: "events",                controller: "events" },
       { name: "growth",                controller: "growth" },
       { name: "listings",              controller: "listings" },

--- a/app/controllers/admin/display_ads_controller.rb
+++ b/app/controllers/admin/display_ads_controller.rb
@@ -1,0 +1,71 @@
+module Admin
+  class DisplayAdsController < Admin::ApplicationController
+    layout "admin"
+
+    def index
+      @display_ads = DisplayAd.order(id: :desc)
+        .select("display_ads.*")
+        .joins(:organization)
+        .includes([:organization])
+        .page(params[:page]).per(50)
+
+      return if params[:search].blank?
+
+      @display_ads = @display_ads.where("organizations.name ILIKE :search", search: "%#{params[:search]}%")
+    end
+
+    def new
+      @display_ad = DisplayAd.new
+    end
+
+    def edit
+      @display_ad = DisplayAd.find(params[:id])
+    end
+
+    def create
+      @display_ad = DisplayAd.new(display_ad_params)
+
+      if @display_ad.save
+        flash[:success] = "Display Ad has been created!"
+        redirect_to admin_display_ads_path
+      else
+        flash[:danger] = @display_ad.errors.full_messages.to_sentence
+        render new_admin_display_ad_path
+      end
+    end
+
+    def update
+      @display_ad = DisplayAd.find(params[:id])
+
+      if @display_ad.update(display_ad_params)
+        flash[:success] = "Display Ad has been updated!"
+        redirect_to admin_display_ads_path
+      else
+        flash[:danger] = @display_ad.errors.full_messages.to_sentence
+        render :edit
+      end
+    end
+
+    def destroy
+      @display_ad = DisplayAd.find(params[:id])
+
+      if @display_ad.destroy
+        flash[:success] = "Display Ad has been deleted!"
+        redirect_to admin_display_ads_path
+      else
+        flash[:danger] = "Something went wrong with deleting the Display Ad."
+        render :edit
+      end
+    end
+
+    private
+
+    def display_ad_params
+      params.permit(:organization_id, :body_markdown, :placement_area, :published, :approved)
+    end
+
+    def authorize_admin
+      authorize DisplayAd, :access?, policy_class: InternalPolicy
+    end
+  end
+end

--- a/app/controllers/admin/display_ads_controller.rb
+++ b/app/controllers/admin/display_ads_controller.rb
@@ -4,7 +4,6 @@ module Admin
 
     def index
       @display_ads = DisplayAd.order(id: :desc)
-        .select("display_ads.*")
         .joins(:organization)
         .includes([:organization])
         .page(params[:page]).per(50)
@@ -29,7 +28,7 @@ module Admin
         flash[:success] = "Display Ad has been created!"
         redirect_to admin_display_ads_path
       else
-        flash[:danger] = @display_ad.errors.full_messages.to_sentence
+        flash[:danger] = @display_ad.errors_as_sentence
         render new_admin_display_ad_path
       end
     end
@@ -41,7 +40,7 @@ module Admin
         flash[:success] = "Display Ad has been updated!"
         redirect_to admin_display_ads_path
       else
-        flash[:danger] = @display_ad.errors.full_messages.to_sentence
+        flash[:danger] = @display_ad.errors_as_sentence
         render :edit
       end
     end

--- a/app/dashboards/dashboard_manifest.rb
+++ b/app/dashboards/dashboard_manifest.rb
@@ -22,7 +22,6 @@ class DashboardManifest
     tags
     email_messages
     feedback_messages
-    display_ads
     badges
     badge_achievements
     html_variants

--- a/app/lib/constants/role.rb
+++ b/app/lib/constants/role.rb
@@ -16,6 +16,7 @@ module Constants
                      "Resource Admin: Page",
                      "Resource Admin: FeedbackMessage",
                      "Resource Admin: Config",
-                     "Resource Admin: Broadcast"].freeze
+                     "Resource Admin: Broadcast",
+                     "Resource Admin: DisplayAd"].freeze
   end
 end

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -1,4 +1,6 @@
 class DisplayAd < ApplicationRecord
+  resourcify
+
   belongs_to :organization
   has_many :display_ad_events, dependent: :destroy
 

--- a/app/views/admin/display_ads/_form.html.erb
+++ b/app/views/admin/display_ads/_form.html.erb
@@ -1,0 +1,24 @@
+<div class="form-group">
+  <%= label_tag :organization_id, "Organization ID:" %>
+  <%= text_field_tag :organization_id, @display_ad.organization_id, class: "form-control" %>
+</div>
+
+<div class="form-group">
+  <%= label_tag :body_markdown, "Body Markdown:" %>
+  <%= text_area_tag :body_markdown, @display_ad.body_markdown, size: "100x10", class: "form-control" %>
+</div>
+
+<div class="form-group">
+  <%= label_tag :placement_area, "Placement area:" %>
+  <%= select_tag :placement_area, options_for_select(%w[sidebar_left sidebar_right], selected: @display_ad.placement_area), include_blank: true %>
+</div>
+
+<div class="form-group">
+  <%= label_tag :published, "Published:" %>
+  <%= select_tag :published, options_for_select([false, true], selected: @display_ad.published) %>
+</div>
+
+<div class="form-group">
+  <%= label_tag :approved, "Approved:" %>
+  <%= select_tag :approved, options_for_select([false, true], selected: @display_ad.approved) %>
+</div>

--- a/app/views/admin/display_ads/_form.html.erb
+++ b/app/views/admin/display_ads/_form.html.erb
@@ -9,7 +9,7 @@
 </div>
 
 <div class="form-group">
-  <%= label_tag :placement_area, "Placement area:" %>
+  <%= label_tag :placement_area, "Placement Area:" %>
   <%= select_tag :placement_area, options_for_select(%w[sidebar_left sidebar_right], selected: @display_ad.placement_area), include_blank: true %>
 </div>
 

--- a/app/views/admin/display_ads/edit.html.erb
+++ b/app/views/admin/display_ads/edit.html.erb
@@ -1,0 +1,7 @@
+<h2 class="fs-2xl s:fs-3xl mb-6">Edit Display Ad:</h2>
+<div class="crayons-card p-6">
+  <%= form_for([:admin, @display_ad], method: :patch) do %>
+    <%= render "form" %>
+    <%= submit_tag "Update Display Ad", class: "btn btn-primary" %>
+  <% end %>
+</div>

--- a/app/views/admin/display_ads/index.html.erb
+++ b/app/views/admin/display_ads/index.html.erb
@@ -1,0 +1,43 @@
+<nav class="flex mb-4" aria-label="Display Ads navigation">
+  <%= form_tag("/admin/display_ads", method: "get") do %>
+    <%= text_field_tag(:search, params[:search], aria: { label: "Search" }, class: "top-bar--search-input crayons-textfield", placeholder: "Search by Org name") %>
+  <% end %>
+  <div class="ml-auto">
+    <div class="justify-content-end">
+      <%= link_to "Make A New Display Ad", new_admin_display_ad_path, class: "crayons-btn" %>
+    </div>
+  </div>
+</nav>
+
+<%= paginate @display_ads %>
+
+<table class="crayons-table" width="100%">
+  <thead>
+    <tr>
+      <th scope="col">ID</th>
+      <th scope="col">Organization</th>
+      <th scope="col">Placement Area</th>
+      <th scope="col">Body Markdown</th>
+      <th scope="col">Published</th>
+      <th scope="col">Approved</th>
+      <th scope="col">Success Rate</th>
+    </tr>
+  </thead>
+  <tbody class="crayons-card">
+    <% @display_ads.each do |display_ad| %>
+        <tr>
+          <td><%= link_to display_ad.id, edit_admin_display_ad_path(display_ad) %></td>
+          <td><%= link_to display_ad.organization.name, admin_organization_path(display_ad.organization) %></td>
+          <td><%= display_ad.placement_area %></td>
+          <td><%= display_ad.body_markdown.truncate(30) %></td>
+          <td><%= display_ad.published %></td>
+          <td><%= display_ad.approved %></td>
+          <td><%= display_ad.success_rate %></td>
+          <td><%= link_to "Edit", edit_admin_display_ad_path(display_ad), class: "crayons-btn" %></td>
+          <td><%= link_to "Destroy", admin_display_ad_path(display_ad), class: "crayons-btn crayons-btn--danger", method: :delete, data: { confirm: "Are you sure?" } %></td>
+        </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @display_ads %>

--- a/app/views/admin/display_ads/new.html.erb
+++ b/app/views/admin/display_ads/new.html.erb
@@ -1,0 +1,7 @@
+<h2 class="fs-2xl s:fs-3xl mb-6">Make a new Display Ad:</h2>
+<div class="crayons-card p-6">
+  <%= form_for([:admin, @display_ad], method: :post) do %>
+    <%= render "form" %>
+    <%= submit_tag "Create Display Ad", class: "btn btn-primary" %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,7 @@ Rails.application.routes.draw do
     resources :webhook_endpoints, only: :index
     resource :config
     resources :badges, only: %i[index edit update new create]
+    resources :display_ads, only: %i[index edit update new create destroy]
     # These redirects serve as a safegaurd to prevent 404s for any Admins
     # who have the old badge_achievement URLs bookmarked.
     get "/badges/badge_achievements", to: redirect("/admin/badge_achievements")

--- a/spec/requests/admin/display_ads_spec.rb
+++ b/spec/requests/admin/display_ads_spec.rb
@@ -1,0 +1,140 @@
+require "rails_helper"
+require "requests/shared_examples/internal_policy_dependant_request"
+
+RSpec.describe "/admin/display_ads", type: :request do
+  let(:get_resource) { get "/admin/display_ads" }
+  let(:org) { create(:organization) }
+  let(:params) do
+    { organization_id: org.id, body_markdown: "[Click here!](https://example.com)", placement_area: "sidebar_left",
+      approved: true, published: true }
+  end
+  let(:post_resource) { post "/admin/display_ads", params: params }
+
+  it_behaves_like "an InternalPolicy dependant request", DisplayAd do
+    let(:request) { get_resource }
+  end
+
+  context "when the user is not an admin" do
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+
+    describe "GET /admin/display_ads" do
+      it "blocks the request" do
+        expect { get_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    describe "POST /admin/display_ads" do
+      it "blocks the request" do
+        expect { post_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+  end
+
+  context "when the user is a super admin" do
+    let(:super_admin) { create(:user, :super_admin) }
+
+    before { sign_in super_admin }
+
+    describe "GET /admin/display_ads" do
+      it "allows the request" do
+        get_resource
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "POST /admin/display_ads" do
+      it "creates a new display_ad" do
+        expect do
+          post_resource
+        end.to change { DisplayAd.all.count }.by(1)
+      end
+    end
+
+    describe "PUT /admin/display_ads" do
+      let!(:display_ad) { create(:display_ad, approved: false) }
+
+      it "updates DisplayAd's approved value" do
+        Timecop.freeze(Time.current) do
+          expect do
+            put "/admin/display_ads/#{display_ad.id}", params: params
+          end.to change { display_ad.reload.approved }.from(false).to(true)
+        end
+      end
+    end
+
+    describe "DELETE /admin/display_ads/:id" do
+      let!(:display_ad) { create(:display_ad) }
+
+      it "deletes the Display Ad" do
+        expect do
+          delete "/admin/display_ads/#{display_ad.id}"
+        end.to change { DisplayAd.all.count }.by(-1)
+        expect(response.body).to redirect_to "/admin/display_ads"
+      end
+    end
+  end
+
+  context "when the user is a single resource admin" do
+    let(:single_resource_admin) { create(:user, :single_resource_admin, resource: DisplayAd) }
+
+    before { sign_in single_resource_admin }
+
+    describe "GET /admin/display_ads" do
+      it "allows the request" do
+        get_resource
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "POST /admin/display_ads" do
+      it "creates a new display_ad" do
+        expect do
+          post_resource
+        end.to change { DisplayAd.all.count }.by(1)
+      end
+    end
+
+    describe "PUT /admin/display_ads" do
+      let!(:display_ad) { create(:display_ad, approved: false) }
+
+      it "updates DisplayAd's approved value" do
+        Timecop.freeze(Time.current) do
+          expect do
+            put "/admin/display_ads/#{display_ad.id}", params: params
+          end.to change { display_ad.reload.approved }.from(false).to(true)
+        end
+      end
+    end
+
+    describe "DELETE /admin/display_ads/:id" do
+      let!(:display_ad) { create(:display_ad) }
+
+      it "deletes the Display Ad" do
+        expect do
+          delete "/admin/display_ads/#{display_ad.id}"
+        end.to change { DisplayAd.all.count }.by(-1)
+        expect(response.body).to redirect_to "/admin/display_ads"
+      end
+    end
+  end
+
+  context "when the user is the wrong single resource admin" do
+    let(:single_resource_admin) { create(:user, :single_resource_admin, resource: Article) }
+
+    before { sign_in single_resource_admin }
+
+    describe "GET /admin/display_ads" do
+      it "blocks the request" do
+        expect { get_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    describe "POST /admin/display_ads" do
+      it "blocks the request" do
+        expect { post_resource }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Extracts Display Ads dashboard from `/resource_admin` (Administrate) into `/admin` dashboard

## QA Instructions, Screenshots, Recordings

CRUD capabilities to manage Display Ads should be available in `/admin/display_ads`

<img width="1355" alt="Screen Shot 2020-09-01 at 23 15 57" src="https://user-images.githubusercontent.com/6045239/91935172-530a4980-ecaa-11ea-9b1d-4c918c14adba.png">


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![dog swimming along](https://media.giphy.com/media/jvucQj4J72dPO/giphy.gif)
