### PR TITLE
Enable CSP in report only mode and use Honeybadger to track violations

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,24 +5,23 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 Rails.application.config.content_security_policy do |policy|
-  if Rails.env.production?
-    policy.default_src :self, :https
-    policy.font_src    :self, :https, :data
-    policy.img_src     :self, :https, :data
-    policy.object_src  :none
-    policy.script_src  :self, :https, :unsafe_inline
-    policy.style_src   :self, :https, :unsafe_inline
+  policy.default_src :self, :https
+  policy.font_src    :self, :https, :data
+  policy.img_src     :self, :https, :data
+  policy.object_src  :none
+  policy.script_src  :self, :https, :unsafe_inline
+  policy.style_src   :self, :https, :unsafe_inline
+
+  if Rails.env.development?
+    # allow webpack-dev-server host as allowed origin for connect-src
+    webpack_host = "#{ApplicationConfig.app_domain_no_port}:3035"
+    policy.connect_src :self, :https, :unsafe_inline, "*.pusher.com", "http://#{webpack_host}", "ws://#{webpack_host}"
+  else
     policy.connect_src :self, :https, :unsafe_inline, "*.pusher.com"
   end
-  #   # Specify URI for violation reports
-  #   # policy.report_uri "/csp-violation-report-endpoint"
 
-  # allow webpack-dev-server host as allowed origin for connect-src
-  if Rails.env.development?
-    webpack_host = "#{ApplicationConfig.app_domain_no_port}:3035"
-    policy.connect_src :self, :https,
-                       "http://#{webpack_host}", "ws://#{webpack_host}"
-  end
+  # Specify URI for violation reports
+  policy.report_uri -> { "https://api.honeybadger.io/v1/browser/csp?api_key=#{ENV['HONEYBADGER_API_KEY']}&report_only=true&env=#{Rails.env}&context[user_id]=#{respond_to?(:current_user) ? current_user&.id : nil}" } # rubocop:disable Layout/LineLength
 end
 
 # If you are using UJS then enable automatic nonce generation
@@ -31,4 +30,4 @@ end
 # Report CSP violations to a specified URI
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-# Rails.application.config.content_security_policy_report_only = true
+Rails.application.config.content_security_policy_report_only = true


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

#10144 added a CSP but the website is too big to be able to encompass all cases ahead of time. I've seen violations related to Pusher and to inline images in the chat for example. Also, the Blazer admin page index is not working for me.

For this reason I propose we use a different approach: enable CSP in report only mode.

This will help us track violations without blocking content, we keep an eye on the rules that need fixing/expanding and then when we have close to no violations we can switch off the reporting mode and keep the report URI for whatever we might have missed.

The alternative is to turn off report only mode but keep the report URI and then keep changing the CSP in the following days until we get close to zero.

We just can't rely on our own browser's console.

I'm using Honeybadger for the report URI 

@mstruve: the HB documentation suggests to create a new app just for the reports as they are going to be numerous. We can sync on that and I can amend the PR when we'll have the new key, unless you think it's fine to keep them in them in the global HB app. See https://docs.honeybadger.io/lib/ruby/integration-guides/rails-exception-tracking.html#content-security-policy-reports

## Related Tickets & Documents

#10144

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
