### PR TITLE
Strip HTML from following list tags short_summary

### DIFF
--- a/app/views/dashboards/following_tags.html.erb
+++ b/app/views/dashboards/following_tags.html.erb
@@ -36,7 +36,9 @@
                   <% end %>
                 </h3>
 
-                <p class="grid-cell__summary truncate-at-3 mb-4 fs-s"><%= tag.short_summary %></p>
+                <p class="grid-cell__summary truncate-at-3 mb-4 fs-s">
+                  <%= strip_tags(tag.short_summary) %>
+                </p>
 
                 <%= form_for(follow, html: { class: "flex items-center flex-nowrap" }) do |f| %>
                   <%= f.label(:points, "Follow weight:", class: "fs-s flex-1 pr-2 color-base-60 align-right whitespace-nowrap") %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Strip any HTML tags from the following lists tags `short_summary`

## Related Tickets & Documents

Closes #10154 

## QA Instructions, Screenshots, Recordings

**Before:**
<img width="337" alt="Screenshot 2020-09-02 at 12 04 46" src="https://user-images.githubusercontent.com/50486078/91973657-808bdd00-ed14-11ea-8b35-243848b8658a.png">

**After:**
<img width="337" alt="Screenshot 2020-09-02 at 12 05 29" src="https://user-images.githubusercontent.com/50486078/91973706-99948e00-ed14-11ea-9d68-b2ee3f950d68.png">

_without the dark mode switch 😅_

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

There are some inconsistencies with the content of `short_summary`, some are using markdown (Rails) and others are using HTML (JavaScript).

