### PR TITLE
Add display_area & show_in_onboarding to the profile setup ui

### DIFF
--- a/app/controllers/admin/profile_fields_controller.rb
+++ b/app/controllers/admin/profile_fields_controller.rb
@@ -1,12 +1,12 @@
 module Admin
   class ProfileFieldsController < Admin::ApplicationController
     ALLOWED_PARAMS = %i[
-      input_type label active placeholder_text description profile_field_group_id
+      input_type label active placeholder_text description profile_field_group_id display_area show_in_onboarding
     ].freeze
     layout "admin"
 
     def index
-      @grouped_profile_fields = ProfileFieldGroup.all.includes(:profile_fields).order(:name)
+      @grouped_profile_fields = ProfileFieldGroup.includes(:profile_fields).order(:name)
       @ungrouped_profile_fields = ProfileField.where(profile_field_group_id: nil).order(:label)
     end
 

--- a/app/views/admin/profile_fields/_grouped_profile_fields.html.erb
+++ b/app/views/admin/profile_fields/_grouped_profile_fields.html.erb
@@ -21,7 +21,6 @@
       </div>
 
       <div id="<%= group_name %>BodyContainer" class="collapse hide p-3" aria-labelledby="<%= group_name %>Header">
-
         <% if group.profile_fields.empty? %>
           <div> There are no profile fields configured for this group. </div>
         <% else %>

--- a/app/views/admin/profile_fields/_profile_field_form.html.erb
+++ b/app/views/admin/profile_fields/_profile_field_form.html.erb
@@ -25,3 +25,11 @@
   <%= form.label :input_type %>
   <%= form.select :input_type, ProfileField.input_types.keys, class: "form-control" %>
 </div>
+<div class="form-group">
+  <%= form.label :display_area %>
+  <%= form.select :display_area, ProfileField.display_areas.keys, class: "form-control" %>
+</div>
+<div class="form-group">
+  <%= form.label :show_in_onboarding %>
+  <%= form.check_box :show_in_onboarding %>
+</div>

--- a/app/views/admin/profile_fields/index.html.erb
+++ b/app/views/admin/profile_fields/index.html.erb
@@ -1,6 +1,5 @@
 <main id="profileFields">
   <%= render "add_group_modal" %>
-
   <%= render "grouped_profile_fields" %>
   <%= render "ungrouped_profile_fields" %>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This simply adds two fields display_area & show_in_onboarding to the profile setup ui, and allows them to be updated. 

## Related Tickets & Documents
Part of #6994

## QA Instructions, Screenshots, Recordings

1. Go to http://localhost:3000/admin/profile_fields
2. You should see display_area as a select & show_in_onboarding as a checkbox
3. You can update them 

<img width="905" alt="Screenshot 2020-09-02 at 13 40 07" src="https://user-images.githubusercontent.com/2786819/91976898-01050a80-ed22-11ea-9f94-ad325fec9af7.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/g3cOYozjt6J9u/giphy.gif)
