### PR TITLE
Add unique index on articles canonical_url

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -51,8 +51,8 @@ class Article < ApplicationRecord
 
   validates :body_markdown, length: { minimum: 0, allow_nil: false }, uniqueness: { scope: %i[user_id title] }
   validates :cached_tag_list, length: { maximum: 126 }
-  validates :canonical_url, url: { allow_blank: true, no_local: true,
-                                   schemes: %w[https http] }, uniqueness: { allow_blank: true }
+  validates :canonical_url, uniqueness: { allow_nil: true }
+  validates :canonical_url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
   validates :feed_source_url, uniqueness: { allow_blank: true }
   validates :main_image, url: { allow_blank: true, schemes: %w[https http] }
   validates :main_image_background_hex_color, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/

--- a/db/migrate/20200902132326_add_unique_index_to_articles_canonical_url.rb
+++ b/db/migrate/20200902132326_add_unique_index_to_articles_canonical_url.rb
@@ -1,0 +1,15 @@
+class AddUniqueIndexToArticlesCanonicalUrl < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    unless index_exists?(:articles, :canonical_url, unique: true)
+      add_index :articles, :canonical_url, unique: true, algorithm: :concurrently
+    end
+  end
+
+  def down
+    if index_exists?(:articles, :canonical_url, unique: true)
+      remove_index :articles, column: :canonical_url, algorithm: :concurrently
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 2020_09_02_204028) do
     t.string "video_state"
     t.string "video_thumbnail_url"
     t.index ["boost_states"], name: "index_articles_on_boost_states", using: :gin
+    t.index ["canonical_url"], name: "index_articles_on_canonical_url", unique: true
     t.index ["comment_score"], name: "index_articles_on_comment_score"
     t.index ["featured_number"], name: "index_articles_on_featured_number"
     t.index ["feed_source_url"], name: "index_articles_on_feed_source_url"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_length_of(:title).is_at_most(128) }
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:user_id) }
-    it { is_expected.to validate_uniqueness_of(:canonical_url).allow_blank }
+    it { is_expected.to validate_uniqueness_of(:canonical_url).allow_nil }
     it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_blank }
     it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:user_id) }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adding the unique index on articles `canonical_url`.

This is in conflict with https://github.com/forem/forem/pull/9788

Thus we need to decide which of these two options:

1. `canonical_url` has to be unique across all articles (drafts and published)
2. `canonical_url` has to be unique only within the scope of published articles (thus this index needs to add `published` in its column list)

I'm not 100% sure what we want here so I though we'd start with this drarft PR

ps. this should be deployed right after https://github.com/forem/forem/pull/10138 - possibly closely after to avoid further duplicates ;)

cc @mstruve @citizen428 due to, respectively, https://github.com/forem/forem/pull/9788#pullrequestreview-472925409 and https://github.com/forem/forem/pull/9788#discussion_r480880463

## Related Tickets & Documents

- https://github.com/forem/forem/pull/8072
- https://github.com/forem/forem/pull/10138

