### PR TITLE
Remove unneeded eager load

### DIFF
--- a/app/labor/sticky_article_collection.rb
+++ b/app/labor/sticky_article_collection.rb
@@ -22,7 +22,6 @@ class StickyArticleCollection
 
   def tag_articles
     @tag_articles ||= Article.published.tagged_with(article_tags, any: true)
-      .includes(:user)
       .where("public_reactions_count > ? OR comments_count > ?", reaction_count_num, comment_count_num)
       .where.not(id: article.id).where.not(user_id: article.user_id)
       .where("featured_number > ?", 5.days.ago.to_i)
@@ -34,7 +33,6 @@ class StickyArticleCollection
     return [] if tag_articles.size > 6
 
     Article.published.tagged_with(%w[career productivity discuss explainlikeimfive], any: true)
-      .includes(:user)
       .where("comments_count > ?", comment_count_num)
       .where.not(id: article.id).where.not(user_id: article.user_id)
       .where("featured_number > ?", 5.days.ago.to_i)

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -72,7 +72,7 @@
           <% @sticky_articles.each_with_index do |article, index| %>
             <a class="crayons-link crayons-link--contentful flex" href="<%= article.path %>">
               <span class="crayons-avatar mr-2 shrink-0">
-                <img src="<%= ProfileImage.new(article.user).get(width: 90) %>" class="crayons-avatar__image" loading="lazy" alt="<%= article.user.name %> profile image">
+                <img src="<%= ProfileImage.new(article.cached_user).get(width: 90) %>" class="crayons-avatar__image" loading="lazy" alt="<%= article.cached_user.name %> profile image">
               </span>
               <div>
                 <%= article.title %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

To pair with #10167, this is on the theme of using the tools at our disposal to avoid extra allocation. Article show pages get a lot of traffic and allocate a lot of extra memory by including users in this query when we don't need them due to our cached user optimization. 😊

<img width="761" alt="Screen Shot 2020-09-02 at 11 38 17 AM" src="https://user-images.githubusercontent.com/3102842/92004905-ce9ee180-ed10-11ea-8498-b30d1a182041.png" placeholder="N+1 Is Bad, Unneeded Memory Allocation Is Worse">

The other PR might require more discussion, this one should be more obvious.