### PR TITLE
Session cookie domain hotfix for login and logout

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -44,6 +44,14 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     )
 
     if user_persisted_and_valid?
+      # Deleting the session cookie with the previous app domain, the one without the leading dot.
+      # This should fix the double cookie scenario
+      domain = Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
+      if domain&.starts_with?(".")
+        domain_without_leading_dot = domain.gsub(/\A./, "")
+        cookies.delete(ApplicationConfig["SESSION_KEY"], domain: domain_without_leading_dot)
+      end
+
       # Devise's Omniauthable does not automatically remember users
       # see <https://github.com/heartcombo/devise/wiki/Omniauthable,-sign-out-action-and-rememberable>
       remember_me(@user)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -46,6 +46,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if user_persisted_and_valid?
       # Deleting the session cookie with the previous app domain, the one without the leading dot.
       # This should fix the double cookie scenario
+      # NOTE: this code is a hotfix, and shall be removed soon (around 2 weeks from deployment)
       domain = Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
       if domain&.starts_with?(".")
         domain_without_leading_dot = domain.gsub(/\A./, "")

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,6 +20,7 @@ class SessionsController < Devise::SessionsController
     Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
   end
 
+  # NOTE: this code is a hotfix, and shall be removed soon (around 2 weeks from deployment)
   def delete_legacy_cookie
     domain = cookie_domain
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,9 +1,33 @@
 class SessionsController < Devise::SessionsController
-  def destroy
-    # Let's say goodbye to all the cookies when someone signs out.
-    domain = Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
-    cookies.clear(domain: domain)
+  def create
+    delete_legacy_cookie
 
     super
+  end
+
+  def destroy
+    # Let's say goodbye to all the cookies when someone signs out.
+    cookies.clear(domain: cookie_domain)
+
+    delete_legacy_cookie
+
+    super
+  end
+
+  private
+
+  def cookie_domain
+    Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
+  end
+
+  def delete_legacy_cookie
+    domain = cookie_domain
+
+    return unless domain&.starts_with?(".")
+
+    # Deleting the session cookie with the previous app domain, the one without the leading dot.
+    # This should fix the double cookie scenario
+    domain_without_leading_dot = domain.gsub(/\A./, "")
+    cookies.delete(ApplicationConfig["SESSION_KEY"], domain: domain_without_leading_dot)
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

TLDR; we have cases of double cookies that have the same name but differ on domain, regardless on the value of `SameSite` (both were changed at the same time). 

This hotfix should work both for those who can't login and those who can't logout

## Related Tickets & Documents

#9967 

## QA Instructions, Screenshots, Recordings

Cross fingers and hope for the best 🤞 
