### PR TITLE
Bug Fix:Sort Reactions by created_at

### DIFF
--- a/app/services/search/query_builders/reaction.rb
+++ b/app/services/search/query_builders/reaction.rb
@@ -22,7 +22,7 @@ module Search
       }.freeze
 
       DEFAULT_PARAMS = {
-        sort_by: "id",
+        sort_by: "created_at",
         sort_direction: "desc",
         size: 0
       }.freeze

--- a/spec/services/search/reaction_spec.rb
+++ b/spec/services/search/reaction_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Search::Reaction, type: :service do
   describe "::search_documents", elasticsearch: "Reaction" do
     let(:article1) { create(:article) }
     let(:article2) { create(:article) }
-    let(:reaction1) { create(:reaction, category: "readinglist", reactable: article1) }
-    let(:reaction2) { create(:reaction, category: "readinglist", reactable: article2) }
+    let(:reaction1) { create(:reaction, category: "readinglist", reactable: article1, created_at: 1.week.ago) }
+    let(:reaction2) { create(:reaction, category: "readinglist", reactable: article2, created_at: Time.current) }
     let(:query_params) { { size: 5 } }
 
     it "parses reaction document hits from search response" do
@@ -112,7 +112,7 @@ RSpec.describe Search::Reaction, type: :service do
     end
 
     context "with default sorting" do
-      xit "sorts by id" do
+      it "sorts by created_at" do
         index_documents([reaction1, reaction2])
 
         reaction_docs = described_class.search_documents(params: query_params)["reactions"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix (Part 2 to https://github.com/forem/forem/pull/10142)

## Description
We store reactions in Elasticsearch and the default way we sort them is by ID desc which will give us the most recent reactions first. HOWEVER, this is not quite the case. IDs are stored in Elasticsearch as strings which means when you are doing a value comparison you end up with weird behavior such as 99 > 100. The means Reactions are not being sorted correctly all the time. This PR switches from using the ID to sort reactions to created_at

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44644200

## Added tests?
- [x] yes


![alt_text](https://media0.giphy.com/media/3o6Zt5jXXzAzdikVmE/200.gif)
