### PR TITLE
Optimization:Add Index for User ID and Mailer to Ahoy Messages

### DIFF
--- a/db/migrate/20200902204028_add_user_id_mailer_index_to_ahoy_messages.rb
+++ b/db/migrate/20200902204028_add_user_id_mailer_index_to_ahoy_messages.rb
@@ -1,0 +1,7 @@
+class AddUserIdMailerIndexToAhoyMessages < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :ahoy_messages, %i[user_id mailer], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_01_084210) do
+ActiveRecord::Schema.define(version: 2020_09_02_204028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2020_09_01_084210) do
     t.string "utm_term"
     t.index ["to"], name: "index_ahoy_messages_on_to"
     t.index ["token"], name: "index_ahoy_messages_on_token"
+    t.index ["user_id", "mailer"], name: "index_ahoy_messages_on_user_id_and_mailer"
     t.index ["user_id", "user_type"], name: "index_ahoy_messages_on_user_id_and_user_type"
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
In our `EmailDigestArticleCollector` we look up a user's most recent ahoy messages to help us determine if we should be sending them a Digest Email. 
```ruby
@last_user_emails ||= @user.email_messages.where(mailer: "DigestMailer#digest_email").limit(10)
```
The average for the lookup time for this query is almost 2 seconds, with it being closer to 10 when the database is under higher load. This should help speed things up a bit. 
![Screen Shot 2020-09-02 at 3 49 47 PM](https://user-images.githubusercontent.com/1813380/92035224-01a69c80-ed34-11ea-9572-2a42974c1c59.png)

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44508249

![](https://i.pinimg.com/originals/ce/39/18/ce39184419ed02046abce62e31597cde.gif)