### PR TITLE
Revert removal of unneeded eager load (if needed)

### DIFF
--- a/app/labor/sticky_article_collection.rb
+++ b/app/labor/sticky_article_collection.rb
@@ -22,6 +22,7 @@ class StickyArticleCollection
 
   def tag_articles
     @tag_articles ||= Article.published.tagged_with(article_tags, any: true)
+      .includes(:user)
       .where("public_reactions_count > ? OR comments_count > ?", reaction_count_num, comment_count_num)
       .where.not(id: article.id).where.not(user_id: article.user_id)
       .where("featured_number > ?", 5.days.ago.to_i)
@@ -33,6 +34,7 @@ class StickyArticleCollection
     return [] if tag_articles.size > 6
 
     Article.published.tagged_with(%w[career productivity discuss explainlikeimfive], any: true)
+      .includes(:user)
       .where("comments_count > ?", comment_count_num)
       .where.not(id: article.id).where.not(user_id: article.user_id)
       .where("featured_number > ?", 5.days.ago.to_i)

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -72,7 +72,8 @@
           <% @sticky_articles.each_with_index do |article, index| %>
             <a class="crayons-link crayons-link--contentful flex" href="<%= article.path %>">
               <span class="crayons-avatar mr-2 shrink-0">
-                <img src="<%= ProfileImage.new(article.cached_user).get(width: 90) %>" class="crayons-avatar__image" loading="lazy" alt="<%= article.cached_user.name %> profile image">              </span>
+                <img src="<%= ProfileImage.new(article.user).get(width: 90) %>" class="crayons-avatar__image" loading="lazy" alt="<%= article.user.name %> profile image">
+              </span>
               <div>
                 <%= article.title %>
                 <div class="crayons-link__secondary -ml-1">

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -72,8 +72,7 @@
           <% @sticky_articles.each_with_index do |article, index| %>
             <a class="crayons-link crayons-link--contentful flex" href="<%= article.path %>">
               <span class="crayons-avatar mr-2 shrink-0">
-                <img src="<%= ProfileImage.new(article.cached_user).get(width: 90) %>" class="crayons-avatar__image" loading="lazy" alt="<%= article.cached_user.name %> profile image">
-              </span>
+                <img src="<%= ProfileImage.new(article.cached_user).get(width: 90) %>" class="crayons-avatar__image" loading="lazy" alt="<%= article.cached_user.name %> profile image">              </span>
               <div>
                 <%= article.title %>
                 <div class="crayons-link__secondary -ml-1">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

After merging this PR we've seen a slow down in requests. #10168

Which makes _zero_ sense to me because the affects of this optimization should be very minimal one way or another as they are behind the fragment cache and generally minimal either way... 

But I figured I'd toss this reversal up unless there's another explanation about activity going on which would cause slower response times.

.... In looking more closely at this code, there are some much bigger optimizations that could be made here either way, but I don't know if this is actually something affecting responses or a coincidence.