### PR TITLE
Add profiles controller

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,13 @@
+class ProfilesController < ApplicationController
+  before_action :authenticate_user!
+
+  def update
+    Profiles::Update.call(current_user.profile, update_params)
+  end
+
+  private
+
+  def update_params
+    params.require(:profile).permit(*Profile.attributes)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,6 +282,7 @@ Rails.application.routes.draw do
     end
 
     resource :onboarding, only: :show
+    resources :profiles, only: %i[update]
     resources :profile_field_groups, only: %i[index], defaults: { format: :json }
 
     get "/verify_email_ownership", to: "email_authorizations#verify", as: :verify_email_authorizations

--- a/spec/requests/profiles_request_spec.rb
+++ b/spec/requests/profiles_request_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Profiles", type: :request do
+  let(:profile) { create(:profile) }
+
+  describe "POST /profiles" do
+    context "when signed out" do
+      it "redirects to the login page" do
+        patch profile_path(profile), params: {}
+        expect(response).to redirect_to(sign_up_path)
+      end
+    end
+
+    context "when signed in" do
+      before do
+        create(:profile_field, label: "Name")
+        Profile.refresh_attributes!
+        sign_in(profile.user)
+      end
+
+      it "updates the profile" do
+        new_name = "New name, who dis?"
+        expect do
+          patch profile_path(profile), params: { profile: { name: new_name } }
+        end.to change { profile.reload.name }.to(new_name)
+      end
+
+      it "syncs the changes back to the user" do
+        new_name = "New name, who dis?"
+        expect do
+          patch profile_path(profile), params: { profile: { name: new_name } }
+        end.to change { profile.user.reload.name }.to(new_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds a simple `ProfilesController` which uses the service object added in #9912 to separate profile from user updates.

## Related Tickets & Documents

Part of #6994.

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
