### PR TITLE
Vertical alignment of post title in notification

### DIFF
--- a/app/assets/stylesheets/notifications.scss
+++ b/app/assets/stylesheets/notifications.scss
@@ -142,6 +142,7 @@
             border-radius: 3px;
           }
           .notification-comment-reacted-link {
+            vertical-align: middle;
             padding: 2px 6px;
             border: 1px solid lighten($medium-gray, 9%);
             border-radius: 3px;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixing vertical alignment of post title in notification

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/10182

## QA Instructions, Screenshots, Recordings
1. Go to dev.to/notifications
2. Look for notification with post title 

### Before
![vertical_align_before](https://user-images.githubusercontent.com/8092120/92084390-f2335c00-ede4-11ea-9b0c-4fb2b48ec111.png)

### After

![fixing_vertical_alignment](https://user-images.githubusercontent.com/8092120/92083967-60c3ea00-ede4-11ea-88a9-dea3796ec99b.png)
 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

