### PR TITLE
Fixed new redirects

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -139,7 +139,9 @@
         // Don't run on harcoded redirects (see config/routes.rb for the list)
         !url.href.includes('/%F0%9F%92%B8') && // 💸 (hiring)
         !url.href.includes('/api') &&
+        !url.href.includes('/forem') &&
         !url.href.includes('/future') &&
+        !url.href.includes('/internal') &&
         !url.href.includes('/podcasts') &&
         !url.href.includes('/shop') &&
         !url.href.includes('/survey') &&


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
Conditions for `/internal` and `/forem` redirects were not added to the serviceworkers file, so these redirects were not working, this pr fixes this problem.

## QA Instructions, Screenshots, Recordings
Open `/internal` page, it should redirect to `/admin/articles`.
`/forem` should redirect to `/devteam/for-empowering-community-2k6h`