### PR TITLE
Move deletion of legacy cookie higher in omniauth callback

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -34,14 +34,11 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private
 
   def callback_for(provider)
-    # Deleting the session cookie with the previous app domain, the one without the leading dot.
-    # This should fix the double cookie scenario
+    # Deleting the session cookie with the legacy app domain, which does NOT include a preceding dot.
+    # This should fix the double cookie scenario.
     # TODO: this code is a hotfix, we should remove it after 09/18/2020.
-    domain = Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
-    if domain&.starts_with?(".")
-      domain_without_leading_dot = domain.gsub(/\A./, "")
-      cookies.delete(ApplicationConfig["SESSION_KEY"], domain: domain_without_leading_dot)
-    end
+    legacy_cookie_domain = Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
+    cookies.delete(ApplicationConfig["SESSION_KEY"], domain: legacy_cookie_domain)
 
     auth_payload = request.env["omniauth.auth"]
     cta_variant = request.env["omniauth.params"]["state"].to_s

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -36,7 +36,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def callback_for(provider)
     # Deleting the session cookie with the previous app domain, the one without the leading dot.
     # This should fix the double cookie scenario
-    # NOTE: this code is a hotfix, and shall be removed soon (around 2 weeks from deployment)
+    # TODO: this code is a hotfix, we should remove it after 09/18/2020.
     domain = Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
     if domain&.starts_with?(".")
       domain_without_leading_dot = domain.gsub(/\A./, "")

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,7 @@ class SessionsController < Devise::SessionsController
     Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
   end
 
-  # NOTE: this code is a hotfix, and shall be removed soon (around 2 weeks from deployment)
+  # TODO: this code is a hotfix, we should remove it after 09/18/2020.
   def delete_legacy_cookie
     domain = cookie_domain
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,29 +6,28 @@ class SessionsController < Devise::SessionsController
   end
 
   def destroy
+    delete_legacy_cookie
+
     # Let's say goodbye to all the cookies when someone signs out.
     cookies.clear(domain: cookie_domain)
-
-    delete_legacy_cookie
 
     super
   end
 
   private
 
-  def cookie_domain
+  def legacy_cookie_domain
     Rails.env.production? ? ApplicationConfig["APP_DOMAIN"] : nil
+  end
+
+  def cookie_domain
+    ".#{legacy_cookie_domain}"
   end
 
   # TODO: this code is a hotfix, we should remove it after 09/18/2020.
   def delete_legacy_cookie
-    domain = cookie_domain
-
-    return unless domain&.starts_with?(".")
-
-    # Deleting the session cookie with the previous app domain, the one without the leading dot.
-    # This should fix the double cookie scenario
-    domain_without_leading_dot = domain.gsub(/\A./, "")
-    cookies.delete(ApplicationConfig["SESSION_KEY"], domain: domain_without_leading_dot)
+    # Deleting the session cookie with the legacy app domain, which does NOT include a preceding dot.
+    # This should fix the double cookie scenario.
+    cookies.delete(ApplicationConfig["SESSION_KEY"], domain: legacy_cookie_domain)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A continuation on https://github.com/forem/forem/pull/10169. As mentioned in that PR, we weren't entirely sure if this was going to work. We had @lisasy test this out on production and we _suspect_ that when signing in with SSO, the cookie might be being deleted too late, so this PR moves it up higher in the `OmniauthCallbacksController#callback_for`.

I also updated the current `NOTE` to a `TODO` with a specific date when we should remove this temporary code :)  

## Related Tickets & Documents

Please see https://github.com/forem/forem/pull/10169 for more context!

## QA Instructions, Screenshots, Recordings

Not really possible to test this unless you are in production _and_ if you have the double cookie instance 🙃 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?

Need to have @lisasy test this out on production once it has been deployed.

