### PR TITLE
Optimization:Select Only Necessary Columns from Ahoy Messages For Digest Emails

### DIFF
--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -81,6 +81,7 @@ class EmailDigestArticleCollector
   end
 
   def last_user_emails
-    @last_user_emails ||= @user.email_messages.where(mailer: "DigestMailer#digest_email").limit(10)
+    @last_user_emails ||= @user.email_messages.select(:sent_at,
+                                                      :opened_at).where(mailer: "DigestMailer#digest_email").limit(10)
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Only select the columns we need from Ahoy Messages when loading them to check about sending digest emails. 


![alt_text](https://media1.tenor.com/images/f5fc501d18254f00a6aa47718c7b9723/tenor.gif?itemid=10109964)
