### PR TITLE
Include locale in fragment cache key

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -184,7 +184,7 @@ module ApplicationHelper
     release_footprint = ApplicationConfig["RELEASE_FOOTPRINT"]
     return path if release_footprint.blank?
 
-    "#{path}-#{release_footprint}"
+    "#{path}-#{params[:locale]}-#{release_footprint}"
   end
 
   def copyright_notice

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -43,7 +43,13 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     it "appends the RELEASE_FOOTPRINT if it is set" do
       allow(ApplicationConfig).to receive(:[]).with("RELEASE_FOOTPRINT").and_return("abc123")
-      expect(helper.release_adjusted_cache_key("cache-me")).to eq("cache-me-abc123")
+      expect(helper.release_adjusted_cache_key("cache-me")).to eq("cache-me--abc123")
+    end
+
+    it "includes locale param if it is set" do
+      allow(ApplicationConfig).to receive(:[]).with("RELEASE_FOOTPRINT").and_return("abc123")
+      params[:locale] = "fr-ca"
+      expect(helper.release_adjusted_cache_key("cache-me")).to eq("cache-me-fr-ca-abc123")
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Only some fragment caches make use of this method...... But it's a starter towards accounting for fragment caches across different locales.

This doesn't account for all fragments (and some we can't just change without thinking through the deployment concerns of cold hits), but this one change should be pretty harmless and let us account for at least this scenario for now.

Let me know what you think.