### PR TITLE
Remove draft articles with duplicate feed source URL and cleanup invalid data

### DIFF
--- a/lib/data_update_scripts/20200904132553_remove_draft_articles_with_duplicate_feed_source_url.rb
+++ b/lib/data_update_scripts/20200904132553_remove_draft_articles_with_duplicate_feed_source_url.rb
@@ -1,0 +1,74 @@
+module DataUpdateScripts
+  class RemoveDraftArticlesWithDuplicateFeedSourceUrl
+    def run
+      # Currently there are duplicate draft articles in the DB with the same feed_source_url.
+
+      # This statement deletes all draft articles in excess found to be duplicate over feed_source_url,
+      # excluding those whose body_markdown is different from the other duplicate occurrences
+      result = ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          WITH duplicates_draft_articles AS
+              (SELECT id
+               FROM
+                   (SELECT id,
+                           published,
+                           body_markdown,
+                           LAG(body_markdown, 1) OVER(PARTITION BY feed_source_url
+                                                      ORDER BY id ASC) AS previous_body_markdown,
+                           ROW_NUMBER() OVER(PARTITION BY feed_source_url
+                                             ORDER BY id ASC) AS row_number
+                    FROM articles
+                    WHERE feed_source_url IS NOT NULL ) duplicates
+               WHERE duplicates.row_number > 1
+                   AND published = 'f' -- drafts
+                   AND body_markdown = previous_body_markdown -- with the same body
+           )
+          DELETE
+          FROM articles
+          WHERE id IN (SELECT id FROM duplicates_draft_articles) RETURNING id;
+        SQL
+      )
+
+      # Sending IDs of deleted articles to Datadog
+      DatadogStatsClient.event(
+        "DataUpdateScripts::RemoveDraftArticlesWithDuplicateFeedSourceUrl",
+        "deleted draft articles with the same feed_source_url and same body_markdown",
+        tags: result.map { |row| row["id"] },
+      )
+
+      # Now that all duplicates with the same body are gone, we need to deal with duplicate feed source URLs
+      # with different bodies.
+      # We thus select the oldest for removal preserving the most recent one
+      result = ActiveRecord::Base.connection.execute(
+        <<~SQL,
+          WITH duplicates_draft_articles AS
+              (SELECT id
+               FROM
+                   (SELECT id,
+                           published,
+                           body_markdown,
+                           LAG(body_markdown, 1) OVER(PARTITION BY feed_source_url
+                                                      ORDER BY created_at DESC) AS previous_body_markdown,
+                           ROW_NUMBER() OVER(PARTITION BY feed_source_url
+                                             ORDER BY created_at DESC) AS row_number
+                    FROM articles
+                    WHERE feed_source_url IS NOT NULL ) duplicates
+               WHERE duplicates.row_number > 1
+                   AND published = 'f' -- drafts
+                   AND body_markdown != previous_body_markdown -- with different bodies
+           )
+          DELETE
+          FROM articles
+          WHERE id IN (SELECT id FROM duplicates_draft_articles) RETURNING id;
+        SQL
+      )
+
+      # Sending IDs of deleted articles to Datadog
+      DatadogStatsClient.event(
+        "DataUpdateScripts::RemoveDraftArticlesWithDuplicateFeedSourceUrl",
+        "deleted draft articles with the same feed_source_url and different body_markdown",
+        tags: result.map { |row| row["id"] },
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200904132553_remove_draft_articles_with_duplicate_feed_source_url.rb
+++ b/lib/data_update_scripts/20200904132553_remove_draft_articles_with_duplicate_feed_source_url.rb
@@ -30,11 +30,13 @@ module DataUpdateScripts
       )
 
       # Sending IDs of deleted articles to Datadog
-      DatadogStatsClient.event(
-        "DataUpdateScripts::RemoveDraftArticlesWithDuplicateFeedSourceUrl",
-        "deleted draft articles with the same feed_source_url and same body_markdown",
-        tags: result.map { |row| row["id"] },
-      )
+      result.map { |row| row["id"] }.in_groups_of(1000) do |ids|
+        DatadogStatsClient.event(
+          "DataUpdateScripts::RemoveDraftArticlesWithDuplicateFeedSourceUrl",
+          "deleted draft articles with the same feed_source_url and same body_markdown",
+          tags: ids,
+        )
+      end
 
       # Now that all duplicates with the same body are gone, we need to deal with duplicate feed source URLs
       # with different bodies.
@@ -64,11 +66,13 @@ module DataUpdateScripts
       )
 
       # Sending IDs of deleted articles to Datadog
-      DatadogStatsClient.event(
-        "DataUpdateScripts::RemoveDraftArticlesWithDuplicateFeedSourceUrl",
-        "deleted draft articles with the same feed_source_url and different body_markdown",
-        tags: result.map { |row| row["id"] },
-      )
+      result.map { |row| row["id"] }.in_groups_of(1000) do |ids|
+        DatadogStatsClient.event(
+          "DataUpdateScripts::RemoveDraftArticlesWithDuplicateFeedSourceUrl",
+          "deleted draft articles with the same feed_source_url and different body_markdown",
+          tags: ids,
+        )
+      end
     end
   end
 end

--- a/lib/data_update_scripts/20200904141057_cleanup_articles_with_invalid_feed_source_url.rb
+++ b/lib/data_update_scripts/20200904141057_cleanup_articles_with_invalid_feed_source_url.rb
@@ -1,0 +1,16 @@
+module DataUpdateScripts
+  class CleanupArticlesWithInvalidFeedSourceUrl
+    def run
+      # We need this to intercept those strings that would be valid URLs if the scheme were added,
+      # so I slightly modified the Ruby URL regexp from https://urlregex.com/ to avoid checking for the scheme
+      almost_url_regexp = %r{\A(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:/[^\s]*)?\z}i # rubocop:disable Layout/LineLength
+
+      Article.where.not(feed_source_url: nil).where("feed_source_url NOT ILIKE ?", "http%").find_each do |article|
+        fixed_feed_source_url = article.canonical_url.presence ||
+          (almost_url_regexp.match?(article.feed_source_url) ? "https://#{article.feed_source_url}" : nil)
+
+        article.update_columns(feed_source_url: fixed_feed_source_url)
+      end
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/cleanup_articles_with_invalid_feed_source_url_spec.rb
+++ b/spec/lib/data_update_scripts/cleanup_articles_with_invalid_feed_source_url_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20200904141057_cleanup_articles_with_invalid_feed_source_url.rb",
+)
+
+describe DataUpdateScripts::CleanupArticlesWithInvalidFeedSourceUrl do
+  it "sets empty string feed source url to nil" do
+    article = create(:article)
+    article.update_columns(feed_source_url: "")
+
+    described_class.new.run
+
+    expect(article.reload.feed_source_url).to be(nil)
+  end
+
+  it "sets totally invalid url to nil" do
+    article = create(:article)
+    article.update_columns(feed_source_url: "not a url")
+
+    described_class.new.run
+
+    expect(article.reload.feed_source_url).to be(nil)
+  end
+
+  it "sets an 'almost URL' to a https URL" do
+    article = create(:article)
+    article.update_columns(feed_source_url: "dev.to")
+
+    described_class.new.run
+
+    expect(article.reload.feed_source_url).to eq("https://dev.to")
+  end
+end

--- a/spec/lib/data_update_scripts/cleanup_articles_with_invalid_feed_source_url_spec.rb
+++ b/spec/lib/data_update_scripts/cleanup_articles_with_invalid_feed_source_url_spec.rb
@@ -4,8 +4,18 @@ require Rails.root.join(
 )
 
 describe DataUpdateScripts::CleanupArticlesWithInvalidFeedSourceUrl do
+  let(:article) { create(:article) }
+
+  it "sets feed_source_url to canonical_url if the latter is present" do
+    canonical_url = "https://example.com/article"
+    article.update_columns(feed_source_url: "", canonical_url: canonical_url)
+
+    described_class.new.run
+
+    expect(article.reload.feed_source_url).to eq(canonical_url)
+  end
+
   it "sets empty string feed source url to nil" do
-    article = create(:article)
     article.update_columns(feed_source_url: "")
 
     described_class.new.run
@@ -14,7 +24,6 @@ describe DataUpdateScripts::CleanupArticlesWithInvalidFeedSourceUrl do
   end
 
   it "sets totally invalid url to nil" do
-    article = create(:article)
     article.update_columns(feed_source_url: "not a url")
 
     described_class.new.run
@@ -23,7 +32,6 @@ describe DataUpdateScripts::CleanupArticlesWithInvalidFeedSourceUrl do
   end
 
   it "sets an 'almost URL' to a https URL" do
-    article = create(:article)
     article.update_columns(feed_source_url: "dev.to")
 
     described_class.new.run

--- a/spec/lib/data_update_scripts/remove_draft_articles_with_duplicate_feed_source_url_spec.rb
+++ b/spec/lib/data_update_scripts/remove_draft_articles_with_duplicate_feed_source_url_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20200904132553_remove_draft_articles_with_duplicate_feed_source_url.rb",
+)
+
+describe DataUpdateScripts::RemoveDraftArticlesWithDuplicateFeedSourceUrl do
+  it "removes draft articles that have the same feed source url and the same body keeping the first" do
+    articles = create_list(:article, 3, published: false)
+
+    # we bypass the callbacks intentionally as feed source url has a unique callback at the Rails level
+    articles.each do |article|
+      article.update_columns(
+        body_markdown: "body",
+        feed_source_url: "https://example.com/article",
+      )
+    end
+
+    number_of_articles_to_remove = articles.size - 1
+
+    expect { described_class.new.run }.to change(Article, :count).by(-number_of_articles_to_remove)
+
+    articles.sort_by!(&:id)
+
+    expect(Article.exists?(articles.first.id)).to be(true)
+    expect(Article.exists?(articles.second.id)).to be(false)
+    expect(Article.exists?(articles.third.id)).to be(false)
+  end
+
+  it "removes draft articles that have the same feed source url and different bodies keeping the most recent" do
+    articles = create_list(:article, 3, published: false)
+
+    # we bypass the callbacks intentionally as feed source url has a unique callback at the Rails level
+    articles.each do |article|
+      article.update_columns(
+        created_at: Faker::Time.between(from: Time.current, to: 2.days.ago),
+        feed_source_url: "https://example.com/article",
+      )
+    end
+
+    number_of_articles_to_remove = articles.size - 1
+
+    expect { described_class.new.run }.to change(Article, :count).by(-number_of_articles_to_remove)
+
+    articles.sort_by! { |a| -a.created_at.to_i }
+
+    expect(Article.exists?(articles.first.id)).to be(true)
+    expect(Article.exists?(articles.second.id)).to be(false)
+    expect(Article.exists?(articles.third.id)).to be(false)
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Similar to https://github.com/forem/forem/pull/10138 but based on `feed_source_url`.

To be able to close the loop on #8072 and add a unique index on feed_source_url we need first to be remove duplicates that have the same feed_source_url.

This PR contains scripts to accomplish the following things:

1. remove all drafts that in a partition have the same body. A partition is determined as a group of articles with the same feed source URL
2. remove all drafts that in a partition have different bodies by keeping the most recent one. A partition is determined as a group of articles with the same feed source URL
3. fixes invalid data for `feed_source_url`. Currently, unlike with `canonical_url`, we don't have a URL validator on the field, thus I found a bunch of invalid URLs in production data, see https://dev.to/admin/blazer/queries/220-articles-with-an-invalid-feed-source-url

Please read the SQL queries closely.

If you want to take a look at the data:

- https://dev.to/admin/blazer/queries/218-duplicate-articles-feed_source_url-with-the-same-body
- https://dev.to/admin/blazer/queries/219-duplicate-articles-feed_source_url-with-different-bodies
- https://dev.to/admin/blazer/queries/220-articles-with-an-invalid-feed-source-url

## Related Tickets & Documents

#10138 
#8072 

## QA Instructions, Screenshots, Recordings

Ideally this should be tested on a copy of the production DB. To make sure it worked I downloaded the sample of duplicates https://dev.to/admin/blazer/queries/221-duplicate-articles-feed_source-url-with-the-same-body-ids - imported them locally and ran the scripts to make sure they worked. They obviously present different results as it's a script run on the subset of duplications (so it works because in some cases we have 2 or more duplicates of the same article).

If you want to test it nonetheless:

- download a CSV from https://dev.to/admin/blazer/queries/221-duplicate-articles-feed_source-url-with-the-same-body-ids
- open the SQL console with `psql PracticalDeveloper_development`
- type `\d articles`
- note the names of the foreign key constraints
- drop the foreign key constraints on the `articles` table, otherwise the `user_id` and `organization_id` won't work:

```sql
alter table articles drop constraint fk_rails_3d31dad1cc;
alter table articles drop constraint fk_rails_7809a1a57d;
```

remember that the constraint names might be different than mine. Please double check with `\d articles` in the SQL console and replace them with yours
- import the data from the downloaded CSV:

```sql
copy articles(id,user_id,title,body_html,slug,created_at,updated_at,main_image,description,published,published_at,featured,processed_html,featured_number,social_image,body_markdown,organization_id,canonical_url,collection_id,show_comments,main_image_background_hex_color,receive_notifications,approved,published_from_feed,comments_count,reactions_count,video,video_code,video_source_url,video_thumbnail_url,video_closed_caption_track_url,hotness_score,feed_source_url,second_user_id,third_user_id,last_buffered,positive_reactions_count,edited_at,crossposted_at,spaminess_rating,language,facebook_last_buffered,cached_tag_list,path,cached_user_name,cached_user_username,last_comment_at,boost_states,video_state,page_views_count,previous_positive_reactions_count,score,reading_time,comment_template,video_duration_in_seconds,experience_level_rating,experience_level_rating_distribution,last_experience_level_rating_at,rating_votes_count,originally_published_at,organic_page_views_count,organic_page_views_past_month_count,organic_page_views_past_week_count,cached_user,cached_organization,archived,any_comments_hidden,nth_published_by_author,comment_score,search_optimized_title_preamble,search_optimized_description_replacement,public_reactions_count,previous_public_reactions_count,user_subscriptions_count) from '/path/to/duplicate-articles-feed_source-url-with-the-same-body-ids.csv' DELIMITER ',' csv header;
```

don't forget to replace the path of the file with the full path of the file you downloaded

- count the number of articles, just to have a quick idea if the script has worked
- run the data update script with `rails data_updates:run` if it's the first time or manually in the console

```ruby
require Rails.root.join("lib/data_update_scripts/20200904132553_remove_draft_articles_with_duplicate_feed_source_url.rb")
DataUpdateScripts::RemoveDraftArticlesWithDuplicateFeedSourceUrl.new.run
```

- re-count the number of articles, it should be less ;-)
- run https://dev.to/admin/blazer/queries/218-duplicate-articles-feed_source_url-with-the-same-body  locally to make sure they are gone



If you would like to test the cleanup script as well, you can do something similar by using:

- https://dev.to/admin/blazer/queries/222-articles-with-an-invalid-feed-source-url-select as the source data
- the following to test:

```ruby
require Rails.root.join("lib/data_update_scripts/20200904141057_cleanup_articles_with_invalid_feed_source_url.rb")
DataUpdateScripts::CleanupArticlesWithInvalidFeedSourceUrl.new.run
```

- re-run https://dev.to/admin/blazer/queries/220-articles-with-an-invalid-feed-source-url locally to check the data has been cleaned


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
