### PR TITLE
Optimization:Increase refresh_interval For Possible High Indexing Indexes

### DIFF
--- a/app/services/search/base.rb
+++ b/app/services/search/base.rb
@@ -33,8 +33,18 @@ module Search
         Search::Client.delete(id: doc_id, index: self::INDEX_ALIAS)
       end
 
+      def index_exists?(index_name: self::INDEX_NAME)
+        Search::Client.indices.exists(index: index_name)
+      end
+
       def create_index(index_name: self::INDEX_NAME)
         Search::Client.indices.create(index: index_name, body: settings)
+      end
+
+      def update_index(index_name: self::INDEX_NAME)
+        return unless dynamic_index_settings.any?
+
+        Search::Client.indices.put_settings(index: index_name, body: dynamic_settings)
       end
 
       def delete_index(index_name: self::INDEX_NAME)
@@ -95,6 +105,14 @@ module Search
 
       def index_settings
         raise "Search classes must implement their own index settings"
+      end
+
+      def dynamic_settings
+        { settings: { index: dynamic_index_settings } }
+      end
+
+      def dynamic_index_settings
+        {}
       end
 
       def process_hashes(indexing_hashes)

--- a/app/services/search/cluster.rb
+++ b/app/services/search/cluster.rb
@@ -18,6 +18,7 @@ module Search
       def setup_indexes
         update_settings
         create_indexes
+        update_indexes
         add_aliases
         update_mappings
       end
@@ -28,10 +29,14 @@ module Search
 
       def create_indexes
         SEARCH_CLASSES.each do |search_class|
-          next if Search::Client.indices.exists(index: search_class::INDEX_NAME)
+          next if search_class.index_exists?
 
           search_class.create_index
         end
+      end
+
+      def update_indexes
+        SEARCH_CLASSES.each(&:update_index)
       end
 
       def add_aliases

--- a/app/services/search/feed_content.rb
+++ b/app/services/search/feed_content.rb
@@ -70,6 +70,14 @@ module Search
           }
         end
       end
+
+      def dynamic_index_settings
+        if Rails.env.production?
+          { refresh_interval: "5s" }
+        else
+          { refresh_interval: "1s" }
+        end
+      end
     end
   end
 end

--- a/app/services/search/reaction.rb
+++ b/app/services/search/reaction.rb
@@ -34,6 +34,14 @@ module Search
           }
         end
       end
+
+      def dynamic_index_settings
+        if Rails.env.production?
+          { refresh_interval: "2s" }
+        else
+          { refresh_interval: "1s" }
+        end
+      end
     end
   end
 end

--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -42,6 +42,14 @@ module Search
           }
         end
       end
+
+      def dynamic_index_settings
+        if Rails.env.production?
+          { refresh_interval: "5s" }
+        else
+          { refresh_interval: "1s" }
+        end
+      end
     end
   end
 end

--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -45,7 +45,7 @@ module Search
 
       def dynamic_index_settings
         if Rails.env.production?
-          { refresh_interval: "5s" }
+          { refresh_interval: "10s" }
         else
           { refresh_interval: "1s" }
         end

--- a/spec/services/search/cluster_spec.rb
+++ b/spec/services/search/cluster_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe Search::Cluster, type: :service do
     end
   end
 
+  describe "::update_indexes" do
+    it "calls update_index for each search class" do
+      described_class::SEARCH_CLASSES.each do |search_class|
+        allow(search_class).to receive(:update_index)
+      end
+      described_class.update_indexes
+      expect(described_class::SEARCH_CLASSES).to all(have_received(:update_index))
+    end
+  end
+
   describe "::delete_indexes" do
     it "calls delete_index for each search class" do
       allow(Search::Client.indices).to receive(:exists).and_return(true)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
On 9/3 we had some of our "Slow Elasticsearch Query" alerts go off indicating that Elasticsearch response times were increasing. When I looked further into the issue I noticed that the leading spike came from indexing requests and we did have an increase in indexing at the time. 
![Screen Shot 2020-09-04 at 4 35 23 PM](https://user-images.githubusercontent.com/1813380/92286468-c095c000-eecc-11ea-9ee5-c9facf4863ab.png)

Another thing I noticed when digging into the Elasticsearch stats was that our refresh time had also spiked during this time. [By default, Elasticsearch will refresh an index every second](https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-indexing-speed.html#_unset_or_increase_the_refresh_interval). Refreshing an index takes a considerable amount of resources which can cause indexing to slow down. To alleviate this pressure, if you don't need near-realtime searching then increasing the refresh interval can help. 

![Screen Shot 2020-09-04 at 4 37 09 PM](https://user-images.githubusercontent.com/1813380/92286709-647f6b80-eecd-11ea-9bc7-8555f56ce1f7.png)

This PR increases the refresh interval on 3 of our indexes, Feed Content, Users, and Reactions. 
- Feed Content and Users -> 5 seconds. We execute these updates in the background so we already dont expect them to be near real-time bc of the worker delay. 5 seconds seemed high enough to give us indexing gains but still low enough to be really snappy. 
- Reactions -> 2 seconds. When a user clicks to save an article to their readinglist, they might then just pop over to the reading list to see what is on it. For this reason, I kept this refresh shorter but still we cut the number of refreshes in half for a little more indexing power. 

For more information about what a Refresh Interval is, check out the "Refresh Interval" section in this blog post https://dev.to/molly_struve/scaling-elasticsearch-part-1-how-to-speed-up-indexing-2pel

CodeClimate can be ignored 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-44926128

## Added tests?
- [x] yes


![alt_text](https://media1.giphy.com/media/3o6Mb4gNHbwGZRdv32/source.gif)
