### PR TITLE
Fix DataUpdateScripts::CreateProfileFields spec

### DIFF
--- a/spec/lib/data_update_scripts/create_profile_fields_spec.rb
+++ b/spec/lib/data_update_scripts/create_profile_fields_spec.rb
@@ -6,6 +6,11 @@ def profile_field_and_group_count
 end
 
 describe DataUpdateScripts::CreateProfileFields do
+  before do
+    ProfileFieldGroup.destroy_all
+    ProfileField.destroy_all
+  end
+
   context "when no profile fields or groups exist" do
     it "creates all profile fields and groups" do
       expect do
@@ -18,11 +23,6 @@ describe DataUpdateScripts::CreateProfileFields do
     before do
       csv = Rails.root.join("lib/data/dev_profile_fields.csv")
       ProfileFields::ImportFromCsv.call(csv)
-    end
-
-    after do
-      ProfileFieldGroup.destroy_all
-      ProfileField.destroy_all
     end
 
     it "works when profile fields or groups already exist", :aggregate_failures do


### PR DESCRIPTION
## What type of PR is this? (check all applicable
- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It seems `spec/lib/data_update_scripts/create_profile_fields_spec.rb` is flaky at times. We'll eventually comment out the data update script and this spec, so for now, I wasn't sure if the script has been run on all environments yet, so I decided to  add some manual cleanup steps to the spec.

## Related Tickets & Documents

Part of #10006 

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
