### PR TITLE
Add LiquidTagsController

### DIFF
--- a/app/controllers/liquid_tags_controller.rb
+++ b/app/controllers/liquid_tags_controller.rb
@@ -1,0 +1,13 @@
+class LiquidTagsController < ApplicationController
+  before_action :authenticate_user!
+
+  FILTER_REGEX = /^(?:NullTag|Liquid::)/.freeze
+
+  def index
+    custom_tags = Liquid::Template.tags.filter_map do |name, tag|
+      name unless tag.match?(FILTER_REGEX)
+    end.sort
+
+    render json: { liquid_tags: custom_tags }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,6 +284,8 @@ Rails.application.routes.draw do
     resources :profiles, only: %i[update]
     resources :profile_field_groups, only: %i[index], defaults: { format: :json }
 
+    resources :liquid_tags, only: %i[index], defaults: { format: :json }
+
     get "/verify_email_ownership", to: "email_authorizations#verify", as: :verify_email_authorizations
     get "/search/tags" => "search#tags"
     get "/search/chat_channels" => "search#chat_channels"

--- a/spec/requests/liquid_tags_request_spec.rb
+++ b/spec/requests/liquid_tags_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "LiquidTags", type: :request do
       it "returns a list of all custom Liquid tags" do
         get liquid_tags_path
 
-        expect(response.status).to eq 401
+        expect(response).to have_http_status(:unauthorized)
       end
     end
 

--- a/spec/requests/liquid_tags_request_spec.rb
+++ b/spec/requests/liquid_tags_request_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "LiquidTags", type: :request do
   describe "GET /liquid_tags" do
@@ -12,15 +12,16 @@ RSpec.describe "LiquidTags", type: :request do
 
     context "when signed in" do
       let(:user) { create(:user) }
+
       before { sign_in(user) }
 
       it "returns an array of all custom Liquid tags", :aggregate_failures do
         get liquid_tags_path
 
-        expect(response.status).to eq 200
-        json = JSON.parse(response.body, symbolize_names: true)
-        expect(json[:liquid_tags]).to be_an_instance_of(Array)
-        expect(json[:liquid_tags]).not_to be_empty
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        expect(json["liquid_tags"]).to be_an_instance_of(Array)
+        expect(json["liquid_tags"]).not_to be_empty
       end
     end
   end

--- a/spec/requests/liquid_tags_request_spec.rb
+++ b/spec/requests/liquid_tags_request_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe "LiquidTags", type: :request do
+  describe "GET /liquid_tags" do
+    context "when not signed in do" do
+      it "returns a list of all custom Liquid tags" do
+        get liquid_tags_path
+
+        expect(response.status).to eq 401
+      end
+    end
+
+    context "when signed in" do
+      let(:user) { create(:user) }
+      before { sign_in(user) }
+
+      it "returns an array of all custom Liquid tags", :aggregate_failures do
+        get liquid_tags_path
+
+        expect(response.status).to eq 200
+        json = JSON.parse(response.body, symbolize_names: true)
+        expect(json[:liquid_tags]).to be_an_instance_of(Array)
+        expect(json[:liquid_tags]).not_to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds an internal API controller for receiving a list of our custom Liquid tags. This can then be used by the frontend to display a typeahead liquid tag dropdown in new editor.

## Related Tickets & Documents

#872

## QA Instructions, Screenshots, Recordings

It's pretty much all covered by the specs.

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
