### PR TITLE
Feature:Add ENV to Skip Fastly Config Update

### DIFF
--- a/lib/tasks/fastly.rake
+++ b/lib/tasks/fastly.rake
@@ -1,19 +1,21 @@
 namespace :fastly do
   desc "Update Fastly configs"
   task update_configs: :environment do
-    fastly_credentials = %w[
-      FASTLY_API_KEY
-      FASTLY_SERVICE_ID
-    ]
+    unless ENV["SKIP_FASTLY_CONFIG_UPDATE"] == "true"
+      fastly_credentials = %w[
+        FASTLY_API_KEY
+        FASTLY_SERVICE_ID
+      ]
 
-    if fastly_credentials.any? { |cred| ApplicationConfig[cred].blank? }
-      Rails.logger.info(
-        "Fastly not configured. Please set #{fastly_credentials.join(', ')} in your environment.",
-      )
+      if fastly_credentials.any? { |cred| ApplicationConfig[cred].blank? }
+        Rails.logger.info(
+          "Fastly not configured. Please set #{fastly_credentials.join(', ')} in your environment.",
+        )
 
-      next
+        next
+      end
+
+      FastlyConfig::Update.call
     end
-
-    FastlyConfig::Update.call
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
In the event of a Fastly outage we need to be able to skip this config update step to allow deploys to happen. 

![](https://media4.giphy.com/media/JGunlb6LbQlz2/giphy.gif)