### PR TITLE
Fixed issue with drag and drop image for cover image in editor in Safari

### DIFF
--- a/app/javascript/article-form/components/ArticleCoverImage.jsx
+++ b/app/javascript/article-form/components/ArticleCoverImage.jsx
@@ -27,8 +27,7 @@ export class ArticleCoverImage extends Component {
     this.clearUploadError();
 
     if (validateFileInputs()) {
-      const { files: image } =
-        event instanceof DragEvent ? event.dataTransfer : event.target;
+      const { files: image } = event.dataTransfer || event.target;
       const payload = { image, wrap_cloudinary: true };
 
       generateMainImage(payload, this.onImageUploadSuccess, this.onUploadError);

--- a/app/javascript/article-form/components/__tests__/ArticleCoverImage.test.jsx
+++ b/app/javascript/article-form/components/__tests__/ArticleCoverImage.test.jsx
@@ -79,8 +79,6 @@ describe('<ArticleCoverImage />', () => {
     });
 
     it('allows a user to change the image', async () => {
-      global.DragEvent = jest.fn();
-
       fetch.mockResponse(
         JSON.stringify({
           image: ['/i/changed-fake-link.jpg'],


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes an issue where Safari fails to upload a cover image in the editor.

## Related Tickets & Documents

#10145

## QA Instructions, Screenshots, Recordings

To test:
1. Use the Safari browser
1. Ensure you are logged in.
1. Navigate to http://localhost:3000/new
1. Drag and drop a cover image on the cover image area of the editor
1. The cover image gets uploaded.
1. Ensure it still works in Firefox and Chrome (Edge Chromium) by repeating the steps above.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![A doge Firefox logo](https://media.giphy.com/media/fvM5D7vFoACAM/giphy.gif)
