### PR TITLE
Proper cache delete_matched

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -109,7 +109,8 @@ module Admin
       CacheBuster.bust("/shell_top") # Cached at edge, sent to service worker.
       CacheBuster.bust("/shell_bottom") # Cached at edge, sent to service worker.
       CacheBuster.bust("/onboarding") # Page is cached at edge.
-      Rails.cache.delete_matched(ApplicationConfig["RELEASE_FOOTPRINT"]) # Delete all caches tied to this key.
+      CacheBuster.bust("/") # Page is cached at edge.
+      Rails.cache.delete_matched("*-#{ApplicationConfig['RELEASE_FOOTPRINT']}") # Delete all caches tied to this key.
     end
 
     # Validations

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -47,6 +47,13 @@ RSpec.describe "/admin/config", type: :request do
         sign_in(admin_plus_config)
       end
 
+      it "deletes release-tied fragment caches" do
+        allow(Rails.cache).to receive(:delete_matched).and_call_original
+        post "/admin/config", params: { site_config: { health_check_token: "token" },
+                                        confirmation: confirmation_message }
+        expect(Rails.cache).to have_received(:delete_matched).with("*-#{ApplicationConfig['RELEASE_FOOTPRINT']}")
+      end
+
       describe "API tokens" do
         it "updates the health_check_token" do
           token = rand(20).to_s


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We had a prior functionality which is meant to delete the core fragment caches that change on every deployment, or in this case, when we update config and want a fresher cache.

This updates it to work as intended (and also tacked on another page purge)...

The original PR did not break anything, but did not appropriately follow the `delete_matched` functionality which requires wildcards to work properly like this. The included test is a basic regression test, not _directly_ exercise this functionality, but at least adds a bit more coverage.