### PR TITLE
Move video_duration_in_minutes_integer to serializer

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -360,10 +360,6 @@ class Article < ApplicationRecord
     "#{duration[:hours]}:#{minutes_and_seconds}"
   end
 
-  def video_duration_in_minutes_integer
-    (video_duration_in_seconds.to_i / 60) % 60
-  end
-
   def update_score
     new_score = reactions.sum(:points) + Reaction.where(reactable_id: user_id, reactable_type: "User").sum(:points)
     update_columns(score: new_score,

--- a/app/serializers/search/article_serializer.rb
+++ b/app/serializers/search/article_serializer.rb
@@ -12,7 +12,9 @@ module Search
     # however, it really is a string in the format 00:00 which is why we
     # added an extra field to handle that string
     attribute :video_duration_string, &:video_duration_in_minutes
-    attribute :video_duration_in_minutes, &:video_duration_in_minutes_integer
+    attribute :video_duration_in_minutes do |article|
+      article.video_duration_in_seconds.to_i / 60
+    end
 
     attribute :readable_publish_date_string, &:readable_publish_date
 

--- a/lib/data_update_scripts/20200911045602_reindex_articles_with_videos.rb
+++ b/lib/data_update_scripts/20200911045602_reindex_articles_with_videos.rb
@@ -1,0 +1,8 @@
+module DataUpdateScripts
+  class ReindexArticlesWithVideos
+    def run
+      articles = Article.where.not(video: nil).or(Article.where.not(video: ""))
+      articles.find_each(&:index_to_elasticsearch_inline)
+    end
+  end
+end

--- a/spec/serializers/search/article_serializer_spec.rb
+++ b/spec/serializers/search/article_serializer_spec.rb
@@ -21,4 +21,16 @@ RSpec.describe Search::ArticleSerializer do
     result = Article::SEARCH_CLASS.index(article.id, data_hash)
     expect(result["result"]).to eq("created")
   end
+
+  it "correctly serializes video duration in minutes when video_duration_in_seconds is nil" do
+    data_hash = described_class.new(article).serializable_hash.dig(:data, :attributes)
+    expect(data_hash[:video_duration_in_minutes]).to eq(0)
+  end
+
+  it "correctly serializes video duration in minutes when video_duration_in_seconds is not nil" do
+    duration = (1.hour + 1.minute).to_i
+    allow(article).to receive(:video_duration_in_seconds).and_return(duration)
+    data_hash = described_class.new(article).serializable_hash.dig(:data, :attributes)
+    expect(data_hash[:video_duration_in_minutes]).to eq(61)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Bug Fix

## Description

In #10256 I refactored `video_duration_in_minutes`. Since this now no longer relies on `video_duration_in_minutes_integer` it was [suggested to move the latter into the search serializer](https://github.com/forem/forem/pull/10256#discussion_r485383795), since that's the only place where it's used.

While doing so I also realized that the method was wrong. Here's the old definition:

```ruby
(video_duration_in_seconds.to_i / 60) % 60
```

This will be wrong for any duration > 1 hour, because of the modulo operation:

```ruby
duration = (1.hour + 1.minute).to_i # should be 61 minutes
#=> 3660
(duration / 60) % 60 # modulo discards the hours
#=> 1 
```

To go from seconds to minutes we only need to divide by 60, so I removed the modulo.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Nothing specific

## Added tests?

- [X] yes

## Added to documentation?

- [X] no documentation needed