### PR TITLE
Cleanup articles with duplicate user_id, title and body_markdown

### DIFF
--- a/lib/data_update_scripts/20200910135958_remove_draft_articles_with_duplicate_user_id_title_body_markdown.rb
+++ b/lib/data_update_scripts/20200910135958_remove_draft_articles_with_duplicate_user_id_title_body_markdown.rb
@@ -1,0 +1,32 @@
+module DataUpdateScripts
+  class RemoveDraftArticlesWithDuplicateUserIdTitleBodyMarkdown
+    def run
+      # Currently there are duplicate draft articles in the DB with the same body_markdown, title, user_id combination
+
+      # This statement deletes all draft articles in excess found to be duplicate over those three columns
+      ActiveRecord::Base.connection.execute(
+        <<~SQL.squish,
+          WITH duplicates_draft_articles AS
+              (SELECT id
+               FROM
+                   (SELECT id,
+                           published,
+                           body_markdown,
+                           title,
+                           user_id,
+                           ROW_NUMBER() OVER(PARTITION BY user_id, title, body_markdown
+                                             ORDER BY id ASC) AS row_number
+                    FROM articles) duplicates
+               WHERE duplicates.row_number > 1
+                   AND published = 'f' -- drafts
+           )
+          DELETE
+          FROM articles
+          WHERE id IN
+                  (SELECT id
+                   FROM duplicates_draft_articles) RETURNING id;
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200910140109_cleanup_published_articles_with_duplicate_user_id_title_body_markdown.rb
+++ b/lib/data_update_scripts/20200910140109_cleanup_published_articles_with_duplicate_user_id_title_body_markdown.rb
@@ -62,28 +62,27 @@ module DataUpdateScripts
       article_id = article_to_keep.id
       articles_to_graft_ids = articles_to_graft.map { |a| a["id"] }
 
+      # NotificationSubscription, Notification and RatingVote rows will be removed
+      # Poll is ignored because it's related to the liquid tag inside the article, also user's can't use polls
+      # TagAdjustment is ignored as there's likely no reason for article to have an adjustment moved over
       models_with_a_direct_relation = [
         BufferUpdate,
         HtmlVariantSuccess,
         HtmlVariantSuccess,
         HtmlVariantTrial,
         PageView,
-        # Poll is ignored because it's related to the liquid tag inside the article,
-        # also user's can't use polls
-        RatingVote,
-        # TagAdjustment is ignored as there's likely no reason for article to have an adjustment moved over
       ]
       models_with_a_direct_relation.each do |model_class|
         model_class.where(article_id: articles_to_graft_ids).update_all(article_id: article_id)
       end
 
-      Comment.where(commentable_type: "Article",
-                    commentable_id: articles_to_graft_ids).update_all(commentable_id: article_id)
-      NotificationSubscription.where(notifiable_type: "Article",
-                                     notifiable_id: articles_to_graft_ids).update_all(notifiable_id: article_id)
-      Notification.where(notifiable_type: "Article",
-                         notifiable_id: articles_to_graft_ids).update_all(notifiable_id: article_id)
-      ProfilePin.where(pinnable_type: "Article", pinnable_id: articles_to_graft_ids).update_all(pinnable_id: article_id)
+      Comment
+        .where(commentable_type: "Article", commentable_id: articles_to_graft_ids)
+        .update_all(commentable_id: article_id)
+
+      ProfilePin
+        .where(pinnable_type: "Article", pinnable_id: articles_to_graft_ids)
+        .update_all(pinnable_id: article_id)
 
       # we add tags that are not already present in the article from the others
       # we don't really need to graft these as the tag objects belonging to the soon to be

--- a/lib/data_update_scripts/20200910140109_cleanup_published_articles_with_duplicate_user_id_title_body_markdown.rb
+++ b/lib/data_update_scripts/20200910140109_cleanup_published_articles_with_duplicate_user_id_title_body_markdown.rb
@@ -1,0 +1,104 @@
+module DataUpdateScripts
+  class CleanupPublishedArticlesWithDuplicateUserIdTitleBodyMarkdown
+    def run
+      # load all published duplicates
+      rows = ActiveRecord::Base.connection.execute(
+        <<~SQL.squish,
+          SELECT *
+          FROM
+              (SELECT *,
+                      ROW_NUMBER() OVER(PARTITION BY user_id, title, body_markdown) AS row_number,
+                      COUNT(*) OVER(PARTITION BY user_id, title, body_markdown) AS num_rows_in_partition
+               FROM articles) duplicates
+          WHERE published = 't'
+              AND num_rows_in_partition > 1 -- we select all rows in each partition with duplicates
+        SQL
+      )
+
+      articles_to_delete_ids = []
+      ActiveRecord::Base.transaction do
+        # now that we have all rows in the partition, we group them by the partition columns
+        # so we can have small groups referring to the same article and graft data of surplus articles
+        # onto the first of the partition (it doesn't really matter which one we're going to use as the "mold")
+        groups = rows.group_by { |row| [row["user_id"], row["title"], row["body_markdown"]] }
+
+        # for each group we select the first, and then graft the data of the other ones on to it
+
+        groups.each_value do |group|
+          article_to_keep = group.first
+          articles_to_graft = group[1..]
+
+          article = Article.find(article_to_keep["id"])
+
+          graft_articles(article, articles_to_graft)
+
+          # save all the magic
+          article.save
+          article.index_to_elasticsearch_inline
+
+          articles_to_delete_ids += articles_to_graft.map { |a| a["id"] }
+        end
+
+        # we shouldn't need to call Articles::Destroy as all the data has been moved over by now
+        Article.where(id: articles_to_delete_ids).destroy_all
+      end
+
+      return if articles_to_delete_ids.blank?
+
+      # Store deleted IDs temporarily in Redis for safe keeping
+      Rails.cache.write(
+        "DataUpdateScripts::CleanupPublishedArticlesWithDuplicateUserIdTitleBodyMarkdown",
+        articles_to_delete_ids,
+        expires_in: 2.weeks,
+      )
+    end
+
+    private
+
+    # Main goal here is copy and merge everything from the duplicates to the main one
+    # NOTE: I'm intentionally ignore the case that two duplicates belong to different orgs
+    # or different collections as it's highly unlikely
+    def graft_articles(article_to_keep, articles_to_graft)
+      article_id = article_to_keep.id
+      articles_to_graft_ids = articles_to_graft.map { |a| a["id"] }
+
+      models_with_a_direct_relation = [
+        BufferUpdate,
+        HtmlVariantSuccess,
+        HtmlVariantSuccess,
+        HtmlVariantTrial,
+        PageView,
+        # Poll is ignored because it's related to the liquid tag inside the article,
+        # also user's can't use polls
+        RatingVote,
+        # TagAdjustment is ignored as there's likely no reason for article to have an adjustment moved over
+      ]
+      models_with_a_direct_relation.each do |model_class|
+        model_class.where(article_id: articles_to_graft_ids).update_all(article_id: article_id)
+      end
+
+      Comment.where(commentable_type: "Article",
+                    commentable_id: articles_to_graft_ids).update_all(commentable_id: article_id)
+      NotificationSubscription.where(notifiable_type: "Article",
+                                     notifiable_id: articles_to_graft_ids).update_all(notifiable_id: article_id)
+      Notification.where(notifiable_type: "Article",
+                         notifiable_id: articles_to_graft_ids).update_all(notifiable_id: article_id)
+      ProfilePin.where(pinnable_type: "Article", pinnable_id: articles_to_graft_ids).update_all(pinnable_id: article_id)
+
+      # we add tags that are not already present in the article from the others
+      # we don't really need to graft these as the tag objects belonging to the soon to be
+      # destroyed copies will be removed when we destroy the articles
+      tag_ids = ActsAsTaggableOn::Tagging
+        .where(taggable_type: "Article", taggable_id: articles_to_graft_ids)
+        .pluck(:tag_id)
+
+      tags = Tag.where(id: tag_ids).pluck(:id, :name)
+
+      # if the union of the two sets equals the article tags, then there's nothing to copy over
+      tag_names_to_maybe_graft = tags.map(&:second)
+      return if article_to_keep.tag_list == article_to_keep.tag_list | tag_names_to_maybe_graft
+
+      article_to_keep.tag_list.add(*(article_to_keep.tag_list - tag_names_to_maybe_graft))
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR contains two scripts

1. the first one deletes duplicate draft articles that have the same combination of `user_id`, `title` and `body_markdown`. The algorithm is the same of https://github.com/forem/forem/pull/10138 and https://github.com/forem/forem/pull/10239

1. the second one "merges" published articles:
  - basically we divide the articles in groups (some articles have 1 duplicate, some have more)
  - of all the groups we take the first article
  - we copy over the data from the others onto this first one
  - we destroy the others

This is where the data is:

- https://dev.to/admin/blazer/queries/232-duplicate-draft-articles-body_markdown-user_id-title
- https://dev.to/admin/blazer/queries/235-duplicate-published-articles-body_markdown-user_id-title
- https://dev.to/admin/blazer/queries/236-published-articles-of-users-with-duplicates

## QA Instructions, Screenshots, Recordings

Ideally this should be tested on a copy of the production DB. To make sure it worked I downloaded the sample of duplicates from https://dev.to/admin/blazer/queries/236-published-articles-of-users-with-duplicates - imported them locally and ran the scripts to make sure they worked. 

If you want to test it:

- download a CSV from https://dev.to/admin/blazer/queries/236-published-articles-of-users-with-duplicates
- open the SQL console with `psql PracticalDeveloper_development`
- type `\d articles`
- note the names of the foreign key constraints
- drop the foreign key constraints on the `articles` table, otherwise the `user_id` and `organization_id` won't work:

```sql
alter table articles drop constraint fk_rails_3d31dad1cc;
alter table articles drop constraint fk_rails_7809a1a57d;
```

remember that the constraint names might be different than mine. Please double check with `\d articles` in the SQL console and replace them with yours
- import the data from the downloaded CSV:

```sql
copy articles(id,user_id,title,body_html,slug,created_at,updated_at,main_image,description,published,published_at,featured,processed_html,featured
 _number,social_image,body_markdown,organization_id,canonical_url,collection_id,show_comments,main_image_background_hex_color,receive_notifications,approved,published_from_feed,c
 omments_count,reactions_count,video,video_code,video_source_url,video_thumbnail_url,video_closed_caption_track_url,hotness_score,feed_source_url,second_user_id,third_user_id,las
 t_buffered,positive_reactions_count,edited_at,crossposted_at,spaminess_rating,language,facebook_last_buffered,cached_tag_list,path,cached_user_name,cached_user_username,last_com
 ment_at,boost_states,video_state,page_views_count,previous_positive_reactions_count,score,reading_time,comment_template,video_duration_in_seconds,experience_level_rating,experie
 nce_level_rating_distribution,last_experience_level_rating_at,rating_votes_count,originally_published_at,organic_page_views_count,organic_page_views_past_month_count,organic_pag
 e_views_past_week_count,cached_user,cached_organization,archived,any_comments_hidden,nth_published_by_author,comment_score,search_optimized_title_preamble,search_optimized_descr
 iption_replacement,public_reactions_count,previous_public_reactions_count,user_subscriptions_count) from '/path/to/file.csv.csv' DELIMITER ',' csv header;
```

don't forget to replace the path of the file with the full path of the file you downloaded

- count the number of articles, just to have a quick idea if the script has worked
- replace `.destroy_all` with `.delete_all` on line https://github.com/forem/forem/pull/10273/files#diff-ae11923370b79ce32bb9abbeebca964dR43 (the reason for this is that you won't have the same user objects locally, but we need to pass through Rails to make sure everything left attached to articles is actually destroyed)
- run the data update script with `rails data_updates:run` if it's the first time or manually in the console

```ruby
require Rails.root.join("lib/data_update_scripts/20200910140109_cleanup_published_articles_with_duplicate_user_id_title_body_markdown.rb")
DataUpdateScripts::CleanupPublishedArticlesWithDuplicateUserIdTitleBodyMarkdown.new.run
```

- re-count the number of articles, it should be less ;-)
- run https://dev.to/admin/blazer/queries/235-duplicate-published-articles-body_markdown-user_id-title locally to make sure they are gone
- also run the two group by queries - https://dev.to/admin/blazer/queries/81-duplicate-draft-articles-by-body_markdown-user_id-title and https://dev.to/admin/blazer/queries/227-duplicate-published-articles-by-body_markdown-user_id-title to double check
