### PR TITLE
Better production container precompiling and bootstrapping

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -53,6 +53,8 @@ RUN mkdir -p "${APP_HOME}"/public/{assets,images,packs,podcasts,uploads}
 
 COPY . "${APP_HOME}"
 
+RUN bundle exec rake assets:precompile
+
 RUN echo $(date -u +'%Y-%m-%dT%H:%M:%SZ') >> "${APP_HOME}"/FOREM_BUILD_DATE && \
     echo $(git rev-parse --short HEAD) >> "${APP_HOME}"/FOREM_BUILD_SHA && \
     rm -rf "${APP_HOME}"/.git/

--- a/Containerfile
+++ b/Containerfile
@@ -38,6 +38,7 @@ WORKDIR "${APP_HOME}"
 
 COPY ./.ruby-version "${APP_HOME}"
 COPY ./Gemfile ./Gemfile.lock "${APP_HOME}"
+COPY ./vendor/cache "${APP_HOME}"/vendor/cache
 
 # Fixes https://github.com/sass/sassc-ruby/issues/146
 RUN bundle config build.sassc --disable-march-tune-native

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - .:/opt/apps/forem:z
       - ./.gems:/opt/apps/bundle:z
-    entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "http://elasticsearch:9200", "-wait", "tcp://redis:6379", "-wait", "file:///opt/apps/bundle/bundle_finished", "-timeout", "300s", "./scripts/entrypoint.sh"]
+    entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "http://elasticsearch:9200", "-wait", "tcp://redis:6379", "-wait", "file:///opt/apps/bundle/bundle_finished", "-timeout", "300s", "./scripts/entrypoint-dev.sh"]
     command: ["bundle", "exec", "rails","server","-b","0.0.0.0","-p","3000"]
 
   bundle:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes:
       - .:/opt/apps/forem:delegated
       - ./.gems:/opt/apps/bundle:delegated
-    entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "http://elasticsearch:9200", "-wait", "tcp://redis:6379", "-wait", "file:///opt/apps/bundle/bundle_finished", "-timeout", "2700s", "./scripts/entrypoint.sh"]
+    entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "http://elasticsearch:9200", "-wait", "tcp://redis:6379", "-wait", "file:///opt/apps/bundle/bundle_finished", "-timeout", "2700s", "./scripts/entrypoint-dev.sh"]
     command: ["bundle", "exec", "rails","server","-b","0.0.0.0","-p","3000"]
 
   bundle:

--- a/scripts/entrypoint-dev.sh
+++ b/scripts/entrypoint-dev.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -f tmp/pids/server.pid ]; then
+  rm -f tmp/pids/server.pid
+fi
+
+export RELEASE_FOOTPRINT=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+export FOREM_BUILD_DATE=$(cat FOREM_BUILD_DATE)
+export FOREM_BUILD_SHA=$(cat FOREM_BUILD_SHA)
+
+echo "Running rake app_initializer:setup..."
+bundle exec rake app_initializer:setup
+
+exec "$@"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -10,7 +10,22 @@ export RELEASE_FOOTPRINT=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 export FOREM_BUILD_DATE=$(cat FOREM_BUILD_DATE)
 export FOREM_BUILD_SHA=$(cat FOREM_BUILD_SHA)
 
-echo "Running rake app_initializer:setup..."
-bundle exec rake app_initializer:setup
+case "$@" in
 
-exec "$@"
+  precompile)
+    echo "Running rake assets:precompile..."
+    bundle exec rake assets:precompile
+    ;;
+
+  bootstrap)
+    echo "Running rake app_initializer:setup..."
+    bundle exec rake app_initializer:setup
+    ;;
+
+  *)
+    echo "Running command:"
+    echo "$@"
+    exec "$@"
+    ;;
+
+esac

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -17,6 +17,16 @@ case "$@" in
     bundle exec rake assets:precompile
     ;;
 
+  clean)
+    echo "Running rake assets:clean..."
+    bundle exec rake assets:clean
+    ;;
+
+  clobber)
+    echo "Running rake assets:clobber..."
+    bundle exec rake assets:clobber
+    ;;
+
   bootstrap)
     echo "Running rake app_initializer:setup..."
     bundle exec rake app_initializer:setup


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This removes the automatic run of `rake app_initializer:setup` in the entrypoint and adds a way to easily call `rake assets:precompile`. It also moves the old entrypoint.sh to entrypoint-dev.sh so the developer experience with Docker / Podman Compose remains the same.

## [optional] What gif best describes this PR or how it makes you feel?

![This will do for now](https://media1.tenor.com/images/cf781e7e13d18e42e833fc6cb33d8cdc/tenor.gif?itemid=3552862)
