### PR TITLE
Check that nginx is available before pinging it

### DIFF
--- a/app/labor/cache_buster.rb
+++ b/app/labor/cache_buster.rb
@@ -20,7 +20,7 @@ module CacheBuster
     # https://github.com/fastly/fastly-ruby#efficient-purging
     if fastly_enabled?
       bust_fastly_cache(path)
-    elsif nginx_enabled?
+    elsif nginx_enabled? && nginx_available?
       bust_nginx_cache(path)
     end
   rescue URI::InvalidURIError => e
@@ -34,6 +34,21 @@ module CacheBuster
 
   def self.nginx_enabled?
     ApplicationConfig["OPENRESTY_PROTOCOL"].present? && ApplicationConfig["OPENRESTY_DOMAIN"].present?
+  end
+
+  def self.openresty_path
+    "#{ApplicationConfig['OPENRESTY_PROTOCOL']}#{ApplicationConfig['OPENRESTY_DOMAIN']}"
+  end
+
+  def self.nginx_available?
+    uri = URI.parse(openresty_path)
+    http = Net::HTTP.new(uri.host, uri.port)
+    response = http.get(uri.request_uri)
+  rescue StandardError
+    # If we can't connect to openresty, alert ourselves that it is unavailable
+    Rails.logger.error("Could not connect to Openresty via #{openresty_path}!")
+
+    response.is_a?(Net::HTTPSuccess)
   end
 
   def self.bust_fastly_cache(path)
@@ -53,7 +68,7 @@ module CacheBuster
   end
 
   def self.bust_nginx_cache(path)
-    uri = URI.parse("#{ApplicationConfig['OPENRESTY_PROTOCOL']}#{ApplicationConfig['OPENRESTY_DOMAIN']}#{path}")
+    uri = URI.parse("#{openresty_path}#{path}")
     http = Net::HTTP.new(uri.host, uri.port)
     response = http.request Net::HTTP::NginxPurge.new(uri.request_uri)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Currently, we don't have a good way of knowing whether Openresty is available before we try to bust an Nginx cache via Openresty's server.

This means that we can potentially make a request to Openresty even when it is unavailable, which causes the app to not be able to boot up when this code path is called.

This PR adds a check to make sure that Openresty is **both** _configured_ **and** _available_ before trying to bust an Nginx cache or before making additional requests to Openresty. Unfortunately, from what I can tell, the only way to know if Openresty is "up" and available is to ping it (make a request to it). In this PR, I'm making a basic `GET` request to the `openresty_path` to just see if it responds with a success or not.

This PR also improves the pre-existing tests and adds some new ones! 😉 

## Related Tickets & Documents

Closes https://github.com/forem/InternalProjectPlanning/issues/38.

## QA Instructions, Screenshots, Recordings

In your local `.env` file, set some `OPENRESTY_` ENV variables:
```bash
export OPENRESTY_DOMAIN=localhost:9090
export OPENRESTY_PROTOCOL=http://
```

Start up your app:
```ruby
bin/startup
```

Your app should boot without any issues.

Then, go into your `rails console`.
Check that the ENV variables are what you expect/set property. Then, trigger a cache bust:
```ruby
➜  forem git:(vaidehijoshi/check-for-openresty-connection) ✗ rails c
Loading development environment (Rails 6.0.3.3)
[1] pry(main)> ApplicationConfig["OPENRESTY_DOMAIN"]
=> "localhost:9090"
[2] pry(main)> CacheBuster.bust("/vaidehijoshi")
Could not connect to Openresty via http://localhost:9090!
=> nil
```
You should see an error logged out, which is caught by the `nginx_available?` method [here](https://github.com/forem/forem/compare/vaidehijoshi/check-for-openresty-connection?expand=1#diff-6e58540a6172a3c1054d1ede7134dd00R49).

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?
Nope!

## What gif best describes this PR or how it makes you feel?

![emotionally unavailable gif](https://media4.giphy.com/media/ReUckuhBEy8hkBmIDD/giphy.webp?cid=5a38a5a283pq7rppl4af4fuvz9kqevyavg0ud9ybug395c9r&rid=giphy.webp)
