### PR TITLE
Feature:Allow for Search by ID for FeedContent

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -35,6 +35,7 @@ class SearchController < ApplicationController
   FEED_PARAMS = [
     :approved,
     :class_name,
+    :id,
     :organization_id,
     :page,
     :per_page,

--- a/app/services/search/query_builders/feed_content.rb
+++ b/app/services/search/query_builders/feed_content.rb
@@ -17,6 +17,7 @@ module Search
       # Search keys from our controllers may not match what we have stored in Elasticsearch so we map them here,
       # this allows us to change our Elasticsearch docs without worrying about the frontend
       TERM_KEYS = {
+        id: "id", # NOTE: FeedContent ids are formatted article_#, podcast_episode_#, comment_#
         tag_names: "tags.name",
         approved: "approved",
         user_id: "user.id",

--- a/spec/services/search/feed_content_spec.rb
+++ b/spec/services/search/feed_content_spec.rb
@@ -148,6 +148,17 @@ RSpec.describe Search::FeedContent, type: :service do
         doc_ids = feed_docs.map { |t| t["id"] }
         expect(doc_ids).to include(pde.id)
       end
+
+      it "filters by id" do
+        index_documents([article1, article2])
+        query_params = { size: 5, id: ["article_#{article1.id}"] }
+
+        feed_docs = described_class.search_documents(params: query_params)
+        expect(feed_docs.count).to eq(1)
+        doc_ids = feed_docs.map { |t| t["id"] }
+        expect(doc_ids).to include(article1.id)
+        expect(doc_ids).not_to include(article2.id)
+      end
     end
 
     context "with range keys" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
In order to be able to fetch saved articles from our feed_content index we need the ability to search by an article's ID. This allows us to do that. This will be followed by a frontend PR to hook this all up to the frontend. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-45322899

## Added tests?
- [x] yes

![alt_text](https://media0.giphy.com/media/3o6Mb3nTBuHdzLvCkU/200.gif)
