### PR TITLE
Update URL.domain not to use SiteConfig

### DIFF
--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -7,7 +7,7 @@ module URL
   end
 
   def self.domain
-    Rails.application&.initialized? ? SiteConfig.app_domain : ApplicationConfig["APP_DOMAIN"]
+    ApplicationConfig["APP_DOMAIN"]
   end
 
   def self.url(uri = nil)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug fix

## Description
For reason beyond me, you can not evoke SiteConfig from within `app/lib/url.rb` because it causes `Siteconfig.authentication_providers` to return `[]`, breaking our sign-in process. 

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
Try signing out and signing back in with either Github or Twitter auth. You should be able to see those options available to you.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a