### PR TITLE
Refactor:Remove unused ReadingList Labor methods

### DIFF
--- a/app/labor/reading_list.rb
+++ b/app/labor/reading_list.rb
@@ -5,14 +5,6 @@ class ReadingList
     @user = user
   end
 
-  def get
-    Article
-      .joins(:reactions)
-      .includes(:user)
-      .where(reactions: reaction_criteria)
-      .order("reactions.created_at" => :desc)
-  end
-
   def cached_ids_of_articles
     Rails.cache.fetch("reading_list_ids_of_articles_#{user.id}_#{user.public_reactions_count}") do
       ids_of_articles
@@ -21,10 +13,6 @@ class ReadingList
 
   def ids_of_articles
     Reaction.where(reaction_criteria).where.not(status: "archived").order(created_at: :desc).pluck(:reactable_id)
-  end
-
-  def count
-    get.size
   end
 
   def reaction_criteria

--- a/spec/labor/reading_list_spec.rb
+++ b/spec/labor/reading_list_spec.rb
@@ -15,28 +15,10 @@ RSpec.describe ReadingList, type: :labor do
     )
   end
 
-  it "returns count of articles if they've been reacted to" do
-    create_reaction(user, article)
-    create_reaction(user, article2)
-
-    expect(described_class.new(user).count).to eq(2)
-  end
-
-  it "returns an article if it's been reacted to" do
-    create_reaction(user, article)
-    create_reaction(user, article2)
-
-    expect(described_class.new(user).get.first.id).to eq(article2.id)
-  end
-
   it "returns cached ids of articles that have been reacted to" do
     create_reaction(user, article)
     create_reaction(user, article2)
 
     expect(described_class.new(user).cached_ids_of_articles).to eq([article2.id, article.id])
-  end
-
-  it "returns an empty count if no reacted article" do
-    expect(described_class.new(user).count).to eq(0)
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
While setting up the reading list to be served from the feed content index I noticed this labor class and that it had a couple unused methods so I removed them. 


![alt_text](https://media3.giphy.com/media/1zljrAoicZwPYv6TXX/giphy.gif)
