### PR TITLE
Fix broken links to admin guide in documentation

### DIFF
--- a/docs/backend/configuration.md
+++ b/docs/backend/configuration.md
@@ -21,7 +21,7 @@ environments. Examples:
 
 Settings managed via your ENV can be found in
 [Configuring Environment Variables](../getting-started/config-env.md)) and
-viewed at `/admin/config` (see [the Admin guide](../admin/readme.md)):
+viewed at `/admin/config` (see [the Admin guide](/admin)):
 
 ![Screenshot of env variable admin interface](https://user-images.githubusercontent.com/47985/73627243-67d41f80-467e-11ea-9121-221275ff8a89.png)
 
@@ -37,7 +37,7 @@ Examples:
 These settings can be accessed via the
 [`SiteConfig`](https://github.com/forem/forem/blob/master/app/models/site_config.rb)
 object and viewed / modified via `/admin/config` (see
-[the Admin guide](../admin/readme.md)).
+[the Admin guide](/admin)).
 
 ![Screenshot of site configuration admin interface](https://user-images.githubusercontent.com/47985/73627238-6276d500-467e-11ea-8724-afb703f056bc.png)
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

`Page Not Found!` will be shown if we click any admin page links on [this page](https://docs.dev.to/backend/configuration/).
I fixed it.