### PR TITLE
Fix URL.domain in development by correctly loading authentication providers

### DIFF
--- a/app/services/authentication/providers.rb
+++ b/app/services/authentication/providers.rb
@@ -1,3 +1,12 @@
+# We require all authentication modules to make sure providers
+# are correctly preloaded and ready to be used at this point as the loading
+# order is important
+require_dependency Rails.root.join("app/services/authentication/providers/provider.rb")
+
+Dir[Rails.root.join("app/services/authentication/**/*.rb")].each do |f|
+  require_dependency(f)
+end
+
 module Authentication
   module Providers
     # Retrieves a provider that is both available and enabled

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,8 +45,8 @@ module PracticalDeveloper
     config.eager_load_paths += Dir["#{config.root}/lib"]
 
     # Middlewares folder is not otherwise autorequired.
-    Dir["./app/middlewares/*.rb"].sort.each do |file|
-      require file
+    Dir["#{config.root}/app/middlewares/**/*.rb"].each do |file|
+      require_dependency(file)
     end
 
     config.active_job.queue_adapter = :sidekiq

--- a/config/initializers/authentication.rb
+++ b/config/initializers/authentication.rb
@@ -1,8 +1,0 @@
-Rails.application.config.to_prepare do
-  # We require all authentication modules to make sure providers
-  # are correctly preloaded and ready to be used at this point as the loading
-  # order is important
-  Dir[Rails.root.join("app/services/authentication/**/*.rb")].each do |f|
-    require_dependency(f)
-  end
-end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently login is broken in development mode.

Thanks to @maestromac we found a weird interconnection between Zeitwerk's ([Rails 6 autoloader](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html)) loading order, the expectation that `SiteConfig` is ready when it should be inside `URL.domain` and the fact that `SiteConfig.authentication_providers` depends on the providers to be already loaded at runtime.

The solution is to basically move 

```ruby
Rails.application.config.to_prepare do
  Dir[Rails.root.join("app/services/authentication/**/*.rb")].each do |f|
    require_dependency(f)
  end
end
```

from the initializer to the `Authentication::Providers` file. The reason why we can't simply remove the [to_prepare](https://api.rubyonrails.org/classes/Rails/Railtie/Configuration.html#method-i-to_prepare) wrapping callback and require those dependency is that Zeitwerk forbids autoloading during initialization (the reason why I used the callback in the first place). I tried to use [after_initialize](https://api.rubyonrails.org/classes/Rails/Railtie/Configuration.html#method-i-after_initialize) but that also doesn't guarantee that the classes are loaded when we needed them.

## Related Tickets & Documents

https://github.com/forem/forem/pull/10206
Supersedes https://github.com/forem/forem/pull/10291

## QA Instructions, Screenshots, Recordings

1. Load `master` in incognito, notice you can't login with SSO options
1. Load this branch, login and logout and see it works

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
