### PR TITLE
Fix SiteConfig's default option of authentication_providers field

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -20,7 +20,7 @@ class SiteConfig < RailsSettings::Base
 
   # Authentication
   field :allow_email_password_registration, type: :boolean, default: false
-  field :authentication_providers, type: :array, default: Authentication::Providers.available
+  field :authentication_providers, type: :array, default: proc { Authentication::Providers.available }
   field :twitter_key, type: :string, default: ApplicationConfig["TWITTER_KEY"]
   field :twitter_secret, type: :string, default: ApplicationConfig["TWITTER_SECRET"]
   field :github_key, type: :string, default: ApplicationConfig["GITHUB_KEY"]


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Though I tried logging in by my GitHub account in my local environment, I found no login button there. So I looked into the code getting authentication providers, and I found that was `authentication_enabled_providers` helper method. Inside of it, `SiteConfig.authentication_providers` is called, and it returned an empty array.

After that, I inspected `SiteConfig.authentication_providers` method, and I found `Authentication::Providers.available` was set to default option. But we should pass Proc to the default option to be made lazy evaluation.

| before | after |
|---|---|
| <img width="664" alt="Screen Shot 2020-09-13 at 19 31 35" src="https://user-images.githubusercontent.com/26132902/93015985-c2f8c800-f5f8-11ea-8f82-cd61871b0900.png"> | <img width="665" alt="Screen Shot 2020-09-13 at 19 29 42" src="https://user-images.githubusercontent.com/26132902/93015987-c68c4f00-f5f8-11ea-863b-4c9d45ec6822.png"> |
