### PR TITLE
Optimization:Move Initialization CacheBust to Background Worker

### DIFF
--- a/config/initializers/initialization_cachebust.rb
+++ b/config/initializers/initialization_cachebust.rb
@@ -1,8 +1,0 @@
-# Trigger cache purges for globally-cached endpoints that could have changed
-CacheBuster.bust("/shell_top")
-CacheBuster.bust("/shell_bottom")
-CacheBuster.bust("/async_info/shell_version")
-CacheBuster.bust("/onboarding")
-
-# We will set RELEASE_FOOTPRINT in our Forem Cloud environment, or use HEROKU_SLUG_COMMIT if set (e.g. Heroku env)
-ENV["RELEASE_FOOTPRINT"] ||= ENV["HEROKU_SLUG_COMMIT"]

--- a/config/initializers/set_release_footprint.rb
+++ b/config/initializers/set_release_footprint.rb
@@ -1,0 +1,2 @@
+# We will set RELEASE_FOOTPRINT in our Forem Cloud environment, or use HEROKU_SLUG_COMMIT if set (e.g. Heroku env)
+ENV["RELEASE_FOOTPRINT"] ||= ENV["HEROKU_SLUG_COMMIT"]

--- a/lib/tasks/app_initializer.rake
+++ b/lib/tasks/app_initializer.rake
@@ -10,6 +10,9 @@ namespace :app_initializer do
     puts "\n== Updating Data =="
     Rake::Task["data_updates:enqueue_data_update_worker"].execute
 
+    puts "\n== Bust Caches =="
+    Rake::Task["cache:enqueue_path_bust_workers"].execute
+
     SiteConfig.health_check_token ||= SecureRandom.hex(10)
   end
 end

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,0 +1,10 @@
+namespace :cache do
+  desc "Enqueue BustCachePathWorker"
+  task enqueue_path_bust_workers: :environment do
+    # Trigger cache purges for globally-cached endpoints that could have changed
+    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/shell_top")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/shell_bottom")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/async_info/shell_version")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/onboarding")
+  end
+end

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -2,9 +2,9 @@ namespace :cache do
   desc "Enqueue BustCachePathWorker"
   task enqueue_path_bust_workers: :environment do
     # Trigger cache purges for globally-cached endpoints that could have changed
-    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/shell_top")
-    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/shell_bottom")
-    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/async_info/shell_version")
-    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/onboarding")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(5.minutes, "/shell_top")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(5.minutes, "/shell_bottom")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(5.minutes, "/onboarding")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(5.minutes, "/async_info/shell_version")
   end
 end

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -2,9 +2,9 @@ namespace :cache do
   desc "Enqueue BustCachePathWorker"
   task enqueue_path_bust_workers: :environment do
     # Trigger cache purges for globally-cached endpoints that could have changed
-    BustCachePathWorker.set(queue: :high_priority).perform_in(5.minutes, "/shell_top")
-    BustCachePathWorker.set(queue: :high_priority).perform_in(5.minutes, "/shell_bottom")
-    BustCachePathWorker.set(queue: :high_priority).perform_in(5.minutes, "/onboarding")
-    BustCachePathWorker.set(queue: :high_priority).perform_in(5.minutes, "/async_info/shell_version")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/shell_top")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/shell_bottom")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/onboarding")
+    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/async_info/shell_version")
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
It is not ideal to talk to an external service in order to bust caches while initializing the application code. This moves that cache-busting out of the app initializer and into a background job that is kicked off by our app_initializer script which runs after the app code is loaded.
 
## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-45328906


![alt_text](https://media1.tenor.com/images/e45a27d53b603887bf29d994e8a8ed5a/tenor.gif?itemid=5323147)
