### PR TITLE
Hide active broadcasts from /connect routes

### DIFF
--- a/app/assets/javascripts/initializers/initializeBroadcast.js
+++ b/app/assets/javascripts/initializers/initializeBroadcast.js
@@ -81,20 +81,27 @@ function renderBroadcast(broadcastElement, data) {
 
 /**
  * A function to determine if a broadcast should render.
- * Does not render a broadcast on the `/new` route or in an iframe.
+ * Does not render a broadcast in an iframe, or on `/connect` and `/new` routes.
  * Does not render a broadcast if the current user has opted-out,
  * if the broadcast has already been inserted, or if the key for
  * the broadcast's title exists in localStorage.
  *
- * If the broadcast exists in the DOM but was hidden by the articleForm,
- * the function will re-display it again by adding a class.
- *
  * @function initializeBroadcast
  */
 function initializeBroadcast() {
+  const shouldHideBroadcast = window.location.pathname.match(
+    /^(?:\/connect|\/new)/,
+  );
+
   // Iframes will attempt to re-render a broadcast, so we want to explicitly
   // avoid initializing one if we are within `window.frameElement`.
-  if (window.frameElement || window.location.pathname === '/new') {
+  if (window.frameElement || shouldHideBroadcast) {
+    const broadcast = document.getElementById('active-broadcast');
+
+    // Hide the broadcast if it exists and we are on a path where it should be hidden.
+    if (broadcast) {
+      broadcast.classList.remove('broadcast-visible');
+    }
     return;
   }
 

--- a/app/javascript/packs/articleForm.jsx
+++ b/app/javascript/packs/articleForm.jsx
@@ -39,22 +39,7 @@ function loadForm() {
   });
 }
 
-/**
- * A function to hide an active broadcast if it exists
- * by removing a `broadcast-visible` class from it.
- *
- * @function hideActiveBroadcast
- */
-function hideActiveBroadcast() {
-  const broadcast = document.getElementById('active-broadcast');
-
-  if (broadcast) {
-    broadcast.classList.remove('broadcast-visible');
-  }
-}
-
 document.ready.then(() => {
-  hideActiveBroadcast();
   loadForm();
   window.InstantClick.on('change', () => {
     if (document.getElementById('article-form')) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes the issue described in https://github.com/forem/forem/issues/9683, wherein an active announcement broadcast would obfuscate the nav bar on `/connect` routes. Since the chat channel code seems to force scrolling down to the latest message, it made the most sense (in my opinion) to completely hide the announcement bar from view on `/connect` (similar to what we do on the `articleForm` component, aka the `/new` routes).

While doing this, I realized that some of this logic could be cleaned up quite nicely. Previously, we had broadcast-related code in both `initializeBroadcast` _and_ within the `articleForm` component. But it would be nicer to have it all live in one place so that we don't need to keep track of that logic in multiple places.

So, to that end, I refactored the `initializeBroadcast` function to handle all broadcast-related logic using regular expressions, and removed all broadcast checks from the `articleForm` component. 🎉  

## Related Tickets & Documents

Fixes https://github.com/forem/forem/issues/9683.

## QA Instructions, Screenshots, Recordings

1. In your local environment, create an active announcement broadcast:
<img width="1468" alt="Screen Shot 2020-09-13 at 3 46 47 PM" src="https://user-images.githubusercontent.com/6921610/93030610-15c28780-f5d9-11ea-9d8b-74d778561c02.png">

2. Next, ensure that the broadcast is showing up throughout the site:
<img width="1468" alt="Screen Shot 2020-09-13 at 3 46 58 PM" src="https://user-images.githubusercontent.com/6921610/93030617-207d1c80-f5d9-11ea-8ffb-4eef7b56084f.png">

3. Navigate to the `/connect` route (view a chat channel). You should not see the broadcast. Do a hard-refresh, and check that it _still_ does **not** show a broadcast:
<img width="1468" alt="Screen Shot 2020-09-13 at 3 47 15 PM" src="https://user-images.githubusercontent.com/6921610/93030625-3e4a8180-f5d9-11ea-9767-3b9df7af5ad1.png">

4. Check that the same happens on the article form (`/new` route). You should not see the broadcast. Do a hard-refresh, and check that it _still_ does **not** show a broadcast:
<img width="1468" alt="Screen Shot 2020-09-13 at 3 47 05 PM" src="https://user-images.githubusercontent.com/6921610/93030635-4e626100-f5d9-11ea-8591-e4c692ae0a7b.png">

5. Navigate back to anywhere else on the site, and the broadcast should render as expected! ✅ 

## Added tests?

- [ ] yes
- [x] no, because ~they aren't needed~ we don't have testing set up yet for our JavaScript initializers (although at some point we should definitely add them!! 😬)
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] ~no documentation needed~ updated inline documentation 

## Are there any post deployment tasks we need to perform?
N/A

## What gif best describes this PR or how it makes you feel?

![happy animal](https://media1.giphy.com/media/9xuUhwozi3qvJdPogI/giphy.gif)
