### PR TITLE
Changes to profile field indexing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -658,6 +658,8 @@ class User < ApplicationRecord
   end
 
   def index_roles(_role)
+    return unless persisted?
+
     index_to_elasticsearch_inline
   end
 

--- a/app/serializers/search/user_serializer.rb
+++ b/app/serializers/search/user_serializer.rb
@@ -1,5 +1,8 @@
 module Search
   class UserSerializer < ApplicationSerializer
+    CUSTOM_ATTRIBUTES = "custom_attributes".freeze
+    HASH_TRANSFORM = ->(key, value) { { name: key, value: value } }
+
     attributes :id,
                :available_for,
                :comments_count,
@@ -17,6 +20,14 @@ module Search
 
     attribute :roles do |user|
       user.roles.map(&:name)
+    end
+
+    attribute :profile_fields do |user|
+      user.profile.data.except(CUSTOM_ATTRIBUTES).map(&HASH_TRANSFORM)
+    end
+
+    attribute :custom_profile_fields do |user|
+      user.profile.data[CUSTOM_ATTRIBUTES].map(&HASH_TRANSFORM)
     end
   end
 end

--- a/app/serializers/search/user_serializer.rb
+++ b/app/serializers/search/user_serializer.rb
@@ -23,11 +23,11 @@ module Search
     end
 
     attribute :profile_fields do |user|
-      user.profile.data.except(CUSTOM_ATTRIBUTES).map(&HASH_TRANSFORM)
+      user.profile.data.except(CUSTOM_ATTRIBUTES).map(&HASH_TRANSFORM) if user.profile
     end
 
     attribute :custom_profile_fields do |user|
-      user.profile.data[CUSTOM_ATTRIBUTES].map(&HASH_TRANSFORM)
+      user.profile.data[CUSTOM_ATTRIBUTES].map(&HASH_TRANSFORM) if user.profile
     end
   end
 end

--- a/config/elasticsearch/mappings/users.json
+++ b/config/elasticsearch/mappings/users.json
@@ -59,6 +59,28 @@
     },
     "username": {
       "type": "keyword"
+    },
+    "profile_fields": {
+      "type": "nested",
+      "properties": {
+        "name": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword"
+        }
+      }
+    },
+    "custom_profile_fields": {
+      "type": "nested",
+      "properties": {
+        "name": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword"
+        }
+      }
     }
   }
 }

--- a/lib/data_update_scripts/20200519142908_re_index_feed_content_and_users_to_elasticsearch.rb
+++ b/lib/data_update_scripts/20200519142908_re_index_feed_content_and_users_to_elasticsearch.rb
@@ -17,11 +17,12 @@ module DataUpdateScripts
         )
       end
 
-      User.select(:id).in_batches(of: 200) do |batch|
-        Search::BulkIndexWorker.set(queue: :default).perform_async(
-          "User", batch.ids
-        )
-      end
+      # See: https://github.com/forem/forem/pull/10313#discussion_r487646864
+      # User.select(:id).in_batches(of: 200) do |batch|
+      #  Search::BulkIndexWorker.set(queue: :default).perform_async(
+      #    "User", batch.ids
+      #  )
+      # end
     end
   end
 end

--- a/lib/data_update_scripts/20200914042434_reindex_users_for_profiles.rb
+++ b/lib/data_update_scripts/20200914042434_reindex_users_for_profiles.rb
@@ -1,7 +1,9 @@
 module DataUpdateScripts
   class ReindexUsersForProfiles
     def run
-      User.find_each(&:index_to_elasticsearch_inline)
+      User.select(:id).in_batches(of: 200) do |batch|
+        Search::BulkIndexWorker.set(queue: :default).perform_async("User", batch.ids)
+      end
     end
   end
 end

--- a/lib/data_update_scripts/20200914042434_reindex_users_for_profiles.rb
+++ b/lib/data_update_scripts/20200914042434_reindex_users_for_profiles.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class ReindexUsersForProfiles
+    def run
+      User.find_each(&:index_to_elasticsearch_inline)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/re_index_feed_content_and_users_to_elasticsearch_spec.rb
+++ b/spec/lib/data_update_scripts/re_index_feed_content_and_users_to_elasticsearch_spec.rb
@@ -4,32 +4,25 @@ require Rails.root.join("lib/data_update_scripts/20200519142908_re_index_feed_co
 describe DataUpdateScripts::ReIndexFeedContentAndUsersToElasticsearch do
   after do
     Search::FeedContent.refresh_index
-    Search::User.refresh_index
   end
 
-  # rubocop:disable RSpec/ExampleLength
   it "indexes feed content(articles, comments, podcast episodes) and users to Elasticsearch", :aggregate_failures do
     article = create(:article)
     podcast_episode = create(:podcast_episode)
     comment = create(:comment)
-    user = create(:user)
 
     expect { article.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
     expect { podcast_episode.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
     expect { comment.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
-    expect { user.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
 
     sidekiq_perform_enqueued_jobs { described_class.new.run }
 
     expect(article.elasticsearch_doc).not_to be_nil
     expect(podcast_episode.elasticsearch_doc).not_to be_nil
     expect(comment.elasticsearch_doc).not_to be_nil
-    expect(user.elasticsearch_doc).not_to be_nil
 
     expect(article.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
     expect(podcast_episode.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
     expect(comment.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
-    expect(user.elasticsearch_doc["_source"].keys).to include "public_reactions_count"
   end
-  # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/serializers/search/user_serializer_spec.rb
+++ b/spec/serializers/search/user_serializer_spec.rb
@@ -13,4 +13,20 @@ RSpec.describe Search::UserSerializer do
     result = User::SEARCH_CLASS.index(user.id, data_hash)
     expect(result["result"]).to eq("created")
   end
+
+  it "indexes profile fields as a nested field", elasticsearch: "User", aggregate_failures: true do
+    data_hash = described_class.new(user).serializable_hash.dig(:data, :attributes)
+    result = User::SEARCH_CLASS.index(user.id, data_hash)
+    expect(result["result"]).to eq("created")
+    indexed_profile_fields = user.reload.elasticsearch_doc.dig("_source", "profile_fields")
+    expect(indexed_profile_fields).to be_an_instance_of(Array)
+  end
+
+  it "indexes custom profile fields as a nested field", elasticsearch: "User", aggregate_failures: true do
+    data_hash = described_class.new(user).serializable_hash.dig(:data, :attributes)
+    result = User::SEARCH_CLASS.index(user.id, data_hash)
+    expect(result["result"]).to eq("created")
+    indexed_custom_fields = user.reload.elasticsearch_doc.dig("_source", "custom_profile_fields")
+    expect(indexed_custom_fields).to be_an_instance_of(Array)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR is part of the ongoing profile generalization work. It specifically deals with how we index the new profile fields in Elasticsearch:

1. Adds two new [nested fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html), `profile_fields` and `custom_profile_fields` to the users mapping.
2. Updates `Search::UserSerializer` to update the two new fields.
3. Adds a data update script for reindexing users.

These are the first 3 steps described in [our Elasticsearch documentation](https://docs.dev.to/backend/elasticsearch/#how-to-add-a-new-field-to-elasticsearch).

## Related Tickets & Documents

Part of #6994

## QA Instructions, Screenshots, Recordings

1. Check out this PR
2. Update your mappings, e.g. with `bin/setup`
3. Index a user, e.g. `user.index_to_elasticsearch_inline`
4. Check that the ES document contains the nested attributes:
    ```ruby
    user.reload.elasticsearch_doc.dig("_source", "profile_fields")
    user.reload.elasticsearch_doc.dig("_source", "custom_profile_fields")
    ```
## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
