### PR TITLE
Stop pinging sitemap tools locally

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -167,4 +167,9 @@ class SiteConfig < RailsSettings::Base
     large: 300,
     xlarge: 250
   }
+
+  # Returns true if we are operating on a local installation, false otherwise
+  def self.local?
+    app_domain.include?("localhost")
+  end
 end

--- a/app/workers/sitemap_refresh_worker.rb
+++ b/app/workers/sitemap_refresh_worker.rb
@@ -5,6 +5,9 @@ class SitemapRefreshWorker
 
   def perform
     Rails.application.load_tasks
-    Rake::Task["sitemap:refresh"].invoke
+
+    sitemap_task = SiteConfig.local? ? "sitemap:refresh:no_ping" : "sitemap:refresh"
+
+    Rake::Task[sitemap_task].invoke
   end
 end

--- a/spec/models/site_config_spec.rb
+++ b/spec/models/site_config_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe SiteConfig, type: :model do
+  describe ".local?" do
+    it "returns true if the .app_domain points to localhost" do
+      allow(described_class).to receive(:app_domain).and_return("localhost:3000")
+
+      expect(described_class.local?).to be(true)
+    end
+
+    it "returns false if the .app_domain points to a regular domain" do
+      allow(described_class).to receive(:app_domain).and_return("forem.dev")
+
+      expect(described_class.local?).to be(false)
+    end
+  end
+end

--- a/spec/workers/sitemap_refresh_worker_spec.rb
+++ b/spec/workers/sitemap_refresh_worker_spec.rb
@@ -5,12 +5,26 @@ RSpec.describe SitemapRefreshWorker, type: :woker do
 
   describe "#perform" do
     let(:worker) { subject }
+    let(:mock_task) { instance_double(Rake::Task, invoke: true) }
 
-    it "runs sitemap refresh rake task" do
+    before do
       allow(Rails.application).to receive(:load_tasks)
-      mock_task = instance_double(Rake::Task, invoke: true)
       allow(Rake::Task).to receive(:[]).and_return(mock_task)
+    end
+
+    it "runs sitemap:refresh:no_ping Rake task locally" do
+      allow(SiteConfig).to receive(:local?).and_return(true)
+
       worker.perform
+
+      expect(Rake::Task).to have_received(:[]).with("sitemap:refresh:no_ping")
+    end
+
+    it "runs sitemap:refresh Rake task on regular installations" do
+      allow(SiteConfig).to receive(:local?).and_return(false)
+
+      worker.perform
+
       expect(Rake::Task).to have_received(:[]).with("sitemap:refresh")
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed the following in the logs:

```
sidekiq   | Pinging with URL 'http://localhost:3000/sitemap.xml.gz':
sidekiq   | Ping failed for Google: #<OpenURI::HTTPError: 400 Bad Request> (URL http://www.google.com/webmasters/tools/ping?sitemap=http%3A%2F%2Flocalhost%3A3000%2Fsitemap.xml.gz)
sidekiq   |   Successful ping of Bing
sidekiq   | 2020-09-14T07:30:12.751Z pid=87981 tid=18p class=SitemapRefreshWorker jid=76604c54535c07b0e2cf6ef8 elapsed=1.328 INFO: done
```

There's no need to ping the sitemap tools when running locally. I've intentionally named the method `local?` instead of `localhost?` as the concept of local installation might be expanded in the future and not just refer to `localhost` (like private instances inside a company DMZ that are not reachable from outside). For now `localhost` should suffice.

## QA Instructions, Screenshots, Recordings

1. boot the console
1. run `SitemapRefreshWorker.new.perform` and notice how it doesn't ping stuff
1. change your app domain to `SiteConfig.app_domain = "forem.dev"` 
1. run `SitemapRefreshWorker.new.perform` and notice it pings stuff

don't forget to change `SiteConfig.app_domain` back to `localhost:3000` :)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
