### PR TITLE
Optimization:Only Enqueue UpdateMainImageBackgroundHexWorker If Main Image Changes

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -422,6 +422,7 @@ class Article < ApplicationRecord
   end
 
   def update_main_image_background_hex
+    return unless saved_changes.key?("main_image")
     return if main_image.blank? || main_image_background_hex_color != "#dddddd"
 
     Articles::UpdateMainImageBackgroundHexWorker.perform_async(id)

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -765,6 +765,15 @@ RSpec.describe Article, type: :model do
         end
         expect(article).to have_received(:update_main_image_background_hex)
       end
+
+      it "does not enqueue a job if main_image has not changed" do
+        article.save
+        allow(article).to receive(:update_main_image_background_hex).and_call_original
+        sidekiq_assert_no_enqueued_jobs(only: Articles::UpdateMainImageBackgroundHexWorker) do
+          article.save
+        end
+        expect(article).to have_received(:update_main_image_background_hex)
+      end
     end
 
     describe "async score calc" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
I noticed when playing around in my local env that this job was getting kicked off every single time we touched an article. Including just to update a comment. Since this is a waste of resources I updated the code to only kick of the job when the main image actually changes. 

## Added tests?
- [x] yes

![alt_text](https://media2.giphy.com/media/jn7sNNFTpsxdfVkAMW/giphy.gif)
