### PR TITLE
Flaky Spec Fix:Set Expired Listing to 2 days ago

### DIFF
--- a/spec/workers/listings/expire_old_listings_worker_spec.rb
+++ b/spec/workers/listings/expire_old_listings_worker_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Listings::ExpireOldListingsWorker, type: :worker do
     it "expires only old listings" do
       Timecop.freeze do
         bumped_listing = create(:listing, bumped_at: 41.days.ago, published: true)
-        expired_listing = create(:listing, expires_at: 1.day.ago, published: true)
+        expired_listing = create(:listing, expires_at: 2.days.ago, published: true)
         valid_listing = create(:listing, expires_at: 1.week.from_now, published: true)
 
         worker.perform


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
I saw this spec be flaky once during a Travis run and when I looked at it I noticed in the expired listing worker we are doing `"expires_at < ?", Time.zone.today` and then in the spec, we set the expired_at to 1.day.ago. I think given time zones there is a point where these might overlap so I increased the expired_at in the spec to 2.days.ago so it is always guaranteed to be less that Time.zone.today

Fixes: 
```
[Zonebie] Setting timezone: ZONEBIE_TZ="International Date Line West"

  1) Listings::ExpireOldListingsWorker#perform expires only old listings
     Failure/Error: expect(expired_listing.reload.published).to eq(false)
       expected: false
            got: true
       (compared using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -false
       +true
     # ./spec/workers/listings/expire_old_listings_worker_spec.rb:18:in `block (4 levels) in <top (required)>'
     # ./spec/workers/listings/expire_old_listings_worker_spec.rb:10:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
```


![alt_text](https://thumbs.gfycat.com/AnxiousEminentGodwit-size_restricted.gif)
