### PR TITLE
Flaky Spec Fix:Ensure Page View Domains are Unique for Analytics Serv…

### DIFF
--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -424,7 +424,9 @@ RSpec.describe AnalyticsService, type: :service do
       end
 
       it "returns 20 domains at most by default" do
-        21.times { create(:page_view, user: user, article: article, referrer: Faker::Internet.url) } # rubocop:disable FactoryBot/CreateList
+        21.times do |n|
+          create(:page_view, user: user, article: article, referrer: "http://fakeurl#{n}.com")
+        end
         expect(analytics_service.referrers[:domains].size).to eq(20)
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
Sometimes this Flaky spec would return less page views than the expected 20. Seeing as we were simply using Faker to generate URLs and then grouping them by domain, there is a chance that some of the URLs ended up with the same domain which would cause our counts to be low. This ensures each domain is unique. 
Fixes: 
```
  1) AnalyticsService#referrers when working on domains returns 20 domains at most by default
     Failure/Error: expect(analytics_service.referrers[:domains].size).to eq(20)
       expected: 20
            got: 19
       (compared using ==)
     # ./spec/services/analytics_service_spec.rb:428:in `block (4 levels) in <top (required)>'
     # ./spec/rails_helper.rb:136:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:136:in `block (2 levels) in <top (required)>'
````

![alt_text](https://media4.giphy.com/media/ete9HLBYGmXIY/200.gif)
