### PR TITLE
Flaky Spec Fix:Ensure We Fill In Article Content Successfully with More Targeted tag

### DIFF
--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Using the editor", type: :system do
 
   def fill_markdown_with(content)
     visit "/new"
-    fill_in "article_body_markdown", with: content
+    within("#article-form") { fill_in "article_body_markdown", with: content }
   end
 
   describe "Previewing an article", js: true do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
In order to recreate this failure I copied this spec 10 times in its spec file and then ran the file. Each time about half of the duplicate examples would fail. When I jumped into the spec with pry I found that it was not filling in the article content and therefore when we went to save the article we would get a validation error, "Title can't be blank". After a little digging, [I found that we could be more targeted with our form fill_in](https://stackoverflow.com/a/18881133/1438582) so I tried that. With the `within` I was able to run the file with the duplicate specs 3 times and none of them ever failed so I think this is the fix we need. Something to keep in mind if we see this in the future. 

Fixes: 
```
  1) Using the editor Submitting an article fill out form and submit
     Failure/Error: article_body = find(:xpath, "//div[@id='article-body']")["innerHTML"]

     Capybara::ElementNotFound:
       Unable to find xpath "//div[@id='article-body']"

     [Screenshot]: /home/travis/build/forem/forem/tmp/screenshots/r_spec_example_groups_using_the_editor_submitting_an_article_fill_out_form_and_submit_594_2020-08-20T13:-41-12-969Z.png

     # ./spec/system/user_uses_the_editor_spec.rb:48:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
     # ./spec/support/initializers/ci_csv_formatter.rb:92:in `block (2 levels) in <top (required)>'
```


![alt_text](https://media3.giphy.com/media/Bf4lQirw2txqU/200.gif)
