### PR TITLE
Optimization:Store Podcast Ep Data in Redis, Rather than Sending as Sidekiq Argument

### DIFF
--- a/app/workers/podcast_episodes/create_worker.rb
+++ b/app/workers/podcast_episodes/create_worker.rb
@@ -4,7 +4,10 @@ module PodcastEpisodes
 
     sidekiq_options queue: :high_priority
 
-    def perform(podcast_id, item)
+    def perform(podcast_id, episode_cache_key)
+      item = Rails.cache.read(episode_cache_key)
+      return unless item
+
       Podcasts::CreateEpisode.call(podcast_id, item.with_indifferent_access)
     end
   end

--- a/spec/services/podcasts/feed_spec.rb
+++ b/spec/services/podcasts/feed_spec.rb
@@ -96,7 +96,10 @@ RSpec.describe Podcasts::Feed, type: :service, vcr: vcr_option do
   end
 
   context "when creating" do
+    let(:cache_store) { ActiveSupport::Cache.lookup_store(:redis_cache_store) }
+
     before do
+      allow(Rails).to receive(:cache).and_return(cache_store)
       stub_request(:head, "https://traffic.libsyn.com/sedaily/AnalyseAsia.mp3").to_return(status: 200)
       stub_request(:head, "https://traffic.libsyn.com/sedaily/IFTTT.mp3").to_return(status: 200)
     end

--- a/spec/services/podcasts/get_episode_spec.rb
+++ b/spec/services/podcasts/get_episode_spec.rb
@@ -82,9 +82,10 @@ RSpec.describe Podcasts::GetEpisode, type: :service do
   end
 
   it "enqueues a worker to create an episode when it doesn't exist" do
+    cache_key = Digest::SHA1.hexdigest(item.to_s)
     allow(podcast).to receive(:existing_episode).and_return(nil)
 
-    sidekiq_assert_enqueued_with(job: PodcastEpisodes::CreateWorker, args: [podcast.id, item.to_h]) do
+    sidekiq_assert_enqueued_with(job: PodcastEpisodes::CreateWorker, args: [podcast.id, cache_key]) do
       described_class.new(podcast).call(item: item)
     end
   end

--- a/spec/workers/podcast_episodes/create_worker_spec.rb
+++ b/spec/workers/podcast_episodes/create_worker_spec.rb
@@ -1,30 +1,31 @@
 require "rails_helper"
 
 RSpec.describe PodcastEpisodes::CreateWorker, type: :worker do
-  include_examples "#enqueues_on_correct_queue", "high_priority", [123, {}]
+  include_examples "#enqueues_on_correct_queue", "high_priority", [123, "cache_key"]
 
   describe "#perform" do
     let(:worker) { subject }
 
     let(:podcast_id) { 781 }
-    let(:item) { { foo: "bar" } }
+    let(:cache_key) { "ep_cache_key" }
 
     before do
       allow(Podcasts::CreateEpisode).to receive(:call)
     end
 
     it "creates a podcast episode" do
-      worker.perform(podcast_id, item)
+      allow(Rails.cache).to receive(:read).and_return({})
+      worker.perform(podcast_id, cache_key)
 
-      expect(Podcasts::CreateEpisode).to have_received(:call).with(podcast_id, item).once
+      expect(Podcasts::CreateEpisode).to have_received(:call).with(podcast_id, {}).once
+      expect(Rails.cache).to have_received(:read).with(cache_key).once
     end
 
-    context "when item has string keys" do
-      it "creates a podcast episode regardless of whether item has string or symbol keys" do
-        worker.perform(podcast_id, item.stringify_keys)
+    it "does not create a podcast episode if item is not found" do
+      allow(Rails.cache).to receive(:read)
+      worker.perform(podcast_id, cache_key)
 
-        expect(Podcasts::CreateEpisode).to have_received(:call).with(podcast_id, item).once
-      end
+      expect(Podcasts::CreateEpisode).not_to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Take it from someone who has made this mistake before, it is a really bad idea to use large Sidekiq arguments. If you end up enqueueing a ton of jobs it will eat up your Redis resources extremely fast from a memory standpoint and from an I/O standpoint bc of all the polling Sidekiq does against the queues. This PR updates our Podcast::CreateWorker so that we store the large `item_data` hash in Redis and send a hashed key representing it instead as an argument to our worker. The worker then looks up the key in Redis and fetches the item data to send to the CreateEpisode service.

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-43005072

## Added tests?
- [x] yes


![alt_text](https://media1.tenor.com/images/72c52c20a66f2eecfd39f0fd58e8d12c/tenor.gif?itemid=5412400)
