### PR TITLE
Optimization:Use delete_by when Destroying HtmlVariant Trials and Successes

### DIFF
--- a/app/workers/html_variants/remove_old_data_worker.rb
+++ b/app/workers/html_variants/remove_old_data_worker.rb
@@ -5,8 +5,8 @@ module HtmlVariants
     sidekiq_options queue: :low_priority, retry: 15
 
     def perform
-      HtmlVariantTrial.destroy_by("created_at < ?", 2.weeks.ago)
-      HtmlVariantSuccess.destroy_by("created_at < ?", 2.weeks.ago)
+      HtmlVariantTrial.delete_by("created_at < ?", 2.weeks.ago)
+      HtmlVariantSuccess.delete_by("created_at < ?", 2.weeks.ago)
       HtmlVariant.find_each do |html_variant|
         html_variant.calculate_success_rate! if html_variant.html_variant_successes.any?
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
`HtmlVariantSuccess` and `HtmlVariantTrial`'s are pretty simple objects that have 0 callbacks or relationships we need to worry about cleaning up when we destroy them. For this reason, rather than using [`destroy_by`](https://apidock.com/rails/v6.0.0/ActiveRecord/Relation/destroy_by) which will go through and delete them all 1 by 1 executing all callback, let's switch to using a quick [`delete_by`](https://apidock.com/rails/v6.0.0/ActiveRecord/Relation/delete_by) which will delete them all in one SQL statement. 

This will eliminate a lot of spans and speed this puppy up quite a bit
![Screen Shot 2020-09-14 at 3 37 06 PM](https://user-images.githubusercontent.com/1813380/93135593-30abff00-f6a0-11ea-8cd2-cac72485038a.png)


## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media2.giphy.com/media/UUzI0kCwbRJc5Ds20K/200.gif)
