### PR TITLE
Bug Fix/Optimization:Clear Github Repo HttpCache Key Daily

### DIFF
--- a/app/workers/github_repos/clear_http_cache_worker.rb
+++ b/app/workers/github_repos/clear_http_cache_worker.rb
@@ -1,0 +1,24 @@
+module GithubRepos
+  class ClearHttpCacheWorker
+    include Sidekiq::Worker
+    GITHUB_REPOS_URL = "https://api.github.com/user/repos?per_page=100".freeze
+
+    sidekiq_options queue: :medium_priority, retry: 10
+
+    def perform
+      return unless SiteConfig.github_key.present? && SiteConfig.github_secret.present?
+
+      # We need a dummy client to access Faraday::HttpCache storage class
+      # this client never actually makes any github requests so credentials are not needed
+      client = Github::OauthClient.new(client_id: "placeholder")
+      middleware_cache = client.middleware.handlers.detect { |h| h == Faraday::HttpCache }
+
+      # Our Github Oauth client uses Faraday::HttpCache (https://github.com/forem/forem/blob/master/app/services/github/oauth_client.rb#L114)
+      # to cache request results which can be served in event of an error.
+      # The problem with this is every time we fetch github repos we add another request to
+      # our Redis key AND we reset the expiration back to 24 hours. This can cause the key in Redis
+      # to grow uncontrollably. To prevent the key from getting too large we delete it once a day.
+      middleware_cache.build.__send__("storage").delete(GITHUB_REPOS_URL)
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -110,4 +110,7 @@ get_podcast_episodes:
 update_latest_github_repos:
   cron: "30 16 * * *" # daily at 4:30 pm UTC
   class: "GithubRepos::UpdateLatestWorker"
+bust_http_github_repo_cache_key:
+  cron: "0 1 * * *" # daily at 1 am UTC
+  class: GithubRepos::ClearHttpCacheWorker
 

--- a/spec/workers/github_repos/clear_http_cache_worker_spec.rb
+++ b/spec/workers/github_repos/clear_http_cache_worker_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe GithubRepos::ClearHttpCacheWorker, type: :worker do
+  let(:worker) { subject }
+  let(:dummy_client) { Github::OauthClient.new(client_id: "placeholder") }
+
+  include_examples "#enqueues_on_correct_queue", "medium_priority"
+
+  describe "#perform" do
+    it "clears user/repos url http cache" do
+      middleware_cache = dummy_client.middleware.handlers.detect { |h| h == Faraday::HttpCache }
+      cache_build = middleware_cache.build
+      storage = cache_build.__send__("storage")
+      allow(Github::OauthClient).to receive(:new).and_return(dummy_client)
+      allow(middleware_cache).to receive(:build).and_return(cache_build)
+      allow(cache_build).to receive(:__send__).with("storage").and_return(storage)
+      allow(storage).to receive(:delete)
+
+      worker.perform
+      expect(storage).to have_received(:delete).with(described_class::GITHUB_REPOS_URL)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
Our Github Oauth client uses [Faraday::HttpCache](https://github.com/forem/forem/blob/master/app/services/github/oauth_client.rb#L114) to cache request results which can be served in event of an error. The problem with this is every time we fetch Github repos we add another request to our Redis key AND we reset the expiration back to 24 hours. This can cause the key in Redis to grow uncontrollably. When it gets really large we start to timeout trying to add to it. You can see this problem in the response time Honeycomb graph below. You can also see the time spent writing to Redis in the next image which is of a Honeycomb trace. To prevent the key from getting too large we delete it once a day.
![Screen Shot 2020-09-14 at 4 01 16 PM](https://user-images.githubusercontent.com/1813380/93264793-41767680-f76d-11ea-9f55-6aa82943e045.png)
<img width="1010" alt="Screen Shot 2020-09-15 at 11 03 52 AM" src="https://user-images.githubusercontent.com/1813380/93264799-45a29400-f76d-11ea-8139-1b0d31b6f7b5.png">

The other option that I first thought of was to set the expiration time for the HttpCache keys to something shorter so they would expire. However, that would mean we would have to ensure that at some point no one would hit the github repos index endpoint so the key could expire and I didn't think that was feasible as we grow so I went with the manual clear. I tried to use the gems code paths as much as possible to avoid issues if the gems change. Unfortunately, it still led to me calling one private method to get the `Faraday::HttpCache` storage object.

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-45548773

## Added tests?
- [x] yes


![alt_text](https://media1.tenor.com/images/88609c038beee3df1e0551755eb68d6d/tenor.gif?itemid=13575751)
