### PR TITLE
Optimization:Use Locally Bundled Gems in Containers

### DIFF
--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -6,5 +6,5 @@ if [ -f /opt/apps/bundle/bundle_finished ]; then
   rm -f /opt/apps/bundle/bundle_finished
 fi
 
-bundle install --jobs 20 --retry 5
+bundle install --local --jobs 20 --retry 5
 echo $(date --utc +%FT%T%Z) > /opt/apps/bundle/bundle_finished


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
I noticed when trying to use Docker with BuildKite that we were downloading and installing all of our gems rather than using our local vendor'ed cache. This updates our container bundle script to use our local gem cache which will save us a bit of time. 


![alt_text](https://media3.giphy.com/media/cUMNWzWZ5n75LvcCIe/200.gif)
