### PR TITLE
Feature:Introduce Buildkite pipeline.yml file

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,13 @@
+steps:
+  - name: ":rspec:"
+    command: "scripts/ci/parallel_specs.sh"
+    artifact_paths: "log/**/*"
+    env:
+      RAILS_ENV: test
+    plugins:
+      - docker-compose#v3.5.0:
+          run: rails
+    parallelism: 3
+    agents:
+      queue: $BUILDKITE_AGENT_META_DATA_QUEUE
+    branches: "mstruve/buildkite*"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
I am in the process of getting [Buildkite](https://buildkite.com/) set up for us to use. I recently enabled a Github webhook which will trigger on pushes to this repo. This adds the file necessary for that step to return green right now despite not being fully configured. The file will only trigger an actual pipeline build for my Buildkite branches and anything else will automatically return green since the branch name is not a match. 

This step is not required but if you are like me you like to see that green dot on your PRs, this will keep them nice and clean 😉 

NOTE: This build shows the buildkite step passing. I deactivated the Webhook after seeing it fail and block another branch from being merged. I will enable it after this is merged. 

![alt_text](https://media0.giphy.com/media/4hxNtWhOONfpu/200.gif)
