### PR TITLE
Bug Fix/Optimization:Remove HttpCache from Github OauthClient

### DIFF
--- a/app/services/github/oauth_client.rb
+++ b/app/services/github/oauth_client.rb
@@ -111,7 +111,6 @@ module Github
       # <https://github.com/octokit/octokit.rb#caching>
       # and <https://github.com/octokit/octokit.rb/blob/master/lib/octokit/default.rb>
       Faraday::RackBuilder.new do |builder|
-        builder.use Faraday::HttpCache, store: Rails.cache, serializer: Marshal, shared_cache: false
         builder.use Faraday::Request::Retry, exceptions: [Octokit::ServerError]
         builder.use Octokit::Middleware::FollowRedirects
         builder.use Octokit::Response::RaiseError


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
Our Github Oauth client uses [Faraday::HttpCache](https://github.com/forem/forem/blob/master/app/services/github/oauth_client.rb#L114) to cache request results which can be served in event of an error. The problem with this is every time we fetch Github repos we add another request to our Redis key AND we reset the expiration back to 24 hours. This can cause the key in Redis to grow uncontrollably. When it gets really large we start to timeout trying to add to it. You can see this problem in the response time Honeycomb graph below. You can also see the time spent writing to Redis in the next image which is of a Honeycomb trace. To prevent this I am removing the cache. 
![Screen Shot 2020-09-14 at 4 01 16 PM](https://user-images.githubusercontent.com/1813380/93264793-41767680-f76d-11ea-9f55-6aa82943e045.png)
<img width="1010" alt="Screen Shot 2020-09-15 at 11 03 52 AM" src="https://user-images.githubusercontent.com/1813380/93264799-45a29400-f76d-11ea-8139-1b0d31b6f7b5.png">

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-45548773

## Added tests?
- [x] yes


![alt_text](https://media1.tenor.com/images/88609c038beee3df1e0551755eb68d6d/tenor.gif?itemid=13575751)
