### PR TITLE
Fix case sensitive published bug for basic markdown posts

### DIFF
--- a/app/labor/markdown_fixer.rb
+++ b/app/labor/markdown_fixer.rb
@@ -4,7 +4,7 @@ class MarkdownFixer
   class << self
     def fix_all(markdown)
       methods = %i[
-        add_quotes_to_title add_quotes_to_description
+        add_quotes_to_title add_quotes_to_description lowercase_published
         modify_hr_tags convert_new_lines split_tags underscores_in_usernames
       ]
       methods.reduce(markdown) { |acc, elem| public_send(elem, acc) }
@@ -33,6 +33,12 @@ class MarkdownFixer
     def modify_hr_tags(markdown)
       markdown.gsub(/-{3}.*?-{3}/m) do |front_matter|
         front_matter.gsub(/^---/).with_index { |match, i| i > 1 ? "#{match}-----" : match }
+      end
+    end
+
+    def lowercase_published(markdown)
+      markdown.gsub(/-{3}.*?-{3}/m) do |front_matter|
+        front_matter.gsub(/^published: /i, "published: ")
       end
     end
 

--- a/spec/labor/markdown_fixer_spec.rb
+++ b/spec/labor/markdown_fixer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe MarkdownFixer, type: :labor do
     <<~HEREDOC
       ---
       title: #{title}
+      published: false
       description: #{description}
       ---
     HEREDOC
@@ -95,6 +96,16 @@ RSpec.describe MarkdownFixer, type: :labor do
       expected_title = "\"hmm\"\n"
       result = described_class.convert_new_lines(front_matter(title: title))
       expect(result).to eq(front_matter(title: expected_title))
+    end
+  end
+
+  describe "::lowercase_published" do
+    it "lowercases the published frontmatter attribute" do
+      cases = %w[Published pubLished PUBLISHED]
+      cases.each do |_word|
+        result = described_class.lowercase_published(front_matter)
+        expect(result.match(/^published: false/).size).to eq 1
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a bug where articles that are using front matter (also known as v1 articles or basic markdown articles) with `Published: true` will fail to publish. This is because the `published` attribute is case sensitive in the `front_matter_parser` gem we use, and therefore needs to be properly lowercased before sending it to the gem for processing.

## QA Instructions, Screenshots, Recordings
1. Go to `localhost:3000/settings/ux` and update your article version to "basic markdown"
2. Click "Write a Post"
3. Try to publish a post with `Published: true`
4. See that it publishes

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![An elephant shows the capital and lowercase letter P.](https://media.giphy.com/media/vRMhjPlVwWvZACqkGG/giphy.gif)