### PR TITLE
Removing close button from right panel in moderation view

### DIFF
--- a/app/javascript/actionsPanel/__tests__/initializeActionsPanelToggle.test.js
+++ b/app/javascript/actionsPanel/__tests__/initializeActionsPanelToggle.test.js
@@ -21,6 +21,12 @@ describe('toggling the actions panel', () => {
 
     test('it should have a click listener that toggles the appropriate classes', () => {
       initializeActionsPanel(path);
+
+      const modContainer = document.getElementById('mod-container');
+      modContainer.contentWindow.document.write(
+        `<html><body><button class="close-actions-panel hidden"></body></html>`,
+      );
+
       const modActionsMenu = document.querySelector('.mod-actions-menu');
       const modActionsMenuBtn = document.querySelector('.mod-actions-menu-btn');
 
@@ -28,6 +34,11 @@ describe('toggling the actions panel', () => {
 
       expect(modActionsMenu.classList.contains('showing')).toBeTruthy();
       expect(modActionsMenuBtn.classList.contains('hidden')).toBeTruthy();
+
+      const panelDocument = modContainer.contentDocument;
+
+      const closeButton = panelDocument.querySelector('.close-actions-panel');
+      expect(closeButton.classList.contains('hidden')).toBeFalsy();
     });
   });
 });

--- a/app/javascript/actionsPanel/initializeActionsPanelToggle.js
+++ b/app/javascript/actionsPanel/initializeActionsPanelToggle.js
@@ -20,6 +20,14 @@ export default function initializeActionsPanel(user, path) {
   function toggleModActionsMenu() {
     document.querySelector('.mod-actions-menu').classList.toggle('showing');
     document.querySelector('.mod-actions-menu-btn').classList.toggle('hidden');
+
+    // showing close icon mod panel is opened by clicking the button
+    const modContainer = document.getElementById('mod-container');
+    const panelDocument = modContainer.contentDocument;
+
+    panelDocument
+      .querySelector('.close-actions-panel')
+      .classList.remove('hidden');
   }
 
   document.querySelector('.mod-actions-menu').innerHTML = modActionsMenuHTML;

--- a/app/javascript/actionsPanel/initializeActionsPanelToggle.js
+++ b/app/javascript/actionsPanel/initializeActionsPanelToggle.js
@@ -21,7 +21,7 @@ export default function initializeActionsPanel(user, path) {
     document.querySelector('.mod-actions-menu').classList.toggle('showing');
     document.querySelector('.mod-actions-menu-btn').classList.toggle('hidden');
 
-    // showing close icon mod panel is opened by clicking the button
+    // showing close icon in the mod panel if it is opened by clicking the button
     const modContainer = document.getElementById('mod-container');
     const panelDocument = modContainer.contentDocument;
 

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -12,7 +12,7 @@
   <header class="top-header">
     <h1>Moderate Post</h1>
     <h2>Rate the quality of this post</h2>
-    <button class="crayons-btn crayons-btn--secondary crayons-btn--icon-rounded close-actions-panel" type="button" title="Close moderator actions panel">
+    <button class="crayons-btn crayons-btn--secondary crayons-btn--icon-rounded close-actions-panel hidden" type="button" title="Close moderator actions panel">
       <%= inline_svg_tag("x.svg", aria: true, class: "crayons-icon", title: "Close moderator actions panel") %>
     </button>
   </header>


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Hides close button in moderator view

## Related Tickets & Documents

closes https://github.com/forem/forem/issues/10265

## QA Instructions, Screenshots, Recordings
### Article view
![article_view](https://user-images.githubusercontent.com/8092120/93373468-02cae400-f873-11ea-8837-16116426e8a4.png)
### Mod view
![mod_view](https://user-images.githubusercontent.com/8092120/93373475-0494a780-f873-11ea-9d58-8a313fff114e.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## What gif best describes this PR or how it makes you feel?

![Happy](https://media1.tenor.com/images/379faefe7d906603844c3c073b290814/tenor.gif?itemid=5108830)