### PR TITLE
Fix bug that shows all self-authored as reacted

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -48,7 +48,6 @@ function initializeCommentsPage() {
                     userActionsEl.innerHTML = '<a data-no-instant href="' + userActionsEl.parentNode.dataset.path + '/delete_confirm" class="edit-butt">DELETE</a>\
                                                 <a href="' + userActionsEl.parentNode.dataset.path + '/edit">EDIT</a>'
                     userActionsEl.style.display = 'inline-block';
-                    document.getElementById('button-for-comment-' + allNodes[i].dataset.commentId).classList.add('reacted');
                   }
                 }
               }


### PR DESCRIPTION
Co-authored with @lauraxm

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR addresses https://github.com/forem/forem/issues/10341, by removing some lines that were severely confusing the Frontend when creating and reacting to self-created comments. 

Previously (on `master`):
- When the FE loads **any** comment that was self created, it is rendered as "liked" even if I specifically unliked it.

Now (in this PR):
- We use the API response to determine what is "reacted" or not.

## Original MR scope



## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/10341

## QA Instructions, Screenshots, Recordings

1. Make a comment on a test post
2. Refresh the page.
3. Unlike the comment.
4. Refresh the page.
5. The comment should show as unliked (currently on `master` it will show as liked)

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help

It probably makes the most sense to add something to `spec/system/comments/user_fills_out_comment_spec.rb`. I can do this but will need to get rspec running locally :smile:

## Added to documentation?

I'm not sure if there's any preexisting documentation for this "auto like your own comments" feature :shrug:

- [ ] docs.forem.com
- [ ] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![uncertain](https://media.giphy.com/media/12Q0TD37LCm0Rq/giphy.gif)

## Edits

There was some confusion on the requirements here. Originally, this MR also changed: 

<details>

Previously (on `master`):
- When a comment is created, we render it as "liked" on the frontend (FE), but the backend (BE) actually doesn't recognize this.

Now (in this PR):
- When a comment is created, we do not render it as "liked" so that it is consistent with the BE.

We believe this new behavior is also consistent with user expectations (it can come across a little haughty to like your own comments).

## QA Instructions, Screenshots, Recordings (Old)

In this MR's previous state, you could test the changes by:

https://youtu.be/WhYLclxpLz0

Instructions taken from https://github.com/forem/forem/issues/10341

1. Make a comment on a test post. The comment should be unhearted by default (matches BE behavior).
2. Heart the comment and reply to your first comment with a second comment.
3. If you try to remove the heart on the first comment, the heart is removed.

</details>