### PR TITLE
Add opacity to HexComparer

### DIFF
--- a/app/labor/hex_comparer.rb
+++ b/app/labor/hex_comparer.rb
@@ -1,45 +1,34 @@
 class HexComparer
+  RGB_REGEX = /^#?(?<r>..)(?<g>..)(?<b>..)$/.freeze
+  ACCENT_MODIFIERS = [1.14, 1.08, 1.06, 0.96, 0.9, 0.8, 0.7, 0.6].freeze
+
   def initialize(hexes, amount = 1)
-    @hexes = hexes
+    @hexes = hexes.sort
     @amount = amount
   end
 
-  def order
-    hexes.sort
-  end
-
   def smallest
-    order.first
+    hexes.first
   end
 
   def biggest
-    order.last
+    hexes.last
   end
 
   def brightness(amount = 1)
-    rgb = smallest.delete("#").scan(/../).map(&:hex).map { |color| color * amount }.map(&:round)
-    format("#%<r>02x%<g>02x%<b>02x", r: rgb[0], g: rgb[1], b: rgb[2])
+    rgb = smallest.match(RGB_REGEX).named_captures.map do |key, color|
+      [key.to_sym, (color.hex * amount).round]
+    end.to_h
+    format("#%<r>02x%<g>02x%<b>02x", rgb)
   rescue StandardError
     smallest
   end
 
+  # Returns the first valid hex string it finds (# + 6 digits)
   def accent
-    if brightness(1.14**amount).size == 7
-      brightness(1.14**amount)
-    elsif brightness(1.08**amount).size == 7
-      brightness(1.08**amount)
-    elsif brightness(1.06**amount).size == 7
-      brightness(1.06**amount)
-    elsif brightness(0.96**amount).size == 7
-      brightness(0.96**amount)
-    elsif brightness(0.9**amount).size == 7
-      brightness(0.9**amount)
-    elsif brightness(0.8**amount).size == 7
-      brightness(0.8**amount)
-    elsif brightness(0.7**amount).size == 7
-      brightness(0.7**amount)
-    elsif brightness(0.6**amount).size == 7
-      brightness(0.6**amount)
+    ACCENT_MODIFIERS.each do |modifier|
+      with_brightness = brightness(modifier**amount)
+      break with_brightness if with_brightness.size == 7
     end
   end
 

--- a/app/labor/hex_comparer.rb
+++ b/app/labor/hex_comparer.rb
@@ -16,9 +16,9 @@ class HexComparer
   end
 
   def brightness(amount = 1)
-    rgb = smallest.match(RGB_REGEX).named_captures.map do |key, color|
-      [key.to_sym, (color.hex * amount).round]
-    end.to_h
+    rgb = hex_to_rgb_hash(smallest).transform_values do |color|
+      (color * amount).round
+    end
     format("#%<r>02x%<g>02x%<b>02x", rgb)
   rescue StandardError
     smallest
@@ -32,7 +32,18 @@ class HexComparer
     end
   end
 
+  def opacity(value = 0.0)
+    rgba = hex_to_rgb_hash(smallest).merge(a: value)
+    format("rgba(%<r>d, %<g>d, %<b>d, %<a>.2f)", rgba)
+  end
+
   private
+
+  def hex_to_rgb_hash(hex)
+    hex.match(RGB_REGEX).named_captures.map do |key, color|
+      [key.to_sym, color.hex]
+    end.to_h
+  end
 
   attr_accessor :hexes, :amount
 end

--- a/spec/labor/hex_comparer_spec.rb
+++ b/spec/labor/hex_comparer_spec.rb
@@ -9,11 +9,6 @@ RSpec.describe HexComparer, type: :labor do
     expect(described_class.new(["#ffffff", "#000000"]).smallest).to eq("#000000")
   end
 
-  it "orders hexes" do
-    result = described_class.new(["#ffffff", "#111111", "#333333", "#000000"]).order
-    expect(result).to eq(["#000000", "#111111", "#333333", "#ffffff"])
-  end
-
   it "changes brightness to the smallest color" do
     hc = described_class.new(["#ccddee", "#ffffff"])
     expect(hc.brightness(0.5)).to eq("#666f77")

--- a/spec/labor/hex_comparer_spec.rb
+++ b/spec/labor/hex_comparer_spec.rb
@@ -18,4 +18,9 @@ RSpec.describe HexComparer, type: :labor do
     hc = described_class.new(["#ccddee", "#ffffff"])
     expect(hc.accent).to eq("#d8eafc")
   end
+
+  it "generates an rgba value with opactity" do
+    rgba = described_class.new(["#123456"]).opacity(0.5)
+    expect(rgba).to eq("rgba(18, 52, 86, 0.50)")
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As requested by @ludwiczakpawel, this PR adds an opacity method to `HexComparer` which turns a hex color into an RGBA value:

```ruby
HexComparer.new(['#123456']).opacity(0.5)
#=> "rgba(18, 52, 86, 0.50)"
```

Following the lead of `brightness`, this uses the smallest of the hex values if more than one was provided. Maybe we should rethink if this class really is a `HexComparor` or if we should call it something else, e.g. `ColorTools`. In the meantime I just refactored the code a bit.

## Related Tickets & Documents

Your friendly neighborhood Slack request.

## QA Instructions, Screenshots, Recordings

Nothing special, you can play arouind with it in a Rails console to make sure it behaves as expected.

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
