### PR TITLE
Cleanup orphan data from tags and feedback_messages

### DIFF
--- a/lib/data_update_scripts/20200917150808_nullify_orphaned_tags_by_mod_chat_channel_id.rb
+++ b/lib/data_update_scripts/20200917150808_nullify_orphaned_tags_by_mod_chat_channel_id.rb
@@ -1,0 +1,15 @@
+module DataUpdateScripts
+  class NullifyOrphanedTagsByModChatChannelId
+    def run
+      # Nullify all Tags mod_chat_channel_id belonging to ChatChannels that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL.squish,
+          UPDATE tags
+          SET mod_chat_channel_id = NULL
+          WHERE mod_chat_channel_id IS NOT NULL
+          AND mod_chat_channel_id NOT IN (SELECT id FROM chat_channels);
+        SQL
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20200917150838_nullify_orphaned_feedback_messages_by_reporter_id.rb
+++ b/lib/data_update_scripts/20200917150838_nullify_orphaned_feedback_messages_by_reporter_id.rb
@@ -1,7 +1,7 @@
 module DataUpdateScripts
   class NullifyOrphanedFeedbackMessagesByReporterId
     def run
-      # Nullify all Tags mod_chat_channel_id belonging to ChatChannels that don't exist anymore
+      # Nullify all FeedbackMessages reporter_id belonging to Users that don't exist anymore
       ActiveRecord::Base.connection.execute(
         <<~SQL.squish,
           UPDATE feedback_messages

--- a/lib/data_update_scripts/20200917150838_nullify_orphaned_feedback_messages_by_reporter_id.rb
+++ b/lib/data_update_scripts/20200917150838_nullify_orphaned_feedback_messages_by_reporter_id.rb
@@ -1,0 +1,15 @@
+module DataUpdateScripts
+  class NullifyOrphanedFeedbackMessagesByReporterId
+    def run
+      # Nullify all Tags mod_chat_channel_id belonging to ChatChannels that don't exist anymore
+      ActiveRecord::Base.connection.execute(
+        <<~SQL.squish,
+          UPDATE feedback_messages
+          SET reporter_id = NULL
+          WHERE reporter_id IS NOT NULL
+          AND reporter_id NOT IN (SELECT id FROM users);
+        SQL
+      )
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Prior to add foreign keys to the following 8 columns - https://dev.to/admin/blazer/queries/246-orphan-rows-2 - we need to cleanup some of them.

This PR nullifies invalid `tags.mod_chat_channel_id` and `feedback_messages.reporter_id`
