### PR TITLE
Removing ElasticSearch Brew instructions

### DIFF
--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -20,7 +20,7 @@ Please refer to their [installation guide](https://yarnpkg.com/en/docs/install).
 
 ### PostgreSQL
 
-Forem requires PostgreSQL version 11 or higher to be running.
+Forem requires PostgreSQL version 11 or higher to run.
 
 The easiest way to get started is to use
 [Postgres.app](https://postgresapp.com/). Alternatively, check out the official
@@ -38,7 +38,7 @@ You can install ImageMagick with `brew install imagemagick`.
 
 ### Redis
 
-Forem requires Redis version 4.0 or higher to be running.
+Forem requires Redis version 4.0 or higher to run.
 
 We recommend using [Homebrew](https://brew.sh):
 
@@ -61,7 +61,7 @@ redis-cli ping
 
 ### Elasticsearch
 
-Forem requires a version of Elasticsearch 7.5 or higher to be running. We recommend version 7.5.2.
+Forem requires Elasticsearch 7.x to run. We recommend version 7.5.2.
 
 You have the option of installing Elasticsearch with Homebrew or through an archive. We **recommend** installing from archive on Mac.
 

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -12,8 +12,7 @@ title: macOS
    [rbenv](https://github.com/rbenv/rbenv). Please follow their
    [installation guide](https://github.com/rbenv/rbenv#installation).
 2. With the Ruby version manager, install the Ruby version listed on our badge.
-   (i.e. with rbenv: `rbenv install *latest badge version*`) 
-    example: `rbenv install 2.7.1`
+   (i.e. with rbenv: `rbenv install $(cat .ruby-version)`)
 
 ### Yarn
 
@@ -62,10 +61,9 @@ redis-cli ping
 
 ### Elasticsearch
 
-Forem requires a version of Elasticsearch between 7.1 and 7.5 to be running. Version 7.6 is
-not supported. We recommend version 7.5.2.
+Forem requires a version of Elasticsearch 7.5 or higher to be running. We recommend version 7.5.2.
 
-We recommend installing from archive on Mac.
+You have the option of installing Elasticsearch with Homebrew or through an archive. We **recommend** installing from archive on Mac.
 
 ### Installing Elasticsearch from the archive
 
@@ -106,6 +104,26 @@ To start elasticsearch as a daemonized process:
 ```shell
 ./bin/elasticsearch -d
 ```
+
+### Installing Elasticsearch with Homebrew
+
+To install Elasticsearch with Homebrew we will use the following commands to: 
+- tap the Elastic Homebrew repository
+- install the latest OSS distribution
+- pin the latest OSS distribution. 
+
+```shell
+brew tap elastic/tap
+brew install elastic/tap/elasticsearch-oss
+brew pin elasticsearch-oss
+```
+
+After installation you can manually test if the Elasticsearch server starts by
+issuing the command `elasticsearch` in the shell. You can then start the server
+as a service with `brew services start elasticsearch-oss`.
+
+You can find further info on your local Elasticsearch installation by typing
+`brew info elastic/tap/elasticsearch-oss`.
 
 #### Troubleshooting startup issues
 

--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -12,7 +12,8 @@ title: macOS
    [rbenv](https://github.com/rbenv/rbenv). Please follow their
    [installation guide](https://github.com/rbenv/rbenv#installation).
 2. With the Ruby version manager, install the Ruby version listed on our badge.
-   (i.e. with rbenv: `rbenv install $(cat .ruby-version)`)
+   (i.e. with rbenv: `rbenv install *latest badge version*`) 
+    example: `rbenv install 2.7.1`
 
 ### Yarn
 
@@ -20,7 +21,7 @@ Please refer to their [installation guide](https://yarnpkg.com/en/docs/install).
 
 ### PostgreSQL
 
-Forem requires PostgreSQL version 11 or higher.
+Forem requires PostgreSQL version 11 or higher to be running.
 
 The easiest way to get started is to use
 [Postgres.app](https://postgresapp.com/). Alternatively, check out the official
@@ -38,7 +39,7 @@ You can install ImageMagick with `brew install imagemagick`.
 
 ### Redis
 
-Forem requires Redis version 4.0 or higher.
+Forem requires Redis version 4.0 or higher to be running.
 
 We recommend using [Homebrew](https://brew.sh):
 
@@ -61,11 +62,10 @@ redis-cli ping
 
 ### Elasticsearch
 
-Forem requires a version of Elasticsearch between 7.1 and 7.5. Version 7.6 is
+Forem requires a version of Elasticsearch between 7.1 and 7.5 to be running. Version 7.6 is
 not supported. We recommend version 7.5.2.
 
-You have the option of installing Elasticsearch with Homebrew or through an
-archive. We recommend installing from archive on Mac.
+We recommend installing from archive on Mac.
 
 ### Installing Elasticsearch from the archive
 
@@ -106,25 +106,6 @@ To start elasticsearch as a daemonized process:
 ```shell
 ./bin/elasticsearch -d
 ```
-
-### Installing Elasticsearch with Homebrew
-
-As the default version of the Homebrew formula points to Elasticsearch 7.6, we
-need to retrieve the correct revision of the formula to make sure we install the
-latest supported version: 7.5.2.
-
-```shell
-brew tap elastic/tap
-brew install https://raw.githubusercontent.com/elastic/homebrew-tap/bed8bc6b03213c2c1a7df6e4b9f928e7082fae46/Formula/elasticsearch-oss.rb
-brew pin elasticsearch-oss
-```
-
-After installation you can manually test if the Elasticsearch server starts by
-issuing the command `elasticsearch` in the shell. You can then start the server
-as a service with `brew services start elasticsearch-oss`.
-
-You can find further info on your local Elasticsearch installation by typing
-`brew info elastic/tap/elasticsearch-oss`.
 
 #### Troubleshooting startup issues
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
If you try to install brew as directed you get this Error:
Error: Calling Installation of elasticsearch-oss from a GitHub commit URL is disabled! Use 'brew extract elasticsearch-oss' to stable tap on GitHub instead.

Brew/ElasticSearch no longer allows you to tap as we previously have suggested in the doc. Also we can no longer grab the 7.5.2 version with brew.

We have decided to remove the instructions for now until we upgrade ElasticSearch if possible.
## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
![Screen Shot 2020-09-17 at 2 10 18 PM](https://user-images.githubusercontent.com/21039864/93522988-8de9bf80-f8ef-11ea-82d2-2bb26faa218d.png)
## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.forem.com
- [ ] readme
- [ ] no documentation needed

