### PR TITLE
More detailed notification when setup is not completed

### DIFF
--- a/app/controllers/concerns/verify_setup_completed.rb
+++ b/app/controllers/concerns/verify_setup_completed.rb
@@ -28,7 +28,11 @@ module VerifySetupCompleted
   end
 
   def setup_completed?
-    MANDATORY_CONFIGS.all? { |config| SiteConfig.public_send(config).present? }
+    missing_configs.empty?
+  end
+
+  def missing_configs
+    MANDATORY_CONFIGS.reject { |config| SiteConfig.public_send(config).present? }
   end
 
   private
@@ -37,8 +41,9 @@ module VerifySetupCompleted
     return if config_path? || setup_completed? || SiteConfig.waiting_on_first_user
 
     link = helpers.link_to("the configuration page", admin_config_path, "data-no-instant" => true)
+    missing_configs_text = missing_configs.map { |c| c.to_s.tr("_", " ") }.join(", ")
     # rubocop:disable Rails/OutputSafety
-    flash[:global_notice] = "Setup not completed yet, please visit #{link}.".html_safe
+    flash[:global_notice] = "Setup not completed yet, missing #{missing_configs_text}. Please visit #{link}.".html_safe
     # rubocop:enable Rails/OutputSafety
   end
 

--- a/spec/system/admin/admin_manages_configuration_spec.rb
+++ b/spec/system/admin/admin_manages_configuration_spec.rb
@@ -20,13 +20,19 @@ RSpec.describe "Admin manages configuration", type: :system do
   context "when mandatory options are missing" do
     it "does not show the banner on the config page" do
       allow(SiteConfig).to receive(:tagline).and_return(nil)
-      expect(page).not_to have_content("Setup not completed yet, please visit the configuration page.")
+      expect(page).not_to have_content("Setup not completed yet")
     end
 
     it "does show the banner on other pages" do
       allow(SiteConfig).to receive(:tagline).and_return(nil)
       visit root_path
-      expect(page).to have_content("Setup not completed yet, please visit the configuration page.")
+      expect(page).to have_content("Setup not completed yet")
+    end
+
+    it "includes information about missing fields on the config pages" do
+      allow(SiteConfig).to receive(:tagline).and_return(nil)
+      visit root_path
+      expect(page.body).to match(/Setup not completed yet, missing(.*)tagline/)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description
Added information about missing fields for admins when the setup is not completed

## QA Instructions, Screenshots, Recordings
![изображение](https://user-images.githubusercontent.com/30115/93566851-5c77ff00-f996-11ea-9c1d-3849cc5b36e0.png)

## Added tests?
- [x] yes
