### PR TITLE
Bug: auto resize on type message connect

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -806,7 +806,7 @@
   height: inherit;
   align-items: stretch;
   position: relative;
-  height: 40px;
+  height: auto;
   padding: var(--su-4);
 
   textarea {
@@ -1028,7 +1028,16 @@
 
 .composer-textarea__edit {
   height: 80px;
+  max-height: 8rem;
   margin-bottom: var(--su-4);
+}
+
+.composer-textarea {
+  height: auto;
+  margin-bottom: var(--su-4);
+  min-height: 2.5rem;
+  resize: vertical;
+  max-height: 8rem;
 }
 
 .composer-btn-group {

--- a/app/javascript/chat/compose.jsx
+++ b/app/javascript/chat/compose.jsx
@@ -1,5 +1,6 @@
 import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
+import Textarea from 'preact-textarea-autosize';
 
 export default class Chat extends Component {
   static propTypes = {
@@ -14,6 +15,14 @@ export default class Chat extends Component {
     editMessageMarkdown: PropTypes.string.isRequired,
     handleEditMessageClose: PropTypes.func.isRequired,
   };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      value: null,
+    };
+  }
 
   componentDidUpdate() {
     const { editMessageMarkdown, markdownEdited, startEditing } = this.props;
@@ -34,8 +43,8 @@ export default class Chat extends Component {
 
     return (
       <div className="composer-container__edit">
-        <textarea
-          className="crayons-textfield composer-textarea composer-textarea__edit"
+        <Textarea
+          className="crayons-textfield composer-textarea__edit"
           id="messageform"
           placeholder="Let's connect"
           onKeyDown={handleKeyDownEdit}
@@ -75,9 +84,24 @@ export default class Chat extends Component {
       handleMention,
       handleKeyUp,
     } = this.props;
+
+    const handleInput = (e) => {
+      this.setState({
+        value: e.target.value,
+      });
+    };
+
+    const handleOnSubmitAction = (e) => {
+      handleSubmitOnClick(e);
+
+      this.setState({
+        value: '',
+      });
+    };
+
     return (
       <div className="messagecomposer">
-        <textarea
+        <Textarea
           className="crayons-textfield composer-textarea"
           id="messageform"
           placeholder="Write message..."
@@ -85,15 +109,19 @@ export default class Chat extends Component {
           onKeyPress={handleMention}
           onKeyUp={handleKeyUp}
           maxLength="1000"
+          value={this.state.value}
+          onInput={handleInput}
           aria-label="Compose a message"
         />
-        <button
-          type="button"
-          className="crayons-btn composer-submit"
-          onClick={handleSubmitOnClick}
-        >
-          Send
-        </button>
+        <div>
+          <button
+            type="button"
+            className="crayons-btn composer-submit"
+            onClick={handleOnSubmitAction}
+          >
+            Send
+          </button>
+        </div>
       </div>
     );
   };


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
connect text input auto grow with the content. There was one PR already but that was not working & no update from last few months. So That's why I took this feature. 

## Related Tickets & Documents
#8842

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

##
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/25151772/93603057-1d22d000-f9e1-11ea-8d4d-8df97456af8d.gif)
