### PR TITLE
Removes Extra Closing Bracket From admin.html.erb

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -25,10 +25,9 @@
 
 </head>
 <body class="admin"
-  data-honybadger-key="<%= ApplicationConfig['HONEYBADGER_JS_API_KEY'] %>"
-  data-release-footprint="<%= ApplicationConfig['RELEASE_FOOTPRINT'] %>"
+  data-honybadger-key="<%= ApplicationConfig["HONEYBADGER_JS_API_KEY"] %>"
+  data-release-footprint="<%= ApplicationConfig["RELEASE_FOOTPRINT"] %>"
   data-ga-tracking="<%= SiteConfig.ga_tracking_id %>">
-  >
   <header class="top-bar" id="top-bar" role="banner">
     <div class="top-bar__container">
       <a href="/" class="top-bar--logo" aria-label="<%= community_name %> Home"><%= logo_svg %></a>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR removes an extra bracket from the Admin view (`admin.html.erb`).

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings
To QA this change, navigate to `/admin` in your local browser and make sure that you no longer see the extra bracket:
**Before:**
<img width="470" alt="Screen Shot 2020-09-18 at 12 12 28 PM" src="https://user-images.githubusercontent.com/32834804/93631165-58ed7380-f9a8-11ea-9d68-34fea452fdd5.png">

**After:**
<img width="471" alt="Screen Shot 2020-09-18 at 12 12 44 PM" src="https://user-images.githubusercontent.com/32834804/93631119-44a97680-f9a8-11ea-817c-d46d78e9569e.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Spongebob is all done](https://media.giphy.com/media/26u4lOMA8JKSnL9Uk/giphy.gif)
