### PR TITLE
Removes second_user_id and third_user_id From the Articles Table

### DIFF
--- a/db/migrate/20200918200231_remove_columns_from_articles.rb
+++ b/db/migrate/20200918200231_remove_columns_from_articles.rb
@@ -1,0 +1,8 @@
+class RemoveColumnsFromArticles < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      remove_column :articles, :second_user_id, :bigint
+      remove_column :articles, :third_user_id, :bigint
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_18_200231) do
+ActiveRecord::Schema.define(version: 2020_10_02_104711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_02_104711) do
+ActiveRecord::Schema.define(version: 2020_09_18_200231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -137,12 +137,10 @@ ActiveRecord::Schema.define(version: 2020_10_02_104711) do
     t.integer "score", default: 0
     t.string "search_optimized_description_replacement"
     t.string "search_optimized_title_preamble"
-    t.bigint "second_user_id"
     t.boolean "show_comments", default: true
     t.text "slug"
     t.string "social_image"
     t.integer "spaminess_rating", default: 0
-    t.bigint "third_user_id"
     t.string "title"
     t.datetime "updated_at", null: false
     t.bigint "user_id"

--- a/lib/data_update_scripts/20200916202343_backfill_co_author_ids_for_articles.rb
+++ b/lib/data_update_scripts/20200916202343_backfill_co_author_ids_for_articles.rb
@@ -1,6 +1,9 @@
 module DataUpdateScripts
   class BackfillCoAuthorIdsForArticles
     def run
+      return unless ActiveRecord::Base.connection.column_exists?(:articles, :second_user_id) ||
+        ActiveRecord::Base.connection.column_exists?(:articles, :third_user_id)
+
       articles = Article.where.not(second_user_id: nil).or(Article.where.not(third_user_id: nil))
       articles.find_each do |article|
         co_author_ids = [article.second_user_id, article.third_user_id].compact


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR removes the `second_user_id` and `third_user_id` columns from the Articles table in favor of the newly added `co_author_ids` column.

## Related Tickets & Documents
Related to PR #10339

## QA Instructions, Screenshots, Recordings
To QA these changes, please ensure that all checks pass. ✅ 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
All post-deployment tasks related to `second_user_id`, `third_user_id`, and `co_author_ids` were taken care of the in the `data_update` script in the previous PR, #10339.

## [optional] What gif best describes this PR or how it makes you feel?

![Skydiving and saying bye](https://media.giphy.com/media/13QpHNxXQDqh42TPEW/giphy.gif)
