### PR TITLE
Better `position: sticky` support

### DIFF
--- a/app/assets/stylesheets/views/article-form.scss
+++ b/app/assets/stylesheets/views/article-form.scss
@@ -164,6 +164,7 @@
   }
 
   &__toolbar {
+    position: -webkit-sticky;
     position: sticky;
     top: 0;
     background: var(--base-0);

--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -329,6 +329,7 @@
     padding-bottom: 0;
     display: grid;
     gap: var(--su-6);
+    position: -wekbit-sticky;
     position: sticky;
     box-shadow: none;
     justify-content: stretch;
@@ -511,6 +512,7 @@
 }
 
 .crayons-article-sticky {
+  position: -webkit-sticky;
   position: sticky;
   top: calc(var(--header-height) + var(--layout-padding));
   .static-navbar-config & {

--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -329,7 +329,7 @@
     padding-bottom: 0;
     display: grid;
     gap: var(--su-6);
-    position: -wekbit-sticky;
+    position: -webkit-sticky;
     position: sticky;
     box-shadow: none;
     justify-content: stretch;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We've been using `position: sticky` here and there and it looks like we can improve browser support for this feature. By adding -webkit vendor prefix we can cover a bit larger audience now. 

Not sure if this is something that used to work before and now doesn't but if that's correct then potential cause could be related to either:

- some changes to autoprefixing couple weeks ago (cc @nickytonline )
- new version of Safari being released few days ago.

## Related Tickets & Documents

Closes #10286 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
