### PR TITLE
Improve setup not completed notification

### DIFF
--- a/app/controllers/concerns/verify_setup_completed.rb
+++ b/app/controllers/concerns/verify_setup_completed.rb
@@ -32,16 +32,20 @@ module VerifySetupCompleted
   end
 
   def missing_configs
-    MANDATORY_CONFIGS.reject { |config| SiteConfig.public_send(config).present? }
+    @missing_configs ||= MANDATORY_CONFIGS.reject { |config| SiteConfig.public_send(config).present? }
   end
 
   private
+
+  def missing_configs_text
+    display_missing = missing_configs.size > 3 ? missing_configs.first(3) + ["others"] : missing_configs
+    display_missing.map { |c| c.to_s.tr("_", " ") }.to_sentence
+  end
 
   def verify_setup_completed
     return if config_path? || setup_completed? || SiteConfig.waiting_on_first_user
 
     link = helpers.link_to("the configuration page", admin_config_path, "data-no-instant" => true)
-    missing_configs_text = missing_configs.map { |c| c.to_s.tr("_", " ") }.join(", ")
     # rubocop:disable Rails/OutputSafety
     flash[:global_notice] = "Setup not completed yet, missing #{missing_configs_text}. Please visit #{link}.".html_safe
     # rubocop:enable Rails/OutputSafety

--- a/spec/system/admin/admin_manages_configuration_spec.rb
+++ b/spec/system/admin/admin_manages_configuration_spec.rb
@@ -31,8 +31,11 @@ RSpec.describe "Admin manages configuration", type: :system do
 
     it "includes information about missing fields on the config pages" do
       allow(SiteConfig).to receive(:tagline).and_return(nil)
+      allow(SiteConfig).to receive(:suggested_users).and_return(nil)
+      allow(SiteConfig).to receive(:suggested_tags).and_return(nil)
+      allow(SiteConfig).to receive(:community_action).and_return(nil)
       visit root_path
-      expect(page.body).to match(/Setup not completed yet, missing(.*)tagline/)
+      expect(page.body).to match(/Setup not completed yet, missing(.*)community action(.*), and others/)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
Follow-up for the #10375 :
- cache `missing_configs` to avoid redundant iteration
- improve notification text

## Added tests?
- [x] yes