### PR TITLE
Update Imgproxy to use predetermined endpoint

### DIFF
--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -40,7 +40,7 @@ module Images
     end
 
     def self.imgproxy_enabled?
-      Imgproxy.config.key.present? && Imgproxy.config.endpoint.present?
+      Imgproxy.config.key.present? && Imgproxy.config.salt.present?
     end
   end
 end

--- a/config/initializers/imgproxy.rb
+++ b/config/initializers/imgproxy.rb
@@ -4,8 +4,13 @@ Imgproxy.configure do |config|
   # Full URL to where your imgproxy lives.
   #
   config.endpoint = if Rails.env.production?
-                      URL.url("images")
+                      # Use /images with the same domain on Production as
+                      # our default configuration
+                      URL.url("images") # ie. https://forem.dev/images
                     else
+                      # On other environments, rely on ApplicationConfig for a
+                      # more flexible configuration
+                      # ie. default imgproxy endpoint is localhost:8080
                       ApplicationConfig["IMGPROXY_ENDPOINT"]
                     end
 

--- a/config/initializers/imgproxy.rb
+++ b/config/initializers/imgproxy.rb
@@ -2,7 +2,12 @@ Imgproxy.configure do |config|
   # imgproxy endpoint
   #
   # Full URL to where your imgproxy lives.
-  config.endpoint = ApplicationConfig["IMGPROXY_ENDPOINT"]
+  #
+  config.endpoint = if Rails.env.production?
+                      URL.url("images")
+                    else
+                      ApplicationConfig["IMGPROXY_ENDPOINT"]
+                    end
 
   # Next, you have to provide your signature key and salt.
   # If unsure, check out https://github.com/imgproxy/imgproxy/blob/master/docs/configuration.md first.

--- a/spec/services/images/optimizer_spec.rb
+++ b/spec/services/images/optimizer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Images::Optimizer, type: :service do
   def stub_imgproxy
     imgproxy_config_stub = Imgproxy::Config.new.tap do |config|
       config.key = "secret"
-      config.endpoint = "https://dev.to"
+      config.salt = "secret"
       config.base64_encode_urls = true
     end
     allow(Imgproxy).to receive(:config).and_return(imgproxy_config_stub)
@@ -25,13 +25,13 @@ RSpec.describe Images::Optimizer, type: :service do
       expect(described_class).to have_received(:cloudinary)
     end
 
-    it "calls cloudinary if imgproxy's key and endpoint is missing" do
+    it "calls cloudinary if imgproxy's key and salt is missing" do
       allow(Imgproxy).to receive(:config).and_return(Imgproxy::Config.new)
       described_class.call(image_url, service: :imgproxy)
       expect(described_class).to have_received(:cloudinary)
     end
 
-    it "calls imgproxy if imgproxy's key and endpoint is provided" do
+    it "calls imgproxy if imgproxy's key and salt is provided" do
       stub_imgproxy
       described_class.call(image_url, service: :imgproxy)
       expect(described_class).to have_received(:imgproxy)
@@ -66,7 +66,7 @@ RSpec.describe Images::Optimizer, type: :service do
     it "works" do
       stub_imgproxy
       imgproxy_url = described_class.imgproxy(image_url, service: :imgproxy, width: 500, height: 500)
-      expect(imgproxy_url).to match(%r{/unsafe/s:500:500/aHR0cHM6Ly9pLmlt/Z3VyLmNvbS9mS1lL/Z280LnBuZw})
+      expect(imgproxy_url).to match(%r{/s:500:500/aHR0cHM6Ly9pLmlt/Z3VyLmNvbS9mS1lL/Z280LnBuZw})
     end
   end
 end

--- a/spec/views/dashboards/show.html.erb_spec.rb
+++ b/spec/views/dashboards/show.html.erb_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "dashboards/show.html.erb", type: :view do
     stub_template "dashboards/_analytics.html.erb" => "stubbed content"
     stub_template "dashboards/_actions.html.erb" => "stubbed content"
 
-    Imgproxy.config.key = "hmm"
-    Imgproxy.config.endpoint = "https://dev.to"
+    Imgproxy.config.key = "secret"
+    Imgproxy.config.salt = "secret"
     SiteConfig.mascot_image_url = "https://i.imgur.com/fKYKgo4.png"
   end
 
@@ -22,7 +22,7 @@ RSpec.describe "dashboards/show.html.erb", type: :view do
       assign(:user, create(:user))
       assign(:articles, [])
       render
-      expect(rendered).to match(%r{unsafe/w:300/aHR0cHM6Ly9pLmlt/Z3VyLmNvbS9mS1lL/Z280LnBuZw})
+      expect(rendered).to match(%r{/w:300/aHR0cHM6Ly9pLmlt/Z3VyLmNvbS9mS1lL/Z280LnBuZw})
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Instead of dedicating an endpoint env var for Imgproxy, we will always default to `/images` to the domain of the Forem instance it belongs to. The also change how we check if Imgproxy should be enabled; now it will check for both KEY and SALT instead of KEY and Endpoint.

## Related Tickets & Documents
https://github.com/orgs/forem/projects/11#card-44712228

## QA Instructions, Screenshots, Recordings
This does not change any existing behavior and only applicable on production.
## Added tests?
- [x] updated existing tests

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a