### PR TITLE
Sets Omniauth full_host config to match the environment

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,1 +1,2 @@
 OmniAuth.config.logger = Rails.logger
+OmniAuth.config.full_host = URL.url

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -71,13 +71,14 @@ module OmniauthHelpers
     OmniAuth.config.mock_auth[provider] = :invalid_credentials
   end
 
-  def omniauth_setup_authentication_error(error)
+  def omniauth_setup_authentication_error(error, params)
     # this hack is needed due to a limitation in how OmniAuth handles
     # failures in mocked/testing environments,
     # see <https://github.com/omniauth/omniauth/issues/654#issuecomment-610851884>
     # for more details
     local_failure_handler = lambda do |env|
       env["omniauth.error"] = error
+      env["omniauth.params"] = params unless params.nil?
       env
     end
 

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -71,7 +71,7 @@ module OmniauthHelpers
     OmniAuth.config.mock_auth[provider] = :invalid_credentials
   end
 
-  def omniauth_setup_authentication_error(error, params)
+  def omniauth_setup_authentication_error(error, params = nil)
     # this hack is needed due to a limitation in how OmniAuth handles
     # failures in mocked/testing environments,
     # see <https://github.com/omniauth/omniauth/issues/654#issuecomment-610851884>

--- a/spec/system/authentication/user_logs_in_with_facebook_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_facebook_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "Authenticating with Facebook" do
           "Callback error", "Error reason", "https://example.com/error"
         )
 
-        omniauth_setup_authentication_error(error)
+        omniauth_setup_authentication_error(error, params)
 
         visit sign_up_path
         click_link(sign_in_link, match: :first)
@@ -133,7 +133,7 @@ RSpec.describe "Authenticating with Facebook" do
         allow(request).to receive(:code).and_return(401)
         allow(request).to receive(:message).and_return("unauthorized")
         error = OAuth::Unauthorized.new(request)
-        omniauth_setup_authentication_error(error)
+        omniauth_setup_authentication_error(error, params)
 
         visit sign_up_path
         click_link(sign_in_link, match: :first)
@@ -146,7 +146,7 @@ RSpec.describe "Authenticating with Facebook" do
 
       it "notifies Datadog even with no OmniAuth error present" do
         error = nil
-        omniauth_setup_authentication_error(error)
+        omniauth_setup_authentication_error(error, params)
 
         visit sign_up_path
         click_link(sign_in_link, match: :first)

--- a/spec/system/authentication/user_logs_in_with_github_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_github_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Authenticating with GitHub" do
           "Callback error", "Error reason", "https://example.com/error"
         )
 
-        omniauth_setup_authentication_error(error)
+        omniauth_setup_authentication_error(error, params)
 
         visit sign_up_path
         click_link(sign_in_link, match: :first)
@@ -100,7 +100,7 @@ RSpec.describe "Authenticating with GitHub" do
         allow(request).to receive(:code).and_return(401)
         allow(request).to receive(:message).and_return("unauthorized")
         error = OAuth::Unauthorized.new(request)
-        omniauth_setup_authentication_error(error)
+        omniauth_setup_authentication_error(error, params)
 
         visit sign_up_path
         click_link(sign_in_link, match: :first)
@@ -113,7 +113,7 @@ RSpec.describe "Authenticating with GitHub" do
 
       it "notifies Datadog even with no OmniAuth error present" do
         error = nil
-        omniauth_setup_authentication_error(error)
+        omniauth_setup_authentication_error(error, params)
 
         visit sign_up_path
         click_link(sign_in_link, match: :first)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The reason Facebook Authentication provider hasn't been working was due to a mismatch in the redirect URL sent in the OAuth process. 

This PR explicitly adds to the Omniauth initializer so it will rely on `URL.url` to build the redirect URL for callbacks.

## Related Tickets & Documents

fixes #10200 and #10102

## QA Instructions, Screenshots, Recordings

All authentication providers in the local development should continue to work as expected. This is a recording of the Facebook authentication working in https://thismmalife.com

https://share.getcloudapp.com/WnuJLJq2

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

Visual representation of the debugging process (aka rabbit hole):
![rabbit hole](https://media.giphy.com/media/l44Qu5o7fPqsadEnm/giphy.gif)
