### PR TITLE
Bug Fix:Update bottom content cache on releases

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -215,7 +215,7 @@
 
       <%= render "articles/full_comment_area" %>
 
-      <% cache("article-bottom-content-#{@article.id}-#{user_signed_in?}", expires_in: 18.hours) do %>
+      <% cache("article-bottom-content-#{@article.id}-#{user_signed_in?}-#{ApplicationConfig['RELEASE_FOOTPRINT']}", expires_in: 18.hours) do %>
         <% suggested_articles = ArticleSuggester.new(@article).articles(max: 4) %>
         <%= render "articles/bottom_content", articles: suggested_articles %>
       <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We recently updated the `bottom_content` CSS which ended up breaking this partial cache bc the cache did not bust since there was no HTML change. To prevent this from happening I updated the cache key to include the release footprint. I'm not sure if we want this long term or if it will bust this cache too much to make it useful but at least for now it will fix production. Within 18 hours all old cache's with old styling will have expired and we could revert this. 

Me when it comes to cache bugs 👇 
![alt_text](https://media2.giphy.com/media/3o7TKxD6awoTUJJ17y/source.gif)
