### PR TITLE
Fixes Omniauth redirect_uri when SiteConfig.app_domain is updated

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,2 +1,2 @@
 OmniAuth.config.logger = Rails.logger
-OmniAuth.config.full_host = URL.url
+OmniAuth.config.full_host = proc { URL.url }

--- a/spec/system/authentication/omniauth_redirect_uri_spec.rb
+++ b/spec/system/authentication/omniauth_redirect_uri_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Omniauth redirect_uri", type: :system do
+  let!(:test_app_domain) { SiteConfig.app_domain }
+
+  # Avoid messing with other tests by resetting back SiteConfig.app_domain
+  after { SiteConfig.app_domain = test_app_domain }
+
+  def provider_redirect_regex(provider_name)
+    %r{
+      /users/auth/#{provider_name}
+      \?callback_url=https%3A%2F%2F
+      #{SiteConfig.app_domain}%2Fusers%2Fauth%2F#{provider_name}%2Fcallback
+    }x
+  end
+
+  it "relies on SiteConfig.app_domain to generate correct callbacks_url" do
+    visit sign_up_path
+    Authentication::Providers.available.each do |provider_name|
+      provider_auth_url = find("a.crayons-btn--brand-#{provider_name}")["href"]
+      expect(provider_auth_url).to match(provider_redirect_regex(provider_name))
+    end
+
+    SiteConfig.app_domain = "test.forem.com"
+    visit sign_up_path
+
+    # After an update the callback_url should now match SiteConfig.app_domain
+    Authentication::Providers.available.each do |provider_name|
+      provider_auth_url = find("a.crayons-btn--brand-#{provider_name}")["href"]
+      expect(provider_auth_url).to match(provider_redirect_regex(provider_name))
+    end
+  end
+end

--- a/spec/system/authentication/omniauth_redirect_uri_spec.rb
+++ b/spec/system/authentication/omniauth_redirect_uri_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Omniauth redirect_uri", type: :system do
   def provider_redirect_regex(provider_name)
     %r{
       /users/auth/#{provider_name}
-      \?callback_url=https%3A%2F%2F
+      \?callback_url=#{URL.protocol}%3A%2F%2F
       #{SiteConfig.app_domain}%2Fusers%2Fauth%2F#{provider_name}%2Fcallback
     }x
   end

--- a/spec/system/authentication/omniauth_redirect_uri_spec.rb
+++ b/spec/system/authentication/omniauth_redirect_uri_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe "Omniauth redirect_uri", type: :system do
   after { SiteConfig.app_domain = test_app_domain }
 
   def provider_redirect_regex(provider_name)
+    # URL encoding translates the query params (i.e. colons/slashes/etc)
     %r{
       /users/auth/#{provider_name}
-      \?callback_url=#{URL.protocol}%3A%2F%2F
-      #{SiteConfig.app_domain}%2Fusers%2Fauth%2F#{provider_name}%2Fcallback
+      \?callback_url=#{ERB::Util.url_encode(URL.protocol)}
+      #{ERB::Util.url_encode(SiteConfig.app_domain)}
+      #{ERB::Util.url_encode("/users/auth/#{provider_name}/callback")}
     }x
   end
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When `SiteConfig.app_domain` is updated in a existing (running) environment we don't get the correct `redirect_uri` generated for OAuth providers. This happens not because we rely on `ApplicationConfig["APP_DOMAIN"]` (since we use `URL.url` for this) but instead because the `full_host` Omniauth config is set in the initializer and it doesn't change if we update `SiteConfig.app_domain` unless we reboot (not what we want).

The fix consists of making `Omniauth.config.full_host` use a Proc instead of a String generated at boot time so the generated value will always use the up-to-date `SiteConfig.app_domain`

## QA Instructions, Screenshots, Recordings

1. Boot the app locally and login with any OAuth provider (successfully)
1. Sign out (otherwise after executing the next step you'll be unable t logout bc of cookie domain settings)
1. Open a rails console and edit `SiteConfig.app_domain = "bad.domain.com"
1. Try to login with any OAuth provider and **it should fail** because the `redirect_uri` is now using an unauthorized URI
1. Revert `SiteConfig.app_domain` (to `localhost:3000` or whatever value you're using locally)
1. It should work again

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![no names](https://media.giphy.com/media/P5wPrhzZDdeJW/giphy.gif)
