### PR TITLE
Bug Fix:Count the Health Checks Controller as Public

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,8 @@ class ApplicationController < ActionController::Base
                           omniauth_callbacks
                           registrations
                           confirmations
-                          passwords].freeze
+                          passwords
+                          health_checks].freeze
   private_constant :PUBLIC_CONTROLLERS
 
   def verify_private_forem


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We need to be able to hit the health check API with only the health check token and no additional authentication. This allows us to do that for private forems


![alt_text](https://media1.tenor.com/images/b32011326330c7b5fb364023507572fe/tenor.gif?itemid=15593507)
