### PR TITLE
Handling empty gist link error in liquid tag

### DIFF
--- a/app/liquid_tags/gist_tag.rb
+++ b/app/liquid_tags/gist_tag.rb
@@ -32,6 +32,10 @@ class GistTag < LiquidTagBase
   end
 
   def parse_link(link)
+    if link.nil?
+      raise StandardError, "You have not provided Gist link"
+    end
+
     input_no_space = link.delete(" ").gsub(".js", "")
     if valid_link?(input_no_space)
       input_no_space

--- a/app/liquid_tags/gist_tag.rb
+++ b/app/liquid_tags/gist_tag.rb
@@ -33,7 +33,7 @@ class GistTag < LiquidTagBase
 
   def parse_link(link)
     if link.nil?
-      raise StandardError, "You have not provided Gist link"
+      raise StandardError, "You have not provided link to the Gist"
     end
 
     input_no_space = link.delete(" ").gsub(".js", "")

--- a/app/liquid_tags/gist_tag.rb
+++ b/app/liquid_tags/gist_tag.rb
@@ -6,6 +6,9 @@ class GistTag < LiquidTagBase
 
   def initialize(_tag_name, link, _parse_context)
     super
+
+    raise StandardError, "Invalid Gist link: You must provide a Gist link" if link.blank?
+
     @uri = build_uri(link)
   end
 
@@ -32,10 +35,6 @@ class GistTag < LiquidTagBase
   end
 
   def parse_link(link)
-    if link.nil?
-      raise StandardError, "Invalid Gist link: You must provide a Gist link"
-    end
-
     input_no_space = link.delete(" ").gsub(".js", "")
     if valid_link?(input_no_space)
       input_no_space

--- a/app/liquid_tags/gist_tag.rb
+++ b/app/liquid_tags/gist_tag.rb
@@ -33,7 +33,7 @@ class GistTag < LiquidTagBase
 
   def parse_link(link)
     if link.nil?
-      raise StandardError, "You have not provided link to the Gist"
+      raise StandardError, "Invalid Gist link: You must provide a Gist link"
     end
 
     input_no_space = link.delete(" ").gsub(".js", "")

--- a/spec/liquid_tags/gist_tag_spec.rb
+++ b/spec/liquid_tags/gist_tag_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe GistTag, type: :liquid_tag do
 
     let(:bad_links) do
       [
-        nil,
         "//pastebin.com/raw/b77FrXUA#gist.github.com",
         "https://gist.github.com@evil.com",
         "https://gist.github.com.evil.com",
@@ -69,6 +68,12 @@ RSpec.describe GistTag, type: :liquid_tag do
     it "rejects invalid gist url" do
       expect do
         generate_new_liquid("really_long_invalid_id")
+      end.to raise_error(StandardError)
+    end
+
+    it "rejects empty gist url" do
+      expect do
+        generate_new_liquid
       end.to raise_error(StandardError)
     end
 

--- a/spec/liquid_tags/gist_tag_spec.rb
+++ b/spec/liquid_tags/gist_tag_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe GistTag, type: :liquid_tag do
       "https://gist.github.com/suntong/3a31faf8129d3d7a380122d5a6d48ff6/44c4e7fa81592f917fffacf689dd76f469ca954c"
     end
 
-    def generate_new_liquid(link)
+    def generate_new_liquid(link:)
       Liquid::Template.register_tag("gist", GistTag)
       Liquid::Template.parse("{% gist #{link} %}")
     end
@@ -42,25 +42,25 @@ RSpec.describe GistTag, type: :liquid_tag do
 
     it "accepts proper gist url" do
       gist_links.each do |link|
-        liquid = generate_new_liquid(link)
+        liquid = generate_new_liquid(link: link)
         expect(liquid.render.tr("\n", " ").delete(" ")).to eq(generate_script(link))
       end
     end
 
     it "handles 'file' option" do
-      liquid = generate_new_liquid(link_with_file_option)
+      liquid = generate_new_liquid(link: link_with_file_option)
       link, option = link_with_file_option.split(" ", 2)
       expect(liquid.render.tr("\n", " ").delete(" ")).to eq(generate_script(link, option))
     end
 
     it "allows embed of specific version" do
-      liquid = generate_new_liquid(gist_link_with_version)
+      liquid = generate_new_liquid(link: gist_link_with_version)
       expect(liquid.render.tr("\n", " ").delete(" ")).to eq(generate_script(gist_link_with_version))
     end
 
     it "allows embed of specific version with 'file' option" do
       version_with_file_option = gist_link_with_version.concat(" file=Images.tmpl")
-      liquid = generate_new_liquid(version_with_file_option)
+      liquid = generate_new_liquid(link: version_with_file_option)
       link, option = version_with_file_option.split(" ", 2)
       expect(liquid.render.tr("\n", " ").delete(" ")).to eq(generate_script(link, option))
     end

--- a/spec/liquid_tags/gist_tag_spec.rb
+++ b/spec/liquid_tags/gist_tag_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe GistTag, type: :liquid_tag do
 
     let(:bad_links) do
       [
+        nil,
         "//pastebin.com/raw/b77FrXUA#gist.github.com",
         "https://gist.github.com@evil.com",
         "https://gist.github.com.evil.com",


### PR DESCRIPTION
## What type of PR is this? 

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Better error message when user does not provide link to the Gist in liquid tag

## Related Tickets & Documents

closes https://github.com/forem/forem/issues/10410

## QA Instructions, Screenshots, Recordings

![empty_gist_link](https://user-images.githubusercontent.com/8092120/94221836-88046780-ff09-11ea-9636-e442d3bb1fa0.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
