### PR TITLE
User agent check fix for native iOS

### DIFF
--- a/app/assets/javascripts/initializers/runtime.js
+++ b/app/assets/javascripts/initializers/runtime.js
@@ -18,7 +18,6 @@ class Runtime {
   static isNativeIOS(namespace = null) {
     const nativeCheck =
       /DEV-Native-ios|forem-native-ios/i.test(navigator.userAgent) &&
-      navigator.userAgent === '' &&
       window &&
       window.webkit &&
       window.webkit.messageHandlers;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This bug was introduced at some point in the refactor that added the `Runtime` helper class. It will never be true that the user agent will match the regex AND that it will be empty 😅

## QA Instructions, Screenshots, Recordings

Playing a podcast locally should continue to work as usual on a browser.

If navigating from the DEV Native iOS app and you start playing a Podcast you'll see that the native audio playback is not being executed (lock the screen and the enhanced controls don't appear). This happens because this check returns `false` (when it should return `true`) and this PR fixes it.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![where did that come from](https://media.giphy.com/media/26uTqoBTEwd1NYkmc/giphy.gif)
