### PR TITLE
Fix newlines being chomped in RSS import

### DIFF
--- a/app/lib/reverse_markdown/converters/custom_text.rb
+++ b/app/lib/reverse_markdown/converters/custom_text.rb
@@ -40,7 +40,7 @@ module ReverseMarkdown
       end
 
       def remove_inner_newlines(text)
-        text.tr("\n\t", "")
+        text.tr("\r\n\t", " ").squeeze(" ")
       end
 
       def preserve_keychars_within_backticks(text)

--- a/config/initializers/reverse_markdown.rb
+++ b/config/initializers/reverse_markdown.rb
@@ -1,0 +1,3 @@
+Dir.glob(Rails.root.join("app/lib/reverse_markdown/converters/*.rb")).sort.each do |filename|
+  require_dependency filename
+end

--- a/spec/lib/reverse_markdown/converters/custom_text_spec.rb
+++ b/spec/lib/reverse_markdown/converters/custom_text_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe ReverseMarkdown::Converters::CustomText, type: :lib do
+  def create_custom_text
+    ReverseMarkdown.config.github_flavored = true
+    described_class.new
+  end
+
+  describe "#convert" do
+    it "keeps some blankspace between lines in the same paragraph" do
+      node = Nokogiri::HTML("newlines\nbecome\nspaces")
+      result = create_custom_text.convert(node)
+      expect(result).to eq("newlines become spaces")
+    end
+  end
+end


### PR DESCRIPTION
The CustomText converter was monkey patched to fix a bug related to
preserve_tags. Somewhere in that process, remove_inner_newlines was
changed to strip newlines completely, instead of replacing them with a
single space. This restores that functionality.

In development mode, files are not eager loaded. That means that the
converters were not being required, so it was not possible to reproduce
that issue in development mode (since it was falling back to the
original converter, which does not have the bug). This commit also adds
an initializer that requires every converter.

This fixes half of #8457.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed