### PR TITLE
Handling links from different domain

### DIFF
--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -21,7 +21,15 @@ class LinkTag < LiquidTagBase
   end
 
   def article_hash(slug)
-    path = Addressable::URI.parse(slug).path
+    url = Addressable::URI.parse(slug)
+    domain = url.port ? "#{url.host}:#{url.port}" : url.host
+    path = url.path
+
+    # If domain is present in url check if it belongs to the app
+    unless domain.blank? || domain&.casecmp?(SiteConfig.app_domain)
+      raise StandardError, "This URL is not an article link: {% link #{slug} %}"
+    end
+
     path.slice!(0) if path.starts_with?("/") # remove leading slash if present
     path.slice!(-1) if path.ends_with?("/") # remove trailing slash if present
     extracted_hash = Addressable::Template.new("{username}/{slug}").extract(path)&.symbolize_keys

--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -27,13 +27,13 @@ class LinkTag < LiquidTagBase
 
     # If domain is present in url check if it belongs to the app
     unless domain.blank? || domain&.casecmp?(SiteConfig.app_domain)
-      raise StandardError, "This URL is not an article link: {% link #{slug} %}"
+      raise StandardError, "This link does not point to an article: {% link #{slug} %}"
     end
 
     path.slice!(0) if path.starts_with?("/") # remove leading slash if present
     path.slice!(-1) if path.ends_with?("/") # remove trailing slash if present
     extracted_hash = Addressable::Template.new("{username}/{slug}").extract(path)&.symbolize_keys
-    raise StandardError, "This URL is not an article link: {% link #{slug} %}" unless extracted_hash
+    raise StandardError, "This link does not point to an article: {% link #{slug} %}" unless extracted_hash
 
     extracted_hash
   end

--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -27,13 +27,13 @@ class LinkTag < LiquidTagBase
 
     # If domain is present in url check if it belongs to the app
     unless domain.blank? || domain&.casecmp?(SiteConfig.app_domain)
-      raise StandardError, "This link does not point to an article: {% link #{slug} %}"
+      raise StandardError, "The article you're looking for does not exist: {% link #{slug} %}"
     end
 
     path.slice!(0) if path.starts_with?("/") # remove leading slash if present
     path.slice!(-1) if path.ends_with?("/") # remove trailing slash if present
     extracted_hash = Addressable::Template.new("{username}/{slug}").extract(path)&.symbolize_keys
-    raise StandardError, "This link does not point to an article: {% link #{slug} %}" unless extracted_hash
+    raise StandardError, "The article you're looking for does not exist: {% link #{slug} %}" unless extracted_hash
 
     extracted_hash
   end

--- a/spec/lib/liquid/raw_spec.rb
+++ b/spec/lib/liquid/raw_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Liquid::Raw, type: :lib do
   it "raise error message when link tag contain non article URL" do
     invalid_markdown = "{% link /some-random-link/ %}"
     expect { Liquid::Template.parse(invalid_markdown) }.to(
-      raise_error(StandardError, "This URL is not an article link: {% link /some-random-link/ %}"),
+      raise_error(StandardError, "The article you're looking for does not exist: {% link /some-random-link/ %}"),
     )
   end
 end

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe LinkTag, type: :liquid_tag do
     create(:article, user_id: user.id, title: "Hello & Hi <3 <script>", tags: "tag")
   end
 
-  def generate_new_liquid(slug)
+  def generate_new_liquid(slug:)
     Liquid::Template.register_tag("link", LinkTag)
     Liquid::Template.parse("{% link #{slug} %}")
   end
 
-  def generate_new_liquid_alias(slug)
+  def generate_new_liquid_alias(slug:)
     Liquid::Template.register_tag("post", described_class)
     Liquid::Template.parse("{% post #{slug} %}")
   end
@@ -64,76 +64,76 @@ RSpec.describe LinkTag, type: :liquid_tag do
   end
 
   it 'can use "post" as an alias' do
-    liquid = generate_new_liquid_alias("/#{user.username}/#{article.slug}")
+    liquid = generate_new_liquid_alias(slug: "/#{user.username}/#{article.slug}")
     expect(liquid.render).to eq(correct_link_html(article))
   end
 
   it "does not raise an error when invalid" do
-    expect { generate_new_liquid("fake_username/fake_article_slug") }
+    expect { generate_new_liquid(slug: "fake_username/fake_article_slug") }
       .not_to raise_error("Invalid link URL or link URL does not exist")
   end
 
   it "renders a proper link tag" do
-    liquid = generate_new_liquid("#{user.username}/#{article.slug}")
+    liquid = generate_new_liquid(slug: "#{user.username}/#{article.slug}")
     expect(liquid.render).to eq(correct_link_html(article))
   end
 
   it "also tries to look for article by organization if failed to find by username" do
-    liquid = generate_new_liquid("#{org_article.username}/#{org_article.slug}")
+    liquid = generate_new_liquid(slug: "#{org_article.username}/#{org_article.slug}")
     expect(liquid.render).to eq(correct_link_html(org_article))
   end
 
   it "renders with a leading slash" do
-    liquid = generate_new_liquid("/#{user.username}/#{article.slug}")
+    liquid = generate_new_liquid(slug: "/#{user.username}/#{article.slug}")
     expect(liquid.render).to eq(correct_link_html(article))
   end
 
   it "renders with a trailing slash" do
-    liquid = generate_new_liquid("#{user.username}/#{article.slug}/")
+    liquid = generate_new_liquid(slug: "#{user.username}/#{article.slug}/")
     expect(liquid.render).to eq(correct_link_html(article))
   end
 
   it "renders with both leading and trailing slashes" do
-    liquid = generate_new_liquid("/#{user.username}/#{article.slug}/")
+    liquid = generate_new_liquid(slug: "/#{user.username}/#{article.slug}/")
     expect(liquid.render).to eq(correct_link_html(article))
   end
 
   it "renders with a full link" do
-    liquid = generate_new_liquid("https://#{SiteConfig.app_domain}/#{user.username}/#{article.slug}")
+    liquid = generate_new_liquid(slug: "https://#{SiteConfig.app_domain}/#{user.username}/#{article.slug}")
     expect(liquid.render).to eq(correct_link_html(article))
   end
 
   it "raise error when url belongs to different domain" do
     expect do
-      generate_new_liquid("https://xkcd.com/2363/")
+      generate_new_liquid(slug: "https://xkcd.com/2363/")
     end.to raise_error(StandardError)
   end
 
   it "renders default reading time of 1 minute for short articles" do
-    liquid = generate_new_liquid("/#{user.username}/#{article.slug}/")
+    liquid = generate_new_liquid(slug: "/#{user.username}/#{article.slug}/")
     expect(liquid.render).to include("1 min read")
   end
 
   it "renders reading time of article lengthy articles" do
     template = file_fixture("article_long_content.txt").read
     article = create(:article, user: user, body_markdown: template)
-    liquid = generate_new_liquid("/#{user.username}/#{article.slug}/")
+    liquid = generate_new_liquid(slug: "/#{user.username}/#{article.slug}/")
     expect(liquid.render).to include("3 min read")
   end
 
   it "renders with a full link with a trailing slash" do
-    liquid = generate_new_liquid("https://#{SiteConfig.app_domain}/#{user.username}/#{article.slug}/")
+    liquid = generate_new_liquid(slug: "https://#{SiteConfig.app_domain}/#{user.username}/#{article.slug}/")
     expect(liquid.render).to eq(correct_link_html(article))
   end
 
   it "renders with missing article" do
     article.delete
-    liquid = generate_new_liquid("https://#{SiteConfig.app_domain}/#{user.username}/#{article.slug}/")
+    liquid = generate_new_liquid(slug: "https://#{SiteConfig.app_domain}/#{user.username}/#{article.slug}/")
     expect(liquid.render).to eq(missing_article_html)
   end
 
   it "escapes title" do
-    liquid = generate_new_liquid("/#{user.username}/#{escaped_article.slug}/")
+    liquid = generate_new_liquid(slug: "/#{user.username}/#{escaped_article.slug}/")
     expect(liquid.render).to eq(correct_link_html(escaped_article))
   end
 end

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -99,8 +99,14 @@ RSpec.describe LinkTag, type: :liquid_tag do
   end
 
   it "renders with a full link" do
-    liquid = generate_new_liquid("https://dev.to/#{user.username}/#{article.slug}")
+    liquid = generate_new_liquid("https://#{SiteConfig.app_domain}/#{user.username}/#{article.slug}")
     expect(liquid.render).to eq(correct_link_html(article))
+  end
+
+  it "raise error when url belongs to different domain" do
+    expect do
+      generate_new_liquid("https://xkcd.com/2363/")
+    end.to raise_error(StandardError)
   end
 
   it "renders default reading time of 1 minute for short articles" do
@@ -116,13 +122,13 @@ RSpec.describe LinkTag, type: :liquid_tag do
   end
 
   it "renders with a full link with a trailing slash" do
-    liquid = generate_new_liquid("https://dev.to/#{user.username}/#{article.slug}/")
+    liquid = generate_new_liquid("https://#{SiteConfig.app_domain}/#{user.username}/#{article.slug}/")
     expect(liquid.render).to eq(correct_link_html(article))
   end
 
   it "renders with missing article" do
     article.delete
-    liquid = generate_new_liquid("https://dev.to/#{user.username}/#{article.slug}/")
+    liquid = generate_new_liquid("https://#{SiteConfig.app_domain}/#{user.username}/#{article.slug}/")
     expect(liquid.render).to eq(missing_article_html)
   end
 


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Shows error message when user uses links from different domain in **link** liquid tag

## Related Tickets & Documents

closes https://github.com/forem/forem/issues/10096

## QA Instructions, Screenshots, Recordings

1. Go to comment section in article
2. Paste the comment 
```
{% link https://www.freecodecamp.org/news/ultimate-dynamodb-2020-cheatsheet/ %}
```
3. Click preview it should that link is not valid article link

![link_error](https://user-images.githubusercontent.com/8092120/94545492-3aba2a00-026a-11eb-8a20-91f0bf0f3a96.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

