### PR TITLE
Update Carrierwave's asset_host for Forem cloud

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -12,7 +12,7 @@ CarrierWave.configure do |config|
     config.storage = :file
     config.enable_processing = Rails.env.development?
   elsif ENV["FILE_STORAGE_LOCATION"] == "file" # @forem/systems production version of file store
-    config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/remoteimages"
+    config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/localimages"
     config.storage = :file
   else
     config.fog_provider = "fog/aws"
@@ -35,7 +35,7 @@ CarrierWave.configure do |config|
       config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" }
     else
       # Fallback on file storage if AWS creds are not present
-      config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/remoteimages"
+      config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/localimages"
       config.storage = :file
     end
     config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -8,14 +8,11 @@ end
 
 # rubocop:disable Metrics/BlockLength
 CarrierWave.configure do |config|
-  if Rails.env.test?
+  if Rails.env.test? || Rails.env.development?
     config.storage = :file
-    config.enable_processing = false
-  elsif Rails.env.development?
-    # config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}"
-    config.storage = :file
+    config.enable_processing = Rails.env.development?
   elsif ENV["FILE_STORAGE_LOCATION"] == "file" # @forem/systems production version of file store
-    config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/images"
+    config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/remoteimages"
     config.storage = :file
   else
     config.fog_provider = "fog/aws"
@@ -25,7 +22,7 @@ CarrierWave.configure do |config|
         use_iam_profile: true,
         region: "us-east-2"
       }
-      config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/images"
+      config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/remoteimages"
       config.fog_public = false
     elsif ApplicationConfig["AWS_ID"].present?
       region = ApplicationConfig["AWS_UPLOAD_REGION"].presence || ApplicationConfig["AWS_DEFAULT_REGION"]
@@ -38,7 +35,7 @@ CarrierWave.configure do |config|
       config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" }
     else
       # Fallback on file storage if AWS creds are not present
-      config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/images"
+      config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/remoteimages"
       config.storage = :file
     end
     config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Cleaning up `carrierwave.rb` up and Update `config.asset_host` to use `/remoteimages` instead of `/images` when in Forem context.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
n/a

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a