### PR TITLE
Add missing presence validators to models

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -48,17 +48,25 @@ class Article < ApplicationRecord
            class_name: "Comment"
 
   validates :body_markdown, length: { minimum: 0, allow_nil: false }, uniqueness: { scope: %i[user_id title] }
+  validates :boost_states, presence: true
   validates :cached_tag_list, length: { maximum: 126 }
   validates :canonical_url, uniqueness: { allow_nil: true }
   validates :canonical_url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
+  validates :comments_count, presence: true
   validates :feed_source_url, uniqueness: { allow_nil: true }
   validates :feed_source_url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
   validates :main_image, url: { allow_blank: true, schemes: %w[https http] }
   validates :main_image_background_hex_color, format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/
+  validates :positive_reactions_count, presence: true
+  validates :previous_public_reactions_count, presence: true
+  validates :public_reactions_count, presence: true
+  validates :rating_votes_count, presence: true
+  validates :reactions_count, presence: true
   validates :slug, presence: { if: :published? }, format: /\A[0-9a-z\-_]*\z/
   validates :slug, uniqueness: { scope: :user_id }
   validates :title, presence: true, length: { maximum: 128 }
   validates :user_id, presence: true
+  validates :user_subscriptions_count, presence: true
   validates :video, url: { allow_blank: true, schemes: %w[https http] }
   validates :video_closed_caption_track_url, url: { allow_blank: true, schemes: ["https"] }
   validates :video_source_url, url: { allow_blank: true, schemes: ["https"] }

--- a/app/models/audit_log.rb
+++ b/app/models/audit_log.rb
@@ -1,3 +1,5 @@
 class AuditLog < ApplicationRecord
   belongs_to :user, optional: true
+
+  validates :data, presence: true
 end

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -8,6 +8,7 @@ class Badge < ApplicationRecord
 
   validates :badge_image, presence: true
   validates :description, presence: true
+  validates :slug, presence: true
   validates :title, presence: true, uniqueness: true
 
   before_validation :generate_slug

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -41,6 +41,9 @@ class Comment < ApplicationRecord
   validates :body_markdown, uniqueness: { scope: %i[user_id ancestry commentable_id commentable_type] }
   validates :commentable_id, presence: true, if: :commentable_type
   validates :commentable_type, inclusion: { in: COMMENTABLE_TYPES }, if: :commentable_id
+  validates :positive_reactions_count, presence: true
+  validates :public_reactions_count, presence: true
+  validates :reactions_count, presence: true
   validates :user_id, presence: true
 
   after_create_commit :record_field_test_event

--- a/app/models/data_update_script.rb
+++ b/app/models/data_update_script.rb
@@ -4,7 +4,9 @@ class DataUpdateScript < ApplicationRecord
   STATUSES = { enqueued: 0, working: 1, succeeded: 2, failed: 3 }.freeze
 
   enum status: STATUSES
-  validates :file_name, uniqueness: true
+
+  validates :file_name, presence: true, uniqueness: true
+  validates :status, presence: true
 
   class << self
     def scripts_to_run

--- a/app/models/email_authorization.rb
+++ b/app/models/email_authorization.rb
@@ -1,15 +1,16 @@
 class EmailAuthorization < ApplicationRecord
-  before_create :generate_confirmation_token
   belongs_to :user
 
   # uuid_issue is a specific case where a user deletes their old auth account and recreates it,
   # leaving us with the incorrect uuid
   TYPES = %w[merge_request account_lockout uuid_issue account_ownership].freeze
 
-  validates :type_of, presence: true
-  validates :type_of, inclusion: { in: TYPES }
+  validates :json_data, presence: true
+  validates :type_of, presence: true, inclusion: { in: TYPES }
 
   alias_attribute :sent_at, :created_at
+
+  before_create :generate_confirmation_token
 
   private
 

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -16,7 +16,7 @@ class Follow < ApplicationRecord
 
   # Follows belong to the "followable" interface, and also to followers
   belongs_to :followable, polymorphic: true
-  belongs_to :follower,   polymorphic: true
+  belongs_to :follower, polymorphic: true
 
   scope :followable_user, ->(id) { where(followable_id: id, followable_type: "User") }
   scope :followable_tag, ->(id) { where(followable_id: id, followable_type: "ActsAsTaggableOn::Tag") }
@@ -33,7 +33,12 @@ class Follow < ApplicationRecord
   after_save :touch_follower
   after_create_commit :create_chat_channel
 
-  validates :subscription_status, inclusion: { in: %w[all_articles none] }
+  validates :blocked, inclusion: { in: [true, false] }
+  validates :followable_id, presence: true
+  validates :followable_type, presence: true
+  validates :follower_id, presence: true
+  validates :follower_type, presence: true
+  validates :subscription_status, presence: true, inclusion: { in: %w[all_articles none] }
 
   def self.need_new_follower_notification_for?(followable_type)
     %w[User Organization].include?(followable_type)

--- a/app/models/notification_subscription.rb
+++ b/app/models/notification_subscription.rb
@@ -1,7 +1,9 @@
 class NotificationSubscription < ApplicationRecord
-  belongs_to :user
   belongs_to :notifiable, polymorphic: true
-  validates :notifiable_type, inclusion: { in: %w[Comment Article] }
+  belongs_to :user
+
+  validates :config, presence: true, inclusion: { in: %w[all_comments top_level_comments only_author_comments] }
+  validates :notifiable_id, presence: true
+  validates :notifiable_type, presence: true, inclusion: { in: %w[Comment Article] }
   validates :user_id, uniqueness: { scope: %i[notifiable_type notifiable_id] }
-  validates :config, inclusion: { in: %w[all_comments top_level_comments only_author_comments] }
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -23,9 +23,11 @@ class Organization < ApplicationRecord
   has_many :unspent_credits, -> { where spent: false }, class_name: "Credit", inverse_of: :organization
   has_many :users, through: :organization_memberships
 
+  validates :articles_count, presence: true
   validates :bg_color_hex, format: COLOR_HEX_REGEXP, allow_blank: true
   validates :company_size, format: { with: INTEGER_REGEXP, message: MESSAGES[:integer_only], allow_blank: true }
   validates :company_size, length: { maximum: 7 }, allow_nil: true
+  validates :credits_count, presence: true
   validates :cta_body_markdown, length: { maximum: 256 }
   validates :cta_button_text, length: { maximum: 20 }
   validates :cta_button_url, length: { maximum: 150 }, url: { allow_blank: true, no_local: true }
@@ -39,11 +41,13 @@ class Organization < ApplicationRecord
   validates :slug, exclusion: { in: ReservedWords.all, message: MESSAGES[:reserved_word] }
   validates :slug, format: { with: SLUG_REGEXP }, length: { in: 2..18 }
   validates :slug, presence: true, uniqueness: { case_sensitive: false }
+  validates :spent_credits_count, presence: true
   validates :summary, length: { maximum: 250 }
   validates :tag_line, length: { maximum: 60 }
   validates :tech_stack, :story, length: { maximum: 640 }
   validates :text_color_hex, format: COLOR_HEX_REGEXP, allow_blank: true
   validates :twitter_username, length: { maximum: 15 }
+  validates :unspent_credits_count, presence: true
   validates :url, length: { maximum: 200 }, url: { allow_blank: true, no_local: true }
 
   validate :unique_slug_including_users_and_podcasts, if: :slug_changed?

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -20,10 +20,12 @@ class PodcastEpisode < ApplicationRecord
   mount_uploader :image, ProfileImageUploader
   mount_uploader :social_image, ProfileImageUploader
 
-  validates :title, presence: true
-  validates :slug, presence: true
-  validates :media_url, presence: true, uniqueness: true
+  validates :comments_count, presence: true
   validates :guid, presence: true, uniqueness: true
+  validates :media_url, presence: true, uniqueness: true
+  validates :reactions_count, presence: true
+  validates :slug, presence: true
+  validates :title, presence: true
 
   before_validation :process_html_and_prefix_all_images
   # NOTE: Any create callbacks will not be run since we use activerecord-import to create episodes

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -9,9 +9,11 @@ class Poll < ApplicationRecord
   has_many :poll_skips, dependent: :destroy
   has_many :poll_votes, dependent: :destroy
 
+  validates :poll_options_count, presence: true
+  validates :poll_options_input_array, presence: true, length: { minimum: 2, maximum: 15 }
+  validates :poll_skips_count, presence: true
+  validates :poll_votes_count, presence: true
   validates :prompt_markdown, presence: true, length: { maximum: 128 }
-  validates :poll_options_input_array, presence: true,
-                                       length: { minimum: 2, maximum: 15 }
 
   before_save :evaluate_markdown
   after_create :create_poll_options

--- a/app/models/poll_option.rb
+++ b/app/models/poll_option.rb
@@ -3,6 +3,7 @@ class PollOption < ApplicationRecord
   has_many :poll_votes, dependent: :destroy
 
   validates :markdown, presence: true, length: { maximum: 128 }
+  validates :poll_votes_count, presence: true
 
   before_save :evaluate_markdown
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,7 @@
 class Profile < ApplicationRecord
   belongs_to :user
 
+  validates :data, presence: true
   validates :user_id, uniqueness: true
 
   has_many :custom_profile_fields, dependent: :destroy

--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -16,6 +16,8 @@ class ProfileField < ApplicationRecord
 
   belongs_to :profile_field_group, optional: true
 
+  validates :display_area, presence: true
+  validates :input_type, presence: true
   validates :show_in_onboarding, inclusion: { in: [true, false] }
 
   def type

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -4,6 +4,8 @@
 class SiteConfig < RailsSettings::Base
   self.table_name = "site_configs"
 
+  validates :var, presence: true
+
   # the site configuration is cached, change this if you want to force update
   # the cache, or call SiteConfig.clear_cache
   cache_prefix { "v1" }

--- a/app/models/sponsorship.rb
+++ b/app/models/sponsorship.rb
@@ -15,10 +15,11 @@ class Sponsorship < ApplicationRecord
   belongs_to :organization, inverse_of: :sponsorships
   belongs_to :sponsorable, polymorphic: true, optional: true
 
-  validates :user, :organization, :featured_number, presence: true
-  validates :level, inclusion: { in: LEVELS }
-  validates :status, inclusion: { in: STATUSES }
+  validates :level, presence: true, inclusion: { in: LEVELS }
+  validates :status, presence: true, inclusion: { in: STATUSES }
   validates :url, url: { allow_blank: true, no_local: true, schemes: %w[http https] }
+  validates :user, :organization, :featured_number, presence: true
+
   validate :validate_tag_uniqueness, if: proc { level.to_s == "tag" }
   validate :validate_level_uniqueness, if: proc { METAL_LEVELS.include?(level) }
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -9,7 +9,9 @@ class Tag < ActsAsTaggableOn::Tag
   # This model doesn't inherit from ApplicationRecord so this has to be included
   include Purgeable
   include Searchable
+
   ALLOWED_CATEGORIES = %w[uncategorized language library tool site_mechanic location subcommunity].freeze
+  HEX_COLOR_REGEXP = /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/.freeze
 
   belongs_to :badge, optional: true
   belongs_to :mod_chat_channel, class_name: "ChatChannel", optional: true
@@ -21,11 +23,9 @@ class Tag < ActsAsTaggableOn::Tag
   mount_uploader :profile_image, ProfileImageUploader
   mount_uploader :social_image, ProfileImageUploader
 
-  validates :text_color_hex,
-            format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, allow_nil: true
-  validates :bg_color_hex,
-            format: /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/, allow_nil: true
-  validates :category, inclusion: { in: ALLOWED_CATEGORIES }
+  validates :text_color_hex, format: HEX_COLOR_REGEXP, allow_nil: true
+  validates :bg_color_hex, format: HEX_COLOR_REGEXP, allow_nil: true
+  validates :category, presence: true, inclusion: { in: ALLOWED_CATEGORIES }
 
   validate :validate_alias_for, if: :alias_for?
   validate :validate_name, if: :name?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -145,23 +145,43 @@ class User < ApplicationRecord
   devise :invitable, :omniauthable, :registerable, :database_authenticatable, :confirmable, :rememberable,
          :recoverable, :lockable
 
+  validates :articles_count, presence: true
+  validates :badge_achievements_count, presence: true
+  validates :blocked_by_count, presence: true
+  validates :blocking_others_count, presence: true
+  validates :comments_count, presence: true
   validates :config_font, inclusion: { in: FONTS + ["default".freeze], message: MESSAGES[:invalid_config_font] }
+  validates :config_font, presence: true
   validates :config_navbar, inclusion: { in: NAVBARS, message: MESSAGES[:invalid_config_navbar] }
+  validates :config_navbar, presence: true
   validates :config_theme, inclusion: { in: THEMES, message: MESSAGES[:invalid_config_theme] }
+  validates :config_theme, presence: true
+  validates :credits_count, presence: true
   validates :currently_streaming_on, inclusion: { in: STREAMING_PLATFORMS }, allow_nil: true
   validates :editor_version, inclusion: { in: EDITORS, message: MESSAGES[:invalid_editor_version] }
   validates :email, length: { maximum: 50 }, email: true, allow_nil: true
   validates :email, uniqueness: { allow_nil: true, case_sensitive: false }, if: :email_changed?
+  validates :email_digest_periodic, inclusion: { in: [true, false] }
   validates :experience_level, numericality: { less_than_or_equal_to: 10 }, allow_blank: true
   validates :feed_referential_link, inclusion: { in: [true, false] }
   validates :feed_url, length: { maximum: 500 }, allow_nil: true
+  validates :following_orgs_count, presence: true
+  validates :following_tags_count, presence: true
+  validates :following_users_count, presence: true
   validates :inbox_guidelines, length: { maximum: 250 }, allow_nil: true
   validates :inbox_type, inclusion: { in: INBOXES }
   validates :name, length: { in: 1..100 }
   validates :password, length: { in: 8..100 }, allow_nil: true
-  validates :username, presence: true, exclusion: { in: ReservedWords.all, message: MESSAGES[:invalid_username] }
+  validates :rating_votes_count, presence: true
+  validates :reactions_count, presence: true
+  validates :sign_in_count, presence: true
+  validates :spent_credits_count, presence: true
+  validates :subscribed_to_user_subscriptions_count, presence: true
+  validates :unspent_credits_count, presence: true
   validates :username, length: { in: 2..USERNAME_MAX_LENGTH }, format: USERNAME_REGEXP
+  validates :username, presence: true, exclusion: { in: ReservedWords.all, message: MESSAGES[:invalid_username] }
   validates :username, uniqueness: { case_sensitive: false }, if: :username_changed?
+  validates :welcome_notifications, inclusion: { in: [true, false] }
 
   # add validators for provider related usernames
   Authentication::Providers.username_fields.each do |username_field|
@@ -558,9 +578,9 @@ class User < ApplicationRecord
   end
 
   def set_config_input
-    self.config_theme = config_theme.tr(" ", "_")
-    self.config_font = config_font.tr(" ", "_")
-    self.config_navbar = config_navbar.tr(" ", "_")
+    self.config_theme = config_theme&.tr(" ", "_")
+    self.config_font = config_font&.tr(" ", "_")
+    self.config_navbar = config_navbar&.tr(" ", "_")
   end
 
   def check_for_username_change

--- a/app/models/webhook/endpoint.rb
+++ b/app/models/webhook/endpoint.rb
@@ -5,8 +5,10 @@ module Webhook
                                    class_name: "Doorkeeper::Application",
                                    inverse_of: :webhook_endpoints
 
+    validates :events, presence: true
+    validates :source, presence: true
     validates :target_url, presence: true, uniqueness: true, url: { schemes: %w[https] }
-    validates :source, :events, presence: true
+    validates :user_id, presence: true
 
     attribute :events, :string, array: true, default: []
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -35,8 +35,18 @@ RSpec.describe Article, type: :model do
 
     it { is_expected.to validate_length_of(:cached_tag_list).is_at_most(126) }
     it { is_expected.to validate_length_of(:title).is_at_most(128) }
+
+    it { is_expected.to validate_presence_of(:boost_states) }
+    it { is_expected.to validate_presence_of(:comments_count) }
+    it { is_expected.to validate_presence_of(:positive_reactions_count) }
+    it { is_expected.to validate_presence_of(:previous_public_reactions_count) }
+    it { is_expected.to validate_presence_of(:public_reactions_count) }
+    it { is_expected.to validate_presence_of(:rating_votes_count) }
+    it { is_expected.to validate_presence_of(:reactions_count) }
+    it { is_expected.to validate_presence_of(:user_subscriptions_count) }
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:user_id) }
+
     it { is_expected.to validate_uniqueness_of(:canonical_url).allow_nil }
     it { is_expected.to validate_uniqueness_of(:feed_source_url).allow_nil }
     it { is_expected.to validate_uniqueness_of(:slug).scoped_to(:user_id) }

--- a/spec/models/audit_log_spec.rb
+++ b/spec/models/audit_log_spec.rb
@@ -1,5 +1,15 @@
 require "rails_helper"
 
 RSpec.describe AuditLog, type: :model do
-  it { is_expected.to belong_to(:user).optional }
+  let(:audit_log) { create(:audit_log) }
+
+  describe "validations" do
+    describe "builtin validations" do
+      subject { audit_log }
+
+      it { is_expected.to belong_to(:user).optional }
+
+      it { is_expected.to validate_presence_of(:data) }
+    end
+  end
 end

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Badge, type: :model do
       it { is_expected.to have_many(:tags).dependent(:restrict_with_error) }
       it { is_expected.to have_many(:users).through(:badge_achievements) }
 
-      it { is_expected.to validate_presence_of(:title) }
-      it { is_expected.to validate_presence_of(:description) }
       it { is_expected.to validate_presence_of(:badge_image) }
+      it { is_expected.to validate_presence_of(:description) }
+      it { is_expected.to validate_presence_of(:title) }
       it { is_expected.to validate_uniqueness_of(:title) }
     end
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe Comment, type: :model do
       it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
 
       it { is_expected.to validate_presence_of(:body_markdown) }
+      it { is_expected.to validate_presence_of(:positive_reactions_count) }
+      it { is_expected.to validate_presence_of(:public_reactions_count) }
+      it { is_expected.to validate_presence_of(:reactions_count) }
       it { is_expected.to validate_presence_of(:user_id) }
     end
 

--- a/spec/models/data_update_script_spec.rb
+++ b/spec/models/data_update_script_spec.rb
@@ -3,7 +3,16 @@ require "rails_helper"
 RSpec.describe DataUpdateScript do
   let(:test_directory) { Rails.root.join("spec/support/fixtures/data_update_scripts") }
 
-  it { is_expected.to validate_uniqueness_of(:file_name) }
+  describe "validations" do
+    describe "builtin validations" do
+      subject { create(:data_update_script) }
+
+      it { is_expected.to validate_presence_of(:file_name) }
+      it { is_expected.to validate_presence_of(:status) }
+
+      it { is_expected.to validate_uniqueness_of(:file_name) }
+    end
+  end
 
   describe ".scripts_to_run" do
     before { stub_const "#{described_class}::DIRECTORY", test_directory }

--- a/spec/models/email_authorization_spec.rb
+++ b/spec/models/email_authorization_spec.rb
@@ -1,12 +1,35 @@
 require "rails_helper"
 
 RSpec.describe EmailAuthorization, type: :model do
-  it { is_expected.to validate_inclusion_of(:type_of).in_array(EmailAuthorization::TYPES) }
+  let(:email_authorization) { create(:email_authorization) }
+
+  describe "validations" do
+    describe "builtin validations" do
+      subject { email_authorization }
+
+      it { is_expected.to validate_inclusion_of(:type_of).in_array(EmailAuthorization::TYPES) }
+
+      it { is_expected.to validate_presence_of(:json_data) }
+      it { is_expected.to validate_presence_of(:type_of) }
+    end
+  end
+
+  describe "#confirmation_token" do
+    it "is created automatically" do
+      expect(email_authorization.confirmation_token).to be_present
+    end
+
+    it "is not changed if already present" do
+      token = email_authorization.confirmation_token
+      email_authorization.save!
+
+      expect(email_authorization.reload.confirmation_token).to eq(token)
+    end
+  end
 
   describe "#sent_at" do
-    it "calls #created_at" do
-      email_auth = create(:email_authorization)
-      expect(email_auth.sent_at).to eq email_auth.created_at
+    it "is aliased to #created_at" do
+      expect(email_authorization.sent_at).to eq(email_authorization.created_at)
     end
   end
 end

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Follow, type: :model do
     subject { user.follow(user_2) }
 
     it { is_expected.to validate_inclusion_of(:subscription_status).in_array(%w[all_articles none]) }
+    it { is_expected.to validate_inclusion_of(:blocked).in_array([true, false]) }
+    it { is_expected.to validate_presence_of(:followable_id) }
+    it { is_expected.to validate_presence_of(:followable_type) }
+    it { is_expected.to validate_presence_of(:follower_id) }
+    it { is_expected.to validate_presence_of(:follower_type) }
+    it { is_expected.to validate_presence_of(:subscription_status) }
   end
 
   it "follows user" do

--- a/spec/models/notification_subscription_spec.rb
+++ b/spec/models/notification_subscription_spec.rb
@@ -1,10 +1,52 @@
 require "rails_helper"
 
 RSpec.describe NotificationSubscription, type: :model do
-  subject { create(:notification_subscription, user: user, notifiable: article) }
-
   let(:user) { create(:user) }
   let(:article) { create(:article, user: user) }
+  let(:notification_subscription) { create(:notification_subscription, user: user, notifiable: article) }
 
-  it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(%i[notifiable_type notifiable_id]) }
+  describe "validations" do
+    describe "builtin validations" do
+      subject(:notification_subscription) { notification_subscription }
+
+      it { is_expected.to belong_to(:notifiable) }
+      it { is_expected.to belong_to(:user) }
+
+      it do
+        expect(notification_subscription).to(
+          validate_inclusion_of(:config).in_array(%w[all_comments top_level_comments only_author_comments]),
+        )
+      end
+
+      it { is_expected.to validate_presence_of(:config) }
+      it { is_expected.to validate_presence_of(:notifiable_id) }
+      it { is_expected.to validate_presence_of(:notifiable_type) }
+
+      it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(%i[notifiable_type notifiable_id]) }
+    end
+
+    describe "#notifiable_type" do
+      it "is valid if equals to Article" do
+        notification_subscription.notifiable_type = "Article"
+
+        expect(notification_subscription).to be_valid
+      end
+
+      it "is valid if equals to Comment" do
+        comment = create(:comment)
+        notification_subscription.notifiable_id = comment.id
+        notification_subscription.notifiable_type = "Comment"
+
+        expect(notification_subscription).to be_valid
+      end
+
+      it "is is invalid with Podcast" do
+        podcast = create(:podcast)
+        notification_subscription.notifiable_id = podcast.id
+        notification_subscription.notifiable_type = "Podcast"
+
+        expect(notification_subscription).not_to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -19,26 +19,30 @@ RSpec.describe Organization, type: :model do
       it { is_expected.to have_many(:unspent_credits).class_name("Credit") }
       it { is_expected.to have_many(:users).through(:organization_memberships) }
 
-      it { is_expected.to validate_presence_of(:name) }
-      it { is_expected.to validate_presence_of(:summary) }
-      it { is_expected.to validate_presence_of(:url) }
-      it { is_expected.to validate_presence_of(:profile_image) }
-      it { is_expected.to validate_presence_of(:slug) }
+      it { is_expected.to validate_length_of(:company_size).is_at_most(7) }
       it { is_expected.to validate_length_of(:cta_body_markdown).is_at_most(256) }
       it { is_expected.to validate_length_of(:cta_button_text).is_at_most(20) }
-      it { is_expected.to validate_length_of(:secret).is_equal_to(100) }
-      it { is_expected.to validate_length_of(:name).is_at_most(50) }
-      it { is_expected.to validate_length_of(:slug).is_at_least(2).is_at_most(18) }
-      it { is_expected.to validate_length_of(:twitter_username).is_at_most(15) }
-      it { is_expected.to validate_length_of(:github_username).is_at_most(50) }
-      it { is_expected.to validate_length_of(:url).is_at_most(200) }
-      it { is_expected.to validate_length_of(:tag_line).is_at_most(60) }
-      it { is_expected.to validate_length_of(:proof).is_at_most(1500) }
-      it { is_expected.to validate_length_of(:location).is_at_most(64) }
       it { is_expected.to validate_length_of(:email).is_at_most(64) }
-      it { is_expected.to validate_length_of(:company_size).is_at_most(7) }
+      it { is_expected.to validate_length_of(:github_username).is_at_most(50) }
+      it { is_expected.to validate_length_of(:location).is_at_most(64) }
+      it { is_expected.to validate_length_of(:name).is_at_most(50) }
+      it { is_expected.to validate_length_of(:proof).is_at_most(1500) }
+      it { is_expected.to validate_length_of(:secret).is_equal_to(100) }
+      it { is_expected.to validate_length_of(:slug).is_at_least(2).is_at_most(18) }
       it { is_expected.to validate_length_of(:story).is_at_most(640) }
+      it { is_expected.to validate_length_of(:tag_line).is_at_most(60) }
       it { is_expected.to validate_length_of(:tech_stack).is_at_most(640) }
+      it { is_expected.to validate_length_of(:twitter_username).is_at_most(15) }
+      it { is_expected.to validate_length_of(:url).is_at_most(200) }
+      it { is_expected.to validate_presence_of(:articles_count) }
+      it { is_expected.to validate_presence_of(:credits_count) }
+      it { is_expected.to validate_presence_of(:name) }
+      it { is_expected.to validate_presence_of(:profile_image) }
+      it { is_expected.to validate_presence_of(:slug) }
+      it { is_expected.to validate_presence_of(:spent_credits_count) }
+      it { is_expected.to validate_presence_of(:summary) }
+      it { is_expected.to validate_presence_of(:unspent_credits_count) }
+      it { is_expected.to validate_presence_of(:url) }
       it { is_expected.to validate_uniqueness_of(:secret).allow_nil }
       it { is_expected.to validate_uniqueness_of(:slug).case_insensitive }
 

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe PodcastEpisode, type: :model do
       it { is_expected.to belong_to(:podcast) }
       it { is_expected.to have_many(:comments).inverse_of(:commentable).dependent(:nullify) }
 
+      it { is_expected.to validate_presence_of(:comments_count) }
       it { is_expected.to validate_presence_of(:guid) }
       it { is_expected.to validate_presence_of(:media_url) }
+      it { is_expected.to validate_presence_of(:reactions_count) }
       it { is_expected.to validate_presence_of(:slug) }
       it { is_expected.to validate_presence_of(:title) }
     end

--- a/spec/models/poll_option_spec.rb
+++ b/spec/models/poll_option_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe PollOption, type: :model do
 
       it { is_expected.to belong_to(:poll) }
       it { is_expected.to have_many(:poll_votes).dependent(:destroy) }
+
+      it { is_expected.to validate_presence_of(:markdown) }
+      it { is_expected.to validate_presence_of(:poll_votes_count) }
     end
 
     it "allows up to 128 markdown characters" do

--- a/spec/models/poll_spec.rb
+++ b/spec/models/poll_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe Poll, type: :model do
       it { is_expected.to have_many(:poll_options).dependent(:destroy) }
       it { is_expected.to have_many(:poll_skips).dependent(:destroy) }
       it { is_expected.to have_many(:poll_votes).dependent(:destroy) }
+
+      it { is_expected.to validate_length_of(:poll_options_input_array).is_at_least(2).is_at_most(15) }
+
+      it { is_expected.to validate_presence_of(:poll_options_count) }
+      it { is_expected.to validate_presence_of(:poll_options_input_array) }
+      it { is_expected.to validate_presence_of(:poll_skips_count) }
+      it { is_expected.to validate_presence_of(:poll_votes_count) }
+      it { is_expected.to validate_presence_of(:prompt_markdown) }
     end
 
     describe "#prompt_markdown" do

--- a/spec/models/profile_field_spec.rb
+++ b/spec/models/profile_field_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe ProfileField, type: :model do
   describe "validations" do
     describe "builtin validations" do
       it { is_expected.to belong_to(:profile_field_group).optional(true) }
+
+      it { is_expected.to validate_presence_of(:display_area) }
+      it { is_expected.to validate_presence_of(:input_type) }
       it { is_expected.to validate_inclusion_of(:show_in_onboarding).in_array([true, false]) }
     end
   end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Profile, type: :model do
     subject { create(:profile) }
 
     it { is_expected.to validate_uniqueness_of(:user_id) }
+    it { is_expected.to validate_presence_of(:data) }
   end
 
   context "when accessing profile fields" do

--- a/spec/models/site_config_spec.rb
+++ b/spec/models/site_config_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe SiteConfig, type: :model do
+  describe "validations" do
+    describe "builtin validations" do
+      it { is_expected.to validate_presence_of(:var) }
+    end
+  end
+
   describe ".local?" do
     it "returns true if the .app_domain points to localhost" do
       allow(described_class).to receive(:app_domain).and_return("localhost:3000")

--- a/spec/models/sponsorship_spec.rb
+++ b/spec/models/sponsorship_spec.rb
@@ -1,19 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Sponsorship, type: :model do
-  it { is_expected.to belong_to(:user) }
-  it { is_expected.to belong_to(:organization).inverse_of(:sponsorships) }
-  it { is_expected.to belong_to(:sponsorable).optional }
-  it { is_expected.to validate_presence_of(:user) }
-  it { is_expected.to validate_presence_of(:organization) }
-  it { is_expected.to validate_inclusion_of(:level).in_array(Sponsorship::LEVELS) }
-  it { is_expected.to validate_inclusion_of(:status).in_array(Sponsorship::STATUSES) }
-  it { is_expected.to allow_values(nil).for(:expires_at) }
-  it { is_expected.not_to allow_values(nil).for(:featured_number) }
-  it { is_expected.to have_db_index(:level) }
-  it { is_expected.to have_db_index(:status) }
-  it { is_expected.to have_db_index(%i[sponsorable_id sponsorable_type]) }
-
   describe "constants" do
     it "has the correct values for constants" do
       expect(Sponsorship::LEVELS).to eq(%w[gold silver bronze tag media devrel])
@@ -51,6 +38,27 @@ RSpec.describe Sponsorship, type: :model do
   describe "validations" do
     let(:user) { create(:user, :org_member) }
     let(:org) { user.organizations.first }
+
+    describe "builtin validations" do
+      it { is_expected.to belong_to(:organization).inverse_of(:sponsorships) }
+      it { is_expected.to belong_to(:sponsorable).optional }
+      it { is_expected.to belong_to(:user) }
+
+      it { is_expected.to have_db_index(%i[sponsorable_id sponsorable_type]) }
+      it { is_expected.to have_db_index(:level) }
+      it { is_expected.to have_db_index(:status) }
+
+      it { is_expected.to validate_inclusion_of(:level).in_array(Sponsorship::LEVELS) }
+      it { is_expected.to validate_inclusion_of(:status).in_array(Sponsorship::STATUSES) }
+
+      it { is_expected.to validate_presence_of(:level) }
+      it { is_expected.to validate_presence_of(:organization) }
+      it { is_expected.to validate_presence_of(:status) }
+      it { is_expected.to validate_presence_of(:user) }
+
+      it { is_expected.not_to allow_values(nil).for(:featured_number) }
+      it { is_expected.to allow_values(nil).for(:expires_at) }
+    end
 
     it "forbids an org to have multiple 'expiring' (bronze-silver-gold) sponsorships" do
       create(:sponsorship, level: :gold, organization: org, expires_at: 2.days.from_now)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Tag, type: :model do
       it { is_expected.to have_one(:sponsorship).inverse_of(:sponsorable).dependent(:destroy) }
 
       it { is_expected.to validate_length_of(:name).is_at_most(30) }
+      it { is_expected.to validate_presence_of(:category) }
+
       it { is_expected.not_to allow_value("#Hello", "c++", "AWS-Lambda").for(:name) }
 
       # rubocop:disable RSpec/NamedSubject
@@ -19,6 +21,11 @@ RSpec.describe Tag, type: :model do
         expect(subject).to belong_to(:mod_chat_channel)
           .class_name("ChatChannel")
           .optional
+      end
+
+      it do
+        expect(subject).to validate_inclusion_of(:category)
+          .in_array(%w[uncategorized language library tool site_mechanic location subcommunity])
       end
       # rubocop:enable RSpec/NamedSubject
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -180,12 +180,34 @@ RSpec.describe User, type: :model do
       it { is_expected.not_to allow_value("AcMe_1%").for(:username) }
       it { is_expected.to allow_value("AcMe_1").for(:username) }
 
+      it { is_expected.to validate_inclusion_of(:email_digest_periodic).in_array([true, false]) }
       it { is_expected.to validate_inclusion_of(:inbox_type).in_array(%w[open private]) }
+      it { is_expected.to validate_inclusion_of(:welcome_notifications).in_array([true, false]) }
+
       it { is_expected.to validate_length_of(:email).is_at_most(50).allow_nil }
       it { is_expected.to validate_length_of(:inbox_guidelines).is_at_most(250).allow_nil }
       it { is_expected.to validate_length_of(:name).is_at_most(100).is_at_least(1) }
       it { is_expected.to validate_length_of(:password).is_at_most(100).is_at_least(8) }
       it { is_expected.to validate_length_of(:username).is_at_most(30).is_at_least(2) }
+
+      it { is_expected.to validate_presence_of(:articles_count) }
+      it { is_expected.to validate_presence_of(:badge_achievements_count) }
+      it { is_expected.to validate_presence_of(:blocked_by_count) }
+      it { is_expected.to validate_presence_of(:blocking_others_count) }
+      it { is_expected.to validate_presence_of(:comments_count) }
+      it { is_expected.to validate_presence_of(:config_font) }
+      it { is_expected.to validate_presence_of(:config_navbar) }
+      it { is_expected.to validate_presence_of(:config_theme) }
+      it { is_expected.to validate_presence_of(:credits_count) }
+      it { is_expected.to validate_presence_of(:following_orgs_count) }
+      it { is_expected.to validate_presence_of(:following_tags_count) }
+      it { is_expected.to validate_presence_of(:following_users_count) }
+      it { is_expected.to validate_presence_of(:rating_votes_count) }
+      it { is_expected.to validate_presence_of(:reactions_count) }
+      it { is_expected.to validate_presence_of(:sign_in_count) }
+      it { is_expected.to validate_presence_of(:spent_credits_count) }
+      it { is_expected.to validate_presence_of(:subscribed_to_user_subscriptions_count) }
+
       it { is_expected.to validate_uniqueness_of(:username).case_insensitive }
 
       Authentication::Providers.username_fields.each do |username_field|

--- a/spec/models/webhook/endpoint_spec.rb
+++ b/spec/models/webhook/endpoint_spec.rb
@@ -11,10 +11,14 @@ RSpec.describe Webhook::Endpoint, type: :model do
   describe "validations" do
     it { is_expected.to belong_to(:user).inverse_of(:webhook_endpoints) }
     it { is_expected.to belong_to(:oauth_application).inverse_of(:webhook_endpoints).optional }
-    it { is_expected.to validate_presence_of(:target_url) }
-    it { is_expected.to validate_presence_of(:source) }
+
     it { is_expected.to validate_presence_of(:events) }
+    it { is_expected.to validate_presence_of(:source) }
+    it { is_expected.to validate_presence_of(:target_url) }
+    it { is_expected.to validate_presence_of(:user_id) }
+
     it { is_expected.to validate_uniqueness_of(:target_url) }
+
     it { is_expected.to allow_value("https://foo.com").for(:target_url) }
     it { is_expected.not_to allow_value("http://foo.com").for(:target_url) }
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

**Disclaimer:** the PR is a little bigger than usual but it's only presence validators.

Basically we're missing a ton of `validates :field, presence: true` as all fields that in the DB are declared as `null: false` should have a presence validator.

Ran `bundle exec rake active_record_doctor:missing_presence_validation` to intercept them, see https://github.com/gregnavis/active_record_doctor#detecting-missing-presence-validations

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
