### PR TITLE
Remove redirect for listings#update

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -133,9 +133,7 @@ class ListingsController < ApplicationController
     # cache.
     #
     # https://github.com/forem/forem/issues/10338#issuecomment-693401481
-    published_listings = Listing.where(published: true)
-
-    @listings = published_listings
+    @listings = Listing.where(published: true)
       .order(bumped_at: :desc)
       .includes(:user, :organization, :taggings)
       .limit(12)

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -33,8 +33,7 @@ class ListingsController < ApplicationController
   # rubocop:enable Rails/LexicallyScopedActionFilter
 
   def index
-    published_listings = Listing.where(published: true)
-    @displayed_listing = published_listings.find_by(slug: params[:slug]) if params[:slug]
+    @displayed_listing = Listing.where(published: true).find_by(slug: params[:slug]) if params[:slug]
 
     if params[:view] == "moderate"
       not_found unless @displayed_listing
@@ -43,10 +42,7 @@ class ListingsController < ApplicationController
 
     @listings =
       if params[:category].blank?
-        published_listings
-          .order(bumped_at: :desc)
-          .includes(:user, :organization, :taggings)
-          .limit(12)
+        listings_for_index_view
       else
         Listing.none
       end
@@ -133,11 +129,7 @@ class ListingsController < ApplicationController
     # cache.
     #
     # https://github.com/forem/forem/issues/10338#issuecomment-693401481
-    @listings = Listing.where(published: true)
-      .order(bumped_at: :desc)
-      .includes(:user, :organization, :taggings)
-      .limit(12)
-
+    @listings = listings_for_index_view
     @listings_json = @listings.to_json(INDEX_JSON_OPTIONS)
 
     render :index
@@ -149,5 +141,14 @@ class ListingsController < ApplicationController
 
   def check_limit
     rate_limit!(:listing_creation)
+  end
+
+  # This is a convenience method to query listings for use in the index view in
+  # the index action and process_after_update method
+  def listings_for_index_view
+    Listing.where(published: true)
+      .order(bumped_at: :desc)
+      .includes(:user, :organization, :taggings)
+      .limit(12)
   end
 end

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -521,6 +521,15 @@ RSpec.describe "/listings", type: :request do
         expect(listing.title).not_to eq("New title!")
         expect(listing.cached_tag_list).not_to include("hey")
       end
+
+      it "doesn't redirect on a successful update" do
+        put "/listings/#{listing.id}", params: {
+          listing: { body_markdown: "hello new markdown", title: "New title!", tag_list: "new, tags, hey" }
+        }
+
+        expect(response).not_to have_http_status(:redirect)
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
This refactors `listings#update` to avoid doing a redirect causing a race condition when busting cache. An alternative approach here is to create a listings "show" page/action to render to avoid issuing queries to populate the necessary data for `index`. I'm open to that as well if folks prefer that option!

## Related Tickets & Documents
https://github.com/forem/forem/issues/10338

## QA Instructions, Screenshots, Recordings

1. Fire up the app locally and sign in.
2. Add credits to your user if you don't have any already. You can do this in a console by running `Credit.add_to(user, 1_000)` where `user` is the `User` object of your signed-in user.
3. Create a listing.
4. Update the listing - you shouldn't see any errors and you'll see it render the index view as it did before this change.

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed - I'll do a separate PR at the end that documents this quirk as a whole.

![dog_racing_human_in_push_car](https://media.giphy.com/media/hqh8NpKgBMRTa/giphy.gif)
