### PR TITLE
Return Cache Bust Response When Busting a Cached Path

### DIFF
--- a/app/services/edge_cache/bust.rb
+++ b/app/services/edge_cache/bust.rb
@@ -16,6 +16,7 @@ module EdgeCache
 
       @path = path
       @provider = determine_provider
+      @response = nil
     end
 
     def call
@@ -23,10 +24,11 @@ module EdgeCache
 
       bust_method = "bust_#{provider}_cache"
       if respond_to?(bust_method, true)
-        __send__(bust_method)
+        @response = __send__(bust_method)
       else
         # We theoretically should never hit this unless someone adds a provider
         # but doesn't add the implementation for it into the #call method.
+        @response = nil
         Rails.logger.warn("EdgeCache::Bust was called with an invalid provider: #{provider}")
         DatadogStatsClient.increment("edgecache_bust.invalid_provider", tags: ["provider:#{provider}"])
       end
@@ -34,7 +36,7 @@ module EdgeCache
       self
     end
 
-    attr_reader :provider, :path
+    attr_reader :provider, :path, :response
 
     private
 

--- a/spec/labor/cache_buster_spec.rb
+++ b/spec/labor/cache_buster_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe CacheBuster, type: :labor do
       expect(edge_cache_bust_service.path).to eq(path)
       expect(edge_cache_bust_service.provider).to eq("fastly")
       expect(edge_cache_bust_service.class).to eq(EdgeCache::Bust)
+      expect(edge_cache_bust_service.response).not_to be(nil)
     end
   end
 

--- a/spec/services/edge_cache/bust_spec.rb
+++ b/spec/services/edge_cache/bust_spec.rb
@@ -4,6 +4,21 @@ RSpec.describe EdgeCache::Bust, type: :service do
   let(:user) { create(:user) }
   let(:path) { "/#{user.username}" }
 
+  describe "#call" do
+    before do
+      configure_fastly
+    end
+
+    let(:cache_bust_service) { described_class.new(path) }
+
+    it "returns cache bust response" do
+      allow(cache_bust_service).to receive(:bust_fastly_cache).and_return("success")
+
+      cache_bust_service.call
+      expect(cache_bust_service.response).to eq("success")
+    end
+  end
+
   describe "#bust_fastly_cache" do
     context "when fastly is not configured" do
       before do

--- a/spec/services/edge_cache/bust_spec.rb
+++ b/spec/services/edge_cache/bust_spec.rb
@@ -4,21 +4,6 @@ RSpec.describe EdgeCache::Bust, type: :service do
   let(:user) { create(:user) }
   let(:path) { "/#{user.username}" }
 
-  describe "#call" do
-    before do
-      configure_fastly
-    end
-
-    let(:cache_bust_service) { described_class.new(path) }
-
-    it "returns cache bust response" do
-      allow(cache_bust_service).to receive(:bust_fastly_cache).and_return("success")
-
-      cache_bust_service.call
-      expect(cache_bust_service.response).to eq("success")
-    end
-  end
-
   describe "#bust_fastly_cache" do
     context "when fastly is not configured" do
       before do
@@ -51,6 +36,13 @@ RSpec.describe EdgeCache::Bust, type: :service do
         cache_bust_service.call
         expect(cache_bust_service.provider).to eq("fastly")
         expect(cache_bust_service).to have_received(:bust_fastly_cache)
+      end
+
+      it "returns cache bust response" do
+        allow(cache_bust_service).to receive(:bust_fastly_cache).and_return("success")
+
+        cache_bust_service.call
+        expect(cache_bust_service.response).to eq("success")
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
When we updated this code to bust the cached paths we went from returning the cache bust response to returning the object we were using to do the busting. This PR adds the cache bust response to that object so we can view it which can be very helpful if you have to manually bust stuff and want to confirm that it was successful or not. Let me know what you all think! 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-45783449

## Added tests?
- [x] yes

![alt_text](https://media.tenor.com/images/a471585e43976065a07d1941f398d4d5/tenor.gif)
