### PR TITLE
Split EdgeCache::Bust into Fastly + Nginx-specific classes

### DIFF
--- a/app/services/edge_cache/bust.rb
+++ b/app/services/edge_cache/bust.rb
@@ -5,13 +5,6 @@ module EdgeCache
     end
 
     def initialize(path)
-      # TODO: (Vaidehi Joshi) - Right now, we are checking that nginx is
-      # available on every purge request/call to this bust service. If we are going
-      # to bust multiple paths, we should be able to check that nginx is
-      # available just once, and persist it on the class with @provider_available?.
-      # Then, we could allow for an array of @paths = [] to be passed in,
-      # and on single bust instance could bust multiple paths in order.
-
       @path = path
       @provider = determine_provider
       @response = nil

--- a/app/services/edge_cache/bust.rb
+++ b/app/services/edge_cache/bust.rb
@@ -1,7 +1,5 @@
 module EdgeCache
   class Bust
-    PROVIDERS = %w[fastly nginx].freeze
-
     def self.call(*args)
       new(*args).call
     end
@@ -20,17 +18,17 @@ module EdgeCache
     end
 
     def call
-      return unless PROVIDERS.include?(provider)
+      return unless provider
 
-      bust_method = "bust_#{provider}_cache"
-      if respond_to?(bust_method, true)
-        @response = __send__(bust_method)
+      provider_class = "#{self.class}::#{provider.capitalize}".constantize
+
+      if provider_class.respond_to?(:call)
+        @response = provider_class.call(path)
       else
-        # We theoretically should never hit this unless someone adds a provider
-        # but doesn't add the implementation for it into the #call method.
         @response = nil
-        Rails.logger.warn("EdgeCache::Bust was called with an invalid provider: #{provider}")
-        DatadogStatsClient.increment("edgecache_bust.invalid_provider", tags: ["provider:#{provider}"])
+        Rails.logger.warn("#{provider_class} cannot be used without a #call implementation!")
+        DatadogStatsClient.increment("edgecache_bust.invalid_provider_class",
+                                     tags: ["provider_class:#{provider_class}"])
       end
 
       self
@@ -43,38 +41,9 @@ module EdgeCache
     def determine_provider
       if fastly_enabled?
         "fastly"
-      elsif nginx_enabled? && nginx_available?
+      elsif nginx_enabled?
         "nginx"
       end
-    end
-
-    def bust_fastly_cache
-      # TODO: (Alex Smith) - It would be "nice to have" the ability to use the
-      # Fastly gem here instead of custom API calls.
-
-      # @forem/systems Fastly-enabled forems don't need "flexible" domains.
-      HTTParty.post(
-        "https://api.fastly.com/purge/https://#{URL.domain}#{path}",
-        headers: {
-          "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"]
-        },
-      )
-      HTTParty.post(
-        "https://api.fastly.com/purge/https://#{URL.domain}#{path}?i=i",
-        headers: {
-          "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"]
-        },
-      )
-    end
-
-    def bust_nginx_cache
-      uri = URI.parse("#{openresty_path}#{path}")
-      http = Net::HTTP.new(uri.host, uri.port)
-      response = http.request Net::HTTP::NginxPurge.new(uri.request_uri)
-
-      raise StandardError, "NginxPurge request failed: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
-
-      response.body
     end
 
     def fastly_enabled?
@@ -84,32 +53,5 @@ module EdgeCache
     def nginx_enabled?
       ApplicationConfig["OPENRESTY_PROTOCOL"].present? && ApplicationConfig["OPENRESTY_DOMAIN"].present?
     end
-
-    def openresty_path
-      "#{ApplicationConfig['OPENRESTY_PROTOCOL']}#{ApplicationConfig['OPENRESTY_DOMAIN']}"
-    end
-
-    def nginx_available?
-      uri = URI.parse(openresty_path)
-      http = Net::HTTP.new(uri.host, uri.port)
-      response = http.get(uri.request_uri)
-
-      return true if response.is_a?(Net::HTTPSuccess)
-    rescue StandardError
-      # If we can't connect to Openresty, alert ourselves that
-      # it is unavailable and return false.
-      Rails.logger.error("Could not connect to Openresty via #{openresty_path}!")
-      DatadogStatsClient.increment("edgecache_bust.service_unavailable", tags: ["path:#{openresty_path}"])
-      false
-    end
   end
-end
-
-# Creates our own purge method for an HTTP request,
-# which is used by Nginx to bust a cache.
-# See Net::HTTPGenericRequest for attributes/methods.
-class Net::HTTP::NginxPurge < Net::HTTPRequest # rubocop:disable Style/ClassAndModuleChildren
-  METHOD = "PURGE".freeze
-  REQUEST_HAS_BODY = false
-  RESPONSE_HAS_BODY = true
 end

--- a/app/services/edge_cache/bust/fastly.rb
+++ b/app/services/edge_cache/bust/fastly.rb
@@ -1,0 +1,24 @@
+module EdgeCache
+  class Bust
+    class Fastly
+      def self.call(path)
+        # TODO: (Alex Smith) - It would be "nice to have" the ability to use the
+        # Fastly gem here instead of custom API calls.
+
+        # @forem/systems Fastly-enabled forems don't need "flexible" domains.
+        HTTParty.post(
+          "https://api.fastly.com/purge/https://#{URL.domain}#{path}",
+          headers: {
+            "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"]
+          },
+        )
+        HTTParty.post(
+          "https://api.fastly.com/purge/https://#{URL.domain}#{path}?i=i",
+          headers: {
+            "Fastly-Key" => ApplicationConfig["FASTLY_API_KEY"]
+          },
+        )
+      end
+    end
+  end
+end

--- a/app/services/edge_cache/bust/nginx.rb
+++ b/app/services/edge_cache/bust/nginx.rb
@@ -1,0 +1,44 @@
+module EdgeCache
+  class Bust
+    class Nginx
+      def self.call(path)
+        return unless nginx_available?
+
+        uri = URI.parse("#{openresty_path}#{path}")
+        http = Net::HTTP.new(uri.host, uri.port)
+        response = http.request Net::HTTP::Purge.new(uri.request_uri)
+
+        raise StandardError, "Nginx Purge request failed: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
+
+        response.body
+      end
+
+      def self.openresty_path
+        "#{ApplicationConfig['OPENRESTY_PROTOCOL']}#{ApplicationConfig['OPENRESTY_DOMAIN']}"
+      end
+
+      def self.nginx_available?
+        uri = URI.parse(openresty_path)
+        http = Net::HTTP.new(uri.host, uri.port)
+        response = http.get(uri.request_uri)
+
+        return true if response.is_a?(Net::HTTPSuccess)
+      rescue StandardError
+        # If we can't connect to Openresty, alert ourselves that
+        # it is unavailable and return false.
+        Rails.logger.error("Could not connect to Openresty via #{openresty_path}!")
+        DatadogStatsClient.increment("edgecache_bust.service_unavailable", tags: ["path:#{openresty_path}"])
+        false
+      end
+    end
+  end
+end
+
+# Creates our own purge method for an HTTP request,
+# which is used by Nginx to bust a cache.
+# See Net::HTTPGenericRequest for attributes/methods.
+class Net::HTTP::Purge < Net::HTTPRequest # rubocop:disable Style/ClassAndModuleChildren
+  METHOD = "PURGE".freeze
+  REQUEST_HAS_BODY = false
+  RESPONSE_HAS_BODY = true
+end

--- a/app/services/edge_cache/bust/nginx.rb
+++ b/app/services/edge_cache/bust/nginx.rb
@@ -18,6 +18,12 @@ module EdgeCache
       end
 
       def self.nginx_available?
+        # TODO: (Vaidehi Joshi) - Right now, we are checking that nginx is
+        # available on every purge request/call to this bust service. If we are going
+        # to bust multiple paths, we should be able to check that nginx is
+        # available just once, and persist it on the class with @provider_available?.
+        # Then, we could allow for an array of @paths = [] to be passed in,
+        # and on single bust instance could bust multiple paths in order.
         uri = URI.parse(openresty_path)
         http = Net::HTTP.new(uri.host, uri.port)
         response = http.get(uri.request_uri)

--- a/spec/services/edge_cache/bust_spec.rb
+++ b/spec/services/edge_cache/bust_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe EdgeCache::Bust, type: :service do
   let(:path) { "/#{user.username}" }
 
   describe "#bust_fastly_cache" do
+    let(:fastly_provider_class) { EdgeCache::Bust::Fastly }
+
     context "when fastly is not configured" do
       before do
         stub_fastly
@@ -14,11 +16,11 @@ RSpec.describe EdgeCache::Bust, type: :service do
       let(:cache_bust_service) { described_class.new(path) }
 
       it "does not bust a fastly cache" do
-        allow(cache_bust_service).to receive(:bust_fastly_cache)
+        allow(fastly_provider_class).to receive(:call)
 
         cache_bust_service.call
         expect(cache_bust_service.provider).to be(nil)
-        expect(cache_bust_service).not_to have_received(:bust_fastly_cache)
+        expect(fastly_provider_class).not_to have_received(:call)
       end
     end
 
@@ -31,15 +33,15 @@ RSpec.describe EdgeCache::Bust, type: :service do
       let(:cache_bust_service) { described_class.new(path) }
 
       it "can bust a fastly cache" do
-        allow(cache_bust_service).to receive(:bust_fastly_cache)
+        allow(fastly_provider_class).to receive(:call)
 
         cache_bust_service.call
         expect(cache_bust_service.provider).to eq("fastly")
-        expect(cache_bust_service).to have_received(:bust_fastly_cache)
+        expect(fastly_provider_class).to have_received(:call)
       end
 
       it "returns cache bust response" do
-        allow(cache_bust_service).to receive(:bust_fastly_cache).and_return("success")
+        allow(fastly_provider_class).to receive(:call).and_return("success")
 
         cache_bust_service.call
         expect(cache_bust_service.response).to eq("success")
@@ -48,6 +50,8 @@ RSpec.describe EdgeCache::Bust, type: :service do
   end
 
   describe "#bust_nginx_cache" do
+    let(:nginx_provider_class) { EdgeCache::Bust::Nginx }
+
     before do
       # Explicitly stub Fastly since we check if Fastly has
       # been configured before we try to use Nginx.
@@ -62,11 +66,11 @@ RSpec.describe EdgeCache::Bust, type: :service do
       let(:cache_bust_service) { described_class.new(path) }
 
       it "does not bust an nginx cache" do
-        allow(cache_bust_service).to receive(:bust_nginx_cache)
+        allow(nginx_provider_class).to receive(:call)
 
         cache_bust_service.call
         expect(cache_bust_service.provider).to eq(nil)
-        expect(cache_bust_service).not_to have_received(:bust_nginx_cache)
+        expect(nginx_provider_class).not_to have_received(:call)
       end
     end
 
@@ -78,11 +82,11 @@ RSpec.describe EdgeCache::Bust, type: :service do
       let(:cache_bust_service) { described_class.new(path) }
 
       it "can bust an nginx cache" do
-        allow(cache_bust_service).to receive(:bust_nginx_cache)
+        allow(nginx_provider_class).to receive(:call)
 
         cache_bust_service.call
         expect(cache_bust_service.provider).to eq("nginx")
-        expect(cache_bust_service).to have_received(:bust_nginx_cache)
+        expect(nginx_provider_class).to have_received(:call)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Back in https://github.com/forem/forem/pull/10369, @citizen428 suggested [the great idea](https://github.com/forem/forem/pull/10369#discussion_r490772050) of splitting up the `EdgeCache::Bust` service into two provider-specific classes:
> What if we made providers their own classes, e.g. `EdgeCache::Bust::Fastly` ... which expose a single `call(path)` class method? This could greatly simplify the local `call` method.

This PR rolls with that suggestion and splits up that service into those classes. Everything should work as expected/as it did before, but now, Fastly-specific logic lives in the `EdgeCache::Bust::Fastly` class, while Nginx-specific logic lives in the `EdgeCache::Bust::Nginx` class! 🙌 


```bash
CacheBuster.bust(some-path-here)
=> #<EdgeCache::Service:0x00007fd6ce30aff0 @path="some-path-here", @provider="your-configured-provider-here" @response="some-response-here">
```

## Related Tickets & Documents

Improving upon https://github.com/forem/forem/pull/10369.

## QA Instructions, Screenshots, Recordings

⚠️  **To QA this PR, you will need have Openresty set up locally on your machine, which is powered by Docker. Please see the [LFSS repo](https://github.com/forem/lfss) for details on how to get yourself situated and set up.**


🚨 **To QA this PR, you will also need two ENV variables set in your local `.env`: `OPENRESTY_PROTOCOL="http://"` and `OPENRESTY_DOMAIN="localhost:9090"`. Be sure to confirm that these are accessible to you from `ApplicationConfig`, otherwise you won't be able to hit Nginx locally!!**

To test this out, you'll want 4 windows open in your terminal:
A. LFSS window with `docker-compose up` running
B. A window to make `curl` requests (to `HIT` the cached content)
C. A window with your `rails server` running
D. A window for your `rails console`

In window **B**, make a `curl` request to an article in your local environment like so:
```bash
➜  lfss git:(edge) curl -I http://localhost:9090/vaidehijoshi/vaidehi-s-test-post-1878
HTTP/1.1 200 OK
Server: openresty
Date: Thu, 17 Sep 2020 18:50:49 GMT
Content-Type: text/html; charset=utf-8
Connection: keep-alive
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Referrer-Policy: strict-origin-when-cross-origin
Cache-Control: public, no-cache
Surrogate-Control: max-age=86400, stale-if-error=26400
Surrogate-Key: articles/27
Vary: Accept-Encoding
ETag: W/"722b30c5411854b65c1f645c813b599d"
Content-Security-Policy: connect-src 'self' https: http://localhost:3035 ws://localhost:3035
X-Request-Id: 12d1ae7d-3ee5-4887-8661-659a927302ab
X-Runtime: 1.110368
X-Cache-Status: MISS
```
You should see a cache `MISS` from that request.

If you look at window **A**, you should also see a cache `MISS`:
```bash
➜  lfss git:(edge) docker-compose up
Starting openresty ... done

openresty    | 172.18.0.1 - - [17/Sep/2020:19:55:46 +0000] "HEAD /vaidehijoshi/vaidehi-s-test-post-1878 HTTP/1.1" 200 0 "-" "curl/7.54.0" "-" "MISS"
```

But, if you make that _same_ `curl` request again, you'll see that your `curl` request now responds with `X-Cache-Status: HIT`, and if you look at window **A** again, you'll see that you now are hitting the cached version of the content:
```bash
➜  lfss git:(edge) docker-compose up
Starting openresty ... done

openresty    | 172.18.0.1 - - [17/Sep/2020:19:55:46 +0000] "HEAD /vaidehijoshi/vaidehi-s-test-post-1878 HTTP/1.1" 200 0 "-" "curl/7.54.0" "-" "MISS"
openresty    | 172.18.0.1 - - [17/Sep/2020:19:56:18 +0000] "HEAD /vaidehijoshi/vaidehi-s-test-post-1878 HTTP/1.1" 200 0 "-" "curl/7.54.0" "-" "HIT"
```

Now, open up window **D**, your `rails console`, and directly invoke the `CacheBuster.bust`, passing in the _path to the article_ you have been `curl`ing to as the argument:
```bash
➜  forem git:(vaidehijoshi/split-edge-cache-bust-service) rails c
[1] pry(main)> CacheBuster.bust("/vaidehijoshi/vaidehi-s-test-post-1878")
=> #<EdgeCache::Service:0x00007fd6ce30aff0 @path="/vaidehijoshi/vaidehi-s-test-post-1878", @provider="nginx" @response="OK\n">
```

**Notice that, because you have the OPENRESTY env vars configured, you can see that the `EdgeCache::Service`, the return value of `CacheBuster.bust` has its `provider` listed as `"nginx"`, and it's `path` should be the article path that you passed to it.**


The request should complete successfully, and you should see the `PURGE` request come through in window **A**:
```bash
openresty    | 172.18.0.1 - - [17/Sep/2020:19:55:46 +0000] "HEAD /vaidehijoshi/vaidehi-s-test-post-1878 HTTP/1.1" 200 0 "-" "curl/7.54.0" "-" "MISS"
openresty    | 172.18.0.1 - - [17/Sep/2020:19:56:18 +0000] "HEAD /vaidehijoshi/vaidehi-s-test-post-1878 HTTP/1.1" 200 0 "-" "curl/7.54.0" "-" "HIT"
openresty    | 172.18.0.1 - - [17/Sep/2020:19:57:39 +0000] "GET / HTTP/1.1" 200 71174 "-" "Ruby" "-" "HIT"
openresty    | 172.18.0.1 - - [17/Sep/2020:19:57:39 +0000] "PURGE /vaidehijoshi/vaidehi-s-test-post-1878 HTTP/1.1" 200 13 "-" "Ruby" "-" "-"
```

Now, you can confirm that caching still works by `curl`ing to that same article again. You should see a `MISS` on the first `curl`, and a `HIT` on the second one:
```bash
openresty    | 172.18.0.1 - - [17/Sep/2020:19:57:39 +0000] "PURGE /vaidehijoshi/vaidehi-s-test-post-1878 HTTP/1.1" 200 13 "-" "Ruby" "-" "-"
openresty    | 172.18.0.1 - - [17/Sep/2020:19:59:19 +0000] "HEAD /vaidehijoshi/vaidehi-s-test-post-1878 HTTP/1.1" 200 0 "-" "curl/7.54.0" "-" "MISS"
openresty    | 172.18.0.1 - - [17/Sep/2020:19:59:20 +0000] "HEAD /vaidehijoshi/vaidehi-s-test-post-1878 HTTP/1.1" 200 0 "-" "curl/7.54.0" "-" "HIT"
```

Success!! 🎉 


You should also test that the `EdgeCache::Service` doesn't try to ping a caching provider unless it has been configured. To do this, you should _remove_ any `OPENRESTY_` env vars entirely, and restart your rails app/rails console. Then, you can test that busting that same article path results in no change:
```bash
➜  forem git:(vaidehijoshi/split-edge-cache-bust-service) ✗ rails c
Loading development environment (Rails 6.0.3.3)
[1] pry(main)> CacheBuster.bust("/vaidehijoshi/vaidehi-s-test-post-1878")
Unset ENV variable: OPENRESTY_PROTOCOL.
=> nil
```

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] ~no documentation needed~ inline documentation

## Are there any post deployment tasks we need to perform?

Make sure that Fastly behaves correctly with regards to purging caches on production!

## What gif best describes this PR or how it makes you feel?

![petting pretty hamster gif](https://media4.giphy.com/media/2SniIf9RfM95m/giphy.webp?cid=5a38a5a26135m7hechcztldp517f9qhcw0hrk7wjjylt7k50&rid=giphy.webp)
