### PR TITLE
Remove superfluous indexes on notifications

### DIFF
--- a/db/migrate/20201001154006_remove_superfluous_indexes_from_notifications.rb
+++ b/db/migrate/20201001154006_remove_superfluous_indexes_from_notifications.rb
@@ -1,0 +1,23 @@
+class RemoveSuperfluousIndexesFromNotifications < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    if index_exists?(:notifications, :organization_id)
+      remove_index :notifications, column: :organization_id, algorithm: :concurrently
+    end
+
+    if index_exists?(:notifications, :user_id)
+      remove_index :notifications, column: :user_id, algorithm: :concurrently
+    end
+  end
+
+  def down
+    unless index_exists?(:notifications, :organization_id)
+      add_index :notifications, :organization_id, algorithm: :concurrently
+    end
+
+    unless index_exists?(:notifications, :user_id)
+      add_index :notifications, :user_id, algorithm: :concurrently
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_21_160153) do
+ActiveRecord::Schema.define(version: 2020_10_01_154006) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -714,11 +714,9 @@ ActiveRecord::Schema.define(version: 2020_09_21_160153) do
     t.index ["notified_at"], name: "index_notifications_on_notified_at"
     t.index ["organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_org_notifiable_and_action_not_null", unique: true, where: "(action IS NOT NULL)"
     t.index ["organization_id", "notifiable_id", "notifiable_type"], name: "index_notifications_on_org_notifiable_action_is_null", unique: true, where: "(action IS NULL)"
-    t.index ["organization_id"], name: "index_notifications_on_organization_id"
     t.index ["user_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_user_notifiable_and_action_not_null", unique: true, where: "(action IS NOT NULL)"
     t.index ["user_id", "notifiable_id", "notifiable_type"], name: "index_notifications_on_user_notifiable_action_is_null", unique: true, where: "(action IS NULL)"
     t.index ["user_id", "organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_user_id_organization_id_notifiable_action", unique: true
-    t.index ["user_id"], name: "index_notifications_on_user_id"
   end
 
   create_table "oauth_access_grants", force: :cascade do |t|


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We have quite a few indexes in the DB and some of them are overlapping. With the help of the [Removing Extraneous Indexes](https://github.com/gregnavis/active_record_doctor#removing-extraneous-indexes) and `EXPLAIN ANALYZE` I confirmed we can remove a few indexes. I'm going to start with likely two biggest ones, on `notifications`:

```text
  index_notifications_on_organization_id (can be handled by index_notifications_on_org_notifiable_action_is_null, index_notifications_on_org_notifiable_and_action_not_null)
  index_notifications_on_user_id (can be handled by index_notifications_on_user_notifiable_action_is_null, index_notifications_on_user_notifiable_and_action_not_null, index_notifications_user_id_organization_id_notifiable_action)
```

this is the output from the tool.

These two indexes are 39 GB each, see https://dev.to/admin/blazer/queries/225-indexes-sizes, so we should be saving around 78GB by dropping them.

**Rationale**: PostgreSQL is smart enough to use a composite index (an index on multiple columns) instead of an index on a single column if only a column is selected. Basically `select * from notifications where organization_id = 1` now uses `index_notifications_on_organization_id` but if you drop it you'll get the following plan:

```sql
PracticalDeveloper_development> explain analyze select * from notifications where organization_id = 1;
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                           |
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Bitmap Heap Scan on notifications  (cost=7.52..12.86 rows=2 width=153) (actual time=0.005..0.006 rows=0 loops=1)                                                     |
|   Recheck Cond: (organization_id = 1)                                                                                                                                |
|   ->  Bitmap Index Scan on index_notifications_user_id_organization_id_notifiable_action  (cost=0.00..7.52 rows=2 width=0) (actual time=0.001..0.001 rows=0 loops=1) |
|         Index Cond: (organization_id = 1)                                                                                                                            |
| Planning Time: 4.285 ms                                                                                                                                              |
| Execution Time: 0.029 ms                                                                                                                                             |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

as you can see the DB is now using `index_notifications_user_id_organization_id_notifiable_action` to achieve the same result.

Same applies to `index_notifications_on_user_id`

## QA Instructions, Screenshots, Recordings

1. fire up `master`
1. open `psql PracticalDeveloper_development` in the terminal
1. run ` set enable_seqscan=false;` to disable sequential scan (which is likely going to happen because locally you have a few rows)
1. run `explain analyze select * from notifications where organization_id = 1;` (or the equivalent for `user_id`)
1. at this point you should get a query plan which mentions `index_notifications_on_organization_id`
1. switch to this branch and run the migration
1. run `explain analyze select * from notifications where organization_id = 1;` (or the equivalent for `user_id`)
1. at this point the index `index_notifications_user_id_organization_id_notifiable_action` should appear in the query plan

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help
