### PR TITLE
Fixes 500 error when viewing the "Tag Mods" page without having the role on the database

### DIFF
--- a/app/queries/admin/moderators_query.rb
+++ b/app/queries/admin/moderators_query.rb
@@ -24,7 +24,7 @@ module Admin
     end
 
     def self.role_id_for(role)
-      Role.find_by!(name: role).id
+      Role.find_by(name: role)&.id
     end
 
     def self.search_relation(relation, search)

--- a/app/views/admin/mods/index.html.erb
+++ b/app/views/admin/mods/index.html.erb
@@ -19,40 +19,43 @@
     <%= f.submit "Search", class: "btn btn-light" %>
   <% end %>
 </div>
+<% if @mods.empty? %>
+    <div class="alert alert-warning">There are no mods matching your search criteria.</div>
+<% else %>
+  <%= paginate @mods, theme: "internal" %>
 
-<%= paginate @mods, theme: "internal" %>
-
-<table class="crayons-table" width="100%">
-  <thead>
-    <tr>
-      <th scope="col">ID</th>
-      <th scope="col">Profile</th>
-      <th scope="col">Comments</th>
-      <th scope="col">Badges</th>
-      <th scope="col">Last Comment</th>
-      <% if params[:state] == "potential" %>
-        <th scope="col">Action</th>
-      <% end %>
-    </tr>
-  </thead>
-  <tbody class="crayons-card">
-    <% @mods.each do |mod| %>
+  <table class="crayons-table" width="100%">
+    <thead>
       <tr>
-        <td><%= mod.id %></td>
-        <td><%= link_to mod.username, admin_user_path(mod.id) %></td>
-        <td><%= mod.comments_count %></td>
-        <td><%= mod.badge_achievements_count %></td>
-        <td><%= time_ago_in_words mod.last_comment_at %> ago</td>
+        <th scope="col">ID</th>
+        <th scope="col">Profile</th>
+        <th scope="col">Comments</th>
+        <th scope="col">Badges</th>
+        <th scope="col">Last Comment</th>
         <% if params[:state] == "potential" %>
-          <td>
-            <%= form_with model: [:admin, mod], url: admin_mod_path(mod.id), method: :patch, local: true do |f| %>
-              <%= f.submit "Make Trusted Mod", class: "btn btn-light js-add-to-mod-channel" %>
-            <% end %>
-          </td>
+          <th scope="col">Action</th>
         <% end %>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody class="crayons-card">
+      <% @mods.each do |mod| %>
+        <tr>
+          <td><%= mod.id %></td>
+          <td><%= link_to mod.username, admin_user_path(mod.id) %></td>
+          <td><%= mod.comments_count %></td>
+          <td><%= mod.badge_achievements_count %></td>
+          <td><%= time_ago_in_words mod.last_comment_at %> ago</td>
+          <% if params[:state] == "potential" %>
+            <td>
+              <%= form_with model: [:admin, mod], url: admin_mod_path(mod.id), method: :patch, local: true do |f| %>
+                <%= f.submit "Make Trusted Mod", class: "btn btn-light js-add-to-mod-channel" %>
+              <% end %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 
-<%= paginate @mods, theme: "internal" %>
+  <%= paginate @mods, theme: "internal" %>
+<% end %>

--- a/spec/queries/admin/moderators_query_spec.rb
+++ b/spec/queries/admin/moderators_query_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Admin::ModeratorsQuery, type: :query do
     context "when state does not exist" do
       let(:options) { { state: "non_existent_role" } }
 
-      it { within_block_is_expected.to raise_error(ActiveRecord::RecordNotFound) }
+      it { is_expected.to match_array([]) }
     end
   end
 end

--- a/spec/requests/admin/mods_spec.rb
+++ b/spec/requests/admin/mods_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe "/admin/mods", type: :request do
       end
     end
 
+    context "when the are no matching mods" do
+      it "displays an warning" do
+        get "/admin/mods?search=no-results&state=tag_moderator"
+        expect(response.body).to include("There are no mods matching your search criteria")
+      end
+    end
+
     it "displays mod user" do
       get "/admin/mods"
       expect(response.body).to include(moderator.username)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I think that the issue (#10060) is self-explanatory. What was happening with @msarit was that she was visiting the `/admin/mods?state=tag_moderator` without having a role named `tag_moderator` on the database.

The query class explicitly "blew up" in this condition. I tried to follow the approach proposed by @Zhao-Andy:

1. The query class now doesn't raise an exception in the scenario above. Instead returns an empty result set

1. The mods page now returns a generic "there are mods matching your search" warning if there are no mods matching the query

## Related Tickets & Documents

#10060 

## QA Instructions, Screenshots, Recordings

1. Go to the `/admin/mods` page
1. Search by a random text string which yields no results and see that a "no results" message is rendered

1. Delete the `tag_moderator` role from your database (`Role.find_by(name: "tag_moderator").delete`)
1. Go to `/admin/mods?state=tag_moderator`
1. See that a "no results" message is rendered

![image](https://user-images.githubusercontent.com/1484824/94843113-29148600-0414-11eb-84a9-1c1df3f30303.png)


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
