### PR TITLE
Disable autoplay on native videos

### DIFF
--- a/app/assets/javascripts/initializers/initializeVideoPlayback.js
+++ b/app/assets/javascripts/initializers/initializeVideoPlayback.js
@@ -72,7 +72,6 @@ function initializeVideoPlayback() {
         playerInstance.setup({
           file: metadata.video_source_url,
           mediaid: metadata.video_code,
-          autostart: true,
           image: metadata.video_thumbnail_url,
           playbackRateControls: true,
           tracks: [
@@ -85,9 +84,6 @@ function initializeVideoPlayback() {
           ],
         });
         if (seconds) {
-          jwplayer().on('ready', function (event) {
-            jwplayer().play();
-          });
           jwplayer().on('firstFrame', function () {
             jwplayer().seek(seconds);
           });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature? or is it
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I'm not sure it 100% closes #6067 because the issue refers to a user setting for video autoplay.

The general consensus, for the moment, was to simply disable autoplay.

The `autostart` value was removed since [it defaults to false](https://developer.jwplayer.com/jwplayer/docs/jw8-javascript-api-reference#section-jwplayer-set-config), and the `play()` on `ready` was also removed.

## Related Tickets & Documents

#6067 

## QA Instructions, Screenshots, Recordings

* Load up any article with a native video
* Verify that it doesn't autoplay

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed