### PR TITLE
Optimization:Dont Notify of Channel Leavings

### DIFF
--- a/app/controllers/chat_channel_memberships_controller.rb
+++ b/app/controllers/chat_channel_memberships_controller.rb
@@ -276,7 +276,7 @@ class ChatChannelMembershipsController < ApplicationController
     temp_message_id = (0...20).map { ("a".."z").to_a[rand(8)] }.join
     message = Message.create("message_markdown" => message, "user_id" => user.id, "chat_channel_id" => channel_id,
                              "chat_action" => action)
-    pusher_message_created(false, message, temp_message_id) unless action == "removed_from_channel"
+    pusher_message_created(false, message, temp_message_id) unless message.left_channel?
   end
 
   def user_not_authorized

--- a/app/controllers/chat_channel_memberships_controller.rb
+++ b/app/controllers/chat_channel_memberships_controller.rb
@@ -276,7 +276,7 @@ class ChatChannelMembershipsController < ApplicationController
     temp_message_id = (0...20).map { ("a".."z").to_a[rand(8)] }.join
     message = Message.create("message_markdown" => message, "user_id" => user.id, "chat_channel_id" => channel_id,
                              "chat_action" => action)
-    pusher_message_created(false, message, temp_message_id)
+    pusher_message_created(false, message, temp_message_id) unless action == "removed_from_channel"
   end
 
   def user_not_authorized

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -23,6 +23,10 @@ class Message < ApplicationRecord
     chat_channel.users.where.not(id: user.id).first
   end
 
+  def left_channel?
+    chat_action == "removed_from_channel" || chat_action == "left_channel"
+  end
+
   private
 
   def update_chat_channel_last_message_at
@@ -31,6 +35,8 @@ class Message < ApplicationRecord
   end
 
   def update_all_has_unopened_messages_statuses
+    return if left_channel?
+
     chat_channel
       .chat_channel_memberships
       .where("last_opened_at < ?", 10.seconds.ago)

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -147,6 +147,23 @@ RSpec.describe Message, type: :model do
     end
   end
 
+  describe "#left_channel?" do
+    it "returns true if chat_action is removed_from_channel" do
+      message.chat_action = "removed_from_channel"
+      expect(message.left_channel?).to eq(true)
+    end
+
+    it "returns true if chat_action is left_channel" do
+      message.chat_action = "left_channel"
+      expect(message.left_channel?).to eq(true)
+    end
+
+    it "returns false if chat_action is NOT removed_from_channel" do
+      message.chat_action = "joined"
+      expect(message.left_channel?).to eq(false)
+    end
+  end
+
   describe "#after_create" do
     it "enqueues ChatChannels::IndexesMembershipsWorker" do
       chat_channel.add_users([user])
@@ -155,6 +172,24 @@ RSpec.describe Message, type: :model do
       create(:message, chat_channel: chat_channel, user: user)
 
       expect(ChatChannels::IndexesMembershipsWorker).to have_received(:perform_async)
+    end
+
+    context "when chat_action is left_channel" do
+      it "does not update unopened message statuses" do
+        chat_channel.add_users([user, user2])
+        create(:message, chat_channel: chat_channel, user: user, chat_action: "left_channel")
+
+        expect(user2.chat_channel_memberships.pluck(:has_unopened_messages).all?(false)).to eq(true)
+      end
+    end
+
+    context "when chat_action is NOT left_channel" do
+      it "updates unopened message statuses" do
+        chat_channel.add_users([user, user2])
+        create(:message, chat_channel: chat_channel, user: user)
+
+        expect(user2.chat_channel_memberships.pluck(:has_unopened_messages).all?(true)).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
I find that notifications when people leave a channel, especially big group channels like CodeNewbie are super noisy and not helpful. This would skip sending push notifications for any "removed_from_channel" actions. What do you all think?

![alt_text](https://media.tenor.com/images/075339fda837f16e31b6741e5f595174/tenor.gif)
