### PR TITLE
Spec Fix:Dont Reuse Same Username and Let Factory Set Title

### DIFF
--- a/spec/system/user/view_user_index_spec.rb
+++ b/spec/system/user/view_user_index_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
 RSpec.describe "User index", type: :system, stub_elasticsearch: true do
-  let!(:user) { create(:user, username: "user3000") }
+  let!(:user) { create(:user) }
   let!(:article) { create(:article, user: user) }
-  let!(:other_article) { create(:article, title: rand(10_000_000).to_s) }
+  let!(:other_article) { create(:article) }
   let!(:comment) { create(:comment, user: user, commentable: other_article) }
   let(:organization) { create(:organization) }
 
   context "when user is unauthorized" do
     context "when 1 article" do
-      before { visit "/user3000" }
+      before { visit "/#{user.username}" }
 
       it "shows the header", js: true do
         within("h1") { expect(page).to have_content(user.name) }
@@ -63,7 +63,7 @@ RSpec.describe "User index", type: :system, stub_elasticsearch: true do
   context "when user has an organization membership" do
     before do
       user.organization_memberships.create(organization: organization, type_of_user: "member")
-      visit "/user3000"
+      visit "/#{user.username}"
     end
 
     it "shows organizations", js: true do
@@ -75,7 +75,7 @@ RSpec.describe "User index", type: :system, stub_elasticsearch: true do
   context "when visiting own profile" do
     before do
       sign_in user
-      visit "/user3000"
+      visit "/#{user.username}"
     end
 
     it "shows the header", js: true do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
Couple issues I noticed in this spec while working with it in docker.
1) Sometimes I would get invalid user errors bc of the repeated username. Not sure why that would happen with transactions but this ensures that it never will bc the factory will set a unique username for us.
2) Let Factory for article set a unique title instead of us setting it and risking a duplicate. 


![alt_text](https://media0.giphy.com/media/cCbf4ryl0UQWBwOLiQ/200.gif)
