### PR TITLE
Slack notification with reminder to delete user gdpr data

### DIFF
--- a/app/services/slack/messengers/user_deleted.rb
+++ b/app/services/slack/messengers/user_deleted.rb
@@ -1,0 +1,39 @@
+module Slack
+  module Messengers
+    class UserDeleted
+      MESSAGE_TEMPLATE = <<~TEXT.chomp.freeze
+        %<name>s (%<user_url>s)
+        self-deleted their account.
+        Please, delete them from Mailchimp & Google Analytics.
+      TEXT
+
+      def initialize(name:, user_url:)
+        @name = name
+        @user_url = user_url
+      end
+
+      def self.call(*args)
+        new(*args).call
+      end
+
+      def call
+        message = format(
+          MESSAGE_TEMPLATE,
+          name: name,
+          user_url: user_url,
+        )
+
+        Slack::Messengers::Worker.perform_async(
+          message: message,
+          channel: "user-deleted",
+          username: "user_deleted_bot",
+          icon_emoji: ":scissors:",
+        )
+      end
+
+      private
+
+      attr_reader :name, :user_url
+    end
+  end
+end

--- a/app/workers/users/delete_worker.rb
+++ b/app/workers/users/delete_worker.rb
@@ -15,6 +15,9 @@ module Users
       # thus we pass the data we need to render to deliver the email, not the
       # whole object
       NotifyMailer.with(name: user.name, email: user.email).account_deleted_email.deliver_now
+
+      # notify admins about self-delete
+      Slack::Messengers::UserDeleted.call(name: user.name, user_url: URL.user(user))
     rescue StandardError => e
       DatadogStatsClient.count("users.delete", 1, tags: ["action:failed", "user_id:#{user.id}"])
       Honeybadger.context({ user_id: user.id })

--- a/spec/services/slack/messengers/user_deleted_spec.rb
+++ b/spec/services/slack/messengers/user_deleted_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Slack::Messengers::UserDeleted, type: :service do
+  let(:user) { build(:user) }
+
+  let(:default_params) do
+    {
+      name: user.name,
+      user_url: URL.user(user)
+    }
+  end
+
+  it "contains the correct info", :aggregate_failures do
+    sidekiq_assert_enqueued_jobs(1, only: Slack::Messengers::Worker) do
+      described_class.call(default_params)
+    end
+
+    job = sidekiq_enqueued_jobs(worker: Slack::Messengers::Worker).last
+    message = job["args"].first["message"]
+
+    expect(message).to include("self-deleted their account")
+    expect(message).to include(URL.user(user))
+  end
+
+  it "messages the proper channel with the proper username and emoji", :aggregate_failures do
+    sidekiq_assert_enqueued_jobs(1, only: Slack::Messengers::Worker) do
+      described_class.call(default_params)
+    end
+
+    job = sidekiq_enqueued_jobs(worker: Slack::Messengers::Worker).last
+    job_args = job["args"].first
+
+    expect(job_args["channel"]).to eq("user-deleted")
+    expect(job_args["username"]).to eq("user_deleted_bot")
+    expect(job_args["icon_emoji"]).to eq(":scissors:")
+  end
+end

--- a/spec/workers/users/delete_worker_spec.rb
+++ b/spec/workers/users/delete_worker_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Users::DeleteWorker, type: :worker do
   let(:mailer_class) { NotifyMailer }
   let(:mailer) { double }
   let(:message_delivery) { double }
+  let(:slack_messenger_class) { Slack::Messengers::UserDeleted }
+  let(:slack_messenger) { double }
 
   describe "#perform" do
     let!(:user) { create(:user) }
@@ -45,6 +47,18 @@ RSpec.describe Users::DeleteWorker, type: :worker do
         expect(mailer_class).to have_received(:with).with(name: user.name, email: user.email)
         expect(mailer).to have_received(:account_deleted_email)
         expect(message_delivery).to have_received(:deliver_now)
+      end
+
+      it "sends the gdpr notification" do
+        allow(slack_messenger_class).to receive(:call)
+        worker.perform(user.id)
+        expect(slack_messenger_class).to have_received(:call).with(name: user.name, user_url: URL.user(user))
+      end
+
+      it "doesn't send the gdpr notification for admin triggered deletion" do
+        allow(slack_messenger_class).to receive(:call)
+        worker.perform(user.id, true)
+        expect(slack_messenger_class).not_to have_received(:call)
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Send a slack notification to remind to delete gdpr data when a user deletes their account.

## Related Tickets & Documents
https://github.com/forem/forem/projects/31#card-45606967

## QA Instructions, Screenshots, Recordings
- self delete the user
- see if a relevant slack message appeared in the #user-deleted slack channel

## Added tests?

- [x] yes