### PR TITLE
Taniyah l jackson/pinned comments on articles

### DIFF
--- a/app/models/profile_pin.rb
+++ b/app/models/profile_pin.rb
@@ -1,4 +1,4 @@
-class GenericPins < ApplicationRecord #migrate later
+class ProfilePin < ApplicationRecord 
   belongs_to :pinnable, polymorphic: true
   belongs_to :profile, polymorphic: true
 
@@ -11,6 +11,21 @@ class GenericPins < ApplicationRecord #migrate later
   validate :article_to_article
 
   private
+
+  #Pseudo for a list of pinned comments on an article
+  #could possibly be recycled for going through a list of pinned articles
+  index = 0
+  display current profile_pins[index]
+
+  def BrowsePinsList
+    increase index by 1
+    scroll to new profile_pins[index] 
+
+    if profile_pins[index] reaches end of profile_pins length:
+      reset index or return
+    end
+  end    
+  #-----------------------------------------------------------------
 
   def only_five_pins_per_profile
     errors.add(:base, "cannot have more than five total pinned posts") if profile.profile_pins.size > 4

--- a/app/models/profile_pin.rb
+++ b/app/models/profile_pin.rb
@@ -8,6 +8,7 @@ class GenericPins < ApplicationRecord #migrate later
   validates :pinnable_type, inclusion: { in: %w[Article Comment] } # Future could be comments, etc.
   validate :only_five_pins_per_profile, on: :create
   validate :pinnable_belongs_to_profile
+  validate :article_to_article
 
   private
 

--- a/app/models/profile_pin.rb
+++ b/app/models/profile_pin.rb
@@ -1,11 +1,11 @@
-class ProfilePin < ApplicationRecord
+class GenericPins < ApplicationRecord #migrate later
   belongs_to :pinnable, polymorphic: true
   belongs_to :profile, polymorphic: true
 
   validates :profile_id, presence: true
-  validates :profile_type, inclusion: { in: %w[User] } # Future could be organization, tag, etc.
+  validates :profile_type, inclusion: { in: %w[User Article] } # Future could be organization, tag, etc.
   validates :pinnable_id, presence: true, uniqueness: { scope: %i[profile_id profile_type pinnable_type] }
-  validates :pinnable_type, inclusion: { in: %w[Article] } # Future could be comments, etc.
+  validates :pinnable_type, inclusion: { in: %w[Article Comment] } # Future could be comments, etc.
   validate :only_five_pins_per_profile, on: :create
   validate :pinnable_belongs_to_profile
 
@@ -17,5 +17,10 @@ class ProfilePin < ApplicationRecord
 
   def pinnable_belongs_to_profile
     errors.add(:pinnable_id, "must have proper permissions for pin") if pinnable.user_id != profile_id
+  end
+
+  # If profile_type && pinnable_type = Article
+  def article_to_article
+    errors.add(:parent_type, "cannot pin articles to each other") if pinnable_type == profile_type
   end
 end


### PR DESCRIPTION
Afternoon! I wanted to ask about the possibility of using a scroll feature. Instead of having the comments surface to the top, the page could scroll to the targeted comment based on an event.  The setup for the front-end could look like a pdf word search, except the search bar could be replaced with '1 out of 5 pins' and updates with the event trigger. I'm aware that it may be a detour from the original idea, but hopefully the approach is similar. Would this be safer and user-friendly or difficult and confusing?