### PR TITLE
Remove tabindex of -1 on upload image input in the write a post editor

### DIFF
--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -68,7 +68,8 @@
   &[href]:focus,
   &:hover:enabled,
   &:active:enabled,
-  &:focus:enabled {
+  &:focus:enabled,
+  &:focus-within {
     background-color: var(--bg-hover);
     border-color: var(--border-hover);
     box-shadow: var(--shadow-hover);

--- a/app/javascript/article-form/components/ImageUploader.jsx
+++ b/app/javascript/article-form/components/ImageUploader.jsx
@@ -146,7 +146,6 @@ export const ImageUploader = () => {
             multiple
             accept="image/*"
             data-max-file-size-mb="25"
-            tabIndex="-1"
             aria-label="Upload an image"
           />
         </Button>

--- a/app/javascript/article-form/components/ImageUploader.jsx
+++ b/app/javascript/article-form/components/ImageUploader.jsx
@@ -135,6 +135,7 @@ export const ImageUploader = () => {
           variant="ghost"
           contentType="icon-left"
           icon={ImageIcon}
+          tabIndex="-1"
         >
           Upload image
           <input

--- a/app/javascript/article-form/components/ImageUploader.jsx
+++ b/app/javascript/article-form/components/ImageUploader.jsx
@@ -135,7 +135,6 @@ export const ImageUploader = () => {
           variant="ghost"
           contentType="icon-left"
           icon={ImageIcon}
-          tabIndex="-1"
         >
           Upload image
           <input


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
In the "Write a post" editor, the "Upload Image" button is skipped while tabbing i.e. while navigating with a keyboard, making it inaccessible to keyboard users. This happens due to the tabindex of -1 set on the "Upload Image" input element. Removing it enables tabbing, thus solving the issue.

## Related Tickets & Documents

Resolves #10521 (second part of the issue) 

[This](https://webaim.org/techniques/keyboard/tabindex) article talks more about how a tabindex of -1 on HTML elements that need to be interacted with, makes them inaccessible to keyboard users

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed