### PR TITLE
Allow glitch id starting with ~

### DIFF
--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -2,7 +2,8 @@ class GlitchTag < LiquidTagBase
   attr_accessor :uri
 
   PARTIAL = "liquids/glitch".freeze
-  ID_REGEXP = /\A~*[a-zA-Z0-9\-]{1,110}\z/.freeze
+  ID_REGEXP = /\A[a-zA-Z0-9\-]{1,110}\z/.freeze
+  TILDE_PREFIX_REGEXP = /\A~*/.freeze
   OPTION_REGEXP = /(app|code|no-files|preview-first|no-attribution|file=\w(\.\w)?)/.freeze
   OPTIONS_TO_QUERY_PAIR = {
     "app" => %w[previewSize 100],
@@ -36,6 +37,7 @@ class GlitchTag < LiquidTagBase
 
   def parse_id(input)
     id = input.split(" ").first
+    id.gsub!(TILDE_PREFIX_REGEXP, '')
     raise StandardError, "Invalid Glitch ID" unless valid_id?(id)
 
     id

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -3,7 +3,7 @@ class GlitchTag < LiquidTagBase
 
   PARTIAL = "liquids/glitch".freeze
   ID_REGEXP = /\A[a-zA-Z0-9\-]{1,110}\z/.freeze
-  TILDE_PREFIX_REGEXP = /\A~*/.freeze
+  TILDE_PREFIX_REGEXP = /\A~/.freeze
   OPTION_REGEXP = /(app|code|no-files|preview-first|no-attribution|file=\w(\.\w)?)/.freeze
   OPTIONS_TO_QUERY_PAIR = {
     "app" => %w[previewSize 100],
@@ -37,7 +37,7 @@ class GlitchTag < LiquidTagBase
 
   def parse_id(input)
     id = input.split(" ").first
-    id.gsub!(TILDE_PREFIX_REGEXP, "")
+    id.sub!(TILDE_PREFIX_REGEXP, "")
     raise StandardError, "Invalid Glitch ID" unless valid_id?(id)
 
     id

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -37,7 +37,7 @@ class GlitchTag < LiquidTagBase
 
   def parse_id(input)
     id = input.split(" ").first
-    id.gsub!(TILDE_PREFIX_REGEXP, '')
+    id.gsub!(TILDE_PREFIX_REGEXP, "")
     raise StandardError, "Invalid Glitch ID" unless valid_id?(id)
 
     id

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -2,7 +2,7 @@ class GlitchTag < LiquidTagBase
   attr_accessor :uri
 
   PARTIAL = "liquids/glitch".freeze
-  ID_REGEXP = /\A[a-zA-Z0-9\-]{1,110}\z/.freeze
+  ID_REGEXP = /\A~*[a-zA-Z0-9\-]{1,110}\z/.freeze
   OPTION_REGEXP = /(app|code|no-files|preview-first|no-attribution|file=\w(\.\w)?)/.freeze
   OPTIONS_TO_QUERY_PAIR = {
     "app" => %w[previewSize 100],

--- a/spec/liquid_tags/glitch_tag_spec.rb
+++ b/spec/liquid_tags/glitch_tag_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe GlitchTag, type: :liquid_tag do
 
   describe "#id" do
     let(:valid_id) { "BXgGcAUjM39" }
-    let(:id_starting_with_tilde) { "~some-id" }
-    let(:id_with_tilde_in_the_middle) { "some~id" }
     let(:id_with_quotes) { 'some-id" onload="alert(42)"' }
     let(:id_with_app_option) { "some-id app" }
     let(:id_with_code_option) { "some-id code" }
@@ -17,18 +15,11 @@ RSpec.describe GlitchTag, type: :liquid_tag do
     let(:id_with_file_option) { "some-id file=script.js" }
     let(:id_with_app_and_code_option) { "some-id app code" }
     let(:id_with_many_options) { "some-id app no-attribution no-files file=script.js" }
+    let(:id_starting_with_tilde) { "~some-id" }
 
     def generate_tag(id)
       Liquid::Template.register_tag("glitch", GlitchTag)
       Liquid::Template.parse("{% glitch #{id} %}")
-    end
-
-    it "accepts a id starting with tilde" do
-      expect { generate_tag(id_starting_with_tilde) }.not_to raise_error
-    end
-
-    it "does not accept ids with tilde in the middle" do
-      expect { generate_tag(id_with_tilde_in_the_middle) }.to raise_error(StandardError)
     end
 
     it "accepts a valid id" do
@@ -83,6 +74,12 @@ RSpec.describe GlitchTag, type: :liquid_tag do
 
     it "'app' and 'code' cancel each other" do
       template = generate_tag(id_with_app_and_code_option)
+      expected = "src=\"#{base_uri}some-id?path=index.html"
+      expect(template.render(nil)).to include(expected)
+    end
+
+    it "removes the tilde prefix of ids" do
+      template = generate_tag(id_starting_with_tilde)
       expected = "src=\"#{base_uri}some-id?path=index.html"
       expect(template.render(nil)).to include(expected)
     end

--- a/spec/liquid_tags/glitch_tag_spec.rb
+++ b/spec/liquid_tags/glitch_tag_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe GlitchTag, type: :liquid_tag do
 
   describe "#id" do
     let(:valid_id) { "BXgGcAUjM39" }
+    let(:id_starting_with_tilde) { "~some-id" }
+    let(:id_with_tilde_in_the_middle) { "some~id" }
     let(:id_with_quotes) { 'some-id" onload="alert(42)"' }
     let(:id_with_app_option) { "some-id app" }
     let(:id_with_code_option) { "some-id code" }
@@ -19,6 +21,14 @@ RSpec.describe GlitchTag, type: :liquid_tag do
     def generate_tag(id)
       Liquid::Template.register_tag("glitch", GlitchTag)
       Liquid::Template.parse("{% glitch #{id} %}")
+    end
+
+    it "accepts a id starting with tilde" do
+      expect { generate_tag(id_starting_with_tilde) }.not_to raise_error
+    end
+
+    it "does not accept ids with tilde in the middle" do
+      expect { generate_tag(id_with_tilde_in_the_middle) }.to raise_error(StandardError)
     end
 
     it "accepts a valid id" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
~This PR improved the regex that is used to validate the glitch id to allow ids starting with `~`.~
This PR improves the `parse_id` method to remove any prefixed `~` before passing it to the template. 

## Related Tickets & Documents
resolves #10427

## QA Instructions, Screenshots, Recordings
Create a new blog post, add `{% glitch ~the-super-tiny-compiler %}` and save -> no validation error should appear.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

