### PR TITLE
Document overriding mailer templates

### DIFF
--- a/docs/backend/emails.md
+++ b/docs/backend/emails.md
@@ -1,0 +1,13 @@
+---
+title: Emails
+---
+
+# Previewing emails in development
+
+You can view email previews at <http://localhost:3000/rails/mailers>.
+
+Previews are setup in the directory `spec/mailers/previews`.
+
+# Overriding mailer templates
+
+To update the contents of emails that the app sends, edit the views under `app/views/mailers`. Note that this app uses the [`devise_invitable` gem](https://github.com/scambra/devise_invitable) for invitations. The views for this gem are stored under `app/views/devise/mailer`.

--- a/docs/backend/previewing-emails.md
+++ b/docs/backend/previewing-emails.md
@@ -1,9 +1,0 @@
----
-title: Previewing Emails
----
-
-# Previewing emails in development
-
-You can view email previews at <http://localhost:3000/rails/mailers>.
-
-Previews are setup in the directory `spec/mailers/previews`.

--- a/docs/backend/readme.md
+++ b/docs/backend/readme.md
@@ -10,12 +10,12 @@ items:
   - configuration.md
   - data-update-scripts.md
   - elasticsearch.md
+  - emails.md
   - fastly.md
   - internationalization.md
   - roles.md
   - pusher.md
   - resource-admin.md
-  - previewing-emails.md
   - notification.md
   - scheduled-jobs.md
   - metrics.md


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Updates documentation relating to emails. In particular, documents how the mailer views can be overridden, especially for `devise_invitable`.

While working on this, I identified that there aren't mailer previews for `devise_invitable` (#10575).

## Related Tickets & Documents

#9849 

## QA Instructions, Screenshots, Recordings

Edit the contents of a mailer view under the given directories, and check the mailer previews to make sure they make sense.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.forem.com
- [ ] readme
- [ ] no documentation needed
