### PR TITLE
Remove code link style so it uses the default link color

### DIFF
--- a/app/assets/stylesheets/base/typography.scss
+++ b/app/assets/stylesheets/base/typography.scss
@@ -64,10 +64,6 @@ body {
   font-family: var(--content-font-family);
 
   a {
-    code {
-      color: var(--link-color);
-    }
-
     &.anchor {
       padding-top: 0;
       margin-top: 0;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently, the link color for the `code` element within articles is very similar to the color for normal `code` elements, making it hard to distinguish what is a link and what isn't. My solution is to remove the style that defines `code` links, so that it falls back to default color for links.

## Related Tickets & Documents

Fixes #9603

## QA Instructions, Screenshots, Recordings

### Screenshots (changes outlined in red box)

**Before**
<img width="514" alt="Screen Shot 2020-10-04 at 2 46 33 PM" src="https://user-images.githubusercontent.com/3276350/95024656-8bf36080-0652-11eb-92ff-5bd27177e3f4.png">

**After**
<img width="514" alt="Screen Shot 2020-10-04 at 2 43 40 PM" src="https://user-images.githubusercontent.com/3276350/95024658-93b30500-0652-11eb-8bd5-821107571c6b.png">

### Steps

Make an article with the following content:

```
<a href="https://www.php.net/manual/en/function.system.php"><code>system()</code></a>

<code>system()</code>

[`My Example`](https://example.com/)
```

First and third elements should have the blue link color (or whatever `--link-brand-color` var is set to)
The second element should be black color (assuming `--color-body-color` was not changed by the tester)

**edit:** Additional test case:

putting this in an article:
```
`My Example`
```
should still render default black color for `code` elements.


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
