### PR TITLE
Update BatchRewarder::REPOSITORIES

### DIFF
--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -2,9 +2,9 @@ module BadgeRewarder
   YEARS = { 1 => "one", 2 => "two", 3 => "three", 4 => "four", 5 => "five", 6 => "six", 7 => "seven" }.freeze
   REPOSITORIES = [
     "forem/forem",
-    "thepracticaldev/DEV-ios",
-    "thepracticaldev/DEV-Android",
     "forem/forem-browser-extension",
+    "thepracticaldev/DEV-Android",
+    "thepracticaldev/DEV-ios",
   ].freeze
 
   LONGEST_STREAK_WEEKS = 16

--- a/app/labor/badge_rewarder.rb
+++ b/app/labor/badge_rewarder.rb
@@ -1,6 +1,11 @@
 module BadgeRewarder
   YEARS = { 1 => "one", 2 => "two", 3 => "three", 4 => "four", 5 => "five", 6 => "six", 7 => "seven" }.freeze
-  REPOSITORIES = ["thepracticaldev/dev.to", "thepracticaldev/DEV-ios", "thepracticaldev/DEV-Android"].freeze
+  REPOSITORIES = [
+    "forem/forem",
+    "thepracticaldev/DEV-ios",
+    "thepracticaldev/DEV-Android",
+    "forem/forem-browser-extension",
+  ].freeze
 
   LONGEST_STREAK_WEEKS = 16
   LONGEST_STREAK_MESSAGE = "16 weeks! You've achieved the longest writing " \


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While looking at #10064 I realized that we never updated `BatchRewarder::REPOSITORIES` to reflect the move from `ThePracticalDev/dev.to` to `forem/forem`. I also added `forem/forem-browser-extension` since it's open-source and had external contributions already.

## Related Tickets & Documents

Related to #10064 

## QA Instructions, Screenshots, Recordings

n/a

## Added tests?

- [ ] yes
- [X] no, because they aren't needed (the existing tests stub the constant so the actual value is not important)
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
