### PR TITLE
Don't use "not_to raise_error" with specific class

### DIFF
--- a/spec/labor/markdown_parser_spec.rb
+++ b/spec/labor/markdown_parser_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe MarkdownParser, type: :labor do
     it "does not raise error if no XSS attempt detected" do
       expect do
         generate_and_parse_markdown("```const data = 'data:text/html';```")
-      end.not_to raise_error(ArgumentError)
+      end.not_to raise_error
     end
   end
 

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe LinkTag, type: :liquid_tag do
 
   it "does not raise an error when invalid" do
     expect { generate_new_liquid(slug: "fake_username/fake_article_slug") }
-      .not_to raise_error("Invalid link URL or link URL does not exist")
+      .not_to raise_error
   end
 
   it "renders a proper link tag" do

--- a/spec/liquid_tags/liquid_tag_base_spec.rb
+++ b/spec/liquid_tags/liquid_tag_base_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe LiquidTagBase, type: :liquid_tag do
       expect do
         liquid_tag_options = { source: source, user: source.user }
         Liquid::Template.parse("{% liquid_tag_base %}", liquid_tag_options)
-      end.not_to raise_error(LiquidTags::Errors::InvalidParseContext)
+      end.not_to raise_error
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe LiquidTagBase, type: :liquid_tag do
       liquid_tag_options = { source: source, user: source.user }
       expect do
         Liquid::Template.parse("{% liquid_tag_base %}", liquid_tag_options)
-      end.not_to raise_error(LiquidTags::Errors::InvalidParseContext)
+      end.not_to raise_error
     end
   end
 
@@ -52,7 +52,7 @@ RSpec.describe LiquidTagBase, type: :liquid_tag do
       stub_const("#{described_class}::VALID_ROLES", %i[admin])
       expect do
         Liquid::Template.parse("{% liquid_tag_base %}", liquid_tag_options)
-      end.not_to raise_error(Pundit::NotAuthorizedError)
+      end.not_to raise_error
     end
 
     it "validates single resource roles" do
@@ -63,7 +63,7 @@ RSpec.describe LiquidTagBase, type: :liquid_tag do
       stub_const("#{described_class}::VALID_ROLES", [[:single_resource_admin, Article]])
       expect do
         Liquid::Template.parse("{% liquid_tag_base %}", liquid_tag_options)
-      end.not_to raise_error(Pundit::NotAuthorizedError)
+      end.not_to raise_error
     end
   end
 
@@ -73,7 +73,7 @@ RSpec.describe LiquidTagBase, type: :liquid_tag do
       liquid_tag_options = { source: source, user: source.user }
       expect do
         Liquid::Template.parse("{% liquid_tag_base %}", liquid_tag_options)
-      end.not_to raise_error(Pundit::NotAuthorizedError)
+      end.not_to raise_error
     end
   end
 end

--- a/spec/services/github/oauth_client_spec.rb
+++ b/spec/services/github/oauth_client_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe Github::OauthClient, type: :service, vcr: true do
     end
 
     it "succeeds if access_token is present" do
-      expect { described_class.new(access_token: "value") }.not_to raise_error(ArgumentError)
+      expect { described_class.new(access_token: "value") }.not_to raise_error
     end
 
     it "succeeds if both client_id and client_secret are present" do
-      expect { described_class.new(client_id: "value", client_secret: "value") }.not_to raise_error(ArgumentError)
+      expect { described_class.new(client_id: "value", client_secret: "value") }.not_to raise_error
     end
   end
 

--- a/spec/workers/search/index_worker_spec.rb
+++ b/spec/workers/search/index_worker_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe Search::IndexWorker, type: :worker, elasticsearch: "Tag" do
   end
 
   it "does not raise an error if record is not found" do
-    expect { worker.perform("Tag", 1234) }.not_to raise_error(ActiveRecord::RecordNotFound)
+    expect { worker.perform("Tag", 1234) }.not_to raise_error
   end
 end

--- a/spec/workers/search/remove_from_index_worker_spec.rb
+++ b/spec/workers/search/remove_from_index_worker_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe Search::RemoveFromIndexWorker, type: :worker do
 
   context "when document is not found" do
     it "does not raise error" do
-      expect { described_class.new.perform(search_class.to_s, 1) }.not_to raise_error(
-        Search::Errors::Transport::NotFound,
-      )
+      expect { described_class.new.perform(search_class.to_s, 1) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A few of our specs used expectation of the form `expect {}.not_to raise_error(<specific error>)`. This is discouraged by RSpec and results in the following warning:

```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives, since literally any other error would cause the expectation to pass, including those raised by Ruby (e.g. NoMethodError, NameError and ArgumentError), meaning the code you are intending to test may not even get reached. Instead consider using `expect { }.not_to raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`.
```

In the interest of making our codebase more robust, I changed all these instances to the `expect {}.not_to raise_error` form as suggested by the warning.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

n/a

## Added tests?

- [X] yes (updated, not added)
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
