### PR TITLE
[HOT FIX] Fix current_user cache issue in comments

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -13,6 +13,12 @@ function initializeUserProfileContent(user) {
   document.getElementById('sidebar-profile').href = '/' + user.username;
 }
 
+function initializeProfileImage(user) {
+  if (!document.getElementById('comment-primary-user-profile--avatar')) return;
+  document.getElementById('comment-primary-user-profile--avatar').src =
+  user.profile_image_90;
+}
+
 function initializeUserSidebar(user) {
   if (!document.getElementById('sidebar-nav')) return;
   initializeUserProfileContent(user);
@@ -116,6 +122,7 @@ function initializeBaseUserData() {
 
   setCurrentUserToNavBar(user);
   initializeUserSidebar(user);
+  initializeProfileImage(user);
   addRelevantButtonsToArticle(user);
   addRelevantButtonsToComments(user);
 }

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -29,11 +29,7 @@
   <% end %>
 
   <span class="crayons-avatar crayons-avatar--l mr-2 shrink-0">
-    <% if user_signed_in? %>
-      <img src="<%= Images::Profile.call(current_user.profile_image_url, length: 50) %>" width="32" height="32" alt="pic" class="crayons-avatar__image">
-    <% else %>
-      <img src="<%= image_path("android-icon-128x128.png") %>" width="32" height="32" alt="pic" class="crayons-avatar__image">
-    <% end %>
+    <img src="<%= SiteConfig.logo_png %>" width="32" height="32" alt="pic" class="crayons-avatar__image" id="comment-primary-user-profile--avatar">
   </span>
   <div class="comment-form__inner">
     <div class="comment-form__field">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This removes `current_user` from the inline HTML because this area is cached and will not work with `current_user` because it will stay in the HTML for the next visitor. This is a hot fix.