### PR TITLE
Removed unused CodeMirror CSS class

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -834,11 +834,6 @@
   @include themeable(color, theme-color, $dark-gray);
 }
 
-.CodeMirror {
-  padding: 12px;
-  font-size: 0.9em;
-}
-
 .cursorelement {
   border-left: 3px solid $red;
   animation: blinker 1s linear infinite;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Was going through old issues, bumped into https://github.com/forem/forem/issues/2165, can't find any mention of CodeMirror around the code anymore, except for this CSS class.

🪓 

## Related Tickets & Documents

#2165 

