### PR TITLE
feedback_message.message is required on backend but not required on view

### DIFF
--- a/app/views/feedback_messages/_form.html.erb
+++ b/app/views/feedback_messages/_form.html.erb
@@ -64,7 +64,7 @@
       Message
       <p class="crayons-field__description m-0">Please provide any additional information or context that will help us understand and handle the situation.</p>
     </label>
-    <%= f.text_area :message, class: "crayons-textfield", placeholder: "...", value: @previous_message %>
+    <%= f.text_area :message, class: "crayons-textfield", placeholder: "...", value: @previous_message, required: true %>
   </div>
 
   <div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
`feedback_message.message` is required on backend validation but not set as required on view https://github.com/forem/forem/blob/0ca4e8b3719995450cec0542ef50268b9bbc3e5c/spec/models/feedback_message_spec.rb#L19

## QA Instructions, Screenshots, Recordings

![Screenshot from 2020-10-05 18-00-47](https://user-images.githubusercontent.com/644551/95103268-b74e7c00-0734-11eb-980a-621f902e7074.png)

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
