### PR TITLE
Add ability for admin to add anti-spam terms

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -56,6 +56,7 @@ module Admin
         facebook_secret
         allow_email_password_registration
         primary_brand_color_hex
+        spam_trigger_terms
       ]
 
       allowed_params = allowed_params |

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -222,6 +222,10 @@ module Constants
         description: "Used as the secondary logo",
         placeholder: "https://image.url"
       },
+      spam_trigger_terms: {
+        description: "Individual (case insensitive) phrases that trigger spam alerts, comma separated.",
+        placeholder: "used cares near you, pokemon go hack"
+      },
       shop_url: {
         description: "Used as the shop url of the community",
         placeholder: "https://shop.url"

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -25,6 +25,7 @@ class Comment < ApplicationRecord
 
   before_validation :evaluate_markdown, if: -> { body_markdown }
   before_save :set_markdown_character_count, if: :body_markdown
+  before_save :create_conditional_autovomits
   before_create :adjust_comment_parent_based_on_depth
   after_create :after_create_checks
   after_create :notify_slack_channel_about_warned_users
@@ -242,6 +243,20 @@ class Comment < ApplicationRecord
 
   def send_email_notification
     Comments::SendEmailNotificationWorker.perform_async(id)
+  end
+
+  def create_conditional_autovomits
+    return unless
+      SiteConfig.spam_trigger_terms.any? { |term| body_markdown.downcase.include?(term.downcase) } &&
+        user.registered_at > 5.days.ago
+
+    self.score = -1
+    Reaction.create(
+      user_id: SiteConfig.mascot_user_id,
+      reactable_id: id,
+      reactable_type: "Article",
+      category: "vomit",
+    )
   end
 
   def should_send_email_notification?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -254,7 +254,7 @@ class Comment < ApplicationRecord
     Reaction.create(
       user_id: SiteConfig.mascot_user_id,
       reactable_id: id,
-      reactable_type: "Article",
+      reactable_type: "Comment",
       category: "vomit",
     )
   end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -173,7 +173,7 @@ class Reaction < ApplicationRecord
   end
 
   def negative_reaction_from_untrusted_user?
-    return if user&.any_admin? || user.id == SiteConfig.mascot_user_id
+    return if user&.any_admin? || user&.id == SiteConfig.mascot_user_id
 
     negative? && !user.trusted
   end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -173,7 +173,7 @@ class Reaction < ApplicationRecord
   end
 
   def negative_reaction_from_untrusted_user?
-    return if user&.any_admin?
+    return if user&.any_admin? || user.id == SiteConfig.mascot_user_id
 
     negative? && !user.trusted
   end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -117,7 +117,7 @@ class SiteConfig < RailsSettings::Base
   field :suggested_tags, type: :array, default: %w[]
   field :suggested_users, type: :array, default: %w[]
 
-  # Rate limits
+  # Rate limits and spam prevention
   field :rate_limit_follow_count_daily, type: :integer, default: 500
   field :rate_limit_comment_creation, type: :integer, default: 9
   field :rate_limit_listing_creation, type: :integer, default: 1
@@ -131,6 +131,8 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_feedback_message_creation, type: :integer, default: 5
   field :rate_limit_user_update, type: :integer, default: 5
   field :rate_limit_user_subscription_creation, type: :integer, default: 3
+
+  field :spam_trigger_terms, type: :array, default: []
 
   # Social Media
   field :social_media_handles, type: :hash, default: {

--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -14,6 +14,8 @@ module Notifications
       end
 
       def call
+        return if comment.score.negative?
+
         user_ids = Set.new(comment_user_ids + subscribed_user_ids + top_level_user_ids + author_subscriber_user_ids)
 
         json_data = {

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -834,7 +834,7 @@
         <div class="card mt-3">
           <%= render partial: "card_header",
                      locals: {
-                       header: "Rate limits",
+                       header: "Rate limits and anti-spam",
                        state: "collapse",
                        target: "rateLimitsBodyContainer",
                        expanded: "false"
@@ -851,6 +851,14 @@
                 <div class="alert alert-info"><%= field_hash[:description] %></div>
               </div>
             <% end %>
+            <div class="form-group">
+              <%= admin_config_label :spam_trigger_terms %>
+              <%= f.text_field :spam_trigger_terms,
+                               class: "form-control",
+                               value: SiteConfig.spam_trigger_terms.to_s,
+                               placeholder: Constants::SiteConfig::DETAILS[:spam_trigger_terms][:placeholder] %>
+              <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:spam_trigger_terms][:description] %></div>
+            </div>
           </div>
         </div>
 

--- a/app/views/admin/feedback_messages/_abuse_reports.html.erb
+++ b/app/views/admin/feedback_messages/_abuse_reports.html.erb
@@ -26,6 +26,9 @@
             <div class="d-flex justify-content-between" data-controller="reaction" data-reaction-id="<%= reaction.id %>">
               <span>
                 🤢 <a href="<%= reaction.user.path %>">@<%= reaction.user.username %></a>
+                <% if reaction.user_id == SiteConfig.mascot_user_id %>
+                  <strong>(auto-generated)</strong>
+                <% end %>
               </span>
               <span>
                 <strong><%= reaction.reactable_type %>:</strong>

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -779,7 +779,7 @@ RSpec.describe Article, type: :model do
     describe "spam" do
       before do
         allow(SiteConfig).to receive(:mascot_user_id).and_return(user.id)
-        allow(SiteConfig).to receive(:spam_trigger_terms).and_return("yahoomagoo gogo")
+        allow(SiteConfig).to receive(:spam_trigger_terms).and_return(["yahoomagoo gogo", "testtestetest"])
       end
 
       it "creates vomit reaction if possible spam" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -776,6 +776,25 @@ RSpec.describe Article, type: :model do
       end
     end
 
+    describe "spam" do
+      it "creates vomit reaction if possible spam" do
+        SiteConfig.mascot_user_id = user.id
+        SiteConfig.spam_trigger_terms = "yahoomagoo gogo"
+        article.body_markdown = article.body_markdown.gsub(article.title, "This post is about Yahoomagoo gogo")
+        article.save
+        expect(Reaction.last.category).to eq("vomit")
+        expect(Reaction.last.user_id).to eq(user.id)
+      end
+
+      it "does not create vomit reaction if does not have matching title" do
+        SiteConfig.mascot_user_id = user.id
+        SiteConfig.spam_trigger_terms = "yahoomagoo gogo"
+
+        article.save
+        expect(Reaction.last).to be nil
+      end
+    end
+
     describe "async score calc" do
       it "enqueues Articles::ScoreCalcWorker if published" do
         sidekiq_assert_enqueued_with(job: Articles::ScoreCalcWorker, args: [article.id]) do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -777,9 +777,12 @@ RSpec.describe Article, type: :model do
     end
 
     describe "spam" do
+      before do
+        allow(SiteConfig).to receive(:mascot_user_id).and_return(user.id)
+        allow(SiteConfig).to receive(:spam_trigger_terms).and_return("yahoomagoo gogo")
+      end
+
       it "creates vomit reaction if possible spam" do
-        SiteConfig.mascot_user_id = user.id
-        SiteConfig.spam_trigger_terms = "yahoomagoo gogo"
         article.body_markdown = article.body_markdown.gsub(article.title, "This post is about Yahoomagoo gogo")
         article.save
         expect(Reaction.last.category).to eq("vomit")
@@ -787,9 +790,6 @@ RSpec.describe Article, type: :model do
       end
 
       it "does not create vomit reaction if does not have matching title" do
-        SiteConfig.mascot_user_id = user.id
-        SiteConfig.spam_trigger_terms = "yahoomagoo gogo"
-
         article.save
         expect(Reaction.last).to be nil
       end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe Comment, type: :model do
   describe "spam" do
     before do
       allow(SiteConfig).to receive(:mascot_user_id).and_return(user.id)
-      allow(SiteConfig).to receive(:spam_trigger_terms).and_return("yahoomagoo gogo")
+      allow(SiteConfig).to receive(:spam_trigger_terms).and_return(["yahoomagoo gogo", "anothertestterm"])
     end
 
     it "creates vomit reaction if possible spam" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -397,6 +397,34 @@ RSpec.describe Comment, type: :model do
     end
   end
 
+  describe "spam" do
+    it "creates vomit reaction if possible spam" do
+      SiteConfig.mascot_user_id = user.id
+      SiteConfig.spam_trigger_terms = "yahoomagoo gogo"
+      comment.body_markdown = "This post is about Yahoomagoo gogo"
+      comment.save
+      expect(Reaction.last.category).to eq("vomit")
+      expect(Reaction.last.user_id).to eq(user.id)
+    end
+
+    it "does not create vomit reaction if user is established in this context" do
+      SiteConfig.mascot_user_id = user.id
+      SiteConfig.spam_trigger_terms = "yahoomagoo gogo"
+      user.update_column(:registered_at, 10.days.ago)
+      comment.body_markdown = "This post is about Yahoomagoo gogo"
+      comment.save
+      expect(Reaction.last).to be nil
+    end
+
+    it "does not create vomit reaction if does not have matching title" do
+      SiteConfig.mascot_user_id = user.id
+      SiteConfig.spam_trigger_terms = "yahoomagoo gogo"
+
+      comment.save
+      expect(Reaction.last).to be nil
+    end
+  end
+
   context "when callbacks are triggered before save" do
     it "generates character count before saving" do
       comment.save

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -398,9 +398,12 @@ RSpec.describe Comment, type: :model do
   end
 
   describe "spam" do
+    before do
+      allow(SiteConfig).to receive(:mascot_user_id).and_return(user.id)
+      allow(SiteConfig).to receive(:spam_trigger_terms).and_return("yahoomagoo gogo")
+    end
+
     it "creates vomit reaction if possible spam" do
-      SiteConfig.mascot_user_id = user.id
-      SiteConfig.spam_trigger_terms = "yahoomagoo gogo"
       comment.body_markdown = "This post is about Yahoomagoo gogo"
       comment.save
       expect(Reaction.last.category).to eq("vomit")
@@ -408,8 +411,6 @@ RSpec.describe Comment, type: :model do
     end
 
     it "does not create vomit reaction if user is established in this context" do
-      SiteConfig.mascot_user_id = user.id
-      SiteConfig.spam_trigger_terms = "yahoomagoo gogo"
       user.update_column(:registered_at, 10.days.ago)
       comment.body_markdown = "This post is about Yahoomagoo gogo"
       comment.save
@@ -417,9 +418,6 @@ RSpec.describe Comment, type: :model do
     end
 
     it "does not create vomit reaction if does not have matching title" do
-      SiteConfig.mascot_user_id = user.id
-      SiteConfig.spam_trigger_terms = "yahoomagoo gogo"
-
       comment.save
       expect(Reaction.last).to be nil
     end

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe "/admin/config", type: :request do
         end
       end
 
-      describe "Rate Limits" do
+      describe "Rate Limits and spam" do
         it "updates rate_limit_follow_count_daily" do
           expect do
             post "/admin/config", params: { site_config: { rate_limit_follow_count_daily: 3 },
@@ -543,6 +543,13 @@ RSpec.describe "/admin/config", type: :request do
             post "/admin/config", params: { site_config: { rate_limit_send_email_confirmation: 3 },
                                             confirmation: confirmation_message }
           end.to change(SiteConfig, :rate_limit_send_email_confirmation).from(2).to(3)
+        end
+
+        it "updates spam_trigger_terms" do
+          spam_trigger_terms = "hey, pokemon go hack"
+          post "/admin/config", params: { site_config: { spam_trigger_terms: spam_trigger_terms },
+                                          confirmation: confirmation_message }
+          expect(SiteConfig.spam_trigger_terms).to eq(["hey", "pokemon go hack"])
         end
       end
 

--- a/spec/services/notifications/new_comment/send_spec.rb
+++ b/spec/services/notifications/new_comment/send_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe Notifications::NewComment::Send, type: :service do
     expect(notification.json_data["user"]["username"]).to eq(child_comment.user.username)
   end
 
+  it "does not send if comment has negative score already" do
+    described_class.call(child_comment)
+
+    notification = child_comment.notifications.last
+    expect(notification).to be_nil
+  end
+
   it "creates the correct comment data for the notification" do
     described_class.call(child_comment)
 

--- a/spec/services/notifications/new_comment/send_spec.rb
+++ b/spec/services/notifications/new_comment/send_spec.rb
@@ -28,10 +28,9 @@ RSpec.describe Notifications::NewComment::Send, type: :service do
   end
 
   it "does not send if comment has negative score already" do
+    prior_notification_size = Notification.all.size
     described_class.call(child_comment)
-
-    notification = child_comment.notifications.last
-    expect(notification).to be_nil
+    expect(Notiifcation.all.size).to eq prior_notification_size
   end
 
   it "creates the correct comment data for the notification" do

--- a/spec/services/notifications/new_comment/send_spec.rb
+++ b/spec/services/notifications/new_comment/send_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Notifications::NewComment::Send, type: :service do
   it "does not send if comment has negative score already" do
     prior_notification_size = Notification.all.size
     described_class.call(child_comment)
-    expect(Notiifcation.all.size).to eq prior_notification_size
+    expect(Notification.all.size).to eq prior_notification_size
   end
 
   it "creates the correct comment data for the notification" do

--- a/spec/services/notifications/new_comment/send_spec.rb
+++ b/spec/services/notifications/new_comment/send_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Notifications::NewComment::Send, type: :service do
 
   it "does not send if comment has negative score already" do
     prior_notification_size = Notification.all.size
+    child_comment.update_column(:score, -1)
     described_class.call(child_comment)
     expect(Notification.all.size).to eq prior_notification_size
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds the ability for admins to modify a list of terms which may indicate spam. But unlike past "quiet" spam indicators, this automatically creates a vomit reaction which an admin can later manually reverse or at least be aware of. In the past we have modified spam-related scores but it hasn't really worked effectively into our workflows. I think this reversible action should be how we raise spam automatically in general.

With comments I decided to limit it to newer accounts because we're examining _the whole comment_ and not just the title. But this can be modified over time. If a support admin is seeing false positives with a term they should consider removing those. We can alter the logic over time to ensure as few false-positive scenarios as possible.