### PR TITLE
Skip service workers in development by default

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,9 +1,11 @@
+# Development options
+export SKIP_SERVICEWORKERS="true"
+
 # App core values
 export APP_DOMAIN="localhost:3000"
 export APP_PROTOCOL="http://"
 export APP_NAME="forem_local"
 export FOREM_OWNER_SECRET="secret"
-
 
 # Openresty domain + Protocol setting for development
 export OPENRESTY_DOMAIN=""

--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -1,5 +1,5 @@
 // Serviceworkers file. This code gets installed in users browsers and runs code before the request is made.
-<% unless Rails.env.test? %>
+<% unless Rails.env.test? || ENV["SKIP_SERVICEWORKERS"] == "true" %>
   const staticCacheName = 'static-1.2';
   const expectedCaches = [
     staticCacheName


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Based on discussions and experience I think _not_ enabling service workers as the default probably makes sense, so that `localhost:3000` does not run the same service workers?

Here is a relevant conversation: https://github.com/forem/forem/issues/10293#issuecomment-691648063

This still makes it easy to have service workers on, but is a pretty straightforward way to turn them off. `ENV` var seems like a decent way to do this, eh?

This still registers service workers, just makes the file empty so no functionality exists. Neither scenario is _perfect_ because either way the user is either dealing with confusion or inconsistency but at least this enables options.