### PR TITLE
Return if receive own message

### DIFF
--- a/app/javascript/utilities/connect/getUnopenedChannels.jsx
+++ b/app/javascript/utilities/connect/getUnopenedChannels.jsx
@@ -99,6 +99,7 @@ class UnopenedChannelNotice extends Component {
 
   receiveNewMessage = (e) => {
     if (
+      e.user_id === window.currentUser.id ||
       (window.location.pathname.startsWith('/connect') &&
         e.user_id === window.currentUser.id &&
         e.channel_type !== 'direct') ||
@@ -174,8 +175,7 @@ class UnopenedChannelNotice extends Component {
           <div>
             {channel.request_type === 'mentioned'
               ? 'You got mentioned in'
-              : 'New Message from'}
-            {' '}
+              : 'New Message from'}{' '}
             <a
               href={`/connect/${channel.adjusted_slug}`}
               style={{


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If you have dev.to open in multiple tabs and you send a message in a chat channel you will get an unread notification in the other tabs for your own message.  This PR fixes that by simply exiting from the `receiveNewMessage` callback early if the message received is your own (same user id).

Possible related refactoring: the `receiveNewMessage` function already had a few checks that I think were supposed to solve this exact issue but didn't.  We may be able to adjust or remove them completely but I would want someone who is more familiar with this feature (preact & pusher) to look at it first and make sure I'm not messing something else up.

```javascript
receiveNewMessage = (e) => {
    if (
      (window.location.pathname.startsWith('/connect') &&
        e.user_id === window.currentUser.id &&
        e.channel_type !== 'direct') ||
      window.location.pathname.includes(e.chat_channel_adjusted_slug)
    ) {
      return;
    }
    /// rest of function excluded
}
```

Basically the function returns if the user: is already in the chat area ('/connect') AND is the same user that sent the message AND the message is for a non-direct channel. I don't see any reason why we wouldn't just return if the user is the same user that sent the message.

```javascript
receiveNewMessage = (e) => {
    if (
      e.user_id === window.currentUser.id ||
      window.location.pathname.includes(e.chat_channel_adjusted_slug)
    ) {
      return;
    }
    /// rest of function excluded
}
```

## Related Tickets & Documents

Fixes issue #10606 


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help

There aren't any tests for this particular utility yet and I don't fell confident enough to start a test suite from scratch.

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
