### PR TITLE
Add default admin to seeds file

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,6 +21,16 @@ class Seeder
       puts "  #{@counter}. #{plural} already exist. Skipping."
     end
   end
+
+  def create_if_doesnt_exist(klass, attribute_name, attribute_value)
+    record = klass.find_by("#{attribute_name}": attribute_value)
+    if record.nil?
+      puts "  #{klass} with #{attribute_name} = #{attribute_value} not found, proceeding..."
+      yield
+    else
+      puts "  #{klass} with #{attribute_name} = #{attribute_value} found, skipping."
+    end
+  end
 end
 
 # we use this to be able to increase the size of the seeded DB at will
@@ -134,6 +144,25 @@ users_in_random_order = seeder.create_if_none(User, num_users) do
   end
 
   User.order(Arel.sql("RANDOM()"))
+end
+
+seeder.create_if_doesnt_exist(User, "email", "admin@forem.local") do
+  user = User.create!(
+    name: "Admin McAdmin",
+    email: "admin@forem.local",
+    username: "Admin_McAdmin",
+    summary: Faker::Lorem.paragraph_by_chars(number: 199, supplemental: false),
+    profile_image: File.open(Rails.root.join("app/assets/images/#{rand(1..40)}.png")),
+    website_url: Faker::Internet.url,
+    email_comment_notifications: false,
+    email_follower_notifications: false,
+    confirmed_at: Time.current,
+    password: "password",
+    password_confirmation: "password",
+  )
+
+  user.add_role(:admin)
+  user.add_role(:single_resource_admin)
 end
 
 ##############################################################################

--- a/docs/getting-started/db.md
+++ b/docs/getting-started/db.md
@@ -46,10 +46,23 @@ It's currently used only for `articles` and `users`.
 
 It can also be used for `rails db:seed` and `rails db:reset`.
 
+## Default Admin User
+
+Seed data creates a handful of regular users, and a single admin user that can
+be used to log into the application with the Email login option:
+
+```
+email: admin@forem.local
+password: admin
+```
+
 ### Other seed modes
 
-To put your local forem into "starter mode", as it would be for a new creator, use `MODE=STARTER` i.e...
+To put your local forem into "starter mode", as it would be for a new creator,
+use `MODE=STARTER` i.e...
 
 ```shell
 MODE=STARTER rails db:setup
 ```
+
+This mode skips creation of all sample data.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [x] Documentation Update

## Description

Currently when a developer/contributor sets up a new development environment, they have to manually create an admin user. This adds significant friction and a learning curve for a new contributor to start testing Forem locally. In addition, developers using cloud based IDEs such as GitPod or GitHub Codespaces will have to do this setup ever time a new space is spun up.

This PR adds a default admin user with the email address 'admin@forem.local' to the seed data.

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.forem.com
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![admin](https://media.giphy.com/media/hvkdNvfmrc80cSvEsk/giphy.gif)
