### PR TITLE
Profile generalization tidbits

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -55,4 +55,8 @@ class Profile < ApplicationRecord
   def custom_profile_attributes
     custom_profile_fields.pluck(:attribute_name)
   end
+
+  def clear!
+    update(data: {})
+  end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -45,6 +45,13 @@ class Profile < ApplicationRecord
     attributes!.map { |attribute| MAPPED_ATTRIBUTES.fetch(attribute, attribute).to_s }
   end
 
+  # NOTE: @citizen428 We want to have a current list of profile attributes the
+  # moment the application loads. However, doing this unconditionally fails if
+  # the profiles table doesn't exist yet (e.g. when running bin/setup in a new
+  # clone). I wish Rails had a hook for code to run after the app started, but
+  # for now this is the best I can come up with.
+  refresh_attributes! if ApplicationRecord.connection.table_exists?("profiles")
+
   def custom_profile_attributes
     custom_profile_fields.pluck(:attribute_name)
   end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -174,4 +174,10 @@ class SiteConfig < RailsSettings::Base
   def self.local?
     app_domain.include?("localhost")
   end
+
+  # Used where we need to keep old DEV features around but don't want to/cannot
+  # expose them to other communities.
+  def self.dev_to?
+    app_domain == "dev.to"
+  end
 end

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -43,6 +43,9 @@ module Moderator
       # TODO: @forem/oss Remove this block once we drop the columns from users.
       user._skip_profile_sync = true
       user.update_columns(
+        twitter_username: nil, github_username: nil, website_url: "", summary: "",
+        location: "", education: "", employer_name: "", employer_url: "", employment_title: "",
+        mostly_work_with: "", currently_learning: "", currently_hacking_on: "", available_for: "",
         email_public: false, facebook_url: nil, youtube_url: nil, dribbble_url: nil,
         medium_url: nil, stackoverflow_url: nil,
         behance_url: nil, linkedin_url: nil, gitlab_url: nil, instagram_url: nil, mastodon_url: nil,

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -39,6 +39,17 @@ module Moderator
 
     def remove_profile_info
       user.profile.clear!
+
+      # TODO: @forem/oss Remove this block once we drop the columns from users.
+      user._skip_profile_sync = true
+      user.update_columns(
+        email_public: false, facebook_url: nil, youtube_url: nil, dribbble_url: nil,
+        medium_url: nil, stackoverflow_url: nil,
+        behance_url: nil, linkedin_url: nil, gitlab_url: nil, instagram_url: nil, mastodon_url: nil,
+        twitch_url: nil, feed_url: nil
+      )
+      user._skip_profile_sync = false
+
       user.update_columns(profile_image: "https://thepracticaldev.s3.amazonaws.com/i/99mvlsfu5tfj9m7ku25d.png")
     end
 

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -38,16 +38,7 @@ module Moderator
     end
 
     def remove_profile_info
-      user.update_columns(
-        twitter_username: nil, github_username: nil, website_url: "", summary: "",
-        location: "", education: "", employer_name: "", employer_url: "", employment_title: "",
-        mostly_work_with: "", currently_learning: "", currently_hacking_on: "", available_for: "",
-        email_public: false, facebook_url: nil, youtube_url: nil, dribbble_url: nil,
-        medium_url: nil, stackoverflow_url: nil,
-        behance_url: nil, linkedin_url: nil, gitlab_url: nil, instagram_url: nil, mastodon_url: nil,
-        twitch_url: nil, feed_url: nil
-      )
-
+      user.profile.clear!
       user.update_columns(profile_image: "https://thepracticaldev.s3.amazonaws.com/i/99mvlsfu5tfj9m7ku25d.png")
     end
 

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "users/additional_authentication" %>
 
-<% if SiteConfig.app_domain == "dev.to" %>
+<% if SiteConfig.dev_to? %>
   <%# @forem/oss Temporary disabling of overly DEV-specialized link. %>
   <%# We should create a generalized version of the badge page, including a permanent proxied path for the badge image for hotlinking. %>
   <div class="crayons-card mb-6 p-6 grid gap-6">

--- a/spec/models/site_config_spec.rb
+++ b/spec/models/site_config_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SiteConfig, type: :model do
       expect(described_class.dev_to?).to be(true)
     end
 
-    it "returns false if the .app_domain is dev.to" do
+    it "returns false if the .app_domain is not dev.to" do
       allow(described_class).to receive(:app_domain).and_return("forem.dev")
 
       expect(described_class.dev_to?).to be(false)

--- a/spec/models/site_config_spec.rb
+++ b/spec/models/site_config_spec.rb
@@ -20,4 +20,18 @@ RSpec.describe SiteConfig, type: :model do
       expect(described_class.local?).to be(false)
     end
   end
+
+  describe ".dev_to?" do
+    it "returns true if the .app_domain is dev.to" do
+      allow(described_class).to receive(:app_domain).and_return("dev.to")
+
+      expect(described_class.dev_to?).to be(true)
+    end
+
+    it "returns false if the .app_domain is dev.to" do
+      allow(described_class).to receive(:app_domain).and_return("forem.dev")
+
+      expect(described_class.dev_to?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Various small changes related to profile generalization.

1. Automatically set up profile attributes on app boot, this time (hopefully) without breaking `bin/setup` (tested locally, works fine).
2. Add `SiteConfig.dev_to?` analogous to `SiteConfig.local?`. This will be used for cases where we don't want DEV to lose a certain feature but don't want to or can't expose it to other communities (see [The path from DEV to Forem](https://forem.dev/citizen428/the-path-from-dev-to-forem-543e))
3. Update `BanishUser#remove_profile_info` to clear profile info via the profile model.

## Related Tickets & Documents

Related to #6994

## QA Instructions, Screenshots, Recordings

Nothing much to test here.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
