### PR TITLE
Remove community_action from SiteConfig

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -141,7 +141,6 @@ module Admin
         community_name
         community_description
         community_member_label
-        community_action
         community_copyright_start_year
         staff_user_id
         tagline

--- a/app/controllers/concerns/verify_setup_completed.rb
+++ b/app/controllers/concerns/verify_setup_completed.rb
@@ -6,7 +6,6 @@ module VerifySetupCompleted
   MANDATORY_CONFIGS = %i[
     community_name
     community_description
-    community_action
 
     main_social_image
     logo_png

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -33,10 +33,6 @@ module Constants
         description: "https://url.com/lander",
         placeholder: "URL campaign sidebar image will link to"
       },
-      community_action: {
-        description: "Used to determine the action of community e.g coding, reading, training etc.",
-        placeholder: "coding"
-      },
       community_copyright_start_year: {
         description: "Used to mark the year this forem was started.",
         placeholder: Time.zone.today.year.to_s

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -42,7 +42,6 @@ class SiteConfig < RailsSettings::Base
   field :community_name, type: :string, default: ApplicationConfig["COMMUNITY_NAME"] || "New Forem"
   field :community_description, type: :string
   field :community_member_label, type: :string, default: "user"
-  field :community_action, type: :string
   field :tagline, type: :string
   field :community_copyright_start_year, type: :integer,
                                          default: ApplicationConfig["COMMUNITY_COPYRIGHT_START_YEAR"] ||

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -300,15 +300,6 @@
               </div>
 
               <div class="form-group">
-                <%= admin_config_label :community_action %>
-                <%= f.text_field :community_action,
-                                 class: "form-control",
-                                 value: SiteConfig.community_action,
-                                 placeholder: Constants::SiteConfig::DETAILS[:community_action][:placeholder] %>
-                <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:community_action][:description] %></div>
-              </div>
-
-              <div class="form-group">
                 <%= admin_config_label :community_copyright_start_year %>
                 <%= f.text_field :community_copyright_start_year,
                                  class: "form-control",

--- a/app/views/mailers/digest_mailer/digest_email.html.erb
+++ b/app/views/mailers/digest_mailer/digest_email.html.erb
@@ -21,12 +21,12 @@
   <em>
     <% if @user.experience_level == nil %>
       <b>
-        You can now add your <%= SiteConfig.community_action %> experience level to your account in order to receive more relevant content.
+        You can now add your experience level to your account in order to receive more relevant content.
       </b>
       <br /><br />
       Visit <b><a href="<%= app_url(user_settings_path(:misc)) %>" style="text-decoration: none;">your settings</a></b> to enter your experience level on a scale of 1-10.
       <br /><br />
-      You can change it any time in the future. Happy <%= SiteConfig.community_action %>!
+      You can change it any time in the future.
     <% elsif @user.following_users_count == 0 %>
       <b>
         <%= community_name %> Digest is a new periodic email featuring the best posts from our community of <%= community_members_label %>.

--- a/app/views/mailers/notify_mailer/trusted_role_email.html.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.html.erb
@@ -15,7 +15,5 @@
   <b><a href="<%= app_url("/community-moderation") %>">Click here for full details about basic mod privileges.</b></a>
 </p>
 <p>
-  Happy <%= SiteConfig.community_action %>!
-  <br>
   - <%= community_name %> Team
 </p>

--- a/app/views/mailers/notify_mailer/trusted_role_email.text.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.text.erb
@@ -8,6 +8,4 @@ You'll occasionally get on-site notifications asking you to take an action. You 
 
 Visit <%= app_url("/community-moderation") %> for full details of what you can do with these new privileges.
 
-Happy <%= SiteConfig.community_action %>!
-
 - <%= community_name %> Team

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -103,13 +103,6 @@ RSpec.describe "/admin/config", type: :request do
           expect(SiteConfig.community_member_label).to eq(name)
         end
 
-        it "updates the community_action" do
-          action = "reading"
-          post "/admin/config", params: { site_config: { community_member_label: action },
-                                          confirmation: confirmation_message }
-          expect(SiteConfig.community_member_label).to eq(action)
-        end
-
         it "updates the community_copyright_start_year" do
           year = "2018"
           post "/admin/config", params: { site_config: { community_copyright_start_year: year },

--- a/spec/system/admin/admin_manages_configuration_spec.rb
+++ b/spec/system/admin/admin_manages_configuration_spec.rb
@@ -33,9 +33,8 @@ RSpec.describe "Admin manages configuration", type: :system do
       allow(SiteConfig).to receive(:tagline).and_return(nil)
       allow(SiteConfig).to receive(:suggested_users).and_return(nil)
       allow(SiteConfig).to receive(:suggested_tags).and_return(nil)
-      allow(SiteConfig).to receive(:community_action).and_return(nil)
       visit root_path
-      expect(page.body).to match(/Setup not completed yet, missing(.*)community action(.*), and others/)
+      expect(page.body).to match(/Setup not completed yet, missing(.*)main social image(.*), and others/)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As part of the Creator Onboarding project, we are removing fields from the SiteConfig that are too DEV-specific and/or that we don't want all Forem creators to have to fill out when they set up a new Forem instance.

Since `community_action` isn't used in too many places (and is currently fairly pretty DEV-specific), we think that it makes more sense to drop this field and update the few instances of where it is used in emails instead.

## Related Tickets & Documents

Fixes https://github.com/forem/InternalProjectPlanning/issues/89.

## QA Instructions, Screenshots, Recordings

Before this change:
<img width="1069" alt="Screen Shot 2020-10-06 at 11 10 50 AM" src="https://user-images.githubusercontent.com/6921610/95242874-a6e5e200-07c4-11eb-9425-f80e51ff49e4.png">

After this change:
<img width="1078" alt="Screen Shot 2020-10-06 at 11 08 29 AM" src="https://user-images.githubusercontent.com/6921610/95242881-a9483c00-07c4-11eb-9a12-d2f0e82c1207.png">

## Added tests?

- [ ] yes
- [x] no, ~because they aren't needed~ but i updated the preexisting ones
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## Are there any post deployment tasks we need to perform?

Since we are just dropping this field, we shouldn't need to take any major action here.

## What gif best describes this PR or how it makes you feel?

![dropping cardboard on a cat's face](https://media4.giphy.com/media/T2xqdmsM1qhPy/giphy.webp?cid=5a38a5a2g00y8xnjxxnipnvahvb3w0n007tc83m1y76ffj2n&rid=giphy.webp)
