### PR TITLE
Auto-suspend multiple-spammers

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -257,6 +257,17 @@ class Comment < ApplicationRecord
       reactable_type: "Comment",
       category: "vomit",
     )
+
+    return unless Reaction.comment_vomits.where(reactable_id: user.comments.pluck(:id)).size > 2
+
+    user.add_role(:banned)
+    Note.create(
+      author_id: SiteConfig.mascot_user_id,
+      noteable_id: user_id,
+      noteable_type: "User",
+      reason: "automatic_ban",
+      content: "User banned for too many spammy articles, triggered by autovomit.",
+    )
   end
 
   def should_send_email_notification?

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -23,6 +23,8 @@ class Reaction < ApplicationRecord
   scope :readinglist, -> { where(category: "readinglist") }
   scope :for_articles, ->(ids) { where(reactable_type: "Article", reactable_id: ids) }
   scope :eager_load_serialized_data, -> { includes(:reactable, :user) }
+  scope :article_vomits, -> { where(category: "vomit", reactable_type: "Article") }
+  scope :comment_vomits, -> { where(category: "vomit", reactable_type: "Comment") }
 
   validates :category, inclusion: { in: CATEGORIES }
   validates :reactable_type, inclusion: { in: REACTABLE_TYPES }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Article, type: :model do
     end
 
     describe "liquid tags" do
-      it "is not valid if it contains invalid liquid tags" do
+      xit "is not valid if it contains invalid liquid tags" do
         body = "{% github /thepracticaldev/dev.to %}"
         article = build(:article, body_markdown: body)
         expect(article).not_to be_valid
@@ -787,6 +787,26 @@ RSpec.describe Article, type: :model do
         article.save
         expect(Reaction.last.category).to eq("vomit")
         expect(Reaction.last.user_id).to eq(user.id)
+      end
+
+      it "does not ban user if only single vomit" do
+        article.body_markdown = article.body_markdown.gsub(article.title, "This post is about Yahoomagoo gogo")
+        article.save
+        expect(article.user.banned).to be false
+      end
+
+      it "bans user with 3 comment vomits" do
+        second_article = create(:article, user: article.user)
+        third_article = create(:article, user: article.user)
+        article.body_markdown = article.body_markdown.gsub(article.title, "This post is about Yahoomagoo gogo")
+        second_article.body_markdown = second_article.body_markdown.gsub(second_article.title, "testtestetest")
+        third_article.body_markdown = third_article.body_markdown.gsub(third_article.title, "yahoomagoo gogo")
+
+        article.save
+        second_article.save
+        third_article.save
+        expect(article.user.banned).to be true
+        expect(Note.last.reason).to eq "automatic_ban"
       end
 
       it "does not create vomit reaction if does not have matching title" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Article, type: :model do
     end
 
     describe "liquid tags" do
-      xit "is not valid if it contains invalid liquid tags" do
+      it "is not valid if it contains invalid liquid tags" do
         body = "{% github /thepracticaldev/dev.to %}"
         article = build(:article, body_markdown: body)
         expect(article).not_to be_valid

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -410,6 +410,24 @@ RSpec.describe Comment, type: :model do
       expect(Reaction.last.user_id).to eq(user.id)
     end
 
+    it "does not ban user if only single vomit" do
+      comment.body_markdown = "This post is about Yahoomagoo gogo"
+      comment.save
+      expect(comment.user.banned).to be false
+    end
+
+    it "bans user with 3 comment vomits" do
+      comment.body_markdown = "This post is about Yahoomagoo gogo"
+      second_comment = create(:comment, user: comment.user, body_markdown: "This post is about Yahoomagoo gogo")
+      third_comment = create(:comment, user: comment.user, body_markdown: "This post is about Yahoomagoo gogo")
+
+      comment.save
+      second_comment.save
+      third_comment.save
+      expect(comment.user.banned).to be true
+      expect(Note.last.reason).to eq "automatic_ban"
+    end
+
     it "does not create vomit reaction if user is established in this context" do
       user.update_column(:registered_at, 10.days.ago)
       comment.body_markdown = "This post is about Yahoomagoo gogo"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This builds on the detection of spam keywords and checks whether that account has at least 3 instances of vomits and automatically suspends them... I figured 3 is decent to not attack false positives too aggressively.

This is a full on "destructive banish", but will inhibit the account's ability to continue creating.