### PR TITLE
Improve Imgproxy's dynamic endpoint

### DIFF
--- a/config/initializers/imgproxy.rb
+++ b/config/initializers/imgproxy.rb
@@ -3,7 +3,7 @@ Imgproxy.configure do |config|
   #
   # Full URL to where your imgproxy lives.
   #
-  config.endpoint = if Rails.env.production?
+  config.endpoint = if Rails.env.production? && ApplicationConfig["APP_DOMAIN"] && ApplicationConfig["APP_PROTOCOL"]
                       # Use /images with the same domain on Production as
                       # our default configuration
                       URL.url("images") # ie. https://forem.dev/images


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
if APP_DOMAIN and APP_PROTOCOL is not provided, the app would break when trying to start. This would instead direct imgproxy to use IMGPROXY_ENDPOINT.

## Related Tickets & Documents
n/a
## QA Instructions, Screenshots, Recordings
You should be able to start the container with `docker-compose build` without an issue.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a