### PR TITLE
Remove random onboarding background images

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,8 +76,10 @@ module ApplicationHelper
     "https://res.cloudinary.com/#{ApplicationConfig['CLOUDINARY_CLOUD_NAME']}/image/upload/#{postfix}"
   end
 
-  def optimized_image_url(url, width: 500, quality: 80, fetch_format: "auto")
-    image_url = url.presence || asset_path("#{rand(1..40)}.png")
+  def optimized_image_url(url, width: 500, quality: 80, fetch_format: "auto", random_fallback: true)
+    fallback_image = asset_path("#{rand(1..40)}.png") if random_fallback
+
+    return unless (image_url = url.presence || fallback_image)
 
     Images::Optimizer.call(SimpleIDN.to_ascii(image_url), width: width, quality: quality, fetch_format: fetch_format)
   end

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -778,7 +778,7 @@
                                  placeholder: Constants::SiteConfig::DETAILS[:onboarding_background_image][:placeholder] %>
                 <div class="row mt-2">
                   <div class="col-12">
-                    <img alt="main social image" class="img-fluid" src="<%= SiteConfig.onboarding_background_image %>" />
+                    <img alt="onboarding background image" class="img-fluid" src="<%= SiteConfig.onboarding_background_image %>" />
                   </div>
                   <div class="col-12">
                     <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:onboarding_background_image][:description] %></div>
@@ -794,7 +794,7 @@
                                  placeholder: Constants::SiteConfig::DETAILS[:onboarding_taskcard_image][:placeholder] %>
                 <div class="row mt-2">
                   <div class="col-12">
-                    <img alt="main social image" class="img-fluid" src="<%= SiteConfig.onboarding_taskcard_image %>" />
+                    <img alt="onboarding taskcard image" class="img-fluid" src="<%= SiteConfig.onboarding_taskcard_image %>" />
                   </div>
                   <div class="col-12">
                     <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:onboarding_taskcard_image][:description] %></div>

--- a/app/views/onboardings/show.html.erb
+++ b/app/views/onboardings/show.html.erb
@@ -15,7 +15,7 @@
   data-community-name="<%= community_name %>"
   data-community-description="<%= SiteConfig.community_description %>"
   data-community-logo="<%= optimized_image_url(safe_logo_url(SiteConfig.onboarding_logo_image)) %>"
-  data-community-background="<%= optimized_image_url(SiteConfig.onboarding_background_image, width: 1680, quality: 75) %>">
+  data-community-background="<%= optimized_image_url(SiteConfig.onboarding_background_image, width: 1680, quality: 75, random_fallback: false) %>">
   <%= javascript_packs_with_chunks_tag "Onboarding", defer: true %>
 </div>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -207,6 +207,11 @@ RSpec.describe ApplicationHelper, type: :helper do
     it "keeps an ASCII domain as ASCII" do
       expect(helper.optimized_image_url("https://www.xn--vnx.dev/image.png")).to include("https://www.xn--vnx.dev")
     end
+
+    it "returns random fallback images as expected" do
+      expect(helper.optimized_image_url("")).not_to be_nil
+      expect(helper.optimized_image_url("", random_fallback: false)).to be_nil
+    end
   end
 
   describe "#optimized_image_tag" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The objective of this change is to remove the random fallback images from onboarding.

Accomplishing that in this way means we won't have to change how this method is being used elsewhere.

## Related Tickets & Documents

Closes https://github.com/forem/InternalProjectPlanning/issues/112

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![](https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Fwww.tovx.com%2Fgraphics2%2FMISC%2Fnopets.gif&f=1&nofb=1)
