### PR TITLE
Move spam check to after save

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -90,10 +90,10 @@ class Article < ApplicationRecord
   before_save :calculate_base_scores
   before_save :fetch_video_duration
   before_save :set_caches
-  before_save :create_conditional_autovomits
   before_create :create_password
   before_destroy :before_destroy_actions, prepend: true
 
+  after_save :create_conditional_autovomits
   after_save :bust_cache, :detect_human_language
   after_save :notify_slack_channel_about_publication
 
@@ -681,7 +681,6 @@ class Article < ApplicationRecord
   def create_conditional_autovomits
     return unless SiteConfig.spam_trigger_terms.any? { |term| Regexp.new(term.downcase).match?(title.downcase) }
 
-    self.score = -25
     Reaction.create(
       user_id: SiteConfig.mascot_user_id,
       reactable_id: id,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I realized that the reactions are not getting created as expected _on the first save_ because the ID is not available yet. It's missing silently, and in the tests we're not exercising this effectively. This fixes up the logic.