### PR TITLE
Limit articles created by newer users

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -165,6 +165,7 @@ module Admin
         rate_limit_follow_count_daily
         rate_limit_image_upload
         rate_limit_published_article_creation
+        rate_limit_published_article_antispam_creation
         rate_limit_organization_creation
         rate_limit_user_subscription_creation
         rate_limit_article_update

--- a/app/helpers/rate_limit_checker_helper.rb
+++ b/app/helpers/rate_limit_checker_helper.rb
@@ -33,7 +33,12 @@ module RateLimitCheckerHelper
     rate_limit_published_article_creation: {
       min: 0,
       placeholder: 9,
-      description: "The number of articles a user can create within 30 seconds"
+      description: "The number of articles that a user can create within 30 seconds"
+    },
+    rate_limit_published_article_antispam_creation: {
+      min: 0,
+      placeholder: 1,
+      description: "The number of articles that a 3-day-old user can create within 5 minutes"
     },
     rate_limit_image_upload: {
       min: 0,

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -121,6 +121,7 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_comment_creation, type: :integer, default: 9
   field :rate_limit_listing_creation, type: :integer, default: 1
   field :rate_limit_published_article_creation, type: :integer, default: 9
+  field :rate_limit_published_article_antispam_creation, type: :integer, default: 1
   field :rate_limit_organization_creation, type: :integer, default: 1
   field :rate_limit_reaction_creation, type: :integer, default: 10
   field :rate_limit_image_upload, type: :integer, default: 9

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -31,7 +31,13 @@ module Articles
     attr_reader :user, :article_params, :event_dispatcher
 
     def rate_limit!
-      user.rate_limiter.check_limit!(:published_article_creation)
+      rate_limit_to_use = if user.created_at > 3.days.ago.beginning_of_day
+                            :published_article_antispam_creation
+                          else
+                            :published_article_creation
+                          end
+
+      user.rate_limiter.check_limit!(rate_limit_to_use)
     end
 
     def dispatch_event(article)

--- a/app/services/rate_limit_checker.rb
+++ b/app/services/rate_limit_checker.rb
@@ -9,6 +9,7 @@ class RateLimitChecker
     listing_creation: { retry_after: 60 },
     organization_creation: { retry_after: 300 },
     published_article_creation: { retry_after: 30 },
+    published_article_antispam_creation: { retry_after: 300 },
     reaction_creation: { retry_after: 30 },
     send_email_confirmation: { retry_after: 120 },
     user_subscription_creation: { retry_after: 30 },
@@ -85,8 +86,15 @@ class RateLimitChecker
   end
 
   def check_published_article_creation_limit
+    # TODO: Vaidehi Joshi - We should make this time frame configurable.
     user.articles.published.where("created_at > ?", 30.seconds.ago).size >
       SiteConfig.rate_limit_published_article_creation
+  end
+
+  def check_published_article_antispam_creation_limit
+    # TODO: Vaidehi Joshi - We should make this time frame configurable.
+    user.articles.published.where("created_at > ?", 5.minutes.ago).size >
+      SiteConfig.rate_limit_published_article_antispam_creation
   end
 
   def check_follow_account_limit

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -468,6 +468,13 @@ RSpec.describe "/admin/config", type: :request do
           end.to change(SiteConfig, :rate_limit_published_article_creation).from(9).to(3)
         end
 
+        it "updates rate_limit_published_article_antispam_creation" do
+          expect do
+            post "/admin/config", params: { site_config: { rate_limit_published_article_antispam_creation: 3 },
+                                            confirmation: confirmation_message }
+          end.to change(SiteConfig, :rate_limit_published_article_antispam_creation).from(1).to(2)
+        end
+
         it "updates rate_limit_organization_creation" do
           expect do
             post "/admin/config", params: { site_config: { rate_limit_organization_creation: 3 },

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -472,7 +472,7 @@ RSpec.describe "/admin/config", type: :request do
           expect do
             post "/admin/config", params: { site_config: { rate_limit_published_article_antispam_creation: 3 },
                                             confirmation: confirmation_message }
-          end.to change(SiteConfig, :rate_limit_published_article_antispam_creation).from(1).to(2)
+          end.to change(SiteConfig, :rate_limit_published_article_antispam_creation).from(1).to(3)
         end
 
         it "updates rate_limit_organization_creation" do

--- a/spec/services/rate_limit_checker_spec.rb
+++ b/spec/services/rate_limit_checker_spec.rb
@@ -26,8 +26,10 @@ RSpec.describe RateLimitChecker, type: :service do
       expect { limiter.limit_by_action(action) }.to raise_error("Invalid Cache Key: no unique component present")
     end
 
-    # published_article_creation limit we check against the database rather than our cache
-    described_class::ACTION_LIMITERS.except(:published_article_creation).each do |action, _options|
+    # We check published_article_creation + :published_article_antispam_creation
+    # limit against database, rather than our cache.
+    described_class::ACTION_LIMITERS.except(:published_article_creation,
+                                            :published_article_antispam_creation).each do |action, _options|
       it "returns true if #{action} limit has been reached" do
         allow(Rails.cache).to receive(:read).with(
           cache_key(action), raw: true
@@ -60,6 +62,12 @@ RSpec.describe RateLimitChecker, type: :service do
       end
     end
 
+    it "returns true if too many published articles at once and potentially spammy" do
+      allow(SiteConfig).to receive(:rate_limit_published_article_antispam_creation).and_return(1)
+      create_list(:article, 2, user_id: user.id, published: true)
+      expect(rate_limit_checker.limit_by_action("published_article_antispam_creation")).to be(true)
+    end
+
     it "returns true if too many published articles at once" do
       allow(SiteConfig).to receive(:rate_limit_published_article_creation).and_return(1)
       create_list(:article, 2, user_id: user.id, published: true)
@@ -88,6 +96,10 @@ RSpec.describe RateLimitChecker, type: :service do
         .and_return(SiteConfig.rate_limit_follow_count_daily)
 
       expect(rate_limit_checker.limit_by_action("follow_account")).to be(false)
+    end
+
+    it "returns false if published articles antispam limit has not been reached" do
+      expect(described_class.new(user).limit_by_action("published_article_antispam_creation")).to be(false)
     end
 
     it "returns false if published articles limit has not been reached" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Allows us to treat "newer" users differently when it comes to rate limiting how many articles they can create.

Admins can configure how many articles a 3-day-old user can create within 5 minutes.

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings

<img width="1109" alt="Screen_Shot_2020-10-06_at_5_17_24_PM" src="https://user-images.githubusercontent.com/6921610/95273636-67d18400-07f8-11eb-8d89-46b04747345f.png">


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] inline documentation
- [ ] docs.forem.com
- [ ] readme
- [ ] no documentation needed
