### PR TITLE
Ensure podcast episodes are created with processed_html

### DIFF
--- a/app/services/podcasts/create_episode.rb
+++ b/app/services/podcasts/create_episode.rb
@@ -70,6 +70,7 @@ module Podcasts
     def finalize(episode)
       episode.purge_all
       episode.index_to_elasticsearch
+      episode.save if episode.processed_html.blank?
     end
   end
 end

--- a/spec/services/podcasts/create_episode_spec.rb
+++ b/spec/services/podcasts/create_episode_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe Podcasts::CreateEpisode, type: :service do
       expect(episode.guid).to include("53b17a1e-271b-40e3-a084-a67b4fcba562")
     end
 
+    it "populates processed_html" do
+      episode = described_class.call(podcast.id, item)
+      expect(episode.processed_html).not_to be_blank
+    end
+
     it "sets correct availability statuses" do
       episode = described_class.call(podcast.id, item)
       expect(episode.https?).to be true


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Because we're upserting, and therefore skipping callbacks, the `processed_html` is often not being processed. I imagine there is an efficiency reason we're upserting, so only running this in the `blank?` scenario.