### PR TITLE
Do not require meta_keywords to be set

### DIFF
--- a/app/controllers/concerns/verify_setup_completed.rb
+++ b/app/controllers/concerns/verify_setup_completed.rb
@@ -14,8 +14,6 @@ module VerifySetupCompleted
     mascot_user_id
     mascot_image_url
 
-    meta_keywords
-
     suggested_tags
     suggested_users
   ].freeze

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -216,10 +216,10 @@ module ApplicationHelper
     SiteConfig.community_member_label.pluralize
   end
 
-  def meta_keywords_tag(tag)
+  def meta_keywords_tag(tag_name)
     return if SiteConfig.meta_keywords[:tag].blank?
 
-    tag(:meta, name: "keywords", content: "#{SiteConfig.meta_keywords[:tag]}, #{tag}")
+    tag.meta name: "keywords", content: "#{SiteConfig.meta_keywords[:tag]}, #{tag_name}"
   end
 
   def app_url(uri = nil)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -216,6 +216,12 @@ module ApplicationHelper
     SiteConfig.community_member_label.pluralize
   end
 
+  def meta_keywords_tag(tag)
+    return if SiteConfig.meta_keywords[:tag].blank?
+
+    tag(:meta, name: "keywords", content: "#{SiteConfig.meta_keywords[:tag]}, #{tag}")
+  end
+
   def app_url(uri = nil)
     URL.url(uri)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -216,6 +216,12 @@ module ApplicationHelper
     SiteConfig.community_member_label.pluralize
   end
 
+  def meta_keywords_default
+    return if SiteConfig.meta_keywords[:default].blank?
+
+    tag.meta name: "keywords", content: SiteConfig.meta_keywords[:default]
+  end
+
   def meta_keywords_tag(tag_name)
     return if SiteConfig.meta_keywords[:tag].blank?
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -222,6 +222,18 @@ module ApplicationHelper
     tag.meta name: "keywords", content: SiteConfig.meta_keywords[:default]
   end
 
+  def meta_keywords_article(article_tags = nil)
+    return if SiteConfig.meta_keywords[:article].blank?
+
+    content = if article_tags.present?
+                "#{article_tags}, #{SiteConfig.meta_keywords[:article]}"
+              else
+                SiteConfig.meta_keywords[:article]
+              end
+
+    tag.meta name: "keywords", content: content
+  end
+
   def meta_keywords_tag(tag_name)
     return if SiteConfig.meta_keywords[:tag].blank?
 

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -642,7 +642,7 @@
                 <%= f.fields_for :meta_keywords do |meta_keywords_field| %>
                   <% SiteConfig.meta_keywords.each do |area, keywords| %>
                     <div>
-                      <%= meta_keywords_field.label "#{area}*" %>
+                      <%= meta_keywords_field.label area.to_s %>
                       <%= meta_keywords_field.text_field area,
                                                          class: "form-control",
                                                          value: SiteConfig.meta_keywords[area],
@@ -814,12 +814,12 @@
           </div>
           <div class="card mt-3">
             <%= render partial: "card_header",
-                      locals: {
-                        header: "Rate limits and anti-spam",
-                        state: "collapse",
-                        target: "rateLimitsBodyContainer",
-                        expanded: "false"
-                      } %>
+                       locals: {
+                         header: "Rate limits and anti-spam",
+                         state: "collapse",
+                         target: "rateLimitsBodyContainer",
+                         expanded: "false"
+                       } %>
             <div id="rateLimitsBodyContainer" class="card-body collapse hide" aria-labelledby="rateLimitsBodyContainer">
               <% configurable_rate_limits.each do |key, field_hash| %>
                 <div class="form-group">
@@ -835,28 +835,28 @@
               <div class="form-group">
                 <%= admin_config_label :spam_trigger_terms %>
                 <%= f.text_field :spam_trigger_terms,
-                                class: "form-control",
-                                value: SiteConfig.spam_trigger_terms.join(","),
-                                placeholder: Constants::SiteConfig::DETAILS[:spam_trigger_terms][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.spam_trigger_terms.join(","),
+                                 placeholder: Constants::SiteConfig::DETAILS[:spam_trigger_terms][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:spam_trigger_terms][:description] %></div>
               </div>
             </div>
           </div>
           <div class="card mt-3">
             <%= render partial: "card_header",
-                      locals: {
-                        header: "Social Media",
-                        state: "collapse",
-                        target: "socialMediaBodyContainer",
-                        expanded: "false"
-                      } %>
+                       locals: {
+                         header: "Social Media",
+                         state: "collapse",
+                         target: "socialMediaBodyContainer",
+                         expanded: "false"
+                       } %>
             <div id="socialMediaBodyContainer" class="card-body collapse hide" aria-labelledby="socialMediaBodyContainer">
               <div class="form-group">
                 <%= admin_config_label :twitter_hashtag %>
                 <%= f.text_field :twitter_hashtag,
-                                class: "form-control",
-                                value: SiteConfig.twitter_hashtag.to_s,
-                                placeholder: Constants::SiteConfig::DETAILS[:twitter_hashtag][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.twitter_hashtag.to_s,
+                                 placeholder: Constants::SiteConfig::DETAILS[:twitter_hashtag][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:twitter_hashtag][:description] %></div>
               </div>
               <div class="form-group">
@@ -878,38 +878,38 @@
 
           <div class="card mt-3">
             <%= render partial: "card_header",
-                      locals: {
-                        header: "Sponsors",
-                        state: "collapse",
-                        target: "sponsorsContainer",
-                        expanded: "false"
-                      } %>
+                       locals: {
+                         header: "Sponsors",
+                         state: "collapse",
+                         target: "sponsorsContainer",
+                         expanded: "false"
+                       } %>
             <div id="sponsorsContainer" class="card-body collapse hide" aria-labelledby="sponsorsContainer">
               <div class="form-group">
                 <%= f.label :sponsor_headline %>
                 <%= f.text_field :sponsor_headline,
-                                class: "form-control",
-                                value: SiteConfig.sponsor_headline,
-                                placeholder: Constants::SiteConfig::DETAILS[:sponsor_headline][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.sponsor_headline,
+                                 placeholder: Constants::SiteConfig::DETAILS[:sponsor_headline][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:sponsor_headline][:description] %></div>
               </div>
             </div>
           </div>
           <div class="card mt-3">
             <%= render partial: "card_header",
-                      locals: {
-                        header: "Tags",
-                        state: "collapse",
-                        target: "tagsBodyContainer",
-                        expanded: "false"
-                      } %>
+                       locals: {
+                         header: "Tags",
+                         state: "collapse",
+                         target: "tagsBodyContainer",
+                         expanded: "false"
+                       } %>
             <div id="tagsBodyContainer" class="card-body collapse hide" aria-labelledby="tagsBodyContainer">
               <div class="form-group">
                 <%= admin_config_label :sidebar_tags %>
                 <%= f.text_field :sidebar_tags,
-                                class: "form-control",
-                                value: SiteConfig.sidebar_tags.join(","),
-                                placeholder: Constants::SiteConfig::DETAILS[:sidebar_tags][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.sidebar_tags.join(","),
+                                 placeholder: Constants::SiteConfig::DETAILS[:sidebar_tags][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:sidebar_tags][:description] %></div>
               </div>
             </div>
@@ -917,47 +917,47 @@
 
           <div class="card mt-3">
             <%= render partial: "card_header",
-                      locals: {
-                        header: "User Experience and Brand",
-                        state: "collapse",
-                        target: "uxBodyContainer",
-                        expanded: "false"
-                      } %>
+                       locals: {
+                         header: "User Experience and Brand",
+                         state: "collapse",
+                         target: "uxBodyContainer",
+                         expanded: "false"
+                       } %>
             <div id="uxBodyContainer" class="card-body collapse hide" aria-labelledby="uxBodyContainer">
               <div class="form-group">
                 <%= f.label :feed_style %>
                 <%= f.text_field :feed_style,
-                                class: "form-control",
-                                value: SiteConfig.feed_style,
-                                placeholder: Constants::SiteConfig::DETAILS[:feed_style][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.feed_style,
+                                 placeholder: Constants::SiteConfig::DETAILS[:feed_style][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:feed_style][:description] %></div>
               </div>
               <div class="form-group">
                 <%= f.label :feed_strategy %>
                 <%= f.text_field :feed_strategy,
-                                class: "form-control",
-                                value: SiteConfig.feed_strategy,
-                                placeholder: Constants::SiteConfig::DETAILS[:feed_strategy][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.feed_strategy,
+                                 placeholder: Constants::SiteConfig::DETAILS[:feed_strategy][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:feed_strategy][:description] %></div>
               </div>
               <div class="form-group">
                 <%= f.label :default_font %>
                 <%= select_tag "site_config[default_font]",
-                              options_for_select(
-                                [%w[sans-serif sans_serif], %w[serif serif], %w[open-dyslexic open_dyslexic]],
-                                SiteConfig.default_font,
-                              ),
-                              multiple: false,
-                              class: "form-control selectpicker" %>
+                               options_for_select(
+                                 [%w[sans-serif sans_serif], %w[serif serif], %w[open-dyslexic open_dyslexic]],
+                                 SiteConfig.default_font,
+                               ),
+                               multiple: false,
+                               class: "form-control selectpicker" %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:default_font][:description] %></div>
               </div>
               <div class="form-group">
                 <%= f.label :primary_brand_color_hex %>
                 <%= f.text_field :primary_brand_color_hex,
-                                class: "form-control",
-                                value: SiteConfig.primary_brand_color_hex,
-                                pattern: "^#+([a-fA-F0-9]{6})$",
-                                placeholder: Constants::SiteConfig::DETAILS[:primary_brand_color_hex][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.primary_brand_color_hex,
+                                 pattern: "^#+([a-fA-F0-9]{6})$",
+                                 placeholder: Constants::SiteConfig::DETAILS[:primary_brand_color_hex][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:primary_brand_color_hex][:description] %></div>
               </div>
               <div class="form-group">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -7,7 +7,7 @@
 
   <link rel="canonical" href="<%= app_url(request.path) %>" />
   <meta name="description" content="<%= SiteConfig.community_description %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= app_url(request.path) %>" />

--- a/app/views/articles/search/_meta.html.erb
+++ b/app/views/articles/search/_meta.html.erb
@@ -1,7 +1,7 @@
 <% title "Search Results" %>
 <link rel="canonical" href="<%= app_url(search_path) %>" />
 <meta name="description" content="<%= SiteConfig.community_description %>">
-<meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+<%= meta_keywords_default %>
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= community_name %> => Search Results" />

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -50,12 +50,12 @@
 <% if internal_navigation? %>
   <link rel="canonical" href="<%= @article.canonical_url.presence || app_url(@article.path) %>" />
   <meta name="description" content="<%= @article.description_and_tags %>">
-  <meta name="keywords" content="<%= @article.cached_tag_list %>, <%= SiteConfig.meta_keywords[:article] %>">
+  <%= meta_keywords_article(@article.cached_tag_list) %>
 <% else %>
   <%= content_for :page_meta do %>
     <link rel="canonical" href="<%= @article.canonical_url.presence || app_url(@article.path) %>" />
     <meta name="description" content="<%= @article.description_and_tags %>">
-    <meta name="keywords" content="<%= @article.cached_tag_list %>, <%= SiteConfig.meta_keywords[:article] %>">
+    <%= meta_keywords_article(@article.cached_tag_list) %>
 
     <meta property="og:type" content="article" />
     <meta property="og:url" content="<%= article_url(@article) %>" />

--- a/app/views/articles/tags/_meta.html.erb
+++ b/app/views/articles/tags/_meta.html.erb
@@ -6,7 +6,7 @@
 
 <link rel="canonical" href="<%= tag_url(@tag_model, @page) %>" />
 <meta name="description" content="<%= @tag %> content on <%= community_name %>">
-<meta name="keywords" content="<%= SiteConfig.meta_keywords[:tag] %>, <%= @tag %>">
+<%= meta_keywords_tag(@tag) %>
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= tag_url(@tag_model, @page) %>" />

--- a/app/views/collections/_meta.html.erb
+++ b/app/views/collections/_meta.html.erb
@@ -1,7 +1,7 @@
 <% title title_string %>
 <link rel="canonical" href="<%= app_url("/about") %>" />
 <meta name="description" content="<%= title_string %> on <%= community_name %>">
-<meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+<%= meta_keywords_default %>
 
 <meta property="og:type" content="article" />
 <meta property="og:url" content="<%= app_url("/about") %>" />

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -6,7 +6,7 @@
 
 <%= content_for :page_meta do %>
   <meta name="description" content="<%= @commentable.description || "An article from the community" %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:article] %>">
+  <%= meta_keywords_article %>
 
   <meta property="og:type" content="article" />
   <meta property="og:title" content="Discussion of <%= @commentable.title %>" />

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,7 +2,8 @@
   <% title("#{community_name} EVENTS") %>
   <link rel="canonical" href="<%= app_url("/events") %>" />
   <meta name="description" content="<%= community_name %> Events">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+<%= meta_keywords_default %>
+
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/events") %>" />
   <meta property="og:title" content="<%= community_name %> Events" />

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -2,7 +2,7 @@
   <% title("#{@event.title} - #{community_name}") %>
   <link rel="canonical" href="<%= app_url("/#{@event.slug}") %>" />
   <meta name="description" content="<%= community_name %> | Events">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+ <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/#{@event.slug}") %>" />

--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -3,7 +3,7 @@
 
   <link rel="canonical" href="<%= app_url(request.path) %>" />
   <meta name="description" content="<%= SiteConfig.community_description %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>y">
+  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= app_url(request.path) %>" />
   <meta property="og:site_name" content="<%= community_qualified_name %>" />

--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -3,7 +3,8 @@
 
   <link rel="canonical" href="<%= app_url(request.path) %>" />
   <meta name="description" content="<%= SiteConfig.community_description %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
+
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= app_url(request.path) %>" />
   <meta property="og:site_name" content="<%= community_qualified_name %>" />

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/notifications") %>" />
   <meta name="description" content="Notifications inbox for <%= community_name %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/notifications") %>" />

--- a/app/views/pages/badges.html.erb
+++ b/app/views/pages/badges.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/p/badges") %>" />
   <meta name="description" content="Add the <%= community_name %> Badge to your personal site">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/p/badges") %>" />

--- a/app/views/pages/code_of_conduct.html.erb
+++ b/app/views/pages/code_of_conduct.html.erb
@@ -3,7 +3,8 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url(code_of_conduct_path) %>" />
   <meta name="description" content="<%= community_qualified_name %> Code of Conduct">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
+
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url(code_of_conduct_path) %>" />
   <meta property="og:title" content="<%= community_qualified_name %> Code of Conduct" />

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/contact") %>" />
   <meta name="description" content="Contact #{community_qualified_name}">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/contact") %>" />

--- a/app/views/pages/editor_guide.html.erb
+++ b/app/views/pages/editor_guide.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/p/editor_guide") %>" />
   <meta name="description" content="<%= community_name %> | editor guideline">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 <% end %>
 
 <div class="blank-space"></div>

--- a/app/views/pages/information.html.erb
+++ b/app/views/pages/information.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/p/information") %>" />
   <meta name="description" content="All information about <%= community_qualified_name %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/p/information") %>" />

--- a/app/views/pages/markdown_basics.html.erb
+++ b/app/views/pages/markdown_basics.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/p/markdown_basics") %>" />
   <meta name="description" content="dev.to | markdown basics">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 <% end %>
 
 <div class="crayons-layout crayons-layout--limited">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/privacy") %>" />
   <meta name="description" content="Privacy Policy for <%= community_name %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/privacy") %>" />

--- a/app/views/pages/publishing_from_rss_guide.html.erb
+++ b/app/views/pages/publishing_from_rss_guide.html.erb
@@ -3,8 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/p/publishing_from_rss_guide") %>" />
   <meta name="description" content="dev.to | publishing from rss guideline">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
-
+  <%= meta_keywords_default %>
 <% end %>
 
 <header>

--- a/app/views/pages/report_abuse.html.erb
+++ b/app/views/pages/report_abuse.html.erb
@@ -2,7 +2,8 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/report-abuse") %>" />
   <meta name="description" content="Report Abuse">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
+
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/report-abuse") %>" />
   <meta property="og:title" content="Report Abuse" />

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -2,7 +2,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url(@page.path) %>" />
   <meta name="description" content="<%= @page.title %> — <%= community_qualified_name %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url(@page.path) %>" />

--- a/app/views/pages/sponsors.html.erb
+++ b/app/views/pages/sponsors.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/sponsors") %>" />
   <meta name="description" content="<%= community_name %> | Sponsors">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 <% end %>
 
 <div class="crayons-layout crayons-layout--limited">

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/terms") %>" />
   <meta name="description" content="Terms of Use for the <%= community_qualified_name %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/terms") %>" />

--- a/app/views/podcast_episodes/_meta.html.erb
+++ b/app/views/podcast_episodes/_meta.html.erb
@@ -4,7 +4,7 @@
   <%= content_for :page_meta do %>
     <link rel="canonical" href="<%= app_url(@podcast.slug) %>" />
     <meta name="description" content="<%= @podcast.description %>">
-    <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+    <%= meta_keywords_default %>
 
     <meta property="og:type" content="article" />
     <meta property="og:url" content="<%= app_url(@podcast.slug) %>" />
@@ -26,7 +26,7 @@
   <%= content_for :page_meta do %>
     <link rel="canonical" href="<%= app_url(pod_path) %>" />
     <meta name="description" content="Discover technical podcasts for <%= community_members_label %>">
-    <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+    <%= meta_keywords_default %>
 
     <meta property="og:type" content="article" />
     <meta property="og:url" content="<%= app_url(pod_path) %>" />

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/#{@podcast.slug}/#{@episode.slug}") %>" />
   <meta name="description" content="<%= truncate(strip_tags(@episode.body), length: 140) %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/#{@podcast.slug}/#{@episode.slug}") %>" />

--- a/app/views/reading_list_items/index.html.erb
+++ b/app/views/reading_list_items/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/readinglist") %>" />
   <meta name="description" content="My saved posts.">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/readinglist") %>" />

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url("/about") %>" />
   <meta name="description" content="Tags to follow on <%= community_name %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/about") %>" />

--- a/app/views/users/_meta.html.erb
+++ b/app/views/users/_meta.html.erb
@@ -1,6 +1,6 @@
 <link rel="canonical" href="<%= user_url(@user) %>" />
 <meta name="description" content="<%= @user.summary %>">
-<meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+<%= meta_keywords_default %>
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= user_url(@user) %>" />

--- a/app/views/videos/index.html.erb
+++ b/app/views/videos/index.html.erb
@@ -3,7 +3,7 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url(request.path) %>" />
   <meta name="description" content="<%= SiteConfig.community_description %>">
-  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
+  <%= meta_keywords_default %>
 
   <meta property="og:type" content="website" />
   <meta property="og:url" content="<%= app_url(request.path) %>" />

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -78,12 +78,23 @@ RSpec.describe "ArticlesShow", type: :request do
   end
   # rubocop:enable RSpec/ExampleLength
 
-  context "when keywords are set up" do
+  context "when keywords are set" do
     it "shows keywords" do
       SiteConfig.meta_keywords = { article: "hello, world" }
       article.update_column(:cached_tag_list, "super sheep")
       get article.path
       expect(response.body).to include('<meta name="keywords" content="super sheep, hello, world">')
+    end
+  end
+
+  context "when keywords are not" do
+    it "does not show keywords" do
+      SiteConfig.meta_keywords = { article: "" }
+      article.update_column(:cached_tag_list, "super sheep")
+      get article.path
+      expect(response.body).not_to include(
+        '<meta name="keywords" content="super sheep, hello, world">',
+      )
     end
   end
 

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -119,10 +119,18 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.headers["X-Accel-Expires"]).to eq("600")
     end
 
-    it "shows default meta keywords" do
+    it "shows default meta keywords if set" do
       SiteConfig.meta_keywords = { default: "cool developers, civil engineers" }
       get "/"
       expect(response.body).to include("<meta name=\"keywords\" content=\"cool developers, civil engineers\">")
+    end
+
+    it "does not show default meta keywords if not set" do
+      SiteConfig.meta_keywords = { default: "" }
+      get "/"
+      expect(response.body).not_to include(
+        "<meta name=\"keywords\" content=\"cool developers, civil engineers\">",
+      )
     end
 
     it "shows only one cover if basic feed style" do
@@ -348,10 +356,18 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.body).to include(sponsorship.blurb_html)
     end
 
-    it "shows meta keywords" do
+    it "shows meta keywords if set" do
       SiteConfig.meta_keywords = { tag: "software engineering, ruby" }
       get "/t/#{tag.name}"
       expect(response.body).to include("<meta name=\"keywords\" content=\"software engineering, ruby, #{tag.name}\">")
+    end
+
+    it "does not show meta keywords if not set" do
+      SiteConfig.meta_keywords = { tag: "" }
+      get "/t/#{tag.name}"
+      expect(response.body).not_to include(
+        "<meta name=\"keywords\" content=\"software engineering, ruby, #{tag.name}\">",
+      )
     end
 
     context "with user signed in" do

--- a/spec/system/admin/admin_manages_configuration_spec.rb
+++ b/spec/system/admin/admin_manages_configuration_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe "Admin manages configuration", type: :system do
     visit admin_config_path
   end
 
-  # Note: The :meta_keywords are handled slightly differently in the view, so we
-  # can't check them the same way as the rest.
-  (VerifySetupCompleted::MANDATORY_CONFIGS - [:meta_keywords]).each do |option|
+  VerifySetupCompleted::MANDATORY_CONFIGS.each do |option|
     it "marks #{option} as required" do
       selector = "label[for='site_config_#{option}']"
       expect(first(selector).text).to include("Required")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As a part of our ongoing Forem creator onboarding project, we are removing some required fields from the SiteConfig and making them optional. This will help reduce the number of fields that a brand new Forem creator will have to fill out when they set up a new Forem instance.

This PR makes `SiteConfig.meta_keywords` **not required**. These fields can still be configured by Forem creators, but _not_ defining them will not stop them from setting up new instances.

Since a `meta_keyword` may or may not be set, I also did some refactoring in this PR to conditionally render a `<meta />` tag if the appropriate keyword is defined for it. This allows us to avoid having to add these guards in a ton of places in our codebase:
```ruby
<% if SiteConfig.meta_keywords[:default].present? %>
  <meta name="keywords" content="<%= SiteConfig.meta_keywords[:default] %>">
<% end %>
```

and instead allows us to just write this, instead:
```ruby
<%= meta_keywords_default %>
```

The helper will generate and render the `<meta />` tag if the keyword exists, and render nothing if it doesn't! 😉 

🗒️  _A note about future work:_ As part of the onboarding process, we will eventually be asking Forem creators for something called `Community tags`. The end goal is to pre-populate the `meta_keywords` in the SiteConfig with the values of `Community tags` -- but this PR doesn't tackle that, it's just the _set up work_ for that eventual feature (which you can [read more about here](https://github.com/forem/InternalProjectPlanning/issues/113)).

## Related Tickets & Documents
Fixes https://github.com/forem/InternalProjectPlanning/issues/87.

## QA Instructions, Screenshots, Recordings

The `meta_keywords` still exist on `/admin/config`, under the `Meta Keywords` section:
<img width="1101" alt="Screen Shot 2020-10-07 at 1 19 05 PM" src="https://user-images.githubusercontent.com/6921610/95383468-1381df00-08a0-11eb-8e07-96b0a822af6f.png">


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

