### PR TITLE
Only show setup completed banner to single resource admins

### DIFF
--- a/app/controllers/concerns/verify_setup_completed.rb
+++ b/app/controllers/concerns/verify_setup_completed.rb
@@ -21,9 +21,9 @@ module VerifySetupCompleted
   ].freeze
 
   included do
-    # rubocop:disable Rails/LexicallyScopedActionFilter
-    before_action :verify_setup_completed, only: %i[index new edit show]
-    # rubocop:enable Rails/LexicallyScopedActionFilter
+    before_action :verify_setup_completed,
+                  only: %i[index new edit show],
+                  if: -> { current_user&.has_role?(:single_resource_admin) }
   end
 
   def setup_completed?

--- a/spec/system/admin/admin_manages_configuration_spec.rb
+++ b/spec/system/admin/admin_manages_configuration_spec.rb
@@ -1,40 +1,70 @@
 require "rails_helper"
 
 RSpec.describe "Admin manages configuration", type: :system do
-  let(:admin) { create(:user, :super_admin) }
+  let(:single_resource_admin) { create(:user, :single_resource_admin) }
 
-  before do
-    sign_in admin
-    visit admin_config_path
-  end
+  context "when on the config page" do
+    before do
+      sign_in single_resource_admin
+      visit admin_config_path
+    end
 
-  # Note: The :meta_keywords are handled slightly differently in the view, so we
-  # can't check them the same way as the rest.
-  (VerifySetupCompleted::MANDATORY_CONFIGS - [:meta_keywords]).each do |option|
-    it "marks #{option} as required" do
-      selector = "label[for='site_config_#{option}']"
-      expect(first(selector).text).to include("Required")
+    # Note: The :meta_keywords are handled slightly differently in the view, so we
+    # can't check them the same way as the rest.
+    (VerifySetupCompleted::MANDATORY_CONFIGS - [:meta_keywords]).each do |option|
+      it "marks #{option} as required" do
+        selector = "label[for='site_config_#{option}']"
+        expect(first(selector).text).to include("Required")
+      end
     end
   end
 
-  context "when mandatory options are missing" do
-    it "does not show the banner on the config page" do
-      allow(SiteConfig).to receive(:tagline).and_return(nil)
-      expect(page).not_to have_content("Setup not completed yet")
+  describe "setup completed banner" do
+    context "when logged in as single resource admin" do
+      it "does not show the banner on the config page" do
+        allow(SiteConfig).to receive(:logo_png).and_return(nil)
+
+        sign_in single_resource_admin
+        visit admin_config_path
+
+        expect(page).not_to have_content("Setup not completed yet")
+      end
+
+      it "shows the banner on other pages for single resource admins" do
+        allow(SiteConfig).to receive(:logo_png).and_return(nil)
+
+        sign_in single_resource_admin
+        visit root_path
+
+        expect(page).to have_content("Setup not completed yet")
+      end
+
+      it "includes information about missing fields on the config pages" do
+        allow(SiteConfig).to receive(:logo_png).and_return(nil)
+        allow(SiteConfig).to receive(:suggested_users).and_return(nil)
+        allow(SiteConfig).to receive(:suggested_tags).and_return(nil)
+
+        sign_in single_resource_admin
+        visit root_path
+
+        expect(page.body).to match(/Setup not completed yet, missing(.*)main social image(.*), and others/)
+      end
     end
 
-    it "does show the banner on other pages" do
-      allow(SiteConfig).to receive(:tagline).and_return(nil)
-      visit root_path
-      expect(page).to have_content("Setup not completed yet")
-    end
+    context "when logged in as other user type" do
+      it "does not show the banner for admins" do
+        sign_in create(:user, :admin)
+        visit root_path
 
-    it "includes information about missing fields on the config pages" do
-      allow(SiteConfig).to receive(:tagline).and_return(nil)
-      allow(SiteConfig).to receive(:suggested_users).and_return(nil)
-      allow(SiteConfig).to receive(:suggested_tags).and_return(nil)
-      visit root_path
-      expect(page.body).to match(/Setup not completed yet, missing(.*)main social image(.*), and others/)
+        expect(page).not_to have_content("Setup not completed yet")
+      end
+
+      it "does not show the banner for users" do
+        sign_in create(:user)
+        visit root_path
+
+        expect(page).not_to have_content("Setup not completed yet")
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

Yesterday we deployed a [PR](https://github.com/forem/forem/pull/10671) that made a `SiteConfig` option to the mandatory configs defined in `VerifySetupCompleted`, without ensuring that this value is actually set on DEV. This led to a brief period where all users could see the following banner:

![image](https://user-images.githubusercontent.com/47985/95419014-e2b6ae00-0962-11eb-9d52-791e626f7955.png)

This PR updates the verification code to only display the banner to single resource admins. They are the only ones who actually can set the missing values, so the banner offers little benefit to other users since there's nothing actionable for them (except for maybe pinging an admin). 

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

* Ensure one of the mandatory configs (e.g. `logo_png` or `logo_svg`) is `nil`.
* Visit the site with a non-admin user, you shouldn't see a banner.
* Visit the site with a single resource admin (`user.add_role(:single_resource_admin)`), you should now see the banner.

## Added tests?

- [X] yes, improved and added

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
