### PR TITLE
Add recaptcha keys to as site-configurable keys

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -58,6 +58,8 @@ module Admin
         allow_email_password_registration
         primary_brand_color_hex
         spam_trigger_terms
+        recaptcha_site_key
+        recaptcha_secret_key
       ]
 
       allowed_params = allowed_params |

--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -9,7 +9,7 @@ class FeedbackMessagesController < ApplicationController
     params = feedback_message_params.merge(reporter_id: current_user&.id)
     @feedback_message = FeedbackMessage.new(params)
 
-    if recaptcha_verified? && @feedback_message.save
+    if (recaptcha_disabled? || recaptcha_verified?) && @feedback_message.save
       Slack::Messengers::Feedback.call(
         user: current_user,
         type: feedback_message_params[:feedback_type],
@@ -30,9 +30,11 @@ class FeedbackMessagesController < ApplicationController
 
   private
 
-  def recaptcha_verified?
-    return true if SiteConfig.recaptcha_site_key.blank? && SiteConfig.recaptcha_secret_key.blank?
+  def recaptcha_disabled?
+    SiteConfig.recaptcha_site_key.blank? && SiteConfig.recaptcha_secret_key.blank?
+  end
 
+  def recaptcha_verified?
     recaptcha_params = { secret_key: SiteConfig.recaptcha_secret_key }
     params["g-recaptcha-response"] && verify_recaptcha(recaptcha_params)
   end

--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -31,7 +31,7 @@ class FeedbackMessagesController < ApplicationController
   private
 
   def recaptcha_verified?
-    recaptcha_params = { secret_key: ApplicationConfig["RECAPTCHA_SECRET"] }
+    recaptcha_params = { secret_key: SiteConfig.recaptcha_secret_key }
     params["g-recaptcha-response"] && verify_recaptcha(recaptcha_params)
   end
 

--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -31,6 +31,8 @@ class FeedbackMessagesController < ApplicationController
   private
 
   def recaptcha_verified?
+    return true if SiteConfig.recaptcha_site_key.blank? && SiteConfig.recaptcha_secret_key.blank?
+
     recaptcha_params = { secret_key: SiteConfig.recaptcha_secret_key }
     params["g-recaptcha-response"] && verify_recaptcha(recaptcha_params)
   end

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -215,6 +215,14 @@ module Constants
         description: "Determines the mininum for the periodic email digest",
         placeholder: 2
       },
+      recaptcha_site_key: {
+        description: "Site key for Google ReCAPTCHA, used for reporting abuse.",
+        placeholder: "..."
+      },
+      recaptcha_secret_key: {
+        description: "Secret key for Google ReCAPTCHA, used for reporting abuse.",
+        placeholder: "..."
+      },
       right_navbar_svg_icon: {
         description: "The SVG icon used to expand the right navbar navigation menu. Should be a max of 24x24px.",
         placeholder: "<svg ...></svg>"

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -220,7 +220,7 @@ module Constants
         placeholder: "..."
       },
       recaptcha_secret_key: {
-        description: "Secret key for Google ReCAPTCHA, used for reporting abuse.",
+        description: "Secret key for Google reCAPTCHA, used for reporting abuse.",
         placeholder: "..."
       },
       right_navbar_svg_icon: {

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -216,7 +216,7 @@ module Constants
         placeholder: 2
       },
       recaptcha_site_key: {
-        description: "Site key for Google ReCAPTCHA, used for reporting abuse.",
+        description: "Site key for Google reCAPTCHA, used for reporting abuse.",
         placeholder: "..."
       },
       recaptcha_secret_key: {

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -67,6 +67,10 @@ class SiteConfig < RailsSettings::Base
   # Google Analytics Tracking ID, e.g. UA-71991000-1
   field :ga_tracking_id, type: :string, default: ApplicationConfig["GA_TRACKING_ID"]
 
+  # Google ReCATPCHA keys
+  field :recaptcha_site_key, type: :string, default: ApplicationConfig["RECAPTCHA_SITE"]
+  field :recaptcha_secret_key, type: :string, default: ApplicationConfig["RECAPTCHA_SECRET"]
+
   # Images
   field :main_social_image, type: :string
   field :favicon_url, type: :string, default: "favicon.ico"

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -474,14 +474,14 @@
                        } %>
             <div id="recaptchaContainer" class="card-body collapse hide" aria-labelledby="recaptchaContainer">
               <div class="form-group">
-                <%= admin_config_label :recaptcha_site_key, "ReCAPTCHA Site Key" %>
+                <%= admin_config_label :recaptcha_site_key, "reCAPTCHA Site Key" %>
                 <%= f.text_field :recaptcha_site_key,
                                  class: "form-control",
                                  value: SiteConfig.recaptcha_site_key %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:recaptcha_site_key][:description] %></div>
               </div>
               <div class="form-group">
-                <%= admin_config_label :recaptcha_secret_key, "ReCAPTCHA Secret Key" %>
+                <%= admin_config_label :recaptcha_secret_key, "reCAPTCHA Secret Key" %>
                 <%= f.text_field :recaptcha_secret_key,
                                  class: "form-control",
                                  value: SiteConfig.recaptcha_secret_key %>

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -467,6 +467,32 @@
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
+                         header: "Google ReCAPTCHA Keys",
+                         state: "collapse",
+                         target: "recaptchaContainer",
+                         expanded: "false"
+                       } %>
+            <div id="recaptchaContainer" class="card-body collapse hide" aria-labelledby="recaptchaContainer">
+              <div class="form-group">
+                <%= admin_config_label :recaptcha_site_key, "ReCAPTCHA Site Key" %>
+                <%= f.text_field :recaptcha_site_key,
+                                 class: "form-control",
+                                 value: SiteConfig.recaptcha_site_key %>
+                <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:recaptcha_site_key][:description] %></div>
+              </div>
+              <div class="form-group">
+                <%= admin_config_label :recaptcha_secret_key, "ReCAPTCHA Secret Key" %>
+                <%= f.text_field :recaptcha_secret_key,
+                                 class: "form-control",
+                                 value: SiteConfig.recaptcha_secret_key %>
+                <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:recaptcha_secret_key][:description] %></div>
+              </div>
+            </div>
+          </div>
+
+          <div class="card mt-3">
+            <%= render partial: "card_header",
+                       locals: {
                          header: "Images",
                          state: "collapse",
                          target: "imagesBodyContainer",
@@ -814,12 +840,12 @@
           </div>
           <div class="card mt-3">
             <%= render partial: "card_header",
-                      locals: {
-                        header: "Rate limits and anti-spam",
-                        state: "collapse",
-                        target: "rateLimitsBodyContainer",
-                        expanded: "false"
-                      } %>
+                       locals: {
+                         header: "Rate limits and anti-spam",
+                         state: "collapse",
+                         target: "rateLimitsBodyContainer",
+                         expanded: "false"
+                       } %>
             <div id="rateLimitsBodyContainer" class="card-body collapse hide" aria-labelledby="rateLimitsBodyContainer">
               <% configurable_rate_limits.each do |key, field_hash| %>
                 <div class="form-group">
@@ -835,28 +861,28 @@
               <div class="form-group">
                 <%= admin_config_label :spam_trigger_terms %>
                 <%= f.text_field :spam_trigger_terms,
-                                class: "form-control",
-                                value: SiteConfig.spam_trigger_terms.join(","),
-                                placeholder: Constants::SiteConfig::DETAILS[:spam_trigger_terms][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.spam_trigger_terms.join(","),
+                                 placeholder: Constants::SiteConfig::DETAILS[:spam_trigger_terms][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:spam_trigger_terms][:description] %></div>
               </div>
             </div>
           </div>
           <div class="card mt-3">
             <%= render partial: "card_header",
-                      locals: {
-                        header: "Social Media",
-                        state: "collapse",
-                        target: "socialMediaBodyContainer",
-                        expanded: "false"
-                      } %>
+                       locals: {
+                         header: "Social Media",
+                         state: "collapse",
+                         target: "socialMediaBodyContainer",
+                         expanded: "false"
+                       } %>
             <div id="socialMediaBodyContainer" class="card-body collapse hide" aria-labelledby="socialMediaBodyContainer">
               <div class="form-group">
                 <%= admin_config_label :twitter_hashtag %>
                 <%= f.text_field :twitter_hashtag,
-                                class: "form-control",
-                                value: SiteConfig.twitter_hashtag.to_s,
-                                placeholder: Constants::SiteConfig::DETAILS[:twitter_hashtag][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.twitter_hashtag.to_s,
+                                 placeholder: Constants::SiteConfig::DETAILS[:twitter_hashtag][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:twitter_hashtag][:description] %></div>
               </div>
               <div class="form-group">
@@ -878,38 +904,38 @@
 
           <div class="card mt-3">
             <%= render partial: "card_header",
-                      locals: {
-                        header: "Sponsors",
-                        state: "collapse",
-                        target: "sponsorsContainer",
-                        expanded: "false"
-                      } %>
+                       locals: {
+                         header: "Sponsors",
+                         state: "collapse",
+                         target: "sponsorsContainer",
+                         expanded: "false"
+                       } %>
             <div id="sponsorsContainer" class="card-body collapse hide" aria-labelledby="sponsorsContainer">
               <div class="form-group">
                 <%= f.label :sponsor_headline %>
                 <%= f.text_field :sponsor_headline,
-                                class: "form-control",
-                                value: SiteConfig.sponsor_headline,
-                                placeholder: Constants::SiteConfig::DETAILS[:sponsor_headline][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.sponsor_headline,
+                                 placeholder: Constants::SiteConfig::DETAILS[:sponsor_headline][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:sponsor_headline][:description] %></div>
               </div>
             </div>
           </div>
           <div class="card mt-3">
             <%= render partial: "card_header",
-                      locals: {
-                        header: "Tags",
-                        state: "collapse",
-                        target: "tagsBodyContainer",
-                        expanded: "false"
-                      } %>
+                       locals: {
+                         header: "Tags",
+                         state: "collapse",
+                         target: "tagsBodyContainer",
+                         expanded: "false"
+                       } %>
             <div id="tagsBodyContainer" class="card-body collapse hide" aria-labelledby="tagsBodyContainer">
               <div class="form-group">
                 <%= admin_config_label :sidebar_tags %>
                 <%= f.text_field :sidebar_tags,
-                                class: "form-control",
-                                value: SiteConfig.sidebar_tags.join(","),
-                                placeholder: Constants::SiteConfig::DETAILS[:sidebar_tags][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.sidebar_tags.join(","),
+                                 placeholder: Constants::SiteConfig::DETAILS[:sidebar_tags][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:sidebar_tags][:description] %></div>
               </div>
             </div>
@@ -917,47 +943,47 @@
 
           <div class="card mt-3">
             <%= render partial: "card_header",
-                      locals: {
-                        header: "User Experience and Brand",
-                        state: "collapse",
-                        target: "uxBodyContainer",
-                        expanded: "false"
-                      } %>
+                       locals: {
+                         header: "User Experience and Brand",
+                         state: "collapse",
+                         target: "uxBodyContainer",
+                         expanded: "false"
+                       } %>
             <div id="uxBodyContainer" class="card-body collapse hide" aria-labelledby="uxBodyContainer">
               <div class="form-group">
                 <%= f.label :feed_style %>
                 <%= f.text_field :feed_style,
-                                class: "form-control",
-                                value: SiteConfig.feed_style,
-                                placeholder: Constants::SiteConfig::DETAILS[:feed_style][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.feed_style,
+                                 placeholder: Constants::SiteConfig::DETAILS[:feed_style][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:feed_style][:description] %></div>
               </div>
               <div class="form-group">
                 <%= f.label :feed_strategy %>
                 <%= f.text_field :feed_strategy,
-                                class: "form-control",
-                                value: SiteConfig.feed_strategy,
-                                placeholder: Constants::SiteConfig::DETAILS[:feed_strategy][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.feed_strategy,
+                                 placeholder: Constants::SiteConfig::DETAILS[:feed_strategy][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:feed_strategy][:description] %></div>
               </div>
               <div class="form-group">
                 <%= f.label :default_font %>
                 <%= select_tag "site_config[default_font]",
-                              options_for_select(
-                                [%w[sans-serif sans_serif], %w[serif serif], %w[open-dyslexic open_dyslexic]],
-                                SiteConfig.default_font,
-                              ),
-                              multiple: false,
-                              class: "form-control selectpicker" %>
+                               options_for_select(
+                                 [%w[sans-serif sans_serif], %w[serif serif], %w[open-dyslexic open_dyslexic]],
+                                 SiteConfig.default_font,
+                               ),
+                               multiple: false,
+                               class: "form-control selectpicker" %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:default_font][:description] %></div>
               </div>
               <div class="form-group">
                 <%= f.label :primary_brand_color_hex %>
                 <%= f.text_field :primary_brand_color_hex,
-                                class: "form-control",
-                                value: SiteConfig.primary_brand_color_hex,
-                                pattern: "^#+([a-fA-F0-9]{6})$",
-                                placeholder: Constants::SiteConfig::DETAILS[:primary_brand_color_hex][:placeholder] %>
+                                 class: "form-control",
+                                 value: SiteConfig.primary_brand_color_hex,
+                                 pattern: "^#+([a-fA-F0-9]{6})$",
+                                 placeholder: Constants::SiteConfig::DETAILS[:primary_brand_color_hex][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:primary_brand_color_hex][:description] %></div>
               </div>
               <div class="form-group">

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -467,7 +467,7 @@
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
-                         header: "Google ReCAPTCHA Keys",
+                         header: "Google reCAPTCHA Keys",
                          state: "collapse",
                          target: "recaptchaContainer",
                          expanded: "false"

--- a/app/views/feedback_messages/_form.html.erb
+++ b/app/views/feedback_messages/_form.html.erb
@@ -68,7 +68,7 @@
   </div>
 
   <div>
-    <%= recaptcha_tags site_key: ApplicationConfig["RECAPTCHA_SITE"] %>
+    <%= recaptcha_tags site_key: SiteConfig.recaptcha_site_key %>
   </div>
 
   <div><button type="submit" name="commit" class="crayons-btn">Send Feedback</button></div>

--- a/app/views/feedback_messages/_form.html.erb
+++ b/app/views/feedback_messages/_form.html.erb
@@ -67,9 +67,11 @@
     <%= f.text_area :message, class: "crayons-textfield", placeholder: "...", value: @previous_message, required: true %>
   </div>
 
-  <div>
+<% if SiteConfig.recaptcha_secret_key.present? && SiteConfig.recaptcha_site_key.present? %>
+  <div class="recaptcha-tag-container">
     <%= recaptcha_tags site_key: SiteConfig.recaptcha_site_key %>
   </div>
+<% end %>
 
   <div><button type="submit" name="commit" class="crayons-btn">Send Feedback</button></div>
 <% end %>

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -551,6 +551,17 @@ RSpec.describe "/admin/config", type: :request do
                                           confirmation: confirmation_message }
           expect(SiteConfig.spam_trigger_terms).to eq(["hey", "pokemon go hack"])
         end
+
+        it "updates recaptcha_site_key and recaptcha_secret_key" do
+          site_key = "hi-ho"
+          secret_key = "lets-go"
+          post "/admin/config", params: {
+            site_config: { recaptcha_site_key: site_key, recaptcha_secret_key: secret_key },
+            confirmation: confirmation_message
+          }
+          expect(SiteConfig.recaptcha_site_key).to eq site_key
+          expect(SiteConfig.recaptcha_secret_key).to eq secret_key
+        end
       end
 
       describe "Social Media" do

--- a/spec/requests/feedback_messages_spec.rb
+++ b/spec/requests/feedback_messages_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe "feedback_messages", type: :request do
       end
     end
 
+    context "with no recaptcha keys set" do
+      before do
+        allow(SiteConfig).to receive(:recaptcha_secret_key).and_return("")
+        allow(SiteConfig).to receive(:recaptcha_site_key).and_return("")
+      end
+
+      it "does not show the recaptcha tag" do
+        get "/report-abuse"
+        expect(response.body).not_to include("recaptcha-tag-container")
+      end
+
+      it "creates a feedback message" do
+        expect do
+          post feedback_messages_path, params: valid_abuse_report_params, headers: headers
+        end.to change(FeedbackMessage, :count).by(1)
+      end
+    end
+
     context "with invalid recaptcha" do
       it "rerenders page" do
         post "/feedback_messages", params: valid_abuse_report_params, headers: headers


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This adds Google ReCAPTCHA keys into `SiteConfig`, so that Forem admins are able to add ReCAPTCHA without having to go through the `.env` file.

## QA Instructions, Screenshots, Recordings
1. Visit /admin/config
2. Find the Google ReCAPTCHA field
3. Update the field to anything
4. Verify that it updated

![Screen Shot 2020-10-08 at 9 35 05 AM](https://user-images.githubusercontent.com/17884966/95465817-9743d600-0949-11eb-8d32-aefc863b9120.png)

## Added tests?
- [x] yes

## Added to documentation?
- [x] to add to forem admin docs

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![Lorelai Gilmore says, "I assuming you have documentation."](https://media.giphy.com/media/3ofT5R8ZsrvUPm75vy/giphy.gif)
