### PR TITLE
Long text goes outside cards

### DIFF
--- a/app/assets/stylesheets/components/cards.scss
+++ b/app/assets/stylesheets/components/cards.scss
@@ -5,7 +5,7 @@
   background: var(--card-bg);
   color: var(--card-color);
   box-shadow: 0 0 0 1px var(--card-border);
-  word-break: break-word;
+  overflow-wrap: anywhere;
 
   &--secondary {
     background: var(--card-secondary-bg);

--- a/app/assets/stylesheets/components/cards.scss
+++ b/app/assets/stylesheets/components/cards.scss
@@ -5,6 +5,7 @@
   background: var(--card-bg);
   color: var(--card-color);
   box-shadow: 0 0 0 1px var(--card-border);
+  word-break: break-word;
 
   &--secondary {
     background: var(--card-secondary-bg);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add word-break to crayons-card this will allow words to be broken if the word is too long but will wrap normally otherwise.

## Related Tickets & Documents
closes: #10629

## QA Instructions, Screenshots, Recordings
![forem__resize-bug](https://user-images.githubusercontent.com/3534427/95484596-92524700-0988-11eb-98c4-57ac7e6eeddc.gif)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![fix it with love](https://media.giphy.com/media/WQwQnLNj888eaF2wjd/giphy.gif)
