### PR TITLE
Move Imgproxy endpoint config to Images::Optimizer

### DIFF
--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -35,7 +35,7 @@ module Images
 
     def self.imgproxy(img_src, **kwargs)
       options = DEFAULT_IMGPROXY_OPTIONS.merge(kwargs).reject { |_, v| v.blank? }
-      Imgproxy.config.endpoint ||= set_imgproxy_endpoint
+      Imgproxy.config.endpoint ||= get_imgproxy_endpoint
       Imgproxy.url_for(img_src, options)
     end
 
@@ -43,7 +43,7 @@ module Images
       Imgproxy.config.key.present? && Imgproxy.config.salt.present?
     end
 
-    def self.set_imgproxy_endpoint
+    def self.get_imgproxy_endpoint
       if Rails.env.production?
         # Use /images with the same domain on Production as
         # our default configuration

--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -35,12 +35,26 @@ module Images
 
     def self.imgproxy(img_src, **kwargs)
       options = DEFAULT_IMGPROXY_OPTIONS.merge(kwargs).reject { |_, v| v.blank? }
-
+      Imgproxy.config.endpoint ||= set_imgproxy_endpoint
       Imgproxy.url_for(img_src, options)
     end
 
     def self.imgproxy_enabled?
       Imgproxy.config.key.present? && Imgproxy.config.salt.present?
+    end
+
+    def self.set_imgproxy_endpoint
+      if Rails.env.production?
+        # Use /images with the same domain on Production as
+        # our default configuration
+        URL.url("images")
+        # ie. https://forem.dev/images
+      else
+        # On other environments, rely on ApplicationConfig for a
+        # more flexible configuration
+        # ie. default imgproxy endpoint is localhost:8080
+        ApplicationConfig["IMGPROXY_ENDPOINT"]
+      end
     end
   end
 end

--- a/config/initializers/imgproxy.rb
+++ b/config/initializers/imgproxy.rb
@@ -3,16 +3,7 @@ Imgproxy.configure do |config|
   #
   # Full URL to where your imgproxy lives.
   #
-  config.endpoint = if Rails.env.production? && ApplicationConfig["APP_DOMAIN"] && ApplicationConfig["APP_PROTOCOL"]
-                      # Use /images with the same domain on Production as
-                      # our default configuration
-                      URL.url("images") # ie. https://forem.dev/images
-                    else
-                      # On other environments, rely on ApplicationConfig for a
-                      # more flexible configuration
-                      # ie. default imgproxy endpoint is localhost:8080
-                      ApplicationConfig["IMGPROXY_ENDPOINT"]
-                    end
+  config.endpoint = nil # Images::Optimizer will set the endpoint because SiteConfig is not ready during boot
 
   # Next, you have to provide your signature key and salt.
   # If unsure, check out https://github.com/imgproxy/imgproxy/blob/master/docs/configuration.md first.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We cannot set `Imgproxy.config.endpoint = URL.url("/images")` in the initializer because it will use the hardcoded `ApplicationConfig["APP_DOMAIN"]` instead of `SiteConfig.app_domain`. Instead, I have to move it closer to the surface, where the App (mainly `URL` module) is completely booted.
## Related Tickets & Documents
n/a
## QA Instructions, Screenshots, Recordings
- Makes sure the app boots correctly.
- For a thorough imgproxy setup guide, please see https://github.com/forem/forem/pull/9909
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
