### PR TITLE
Link Email Account creation UI to existing Create Account UI

### DIFF
--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -16,6 +16,10 @@
   --brand-facebook-bg: #4267b2;
   --brand-facebook-color: #fff;
   --brand-facebook-bg-hover: #476fbf;
+
+  --brand-email-bg: #24292e;
+  --brand-email-color: #fff;
+  --brand-email-bg-hover: #000;
 }
 
 // Basic styling
@@ -274,6 +278,17 @@
   --bg-inverted-hover: var(--brand-facebook-bg-hover);
   --color-inverted: var(--brand-facebook-color);
   --color-inverted-hover: var(--brand-facebook-color);
+}
+
+.crayons-btn--brand-email {
+  --bg: var(--brand-email-bg);
+  --bg-hover: var(--brand-email-bg-hover);
+  --color: var(--brand-email-color);
+  --color-hover: var(--brand-email-color);
+  --bg-inverted: var(--brand-email-bg);
+  --bg-inverted-hover: var(--brand-email-bg-hover);
+  --color-inverted: var(--brand-email-color);
+  --color-inverted-hover: var(--brand-email-color);
 }
 
 // Icon alone

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,8 +1,8 @@
 <% title "Welcome!" %>
 
-<% if params[:state] == "beta_email_signup" && SiteConfig.allow_email_password_registration %>
+<% if params[:state] == "email_signup" && SiteConfig.allow_email_password_registration %>
   <%= render "shared/authentication/email_registration_form" %>
-<% elsif params[:state] == "beta_email_signup" %>
+<% elsif params[:state] == "email_signup" %>
   <div class="crayons-notice crayons-notice--danger mb-10 mt-8 mx-auto" style="width: 680px;max-width:94%;">
     Email authentication is not enabled for this Forem.
   </div>

--- a/app/views/shared/authentication/_providers_registration_form.html.erb
+++ b/app/views/shared/authentication/_providers_registration_form.html.erb
@@ -10,7 +10,7 @@
   <% end %>
   <% if params[:state] == "new-user" && SiteConfig.allow_email_password_registration %>
     <%= link_to inline_svg_tag("email.svg", aria: true, class: "crayons-icon", title: "email") + "Sign up with Email", 
-      request.params.merge(state: "beta_email_signup"),
+      request.params.merge(state: "email_signup"),
       class: "crayons-btn crayons-btn--l crayons-btn--brand-email crayons-btn--icon-left whitespace-nowrap",
       data: {no_instant: ""}
     %>

--- a/app/views/shared/authentication/_providers_registration_form.html.erb
+++ b/app/views/shared/authentication/_providers_registration_form.html.erb
@@ -5,7 +5,14 @@
       class="crayons-btn crayons-btn--l crayons-btn--brand-<%= provider.provider_name %> crayons-btn--icon-left whitespace-nowrap"
       data-no-instant>
       <%= inline_svg_tag("#{provider.provider_name}.svg", aria: true, class: "crayons-icon", title: provider.provider_name) %>
-      Continue with <%= provider.official_name %>
+      <%= params[:state] == "new-user" ? "Sign up" : "Continue" %> with <%= provider.official_name %>
     </a>
+  <% end %>
+  <% if params[:state] == "new-user" && SiteConfig.allow_email_password_registration %>
+    <%= link_to inline_svg_tag("email.svg", aria: true, class: "crayons-icon", title: "email") + "Sign up with Email", 
+      request.params.merge(state: "beta_email_signup"),
+      class: "crayons-btn crayons-btn--l crayons-btn--brand-email crayons-btn--icon-left whitespace-nowrap",
+      data: {no_instant: ""}
+    %>
   <% end %>
 </div>

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Registrations", type: :request do
   let(:user) { create(:user) }
 
-  describe "Sign up" do
+  describe "Log In" do
     context "when not logged in" do
       it "shows the sign in page with single sign on options" do
         get sign_up_path
@@ -40,6 +40,45 @@ RSpec.describe "Registrations", type: :request do
     end
 
     context "when logged in" do
+      it "redirects to main feed" do
+        sign_in user
+
+        get sign_up_path
+        expect(response).to redirect_to("/?signin=true")
+      end
+    end
+  end
+
+  describe "Create Account" do
+    context "when email registration allowed" do
+      before { SiteConfig.allow_email_password_registration = true }
+
+      it "shows the sign in page with email option" do
+        get sign_up_path, params: { state: "new-user" }
+
+        expect(response.body).to include("Sign up with Email")
+      end
+
+      it "shows the sign in text for password based authentication" do
+        get sign_up_path, params: { state: "new-user" }
+
+        expect(response.body).to include("View more sign in options")
+      end
+    end
+
+    context "when email registration not allowed" do
+      before { SiteConfig.allow_email_password_registration = false }
+
+      it "does not show email sign up option" do
+        SiteConfig.allow_email_password_registration = false
+
+        get sign_up_path, params: { state: "new-user" }
+
+        expect(response.body).not_to include("Sign up with Email")
+      end
+    end
+
+    context "when user logged in" do
       it "redirects to main feed" do
         sign_in user
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a button to the existing `Create Account` page allowing users to create a Forem account with an email and password if the corresponding option has been enabled in the admin console. (Text on the existing login options button has been adjusted to reflect different log in versus account creation states as well).

## Related Tickets & Documents

closes https://github.com/forem/InternalProjectPlanning/issues/99

## QA Instructions, Screenshots, Recordings

![Welcome__-_Forem](https://user-images.githubusercontent.com/37842/95517555-da706a00-0986-11eb-8cbe-e7badb968ac3.jpg)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Pressing buttons](https://media.giphy.com/media/9DavVitIZ26jH0aK7s/giphy.gif)
