### PR TITLE
Remove Superfluous `sign_in` From `users_onboarding_spec.rb`

### DIFF
--- a/spec/requests/users_onboarding_spec.rb
+++ b/spec/requests/users_onboarding_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe "UsersOnboarding", type: :request do
       before { sign_in user }
 
       it "updates saw_onboarding boolean" do
-        sign_in user
         patch "/onboarding_update.json", params: {}
         expect(user.saw_onboarding).to eq(true)
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
While I was working on debugging a forem bug, I noticed that there was an extra `sign_in` in the `users_onboarding_spec.rb` -- this PR removes it.

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings
Ensure that the Travis build is green. 🟢 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![AOL sign in](https://media.giphy.com/media/DOitPFO8XSUcU/giphy.gif)
