### PR TITLE
fix dropdown svg for dark themes - comment section

### DIFF
--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -47,7 +47,7 @@
         <% end %>
         <%= render "comments/comment_date", decorated_comment: decorated_comment %>
         <button class="dropbtn" aria-label="Toggle dropdown menu">
-          <%= image_tag("overflow-horizontal.svg", class: "dropdown-icon", alt: "Dropdown menu") %>
+          <%= inline_svg_tag("overflow-horizontal.svg", aria: true, class: "dropdown-icon", title: "Dropdown menu") %>
         </button>
         <div class="dropdown">
           <div class="crayons-dropdown p-1 z-30 right-1 left-1 s:right-0 s:left-auto fs-base">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- Bug Fix

## Description

If I understand this PR https://github.com/forem/forem/pull/9177 correctly, this modification solves the problem. Currently, with dark themes, the dropdown button is hidden.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

no

## Added to documentation?

no

## [optional] What gif best describes this PR or how it makes you feel?

![Screenshot 2020-10-11 at 15 44 13](https://user-images.githubusercontent.com/6878027/95681166-a099a080-0bde-11eb-86f5-b837b80b43ab.jpg)

