### PR TITLE
Fix overflow of indented code-blocks in lists

### DIFF
--- a/app/assets/stylesheets/components/syntax.scss
+++ b/app/assets/stylesheets/components/syntax.scss
@@ -12,7 +12,8 @@
 }
 
 pre:not(.highlight),
-div.highlight {
+div.highlight,
+li pre.highlight {
   background: var(--syntax-background-color);
   color: var(--syntax-text-color);
   font-size: 80%;

--- a/app/assets/stylesheets/components/syntax.scss
+++ b/app/assets/stylesheets/components/syntax.scss
@@ -13,7 +13,8 @@
 
 pre:not(.highlight),
 div.highlight,
-li pre.highlight {
+li pre.highlight,
+blockquote pre.highlight {
   background: var(--syntax-background-color);
   color: var(--syntax-text-color);
   font-size: 80%;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds styling for `.highlight` to `<pre>` inside `<li>`. I checked out the [`Rouge/redcarpet` plugin file](https://github.com/rouge-ruby/rouge/blob/master/lib/rouge/plugins/redcarpet.rb) which indicates that the `.highlight` class should be applied to all code-blocks by default since DEV is using the default version too. I felt it would be a simpler fix via the CSS Route instead of configuring a custom renderer, which might lead to more bugs.

I did basic testing with the following article piece, to ensure that behavior for other elements didn't get switched:

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin eget nunc sed dolor molestie eleifend. Nulla ut ante ultricies quam accumsan commodo.

```yml
- name: Get a dad-joke
  run: |
    echo "::set-env name=TEMP::$(curl -H "Accept: text/plain" https://icanhazdadjoke.com/ | sed -r ':a;N;$!ba;s/\n/<br>/g' | tr -d '\r')"
\```

<pre>echo "::set-env name=TEMP::$(curl -H "Accept: text/plain" https://icanhazdadjoke.com/ | sed -r ':a;N;$!ba;s/\n/<br>/g' | tr -d '\r')"</pre>
<code>echo "::set-env name=TEMP::$(curl -H "Accept: text/plain" https://icanhazdadjoke.com/ | sed -r ':a;N;$!ba;s/\n/<br>/g' | tr -d '\r')"</code>

1. Curabitur vel tempus libero, vitae elementum purus. Cras et enim porttitor, congue odio in, eleifend mi.

    <pre>echo "::set-env name=TEMP::$(curl -H "Accept: text/plain" https://icanhazdadjoke.com/ | sed -r ':a;N;$!ba;s/\n/<br>/g' | tr -d '\r')"</pre>
    <code>echo "::set-env name=TEMP::$(curl -H "Accept: text/plain" https://icanhazdadjoke.com/ | sed -r ':a;N;$!ba;s/\n/<br>/g' | tr -d '\r')"</code>

    ```yml
    - name: Get a dad-joke
      run: |
        echo "::set-env name=TEMP::$(curl -H "Accept: text/plain" https://icanhazdadjoke.com/ | sed -r ':a;N;$!ba;s/\n/<br>/g' | tr -d '\r')"
    ```

2. Curabitur vel tempus libero, vitae elementum purus. Cras et enim porttitor, congue odio in, eleifend mi.
```

## Related Tickets & Documents
Fixes #9988

## QA Instructions, Screenshots, Recordings

If there are any instances of `<pre>` blocks existing inside an `<li>` are there, a check will be needed to verify their behavior don't get changed. Would also love some feedback on whether it is better to fix this via a custom Renderer or is the CSS fix good? I would love to resend another PR with the renderer fix, albeit after more research on the same if it is the better solution.

### Bug:
![Bugged image, showing overflow](https://user-images.githubusercontent.com/22113778/95689257-0f054f80-0c2d-11eb-9e5b-a75486706c7a.png)

### Fixed:
![Fixed image, with no overflow](https://user-images.githubusercontent.com/22113778/95689308-6efbf600-0c2d-11eb-8947-c4db80d01e68.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![stopping that leak](https://media.giphy.com/media/3ohhwMZ90bjHMNw8eI/giphy.gif)
