### PR TITLE
Fix missing category in delete draft listing URL

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -13,9 +13,10 @@ class ListingsController < ApplicationController
 
   DASHBOARD_JSON_OPTIONS = {
     only: %i[
-      title tag_list created_at expires_at bumped_at updated_at category id
+      title tag_list created_at expires_at bumped_at updated_at id
       user_id slug organization_id location published
     ],
+    methods: %i[category],
     include: {
       author: { only: %i[username name], methods: %i[username profile_image_90] }
     }
@@ -68,7 +69,7 @@ class ListingsController < ApplicationController
 
   def dashboard
     listings = current_user.listings
-      .includes(:organization, :taggings)
+      .includes(:organization, :taggings, :listing_category)
     @listings_json = listings.to_json(DASHBOARD_JSON_OPTIONS)
 
     organizations_ids = current_user.organization_memberships

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -80,6 +80,16 @@ RSpec.describe "/listings", type: :request do
     end
   end
 
+  describe "GET /listings/dashboard" do
+    before { sign_in user }
+
+    it "returns a category for draft listings" do
+      post "/listings", params: draft_params
+      get "/listings/dashboard"
+      expect(response.body).to include(CGI.escapeHTML("\"category\":\"#{edu_category.slug}\""))
+    end
+  end
+
   describe "GET /listings/new" do
     before { sign_in user }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The JSON for listings on the listing dashboard page is missing the category key which causes an `undefined` in the delete listing URL. This PR adds the category key in the JSON.

## Related Tickets & Documents
Fixes #10800

## QA Instructions, Screenshots, Recordings

**Before**

![Before](https://user-images.githubusercontent.com/8092120/95714109-57505c00-0c85-11eb-8bcd-952b41147cc6.png)

**After**

![After](https://user-images.githubusercontent.com/8535863/95763297-7b835b80-0ccc-11eb-8429-83a31849934e.png)


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed