### PR TITLE
Flaky Spec Fix:Clear Article Content Before Filling In

### DIFF
--- a/spec/system/articles/user_edits_an_article_spec.rb
+++ b/spec/system/articles/user_edits_an_article_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Editing with an editor", type: :system, js: true do
 
   it "user unpublishes their post" do
     visit "/#{user.username}/#{article.slug}/edit"
-    fill_in "article_body_markdown", with: template.gsub("true", "false")
+    fill_in("article_body_markdown", with: template.gsub("true", "false"), fill_options: { clear: :backspace })
     click_button("Save changes")
     expect(page).to have_text("Unpublished Post.")
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
I noticed this spec failing on some contributor's builds. When I tried to run it locally I also found it failing with the same issue. It appears that the additional template was getting appended to the text field causing the parsing to be incorrect when saved. This change ensures the field is cleared before the new template is applied. I am not sure what causes this in some instances and not in others but this fixed it for me locally.
Fixes:
```
 1) Editing with an editor user unpublishes their post
     Failure/Error: expect(page).to have_text("Unpublished Post.")
       expected to find text "Unpublished Post." in "Write a post\nSetup not completed yet, missing main social image, logo png, logo svg, and others. Please visit the configuration page.\nHeart\n0\nUnicorn\n0\nSaved\n0\nMore...\nSample Article\n#test\nNadine Macejkovic\nOct 12 ・1 min read\nEditManage\nSuspendisse ac lobortis velit, a feugiat sapien. Aenean condimentum, nulla at fermentum sagittis, tellus nisi suscipit velit, vel sollicitudin odio ligula a odio. Integer eget efficitur massa, in sodales velit. Nunc fermentum consequat scelerisque. Morbi elementum tristique faucibus. Nulla vel lectus non justo euismod varius. Vivamus id nisl sit amet odio tincidunt fringilla. Pellentesque odio odio, vulputate in risus eu, lacinia porttitor lorem. Nunc posuere tempus est, imperdiet suscipit odio maximus id. Nam eget feugiat magna.\ntitle: Sample Article\npublished: false\ndescription: this is a sample article\ntags: test\nSuspendisse ac lobortis velit, a feugiat sapien. Aenean condimentum, nulla at fermentum sagittis, tellus nisi suscipit velit, vel sollicitudin odio ligula a odio. Integer eget efficitur massa, in sodales velit. Nunc fermentum consequat scelerisque. Morbi elementum tristique faucibus. Nulla vel lectus non justo euismod varius. Vivamus id nisl sit amet odio tincidunt fringilla. Pellentesque odio odio, vulputate in risus eu, lacinia porttitor lorem. Nunc posuere tempus est, imperdiet suscipit odio maximus id. Nam eget feugiat magna.\nPosted on Oct 12 by:\nNadine Macejkovic\n@username2190\nQuia facilis aut. Similique consequatur\nEdit profile\nTwitter\nGitHub\nWebsite\nDiscussion\nSubscribe\nCode of Conduct • Report abuse\nRead next\nSome description\nDEV(local) Community copyright 2020\nBuilt on Forem — the open source software that powers DEV and other inclusive communities.\nMade with love and Ruby on Rails.\nHome\nReading list\nListings\nPodcasts\nVideos\nTags\nWrite a post\nCode of Conduct\nFAQ\nAbout\nPrivacy policy\nTerms of use\nContact\nSponsors"

     [Screenshot]: /home/travis/build/forem/forem/tmp/screenshots/failures_r_spec_example_groups_editing_with_an_editor_user_unpublishes_their_post_935.png

     # ./spec/system/articles/user_edits_an_article_spec.rb:30:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:130:in `block (2 levels) in <top (required)>'
     # ./spec/support/initializers/ci_csv_formatter.rb:92:in `block (2 levels) in <top (required)>'
Finished in 9 minutes 45 seconds (files took 7.94 seconds to load)
1631 examples, 1 failure, 4 pending
Failed examples:
rspec ./spec/system/articles/user_edits_an_article_spec.rb:26 # Editing with an editor user unpublishes their post
```


![alt_text](https://media4.giphy.com/media/dy4swYs1dp430jChRa/giphy.gif)
