### PR TITLE
Centralize on "trusted" language: Add new copy and some slight feature adjustments.

### DIFF
--- a/app/queries/admin/moderators_query.rb
+++ b/app/queries/admin/moderators_query.rb
@@ -10,8 +10,10 @@ module Admin
 
       relation = if state.to_s == "potential"
                    relation.where(
-                     "id NOT IN (SELECT user_id FROM users_roles WHERE role_id = ?)",
+                     "id NOT IN (SELECT user_id FROM users_roles WHERE role_id = ?)
+                     AND id NOT IN (SELECT user_id FROM users_roles WHERE role_id = ?)",
                      role_id_for(:trusted),
+                     role_id_for(:banned),
                    ).order("users.comments_count" => :desc)
                  else
                    relation.joins(:roles)

--- a/app/views/admin/mods/index.html.erb
+++ b/app/views/admin/mods/index.html.erb
@@ -48,7 +48,7 @@
           <% if params[:state] == "potential" %>
             <td>
               <%= form_with model: [:admin, mod], url: admin_mod_path(mod.id), method: :patch, local: true do |f| %>
-                <%= f.submit "Make Trusted Mod", class: "btn btn-light js-add-to-mod-channel" %>
+                <%= f.submit "Make Trusted", class: "btn btn-light js-add-to-mod-channel" %>
               <% end %>
             </td>
           <% end %>

--- a/app/views/mailers/notify_mailer/trusted_role_email.html.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.html.erb
@@ -2,17 +2,16 @@
   Hey <%= @user.name %>!
 </p>
 <p>
-  This is an email to let you know that we've upgraded your account to have <b>basic moderation privileges</b>.
-  This means you can apply "negative reactions" to posts as well as certain other actions which help us maintain a constructive community and uphold our <a href="<%= app_url(code_of_conduct_path) %>">code of conduct</a>.
+  We are happy to let you know that your <%= community_name %> account has just been upgraded to "trusted" status.
 </p>
 <p>
-  There are no specific responsibilities with this new privilege except that you use it respectfully and empathetically. If for any reason you'd like to forego these new features, let us know.
+  This gives you the power to privately downvote content which is low quality or spam and harassment, alongside a bit of additional functionality to help ensure the success of the community. Anywhere you now see a shield on the site indicates a place you can go to join our community's crowd-sourced moderation initiative. 
 </p>
 <p>
-  You'll occasionally get on-site notifications asking you to take an action. You are never required to take any actions and feel free to unsubscribe in <a href="<%= app_url(user_settings_path(:notifications)) %>">your notification settings</a> at any point without giving up the rest of the features.
+  You may occasionally receive notifications about optional moderation actions, but you can  <a href="<%= app_url(user_settings_path(:notifications)) %>">unsubscribe</a> if you do not want to receive these notices.
 </p>
 <p>
-  <b><a href="<%= app_url("/community-moderation") %>">Click here for full details about basic mod privileges.</b></a>
+  <b><a href="<%= app_url("/community-moderation") %>">Click here for full details about what you can do with the trusted role.</b></a>
 </p>
 <p>
   - <%= community_name %> Team

--- a/app/views/mailers/notify_mailer/trusted_role_email.text.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.text.erb
@@ -1,11 +1,11 @@
 Hey <%= @user.name %>!
 
-This is an email to let you know that we've upgraded your account to have basic mod privileges. This means you can apply "negative reactions" to posts as well as certain other actions which help us maintain a constructive community and uphold our code of conduct.
+We are happy to let you know that your <%= community_name %> account has just been upgraded to "trusted" status.
 
-There are no specific responsibilities with this new privilege except that you use it respectfully and empathetically. If for any reason you'd like to forego these new features, let us know.
+This gives you the power to privately downvote content which is low quality or spam and harassment, alongside a bit of additional functionality to help ensure the success of the community. Anywhere you now see a shield on the site indicates a place you can go to join our community's crowd-sourced moderation initiative. 
 
-You'll occasionally get on-site notifications asking you to take an action. You are never required to take any actions and feel free to unsubscribe in your notification settings at any point without giving up the rest of the features.
+You may occasionally receive notifications about optional moderation actions, but you can unsubscribe (<%= app_url(user_settings_path(:notifications)) %>) if you do not want to receive these notices.
 
-Visit <%= app_url("/community-moderation") %> for full details of what you can do with these new privileges.
+For more information about what you can do as a "trusted" user, check out this page: <%= app_url("/community-moderation") %>
 
 - <%= community_name %> Team

--- a/spec/queries/admin/moderators_query_spec.rb
+++ b/spec/queries/admin/moderators_query_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Admin::ModeratorsQuery, type: :query do
   let!(:user4) { create(:user, :admin, name: "Susi", comments_count: 10) }
   let(:user5) { create(:user, :trusted, :admin, name: "Beth") }
   let(:user6) { create(:user, :admin, name: "Jean", comments_count: 5) }
+  let(:user7) { create(:user, :banned, name: "Harry") }
 
   describe ".call" do
     context "when no arguments are given" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This changes the language from "community mod" to "trusted" to align with the language we use _in the role_.... So rather than have the role called `trusted` but the email and on-site information mostly speak about "community moderation", we'd rather centralize on these being "trusted" users... They can still _do_ community moderation, but the name of the role and how it is introduced can centralize around `trusted`....

This also removes `banned` users from the query for users to "potentially" make trusted. We do not want to accidentally "entrust" a banned user.

Closes #10734