### PR TITLE
Skip edge caching for private forems

### DIFF
--- a/app/controllers/concerns/caching_headers.rb
+++ b/app/controllers/concerns/caching_headers.rb
@@ -17,7 +17,7 @@ module CachingHeaders
     stale_while_revalidate: nil,
     stale_if_error: 26_400
   )
-    return unless SiteConfig.public # Only public forems should be edge-cached (until some kind of edge auth is in place).
+    return unless SiteConfig.public # Only public forems should be edge-cached based on current functionality.
 
     request.session_options[:skip] = true # no cookies
 

--- a/app/controllers/concerns/caching_headers.rb
+++ b/app/controllers/concerns/caching_headers.rb
@@ -17,6 +17,8 @@ module CachingHeaders
     stale_while_revalidate: nil,
     stale_if_error: 26_400
   )
+    return unless SiteConfig.public # Only public forems should be edge-cached (until some kind of edge auth is in place).
+
     request.session_options[:skip] = true # no cookies
 
     response.headers["Cache-Control"] = "public, no-cache" # Used only by Fastly.

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -104,6 +104,15 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.body).to include(CGI.escapeHTML(listing.title))
     end
 
+    it "does not set surrogate headers if private" do
+      allow(SiteConfig).to receive(:public).and_return(false)
+      get "/"
+      expect(response.status).to eq(200)
+
+      expected_surrogate_key_headers = %w[main_app_home_page]
+      expect(response.headers["Surrogate-Key"].split(", ")).not_to match_array(expected_surrogate_key_headers)
+    end
+
     it "sets Fastly Surrogate-Key headers" do
       get "/"
       expect(response.status).to eq(200)

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -104,11 +104,13 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.body).to include(CGI.escapeHTML(listing.title))
     end
 
-    it "does not set surrogate headers if private" do
+    it "does not set cache-related headers if private" do
       allow(SiteConfig).to receive(:public).and_return(false)
       get "/"
       expect(response.status).to eq(200)
 
+      expect(response.headers["X-Accel-Expires"]).to eq(nil)
+      expect(response.headers["Cache-Control"]).not_to eq("public, no-cache")
       expect(response.headers["Surrogate-Key"]).to eq(nil)
     end
 

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -109,8 +109,7 @@ RSpec.describe "StoriesIndex", type: :request do
       get "/"
       expect(response.status).to eq(200)
 
-      expected_surrogate_key_headers = %w[main_app_home_page]
-      expect(response.headers["Surrogate-Key"].split(", ")).not_to match_array(expected_surrogate_key_headers)
+      expect(response.headers["Surrogate-Key"]).to eq(nil)
     end
 
     it "sets Fastly Surrogate-Key headers" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently if you use a "private" Forem, the ability to peak into internal pages could be spoofed, because the way we differentiate at the edge is not meant for data that needs to remain private. Privacy on DEV is currently reserved for pages which don't add edge cache headers, but our "high traffic public pages" all have heavy caching....

In order to perform caching _within_ private communities we will either want a solution for something akin to Action Caching in place where edge caching would otherwise be, because this kind of caching can happen _after_ authentication. There may also be ways we could do auth _within_ nginx in a clever way in the future, but that path is less obvious to me.

Either way, this PR makes the tradeoff to enable _truly_ private Forems now while we figure out how to do approach caching. Luckily, private forems are, in general, more specialized and lower traffic. They will be, by definition, more capable of dealing with this transition.