### PR TITLE
Feature:Add Video States Encoder Key to SiteConfig

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -62,6 +62,7 @@ module Admin
         spam_trigger_terms
         recaptcha_site_key
         recaptcha_secret_key
+        video_encoder_key
       ]
 
       allowed_params = allowed_params |

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -295,6 +295,10 @@ module Constants
       twitter_secret: {
         description: "The \"API secret key\" portion of consumer keys in the Twitter developer portal.",
         placeholder: ""
+      },
+      video_encoder_key: {
+        description: "Secret key used to allow AWS video encoding through the VideoStatesController",
+        placeholder: ""
       }
       # Dynamic values ommitted: configurable_rate_limits and social_media_handles
     }.freeze

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -19,6 +19,7 @@ class SiteConfig < RailsSettings::Base
 
   # API Tokens
   field :health_check_token, type: :string
+  field :video_encoder_key, type: :string
 
   # Authentication
   field :allow_email_password_registration, type: :boolean, default: false

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -104,6 +104,14 @@
                                  placeholder: Constants::SiteConfig::DETAILS[:health_check_token][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:health_check_token][:description] %></div>
               </div>
+              <div class="form-group">
+                <%= admin_config_label :video_encoder_key %>
+                <%= f.text_field :video_encoder_key,
+                                 class: "form-control",
+                                 value: SiteConfig.video_encoder_key,
+                                 placeholder: Constants::SiteConfig::DETAILS[:video_encoder_key][:placeholder] %>
+                <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:video_encoder_key][:description] %></div>
+              </div>
             </div>
           </div>
 

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe "/admin/config", type: :request do
                                           confirmation: confirmation_message }
           expect(SiteConfig.health_check_token).to eq token
         end
+
+        it "sets video_encoder_key" do
+          post "/admin/config", params: { site_config: { video_encoder_key: "123abc" },
+                                          confirmation: confirmation_message }
+          expect(SiteConfig.video_encoder_key).to eq("123abc")
+        end
       end
 
       describe "Authentication" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
Currently the AWS video encoder key we use to encode videos is linked to a single user in our database. This should not be the case since this value is used for the entire application. This moves the encoder value to SiteConfig so that it can easily be set by the site admin. Once this is merged then I will update the VideoStatesController to use the new SiteConfig value rather than the individual user's secret. 

As far as I know @leewynne is the only other Forem using this feature. I will be sure to followup with him on getting this key setup properly on his Forem. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-46047741

## Added tests?
- [x] yes

![alt_text](https://media2.giphy.com/media/dWy2WwcB3wvX8QA1Iu/giphy.gif?cid=ecf05e474il4e1mve18hds9vyqgl3loji1asyux5q0j8opyu&rid=giphy.gif)
