### PR TITLE
Ensure serviceworker bypass only checks path

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -128,7 +128,7 @@
       '/users/auth',           // Don't run on authentication.
       '/welcome',              // Don't run on welcome reroutes.
       '/workshops',            // redirects
-    ].some(path => url.href.includes(path))
+    ].some(path => url.pathname.includes(path))
   }
 
   self.addEventListener('fetch', event => {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This functionality _naively_ checks for which paths to skip over for service workers. The reason it can be pretty naive is that it is not that big a deal if it's a little too aggressive. Occasionally skipping service workers is fine.

But one problem is that `https://forem.dev` _includes `/forem`........ Which is a problem because it _always_ skipped over and did nothing. This changes the code to check only path, which is what it should have been before.

There is definitely still a need to make this more precise, but for now this solves this particular defect.