### PR TITLE
Flaky Spec Fix: Wait for button before trying to click it

### DIFF
--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
     before do
       sign_in subscriber
       visit article_with_user_subscription_tag.path
+      wait_for_javascript
     end
 
     it "shows the signed in UX" do

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -46,13 +46,16 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
     before do
       sign_in subscriber
       visit article_with_user_subscription_tag.path
-      wait_for_javascript
     end
 
-    it "shows the signed in UX" do
+    def has_basic_subscription_components
       expect(page).to have_css("#subscription-signed-out", visible: :hidden)
       expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
       expect(page).to have_css("#response-message", visible: :hidden)
+    end
+
+    it "shows the signed in UX" do
+      has_basic_subscription_components
       expect(page).to have_css("#subscription-signed-in", visible: :visible)
       css_class = "img.ltag__user-subscription-tag__subscriber-profile-image[src='#{subscriber.profile_image_90}']"
       expect(page).to have_css(css_class)
@@ -60,17 +63,17 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
 
     it "asks the user to confirm their subscription" do
       expect(page).to have_css("#user-subscription-confirmation-modal", visible: :hidden)
-      click_button("Subscribe", id: "subscribe-btn")
+      click_loaded_button("#subscribe-btn", "Subscribe")
       expect(page).to have_css("#user-subscription-confirmation-modal", visible: :visible)
     end
 
     it "displays a sucess mesage when a subscription is created" do
-      expect(page).to have_css("#subscription-signed-out", visible: :hidden)
-      expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
-      expect(page).to have_css("#response-message", visible: :hidden)
+      has_basic_subscription_components
       expect(page).to have_css("#subscription-signed-in", visible: :visible)
-      click_button("Subscribe", id: "subscribe-btn")
-      click_button("Confirm subscription", id: "confirmation-btn")
+
+      click_loaded_button("#subscribe-btn", "Subscribe")
+      click_loaded_button("#confirmation-btn", "Confirm subscription")
+
       expect(page).to have_css("#subscription-signed-in", visible: :hidden)
       expect(page).to have_css("#response-message.crayons-notice--success", visible: :visible)
 
@@ -79,7 +82,6 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
       end
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it "displays errors when there's an error creating a subscription" do
       # Create a subscription so it causes an error by already being subscribed
       create(
@@ -89,12 +91,12 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
         user_subscription_sourceable: article_with_user_subscription_tag
       )
 
-      expect(page).to have_css("#subscription-signed-out", visible: :hidden)
-      expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
-      expect(page).to have_css("#response-message", visible: :hidden)
+      has_basic_subscription_components
       expect(page).to have_css("#subscription-signed-in", visible: :visible)
-      click_button("Subscribe", id: "subscribe-btn")
-      click_button("Confirm subscription", id: "confirmation-btn")
+
+      click_loaded_button("#subscribe-btn", "Subscribe")
+      click_loaded_button("#confirmation-btn", "Confirm subscription")
+
       expect(page).to have_css("#subscription-signed-in", visible: :hidden)
       expect(page).to have_css("#response-message.crayons-notice--danger", visible: :visible)
 
@@ -102,7 +104,6 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
         expect(page).to have_text("Subscriber has already been taken")
       end
     end
-    # rubocop:enable RSpec/ExampleLength
 
     it "tells the user they're already subscribed by default if they're already subscribed" do
       create(

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
 
     it "asks the user to confirm their subscription" do
       expect(page).to have_css("#user-subscription-confirmation-modal", visible: :hidden)
-      click_loaded_button("#subscribe-btn", "Subscribe")
+      click_loaded_button("subscribe-btn", "Subscribe")
       expect(page).to have_css("#user-subscription-confirmation-modal", visible: :visible)
     end
 
@@ -71,8 +71,8 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
       has_basic_subscription_components
       expect(page).to have_css("#subscription-signed-in", visible: :visible)
 
-      click_loaded_button("#subscribe-btn", "Subscribe")
-      click_loaded_button("#confirmation-btn", "Confirm subscription")
+      click_loaded_button("subscribe-btn", "Subscribe")
+      click_loaded_button("confirmation-btn", "Confirm subscription")
 
       expect(page).to have_css("#subscription-signed-in", visible: :hidden)
       expect(page).to have_css("#response-message.crayons-notice--success", visible: :visible)
@@ -94,8 +94,8 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
       has_basic_subscription_components
       expect(page).to have_css("#subscription-signed-in", visible: :visible)
 
-      click_loaded_button("#subscribe-btn", "Subscribe")
-      click_loaded_button("#confirmation-btn", "Confirm subscription")
+      click_loaded_button("subscribe-btn", "Subscribe")
+      click_loaded_button("confirmation-btn", "Confirm subscription")
 
       expect(page).to have_css("#subscription-signed-in", visible: :hidden)
       expect(page).to have_css("#response-message.crayons-notice--danger", visible: :visible)

--- a/spec/support/initializers/capybara.rb
+++ b/spec/support/initializers/capybara.rb
@@ -42,3 +42,8 @@ def wait_for_javascript
 
   raise "wait_for_javascript timeout" unless finished
 end
+
+def click_loaded_button(button_id, button_text)
+  expect(page).to have_css(button_id, visible: :visible)
+  click_button(button_text, id: button_id)
+end

--- a/spec/support/initializers/capybara.rb
+++ b/spec/support/initializers/capybara.rb
@@ -44,6 +44,6 @@ def wait_for_javascript
 end
 
 def click_loaded_button(button_id, button_text)
-  expect(page).to have_css(button_id, visible: :visible)
+  expect(page).to have_css("##{button_id}", visible: :visible)
   click_button(button_text, id: button_id)
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
It appears that sometimes during this spec we cannot find the Subscription button. I believe this happens when the page loads and we check for the button before the javascript has time to create the tag. I tested this by duplicating the failing spec 10 times and running the file. It would pretty consistently get the error below without waiting for the javascript. 



![alt_text](gif_link)
