### PR TITLE
Add Specs for Basic Feed Class

### DIFF
--- a/spec/services/articles/feeds/basic_spec.rb
+++ b/spec/services/articles/feeds/basic_spec.rb
@@ -2,23 +2,39 @@ require "rails_helper"
 
 RSpec.describe Articles::Feeds::Basic, type: :service do
   let(:user) { create(:user) }
-  let!(:feed) { described_class.new(user: user, number_of_articles: 100, page: 1) }
-  let!(:article) { create(:article) }
+  let(:unique_tag_name) { "foo" }
+  let!(:article) { create(:article, hotness_score: 10) }
   let!(:hot_story) { create(:article, hotness_score: 1000, score: 1000, published_at: 3.hours.ago) }
-  let!(:old_story) { create(:article, published_at: 3.days.ago) }
+  let!(:old_story) { create(:article, hotness_score: 500, published_at: 3.days.ago, tags: unique_tag_name) }
   let!(:low_scoring_article) { create(:article, score: -1000) }
-  let!(:month_old_story) { create(:article, published_at: 1.month.ago) }
+  let!(:month_old_story) { create(:article, published_at: 1.month.ago) } # rubocop:disable RSpec/LetSetup
 
-  xit "returns articles in approximately published order" do
-    result = feed.feed
-    expect(result.first).to eq hot_story
-    expect(result.second).to eq article
-    expect(result.third).to eq old_story
-    expect(result.last).to eq month_old_story
+  context "without a user" do
+    let(:feed) { described_class.new(user: nil, number_of_articles: 100, page: 1) }
+
+    it "returns articles with score above 0 in order of hotness score" do
+      result = feed.feed
+      expect(result.first).to eq hot_story
+      expect(result.second).to eq old_story
+      expect(result.third).to eq article
+      expect(result).not_to include(low_scoring_article)
+    end
   end
 
-  it "does not include low quality" do
-    result = feed.feed
-    expect(result).not_to include(low_scoring_article)
+  context "with a user" do
+    let(:feed) { described_class.new(user: user, number_of_articles: 100, page: 1) }
+
+    it "returns articles with score above 0 sorted by user preference scores" do
+      allow(feed).to receive(:user_following_users_ids).and_return([old_story.user_id])
+      old_story_tag = Tag.find_by(name: unique_tag_name)
+      old_story_tag.update(points: 10)
+      allow(feed).to receive(:user_followed_tags).and_return([old_story_tag])
+
+      result = feed.feed
+      expect(result.first).to eq old_story
+      expect(result.second).to eq hot_story
+      expect(result.third).to eq article
+      expect(result).not_to include(low_scoring_article)
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
In #10831 I commented this spec out because it was not properly testing the basic feed class. This adds 2 tests to deal with the 2 scenarios a Basic Feed class may encounter, with and without a user. Each scenario orders the articles slightly differently which I made sure to account for. I also included the `"does not include low quality"` assertion in both specs so you get more bang for your buck out of them. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-47296483

## Added tests?
- [x] yes


![alt_text](https://thumbs.gfycat.com/AshamedEmotionalGull-small.gif)
