### PR TITLE
Add releasedate meta data

### DIFF
--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -50,6 +50,7 @@
       <meta property="forem:name" content="<%= community_name %>" />
       <meta property="forem:logo" content="<%= optimized_image_url(SiteConfig.logo_png, width: 512, fetch_format: "png") %>" />
       <meta property="forem:domain" content="<%= SiteConfig.app_domain %>" />
+      <meta property="forem:releasedate" content="<%= ENV["RELEASE_FOOTPRINT"] %>" />
     <% end %>
   </head>
   <% unless internal_navigation? %>

--- a/config/initializers/set_release_footprint.rb
+++ b/config/initializers/set_release_footprint.rb
@@ -1,2 +1,2 @@
-# We will set RELEASE_FOOTPRINT in our Forem Cloud environment, or use HEROKU_SLUG_COMMIT if set (e.g. Heroku env)
-ENV["RELEASE_FOOTPRINT"] ||= ENV["HEROKU_SLUG_COMMIT"]
+# We will set RELEASE_FOOTPRINT in our Forem Cloud environment, or use HEROKU_RELEASE_CREATED_AT if set (e.g. Heroku env)
+ENV["RELEASE_FOOTPRINT"] ||= ENV["HEROKU_RELEASE_CREATED_AT"]

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -61,7 +61,7 @@ if (process.env.HONEYBADGER_API_KEY && process.env.ASSETS_URL) {
       assetsUrl: process.env.ASSETS_URL,
       silent: false,
       ignoreErrors: false,
-      revision: process.env.RELEASE_FOOTPRINT || process.env.HEROKU_SLUG_COMMIT || 'master',
+      revision: process.env.RELEASE_FOOTPRINT || process.env.HEROKU_RELEASE_CREATED_AT || 'master',
     }),
   );
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It will prove useful to know when a forem was released in whatever context we need to view it.

This could complement well other meta data such as release version, to give something humans and computers can use as needed when crawling meta data.

This also modifies the Heroku version of `RELEASE_FOOTPRINT` to check for the date instead of commit slug because the way we calculate `RELEASE_FOOTPRINT` is by date in Forem Cloud.

I feel like we could use this in the short term for more info for humans to better understand when a forem page was released (or possibly cached) and this is a small thing that could help in our big picture.