### PR TITLE
Begin cleaning up and generalizing events

### DIFF
--- a/app/assets/images/sustaining-membership.svg
+++ b/app/assets/images/sustaining-membership.svg
@@ -1,8 +1,0 @@
-<svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 360">
-    <circle cx="180" cy="180" r="156.28" stroke-width="6" stroke="#232323" stroke-miterlimit="10" fill="none"/>
-    <path stroke-width="9" fill="#d1d5ec" stroke="#232323" stroke-miterlimit="10" d="M180 106.54L91.63 229.46"/>
-    <path stroke-width="9" stroke="#232323" stroke-miterlimit="10" fill="none" d="M180 106.54l88.37 122.92"/>
-    <circle cx="180" cy="106.54" r="33.04" stroke-width="9.8" fill="#fbf395" stroke="#232323" stroke-miterlimit="10"/>
-    <path d="M301.39 229.46c1-18.33-14.73-33-33-33a33 33 0 100 66.09c18.21-.05 31.98-14.87 33-33.09z" fill="#78ccc8" stroke-width="9.8" stroke="#232323" stroke-miterlimit="10"/>
-    <path d="M124.65 229.46c1-18.33-14.73-33-33-33a33 33 0 100 66.09c18.2-.05 31.97-14.87 33-33.09z" fill="#4356a6" stroke-width="9.8" stroke="#232323" stroke-miterlimit="10"/>
-</svg>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -28,9 +28,9 @@
     <% end %>
 
     <% if @events.none? %>
-      <h3 class="mt-0 color-base-70">
+      <div class="crayons-notice">
         There are no upcoming events currently scheduled
-      </h3>
+      </div>
     <% end %>
 
     <% if @past_events.any? %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -7,40 +7,37 @@
   <meta property="og:type" content="article" />
   <meta property="og:url" content="<%= app_url("/events") %>" />
   <meta property="og:title" content="<%= community_name %> Events" />
-  <meta property="og:image" content="https://thepracticaldev.s3.amazonaws.com/i/bhavxzyx2e7bdsyvysve.jpg" />
-  <meta property="og:description" content="Talks and workshops designed to help community members level up." />
+  <meta property="og:description" content="Community events." />
   <meta property="og:site_name" content="<%= community_qualified_name %>" />
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@<%= SiteConfig.social_media_handles["twitter"] %>">
   <meta name="twitter:title" content="<%= community_name %> Events">
-  <meta name="twitter:image:src" content="https://thepracticaldev.s3.amazonaws.com/i/bhavxzyx2e7bdsyvysve.jpg">
 <% end %>
-
-<div class="blank-space"></div>
 
 <script type="text/javascript" src="https://addevent.com/libs/atc/1.6.1/atc.min.js" async defer></script>
 
-<div class="container article">
-  <div style="height:30px">
-  </div>
-  <div class="body">
-    <img src="<%= asset_path "sustaining-membership.svg" %>" style="height:200px;margin-top:30px;" alt="<%= community_name %> membership logo">
-    <h1 style="font-size:1.9em;font-weight:600;text-align:center;">
-      UPCOMING <br> EVENTS
+
+<div class="crayons-layout crayons-layout--limited-l">
+  <div class="crayons-card text-styles text-padding">
+    <h1 class="fs-3xl s:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight mb-4 mt-0">
+      Upcoming Events
     </h1>
-    <p><%= community_name %> Events is a series of ongoing talks and workshops designed to cover important topics to help community members level up. Because we have a global community we will be hosting events at varying times so nobody is restricted by time zone. Additionally,
-      <strong>some workshops are repeated multiple times</strong> to further account for this.</p>
-    <p>We have many more planned if you do not see a topic that interests you. Email
-      <%= email_link(:members) %> to request a topic. And if you're interested in speaking, please
-      <a href="https://dev.to/jess/would-you-like-to-give-a-dev-talkworkshop--31c6">apply to our CFP</a>.</p>
 
     <% @events.each do |event| %>
       <%= render "event", event: event %>
     <% end %>
 
-    <h1 style="font-size:1.9em;font-weight:600;text-align:center;">
-      PAST <br> EVENTS
-    </h1>
+    <% if @events.none? %>
+      <h3 class="mt-0 color-base-70">
+        There are no upcoming events currently scheduled
+      </h3>
+    <% end %>
+
+    <% if @past_events.any? %>
+      <h1>
+        Past Events
+      </h1>
+    <% end %>
 
     <% @past_events.each do |event| %>
       <%= render "event", event: event %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Let's rewind the clock a few years..... DEV decides to put on live online events as a component of a membership program designed to deliver community value and help develop out a component of the business model.

Despite a good deal success, the overhead of the initiative proves a little much given we're also building out the technical platform and we are radically under-resourced.

Fast forward a few years, we're now rolling out Forems, and this feature we never fully said goodbye to is intriguing to several Forem creators— for good reason. Events make up a good deal of what "community" can be. It's also a feature social platforms like Facebook normalized as a component of the overall experience. DEV itself is now back to putting on events and could use this feature IMO.

We said goodbye to _events_ in favor of _listings_, but realistically both can serve a place within a community. Right now as events can be something _the community_ puts on, and the events category of listings can be more ad hoc. This could change over time, but all in all with a certain amount of reflection I'm glad we never let the ship sail on this feature as a component of the ecosystem.

All in all, the basics of events are all in place, but they need to be cleaned up and generalized. This is a small initial PR to get the ball rolling.

See events live in all their glory at https://dev.to/events

......... It's possible events could be _extracted_ into a plug-in. I'm going to keep my eyes on this possibility as I look into this.