### PR TITLE
Make allow email password login default true

### DIFF
--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -6,7 +6,7 @@ module Constants
         placeholder: ""
       },
       allow_email_password_login: {
-        description: "Can users login with only email and password?",
+        description: "Can users login using email and password?",
         placeholder: ""
       },
       authentication_providers: {

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -23,7 +23,7 @@ class SiteConfig < RailsSettings::Base
 
   # Authentication
   field :allow_email_password_registration, type: :boolean, default: false
-  field :allow_email_password_login, type: :boolean, default: false
+  field :allow_email_password_login, type: :boolean, default: true
   field :authentication_providers, type: :array, default: proc { Authentication::Providers.available }
   field :invite_only_mode, type: :boolean, default: false
   field :twitter_key, type: :string, default: ApplicationConfig["TWITTER_KEY"]

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Registrations", type: :request do
 
       it "only shows the single sign on options if they are present" do
         allow(Authentication::Providers).to receive(:enabled).and_return([])
+        allow(SiteConfig).to receive(:allow_email_password_login).and_return(false)
 
         get sign_up_path
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Related issue

Closes https://github.com/forem/InternalProjectPlanning/issues/91

## Description

Technically regardless of registration mechanism, the _default_ for logging in should be to allow this, because even someone who has signed up with social or invitation can _technically_ log in. If a forem wants to disable that for any reason they could do so.

At least for now I think this makes sense.