### PR TITLE
Fix ui for signup with email 

### DIFF
--- a/app/views/shared/authentication/_providers_registration_form.html.erb
+++ b/app/views/shared/authentication/_providers_registration_form.html.erb
@@ -9,7 +9,7 @@
     </a>
   <% end %>
   <% if params[:state] == "new-user" && SiteConfig.allow_email_password_registration %>
-    <%= link_to "#{inline_svg_tag('email.svg', aria: true, class: 'crayons-icon', title: 'email')}Sign up with Email",
+    <%= link_to "#{inline_svg_tag('email.svg', aria: true, class: "crayons-icon", title: "email")}Sign up with Email".html_safe,
                 request.params.merge(state: "email_signup"),
                 class: "crayons-btn crayons-btn--l crayons-btn--brand-email crayons-btn--icon-left whitespace-nowrap",
                 data: { no_instant: "" } %>

--- a/app/views/shared/authentication/_providers_registration_form.html.erb
+++ b/app/views/shared/authentication/_providers_registration_form.html.erb
@@ -9,7 +9,7 @@
     </a>
   <% end %>
   <% if params[:state] == "new-user" && SiteConfig.allow_email_password_registration %>
-    <%= link_to "#{inline_svg_tag('email.svg', aria: true, class: "crayons-icon", title: "email")}Sign up with Email".html_safe,
+    <%= link_to "#{inline_svg_tag('email.svg', aria: true, class: 'crayons-icon', title: 'email')}Sign up with Email".html_safe,
                 request.params.merge(state: "email_signup"),
                 class: "crayons-btn crayons-btn--l crayons-btn--brand-email crayons-btn--icon-left whitespace-nowrap",
                 data: { no_instant: "" } %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When you try and create an account via email, the UI is broken. The email svg is not getting rendered as html but rather as a string.

<img width="1669" alt="Screenshot 2020-10-14 at 11 17 00" src="https://user-images.githubusercontent.com/2786819/95971732-decad600-0e11-11eb-984e-99f6ca3cd28d.png">


## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/142

## QA Instructions, Screenshots, Recordings

Go to http://localhost:3000/enter?state=new-user, and you should see a fixed version:
<img width="955" alt="Screenshot 2020-10-14 at 11 39 51" src="https://user-images.githubusercontent.com/2786819/95971821-fe61fe80-0e11-11eb-9e0b-76b4d11ae9b2.png">


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/6q29hxDKvJvPy/giphy.gif)
