### PR TITLE
Make feed_url nullable in RssReader

### DIFF
--- a/app/services/rss_reader/assembler.rb
+++ b/app/services/rss_reader/assembler.rb
@@ -63,12 +63,12 @@ class RssReader
       find_and_replace_possible_links!(html_doc) if @user.feed_referential_link
       find_and_replace_picture_tags_with_img!(html_doc)
 
-      if feed_url.include?("medium.com")
+      if feed_url&.include?("medium.com")
         parse_and_translate_gist_iframe!(html_doc)
         parse_and_translate_youtube_iframe!(html_doc)
         parse_and_translate_tweet!(html_doc)
         parse_liquid_variable!(html_doc)
-      else
+      elsif feed_url
         clean_relative_path!(html_doc, feed_url)
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
A certain RSS feed is missing feed URL. This technically makes the feed invalid but we should dampen down the error that it's producing.

## Related Tickets & Documents
Resolves https://app.honeybadger.io/fault/66984/41f0215fe0636317d1c0c8b651c0fb42
## QA Instructions, Screenshots, Recordings
the test should just pass really.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a