### PR TITLE
Refactor/Feature:Use SiteConfig video_encoder_key For Processing Videos

### DIFF
--- a/app/controllers/video_states_controller.rb
+++ b/app/controllers/video_states_controller.rb
@@ -4,8 +4,8 @@ class VideoStatesController < ApplicationController
   # This is purely for responding to AWS video state changes.
 
   def create
-    unless valid_user
-      render json: { message: "invalid_user" }, status: :unprocessable_entity
+    unless valid_key
+      render json: { message: "invalid_key" }, status: :unprocessable_entity
       return
     end
     begin
@@ -27,9 +27,9 @@ class VideoStatesController < ApplicationController
     end
   end
 
-  def valid_user
-    user = User.find_by(secret: params[:key])
-    user = nil unless user.has_role?(:super_admin)
-    user
+  private
+
+  def valid_key
+    params[:key] == SiteConfig.video_encoder_key
   end
 end

--- a/spec/requests/video_states_update_spec.rb
+++ b/spec/requests/video_states_update_spec.rb
@@ -1,28 +1,30 @@
-# http://localhost:3000/api/comments?a_id=23
 require "rails_helper"
 
 RSpec.describe "VideoStatesUpdate", type: :request do
-  let(:authorized_user) { create(:user, :super_admin, secret: "TEST_SECRET") }
-  let(:regular_user) { create(:user, secret: "TEST_SECRET") }
+  let(:encoder_key) { "TEST_SECRET" }
   let(:article) { create(:article, video_code: "DUMMY_VID_CODE") }
+
+  before do
+    allow(SiteConfig).to receive(:video_encoder_key).and_return(encoder_key)
+  end
 
   describe "POST /video_states" do
     it "updates video state" do
       input = JSON.unparse(input: { key: article.video_code })
-      post "/video_states?key=#{authorized_user.secret}",
+      post "/video_states?key=#{encoder_key}",
            params: { Message: input }.to_json
       expect(Article.last.video_state).to eq("COMPLETED")
     end
 
-    it "rejects non-authorized users" do
-      post "/video_states?key=#{regular_user.secret}",
+    it "rejects invalid key" do
+      post "/video_states?key=not_a_valid_key",
            params: { input: { key: article.video_code } }
       expect(response).to have_http_status(:unprocessable_entity)
     end
 
     it "returns not_found if video article is not found" do
       input = JSON.unparse(input: { key: "abc" })
-      post "/video_states?key=#{authorized_user.secret}",
+      post "/video_states?key=#{encoder_key}",
            params: { Message: input }.to_json
       expect(response).to have_http_status(:not_found)
       expect(response.parsed_body["message"]).to eq("Related article not found")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
This PR updates the VideoStatesController to use the SiteConfig video_encoder_key value to allow for video processing rather than a single user's secret.

cc @leewynne this is coming down the pipe! Make sure you have this secret set 😃 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-46047741

## Added tests?
- [x] yes

![alt_text](https://media3.giphy.com/media/6ivJWCpuh3CNi/giphy.gif?cid=ecf05e479mab3vq0vyh56qcbd31jtez15z45ealsgdtdnfyi&rid=giphy.gif)
