### PR TITLE
Optimization:Break up SiteConfig Updates by Groups

### DIFF
--- a/app/views/admin/configs/_form_submission.html.erb
+++ b/app/views/admin/configs/_form_submission.html.erb
@@ -1,0 +1,8 @@
+<% if current_user.has_role?(:single_resource_admin, Config) %>
+  <div class="form-group">
+    <%= label_tag :confirmation_update %>
+    <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off", required: true, pattern: @confirmation_text %>
+    <div class="alert alert-info">Type the sentence: <%= @confirmation_text %></div>
+    <%= f.submit "Update Site Configuration", class: "btn btn-danger btn-lg" %>
+  </div>
+<% end %>

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -112,9 +112,12 @@
                                  placeholder: Constants::SiteConfig::DETAILS[:video_encoder_key][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:video_encoder_key][:description] %></div>
               </div>
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -313,9 +316,13 @@
               <div class="crayons-notice crayons-notice--info mb-4">
                 Changing authentication keys will not take affect until this forem instance is restarted.
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -379,9 +386,13 @@
                                  placeholder: Constants::SiteConfig::DETAILS[:campaign_featured_tags][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:campaign_featured_tags][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -444,9 +455,13 @@
                                  placeholder: Constants::SiteConfig::DETAILS[:staff_user_id][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:staff_user_id][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -485,9 +500,13 @@
                   <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:credit_prices_in_cents][:xlarge][:description] %></div>
                 </div>
               <% end %>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -516,9 +535,13 @@
                 <% end %>
               <% end %>
             </div>
+
+            <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -545,9 +568,13 @@
                                    placeholder: Constants::SiteConfig::DETAILS[:periodic_email_digest_max][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:periodic_email_digest_max][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -570,9 +597,13 @@
                 <%= f.check_box :display_jobs_banner, checked: SiteConfig.display_jobs_banner %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:display_jobs_banner][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -589,9 +620,13 @@
                                  value: SiteConfig.ga_tracking_id %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:ga_tracking_id][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -615,9 +650,13 @@
                                  value: SiteConfig.recaptcha_secret_key %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:recaptcha_secret_key][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -709,9 +748,13 @@
                   <%= SiteConfig.right_navbar_svg_icon.html_safe %>
                 </div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -782,9 +825,13 @@
                                  value: SiteConfig.mascot_image_description %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:mascot_image_description][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -808,9 +855,13 @@
                   <% end %>
                 <% end %>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -855,9 +906,13 @@
                                  placeholder: Constants::SiteConfig::DETAILS[:payment_pointer][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:payment_pointer][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -898,9 +953,13 @@
                                  value: SiteConfig.mailchimp_community_moderators_id %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:mailchimp_community_moderators_id][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -966,8 +1025,13 @@
                                  placeholder: Constants::SiteConfig::DETAILS[:suggested_users][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:suggested_users][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
+
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -996,8 +1060,13 @@
                                  placeholder: Constants::SiteConfig::DETAILS[:spam_trigger_terms][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:spam_trigger_terms][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
+
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -1029,9 +1098,13 @@
                   <% end %>
                 <% end %>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -1049,8 +1122,13 @@
                                  placeholder: Constants::SiteConfig::DETAILS[:sponsor_headline][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:sponsor_headline][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
+
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -1069,9 +1147,13 @@
                                  pattern: "[a-z0-9,]+" %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:sidebar_tags][:description] %></div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
+        <% end %>
 
+        <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
           <div class="card mt-3">
             <%= render partial: "card_header",
                        locals: {
@@ -1122,21 +1204,10 @@
                 <%= f.check_box :public, checked: SiteConfig.public %>
                 <div class="alert alert-info">Are most of the site pages (posts, profiles, etc. public?) — BE VERY CAUTIOUS IN CHANGING THIS</div>
               </div>
+
+              <%= render "form_submission", f: f %>
             </div>
           </div>
-          <% if current_user.has_role?(:single_resource_admin, Config) %>
-            <div class="card mt-3">
-              <div class="card-header">Confirm and Submit</div>
-              <div class="card-body">
-                <div class="form-group">
-                  <%= label_tag :confirmation %>
-                  <%= text_field_tag :confirmation, nil, class: "form-control", placeholder: "Confirmation text", autocomplete: "off", required: true, pattern: @confirmation_text %>
-                  <div class="alert alert-info">Type the sentence: <%= @confirmation_text %></div>
-                  <%= f.submit "Update Site Configuration", class: "btn btn-danger btn-lg" %>
-                </div>
-              </div>
-            </div>
-          <% end %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Every time when we would save a SiteConfig we would update every single config whether or not it actually got changed. This led to 20+ second response times and thousands of unnecessary hits to our databases which you can see in the Honeycomb trace screenshot below. To fix this I split each section into its own form so we only update those values in each section instead of every single one. The view could likely be refactored further and we could get more technical about what is actually changing during updates but this seemed like a quick easy way to get better performance from this endpoint. 
![Screen Shot 2020-10-14 at 1 17 28 PM](https://user-images.githubusercontent.com/1813380/96026168-c52e8c00-0e1b-11eb-83d6-9d35dfe2358a.png)

I am also a fan of only updating sections bc I think it ensures that something doesn't get edited and forgotten about and then accidentally changed when other changes are meant to be saved. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-47372705

## QA Instructions, Screenshots, Recordings
Test that making config changes in admin still works. 

## Added tests?
- [x] no, because they aren't needed

![alt_text](https://media1.tenor.com/images/20781e6762116fb5d95ae5c6b30a0191/tenor.gif?itemid=15443324)
