### PR TITLE
Resave users for Imgproxy migration

### DIFF
--- a/lib/data_update_scripts/20201014184856_resave_users_for_imgproxy.rb
+++ b/lib/data_update_scripts/20201014184856_resave_users_for_imgproxy.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class ResaveUsersForImgproxy
+    def run
+      return unless ENV["FOREM_CONTEXT"] == "forem_cloud"
+
+      User.find_each(&:save)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We need to resave users to bust their image cache in order for a proper transition to Imgproxy.

## Related Tickets & Documents
Should've been part of https://github.com/forem/forem/pull/10819
## QA Instructions, Screenshots, Recordings
n/a

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a