### PR TITLE
Fix required button styling in SiteConfig

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -56,6 +56,7 @@ label {
 .site-config__label {
   display: flex;
   justify-content: space-between;
+  padding-bottom: var(--su-2);
 }
 
 .profile__group-toggle {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -285,7 +285,7 @@ module ApplicationHelper
   def admin_config_label(method, content = nil)
     content ||= raw("<span>#{method.to_s.humanize}</span>")
     if method.to_sym.in?(VerifySetupCompleted::MANDATORY_CONFIGS)
-      content = safe_join([content, raw("<span class='crayons-indicator'>Required</span>")])
+      content = safe_join([content, raw("<span class='crayons-indicator crayons-indicator--critical'>Required</span>")])
     end
 
     tag.label(content, class: "site-config__label crayons-field__label", for: "site_config_#{method}")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While QAing one of @mstruve's [recent PRs to the SiteConfig view](https://github.com/forem/forem/pull/10851#pullrequestreview-508699494), I noticed a regression. This regression was caused by a [different PR](https://github.com/forem/forem/pull/10694), which deprecated old button styling (opting instead for the crayons versions of buttons).

However, in the SiteConfig view, the button styling looked pretty odd and almost missable:
<img width="1006" alt="Screen Shot 2020-10-14 at 1 21 10 PM" src="https://user-images.githubusercontent.com/6921610/96047997-d7fc8d00-0e2a-11eb-88b8-66a5ca8267be.png">

I updated the crayons class used here to be something more obvious:
<img width="1532" alt="Screen Shot 2020-10-14 at 2 35 13 PM" src="https://user-images.githubusercontent.com/6921610/96048058-ed71b700-0e2a-11eb-99d4-a16da3d60bf7.png">

This is a very close match to what we had in the site config view earlier:
<img width="1000" alt="Screen Shot 2020-10-14 at 1 20 44 PM" src="https://user-images.githubusercontent.com/6921610/96048097-fcf10000-0e2a-11eb-8d6f-e75ef7bffbee.png">

...except that we use a crayons class here now 🖍️ 😄 .

I _also_ added some padding to make sure that the bottom of the button doesn't touch the `<input>`.

## Related Tickets & Documents

Please see [my original comment](https://github.com/forem/forem/pull/10851#pullrequestreview-508699494) on this regression, and [this relevant PR](https://github.com/forem/forem/pull/10694).

## QA Instructions, Screenshots, Recordings

Head over to `/admin/config` and click on "toggle get started" to see these changes.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
