### PR TITLE
Move settings tabs to constant

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -6,7 +6,6 @@ class OrganizationsController < ApplicationController
 
     @tab = "organization"
     @user = current_user
-    @tab_list = @user.settings_tab_list
 
     unless valid_image?
       render template: "users/edit"
@@ -29,7 +28,6 @@ class OrganizationsController < ApplicationController
   def update
     @user = current_user
     @tab = "organization"
-    @tab_list = @user.settings_tab_list
     set_organization
 
     unless valid_image?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,13 +31,13 @@ class UsersController < ApplicationController
       return redirect_to sign_up_path
     end
     set_user
-    set_tabs(params["tab"] || "profile")
+    set_current_tab(params["tab"] || "profile")
     handle_settings_tab
   end
 
   # PATCH/PUT /users/:id.:format
   def update
-    set_tabs(params["user"]["tab"])
+    set_current_tab(params["user"]["tab"])
 
     unless valid_image?
       render :edit, status: :bad_request
@@ -73,7 +73,7 @@ class UsersController < ApplicationController
   end
 
   def update_language_settings
-    set_tabs("misc")
+    set_current_tab("misc")
     @user.language_settings["preferred_languages"] = Languages::LIST.keys & params[:user][:preferred_languages].to_a
     if @user.save
       flash[:settings_notice] = "Your language settings were successfully updated."
@@ -85,7 +85,7 @@ class UsersController < ApplicationController
   end
 
   def request_destroy
-    set_tabs("account")
+    set_current_tab("account")
 
     if destroy_request_in_progress?
       notice = "You have already requested account deletion. Please, check your email for further instructions."
@@ -106,11 +106,11 @@ class UsersController < ApplicationController
     destroy_token = Rails.cache.read("user-destroy-token-#{@user.id}")
     raise ActionController::RoutingError, "Not Found" unless destroy_token.present? && destroy_token == params[:token]
 
-    set_tabs("account")
+    set_current_tab("account")
   end
 
   def full_delete
-    set_tabs("account")
+    set_current_tab("account")
     if @user.email?
       Users::DeleteWorker.perform_async(@user.id)
       sign_out @user
@@ -123,7 +123,7 @@ class UsersController < ApplicationController
   end
 
   def remove_identity
-    set_tabs("account")
+    set_current_tab("account")
 
     error_message = "An error occurred. Please try again or send an email to: #{SiteConfig.email_addresses[:default]}"
     unless Authentication::Providers.enabled?(params[:provider])
@@ -256,7 +256,7 @@ class UsersController < ApplicationController
     when "response-templates"
       handle_response_templates_tab
     else
-      not_found unless @tab_list.map { |t| t.downcase.tr(" ", "-") }.include? @tab
+      not_found unless @tab.in?(Constants::Settings::TAB_LIST.map { |t| t.downcase.tr(" ", "-") })
     end
   end
 
@@ -331,8 +331,7 @@ class UsersController < ApplicationController
     authorize @user
   end
 
-  def set_tabs(current_tab = "profile")
-    @tab_list = @user.settings_tab_list
+  def set_current_tab(current_tab = "profile")
     @tab = current_tab
   end
 

--- a/app/lib/constants/settings.rb
+++ b/app/lib/constants/settings.rb
@@ -1,0 +1,16 @@
+module Constants
+  module Settings
+    TAB_LIST = %w[
+      Profile
+      UX
+      Integrations
+      Notifications
+      Publishing\ from\ RSS
+      Organization
+      Response\ Templates
+      Billing
+      Account
+      Misc
+    ].freeze
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -448,21 +448,6 @@ class User < ApplicationRecord
     end
   end
 
-  def settings_tab_list
-    %w[
-      Profile
-      UX
-      Integrations
-      Notifications
-      Publishing\ from\ RSS
-      Organization
-      Response\ Templates
-      Billing
-      Account
-      Misc
-    ]
-  end
-
   def profile_image_90
     Images::Profile.call(profile_image_url, length: 90)
   end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -45,7 +45,7 @@
 <main class="crayons-layout crayons-layout--2-cols crayons-layout--limited-l">
   <div class="crayons-layout__left-sidebar">
     <nav class="hidden m:block">
-      <% @tab_list.each do |possible_tab| %>
+      <% Constants::Settings::TAB_LIST.each do |possible_tab| %>
         <a class="crayons-link crayons-link--block <% if @tab == possible_tab.downcase.tr(' ', '-') %>crayons-link--current<% end %>" href="/settings/<%= possible_tab.downcase.tr(" ", "-") %>">
           <%= possible_tab %>
         </a>
@@ -53,7 +53,7 @@
     </nav>
     <div class="m:hidden p-2 pt-0">
       <select id="mobile-page-selector" class="crayons-select">
-        <% @tab_list.each do |possible_tab| %>
+        <% Constants::Settings::TAB_LIST.each do |possible_tab| %>
           <option value="/settings/<%= possible_tab.downcase.tr(" ", "-") %>" <% if @tab == possible_tab.downcase.tr(' ', '-') %> selected <% end %>>
             <%= possible_tab %>
           </option>

--- a/spec/views/users/settings_spec.rb
+++ b/spec/views/users/settings_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe "users/edit", type: :view do
     before do
       sign_in user
       assign(:user, user)
-      assign(:tab_list, user.settings_tab_list)
       assign(:tab, "organization")
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

While working on `User` during profile generalization I noticed the method `settings_tab_list` which returns a constant array. I removed the method, added a constant and changed the code accordingly.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Nothing specific, the tests should pass and you should still be able to interact with the settings tabs in the app.

## Added tests?

- [x] no, because they aren't needed

## Added to documentation?

- [x] no documentation needed
