### PR TITLE
Optimization/Flaky Fix:Combine Spec Assertions and Use Timecop for Datetime Assertion

### DIFF
--- a/spec/system/user/view_user_index_spec.rb
+++ b/spec/system/user/view_user_index_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "User index", type: :system, stub_elasticsearch: true do
       visit "/#{user.username}"
     end
 
-    it "shows all proper eleiments", :aggregate_failures, js: true do
+    it "shows all proper elements", :aggregate_failures, js: true do
       shows_header
       shows_articles
       shows_comments

--- a/spec/system/user/view_user_index_spec.rb
+++ b/spec/system/user/view_user_index_spec.rb
@@ -11,38 +11,42 @@ RSpec.describe "User index", type: :system, stub_elasticsearch: true do
     context "when 1 article" do
       before { visit "/#{user.username}" }
 
-      it "shows the header", js: true do
+      it "shows all proper elements", :aggregate_failures, js: true do
+        shows_header
+        shows_title
+        shows_articles
+        shows_comments
+        shows_comment_timestamp
+      end
+
+      def shows_header
         within("h1") { expect(page).to have_content(user.name) }
         within(".profile-header__actions") do
           expect(page).to have_button("Follow")
         end
       end
 
-      it "shows proper title tag" do
+      def shows_title
         expect(page).to have_title("#{user.name} - #{SiteConfig.community_name}")
       end
 
-      it "shows user's articles" do
+      def shows_articles
         within(".crayons-story") do
           expect(page).to have_content(article.title)
           expect(page).not_to have_content(other_article.title)
         end
       end
 
-      it "shows user's comments" do
+      def shows_comments
         within("#substories div.index-comments") do
           expect(page).to have_content("Recent Comments")
           expect(page).to have_link(nil, href: comment.path)
         end
-      end
 
-      it "shows user's comments once" do
         within("#substories") do
           expect(page).to have_selector(".index-comments", count: 1)
         end
-      end
 
-      it "shows comment date" do
         within("#substories .index-comments .single-comment") do
           # %e blank pads days from 1 to 9, the double space isn't in the HTML
           comment_date = comment.readable_publish_date.gsub("  ", " ")
@@ -50,7 +54,7 @@ RSpec.describe "User index", type: :system, stub_elasticsearch: true do
         end
       end
 
-      it "embeds comment timestamp" do
+      def shows_comment_timestamp
         within("#substories .index-comments .single-comment") do
           ts = comment.decorate.published_timestamp
           timestamp_selector = ".comment-date time[datetime='#{ts}']"
@@ -78,21 +82,27 @@ RSpec.describe "User index", type: :system, stub_elasticsearch: true do
       visit "/#{user.username}"
     end
 
-    it "shows the header", js: true do
+    it "shows all proper eleiments", :aggregate_failures, js: true do
+      shows_header
+      shows_articles
+      shows_comments
+    end
+
+    def shows_header
       within("h1") { expect(page).to have_content(user.name) }
       within(".profile-header__actions") do
         expect(page).to have_button("Edit profile")
       end
     end
 
-    it "shows user's articles" do
+    def shows_articles
       within(".crayons-story") do
         expect(page).to have_content(article.title)
         expect(page).not_to have_content(other_article.title)
       end
     end
 
-    it "shows user's comments" do
+    def shows_comments
       within("#substories div.index-comments") do
         expect(page).to have_content("Recent Comments")
         expect(page).to have_link(nil, href: comment.path)

--- a/spec/system/user/view_user_index_spec.rb
+++ b/spec/system/user/view_user_index_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe "User index", type: :system, stub_elasticsearch: true do
 
   context "when user is unauthorized" do
     context "when 1 article" do
-      before { visit "/#{user.username}" }
+      before do
+        Timecop.freeze
+        visit "/#{user.username}"
+      end
+
+      after { Timecop.return }
 
       it "shows all proper elements", :aggregate_failures, js: true do
         shows_header
@@ -48,7 +53,6 @@ RSpec.describe "User index", type: :system, stub_elasticsearch: true do
         end
 
         within("#substories .index-comments .single-comment") do
-          # %e blank pads days from 1 to 9, the double space isn't in the HTML
           comment_date = comment.readable_publish_date.gsub("  ", " ")
           expect(page).to have_selector(".comment-date", text: comment_date)
         end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Optimization

## Description
Let me know what you think of using methods and assertions this way with aggregate failures. I noticed we are not doing anything in the individual assertions beyond just looking for different content on the page. To avoid reloading the entire page each time, I combined the assertions into a single one. This took the spec run time from around 6.5 seconds to around 3.5 seconds(excluding about 8 second load time for files). Not a giant win, but if people like it, I think this is a pattern we could repeat for other specs to speed them up. 

While running this spec I just found a flaky component to it where the date asserted and the date shown down match due to straddling a date. Adding Timecop fixes this issue. 
Fixes: 
```
  1) User index when user is unauthorized when 1 article shows all proper elements
     Failure/Error: expect(page).to have_selector(".comment-date", text: comment_date)
       expected to find visible css ".comment-date" with text "Oct 16" within #<Capybara::Node::Element tag="div" path="/HTML/BODY[1]/DIV[7]/DIV[2]/DIV[2]/DIV[2]/DIV[2]/DIV[3]/A[1]/DIV[1]"> but there were no matches. Also found "Oct 15", which matched the selector but not all filters. 

     # ./spec/system/user/view_user_index_spec.rb:53:in `block in shows_comments'
     # ./spec/system/user/view_user_index_spec.rb:50:in `shows_comments'
```

![alt_text](https://www.photopea.com/tuts/wp-content/uploads/2019/07/combined.gif)
