### PR TITLE
Fix tag display bug and crayonsify area

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -22,25 +22,6 @@ function initializeProfileImage(user) {
 function initializeUserSidebar(user) {
   if (!document.getElementById('sidebar-nav')) return;
   initializeUserProfileContent(user);
-
-  let followedTags = JSON.parse(user.followed_tags);
-  const tagSeparatorLabel =
-    followedTags.length === 0
-      ? 'FOLLOW TAGS TO IMPROVE YOUR FEED'
-      : 'OTHER POPULAR TAGS';
-
-  followedTags.forEach((tag) => {
-    const element = document.getElementById(
-      'default-sidebar-element-' + tag.name,
-    );
-
-    if (element) {
-      element.remove();
-    }
-  });
-
-  document.getElementById('tag-separator').innerHTML = tagSeparatorLabel;
-  document.getElementById('sidebar-nav-default-tags').classList.add('showing');
 }
 
 function addRelevantButtonsToArticle(user) {

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -84,17 +84,6 @@
       display: block;
     }
 
-    .sidebar-nav {
-      .sidebar-nav-block {
-        .sidebar-nav-default-tags {
-          display: none;
-          &.showing {
-            display: block;
-          }
-        }
-      }
-    }
-
     .search-partner-mention {
       display: none;
       text-align: center;

--- a/app/assets/stylesheets/base/main.scss
+++ b/app/assets/stylesheets/base/main.scss
@@ -20,6 +20,22 @@ body {
     }
   }
 
+  &.user-tags-followed-0, &.user-tags-followed-1, &.user-tags-followed-2{
+    #sidebar-nav-followed-tags {
+      height: 90px;
+    }
+  }
+  &.user-tags-followed-3, &.user-tags-followed-4, &.user-tags-followed-5{
+    #sidebar-nav-followed-tags {
+      height: 205px;
+    }
+  }
+  &.user-tags-followed-max {
+    #sidebar-nav-followed-tags {
+      height: 42vh;
+    }
+  }
+
   &.default-header {
     padding-top: var(--header-height);
     min-height: calc(100vh - var(--header-height));

--- a/app/javascript/leftSidebar/TagsFollowed.jsx
+++ b/app/javascript/leftSidebar/TagsFollowed.jsx
@@ -14,7 +14,7 @@ export const TagsFollowed = ({ tags = [] }) => {
         >
           <a
             title={`${tag.name} tag`}
-            className="crayons-link crayons-link--contentful py-2"
+            className="crayons-link crayons-link--contentful py-2 px-2"
             href={`/t/${tag.name}`}
           >
             {`#${tag.name}`}

--- a/app/javascript/leftSidebar/TagsFollowed.jsx
+++ b/app/javascript/leftSidebar/TagsFollowed.jsx
@@ -14,7 +14,7 @@ export const TagsFollowed = ({ tags = [] }) => {
         >
           <a
             title={`${tag.name} tag`}
-            className="crayons-link crayons-link--block spec__tag-link"
+            className="crayons-link crayons-link--contentful"
             href={`/t/${tag.name}`}
           >
             {`#${tag.name}`}

--- a/app/javascript/leftSidebar/TagsFollowed.jsx
+++ b/app/javascript/leftSidebar/TagsFollowed.jsx
@@ -14,7 +14,7 @@ export const TagsFollowed = ({ tags = [] }) => {
         >
           <a
             title={`${tag.name} tag`}
-            className="crayons-link crayons-link--contentful"
+            className="crayons-link crayons-link--contentful py-2"
             href={`/t/${tag.name}`}
           >
             {`#${tag.name}`}

--- a/app/javascript/packs/homePage.jsx
+++ b/app/javascript/packs/homePage.jsx
@@ -1,7 +1,7 @@
 import { h, render } from 'preact';
+import { TagsFollowed } from '../leftSidebar/TagsFollowed';
 
 /* global userData */
-
 // This logic is similar to that in initScrolling.js.erb
 const frontPageFeedPathNames = new Map([
   ['/', ''],
@@ -34,26 +34,24 @@ function renderTagsFollowed(tagsFollowedContainer, user = userData()) {
   }
 
   // Only render if a user is logged on.
-  import('../leftSidebar/TagsFollowed').then(({ TagsFollowed }) => {
-    const { followed_tags } = user; // eslint-disable-line camelcase
-    const followedTags = JSON.parse(followed_tags);
+  const { followed_tags } = user; // eslint-disable-line camelcase
+  const followedTags = JSON.parse(followed_tags);
 
-    // This should be done server-side potentially
-    // sort tags by descending weight, descending popularity and name
-    followedTags.sort((tagA, tagB) => {
-      return (
-        tagB.points - tagA.points ||
-        tagB.hotness_score - tagA.hotness_score ||
-        tagA.name.localeCompare(tagB.name)
-      );
-    });
-
-    render(
-      <TagsFollowed tags={followedTags} />,
-      tagsFollowedContainer,
-      tagsFollowedContainer.firstElementChild,
+  // This should be done server-side potentially
+  // sort tags by descending weight, descending popularity and name
+  followedTags.sort((tagA, tagB) => {
+    return (
+      tagB.points - tagA.points ||
+      tagB.hotness_score - tagA.hotness_score ||
+      tagA.name.localeCompare(tagB.name)
     );
   });
+
+  render(
+    <TagsFollowed tags={followedTags} />,
+    tagsFollowedContainer,
+    tagsFollowedContainer.firstElementChild,
+  );
 }
 
 const feedTimeFrame = frontPageFeedPathNames.get(window.location.pathname);
@@ -96,13 +94,13 @@ if (!document.getElementById('featured-story-marker')) {
   }, 2);
 }
 
-InstantClick.on('receive', (address, body, title) => {
+InstantClick.on('change', () => {
   if (document.body.dataset.userStatus !== 'logged-in') {
     // Nothing to do, the user is not logged on.
     return false;
   }
 
-  const tagsFollowedContainer = body.querySelector(
+  const tagsFollowedContainer = document.body.querySelector(
     '#sidebar-nav-followed-tags',
   );
 
@@ -112,10 +110,5 @@ InstantClick.on('receive', (address, body, title) => {
   }
 
   renderTagsFollowed(tagsFollowedContainer);
-
-  return {
-    body,
-    title,
-  };
 });
 InstantClick.init();

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -41,10 +41,10 @@
   <% end %>
 </nav>
 
-<nav class="crayons-card crayons-card--secondary" aria-label="Secondary sidebar nav">
+<nav aria-label="Secondary sidebar nav">
   <% if user_signed_in? %>
-    <header class="crayons-card__header pr-2">
-      <h3 class="crayons-subtitle-2 flex items-right w-100">
+    <header class="crayons-card__header pr-2 pb-0">
+      <h3 class="crayons-subtitle-3 flex items-right w-100">
         <span class="grow-1 inline-block mt-1">My Tags</span>
         <a href="/dashboard/following_tags" class="crayons-btn crayons-btn--ghost-dimmed px-2" aria-label="Customize tag priority" title="Customize tag priority">
           <%= inline_svg_tag("cog.svg", aria: true, class: "crayons-icon") %>

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -51,7 +51,7 @@
         </a>
       </h3>
     </header>
-    <div id="sidebar-nav-followed-tags" class="overflow-y-auto" style="height: 42vh"></div>
+    <div id="sidebar-nav-followed-tags" class="overflow-y-auto mb-2" style="max-height: 42vh;"></div>
   <% else %>
     <header class="crayons-card__header px-2 pb-0">
       <h3 class="crayons-subtitle-3 flex items-right w-100">

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -59,17 +59,18 @@
       </h3>
     </header>
     <div id="sidebar-nav-default-tags" class="overflow-y-auto" style="height: 42vh">
-    <% Tag.where(supported: true).order(hotness_score: :desc).limit(30).pluck(:id, :name).each do |tag_array| %>
-      <div class="sidebar-nav-element" id="default-sidebar-element-<%= tag_array.second %>">
-        <a class="crayons-link crayons-link--contentful" href="<%= tag_path(tag_array.second) %>">
-          #<%= tag_array.second %>
-        </a>
-        <a class="follow-action-button sidebar-nav-link-follow crayons-btn crayons-btn--s crayons-btn--secondary_"
-          href="#" id="sidebar-nav-link-follow-<%= tag_array.second %>"
-          data-info='{"id":<%= tag_array.first %>,"className":"Tag"}'>
-          Follow
-        </a>
-      </div>
-    <% end %>
+      <% Tag.where(supported: true).order(hotness_score: :desc).limit(30).pluck(:id, :name).each do |tag_array| %>
+        <div class="sidebar-nav-element" id="default-sidebar-element-<%= tag_array.second %>">
+          <a class="crayons-link crayons-link--contentful" href="<%= tag_path(tag_array.second) %>">
+            #<%= tag_array.second %>
+          </a>
+          <a class="follow-action-button sidebar-nav-link-follow crayons-btn crayons-btn--s crayons-btn--secondary_"
+            href="#" id="sidebar-nav-link-follow-<%= tag_array.second %>"
+            data-info='{"id":<%= tag_array.first %>,"className":"Tag"}'>
+            Follow
+          </a>
+        </div>
+      <% end %>
+    </div>
   <% end %>
 </nav>

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -41,22 +41,27 @@
   <% end %>
 </nav>
 
-<nav class="sidebar-tags-browser mb-6 overflow-y-auto scrolling-touch" aria-label="Secondary sidebar nav">
+<nav class="crayons-card crayons-card--secondary" aria-label="Secondary sidebar nav">
   <% if user_signed_in? %>
-    <header class="fs-xs color-base-50 ff-monospace fw-bold p-2">MY TAGS</header>
-    <div id="sidebar-nav-followed-tags" class="sidebar-nav-followed-tags"></div>
-  <% end %>
-  <div id="sidebar-nav-default-tags" class="sidebar-nav-default-tags <%= "showing" unless user_signed_in? %>">
-    <header id="tag-separator" class="fs-xs color-base-50 ff-monospace fw-bold p-2">
-      <% if user_signed_in? %>
-        OTHER POPULAR TAGS
-      <% else %>
-        DESIGN YOUR EXPERIENCE
-      <% end %>
+    <header class="crayons-card__header pr-2">
+      <h3 class="crayons-subtitle-2 flex items-right w-100">
+        <span class="grow-1 inline-block mt-1">My Tags</span>
+        <a href="/dashboard/following_tags" class="crayons-btn crayons-btn--ghost-dimmed px-2" aria-label="Customize tag priority" title="Customize tag priority">
+          <%= inline_svg_tag("cog.svg", aria: true, class: "crayons-icon") %>
+        </a>
+      </h3>
     </header>
+    <div id="sidebar-nav-followed-tags" class="overflow-y-auto" style="height: 42vh"></div>
+  <% else %>
+    <header class="crayons-card__header pr-3">
+      <h3 class="crayons-subtitle-2 flex items-right w-100">
+        <span class="grow-1 inline-block mt-1">Popular Tags</span>
+      </h3>
+    </header>
+    <div id="sidebar-nav-default-tags" class="overflow-y-auto" style="height: 42vh">
     <% Tag.where(supported: true).order(hotness_score: :desc).limit(30).pluck(:id, :name).each do |tag_array| %>
       <div class="sidebar-nav-element" id="default-sidebar-element-<%= tag_array.second %>">
-        <a class="crayons-link crayons-link--block" href="<%= tag_path(tag_array.second) %>">
+        <a class="crayons-link crayons-link--contentful" href="<%= tag_path(tag_array.second) %>">
           #<%= tag_array.second %>
         </a>
         <a class="follow-action-button sidebar-nav-link-follow crayons-btn crayons-btn--s crayons-btn--secondary_"
@@ -66,4 +71,5 @@
         </a>
       </div>
     <% end %>
+  <% end %>
 </nav>

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -43,7 +43,7 @@
 
 <nav aria-label="Secondary sidebar nav">
   <% if user_signed_in? %>
-    <header class="crayons-card__header pr-2 pb-0">
+    <header class="crayons-card__header px-2 pb-0">
       <h3 class="crayons-subtitle-3 flex items-right w-100">
         <span class="grow-1 inline-block mt-1">My Tags</span>
         <a href="/dashboard/following_tags" class="crayons-btn crayons-btn--ghost-dimmed px-2" aria-label="Customize tag priority" title="Customize tag priority">
@@ -53,15 +53,15 @@
     </header>
     <div id="sidebar-nav-followed-tags" class="overflow-y-auto" style="height: 42vh"></div>
   <% else %>
-    <header class="crayons-card__header pr-3">
-      <h3 class="crayons-subtitle-2 flex items-right w-100">
+    <header class="crayons-card__header px-2 pb-0">
+      <h3 class="crayons-subtitle-3 flex items-right w-100">
         <span class="grow-1 inline-block mt-1">Popular Tags</span>
       </h3>
     </header>
     <div id="sidebar-nav-default-tags" class="overflow-y-auto" style="height: 42vh">
       <% Tag.where(supported: true).order(hotness_score: :desc).limit(30).pluck(:id, :name).each do |tag_array| %>
         <div class="sidebar-nav-element" id="default-sidebar-element-<%= tag_array.second %>">
-          <a class="crayons-link crayons-link--contentful" href="<%= tag_path(tag_array.second) %>">
+          <a class="crayons-link crayons-link--contentful py-2 px-2" href="<%= tag_path(tag_array.second) %>">
             #<%= tag_array.second %>
           </a>
           <a class="follow-action-button sidebar-nav-link-follow crayons-btn crayons-btn--s crayons-btn--secondary_"

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -77,7 +77,7 @@
       </header>
 
       <% if user_signed_in? %>
-        <div id="homepage-feed"></div>
+        <div id="homepage-feed" style="min-height: 90vh"></div>
       <% else %>
         <%= render "stories/main_stories_feed" %>
       <% end %>

--- a/app/views/dashboards/following_tags.html.erb
+++ b/app/views/dashboards/following_tags.html.erb
@@ -13,12 +13,11 @@
       <%= render "actions" %>
     </aside>
 
-    <div class="crayons-layout__content" id="user-dashboard">
+    <div class="crayons-layout__content mb-5" id="user-dashboard">
       <% if @followed_tags.any? %>
-        <div class="crayons-card crayons-card--secondary p-4 px-6 fs-s mb-2 mx-2 m:mx-0">
-          <i>
-            Adjust <strong>Follow Weight</strong> to make a tag show up less or more in your feed (default 1.0). Raising the number will make it so that a tag appears more in your feed, while lowering the number will make a tag less followed. Note that you can even make the follow weight negative for tags that you want to avoid seeing.
-          </i>
+        <div class="crayons-notice p-4 px-6 mb-4 mx-2 m:mx-0">
+            Adjust tag weight to modify your home feed. Higher values mean more appearances for that tag.
+            <span class="crayons-indicator crayons-indicator--outlined crayons-indicator--accent ml-3">Default 1.0</span>
         </div>
         <div id="following-wrapper" class="grid gap-3 m:gap-4 s:grid-cols-2 l:grid-cols-3 px-2 m:px-0">
           <% negative_follow_shown_once = false %>
@@ -40,10 +39,9 @@
                   <%= strip_tags(tag.short_summary) %>
                 </p>
 
-                <%= form_for(follow, html: { class: "flex items-center flex-nowrap" }) do |f| %>
-                  <%= f.label(:points, "Follow weight:", class: "fs-s flex-1 pr-2 color-base-60 align-right whitespace-nowrap") %>
-                  <%= f.number_field(:points, step: :any, required: true, class: "crayons-textfield flex-1 fs-s", style: "max-width:90px") %>
-                  <button type="submit" class="crayons-btn crayons-btn--ghost crayons-btn--s" name="commit">Save</button>
+                <%= form_for(follow, html: { class: "flex items-right w-100" }) do |f| %>
+                  <%= f.number_field(:points, step: :any, required: true, class: "crayons-textfield grow-1 fs-s inline-block w-75") %>
+                  <button type="submit" class="crayons-btn crayons-btn--ghost crayons-btn--s inline-block ml-2" name="commit" style="min-width:60px;">Save</button>
                 <% end %>
               </div>
             <% end %>

--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -1,6 +1,7 @@
 <script>
   try {
     const bodyClass = localStorage.getItem('config_body_class');
+    const userString = localStorage.getItem('current_user');
 
     if (bodyClass) {
       document.body.className = bodyClass;
@@ -29,6 +30,17 @@
     }
     if (window.frameElement) { // Hide top bar and footer when loaded within iframe
       document.body.classList.add("hidden-shell");
+    }
+    if (userString && userString.length > 0) {
+      const user = JSON.parse(userString)
+      const numTags = JSON.parse(user.followed_tags).length
+      if (numTags < 6) {
+        document.body.classList.add("user-tags-followed-"+numTags);
+      } else {
+        document.body.classList.add("user-tags-followed-max");
+      }
+      sidebarTags.style.height = "100vh"
+      sidebarTags.style.backgroundColor = "green"
     }
   } catch(e) {
       Honeybadger.notify(e);

--- a/spec/system/homepage/user_visits_homepage_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "User visits a homepage", type: :system do
         end
       end
 
-      expect(page).to have_text("DESIGN YOUR EXPERIENCE")
+      expect(page).to have_text("Popular Tags")
     end
 
     describe "link tags" do
@@ -63,14 +63,6 @@ RSpec.describe "User visits a homepage", type: :system do
       sign_in(user)
     end
 
-    it "offers to follow tags", js: true do
-      visit "/"
-
-      within("#sidebar-nav-default-tags") do
-        expect(page).to have_text("FOLLOW TAGS TO IMPROVE YOUR FEED")
-      end
-    end
-
     context "when rendering broadcasts" do
       let!(:broadcast) { create(:announcement_broadcast) }
 
@@ -100,7 +92,7 @@ RSpec.describe "User visits a homepage", type: :system do
       end
 
       it "shows the followed tags", js: true do
-        expect(page).to have_text("MY TAGS")
+        expect(page).to have_text("My Tags")
 
         # Need to ensure the user data is loaded before doing any checks
         find("body")["data-user"]
@@ -115,15 +107,7 @@ RSpec.describe "User visits a homepage", type: :system do
         find("body")["data-user"]
 
         within("#sidebar-nav-followed-tags") do
-          expect(all(".spec__tag-link").map(&:text)).to eq(%w[#javascript #go #ruby])
-        end
-      end
-
-      it "shows other tags", js: true do
-        expect(page).to have_text("OTHER POPULAR TAGS")
-        within("#sidebar-nav-default-tags") do
-          expect(page).to have_link("#webdev", href: "/t/webdev")
-          expect(page).not_to have_link("#ruby", href: "/t/ruby")
+          expect(all(".crayons-link--contentful").map(&:text)).to eq(%w[#javascript #go #ruby])
         end
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This pull request fixes a bug where inter-page navigation messes with the display of tags.

It also updates tags to crayons design and adds a quick link to adjusting tags. I made small design and copy adjustments to that page as well.

In my opinion navigating to tags from this area is still a valuable feature but is inhibited by poor design and lack of awareness around the customization.... And the bug that was in place.

(It was my old design so I think I'm allowed to be blunt about its poor quality 😄)

Beyond just the bug fixes I think this is an improvement we should lean in on.

A follow-up feature which I think could add more usability here could be an `indicator` mentioning the number of posts for that tag in the last 24 hours or since you last visited the page. Could encourage simpler and more intuitive navigation to that area.


<img width="282" alt="Screen Shot 2020-10-15 at 1 48 02 PM" src="https://user-images.githubusercontent.com/3102842/96168344-9503ed80-0eee-11eb-8670-3e3d2e141fd7.png">
<img width="1020" alt="Screen Shot 2020-10-15 at 1 47 57 PM" src="https://user-images.githubusercontent.com/3102842/96168240-7bfb3c80-0eee-11eb-93ea-79cfbf2fb4d5.png">
