### PR TITLE
User color fields in admin

### DIFF
--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -1192,11 +1192,11 @@
               </div>
               <div class="form-group">
                 <%= f.label :primary_brand_color_hex %>
-                <%= f.text_field :primary_brand_color_hex,
-                                 class: "form-control",
-                                 value: SiteConfig.primary_brand_color_hex,
-                                 pattern: "^#+([a-fA-F0-9]{6})$",
-                                 placeholder: Constants::SiteConfig::DETAILS[:primary_brand_color_hex][:placeholder] %>
+                <%= f.color_field :primary_brand_color_hex,
+                                  class: "form-control",
+                                  value: SiteConfig.primary_brand_color_hex,
+                                  pattern: "^#+([a-fA-F0-9]{6})$",
+                                  placeholder: Constants::SiteConfig::DETAILS[:primary_brand_color_hex][:placeholder] %>
                 <div class="alert alert-info"><%= Constants::SiteConfig::DETAILS[:primary_brand_color_hex][:description] %></div>
               </div>
               <div class="form-group">

--- a/app/views/admin/tags/show.html.erb
+++ b/app/views/admin/tags/show.html.erb
@@ -82,11 +82,11 @@
       </div>
       <div class="form-group">
         <%= f.label :bg_color_hex %>
-        <%= f.text_field :bg_color_hex, class: "color-picker form-control", required: true %>
+        <%= f.color_field :bg_color_hex, class: "color-picker form-control", required: true %>
       </div>
       <div class="form-group">
         <%= f.label :text_color_hex %>
-        <%= f.text_field :text_color_hex, class: "color-picker form-control", required: true %>
+        <%= f.color_field :text_color_hex, class: "color-picker form-control", required: true %>
       </div>
       <%= f.submit class: "btn btn-primary float-right" %>
     <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR makes color pickers in the admin actual color fields instead of text inputs, similar to how we do it on the settings page.

## Related Tickets & Documents

Closes #10872 

## QA Instructions, Screenshots, Recordings

<img width="976" alt="Screen Shot 2020-10-16 at 10 49 40" src="https://user-images.githubusercontent.com/47985/96211274-11093e80-0f9e-11eb-8cbd-ddf02449bd00.png">
<img width="962" alt="Screen Shot 2020-10-16 at 10 50 17" src="https://user-images.githubusercontent.com/47985/96211279-136b9880-0f9e-11eb-8511-a84f7c37b31f.png">

This could certainly be prettier, but it's internal, so probably good enough for now. I noticed that there's currently some styling work going on in the admin area anyway, so someone more qualified than me can add the ✨

## Added tests?

- [ ] yes
- [X] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
