### PR TITLE
Add a simple image uploader partial

### DIFF
--- a/app/javascript/admin/controllers/image_upload_controller.js
+++ b/app/javascript/admin/controllers/image_upload_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from 'stimulus';
+
+export default class ImageUploadController extends Controller {
+  static targets = ['fileField', 'imageResult'];
+
+  onFormSubmit(event) {
+    event.preventDefault();
+    let token = document.getElementsByName('authenticity_token')[0].value;
+    let image = this.fileFieldTarget.files[0];
+    let formData = new FormData();
+
+    formData.append('authenticity_token', token);
+    formData.append('image', image);
+
+    fetch('/image_uploads', {
+      method: 'POST',
+      headers: {
+        'X-CSRF_Token': window.csrfToken,
+      },
+      body: formData,
+      credentials: 'same-origin',
+    })
+      .then((response) => response.json())
+      .then((json) => {
+        if (json.error) {
+          throw new Error(json.error);
+        }
+        const { links } = json;
+        return this.onUploadSuccess(links);
+      });
+  }
+
+  onUploadSuccess(result) {
+    this.imageResultTarget.classList.remove('d-none');
+    const output = `
+      <div class="form-group">
+        <label for="output">Image URL:</label>
+        <textfield id="output" name="output" class="form-control" readonly>
+          ${result}
+        </textfield>
+      </div>
+      <img width="300px" src=${result}>
+    `;
+    this.imageResultTarget.innerHTML = output;
+  }
+}

--- a/app/views/admin/shared/_image_uploader.html.erb
+++ b/app/views/admin/shared/_image_uploader.html.erb
@@ -1,0 +1,15 @@
+<div class="crayons-card p-6" data-controller="image-upload">
+  <h2 class="crayons-title mb-4">Upload an Image</h2>
+  <p class="mb-6">Quickly upload an image.</p>
+  <% # Multipart, remote forms are tricky, the data is actually sent in the Stimulus controller. %>
+  <%= form_with(url: image_uploads_path, multipart: true) do |f| %>
+    <div class="form-group">
+      <%= f.label(:image, "Image:") %>
+      <%= f.file_field "image", class: "form-control", required: true, data: { target: "image-upload.fileField" } %>
+    </div>
+    <%= f.submit "Upload", class: "btn btn-primary", data: { action: "image-upload#onFormSubmit" } %>
+  <% end %>
+
+  <div class="mt-4 d-none" data-target="image-upload.imageResult">
+  </div>
+</div>

--- a/app/views/admin/tools/index.html.erb
+++ b/app/views/admin/tools/index.html.erb
@@ -11,7 +11,7 @@
   <% end %>
 </div>
 
-<div class="crayons-card p-6">
+<div class="crayons-card p-6 mb-6">
   <h2 class="crayons-title mb-4">Bust Cache For Specific Content</h2>
   <p class="mb-6">This clears both the Rails cache & the Fastly cache.</p>
     <%= form_tag bust_cache_admin_tools_path do %>
@@ -29,3 +29,5 @@
       </div>
     <% end %>
 </div>
+
+<%= render "admin/shared/image_uploader" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a little image uploading widget to the admin area. This partial can be rendered on any page, so it might be neat to think of a pattern that makes this tool (and others like it) more generally available kind of like how the mod tools work on article pages.

I spent some time thinking about improvements that needed to be made to image management on the site and started working on those, but scrapped that in order to focus on solving the immediate need.

## Related Tickets & Documents

Closes https://github.com/forem/InternalProjectPlanning/issues/122

## QA Instructions, Screenshots, Recordings

![image](https://user-images.githubusercontent.com/11466782/96324098-8e0bd680-0fe5-11eb-923e-b9a78040987a.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed