### PR TITLE
Revert "Allow all third party auth providers to be deactivated" 

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -137,7 +137,7 @@ module Admin
 
       config_params.each do |key, value|
         if value.is_a?(Array)
-          update_siteconfig_with_array(key, value)
+          SiteConfig.public_send("#{key}=", value.reject(&:blank?)) unless value.empty?
         elsif value.respond_to?(:to_h)
           SiteConfig.public_send("#{key}=", value.to_h) unless value.empty?
         else
@@ -175,7 +175,7 @@ module Admin
         email_addresses: SiteConfig.email_addresses.keys,
         meta_keywords: SiteConfig.meta_keywords.keys,
         credit_prices_in_cents: SiteConfig.credit_prices_in_cents.keys,
-      )&.with_defaults(authentication_providers: [])
+      )
     end
 
     def raise_confirmation_mismatch_error
@@ -222,12 +222,6 @@ module Admin
     def brand_color_not_hex
       hex = params.dig(:site_config, :primary_brand_color_hex)
       hex.present? && !hex.match?(/\A#(\h{6}|\h{3})\z/)
-    end
-
-    def update_siteconfig_with_array(key, value)
-      return if value.empty? && ALLOWED_EMPTY_ENUMERABLES.exclude?(key.to_sym)
-
-      SiteConfig.public_send("#{key}=", value.reject(&:blank?))
     end
   end
 end

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -84,21 +84,6 @@ RSpec.describe "/admin/config", type: :request do
                                           confirmation: confirmation_message }
           expect(SiteConfig.authentication_providers).to eq([provider])
         end
-
-        it "allows all providers to be disabled" do
-          # We have to send _something_ for an update, so we'll simulate the borwser omitting the auth
-          # providers array when no options are selected
-          expect do
-            post "/admin/config", params: { site_config: { ga_tracking_id: "123" },
-                                            confirmation: confirmation_message }
-          end.to change(SiteConfig, :authentication_providers).to([])
-        end
-
-        it "allows all authentication providers to be unset" do
-          post "/admin/config", params: { site_config: { authentication_providers: [] },
-                                          confirmation: confirmation_message }
-          expect(SiteConfig.authentication_providers).to be_empty
-        end
       end
 
       describe "Community Content" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Revert

## Description
PR https://github.com/forem/forem/pull/10812 attempted to fix a longstanding bug that prevents admins from turning off all third party authentication providers. While this worked, it introduced another bug: setting admin config options in any section **other** than the Authentication section would result in all authentication providers being unselected.

Not exactly what we were going for.

PR https://github.com/forem/forem/pull/10758 enabled an 'invite only' mode for forums, which goes a long way towards mitaging the UI issue PR https://github.com/forem/forem/pull/10812 was trying to fix. As a result, I'm submitting this revert.

(There have been significant changes to `app/controllers/admin/configs_controller.rb` since the original PR was merged, so automatic revert via GitHub isn't an option. This PR is a manual attempt to pull out the offending code while retaining the refactoring in that class).

## Related Tickets & Documents
https://github.com/forem/forem/pull/10812
 https://github.com/forem/forem/pull/10758

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/h4wgkChuHbc2dhd2L0/giphy.gif)
