### PR TITLE
Avoid CSS word wrap in video player duration

### DIFF
--- a/app/assets/stylesheets/video-player.scss
+++ b/app/assets/stylesheets/video-player.scss
@@ -2,6 +2,9 @@
 @import '_mixins';
 
 .crayons-article__video {
+  overflow-wrap: normal;
+  word-break: normal;
+
   .crayons-article__video__player {
     background-position: center;
     background-size: cover;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

These new CSS rules override the `overflow-wrap: anywhere` and `word-break: break-word` rules in `.crayons-article__header` and also the `overflow-wrap: anywhere` rule in `.crayons-card`, but only for the JW player part of the DOM.

## Related Tickets & Documents

Closes #10799

## QA Instructions, Screenshots, Recordings

Before:
![forem_before](https://user-images.githubusercontent.com/2506871/96338128-bacaf700-1094-11eb-8bf4-8b6a05add9c9.png)

After:
![forem_after](https://user-images.githubusercontent.com/2506871/96338130-bdc5e780-1094-11eb-9a4b-b1cdc2d05e08.png)


## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
