### PR TITLE
Flaky Spec Fix:Set TimeZone For All Spec Requests to Match Zonebie

### DIFF
--- a/app/lib/middleware/time_zone_setter.rb
+++ b/app/lib/middleware/time_zone_setter.rb
@@ -5,7 +5,7 @@ module Middleware
     end
 
     def call(env)
-      Time.zone = ActiveSupport::TimeZone.new(ENV["TZ"])
+      Time.zone = ActiveSupport::TimeZone.new(ENV["TZ"]) if ENV["TZ"]
 
       @app.call(env)
     end

--- a/app/lib/middleware/time_zone_setter.rb
+++ b/app/lib/middleware/time_zone_setter.rb
@@ -1,0 +1,13 @@
+module Middleware
+  class TimeZoneSetter
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      Time.zone = ActiveSupport::TimeZone.new(ENV["TZ"])
+
+      @app.call(env)
+    end
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,6 +5,10 @@ $VERBOSE = nil
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Include middleware to ensure timezone for browser requests for Capybara specs
+  # matches the random zonebie timezone set at the beginning of our spec run
+  config.middleware.use(Middleware::TimeZoneSetter)
+
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,6 +84,10 @@ RSpec.configure do |config|
   end
 
   config.before(:suite) do
+    # Set the TZ ENV variable with the current random timezone from zonebie
+    # which we can then use to properly set the browser time for Capybara specs
+    ENV["TZ"] = Time.zone.tzinfo.name
+
     Search::Cluster.recreate_indexes
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
Using middleware here we set the timezone for our browser requests from the ENV variable "TZ" rather than the default server timezone. This ensures that the timezone in our browser matches the random timezone set by [zonebie](https://github.com/alindeman/zonebie) which is a gem we use to randomize timezones in our specs to ensure we don't end up with Timezone bugs. 

Fixes this failure and possibly a few others we have seen pop up. 
```
Failures:
  1) User index when user is unauthorized when 1 article shows all proper elements
     Failure/Error: expect(page).to have_selector(".comment-date", text: comment_date)
       expected to find visible css ".comment-date" with text "Oct 17" within #<Capybara::Node::Element tag="div" path="/HTML/BODY[1]/DIV[7]/DIV[2]/DIV[2]/DIV[2]/DIV[2]/DIV[3]/A[1]/DIV[1]"> but there were no matches. Also found "Oct 16", which matched the selector but not all filters.
     [Screenshot]: /home/travis/build/forem/forem/tmp/screenshots/failures_r_spec_example_groups_user_index_when_user_is_unauthorized_when1_article_shows_all_proper_elements_799.png
     # ./spec/system/user/view_user_index_spec.rb:57:in `block in shows_comments'
     # ./spec/system/user/view_user_index_spec.rb:55:in `shows_comments'
     # ./spec/system/user/view_user_index_spec.rb:23:in `block (4 levels) in <top (required)>'
```

## QA Instructions, Screenshots, Recordings
1) Add this puts statement to the [comment section partial for the users index](https://github.com/forem/forem/blob/master/app/views/users/_comments_section.html.erb#L33)
```ruby
<% puts Time.zone.name %>
<time datetime="<%= comment.decorate.published_timestamp %>"><%= comment.readable_publish_date %></time>
```
2) Run the view user index spec: `spec/system/user/view_user_index_spec.rb`
3) You should see the timezone set by Zonebie printed correctly in the view. 
```spec
$ bundle exec rspec spec/system/user/view_user_index_spec.rb
[Zonebie] Setting timezone: ZONEBIE_TZ="Kuala Lumpur"
Asia/Kuala_Lumpur
.Asia/Kuala_Lumpur
.Asia/Kuala_Lumpur
.

Finished in 16.42 seconds (files took 9.11 seconds to load)
3 examples, 0 failures
```

![alt_text](https://media.tenor.com/images/f51423c49b8d52b559a3bf8e8ac486b2/tenor.gif)
