### PR TITLE
Allow admins to change user email to fix email edge cases

### DIFF
--- a/app/controllers/resource_admin/users_controller.rb
+++ b/app/controllers/resource_admin/users_controller.rb
@@ -2,9 +2,11 @@ module ResourceAdmin
   class UsersController < ResourceAdmin::ApplicationController
     def update
       user = User.find(params[:id])
+      # Email normally needs confirmation. We skip it here when acting as admin
+      user.update_column(:email, user_params[:email]) if user_params[:email].present?
       if user.errors.messages.blank? && user.update(user_params)
         flash[:notice] = "User successfully updated"
-        redirect_to "/ResourceAdmin/users/#{params[:id]}"
+        redirect_to "/resource_admin/users/#{params[:id]}"
       else
         render :new, locals: { page: Administrate::Page::Form.new(dashboard, user) }
       end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -69,6 +69,7 @@ class UserDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     name
     username
+    email
     twitter_username
     github_username
     profile_image


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a bit of a temp fix to help admins get out of a jam if they have an invitation for a user with a certain email and need to unblock it for them to register another way.

It's overall reasonable that an admin could do this and override the typical devise settings.