### PR TITLE
Uncheck email preferences by default

### DIFF
--- a/app/javascript/onboarding/components/EmailPreferencesForm.jsx
+++ b/app/javascript/onboarding/components/EmailPreferencesForm.jsx
@@ -13,8 +13,8 @@ class EmailPreferencesForm extends Component {
     this.onSubmit = this.onSubmit.bind(this);
 
     this.state = {
-      email_newsletter: true,
-      email_digest_periodic: true,
+      email_newsletter: false,
+      email_digest_periodic: false,
     };
   }
 

--- a/app/javascript/onboarding/components/__tests__/EmailPreferencesForm.test.jsx
+++ b/app/javascript/onboarding/components/__tests__/EmailPreferencesForm.test.jsx
@@ -39,7 +39,7 @@ describe('EmailPreferencesForm', () => {
     document.body.setAttribute('data-user', getUserData());
   });
 
-  it('should have no a11y violatiogs', async () => {
+  it('should have no a11y violations', async () => {
     const { container } = render(renderEmailPreferencesForm());
     const results = await axe(container);
 

--- a/app/javascript/onboarding/components/__tests__/EmailPreferencesForm.test.jsx
+++ b/app/javascript/onboarding/components/__tests__/EmailPreferencesForm.test.jsx
@@ -39,7 +39,7 @@ describe('EmailPreferencesForm', () => {
     document.body.setAttribute('data-user', getUserData());
   });
 
-  it('should have no a11y violations', async () => {
+  it('should have no a11y violatiogs', async () => {
     const { container } = render(renderEmailPreferencesForm());
     const results = await axe(container);
 
@@ -56,11 +56,11 @@ describe('EmailPreferencesForm', () => {
     expect(queryByText('Email preferences')).toBeDefined();
   });
 
-  it('should show the two checkboxes', () => {
+  it('should show the two checkboxes unchecked', () => {
     const { queryByLabelText } = renderEmailPreferencesForm();
 
-    expect(queryByLabelText(/receive weekly newsletter/i)).toBeDefined();
-    expect(queryByLabelText(/receive a periodic digest/i)).toBeDefined();
+    expect(queryByLabelText(/receive weekly newsletter/i).checked).toBe(false);
+    expect(queryByLabelText(/receive a periodic digest/i).checked).toBe(false);
   });
 
   it('should render a stepper', () => {

--- a/db/migrate/20201019012200_change_email_preference_default_values.rb
+++ b/db/migrate/20201019012200_change_email_preference_default_values.rb
@@ -1,0 +1,6 @@
+class ChangeEmailPreferenceDefaultValues < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default(:users, :email_newsletter, from: true, to: false)
+    change_column_default(:users, :email_digest_periodic, from: true, to: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_040438) do
+ActiveRecord::Schema.define(version: 2020_10_19_012200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1217,11 +1217,11 @@ ActiveRecord::Schema.define(version: 2020_10_09_040438) do
     t.boolean "email_comment_notifications", default: true
     t.boolean "email_community_mod_newsletter", default: false
     t.boolean "email_connect_messages", default: true
-    t.boolean "email_digest_periodic", default: true, null: false
+    t.boolean "email_digest_periodic", default: false, null: false
     t.boolean "email_follower_notifications", default: true
     t.boolean "email_membership_newsletter", default: false
     t.boolean "email_mention_notifications", default: true
-    t.boolean "email_newsletter", default: true
+    t.boolean "email_newsletter", default: false
     t.boolean "email_public", default: false
     t.boolean "email_tag_mod_newsletter", default: false
     t.boolean "email_unread_notifications", default: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -169,5 +169,10 @@ FactoryBot.define do
     trait :without_profile do
       _skip_creating_profile { true }
     end
+
+    trait :with_newsletters do
+      email_newsletter { true }
+      email_digest_periodic { true }
+    end
   end
 end

--- a/spec/labor/mailchimp_bot_spec.rb
+++ b/spec/labor/mailchimp_bot_spec.rb
@@ -22,7 +22,7 @@ class FakeGibbonRequest < Gibbon::Request
 end
 
 RSpec.describe MailchimpBot, type: :labor do
-  let(:user) { create(:user, :ignore_mailchimp_subscribe_callback) }
+  let(:user) { create(:user, :with_newsletters, :ignore_mailchimp_subscribe_callback) }
   let(:article) { create(:article, user_id: user.id) }
   let(:my_gibbon_client) { instance_double(FakeGibbonRequest) }
   let(:tag) do

--- a/spec/requests/incoming_webhooks/mailchimp/unsubscribe_spec.rb
+++ b/spec/requests/incoming_webhooks/mailchimp/unsubscribe_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "IncomingWebhooks::MailchimpUnsubscribesController", type: :request do
-  let(:user) { create(:user, email_digest_periodic: true) }
+  let(:user) { create(:user, :with_newsletters) }
   let(:secret) { "secret" }
 
   before do


### PR DESCRIPTION
#9876  What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I recently noticed a potential GDPR issue in our onboarding flow: the email preference checkboxes should be deselected by default, see[ GDPR Recital 32](https://gdpr-info.eu/recitals/no-32/):

> Consent should be given by a clear affirmative act […] Silence, pre-ticked boxes or inactivity should not therefore constitute consent.

This PR updates the `EmailPreferencesForm` component used during the onboarding flow and also changes the DB-level default value for these two columns from `true` to `false` so we have consistent behavior no matter how an account is created.

## Related Tickets & Documents

Closes https://github.com/forem/InternalProjectPlanning/issues/176

## QA Instructions, Screenshots, Recordings

Go through the onboarding flow and verify that the following two checkboxes are unchecked by default:

![Uploading Screen Shot 2020-10-19 at 08.59.25.png…]()

## Added tests?

- [X] yes, updated existing tests
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/47985/96393747-430ee080-11ea-11eb-8e38-6100d36869b5.png)

