### PR TITLE
Make the footer links dynamic

### DIFF
--- a/app/assets/stylesheets/views/footer.scss
+++ b/app/assets/stylesheets/views/footer.scss
@@ -30,7 +30,6 @@
 
   &__nav {
     display: grid;
-    gap: var(--su-4);
     flex: 1 auto;
     grid-template-columns: repeat(2, 1fr);
 

--- a/app/assets/stylesheets/views/footer.scss
+++ b/app/assets/stylesheets/views/footer.scss
@@ -30,15 +30,18 @@
 
   &__nav {
     display: grid;
-    flex: 1 auto;
-    grid-template-columns: repeat(2, 1fr);
+    column-gap: var(--su-4);
+    grid-template-rows: repeat(9, 1fr);
+    grid-auto-flow: column;
 
     @media (min-width: $breakpoint-s) {
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-rows: repeat(6, 1fr);
+      column-gap: var(--su-8);
     }
 
     @media (min-width: $breakpoint-l) {
-      grid-template-columns: repeat(3, 200px);
+      grid-template-rows: repeat(6, 1fr);
+      column-gap: var(--su-10);
     }
   }
 

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -37,8 +37,8 @@
           <%= render "articles/sidebar_nav_link", link: link %>
         <% end %>
       </div>
+    <% end %>
   </div>
-  <% end %>
 </nav>
 
 <nav class="sidebar-tags-browser mb-6 overflow-y-auto scrolling-touch" aria-label="Secondary sidebar nav">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -11,15 +11,14 @@
     </div>
 
     <nav class="crayons-footer__nav">
-      <div>
         <a href="/" class="crayons-link crayons-link--block">Home</a>
-        <% if user_signed_in? %>
-          <a href="<%= readinglist_path %>" class="crayons-link crayons-link--block">Reading list</a>
+        <% NavigationLink.ordered.each do |link| %>
+          <% if !link.display_only_when_signed_in || (link.display_only_when_signed_in && user_signed_in?) %>
+            <a href="<%= link.url %>" class="crayons-link crayons-link--block">
+              <%= link.name %>
+            </a>
+          <% end %>
         <% end %>
-        <a href="<%= listings_path %>" class="crayons-link crayons-link--block">Listings</a>
-        <a href="<%= pod_path %>" class="crayons-link crayons-link--block">Podcasts</a>
-        <a href="<%= videos_path %>" class="crayons-link crayons-link--block">Videos</a>
-        <a href="<%= tags_path %>" class="crayons-link crayons-link--block">Tags</a>
         <% unless user_signed_in? %>
           <a href="<%= sign_up_path %>" class="crayons-link crayons-link--block fw-bold">
             Sign In/Up
@@ -27,23 +26,6 @@
         <% else %>
           <a href="/new" class="crayons-link crayons-link--block fw-bold">Write a post</a>
         <% end %>
-      </div>
-
-      <div>
-        <a href="/code-of-conduct" class="crayons-link crayons-link--block">Code of Conduct</a>
-        <a href="/faq" class="crayons-link crayons-link--block">FAQ</a>
-        <a href="/about" class="crayons-link crayons-link--block">About</a>
-        <a href="/privacy" class="crayons-link crayons-link--block">Privacy policy</a>
-        <a href="/terms" class="crayons-link crayons-link--block">Terms of use</a>
-        <a href="/contact" class="crayons-link crayons-link--block">Contact</a>
-      </div>
-
-      <div>
-        <a href="/sponsors" class="crayons-link crayons-link--block">Sponsors</a>
-        <% if SiteConfig.shop_url.present? %>
-          <a href="<%= SiteConfig.shop_url %>" class="crayons-link crayons-link--block"><%= community_name %> Shop</a>
-        <% end %>
-      </div>
     </nav>
 
     <% if SiteConfig.mascot_footer_image_url.present? %>

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -44,8 +44,9 @@ RSpec.describe "StoriesIndex", type: :request do
     end
 
     it "renders page with proper sidebar" do
+      navigation_link = create(:navigation_link)
       get "/"
-      expect(response.body).to include("Podcasts")
+      expect(response.body).to include(navigation_link.name)
     end
 
     it "renders left display_ads when published and approved" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In [another PR](https://github.com/forem/forem/pull/10754) we added a NavigationLinks Table and made all the links on the sidebar dynamic, such that an admin can configure what links they want to show on http://localhost:3000/admin/navigation_links and it will appear on the sidebar. 

We now applying that same workflow to the footer and rendering the items from the NavigationLinks Table instead of hardcoding them. 

_Note: I've had to amend use grids more dynamically and make the template render in a dynamic way. This means that we were not able to group the links in the same manner_

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/projects/5#card-47436154

## QA Instructions, Screenshots, Recordings
**Hardcoded Links:** 
<img width="1680" alt="Screenshot 2020-10-19 at 11 22 08" src="https://user-images.githubusercontent.com/2786819/96426348-6a22dd80-11fd-11eb-900e-fcfa8f643967.png">

**Dynamic Links:**
<img width="1679" alt="Screenshot 2020-10-19 at 14 14 02" src="https://user-images.githubusercontent.com/2786819/96449722-90547780-1215-11eb-86d7-0a333746af4f.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/SqIFuwPiZgvBgx6Uvl/giphy.gif)
