### PR TITLE
Allow the Pages contact page to override the hardcoded one

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -40,6 +40,12 @@ class PagesController < ApplicationController
     set_surrogate_key_header "community_moderation_page"
   end
 
+  def contact
+    @page = Page.find_by(slug: "contact")
+    render :show if @page
+    set_surrogate_key_header "contact"
+  end
+
   def faq
     @page = Page.find_by(slug: "faq")
     render :show if @page

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -118,6 +118,13 @@ RSpec.describe "Pages", type: :request do
     end
   end
 
+  describe "GET /contact" do
+    it "has proper headline" do
+      get "/contact"
+      expect(response.body).to include("Contact")
+    end
+  end
+
   describe "GET /welcome" do
     let(:user) { create(:user, id: 1) }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I've added the contact page to the pages controller so that other forems can override the hardcoded version of teh contact page.  

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/184

## QA Instructions, Screenshots, Recordings
Create a Page with slug=contact. Add some html, this should override the default contact page. 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
