### PR TITLE
Flaky Spec Fix:Don't Hard Code Comment Date

### DIFF
--- a/spec/system/comments/user_views_a_comment_spec.rb
+++ b/spec/system/comments/user_views_a_comment_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe "Viewing a comment", type: :system, js: true do
   let(:user) { create(:user) }
   let(:article) { create(:article, user_id: user.id, show_comments: true) }
   let(:comment) { create(:comment, commentable: article, user: user) }
-  let!(:timestamp) { "2019-03-04T10:00:00Z" }
 
   before do
-    Timecop.freeze(timestamp)
+    Timecop.freeze
     sign_in user
     visit comment.path
   end
@@ -18,10 +17,12 @@ RSpec.describe "Viewing a comment", type: :system, js: true do
 
   context "when showing the date" do
     it "shows the readable publish date" do
-      expect(page).to have_selector(".comment-date time", text: "Mar 4")
+      comment_date = comment.readable_publish_date.gsub("  ", " ")
+      expect(page).to have_selector(".comment-date time", text: comment_date)
     end
 
     it "embeds the published timestamp" do
+      timestamp = comment.decorate.published_timestamp
       selector = ".comment-date time[datetime='#{timestamp}']"
       expect(page).to have_selector(selector)
     end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
Here we do not want to be hardcoding our Timestamp and then assuming the displayed date. The reason for this is because that timestamp, depending on our randomly chosen timezone from Zonbie, might actually be a different day which causes this spec to fail. This ensures that we check for the timestamp generated in the random timezone set in our specs. 
Fixes: 
```
  1) Viewing a comment when showing the date shows the readable publish date
     Failure/Error: expect(page).to have_selector(".comment-date time", text: "Mar 4")
       expected to find visible css ".comment-date time" with text "Mar 4" but there were no matches. Also found "Mar 3", which matched the selector but not all filters. 
     [Screenshot]: /home/travis/build/forem/forem/tmp/screenshots/failures_r_spec_example_groups_viewing_a_comment_when_showing_the_date_shows_the_readable_publish_date_419.png
     # ./spec/system/comments/user_views_a_comment_spec.rb:21:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:134:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:134:in `block (2 levels) in <top (required)>'
     # ./spec/support/initializers/ci_csv_formatter.rb:92:in `block (2 levels) in <top (required)>'
```

![image](https://user-images.githubusercontent.com/1813380/96470065-86ba1800-11f3-11eb-9609-ab87bdafca5d.png)

