### PR TITLE
Fix Reading List Counter Without last_reacted_at Default

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -77,6 +77,7 @@ class AsyncInfoController < ApplicationController
     #{current_user&.last_sign_in_at}__
     #{current_user&.following_tags_count}__
     #{current_user&.last_followed_at}__
+    #{current_user&.last_reacted_at}__
     #{current_user&.updated_at}__
     #{current_user&.reactions_count}__
     #{current_user&.articles_count}__

--- a/app/controllers/reading_list_items_controller.rb
+++ b/app/controllers/reading_list_items_controller.rb
@@ -10,6 +10,8 @@ class ReadingListItemsController < ApplicationController
 
     @reaction.status = params[:current_status] == "archived" ? "valid" : "archived"
     @reaction.save
+    @reaction.user.touch(:last_reacted_at)
+
     head :ok
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -286,7 +286,7 @@ class User < ApplicationRecord
   end
 
   def cached_reading_list_article_ids
-    Rails.cache.fetch("reading_list_ids_of_articles_#{id}_#{public_reactions_count}") do
+    Rails.cache.fetch("reading_list_ids_of_articles_#{id}_#{public_reactions_count}_#{last_reacted_at}") do
       Reaction.readinglist.where(
         user_id: id, reactable_type: "Article",
       ).where.not(status: "archived").order(created_at: :desc).pluck(:reactable_id)

--- a/db/migrate/20201017160628_add_last_reacted_at_to_user.rb
+++ b/db/migrate/20201017160628_add_last_reacted_at_to_user.rb
@@ -1,0 +1,5 @@
+class AddLastReactedAtToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :last_reacted_at, :datetime, default: "2017-01-01 05:00:00"
+  end
+end

--- a/db/migrate/20201017160628_add_last_reacted_at_to_user.rb
+++ b/db/migrate/20201017160628_add_last_reacted_at_to_user.rb
@@ -1,5 +1,5 @@
 class AddLastReactedAtToUser < ActiveRecord::Migration[6.0]
   def change
-    add_column :users, :last_reacted_at, :datetime, default: "2017-01-01 05:00:00"
+    add_column :users, :last_reacted_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1266,6 +1266,7 @@ ActiveRecord::Schema.define(version: 2020_10_19_012200) do
     t.datetime "last_moderation_notification", default: "2017-01-01 05:00:00"
     t.datetime "last_notification_activity"
     t.string "last_onboarding_page"
+    t.datetime "last_reacted_at", default: "2017-01-01 05:00:00"
     t.datetime "last_sign_in_at"
     t.inet "last_sign_in_ip"
     t.string "linkedin_url"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1266,7 +1266,7 @@ ActiveRecord::Schema.define(version: 2020_10_19_012200) do
     t.datetime "last_moderation_notification", default: "2017-01-01 05:00:00"
     t.datetime "last_notification_activity"
     t.string "last_onboarding_page"
-    t.datetime "last_reacted_at", default: "2017-01-01 05:00:00"
+    t.datetime "last_reacted_at"
     t.datetime "last_sign_in_at"
     t.inet "last_sign_in_ip"
     t.string "linkedin_url"

--- a/spec/requests/reading_list_items_spec.rb
+++ b/spec/requests/reading_list_items_spec.rb
@@ -20,12 +20,16 @@ RSpec.describe "ReadingListItems", type: :request do
 
   describe "PUT reading_list_items/:id" do
     it "returns archives item if no param" do
-      put "/reading_list_items/#{reaction.id}"
+      expect do
+        put "/reading_list_items/#{reaction.id}"
+      end.to change { user.reload.last_reacted_at }
       expect(reaction.reload.status).to eq("archived")
     end
 
     it "unarchives an item if current_status is passed as archived" do
-      put "/reading_list_items/#{reaction.id}", params: { current_status: "archived" }
+      expect do
+        put "/reading_list_items/#{reaction.id}", params: { current_status: "archived" }
+      end.to change { user.reload.last_reacted_at }
       expect(reaction.reload.status).to eq("valid")
     end
 


### PR DESCRIPTION
Same as #10763 but without the default for the column which locked up our database for 20+ min. `last_reacted_at` should be fine being nil.

![alt_text](https://i.pinimg.com/originals/f5/be/27/f5be276208920a79aadc0f2e4bbad516.gif)
