### PR TITLE
Add invitations controller to Allow List

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,7 @@ class ApplicationController < ActionController::Base
                           omniauth_callbacks
                           registrations
                           confirmations
+                          invitations
                           passwords
                           health_checks].freeze
   private_constant :PUBLIC_CONTROLLERS

--- a/spec/requests/invitations_spec.rb
+++ b/spec/requests/invitations_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe "Invitations", type: :request do
+  let(:user) { create(:user) }
+
+  describe "Accept invitation" do
+    it "renders normal response even if site config is private" do
+      allow(SiteConfig).to receive(:public).and_return(false)
+      get "/users/invitation/accept?invitation_token=blahblahblahblah"
+      # This is a fake token, so the only thing we're testing for here is
+      # that we *do not* land on the "registrations" page which shouldn't
+      # interrupt the request, even for private forems. 
+      expect(response.body).not_to include("registration__actions")
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a forem is private it intercepts _most_ requests and delivers the auth page..... We have a list of controllers which should not have this functionality, and invitations should be one of them.