### PR TITLE
Flaky Spec Fixes:Correctly Assert Dates in Views

### DIFF
--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "Views an article", type: :system do
   let(:article) do
     create(:article, :with_notification_subscription, user: user)
   end
-  let(:timestamp) { "2019-03-04T10:00:00Z" }
 
   before do
     sign_in user
@@ -28,24 +27,21 @@ RSpec.describe "Views an article", type: :system do
   end
 
   describe "when showing the date" do
-    before do
-      article.update_columns(published_at: Time.zone.parse(timestamp))
-    end
-
     it "shows the readable publish date", js: true do
       visit article.path
-      expect(page).to have_selector("article time", text: "Mar 4")
+      expect(page).to have_selector("article time", text: article.readable_publish_date)
     end
 
     it "embeds the published timestamp" do
       visit article.path
-      selector = "article time[datetime='#{timestamp}']"
+
+      selector = "article time[datetime='#{article.decorate.published_timestamp}']"
       expect(page).to have_selector(selector)
     end
 
     context "when articles have long markdowns and different published dates" do
-      let(:first_article) { build(:article, published_at: "2019-03-04T10:00:00Z") }
-      let(:second_article) { build(:article, published_at: "2019-03-05T10:00:00Z") }
+      let(:first_article) { build(:article) }
+      let(:second_article) { build(:article) }
 
       before do
         [first_article, second_article].each do |article|
@@ -57,11 +53,11 @@ RSpec.describe "Views an article", type: :system do
 
       it "shows the identical readable publish dates in each page", js: true do
         visit first_article.path
-        expect(page).to have_selector("article time", text: "Mar 4")
-        expect(page).to have_selector(".crayons-card--secondary time", text: "Mar 4")
+        expect(page).to have_selector("article time", text: first_article.readable_publish_date)
+        expect(page).to have_selector(".crayons-card--secondary time", text: first_article.readable_publish_date)
         visit second_article.path
-        expect(page).to have_selector("article time", text: "Mar 5")
-        expect(page).to have_selector(".crayons-card--secondary time", text: "Mar 5")
+        expect(page).to have_selector("article time", text: second_article.readable_publish_date)
+        expect(page).to have_selector(".crayons-card--secondary time", text: second_article.readable_publish_date)
       end
     end
   end

--- a/spec/system/comments/user_views_a_comment_spec.rb
+++ b/spec/system/comments/user_views_a_comment_spec.rb
@@ -16,15 +16,12 @@ RSpec.describe "Viewing a comment", type: :system, js: true do
   end
 
   context "when showing the date" do
-    it "shows the readable publish date" do
+    it "shows all published data" do
       comment_date = comment.readable_publish_date.gsub("  ", " ")
-      expect(page).to have_selector(".comment-date time", text: comment_date)
-    end
-
-    it "embeds the published timestamp" do
       timestamp = comment.decorate.published_timestamp
-      selector = ".comment-date time[datetime='#{timestamp}']"
-      expect(page).to have_selector(selector)
+
+      expect(page).to have_selector(".comment-date time", text: comment_date)
+      expect(page).to have_selector(".comment-date time[datetime='#{timestamp}']")
     end
   end
 end

--- a/spec/system/homepage/user_visits_homepage_articles_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_articles_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe "User visits a homepage", type: :system do
   let!(:article) { create(:article, reactions_count: 12, featured: true, user: create(:user, profile_image: nil)) }
   let!(:article2) { create(:article, reactions_count: 20, featured: true, user: create(:user, profile_image: nil)) }
   let!(:timestamp) { "2019-03-04T10:00:00Z" }
+  let(:published_datetime) { Time.zone.parse(timestamp) }
+  let(:published_date) { published_datetime.strftime("%b %e").gsub("  ", " ") }
 
   context "when no options specified" do
     context "when main featured article" do
       before do
-        article.update_column(:published_at, Time.zone.parse(timestamp))
-        article2.update_column(:published_at, Time.zone.parse(timestamp))
+        article.update_column(:published_at, published_datetime)
+        article2.update_column(:published_at, published_datetime)
         visit "/"
       end
 
@@ -17,11 +19,8 @@ RSpec.describe "User visits a homepage", type: :system do
         expect(page).to have_selector(".crayons-story--featured", visible: :visible)
       end
 
-      it "shows the main article readable date", js: true, stub_elasticsearch: true do
-        expect(page).to have_selector(".crayons-story--featured time", text: "Mar 4")
-      end
-
-      it "embeds the main article published timestamp" do
+      it "shows the main article readable date and time", js: true, stub_elasticsearch: true do
+        expect(page).to have_selector(".crayons-story--featured time", text: published_date)
         selector = ".crayons-story--featured time[datetime='#{timestamp}']"
         expect(page).to have_selector(selector)
       end
@@ -29,8 +28,8 @@ RSpec.describe "User visits a homepage", type: :system do
 
     context "when all other articles" do
       before do
-        article.update_columns(score: 15, published_at: Time.zone.parse(timestamp))
-        article2.update_columns(score: 15, published_at: Time.zone.parse(timestamp))
+        article.update_columns(score: 15, published_at: published_datetime)
+        article2.update_columns(score: 15, published_at: published_datetime)
         visit "/"
       end
 
@@ -40,11 +39,8 @@ RSpec.describe "User visits a homepage", type: :system do
         expect(page).to have_text(article2.title)
       end
 
-      it "shows all articles dates", js: true, stub_elasticsearch: true do
-        expect(page).to have_selector(".crayons-story time", text: "Mar 4", count: 2)
-      end
-
-      it "embeds all articles published timestamps" do
+      it "shows all articles' dates and times", js: true, stub_elasticsearch: true do
+        expect(page).to have_selector(".crayons-story time", text: published_date, count: 2)
         selector = ".crayons-story time[datetime='#{timestamp}']"
         expect(page).to have_selector(selector, count: 2)
       end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
Rather than relying on hard-coded dates in our specs which will sometimes not match our views due to random timezones, I updated those specs to either use fluid dates or to ensure the hardcoded dates are read and parsed correctly for the given timezone.  Honestly, for the first 2 specs I removed the hardcoded dates since they were done incorrectly.  When I got to the final spec, I realized the hard coded date was being "set correctly" but not asserted on correctly so I left it and only updated the assertions. 


![alt_text](https://media2.giphy.com/media/l1J9umIq8fkmhMN7W/200.gif)
