### PR TITLE
Add forem_owner_secret to params

### DIFF
--- a/app/views/shared/authentication/_email_registration_form.html.erb
+++ b/app/views/shared/authentication/_email_registration_form.html.erb
@@ -49,10 +49,14 @@
     </div>
 
     <% if ENV["FOREM_OWNER_SECRET"].present? && SiteConfig.waiting_on_first_user %>
-      <div class="crayons-field mt-2">
-        <%= f.label :forem_owner_secret, "Few Forem Secret", class: "crayons-field__label" %>
-        <%= f.password_field :forem_owner_secret, autocomplete: "current-password", class: "crayons-textfield", required: true, placeholder: "As provided by your Forem host" %>
-      </div>
+      <% if params[:forem_owner_secret].present? %>
+        <%= f.hidden_field :forem_owner_secret, value: params[:forem_owner_secret] %>
+      <% else %>
+        <div class="crayons-field mt-2">
+          <%= f.label :forem_owner_secret, "New Forem Secret", class: "crayons-field__label" %>
+          <%= f.password_field :forem_owner_secret, class: "crayons-textfield", required: true, placeholder: "As provided by your Forem host" %>
+        </div>
+      <% end %>
     <% end %>
     <div class="actions pt-3">
       <%= f.submit "Sign up", class: "crayons-btn" %>

--- a/config/fastly/snippets/safe_params_list.vcl
+++ b/config/fastly/snippets/safe_params_list.vcl
@@ -2,6 +2,6 @@ import querystring;
 sub vcl_recv {
     # return this URL with only the parameters that match this regular expression
     if (req.url !~ "/admin/" && req.url !~ "/search/" && req.url !~ "/bulk_show") {
-      set req.url = querystring.regfilter_except(req.url, "^(a_id|args|article_id|article_ids|articles|asc|callback_url|category|chat_channel_id|client_id|code|collection_id|commentable_id|commentable_type|confirmation_token|created_at|end|filter|followable_id|followable_type|fork_id|i|key|message_offset|name|oauth_token|oauth_verifier|offset|org_id|organization_id|p|page|per_page|p_id|prefill|preview|purchaser|reactable_ids|redirect_uri|reported_url|reporter_username|response_type|scope|search|signature|sort|source_id|source_type|start|state|status|tag|tag_list|top|type_of|url|username|invitation_token|reset_password_token|ut|verb|invitation_slug)$");
+      set req.url = querystring.regfilter_except(req.url, "^(a_id|args|article_id|article_ids|articles|asc|callback_url|category|chat_channel_id|client_id|code|collection_id|commentable_id|commentable_type|confirmation_token|created_at|end|filter|followable_id|followable_type|forem_owner_secret|fork_id|i|key|message_offset|name|oauth_token|oauth_verifier|offset|org_id|organization_id|p|page|per_page|p_id|prefill|preview|purchaser|reactable_ids|redirect_uri|reported_url|reporter_username|response_type|scope|search|signature|sort|source_id|source_type|start|state|status|tag|tag_list|top|type_of|url|username|invitation_token|reset_password_token|ut|verb|invitation_slug)$");
     }
 }

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -98,6 +98,31 @@ RSpec.describe "Registrations", type: :request do
     end
   end
 
+  describe "GET /users/signup" do
+    context "when site is in waiting_on_first_user state" do
+      before do
+        SiteConfig.waiting_on_first_user = true
+        ENV["FOREM_OWNER_SECRET"] = "test"
+      end
+
+      after do
+        SiteConfig.waiting_on_first_user = false
+        ENV["FOREM_OWNER_SECRET"] = nil
+      end
+
+      it "auto-populates forem_owner_secret if included in querystring params" do
+        get new_user_registration_path(forem_owner_secret: ENV["FOREM_OWNER_SECRET"])
+        expect(response.body).not_to include("New Forem Secret")
+        expect(response.body).to include(ENV["FOREM_OWNER_SECRET"])
+      end
+
+      it "shows forem_owner_secret field if it's not included in querystring params" do
+        get new_user_registration_path
+        expect(response.body).to include("New Forem Secret")
+      end
+    end
+  end
+
   describe "POST /users" do
     context "when site is not configured to accept email registration" do
       before do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
This PR adds functionality for creators configuring a new Forem instance to read the `forem_owner_secret` from the querystring parameters if provided.

This will be used soon. We'll be emailing creators a URL to their new Forem that includes the `forem_owner_secret` param so that they don't have to type it in. That will be something along the lines of:

```
Hey, Alex! Your new Forem is ready. Please click this link https://localhost:3000?forem_owner_secret=test to configure your new Forem.
```

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings
The original functionality still works if `?forem_owner_secret` is not present in the URL:
![no_param](https://user-images.githubusercontent.com/15987080/96502399-b848d880-121f-11eb-877f-1292bc1cd463.png)

If the param is found, the form field is rendered as a hidden field with the value updated from the parameter automatically - rendering one less field that's required to be completed 🎉 .
![with_param](https://user-images.githubusercontent.com/15987080/96502462-d0205c80-121f-11eb-86ec-abb9df4e9fd4.png)

1. Set your local app into "starter mode" by setting `ENV["MODE"] = "STARTER"` in your environment.
2. Set your `ENV["FOREM_OWNER_SECRET"]` to any value (i.e. `"test"`).
2. Reset your DB (`rails db:reset`) - **warning** this will erase your local data.
3. Fire up the app locally (`rails s`).
4. Visit the home page [localhost:3000](http://localhost:3000) - you should see the form as usual that includes a field to enter the secret token.
5. Visit the home page with the querystring param matching the value you set from step 2 - [localhost:3000?forem_owner_secret=test](http://localhost:3000?forem_owner_secret=test). You should no longer see the form field to enter a Forem secret token.
6. Open up your browser's inspector - you should be able to find the hidden form field containing the value of the token.
7. Submit the form 🎉 .

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

![jimmy_fallon_ive_got_a_secret_gif](https://media.giphy.com/media/wDGCA2dv9VJxC/giphy.gif)
