### PR TITLE
Data update Script: Backfill Created, but Unregistered Users

### DIFF
--- a/lib/data_update_scripts/20201019192035_backfill_registered_for_users.rb
+++ b/lib/data_update_scripts/20201019192035_backfill_registered_for_users.rb
@@ -1,10 +1,8 @@
 module DataUpdateScripts
   class BackfillRegisteredForUsers
     def run
-      users = User.where(registered: false).or(User.where(registered_at: nil))
+      users = User.where.not(invitation_accepted_at: nil).where(registered: false).or(User.where(registered_at: nil))
       users.find_each do |user|
-        next if user.invitation_accepted_at.nil?
-
         user.update_columns(registered: true, registered_at: user.invitation_accepted_at)
       end
     end

--- a/lib/data_update_scripts/20201019192035_backfill_registered_for_users.rb
+++ b/lib/data_update_scripts/20201019192035_backfill_registered_for_users.rb
@@ -1,0 +1,12 @@
+module DataUpdateScripts
+  class BackfillRegisteredForUsers
+    def run
+      return if User.created_at.nil?
+
+      users = User.where(registered: false).or(User.where(registered_at: nil))
+      users.find_each do |user|
+        user.update_columns(registered: true, registered_at: user.created_at)
+      end
+    end
+  end
+end

--- a/lib/data_update_scripts/20201019192035_backfill_registered_for_users.rb
+++ b/lib/data_update_scripts/20201019192035_backfill_registered_for_users.rb
@@ -1,11 +1,11 @@
 module DataUpdateScripts
   class BackfillRegisteredForUsers
     def run
-      return if User.created_at.nil?
-
       users = User.where(registered: false).or(User.where(registered_at: nil))
       users.find_each do |user|
-        user.update_columns(registered: true, registered_at: user.created_at)
+        next if user.created_at.nil? || user.invitation_accepted_at.nil?
+
+        user.update_columns(registered: true, registered_at: user.invitation_accepted_at)
       end
     end
   end

--- a/lib/data_update_scripts/20201019192035_backfill_registered_for_users.rb
+++ b/lib/data_update_scripts/20201019192035_backfill_registered_for_users.rb
@@ -3,7 +3,7 @@ module DataUpdateScripts
     def run
       users = User.where(registered: false).or(User.where(registered_at: nil))
       users.find_each do |user|
-        next if user.created_at.nil? || user.invitation_accepted_at.nil?
+        next if user.invitation_accepted_at.nil?
 
         user.update_columns(registered: true, registered_at: user.invitation_accepted_at)
       end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds a `data_update` script to backfill the `registered` and `registered_at` columns on users who are created, but not registered. Currently, there are some users who still are considered `registered: false` even though they've created an account via an invitation by email. By adding this `data_update` script, we'll "fix" the `registered` columns for those particular users, creating a clean slate for us to test whether or not the root issue of this problem has been fixed via pull request #10882 

## Related Tickets & Documents
Relates to PR #10882 and closes [Internal issue #133](https://github.com/forem/InternalProjectPlanning/issues/133).

## QA Instructions, Screenshots, Recordings
Make sure that Travis and all other checks build green! ♻️ 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
This _is_ a post-deployment task. 😎 

## [optional] What gif best describes this PR or how it makes you feel?

![Miss Piggy Invited](https://media.giphy.com/media/l41m5YJ56zcextOSY/giphy.gif)
