### PR TITLE
Redirect to SiteConfig.app_domain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   before_action :verify_private_forem
   protect_from_forgery with: :exception, prepend: true
   before_action :remember_cookie_sync
+  before_action :forward_to_app_config_domain
 
   include SessionCurrentUser
   include ValidRequest
@@ -161,6 +162,14 @@ class ApplicationController < ActionController::Base
       current_user.remember_me!
       remember_me(current_user)
     end
+  end
+
+  def forward_to_app_config_domain
+    return unless request.get? && # Let's only redirect get requests for this purpose.
+      request.host == ENV["APP_DOMAIN"] && # If the request equals the original set domain, e.g. forem-x.forem.cloud.
+      ENV["APP_DOMAIN"] != SiteConfig.app_domain # If the app domain config has now been set, let's go there instead.
+
+    redirect_to "#{request.protocol}#{SiteConfig.app_domain}#{request.fullpath}"
   end
 
   protected

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -169,7 +169,7 @@ class ApplicationController < ActionController::Base
       request.host == ENV["APP_DOMAIN"] && # If the request equals the original set domain, e.g. forem-x.forem.cloud.
       ENV["APP_DOMAIN"] != SiteConfig.app_domain # If the app domain config has now been set, let's go there instead.
 
-    redirect_to "#{request.protocol}#{SiteConfig.app_domain}#{request.fullpath}"
+    redirect_to URL.url(request.fullpath)
   end
 
   protected


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I'm not totally sure what the best way to test this is, so if anyone wants to merge a test in here or suggest something, be my guest.

This functionality redirects from the originally set app domain to the current one. This should take care of some edge cases when domains change.