### PR TITLE
Fill organization userpic background fully to avoid empty corners

### DIFF
--- a/app/assets/stylesheets/views/profile.scss
+++ b/app/assets/stylesheets/views/profile.scss
@@ -101,10 +101,11 @@
   .crayons-logo {
     width: var(--su-9);
     height: var(--su-9);
-    border: var(--su-1) solid var(--profile-brand-color);
+    background-color: var(--profile-brand-color);
+    padding: var(--su-1);
 
     @media (min-width: $breakpoint-m) {
-      border-width: var(--su-2);
+      padding: var(--su-2);
       width: var(--su-10);
       height: var(--su-10);
     }

--- a/app/assets/stylesheets/views/profile.scss
+++ b/app/assets/stylesheets/views/profile.scss
@@ -104,6 +104,10 @@
     background-color: var(--profile-brand-color);
     padding: var(--su-1);
 
+    &::after {
+      content: none;
+    }
+
     @media (min-width: $breakpoint-m) {
       padding: var(--su-2);
       width: var(--su-10);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR makes organization user pic background to be fully covered which resolves empty corners issues described in #10815

## Related Tickets & Documents

Closes #10815

## QA Instructions, Screenshots, Recordings

<img width="1680" alt="Screen Shot 2020-10-20 at 10 16 59" src="https://user-images.githubusercontent.com/160712/96536388-247a1980-12be-11eb-8c3c-0fddd6ab3799.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed