### PR TITLE
Fix RSpec unit testing when using Docker dev setup

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,7 +48,7 @@ allowed_sites = [
   "selenium-release.storage.googleapis.com",
   "developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
   "api.knapsackpro.com",
-  "elasticsearch:9200",
+  "elasticsearch",
 ]
 WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,7 @@ allowed_sites = [
   "selenium-release.storage.googleapis.com",
   "developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
   "api.knapsackpro.com",
+  "elasticsearch:9200",
 ]
 WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)
 

--- a/spec/support/initializers/vcr.rb
+++ b/spec/support/initializers/vcr.rb
@@ -13,7 +13,7 @@ VCR.configure do |config|
     "github.com/mozilla/geckodriver/releases",
     "selenium-release.storage.googleapis.com",
     "developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
-    "api.knapsackpro.com", "localhost", "127.0.0.1", "0.0.0.0"
+    "api.knapsackpro.com", "localhost", "127.0.0.1", "0.0.0.0", "elasticsearch"
   )
 
   # Removes all private data (Basic Auth, Set-Cookie headers...)

--- a/spec/support/initializers/vcr.rb
+++ b/spec/support/initializers/vcr.rb
@@ -13,7 +13,8 @@ VCR.configure do |config|
     "github.com/mozilla/geckodriver/releases",
     "selenium-release.storage.googleapis.com",
     "developer.microsoft.com/en-us/microsoft-edge/tools/webdriver",
-    "api.knapsackpro.com", "localhost", "127.0.0.1", "0.0.0.0", "elasticsearch"
+    "api.knapsackpro.com", "localhost", "127.0.0.1", "0.0.0.0",
+    "elasticsearch"
   )
 
   # Removes all private data (Basic Auth, Set-Cookie headers...)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When using the Docker dev setup, Elasticsearch is available at `elasticsearch:9200` instead of `localhost:9200` so the VCR testing config was not ignoring the requests needed for RSpec setup when doing `Search::Cluster.recreate_indexes` in `spec/rails_helper.rb`. Also the WebMock setup allows `localhost` requests which should also include Elasticsearch requests.

This seems okay to me, but I'm not sure if there is a better solution. One issue I might have is that a detail related to the Docker dev setup is bleeding into common RSpec configs. What do you think, @citizen428?

## Related Tickets & Documents

Closes #10579 

## QA Instructions, Screenshots, Recordings

With this change you can run unit tests when using the Docker dev setup, for example this spec was failing at `Search::Cluster.recreate_indexes` in `spec/rails_helper.rb` and is now passing.

```
bundle exec rspec spec/liquid_tags/vimeo_tag_spec.rb
```

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
