### PR TITLE
Use matched substring in Spotify liquid tag to avoid trailing whitespace

### DIFF
--- a/app/liquid_tags/spotify_tag.rb
+++ b/app/liquid_tags/spotify_tag.rb
@@ -15,7 +15,7 @@ class SpotifyTag < LiquidTagBase
   def initialize(_tag_name, uri, _parse_context)
     super
     @parsed_uri = parse_uri(uri)
-    @embed_link = generate_embed_link(@parsed_uri)
+    @embed_link = generate_embed_link(@parsed_uri[0])
     @type = @parsed_uri[1] || @parsed_uri[2]
     @height = TYPE_HEIGHT[@type.to_sym]
   end
@@ -37,7 +37,7 @@ class SpotifyTag < LiquidTagBase
   end
 
   def generate_embed_link(parsed_uri)
-    parsed_uri.string.split(":")[1..].unshift("https://open.spotify.com/embed").join("/")
+    parsed_uri.split(":")[1..].unshift("https://open.spotify.com/embed").join("/")
   end
 
   def raise_error

--- a/spec/liquid_tags/spotify_tag_spec.rb
+++ b/spec/liquid_tags/spotify_tag_spec.rb
@@ -12,8 +12,7 @@ RSpec.describe SpotifyTag, type: :liquid_tag do
       Liquid::Template.parse("{% spotify #{link} %}")
     end
 
-    def generate_iframe(uri, height)
-      parsed_uri = uri.split(":")[1..].unshift("https://open.spotify.com/embed").join("/")
+    def generate_iframe(embed_path, height)
       <<~HTML
         <iframe
           width="100%"
@@ -22,14 +21,14 @@ RSpec.describe SpotifyTag, type: :liquid_tag do
           frameborder="0"
           allowtransparency="true"
           allow="encrypted-media"
-          src="#{parsed_uri} "
+          src="https://open.spotify.com/embed/#{embed_path}"
           loading="lazy">
         </iframe>
       HTML
     end
 
     it "generals the proper iframe if the uri is valid" do
-      expect(generate_tag(valid_uri).render).to eq(generate_iframe(valid_uri, 80))
+      expect(generate_tag(valid_uri).render).to eq(generate_iframe("track/0K1UpnetfCKtcNu37rJmCg", 80))
     end
 
     it "does not raise an error if the uri is valid" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The bug was caused by a trailing whitespace character in the embed URL. Using the matched substring from `MatchData` avoids any additional whitespace. Also updated the spec to use explicit values instead of duplicating the logic from the code.

## Related Tickets & Documents

Closes #10951 

## QA Instructions, Screenshots, Recordings

Adding a Spotify liquid tag to an Article will now result in a valid embed iframe, while before it would display the text "Bad Request".

For example:
```
{% spotify spotify:track:3GfOAdcoc3X5GPiiXmpBjK %}
```

Before:
![forem_spotify_before](https://user-images.githubusercontent.com/2506871/96581501-94020000-12e2-11eb-91b5-eb2a2adde044.png)

After:
![forem_spotify_after](https://user-images.githubusercontent.com/2506871/96581521-97958700-12e2-11eb-93b7-2be4bef477db.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
