### PR TITLE
Disable ability to upload videos on *some* forems Part 1

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -86,6 +86,7 @@ class SiteConfig < RailsSettings::Base
 
   field :left_navbar_svg_icon, type: :string, default: STACK_ICON
   field :right_navbar_svg_icon, type: :string, default: LIGHTNING_ICON
+  field :enable_video_upload, type: :boolean, default: false
 
   # Mascot
   field :mascot_user_id, type: :integer, default: 1


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As a Forem admin, video upload does not work so I do not want videos highlighted to my community or have it appear as an option to my members.

**Ideal Solution**
One day, we'll figure out whether or not we can support native video for all Forems but until then, let's:

- remove the 'upload a video' button from /dashboard

**Additional Context:**
We'll want to continue supporting videos on DEV so want to note that the upload button should still exist on DEV.

In this PR I create a config variable to determine whether to enable videos for a Forem. I do not expose it through the config UI since admins don't need control over this at the moment. We simply want to disable it for all Forems except DEV.
 
Once we deploy this, I'll add an additional check:
```
  <% if policy(:video).new? && SiteConfig.enable_video_upload %>
    <a class="crayons-btn crayons-btn--secondary w-100 mt-4" href="<%= new_video_path %>" data-no-instant> Upload a video
    </a>
  <% end %>
```

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/149

## QA Instructions, Screenshots, Recordings

1. Open the console.
2. Run SiteConfig.enable_video_upload

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

YES, please. Set the variable `SiteConfig.enable_video_upload = true` on DEV. Once this is done, I'll deploy a change where we only show the upload button when SiteConfig.enable_video_upload is true.

Please let me know when this is done.

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
