### PR TITLE
Give Admins Ability to Delete Invitations

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -21,5 +21,18 @@ module Admin
                    registered: false)
       redirect_to admin_invitations_path
     end
+
+    def destroy
+      # User.where(registered: false).each do |invitation|
+      # @invitations.each do |invitation|
+      invitation = User.where(registered: false)
+      if invitation.destroy
+        flash[:success] = "Invitation has been deleted!"
+      else
+        flash[:danger] = invitation.errors_as_sentence
+        redirect_to admin_invitations_path
+        # end
+      end
+    end
   end
 end

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -19,13 +19,14 @@ module Admin
                    saw_onboarding: false,
                    editor_version: :v2,
                    registered: false)
+      flash[:success] = "The invite has been sent to the user's email."
       redirect_to admin_invitations_path
     end
 
     def destroy
       @invitation = User.where(registered: false).find(params[:id])
       if @invitation.destroy
-        flash[:success] = "Invitation has been deleted!"
+        flash[:success] = "The invitation has been deleted."
       else
         flash[:danger] = @invitation.errors_as_sentence
       end

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -23,16 +23,13 @@ module Admin
     end
 
     def destroy
-      # User.where(registered: false).each do |invitation|
-      # @invitations.each do |invitation|
-      invitation = User.where(registered: false)
-      if invitation.destroy
+      @invitation = User.where(registered: false).find(params[:id])
+      if @invitation.destroy
         flash[:success] = "Invitation has been deleted!"
       else
-        flash[:danger] = invitation.errors_as_sentence
-        redirect_to admin_invitations_path
-        # end
+        flash[:danger] = @invitation.errors_as_sentence
       end
+      redirect_to admin_invitations_path
     end
   end
 end

--- a/app/views/admin/invitations/index.html.erb
+++ b/app/views/admin/invitations/index.html.erb
@@ -25,6 +25,9 @@
       <td><%= user.id %></td>
       <td><%= user.name %></td>
       <td><%= user.email %></td>
+       <h5>
+        <td><%= link_to "Delete", url_for(action: :destroy, id: user.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger" %></td>
+      </h5>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/invitations/index.html.erb
+++ b/app/views/admin/invitations/index.html.erb
@@ -26,7 +26,7 @@
       <td><%= user.name %></td>
       <td><%= user.email %></td>
        <h5>
-        <td><%= link_to "Delete", url_for(action: :destroy, id: user.id), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger" %></td>
+        <td><%= link_to "Delete", url_for(action: :destroy, id: user.id), method: :delete, data: { confirm: "Are you sure you want to delete this pending invite?" }, class: "btn btn-danger" %></td>
       </h5>
     </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
       resources :comments, only: [:index]
       resources :events, only: %i[index create update]
       resources :feedback_messages, only: %i[index show]
-      resources :invitations, only: %i[index new create]
+      resources :invitations, only: %i[index new create destroy]
       resources :pages, only: %i[index new create edit update destroy]
       resources :mods, only: %i[index update]
       resources :moderator_actions, only: %i[index]

--- a/spec/requests/admin/invitations_spec.rb
+++ b/spec/requests/admin/invitations_spec.rb
@@ -30,4 +30,19 @@ RSpec.describe "/admin/invitations", type: :request do
       expect(User.last.registered).to be false
     end
   end
+
+  describe "DELETE /admin/invitations" do
+    let!(:invitation) { create(:user, registered: false) }
+
+    before do
+      sign_in admin
+    end
+
+    it "deletes the invitation" do
+      expect do
+        delete "/admin/invitations/#{invitation.id}"
+      end.to change { User.all.count }.by(-1)
+      expect(response.body).to redirect_to "/admin/invitations"
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR gives Admins the ability to delete any pending invitations in `/admin/invitations`. In order to accomplish this, this PR does the following:

- [x] Adds `#destroy` to the `Admin::InvitationsController` that enables Admins to delete the invitation and its associated user

- [x] Adds a `destroy` route to the Admin invitation routes in `routes.rb`

- [x] Adds a `flash[:success]` message to the `Admin::InvitationsController` so that Admins are alerted after successfully sending an invitation to a new user in `/admin/invitations`

- [x] Adds a "Delete" button and confirmation message to `/admin/invitations`

- [x] Adds a test to `/admin/invitations_spec.rb` that tests that invitations and their associated users are properly deleted

## Related Tickets & Documents
This PR closes Internal [issue #181](https://github.com/forem/InternalProjectPlanning/issues/181).

## QA Instructions, Screenshots, Recordings
**To QA these changes, please make sure that you have `admin` status and then do the following**:

- Navigate to `/admin/invitations/new` and invite a new user to the site by filling out the form and clicking "Create User":
<img width="1343" alt="Screen Shot 2020-10-20 at 9 23 48 AM" src="https://user-images.githubusercontent.com/32834804/96607815-f7c20400-12b5-11eb-9d9f-9d366c1b0fc5.png">

- Once you have clicked "Create User" you should be shown a message indicating that the creation was successful and that an invitation has been sent to the user:
<img width="1376" alt="Screen Shot 2020-10-20 at 9 24 28 AM" src="https://user-images.githubusercontent.com/32834804/96607920-0f998800-12b6-11eb-95b4-23abad72a942.png">

- Drop into your console and check that the user you just created exists:
```
User.last
=> #<User id: 55, articles_count: 0, available_for: nil, badge_achievements_count: 0, behance_url: nil, bg_color_hex: nil, blocked_by_count: 0, blocking_others_count: 0, checked_code_of_conduct: false, checked_terms_and_conditions: false, comments_count: 0, config_font: "default", config_navbar: "default", config_theme: "default", contact_consent: false, created_at: "2020-10-20 15:30:48"...
```

- Click the "delete" button next to the user you just invited and hit "OK" when the confirmation message appears:
<img width="1349" alt="Screen Shot 2020-10-20 at 9 26 47 AM" src="https://user-images.githubusercontent.com/32834804/96608251-61daa900-12b6-11eb-9897-d444c27d8c1b.png">

- After clicking on "OK," you should be redirected to `/admin/invitations` where you should no longer see the user you just invited, but where you should see a confirmation message confirming the deletion of the pending invitation and user:
<img width="1384" alt="Screen Shot 2020-10-20 at 9 28 06 AM" src="https://user-images.githubusercontent.com/32834804/96608398-92224780-12b6-11eb-823f-e22978b3fad8.png">

- Drop into your console on last time to make sure that the user no longer exists:
```
User.find_by_id(55)
User Load (0.9ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 55], ["LIMIT", 1]]
=> nil
```

- Try to break things ⚒️ 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Delete Button](https://media.giphy.com/media/XGNafjOYE7g88/giphy.gif)
