### PR TITLE
Spec Fix:Add Fragment to test html

### DIFF
--- a/app/javascript/modCenter/singleArticle/__tests__/singleArticle.test.jsx
+++ b/app/javascript/modCenter/singleArticle/__tests__/singleArticle.test.jsx
@@ -48,13 +48,13 @@ describe('<SingleArticle />', () => {
 
   it('renders the new clickable article title', () => {
     const { container } = render(
-      <>
+      <Fragment>
         <SingleArticle {...getTestArticle()} toggleArticle={jest.fn()} />
         <div
           data-testid="flag-user-modal"
           class="flag-user-modal-container hidden"
         />
-      </>,
+      </Fragment>,
     );
     const text = getNodeText(container.querySelector('.article-title-link'));
     expect(text).toContain(getTestArticle().title);


### PR DESCRIPTION
Fixes: 
```
Summary of all failing tests
 FAIL  app/javascript/modCenter/singleArticle/__tests__/singleArticle.test.jsx
  ● <SingleArticle /> › renders the new clickable article title
    ReferenceError: React is not defined
      49 |   it('renders the new clickable article title', () => {
      50 |     const { container } = render(
    > 51 |       <>
         |       ^
      52 |         <SingleArticle {...getTestArticle()} toggleArticle={jest.fn()} />
      53 |         <div
      54 |           data-testid="flag-user-modal"
      at Object.<anonymous> (app/javascript/modCenter/singleArticle/__tests__/singleArticle.test.jsx:51:7)
```

![alt_text](https://media.tenor.com/images/b21b5b8a7305cf11d7ba47f79952fa4b/tenor.gif)
