### PR TITLE
Update hardcoded "contact" email in Connect

### DIFF
--- a/app/controllers/chat_channel_memberships_controller.rb
+++ b/app/controllers/chat_channel_memberships_controller.rb
@@ -33,6 +33,7 @@ class ChatChannelMembershipsController < ApplicationController
       "invitation-link-#{SecureRandom.hex(3)}"
     end
     @invitation_link = "/join_channel_invitation/#{@channel.slug}?invitation_slug=#{invitation_slug}"
+    @support_email = SiteConfig.email_addresses[:default]
   end
 
   def create_membership_request

--- a/app/javascript/chat/ChatChannelSettings/ChatChannelSettings.jsx
+++ b/app/javascript/chat/ChatChannelSettings/ChatChannelSettings.jsx
@@ -41,6 +41,7 @@ export default class ChatChannelSettings extends Component {
       displaySettings: true,
       displayMembershipManager: false,
       invitationLink: null,
+      supportEmail: null,
     };
   }
 
@@ -73,6 +74,7 @@ export default class ChatChannelSettings extends Component {
             showGlobalBadgeNotification:
               result.current_membership.show_global_badge_notification,
             invitationLink: result.invitation_link,
+            supportEmail: result.chat_channel.support_email,
           });
         } else {
           this.setState({
@@ -379,6 +381,7 @@ export default class ChatChannelSettings extends Component {
       showGlobalBadgeNotification,
       displaySettings,
       invitationLink,
+      supportEmail,
     } = this.state;
 
     if (!chatChannel) {
@@ -416,6 +419,7 @@ export default class ChatChannelSettings extends Component {
               requestedMemberships={requestedMemberships}
               invitationUsernames={invitationUsernames}
               showGlobalBadgeNotification={showGlobalBadgeNotification}
+              supportEmail={supportEmail}
             />
           ) : (
             <ManageActiveMembership

--- a/app/javascript/chat/ChatChannelSettings/ChatChannelSettingsSection.jsx
+++ b/app/javascript/chat/ChatChannelSettings/ChatChannelSettingsSection.jsx
@@ -29,6 +29,7 @@ const ChatChannelSettingsSection = ({
   requestedMemberships,
   invitationUsernames,
   showGlobalBadgeNotification,
+  supportEmail,
 }) => (
   <div>
     <ChannelDescriptionSection
@@ -74,7 +75,7 @@ const ChatChannelSettingsSection = ({
     />
     <ModFaqSection
       currentMembershipRole={currentMembership.role}
-      email="yo@dev.to"
+      email={supportEmail}
       className="channel-mod-faq"
     />
   </div>
@@ -83,6 +84,7 @@ const ChatChannelSettingsSection = ({
 ChatChannelSettingsSection.propTypes = {
   chatChannel: PropTypes.isRequired,
   currentMembership: PropTypes.isRequired,
+  supportEmail: PropTypes.string.isRequired,
   activeMemberships: PropTypes.isRequired,
   pendingMemberships: PropTypes.isRequired,
   requestedMemberships: PropTypes.isRequired,

--- a/app/javascript/chat/ChatChannelSettings/ModFaqSection.jsx
+++ b/app/javascript/chat/ChatChannelSettings/ModFaqSection.jsx
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import PropTypes from 'prop-types';
 
 const ModFaqSection = ({ email, currentMembershipRole }) => {
-  if (currentMembershipRole === 'member') {
+  if (currentMembershipRole === 'member' && !email) {
     return null;
   }
 

--- a/app/views/chat_channel_memberships/chat_channel_info.json.jbuilder
+++ b/app/views/chat_channel_memberships/chat_channel_info.json.jbuilder
@@ -8,6 +8,7 @@ json.result do
     json.slug @channel.slug
     json.status @channel.status
     json.id @channel.id
+    json.support_email @support_email
   end
 
   json.memberships do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

yo@dev.to was hardcoded in the channel info. I've passed the site config variable through the API endpoint to the javascript frontend to display the dynamic email value for each Forem.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/165

## QA Instructions, Screenshots, Recordings

1. Make yourself a mod of a channel or quickly comment out the ffg code in ⁨app⁩ app/javascript/chat/ChatChannelSettings/ModFaqSection.jsx
```
  if (currentMembershipRole === 'member' && !email) {
    return null;
  }
```

2. You should see the non-hardcoded value that will pull dynamically from the API. 
You can also inspect the network call to see the email being passed through.


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
None

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
