### PR TITLE
Add a button to delete pages

### DIFF
--- a/app/views/admin/pages/_form.html.erb
+++ b/app/views/admin/pages/_form.html.erb
@@ -60,6 +60,12 @@
     </div>
     <%= form.submit class: "btn btn-primary" %>
   <% end %>
+
+  <% if @page.persisted? %>
+    <%= form_with model: [:admin, @page], local: true, method: :delete, class: "mt-3" do |f| %>
+      <%= f.submit "Delete Page", class: "btn btn-danger", data: { confirm: "Are you sure?" } %>
+    <% end %>
+  <% end %>
 </div>
 
 <script>

--- a/spec/system/admin/admin_manages_pages_spec.rb
+++ b/spec/system/admin/admin_manages_pages_spec.rb
@@ -1,10 +1,15 @@
 require "rails_helper"
 
 RSpec.describe "Admin manages pages", type: :system do
-
   let(:admin) { create(:user, :super_admin) }
 
   before do
+    create(:page,
+           slug: "test-page",
+           body_html: "<div>hello there</div>",
+           title: "Test Page",
+           description: "A test page",
+           is_top_level_path: true)
     sign_in admin
     visit admin_pages_path
   end
@@ -43,10 +48,19 @@ RSpec.describe "Admin manages pages", type: :system do
 
     it "does not show any of the links in the pages table" do
       within(".pages__table") do
-        expect(page).to_not have_content("Terms of Use")
-        expect(page).to_not have_content("Code of Conduct")
-        expect(page).to_not have_content("Privacy Policy")
+        expect(page).not_to have_content("Terms of Use")
+        expect(page).not_to have_content("Code of Conduct")
+        expect(page).not_to have_content("Privacy Policy")
       end
+    end
+
+    it "allows a page to be deleted" do
+      expect(page).to have_content("Test Page")
+      click_on("Edit")
+      expect(page).to have_selector("input[type=submit][value='Delete Page']")
+      click_on("Delete Page")
+      expect(page).to have_current_path(admin_pages_path)
+      expect(page).not_to have_content("Test Page")
     end
   end
 
@@ -62,15 +76,13 @@ RSpec.describe "Admin manages pages", type: :system do
              slug: "privacy",
              body_html: "<div>Privacy Policy</div>",
              title: "Privacy Policy",
-             description: "A page that describes the privacy policy", is_top_level_path: true
-            )
+             description: "A page that describes the privacy policy", is_top_level_path: true)
       create(:page,
              slug: "terms",
              body_html: "<div>Terms of Use</div>",
              title: "Terms of Use",
              description: "A page that describes the terms of use for the application",
-             is_top_level_path: true
-            )
+             is_top_level_path: true)
       sign_in admin
       visit admin_pages_path
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change adds a button for admins to delete pages.

## Related Tickets & Documents

Closes https://github.com/forem/InternalProjectPlanning/issues/174

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._
![image](https://user-images.githubusercontent.com/11466782/96649284-7474d280-12f6-11eb-9019-d8f78b7ca278.png)

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
