### PR TITLE
Fix extra spacing in connect contact message

### DIFF
--- a/app/javascript/chat/ChatChannelSettings/ModFaqSection.jsx
+++ b/app/javascript/chat/ChatChannelSettings/ModFaqSection.jsx
@@ -14,7 +14,7 @@ const ModFaqSection = ({ email, currentMembershipRole }) => {
           href={`mailto:${email}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="mx-2 url-link"
+          className="mx-1 url-link"
         >
           {email}
         </a>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix ?
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed the margin looks like a double space, lowering it a bit looks more like a single space.

## QA Instructions, Screenshots, Recordings

Before:
![Screenshot_2020-10-20 DEV(local) Connect 👩‍💻💬👨‍💻(1)](https://user-images.githubusercontent.com/11466782/96654456-f7028f80-1300-11eb-9bbe-0ceed62d37dd.png)

After:
![Screenshot_2020-10-20 DEV(local) Connect 👩‍💻💬👨‍💻](https://user-images.githubusercontent.com/11466782/96654457-f79b2600-1300-11eb-803b-3b071698938b.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
