### PR TITLE
Spec Fix:Ensure Nav Link Names are Escaped for Assertion

### DIFF
--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "StoriesIndex", type: :request do
     it "renders page with proper sidebar" do
       navigation_link = create(:navigation_link)
       get "/"
-      expect(response.body).to include(navigation_link.name)
+      expect(response.body).to include(CGI.escapeHTML(navigation_link.name))
     end
 
     it "renders left display_ads when published and approved" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
When a Navigation link has a name with a special character in it, that character will get escaped in the HTML. This ensures that we also escape the special character in our assertion for the spec. 
Fixes: 
```
  1) StoriesIndex GET stories index renders page with proper sidebar
     Failure/Error: expect(response.body).to include(navigation_link.name)
       expected "<!DOCTYPE html>\n<html lang=\"en\">\n  <head>\n    <meta charset=\"utf-8\">\n    <title>DEV(local) C...ba8488d21cd8ee1fee097b8410db9deaa41d0ca30b004c0c63de0a479114156f.svg\" />\n  </body>\n  </html>\n\n" to include "The Stars' Tennis Balls 901"
       Diff:
       @@ -1,2 +1,456 @@
       -The Stars' Tennis Balls 901
       +<!DOCTYPE HTML>
...
+    &nbsp;The Stars&#39; Tennis Balls 901
...
```


![alt_text](https://media1.tenor.com/images/6801a7fd8bce4c0a5a791d2bc02c8817/tenor.gif?itemid=14965729)
