### PR TITLE
Fix dropdowns breaking after adding comment

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentDropdown.js
+++ b/app/assets/javascripts/initializers/initializeCommentDropdown.js
@@ -123,7 +123,10 @@ function initializeCommentDropdown() {
   }
 
   function addDropdownListener(dropdown) {
-    dropdown.addEventListener('click', dropdownFunction);
+    if (!dropdown.getAttribute('has-dropdown-listener')) {
+      dropdown.addEventListener('click', dropdownFunction);
+      dropdown.setAttribute('has-dropdown-listener', 'true');
+    }
   }
 
   setTimeout(function addListeners() {


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Closes #10842 (bug).
### What was wrong?
`initializeCommentDropdown` is called when a new comment is added.
`initializeCommentDropdown` calls `addDropdownListener(dropdown)` on all
`.dropbtn` elements. Elements with the `.dropbtn` class already exist on
the page so an extra listener is added to the element whenever a comment is
added. Since there is two listeners on one button, it is as if the user quickly 
clicks the button to open the dropbown, and then instantly clicks again to close 
it every time they click once.

### How was it fixed?
Whenever a dropdown listener is added to an element with the
`.dropbtn` class, an attribute is set on that element so we know it
already has a dropdown listener. When we add listeners to elements with
the `.dropbtn` class in the future, we don't add them to elements with
the attribute.

## Related Tickets & Documents
#10842
Also see [my comment with my notes on the issue](https://github.com/forem/forem/issues/10842#issuecomment-713171469).

## QA Instructions, Screenshots, Recordings
To check the correct/expected behavior:
1. Make sure you are logged in as any user. 
2. Navigate to any post.
3. Click the ellipsis / sharing menu button on the side of the post below the "bookmark" button.
4. Observe that a sharing menu pops up with links such as "Share to Twitter", "Share to LinkedIn", etc.
5. Scroll to the bottom of the post, type a comment and Submit it.
6. Once again, click the ellipsis / sharing menu button on the side of the post below the "bookmark" button.
7. If the bug is fixed, we expect to once again observe that a sharing menu pops up with links such as "Share to Twitter", "Share to LinkedIn", etc.

Here is a recording show a reproduction of the issue, courtesy of @fdoxyz: 
https://share.getcloudapp.com/v1ux0Joe
Here is a screenshot of what the dropdown **should** look like: ![https://user-images.githubusercontent.com/11048570/95987969-2d6a7700-0df6-11eb-8fc0-0f6e61004e3e.png](https://user-images.githubusercontent.com/11048570/95987969-2d6a7700-0df6-11eb-8fc0-0f6e61004e3e.png)

## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [x] no, because I need help (Elliot's comment: are tests needed / possible for this issue?)

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![dog running fast](https://media2.giphy.com/media/UERqWUj6MNI3u/giphy.gif?cid=ecf05e47dxhs1mk2ttfzaa1d5qg54bluhazdwidffcez4925&rid=giphy.gif)
