### PR TITLE
Make profile fields without user columns work

### DIFF
--- a/spec/services/profiles/update_spec.rb
+++ b/spec/services/profiles/update_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Profiles::Update, type: :service do
   end
 
   it "sets custom attributes for the user" do
-    custom_profile_field = create(:custom_profile_field, profile: profile)
+    custom_profile_field = create(:custom_profile_field, label: "Custom test", profile: profile)
     custom_attribute = custom_profile_field.attribute_name
 
     described_class.call(user, profile: { custom_attribute => "Test" }, user: {})
@@ -76,5 +76,14 @@ RSpec.describe Profiles::Update, type: :service do
 
     expect(service.success?).to be false
     expect(service.error_message).to eq "filename too long - the max is 250 characters."
+  end
+
+  it "works correctly if a profile field does not exist for the User model" do
+    profile_field = create(:profile_field, label: "No User Test")
+    Profile.refresh_attributes!
+
+    expect do
+      described_class.call(user, profile: { profile_field.attribute_name => "Test" }, user: {})
+    end.to change { profile.reload.public_send(profile_field.attribute_name) }
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

One of our new communities had a problem during profile updates: if they had custom fields that don't exist on user, the saw an error like this:

![image](https://user-images.githubusercontent.com/47985/96667950-476f0100-1384-11eb-8216-85b50aa0944d.png)

This PR addresses this. It's a quickfix, since there will soon be a much larger PR that removes the syncing between users and profiles.

## Related Tickets & Documents

Part of #6994

## QA Instructions, Screenshots, Recordings

1. Add a profile field that doesn't exist as a column on user.
2. Go to `/settings/profile`
3. Update any value
4. It should work

## Added tests?

- [X] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/47985/96668064-8f8e2380-1384-11eb-942a-f9c14597e077.png)

