### PR TITLE
Standardize Image Placeholder Text in SiteConfig

### DIFF
--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -34,7 +34,7 @@ module Constants
         placeholder: "Campaign sidebar enabled or not"
       },
       campaign_sidebar_image: {
-        description: "https://image.url/image.png",
+        description: "https://url/image.png",
         placeholder: "Used at the top of the campaign sidebar"
       },
       campaign_url: {
@@ -107,7 +107,7 @@ module Constants
       },
       favicon_url: {
         description: "Used as the site favicon",
-        placeholder: "https://image.url/image.png"
+        placeholder: "https://url/image.png"
       },
       feed_strategy: {
         description: "Determines the main feed algorithm approach the app takes: basic or large_forem_experimental
@@ -156,7 +156,7 @@ module Constants
       },
       logo_png: {
         description: "Minimum 1024px, used for PWA etc.",
-        placeholder: "https://image.url/image.png"
+        placeholder: "https://url/image.png"
       },
       logo_svg: {
         description: "Used as the SVG logo of the community",
@@ -164,7 +164,7 @@ module Constants
       },
       main_social_image: {
         description: "Used as the main image in social networks and OpenGraph",
-        placeholder: "https://image.url/image.png"
+        placeholder: "https://url/image.png"
       },
       mailchimp_api_key: {
         description: "API key used to connect Mailchimp account. Found in Mailchimp backend",
@@ -188,7 +188,7 @@ module Constants
       },
       mascot_footer_image_url: {
         description: "Special cute mascot image used in the footer.",
-        placeholder: "https://image.url/image.png"
+        placeholder: "https://url/image.png"
       },
       mascot_footer_image_width: {
         description: "The footer mascot width will resized to this value, defaults to 52",
@@ -204,7 +204,7 @@ module Constants
       },
       mascot_image_url: {
         description: "Used as the mascot image.",
-        placeholder: "https://image.url/image.png"
+        placeholder: "https://url/image.png"
       },
       mascot_user_id: {
         description: "User ID of the Mascot account",
@@ -216,15 +216,15 @@ module Constants
       },
       onboarding_background_image: {
         description: "Background for onboarding splash page",
-        placeholder: "https://image.url/image.png"
+        placeholder: "https://url/image.png"
       },
       onboarding_logo_image: {
         description: "Main onboarding display logo image",
-        placeholder: "https://image.url/image.png"
+        placeholder: "https://url/image.png"
       },
       onboarding_taskcard_image: {
         description: "Used as the onboarding task-card image",
-        placeholder: "https://image.url/image.png"
+        placeholder: "https://url/image.png"
       },
       payment_pointer: {
         description: "Used for site-wide web monetization. " \
@@ -253,7 +253,7 @@ module Constants
       },
       secondary_logo_url: {
         description: "Used as the secondary logo",
-        placeholder: "https://image.url/image.png"
+        placeholder: "https://url/image.png"
       },
       spam_trigger_terms: {
         description: "Individual (case insensitive) phrases that trigger spam alerts, comma separated.",

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -34,7 +34,7 @@ module Constants
         placeholder: "Campaign sidebar enabled or not"
       },
       campaign_sidebar_image: {
-        description: "https://image.url",
+        description: "https://image.url/image.png",
         placeholder: "Used at the top of the campaign sidebar"
       },
       campaign_url: {
@@ -107,7 +107,7 @@ module Constants
       },
       favicon_url: {
         description: "Used as the site favicon",
-        placeholder: "https://image.url"
+        placeholder: "https://image.url/image.png"
       },
       feed_strategy: {
         description: "Determines the main feed algorithm approach the app takes: basic or large_forem_experimental
@@ -164,7 +164,7 @@ module Constants
       },
       main_social_image: {
         description: "Used as the main image in social networks and OpenGraph",
-        placeholder: "https://image.url"
+        placeholder: "https://image.url/image.png"
       },
       mailchimp_api_key: {
         description: "API key used to connect Mailchimp account. Found in Mailchimp backend",
@@ -188,7 +188,7 @@ module Constants
       },
       mascot_footer_image_url: {
         description: "Special cute mascot image used in the footer.",
-        placeholder: "https://image.url"
+        placeholder: "https://image.url/image.png"
       },
       mascot_footer_image_width: {
         description: "The footer mascot width will resized to this value, defaults to 52",
@@ -204,7 +204,7 @@ module Constants
       },
       mascot_image_url: {
         description: "Used as the mascot image.",
-        placeholder: "https://image.url"
+        placeholder: "https://image.url/image.png"
       },
       mascot_user_id: {
         description: "User ID of the Mascot account",
@@ -216,15 +216,15 @@ module Constants
       },
       onboarding_background_image: {
         description: "Background for onboarding splash page",
-        placeholder: "https://image.url"
+        placeholder: "https://image.url/image.png"
       },
       onboarding_logo_image: {
         description: "Main onboarding display logo image",
-        placeholder: "https://image.url"
+        placeholder: "https://image.url/image.png"
       },
       onboarding_taskcard_image: {
         description: "Used as the onboarding task-card image",
-        placeholder: "https://image.url"
+        placeholder: "https://image.url/image.png"
       },
       payment_pointer: {
         description: "Used for site-wide web monetization. " \
@@ -253,7 +253,7 @@ module Constants
       },
       secondary_logo_url: {
         description: "Used as the secondary logo",
-        placeholder: "https://image.url"
+        placeholder: "https://image.url/image.png"
       },
       spam_trigger_terms: {
         description: "Individual (case insensitive) phrases that trigger spam alerts, comma separated.",

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -1,5 +1,7 @@
 module Constants
   module SiteConfig
+    IMAGE_PLACEHOLDER = "https://url/image.png".freeze
+
     DETAILS = {
       allow_email_password_registration: {
         description: "People can sign up using their email and password",
@@ -34,7 +36,7 @@ module Constants
         placeholder: "Campaign sidebar enabled or not"
       },
       campaign_sidebar_image: {
-        description: "https://url/image.png",
+        description: IMAGE_PLACEHOLDER,
         placeholder: "Used at the top of the campaign sidebar"
       },
       campaign_url: {
@@ -107,7 +109,7 @@ module Constants
       },
       favicon_url: {
         description: "Used as the site favicon",
-        placeholder: "https://url/image.png"
+        placeholder: IMAGE_PLACEHOLDER
       },
       feed_strategy: {
         description: "Determines the main feed algorithm approach the app takes: basic or large_forem_experimental
@@ -156,7 +158,7 @@ module Constants
       },
       logo_png: {
         description: "Minimum 1024px, used for PWA etc.",
-        placeholder: "https://url/image.png"
+        placeholder: IMAGE_PLACEHOLDER
       },
       logo_svg: {
         description: "Used as the SVG logo of the community",
@@ -164,7 +166,7 @@ module Constants
       },
       main_social_image: {
         description: "Used as the main image in social networks and OpenGraph",
-        placeholder: "https://url/image.png"
+        placeholder: IMAGE_PLACEHOLDER
       },
       mailchimp_api_key: {
         description: "API key used to connect Mailchimp account. Found in Mailchimp backend",
@@ -188,7 +190,7 @@ module Constants
       },
       mascot_footer_image_url: {
         description: "Special cute mascot image used in the footer.",
-        placeholder: "https://url/image.png"
+        placeholder: IMAGE_PLACEHOLDER
       },
       mascot_footer_image_width: {
         description: "The footer mascot width will resized to this value, defaults to 52",
@@ -204,7 +206,7 @@ module Constants
       },
       mascot_image_url: {
         description: "Used as the mascot image.",
-        placeholder: "https://url/image.png"
+        placeholder: IMAGE_PLACEHOLDER
       },
       mascot_user_id: {
         description: "User ID of the Mascot account",
@@ -216,15 +218,15 @@ module Constants
       },
       onboarding_background_image: {
         description: "Background for onboarding splash page",
-        placeholder: "https://url/image.png"
+        placeholder: IMAGE_PLACEHOLDER
       },
       onboarding_logo_image: {
         description: "Main onboarding display logo image",
-        placeholder: "https://url/image.png"
+        placeholder: IMAGE_PLACEHOLDER
       },
       onboarding_taskcard_image: {
         description: "Used as the onboarding task-card image",
-        placeholder: "https://url/image.png"
+        placeholder: IMAGE_PLACEHOLDER
       },
       payment_pointer: {
         description: "Used for site-wide web monetization. " \
@@ -253,7 +255,7 @@ module Constants
       },
       secondary_logo_url: {
         description: "Used as the secondary logo",
-        placeholder: "https://url/image.png"
+        placeholder: IMAGE_PLACEHOLDER
       },
       spam_trigger_terms: {
         description: "Individual (case insensitive) phrases that trigger spam alerts, comma separated.",


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR standardizes the image placeholder text throughout the SiteConfig. Prior to this change, we used both `https://image.url/` and `https://image.url/image.png` -- this PR makes it so that we only use `https://image.url/image.png` as an image's placeholder text.

## Related Tickets & Documents
Closes [issue #172](https://github.com/forem/InternalProjectPlanning).

## QA Instructions, Screenshots, Recordings
**To QA this change, please ensure that all of the checks pass and that all the SiteConfig only uses `https://image.url/image.png` as its image placeholder text and not `https://image.url/`.**

**Before**:
![Screen Shot 2020-10-21 at 9 22 05 AM](https://user-images.githubusercontent.com/32834804/96741428-02949b80-137f-11eb-90df-41e3f7d770dd.png)

**After**:
![Screen Shot 2020-10-21 at 9 19 39 AM](https://user-images.githubusercontent.com/32834804/96741132-be090000-137e-11eb-8f05-6cb06718c3aa.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
Nope!

## [optional] What gif best describes this PR or how it makes you feel?

![Mindy Kaling High Standards](https://media.giphy.com/media/blSEr2IT4jok0/giphy.gif)
