### PR TITLE
User better admin detection for blazer and feature flags

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
     namespace :admin do
       get "/" => "admin_portals#index"
 
-      authenticate :user, ->(user) { user.has_role?(:tech_admin) } do
+      authenticate :user, ->(user) { user.tech_admin? } do
         mount Blazer::Engine, at: "blazer"
 
         flipper_ui = Flipper::UI.app(Flipper,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently we're looking for the `tech_admin` role to give access to developer tools like Blazer and Feature Flags. In development the default admin account (`admin@forem.local`) only has the `super_admin` and `single_resource_admin` roles, which prevents them from accessing Blazer or Feature Flags locally.

 Instead of just this role, we should be using the more inclusive admin check `User.tech_admin?` that looks for both `tech_admin` as well as `super_admin` roles.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [ x] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/IfsgBS0epiKnMTkNLw/giphy.gif)
