### PR TITLE
Optimization:Remove 2 Feed Experiments

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -3,8 +3,6 @@ module Stories
     respond_to :json
 
     VARIANTS = {
-      "more_random_experiment" => :default_home_feed_with_more_randomness_experiment,
-      "mix_base_more_random_experiment" => :mix_default_and_more_random_experiment,
       "more_tag_weight_experiment" => :more_tag_weight_experiment,
       "more_tag_weight_more_random_experiment" => :more_tag_weight_more_random_experiment,
       "more_comments_experiment" => :more_comments_experiment,

--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -60,13 +60,6 @@ module Articles
         stories
       end
 
-      # Test variation: More random
-      def default_home_feed_with_more_randomness_experiment
-        @randomness = 7
-        _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
-        stories
-      end
-
       # Test variation: tags make bigger impact
       def more_tag_weight_experiment
         @tag_weight = 2
@@ -79,15 +72,6 @@ module Articles
         @randomness = 7
         _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
         stories
-      end
-
-      # Test variation: Base half the time, more random other half. Varies on impressions.
-      def mix_default_and_more_random_experiment
-        if rand(2) == 1
-          default_home_feed(user_signed_in: true)
-        else
-          default_home_feed_with_more_randomness_experiment
-        end
       end
 
       # Test variation: the more comments a post has, the higher it's rated!
@@ -118,30 +102,26 @@ module Articles
       end
 
       def mix_of_everything_experiment
-        case rand(12)
+        case rand(10)
         when 0
           default_home_feed(user_signed_in: true)
         when 1
-          default_home_feed_with_more_randomness_experiment
-        when 2
-          mix_default_and_more_random_experiment
-        when 3
           more_tag_weight_experiment
-        when 4
+        when 2
           more_tag_weight_more_random_experiment
-        when 5
+        when 3
           more_comments_experiment
-        when 6
+        when 4
           more_experience_level_weight_experiment
-        when 7
+        when 5
           more_tag_weight_randomized_at_end_experiment
-        when 8
+        when 6
           more_experience_level_weight_randomized_at_end_experiment
-        when 9
+        when 7
           more_comments_randomized_at_end_experiment
-        when 10
+        when 8
           more_comments_medium_weight_randomized_at_end_experiment
-        when 11
+        when 9
           more_comments_minimal_weight_randomized_at_end_experiment
         else
           default_home_feed(user_signed_in: true)

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -2,9 +2,7 @@ experiments:
   user_home_feed: # Home feed collection for logged in user
     variants:
       - base
-      - more_random_experiment
       - more_tag_weight_experiment
-      - mix_base_more_random_experiment
       - more_tag_weight_more_random_experiment
       - more_comments_experiment
       - more_experience_level_weight_experiment
@@ -15,11 +13,9 @@ experiments:
       - more_comments_medium_weight_randomized_at_end_experiment
       - more_comments_minimal_weight_randomized_at_end_experiment
     weights:
-      - 5
-      - 5
-      - 5
       - 10
-      - 5
+      - 10
+      - 10
       - 5
       - 5
       - 10

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 NON_DEFAULT_EXPERIMENTS = %i[
-  default_home_feed_with_more_randomness_experiment
-  mix_default_and_more_random_experiment
   more_tag_weight_experiment
   more_tag_weight_more_random_experiment
   more_comments_experiment


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
We have been running these feed experiments for a while now and recently they came up in a PR. I took the initiative to start closing the loop on them. The reason I want to close the loop on this is that multiple code paths add complexity to our codebase and additional time to our specs when we test them. If we can narrow down to the ideal paths(doesn't even have to be 1!) then we can begin to optimize those paths for performance and other Forems. 

I recently looked [at the results of our A/B tests](https://dev.to/abtests) and found that because we have so many experiments running it's pretty hard to tell if any are the "true winner". In this case, I took a couple of experiments that seemed to have lower or very middle of the pack results and removed them. After allowing these tests to run with the new configurations we can check the results again in a week or two and continue to narrow down the scope of the experiment. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-47841833

## Added tests?
- [x] no, because they aren't needed


![alt_text](https://media1.tenor.com/images/36b4c0e9a413e5895a8b562abe125dd8/tenor.gif?itemid=7885436)
