### PR TITLE
Fix missing registration data change

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -22,6 +22,8 @@ class RegistrationsController < Devise::RegistrationsController
     if recaptcha_disabled? || recaptcha_verified?
       build_resource(sign_up_params)
       resource.saw_onboarding = false
+      resource.registered = true
+      resource.registered_at = Time.current
       resource.editor_version = "v2"
       resource.save if resource.email.present?
       yield resource if block_given?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,6 +94,8 @@ users_in_random_order = seeder.create_if_none(User, num_users) do
       # Emails limited to 50 characters
       email: Faker::Internet.email(name: name, separators: "+", domain: Faker::Internet.domain_word.first(20)),
       confirmed_at: Time.current,
+      registered_at: Time.current,
+      registered: true,
       password: "password",
       password_confirmation: "password",
     )

--- a/lib/data_update_scripts/20201022161311_backfill_user_registrations_in_registrations_controller_path.rb
+++ b/lib/data_update_scripts/20201022161311_backfill_user_registrations_in_registrations_controller_path.rb
@@ -3,7 +3,7 @@ module DataUpdateScripts
     def run
       # Users who _were not invited_ should by definition have registered already in order to exist
       User.where(registered_at: nil, invitation_sent_at: nil).find_each do |user|
-        user.update_column(:registered_at, user.created_at, registered: true)
+        user.update_columns(registered_at: user.created_at, registered: true)
       end
     end
   end

--- a/lib/data_update_scripts/20201022161311_backfill_user_registrations_in_registrations_controller_path.rb
+++ b/lib/data_update_scripts/20201022161311_backfill_user_registrations_in_registrations_controller_path.rb
@@ -1,0 +1,10 @@
+module DataUpdateScripts
+  class BackfillUserRegistrationsInRegistrationsControllerPath
+    def run
+      # Users who _were not invited_ should by definition have registered already in order to exist
+      User.where(registered_at: nil, invitation_sent_at: nil).find_each do |user|
+        user.update_column(:registered_at, user.created_at, registered: true)
+      end
+    end
+  end
+end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -179,6 +179,17 @@ RSpec.describe "Registrations", type: :request do
         expect(User.all.size).to be 1
       end
 
+      it "marks as registerd" do
+        post "/users", params:
+        { user: { name: "test #{rand(10)}",
+                  username: "haha_#{rand(10)}",
+                  email: "yoooo#{rand(100)}@yo.co",
+                  password: "PaSSw0rd_yo000",
+                  password_confirmation: "PaSSw0rd_yo000" } }
+        expect(User.last.registered).to be true
+        expect(User.last.registered_at).not_to be nil
+      end
+
       it "does not create user with password confirmation mismatch" do
         post "/users", params:
         { user: { name: "test #{rand(100)}",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We're currently failing to mark folks as `registered_at`, which we use in certain places after the fact, on the email registration path..... This causes miscellaneous issues.

`registered_at` is different than `created_at` because we create the row in the database when we `invite` them, but they are not yet "registered" for the purpose of application functionality until they actually register.

Of course, this similar functionality exists in several places, and we should refactor this, but for now I think this is good enough with fixing the problem in the place and adding a test.