### PR TITLE
Fix Search Navigation Disconnect Between URL and Search Input

### DIFF
--- a/app/javascript/Search/Search.jsx
+++ b/app/javascript/Search/Search.jsx
@@ -21,6 +21,7 @@ export class Search extends Component {
   constructor(props) {
     super(props);
     this.enableSearchPageChecker = true;
+    this.syncSearchUrlWithInput = this.syncSearchUrlWithInput.bind(this);
   }
 
   componentWillMount() {
@@ -48,28 +49,33 @@ export class Search extends Component {
     searchPageChecker();
   }
 
+  /**
+   * Synchronizes the search input value with the search term defined in the URL.
+   */
+  syncSearchUrlWithInput() {
+    // TODO: Consolidate search functionality.
+    // Note that push states for search occur in _search.html.erb
+    // in initializeSortingTabs(query)
+    const { searchBoxId } = this.props;
+    const searchTerm = getInitialSearchTerm(window.location.search);
+
+    // We set the value outside of React state so that there is no flickering of placeholder
+    // to search term.
+    const searchBox = document.getElementById(searchBoxId);
+    searchBox.value = searchTerm;
+
+    // Even though we set the search term directly via the DOM, it still needs to reside
+    // in component state.
+    this.setState({
+      searchTerm,
+    });
+  }
+
   componentDidMount() {
     this.registerGlobalKeysListener();
     InstantClick.on('change', this.enableSearchPageListener);
 
-    window.onpopstate = () => {
-      // TODO: Consolidate search functionality.
-      // Note that push states for search occur in _search.html.erb
-      // in initializeSortingTabs(query)
-      const { searchBoxId } = this.props;
-      const searchTerm = getInitialSearchTerm(window.location.search);
-
-      // We set the value outside of React state so that there is no flickering of placeholder
-      // to search term.
-      const searchBox = document.getElementById(searchBoxId);
-      searchBox.value = searchTerm;
-
-      // Even though we set the search term directly via the DOM, it still needs to reside
-      // in component state.
-      this.setState({
-        searchTerm,
-      });
-    };
+    window.addEventListener('popstate', this.syncSearchUrlWithInput);
   }
 
   enableSearchPageListener = () => {
@@ -100,8 +106,9 @@ export class Search extends Component {
     }
   }
 
-  componentDidUnmount() {
+  componentWillUnmount() {
     document.removeEventListener('keydown', this.globalKeysListener);
+    window.removeEventListener('popstate', this.syncSearchUrlWithInput);
     InstantClick.off('change', this.enableSearchPageListener);
   }
 

--- a/app/javascript/Search/Search.jsx
+++ b/app/javascript/Search/Search.jsx
@@ -51,6 +51,25 @@ export class Search extends Component {
   componentDidMount() {
     this.registerGlobalKeysListener();
     InstantClick.on('change', this.enableSearchPageListener);
+
+    window.onpopstate = () => {
+      // TODO: Consolidate search functionality.
+      // Note that push states for search occur in _search.html.erb
+      // in initializeSortingTabs(query)
+      const { searchBoxId } = this.props;
+      const searchTerm = getInitialSearchTerm(window.location.search);
+
+      // We set the value outside of React state so that there is no flickering of placeholder
+      // to search term.
+      const searchBox = document.getElementById(searchBoxId);
+      searchBox.value = searchTerm;
+
+      // Even though we set the search term directly via the DOM, it still needs to reside
+      // in component state.
+      this.setState({
+        searchTerm,
+      });
+    };
   }
 
   enableSearchPageListener = () => {

--- a/app/javascript/Search/__tests__/Search.test.jsx
+++ b/app/javascript/Search/__tests__/Search.test.jsx
@@ -9,6 +9,7 @@ describe('<Search />', () => {
     global.filterXSS = jest.fn();
     global.InstantClick = jest.fn(() => ({
       on: jest.fn(),
+      off: jest.fn(),
       preload: jest.fn(),
       display: jest.fn(),
     }))();
@@ -79,13 +80,33 @@ describe('<Search />', () => {
     expect(Search.prototype.search).toHaveBeenCalledWith('Enter', 'hello');
   });
 
-  it('should be listening for history state changes', () => {
+  it('should be listening for history state changes', async () => {
     // This is an implementation detail, but I want to make sure that this
     // listener is registered as it affects the UI.
-    window.onpopstate = null;
+    jest.spyOn(window, 'addEventListener');
 
     render(<Search />);
 
-    expect(typeof window.onpopstate).toEqual('function');
+    expect(window.addEventListener).toHaveBeenCalledTimes(1);
+    expect(window.addEventListener).toHaveBeenCalledWith(
+      'popstate',
+      expect.any(Function),
+    );
+  });
+
+  it('should stop listening for history state changes when the component is destroyed', async () => {
+    // This is an implementation detail, but I want to make sure that this
+    // listener is unregistered as it affects the UI.
+    jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = render(<Search />);
+
+    unmount();
+
+    expect(window.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(window.removeEventListener).toHaveBeenCalledWith(
+      'popstate',
+      expect.any(Function),
+    );
   });
 });

--- a/app/javascript/Search/__tests__/Search.test.jsx
+++ b/app/javascript/Search/__tests__/Search.test.jsx
@@ -78,4 +78,14 @@ describe('<Search />', () => {
     expect(searchInput.value).toEqual('hello');
     expect(Search.prototype.search).toHaveBeenCalledWith('Enter', 'hello');
   });
+
+  it('should be listening for history state changes', () => {
+    // This is an implementation detail, but I want to make sure that this
+    // listener is registered as it affects the UI.
+    window.onpopstate = null;
+
+    render(<Search />);
+
+    expect(typeof window.onpopstate).toEqual('function');
+  });
 });

--- a/app/javascript/utilities/__tests__/search.test.js
+++ b/app/javascript/utilities/__tests__/search.test.js
@@ -58,6 +58,15 @@ describe('Search utilities', () => {
         const actual = getInitialSearchTerm(querystring);
         expect(actual).toEqual(expected);
       });
+
+      it(`should return an empty string when the search term is not defined`, () => {
+        /* eslint-disable-next-line no-global-assign */
+        filterXSS = jest.fn(() => undefined);
+        const querystring = `?q=`;
+
+        const actual = getInitialSearchTerm(querystring);
+        expect(actual).toEqual('');
+      });
     });
 
     describe(`When the querystring key 'q' does not exist`, () => {

--- a/app/javascript/utilities/__tests__/search.test.js
+++ b/app/javascript/utilities/__tests__/search.test.js
@@ -135,40 +135,6 @@ describe('Search utilities', () => {
 
         expect(InstantClick.preload).toHaveBeenCalledTimes(1);
       });
-
-      it('should update the browser URL when the search term changes', () => {
-        const location = {
-          origin: 'http://localhost',
-          href: 'http://localhost',
-        };
-        const searchTerm = 'ruby';
-        const mockWindow = { history: { pushState: jest.fn() } };
-        preloadSearchResults({ searchTerm, location, context: mockWindow });
-
-        expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
-        expect(mockWindow.history.pushState).toHaveBeenCalledWith(
-          {},
-          '',
-          'http://localhost/search?q=ruby',
-        );
-      });
-
-      it('should update the browser URL when the search term is empty', () => {
-        const location = {
-          origin: 'http://localhost',
-          href: 'http://localhost',
-        };
-        const searchTerm = '';
-        const mockWindow = { history: { pushState: jest.fn() } };
-        preloadSearchResults({ searchTerm, location, context: mockWindow });
-
-        expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
-        expect(mockWindow.history.pushState).toHaveBeenCalledWith(
-          {},
-          '',
-          'http://localhost/search?q=',
-        );
-      });
     });
   });
 

--- a/app/javascript/utilities/__tests__/search.test.js
+++ b/app/javascript/utilities/__tests__/search.test.js
@@ -135,6 +135,40 @@ describe('Search utilities', () => {
 
         expect(InstantClick.preload).toHaveBeenCalledTimes(1);
       });
+
+      it('should update the browser URL when the search term changes', () => {
+        const location = {
+          origin: 'http://localhost',
+          href: 'http://localhost',
+        };
+        const searchTerm = 'ruby';
+        const mockWindow = { history: { pushState: jest.fn() } };
+        preloadSearchResults({ searchTerm, location, context: mockWindow });
+
+        expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+        expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+          {},
+          '',
+          'http://localhost/search?q=ruby',
+        );
+      });
+
+      it('should update the browser URL when the search term is empty', () => {
+        const location = {
+          origin: 'http://localhost',
+          href: 'http://localhost',
+        };
+        const searchTerm = '';
+        const mockWindow = { history: { pushState: jest.fn() } };
+        preloadSearchResults({ searchTerm, location, context: mockWindow });
+
+        expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+        expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+          {},
+          '',
+          'http://localhost/search?q=',
+        );
+      });
     });
   });
 

--- a/app/javascript/utilities/search/index.js
+++ b/app/javascript/utilities/search/index.js
@@ -82,7 +82,6 @@ export function getInitialSearchTerm(querystring) {
 export function preloadSearchResults({
   searchTerm,
   location = window.location,
-  context = window,
 }) {
   const encodedQuery = fixedEncodeURIComponent(
     searchTerm.replace(/^[ ]+|[ ]+$/g, ''),
@@ -91,7 +90,6 @@ export function preloadSearchResults({
     location.origin
   }/search?q=${encodedQuery}${getFilterParameters(location.href)}`;
   InstantClick.preload(searchUrl);
-  context.history.pushState({}, '', searchUrl);
 }
 
 export function createSearchUrl(dataHash) {

--- a/app/javascript/utilities/search/index.js
+++ b/app/javascript/utilities/search/index.js
@@ -70,7 +70,7 @@ export function getInitialSearchTerm(querystring) {
     matches !== null && matches.length === 2
       ? decodeURIComponent(matches[1].replace(/\+/g, '%20'))
       : '';
-  const query = filterXSS(rawSearchTerm);
+  const query = filterXSS(rawSearchTerm) || '';
   const divForDecode = document.createElement('div');
   divForDecode.innerHTML = query;
 
@@ -82,15 +82,16 @@ export function getInitialSearchTerm(querystring) {
 export function preloadSearchResults({
   searchTerm,
   location = window.location,
+  context = window,
 }) {
   const encodedQuery = fixedEncodeURIComponent(
     searchTerm.replace(/^[ ]+|[ ]+$/g, ''),
   );
-  InstantClick.preload(
-    `${location.origin}/search?q=${encodedQuery}${getFilterParameters(
-      location.href,
-    )}`,
-  );
+  const searchUrl = `${
+    location.origin
+  }/search?q=${encodedQuery}${getFilterParameters(location.href)}`;
+  InstantClick.preload(searchUrl);
+  context.history.pushState({}, '', searchUrl);
 }
 
 export function createSearchUrl(dataHash) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Prior to this PR, when searching for things on DEV, search in the UI worked but if we went back and forward in browser history, the search input would not reflect the search term in the URL of the browser.

## Related Tickets & Documents

Closes #11010

## QA Instructions, Screenshots, Recordings

Before

![image](https://user-images.githubusercontent.com/833231/96809485-f34a3800-13e8-11eb-9566-09b5dc2f715f.png)

See it in action in the Loom video

https://www.loom.com/share/0b6cefcfa85a4cce875f99764c107e64

After

![image](https://user-images.githubusercontent.com/833231/96812603-3e187f80-13ea-11eb-9f8a-a1280ada59f9.png)

See it in action in the Loom video

https://www.loom.com/share/3fa9e1f9892d480199fb2c48be130dd3

1. Go to https://dev.to
2. In the search at the top of the page, type in `ruby` and press enter.
3. The URL in the browser will switch to `https://dev.to/search?q=ruby`.
4. Do another search, but this time for `javascript`
5. The URL in the browser will switch to `https://dev.to/search?q=javascript`.
6. Hit the back button of the browser.
7. The URL in the browser will switch to `https://dev.to/search?q=ruby`.
8. If you look at the search term in the search input in the top of the page, it will say `ruby`.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![A dancing animated skeleton](https://media.giphy.com/media/gfcxvtqOLogOYjTRnI/giphy.gif)
