### PR TITLE
Only show user count for large userbases

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,8 +2,6 @@ class RegistrationsController < Devise::RegistrationsController
   prepend_before_action :require_no_authentication, only: []
 
   def new
-    @registered_users_count = User.registered.estimated_count
-
     if user_signed_in?
       redirect_to root_path(signin: "true")
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,8 @@ module ApplicationHelper
   )
   # rubocop:enable Performance/OpenStruct
 
+  LARGE_USERBASE_THRESHOLD = 1000
+
   def user_logged_in_status
     user_signed_in? ? "logged-in" : "logged-out"
   end
@@ -279,6 +281,14 @@ module ApplicationHelper
   def sanitize_and_decode(str)
     # using to_str instead of to_s to prevent removal of html entity code
     HTMLEntities.new.decode(sanitize(str).to_str)
+  end
+
+  def estimated_user_count
+    User.registered.estimated_count
+  end
+
+  def display_estimated_user_count?
+    estimated_user_count > LARGE_USERBASE_THRESHOLD
   end
 
   # rubocop:disable Rails/OutputSafety

--- a/app/views/articles/_sidebar_additional.html.erb
+++ b/app/views/articles/_sidebar_additional.html.erb
@@ -10,22 +10,13 @@
           </figure>
           <div class="authentication-widget__content">
             <h3 class="authentication-widget__title">
-      <a href="/"><%= community_name %></a> is a community of <%= number_with_delimiter User.registered.estimated_count %> amazing <%= community_members_label %>
+              <%= render "shared/authentication_title" %>
             </h3>
             <p class="authentication-widget__description">
-              <% if SiteConfig.tagline.present? %>
-                <%= SiteConfig.tagline %>
-              <% else %>
-                Log in to customize your experience and get involved.
-              <% end %>
+              <%= render "shared/authentication_description" %>
             </p>
             <div class="authentication-widget__actions">
-              <a href="<%= sign_up_path(state: "new-user") %>" class="crayons-btn" aria-label="Create new account">
-                Create new account
-              </a>
-              <a href="<%= sign_up_path %>" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">
-                Log in
-              </a>
+              <%= render "shared/authentication_actions" %>
             </div>
           </div>
         </div>

--- a/app/views/devise/registrations/_registration_form.html.erb
+++ b/app/views/devise/registrations/_registration_form.html.erb
@@ -9,9 +9,7 @@
         <% end %>
       </h1>
       <p class="registration__description">
-        <a href="/"><%= community_name %></a> is a community of
-        <%= number_with_delimiter(@registered_users_count) %>
-        amazing <%= community_members_label %>.
+        <%= render "shared/authentication_title" %>
       </p>
     </div>
 

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -29,22 +29,13 @@
       </figure>
       <div class="authentication-header__content">
         <h2 class="authentication-header__title">
-          <a href="/"><%= community_name %></a> is a community of <%= number_with_delimiter User.registered.estimated_count %> amazing <%= community_members_label %>
+          <%= render "shared/authentication_title" %>
         </h2>
         <p class="authentication-header__description">
-          <% if SiteConfig.tagline.present? %>
-            <%= SiteConfig.tagline %>
-          <% else %>
-            Log in to customize your experience and get involved.
-          <% end %>
+          <%= render "shared/authentication_description" %>
         </p>
         <div class="authentication-header__actions">
-          <a href="<%= sign_up_path(state: "new-user") %>" class="crayons-btn" aria-label="Create new account">
-            Create new account
-          </a>
-          <a href="<%= sign_up_path %>" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">
-            Log in
-          </a>
+          <%= render "shared/authentication_actions" %>
         </div>
       </div>
     </div>

--- a/app/views/shared/_authentication_actions.html.erb
+++ b/app/views/shared/_authentication_actions.html.erb
@@ -1,0 +1,6 @@
+<a href="<%= sign_up_path(state: "new-user") %>" class="crayons-btn" aria-label="Create new account">
+  Create new account
+</a>
+<a href="<%= sign_up_path %>" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">
+  Log in
+</a>

--- a/app/views/shared/_authentication_description.html.erb
+++ b/app/views/shared/_authentication_description.html.erb
@@ -1,0 +1,5 @@
+<% if SiteConfig.tagline.present? %>
+  <%= SiteConfig.tagline %>
+<% else %>
+  Log in to customize your experience and get involved.
+<% end %>

--- a/app/views/shared/_authentication_title.html.erb
+++ b/app/views/shared/_authentication_title.html.erb
@@ -1,0 +1,1 @@
+<a href="/"><%= community_name %></a> is a community of <%= display_estimated_user_count? ? number_with_delimiter(estimated_user_count) : "" %> amazing <%= community_members_label %>

--- a/app/views/stories/_sign_in_invitation.html.erb
+++ b/app/views/stories/_sign_in_invitation.html.erb
@@ -6,25 +6,15 @@
     </figure>
     <div class="authentication-feed__content">
       <h2 class="authentication-feed__title">
-<a href="/"><%= community_name %></a> is a community of <br />
-        <%= number_with_delimiter User.registered.estimated_count %> amazing <%= community_members_label %>
+        <%= render "shared/authentication_title" %>
       </h2>
       <p class="authentication-feed__description">
-        <% if SiteConfig.tagline.present? %>
-          <%= SiteConfig.tagline %>
-        <% else %>
-          Log in to customize your experience and get involved.
-        <% end %>
+        <%= render "shared/authentication_description" %>
       </p>
     </div>
   </div>
 
   <div class="authentication-feed__actions">
-    <a href="<%= sign_up_path %>" class="crayons-btn" aria-label="Create new account">
-      Create new account
-    </a>
-    <a href="<%= sign_up_path %>" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">
-      Log in
-    </a>
+    <%= render "shared/authentication_actions" %>
   </div>
 </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a request from one of our early adopter Forems. We should only
render the user count that appears on most of our sign up CTAs when a
Forem has a large userbase (initially, I'm setting that to 1000 users).

The change also removes a lot of duplicated markup by using some
partials to render the copy in the various auth CTAs.

Hopefully, this is written in such a way that changing opening up more
fine-grained control of these partials is trivial.

## Related Tickets & Documents

Closes https://github.com/forem/InternalProjectPlanning/issues/209

## QA Instructions, Screenshots, Recordings

Basically, we drop the number of users until there are more than 1000 users.

Mobile Dropdown Menu:
![cta_mobile](https://user-images.githubusercontent.com/11466782/96903916-0ba76a80-145c-11eb-9f8e-33f3620b3a33.png)

Registration Screen:
![cta_registration](https://user-images.githubusercontent.com/11466782/96903917-0c400100-145c-11eb-873b-5a2669be3573.png)

In-feed CTA:
![cta_feed](https://user-images.githubusercontent.com/11466782/96903919-0cd89780-145c-11eb-9e99-46ee075d194b.png)

Sidebar:
![cta_sidebar](https://user-images.githubusercontent.com/11466782/96903921-0cd89780-145c-11eb-8480-f849615636d3.png)

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
