### PR TITLE
Add Explore Tags for Signed-In Users

### DIFF
--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -56,9 +56,8 @@
     <div id="sidebar-nav-followed-tags" class="overflow-y-auto mb-2" style="max-height: 42vh;"></div>
     <% elsif user_signed_in? %>
       <header class="p-2 pr-0 flex items-center justify-between">
-        <h3 class="crayons-subtitle-3">Explore Tags</h3>
         <a href="/tags" class="crayons-btn crayons-btn--icon crayons-btn--ghost-dimmed" aria-label="Tags Overview" title="Tags Overview">
-          <%= inline_svg_tag("cog.svg", aria: true, class: "crayons-icon") %>
+          <h3 class="crayons-subtitle-3">Explore Tags</h3>
         </a>
       </header>
       <div id="sidebar-nav-explore-tags" class="overflow-y-auto" style="max-height: 42vh">

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -46,7 +46,7 @@
 
 <nav class="mb-6" aria-label="Secondary sidebar nav">
 <nav class="mb-6" aria-label="Secondary sidebar nav">
-  <% if user_signed_in? && current_user.following_tags_count >= 1 %>
+  <% if user_signed_in? && current_user.following_tags_count.positive? %>
     <header class="p-2 pr-0 flex items-center justify-between">
       <h3 class="crayons-subtitle-3">My Tags</h3>
       <a href="/dashboard/following_tags" class="crayons-btn crayons-btn--icon crayons-btn--ghost-dimmed" aria-label="Customize tag priority" title="Customize tag priority">
@@ -55,9 +55,10 @@
     </header>
     <div id="sidebar-nav-followed-tags" class="overflow-y-auto mb-2" style="max-height: 42vh;"></div>
     <% elsif user_signed_in? %>
-      <header class="p-2 pr-0 flex items-center justify-between">
-        <a href="/tags" class="crayons-btn crayons-btn--icon crayons-btn--ghost-dimmed" aria-label="Tags Overview" title="Tags Overview">
-          <h3 class="crayons-subtitle-3">Explore Tags</h3>
+     <header class="p-2 pr-0 flex items-center justify-between">
+       <h3 class="crayons-subtitle-3">Explore</h3>
+       <a href="<%= tags_path %>" class="fs-s crayons-link crayons-link--brand pr-2" title="Browse all tags">
+        All tags
         </a>
       </header>
       <div id="sidebar-nav-explore-tags" class="overflow-y-auto" style="max-height: 42vh">

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -53,7 +53,7 @@
         <%= inline_svg_tag("cog.svg", aria: true, class: "crayons-icon") %>
       </a>
     </header>
-    <div id="sidebar-nav-explore-tags" class="overflow-y-auto mb-2" style="max-height: 42vh;"></div>
+    <div id="sidebar-nav-followed-tags" class="overflow-y-auto mb-2" style="max-height: 42vh;"></div>
     <% elsif user_signed_in? %>
       <header class="p-2 pr-0 flex items-center justify-between">
         <h3 class="crayons-subtitle-3">Explore Tags</h3>

--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -45,28 +45,50 @@
 </nav>
 
 <nav class="mb-6" aria-label="Secondary sidebar nav">
-  <% if user_signed_in? %>
+<nav class="mb-6" aria-label="Secondary sidebar nav">
+  <% if user_signed_in? && current_user.following_tags_count >= 1 %>
     <header class="p-2 pr-0 flex items-center justify-between">
       <h3 class="crayons-subtitle-3">My Tags</h3>
       <a href="/dashboard/following_tags" class="crayons-btn crayons-btn--icon crayons-btn--ghost-dimmed" aria-label="Customize tag priority" title="Customize tag priority">
         <%= inline_svg_tag("cog.svg", aria: true, class: "crayons-icon") %>
       </a>
     </header>
-    <div id="sidebar-nav-followed-tags" class="overflow-y-auto mb-2" style="max-height: 42vh;"></div>
-  <% else %>
-    <h3 class="crayons-subtitle-3 p-2">Popular Tags</h3>
-    <div id="sidebar-nav-default-tags" class="overflow-y-auto" style="max-height: 42vh">
-      <% Tag.where(supported: true).order(hotness_score: :desc).limit(30).pluck(:id, :name).each do |tag_array| %>
-        <div class="sidebar-nav-element" id="default-sidebar-element-<%= tag_array.second %>">
-          <a class="crayons-link crayons-link--block py-2 px-2" href="<%= tag_path(tag_array.second) %>">
-            #<%= tag_array.second %>
-          </a>
-          <a class="follow-action-button sidebar-nav-link-follow crayons-btn crayons-btn--s"
-            href="#" id="sidebar-nav-link-follow-<%= tag_array.second %>"
-            data-info='{"id":<%= tag_array.first %>,"className":"Tag"}'>
-            Follow
-          </a>
+    <div id="sidebar-nav-explore-tags" class="overflow-y-auto mb-2" style="max-height: 42vh;"></div>
+    <% elsif user_signed_in? %>
+      <header class="p-2 pr-0 flex items-center justify-between">
+        <h3 class="crayons-subtitle-3">Explore Tags</h3>
+        <a href="/tags" class="crayons-btn crayons-btn--icon crayons-btn--ghost-dimmed" aria-label="Tags Overview" title="Tags Overview">
+          <%= inline_svg_tag("cog.svg", aria: true, class: "crayons-icon") %>
+        </a>
+      </header>
+      <div id="sidebar-nav-explore-tags" class="overflow-y-auto" style="max-height: 42vh">
+        <% Tag.where(supported: true).order(hotness_score: :desc).limit(5).pluck(:id, :name).each do |tag_array| %>
+          <div class="sidebar-nav-element" id="default-sidebar-element-<%= tag_array.second %>">
+            <a class="crayons-link crayons-link--block py-2 px-2" href="<%= tag_path(tag_array.second) %>">
+              #<%= tag_array.second %>
+            </a>
+            <a class="follow-action-button sidebar-nav-link-follow crayons-btn crayons-btn--s"
+              href="#" id="sidebar-nav-link-follow-<%= tag_array.second %>"
+              data-info='{"id":<%= tag_array.first %>,"className":"Tag"}'>
+              Follow
+            </a>
         </div>
+      <% end %>
+    </div>
+    <% else %>
+      <h3 class="crayons-subtitle-3 p-2">Popular Tags</h3>
+      <div id="sidebar-nav-default-tags" class="overflow-y-auto" style="max-height: 42vh">
+        <% Tag.where(supported: true).order(hotness_score: :desc).limit(30).pluck(:id, :name).each do |tag_array| %>
+          <div class="sidebar-nav-element" id="default-sidebar-element-<%= tag_array.second %>">
+            <a class="crayons-link crayons-link--block py-2 px-2" href="<%= tag_path(tag_array.second) %>">
+              #<%= tag_array.second %>
+            </a>
+            <a class="follow-action-button sidebar-nav-link-follow crayons-btn crayons-btn--s"
+              href="#" id="sidebar-nav-link-follow-<%= tag_array.second %>"
+              data-info='{"id":<%= tag_array.first %>,"className":"Tag"}'>
+              Follow
+            </a>
+          </div>
       <% end %>
     </div>
   <% end %>

--- a/spec/system/homepage/user_visits_homepage_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_spec.rb
@@ -87,13 +87,12 @@ RSpec.describe "User visits a homepage", type: :system do
         user.follows.create!(followable: ruby_tag)
         user.follows.create!(followable: create(:tag, name: "go", hotness_score: 99))
         user.follows.create!(followable: create(:tag, name: "javascript"), points: 3)
+        user.update!(following_tags_count: 3)
 
         visit "/"
       end
 
       it "shows the followed tags", js: true do
-        # byebug
-        user.update!(following_tags_count: 3)
         expect(page).to have_text("My Tags")
 
         # Need to ensure the user data is loaded before doing any checks
@@ -120,32 +119,9 @@ RSpec.describe "User visits a homepage", type: :system do
       end
 
       it "shows 'Explore Tags' and links to /tags", js: true do
-        user.following_tags_count = 0
         expect(page).to have_text("Explore Tags")
-
-        within("#sidebar-nav-explore-tags") do
-          expect(page).to have_link("cog.svg", href: "/tags")
-        end
+        expect(page).to have_selector(:css, 'a[href="/tags"]')
       end
-
-      # it "shows recommended tags ordered by weight and name", js: true, elasticsearch: "FeedContent" do
-      #   # Need to ensure the user data is loaded before doing any checks
-      #   find("body")["data-user"]
-
-      #   within("#sidebar-nav-followed-tags") do
-      #     expect(all(".crayons-link--block").map(&:text)).to eq(%w[#javascript #go #ruby])
-      #   end
-      # end
-      # it "shows the tags block" do
-      #   # visit "/"
-      #   within("#sidebar-nav-explore-tags") do
-      #     Tag.where(supported: true).limit(5).each do |tag|
-      #       expect(page).to have_link("##{tag.name}", href: "/t/#{tag.name}")
-      #     end
-      #   end
-
-      #   expect(page).to have_text("Explore Tags")
-      # end
     end
 
     context "when rendering < 5 navigation links" do

--- a/spec/system/homepage/user_visits_homepage_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_spec.rb
@@ -92,6 +92,8 @@ RSpec.describe "User visits a homepage", type: :system do
       end
 
       it "shows the followed tags", js: true do
+        # byebug
+        user.update!(following_tags_count: 3)
         expect(page).to have_text("My Tags")
 
         # Need to ensure the user data is loaded before doing any checks
@@ -110,6 +112,40 @@ RSpec.describe "User visits a homepage", type: :system do
           expect(all(".crayons-link--block").map(&:text)).to eq(%w[#javascript #go #ruby])
         end
       end
+    end
+
+    context "when user does not follow tags" do
+      before do
+        visit "/"
+      end
+
+      it "shows 'Explore Tags' and links to /tags", js: true do
+        user.following_tags_count = 0
+        expect(page).to have_text("Explore Tags")
+
+        within("#sidebar-nav-explore-tags") do
+          expect(page).to have_link("cog.svg", href: "/tags")
+        end
+      end
+
+      # it "shows recommended tags ordered by weight and name", js: true, elasticsearch: "FeedContent" do
+      #   # Need to ensure the user data is loaded before doing any checks
+      #   find("body")["data-user"]
+
+      #   within("#sidebar-nav-followed-tags") do
+      #     expect(all(".crayons-link--block").map(&:text)).to eq(%w[#javascript #go #ruby])
+      #   end
+      # end
+      # it "shows the tags block" do
+      #   # visit "/"
+      #   within("#sidebar-nav-explore-tags") do
+      #     Tag.where(supported: true).limit(5).each do |tag|
+      #       expect(page).to have_link("##{tag.name}", href: "/t/#{tag.name}")
+      #     end
+      #   end
+
+      #   expect(page).to have_text("Explore Tags")
+      # end
     end
 
     context "when rendering < 5 navigation links" do

--- a/spec/system/homepage/user_visits_homepage_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "User visits a homepage", type: :system do
       end
 
       it "shows 'Explore Tags' and links to /tags", js: true do
-        expect(page).to have_text("Explore Tags")
+        expect(page).to have_text("Explore")
         expect(page).to have_selector(:css, 'a[href="/tags"]')
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds an "Explore Tags" section to the sidebar nav for signed-in users who _do not_ follow any tags. Rather than linking to `/dashboard/tags` like the `cog.svg` does for signed-in users who _follow_ tags, the `cog.svg` links to the tags overview, `/tags`. Additionally, below the "Explore Tags" header, the top five tags for the site are displayed with the option to follow them, making it easy for users to begin following loved tags. This PR allows adds a test to ensure that "Explore Tags" works properly.

## Related Tickets & Documents
Closes https://github.com/forem/InternalProjectPlanning/issues/199

## QA Instructions, Screenshots, Recordings
**To QA this PR, please do the following:**

- Navigate to `localhost:3000` as a signed-in user. If you are following tags you should see the header, "My Tags" displayed with the tags that you're following below the header. Additionally, if you click on the cog to the right of the header, you should be brought to the `/dashboard/tags` page:
<img width="299" alt="Screen Shot 2020-10-22 at 11 01 43 AM" src="https://user-images.githubusercontent.com/32834804/96905655-fa5b5f80-1455-11eb-9e04-274fd1f5915e.png">
<img width="1221" alt="Screen Shot 2020-10-22 at 11 02 05 AM" src="https://user-images.githubusercontent.com/32834804/96905689-0810e500-1456-11eb-8205-fee9b328183e.png">

- Navigate to `localhost:3000` as a signed-in user. If you are _not_ following any tags, you should see the header "Explore" displayed with the top 5 tags for the site below the header. Upon hover, you should be shown a "Follow" button, giving you the option to follow the tags right from the navbar. Additionally, if you click on the link to the right of the "Explore" header, "All tags", you should be brought to the `/tags` page where you should see a list of the  "Top Tags" for the site:
![Screen Shot 2020-10-23 at 8 18 06 AM](https://user-images.githubusercontent.com/32834804/97015138-6f876d00-1508-11eb-8d2d-1bcc3593db50.png)
<img width="1250" alt="Screen Shot 2020-10-22 at 11 00 54 AM" src="https://user-images.githubusercontent.com/32834804/96905585-dd269100-1455-11eb-8a58-2ac9fe61298e.png">

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
Nope!

## [optional] What gif best describes this PR or how it makes you feel?

![Astronaut Holding Exploration Sign](https://media.giphy.com/media/fVmf5KIsskjqJ2rjj9/giphy.gif)
