### PR TITLE
General alert modal for rate limits

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -247,7 +247,7 @@ function handleCommentSubmit(event) {
       } else {
         response.json().then(function parseError(errorReponse) {
           form.classList.remove('submitting');
-           showRateLimitModal();
+          showRateLimitModal();
           return false;
         });
       }

--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -247,7 +247,7 @@ function handleCommentSubmit(event) {
       } else {
         response.json().then(function parseError(errorReponse) {
           form.classList.remove('submitting');
-          window.alert(errorReponse.error); // eslint-disable-line no-alert
+           showRateLimitModal();
           return false;
         });
       }

--- a/app/assets/javascripts/utilities/showModal.js
+++ b/app/assets/javascripts/utilities/showModal.js
@@ -12,3 +12,10 @@ function showModal(context) {
   document.body.classList.add('modal-open');
   initSignupModal();
 }
+
+function showRateLimitModal() {
+    if(document.getElementsByClassName('crayons-modal')[0]) {
+      document.getElementsByClassName('crayons-modal')[0].classList.remove('hidden');
+    } 
+}
+

--- a/app/javascript/packs/rateLimitModal.jsx
+++ b/app/javascript/packs/rateLimitModal.jsx
@@ -1,0 +1,23 @@
+import { h, render } from 'preact';
+import { Modal } from '../crayons/Modal'; 
+
+function closeRateLimitModal() {
+  if(document.getElementsByClassName('crayons-modal')[0]) {
+    document.getElementsByClassName('crayons-modal')[0].classList.add('hidden');
+  } 
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.getElementById('rate-limit-modal');
+
+  render(
+    <Modal 
+      title="This is a modal title"
+      className='hidden'
+      onClose={closeRateLimitModal}
+    >
+      This is the modal body content
+    </Modal>
+  , root);
+});
+

--- a/app/javascript/packs/rateLimitModal.jsx
+++ b/app/javascript/packs/rateLimitModal.jsx
@@ -1,23 +1,16 @@
 import { h, render } from 'preact';
-import { Modal } from '../crayons/Modal'; 
-
-function closeRateLimitModal() {
-  if(document.getElementsByClassName('crayons-modal')[0]) {
-    document.getElementsByClassName('crayons-modal')[0].classList.add('hidden');
-  } 
-}
+import { RateLimitModal } from '../rateLimitModal/rateLimitModal'; 
 
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.getElementById('rate-limit-modal');
 
   render(
-    <Modal 
+    <RateLimitModal 
       title="This is a modal title"
       className='hidden'
-      onClose={closeRateLimitModal}
     >
       This is the modal body content
-    </Modal>
+    </RateLimitModal>
   , root);
 });
 

--- a/app/javascript/packs/rateLimitModal.jsx
+++ b/app/javascript/packs/rateLimitModal.jsx
@@ -7,10 +7,9 @@ document.addEventListener('DOMContentLoaded', () => {
   render(
     <RateLimitModal 
       title="This is a modal title"
+      text="This is the modal body content from a prop"
       className='hidden'
-    >
-      This is the modal body content
-    </RateLimitModal>
+    />
   , root);
 });
 

--- a/app/javascript/rateLimitModal/rateLimitModal.jsx
+++ b/app/javascript/rateLimitModal/rateLimitModal.jsx
@@ -3,12 +3,6 @@ import PropTypes from 'prop-types';
 import { Modal } from '../crayons/Modal'
 
 export class RateLimitModal extends Component {
-
-  constructor() {
-    super();
-    this.state = { };
-  }
-
   closeRateLimitModal = () => {
     if(document.getElementsByClassName('crayons-modal')[0]) {
       document.getElementsByClassName('crayons-modal')[0].classList.add('hidden');
@@ -22,9 +16,13 @@ export class RateLimitModal extends Component {
         className='hidden'
         onClose={this.closeRateLimitModal}
       >
-        This is the rate limit modal body content
+        {this.props.text}
       </Modal>
     )
   }
 
 }
+
+RateLimitModal.propTypes = {
+  text: PropTypes.arrayOf(PropTypes.string).isRequired,
+};

--- a/app/javascript/rateLimitModal/rateLimitModal.jsx
+++ b/app/javascript/rateLimitModal/rateLimitModal.jsx
@@ -1,0 +1,30 @@
+import { h, Component } from 'preact';
+import PropTypes from 'prop-types';
+import { Modal } from '../crayons/Modal'
+
+export class RateLimitModal extends Component {
+
+  constructor() {
+    super();
+    this.state = { };
+  }
+
+  closeRateLimitModal = () => {
+    if(document.getElementsByClassName('crayons-modal')[0]) {
+      document.getElementsByClassName('crayons-modal')[0].classList.add('hidden');
+    } 
+  }
+
+  render() {
+    return (
+      <Modal 
+        title="This is a rate limit modal title"
+        className='hidden'
+        onClose={this.closeRateLimitModal}
+      >
+        This is the rate limit modal body content
+      </Modal>
+    )
+  }
+
+}

--- a/app/views/shell/_bottom.html.erb
+++ b/app/views/shell/_bottom.html.erb
@@ -4,6 +4,10 @@
     <%= render "layouts/footer" %>
     <%= render "layouts/signup_modal" unless user_signed_in? %>
   <% end %>
+  <% if user_signed_in?%>
+    <div id="rate-limit-modal"></div>
+    <%= javascript_packs_with_chunks_tag "rateLimitModal", defer: true %>
+  <% end %>
   <div id="live-article-indicator" class="live-article-indicator"></div>
   <%= image_tag("twitter-logo.svg", class: "icon-img", style: "display:none", alt: "twitter logo") %>
   <%= image_tag("github-logo.svg", class: "icon-img", style: "display:none", alt: "github logo") %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

**Concept**: we want to create reusable messaging to alert users about exceeding rate limits or user interaction limits. Right now these limits are indicated by backend throwing HTTP status code `429 RATE LIMIT EXCEEDED`, but it's up to the frontend to do something with it. Some UIs catch this error and show it in an `alert`, others just throw it away and don't inform the user. Ideally the frontend would have a reusable modal to display (design listed here: https://www.figma.com/file/W0NVUGtoMdQwRc9pH4M5dd/Interaction-limits?node-id=16%3A1)

**Help wanted**: I need help understanding where best to place code. Here's the approach I've taken
- I'm using the crayons `<Modal>` preact component, but would plan to wrap it in a `<RateLimitModal>` component that could dynamically set the explanation text depending on which rate limit was exceeded (individual views would pass this information in when the tried to display the model).
- To be able to use this modal on any view in the application, I created a Javascript pack that's loaded with `javascript_packs_with_chunks_tag` and included in the shell's bottom section.
- I added a utility in `app/assets/javascripts/utilities/showModal.js` to allow Javascript running anywhere in the application the ability to show the rate limit modal
- As a proof of concept, I've hooked up the rate limit modal on the comment posting page (this view is using Javascript, but not Preact components).

There's an alternate path I could see taking:
- Don't use the `<Modal>` preact component, and instead use standard HTML markup
- Expand the plain old Javascript code in `app/assets/javascripts/utilities/showModal.js` (or something in `app/assets/javascripts/initializers`) to handle showing, modifying, and hiding the modal

Additionally:
- Is trying to make this globally available a good idea?

**Please let me know what you think!!**

## Related Tickets & Documents
closes https://github.com/forem/InternalProjectPlanning/issues/192

## QA Instructions, Screenshots, Recordings

![A_Catskill_Eagle_Similique_commodi_-_Forem_Community_👩💻👨💻](https://user-images.githubusercontent.com/37842/96907360-be79c780-1460-11eb-9029-a3116d646945.jpg)


## Added tests?

- [ ] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [ ] no documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![halp!](https://media.giphy.com/media/l46Cbqvg6gxGvh2PS/giphy.gif)
