### PR TITLE
Spec Fix:Set Javascript Locale to Match Time.zone

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -6,6 +6,16 @@
 //= require honeybadger-js/dist/honeybadger.js
 //= require ahoy.js/dist/ahoy.js
 //= require serviceworker-companion
+//= require timemachine.js
+
+<% if Rails.env.test? %>
+  // Ensure that locale time in javascript matches the Timezone on
+  // our server during testing
+  timemachine.config({
+    dateString: '<%= Time.zone.now.iso8601 %>',
+    tick: true
+  });
+<% end %>
 
 var instantClick
   , InstantClick = instantClick = function(document, location, $userAgent) {

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -6,16 +6,6 @@
 //= require honeybadger-js/dist/honeybadger.js
 //= require ahoy.js/dist/ahoy.js
 //= require serviceworker-companion
-//= require timemachine.js
-
-<% if Rails.env.test? %>
-  // Ensure that locale time in javascript matches the Timezone on
-  // our server during testing
-  timemachine.config({
-    dateString: '<%= Time.zone.now.iso8601 %>',
-    tick: true
-  });
-<% end %>
 
 var instantClick
   , InstantClick = instantClick = function(document, location, $userAgent) {

--- a/app/assets/javascripts/initializers/initializeTimemachine.js.erb
+++ b/app/assets/javascripts/initializers/initializeTimemachine.js.erb
@@ -1,0 +1,10 @@
+//= require timemachine.js
+
+<% if Rails.env.test? %>
+  // Ensure that locale time in javascript matches the Timezone on
+  // our server during testing
+  timemachine.config({
+    dateString: '<%= Time.current.iso8601 %>',
+    tick: true
+  });
+<% end %>

--- a/app/assets/javascripts/initializers/initializeTimemachine.js.erb
+++ b/app/assets/javascripts/initializers/initializeTimemachine.js.erb
@@ -1,7 +1,7 @@
 //= require timemachine.js
 
 <% if Rails.env.test? %>
-  // Ensure that locale time in javascript matches the Timezone on
+  // Ensure that locale time in JavaScript matches the Timezone on
   // our server during testing
   timemachine.config({
     dateString: '<%= Time.current.iso8601 %>',

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "pusher-js": "^7.0.0",
     "rails-erb-loader": "^5.5.2",
     "stimulus": "^1.1.1",
+    "timemachine": "^0.3.2",
     "twilio-video": "^2.7.2",
     "web-share-wrapper": "^0.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "sass-loader": "^10.0.3",
     "style-loader": "^2.0.0",
     "svgo": "1.3.2",
+    "timemachine": "^0.3.2",
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
@@ -164,7 +165,6 @@
     "pusher-js": "^7.0.0",
     "rails-erb-loader": "^5.5.2",
     "stimulus": "^1.1.1",
-    "timemachine": "^0.3.2",
     "twilio-video": "^2.7.2",
     "web-share-wrapper": "^0.2.1"
   },

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -29,10 +29,6 @@ RSpec.describe "Views an article", type: :system do
   describe "when showing the date" do
     it "shows the readable publish date", js: true do
       visit article.path
-      # TODO: Molly investigating spec failures if this fails retry your build
-      puts "Readable Compare date #{article.displayable_published_at}"
-      puts find("article time")[:datetime]
-      puts find("article time")[:title]
       expect(page).to have_selector("article time", text: article.readable_publish_date)
     end
 
@@ -55,8 +51,7 @@ RSpec.describe "Views an article", type: :system do
         end
       end
 
-      # TODO: Molly is investigating
-      xit "shows the identical readable publish dates in each page", js: true do
+      it "shows the identical readable publish dates in each page", js: true do
         visit first_article.path
         expect(page).to have_selector("article time", text: first_article.readable_publish_date)
         expect(page).to have_selector(".crayons-card--secondary time", text: first_article.readable_publish_date)

--- a/yarn.lock
+++ b/yarn.lock
@@ -16897,6 +16897,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+timemachine@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/timemachine/-/timemachine-0.3.2.tgz#83c594d0271c3608d5fab13636cd3b7c979ea2c5"
+  integrity sha512-JNKeKZXQJc8UC19JcIq0XziBud+fNNJfatZ57lwk+o1O9mpW2FmzWvRw7FTTOKuN6M0zsjGIlNi0O0QrF5WVRA==
+
 timers-browserify@^2.0.4:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix(I think)

## Description
I got some information from my logging that was showing that the date we were displaying from the local_date helper did not match UTC or the Timezone set by zonebie.
Broken on Travis
```ruby
# Readable Compare date 2020-10-23 00:30:08 +0800 (timezone)
# 2020-10-22T16:30:08Z (utc)
# Thursday, October 22, 2020, 8:30:08 PM (??? some other locale time)
```
When I went back to the `local_date()` helper method I tracked it back to the PR that created it. It was here I realized that the helper method was not the final say in the date. Instead, it [actually gets set by a javascript date helper](https://github.com/forem/forem/blob/master/app/assets/javascripts/initializers/initializeArticleDate.js#L6) to ensure it matches the user's locale time. This made me realize we needed to go a step further and not only did the backend of the browser need to match our Time.zone set by Zonebie, but our javascript needed to as well. After a lot of googling I came across [this old post](https://makandracards.com/makandra/10753-mock-the-browser-time-or-time-zone-in-selenium-features) about [timemachine.js](https://github.com/schickling/timemachine) that you can use to set the time in your javascript. It's a little older but since it's only for our tests I figured it would be fine. 

@nickytonline would love your thoughts on this!

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-47746166

![alt_text](https://media.tenor.com/images/b29cf0528e8e3649d3084c03487c7273/tenor.gif)
