### PR TITLE
Use APP_NAME rather than APP_DOMAIN in chat channels

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -4,7 +4,6 @@ export SKIP_SERVICEWORKERS="true"
 # App core values
 export APP_DOMAIN="localhost:3000"
 export APP_PROTOCOL="http://"
-export APP_NAME="forem_local"
 export FOREM_OWNER_SECRET="secret"
 
 # Openresty domain + Protocol setting for development

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -113,9 +113,9 @@ class ChatChannel < ApplicationRecord
 
   def pusher_channels
     if invite_only?
-      "private-channel--#{ApplicationConfig['APP_NAME']}-#{id}"
+      "private-channel--#{ApplicationConfig['APP_DOMAIN']}-#{id}"
     elsif open?
-      "open-channel--#{ApplicationConfig['APP_NAME']}-#{id}"
+      "open-channel--#{ApplicationConfig['APP_DOMAIN']}-#{id}"
     else
       chat_channel_memberships.pluck(:user_id).map { |id| ChatChannel.pm_notifications_channel(id) }
     end
@@ -165,7 +165,7 @@ class ChatChannel < ApplicationRecord
   end
 
   def self.pm_notifications_channel(user_id)
-    "private-message-notifications--#{ApplicationConfig['APP_NAME']}-#{user_id}"
+    "private-message-notifications--#{ApplicationConfig['APP_DOMAIN']}-#{user_id}"
   end
 
   private

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -112,6 +112,7 @@ class ChatChannel < ApplicationRecord
   end
 
   def pusher_channels
+    # TODO: use something more unique here (uuid?) rather than just id.
     if invite_only?
       "private-channel--#{ApplicationConfig['APP_DOMAIN']}-#{id}"
     elsif open?

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -58,7 +58,7 @@
         data-user-status="<%= user_logged_in_status %>"
         class="<%= SiteConfig.default_font.tr("_", "-") %>-article-body default-header"
         data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>"
-        data-app-name="<%= ApplicationConfig["APP_NAME"] %>"
+        data-app-name="<%= ApplicationConfig["APP_DOMAIN"] %>"
         data-honeybadger-key="<%= ApplicationConfig["HONEYBADGER_JS_API_KEY"] %>"
         data-release-footprint="<%= ApplicationConfig["RELEASE_FOOTPRINT"] %>"
         data-ga-tracking="<%= SiteConfig.ga_tracking_id %>">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
`APP_NAME` may not always be set (it is not "required" per se), which can cause issues while deriving the `pusher_channels`. 

We should use `APP_DOMAIN`, which is more common and always has a default value.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/212

## QA Instructions, Screenshots, Recordings

Ensure that chat works correctly.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed 
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [X] no documentation needed
