### PR TITLE
Forem creator feature flag + onboarding signup form

### DIFF
--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -172,7 +172,7 @@
   --form-border-focus: var(--accent-brand);
   --form-placeholder-color: var(--base-60);
 
-  // Form lables
+  // Form labels
   --label-primary: var(--base-90);
   --label-secondary: var(--base-60);
 

--- a/app/assets/stylesheets/themes/hacker.scss
+++ b/app/assets/stylesheets/themes/hacker.scss
@@ -165,7 +165,7 @@
   --form-border-focus: var(--accent-brand);
   --form-placeholder-color: var(--base-60);
 
-  // Form lables
+  // Form labels
   --label-primary: var(--accent-brand);
   --label-secondary: var(--accent-brand-darker);
 

--- a/app/assets/stylesheets/themes/minimal.scss
+++ b/app/assets/stylesheets/themes/minimal.scss
@@ -163,7 +163,7 @@
   --form-border-focus: var(--accent-brand);
   --form-placeholder-color: var(--base-60);
 
-  // Form lables
+  // Form labels
   --label-primary: var(--base-90);
   --label-secondary: var(--base-60);
 

--- a/app/assets/stylesheets/themes/night.scss
+++ b/app/assets/stylesheets/themes/night.scss
@@ -163,7 +163,7 @@
   --form-border-focus: var(--accent-brand);
   --form-placeholder-color: var(--base-60);
 
-  // Form lables
+  // Form labels
   --label-primary: var(--base-90);
   --label-secondary: var(--base-60);
 

--- a/app/assets/stylesheets/themes/pink.scss
+++ b/app/assets/stylesheets/themes/pink.scss
@@ -163,7 +163,7 @@
   --form-border-focus: var(--base-60);
   --form-placeholder-color: var(--base-60);
 
-  // Form lables
+  // Form labels
   --label-primary: var(--base-100);
   --label-secondary: var(--base-90);
 

--- a/app/helpers/authentication_helper.rb
+++ b/app/helpers/authentication_helper.rb
@@ -24,4 +24,12 @@ module AuthenticationHelper
       SiteConfig.recaptcha_site_key.present? &&
       SiteConfig.require_captcha_for_email_password_registration
   end
+
+  def forem_creator_flow_enabled?
+    Flipper.enabled?(:creator_onboarding) && waiting_on_first_user?
+  end
+
+  def waiting_on_first_user?
+    SiteConfig.waiting_on_first_user
+  end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,7 +6,10 @@
   <div class="crayons-notice crayons-notice--danger mb-10 mt-8 mx-auto" style="width: 680px;max-width:94%;">
     Email authentication is not enabled for this Forem.
   </div>
-<% elsif SiteConfig.waiting_on_first_user %>
+<% elsif forem_creator_flow_enabled? %>
+  <%= render "shared/authentication/forem_creator_signup" %>
+<% elsif waiting_on_first_user? %>
+  <%# TODO: Vaidehi Joshi - Delete this view once forem creator onboarding is shipped %>
   <%= render "shared/authentication/initial_account_wizard" %>
 <% else %>
   <%= render "devise/shared/authorization_error" %>

--- a/app/views/shared/authentication/_email_registration_form.html.erb
+++ b/app/views/shared/authentication/_email_registration_form.html.erb
@@ -20,6 +20,12 @@
           </ul>
         </div>
       </div>
+    <% elsif forem_creator_flow_enabled? %>
+      <%# TODO: Vaidehi Joshi - Extract this into its own form %>
+      <div class="align-center">
+        <p class="pb-4 fw-bold">Almost there!</p>
+        <p class="registration__description">Let's create an admin account for your community.</p>
+      </div>
     <% else %>
       <p class="pb-4 fw-bold">Create your account</p>
     <% end %>
@@ -69,8 +75,16 @@
         <%= recaptcha_tags site_key: SiteConfig.recaptcha_site_key %>
       </div>
     <% end %>
-    <div class="actions pt-3">
-      <%= f.submit "Sign up", class: "crayons-btn" %>
-    </div>
+
+    <% if forem_creator_flow_enabled? %>
+      <%# TODO: Vaidehi Joshi - Extract this into its own form %>
+      <div class="flex flex-col pt-3">
+        <%= f.submit "Create admin account", class: "crayons-btn" %>
+      </div>
+    <% else %>
+      <div class="actions pt-3">
+        <%= f.submit "Sign up", class: "crayons-btn" %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/shared/authentication/_forem_creator_signup.html.erb
+++ b/app/views/shared/authentication/_forem_creator_signup.html.erb
@@ -1,0 +1,3 @@
+<div class="mx-auto mt-8 mb-10 p-4 fs-2xl lh-base align-center" style="width:96%;max-width:1300px;">
+  <%= render "shared/authentication/email_registration_form" %>
+</div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Right now, we have many different ways to sign up for a new Forem. When a new Forem creator goes to sign up for and "activate" a new Forem, this is sign up form that they will see:
<img width="1470" alt="Screen Shot 2020-10-22 at 5 35 54 PM" src="https://user-images.githubusercontent.com/6921610/96943491-2d6d1580-148d-11eb-92b1-8fda0f722ea5.png">

**This PR adds the new form for the Forem creator onboarding flow, which is hidden behind the `creator_onboarding` feature flag (!!).**

Please note that all this PR is really doing is creating the new form, and hiding it behind the feature flag. This will allow me to ship small, encapsulated PRs without changing what a Forem creator sees. I will eventually remove the "old" Forem creator form and replace it with our new one by removing the feature flag altogether! 👏 

## Related Tickets & Documents

A step towards completing https://github.com/forem/InternalProjectPlanning/issues/81, which will be a series of smaller PRs! 😸 

## QA Instructions, Screenshots, Recordings
1. Go into the `rails console` and enable the appropriate feature flag and set `waiting_on_first_user` to `true`. You will need _both_ of these set in order to go through the flow:
```ruby
> Flipper.enable(:creator_onboarding)
=> true
> SiteConfig.waiting_on_first_user = true
=> true
```

2. Head over to your local `forem` instance (make sure the server is on!). When you click on `Log in`, you should see the new, Forem creator form:
<img width="1455" alt="Screen Shot 2020-10-22 at 4 55 40 PM" src="https://user-images.githubusercontent.com/6921610/96943714-c3a13b80-148d-11eb-94e5-a03d02d2701c.png">

3. Ensure that you can sign up for an account, as though you were a Forem creator:
<img width="1455" alt="Screen Shot 2020-10-22 at 4 56 05 PM" src="https://user-images.githubusercontent.com/6921610/96943788-f9462480-148d-11eb-9ef8-ed356e7f53d9.png">

_You should be able to create your admin account (you may need to go into the console and call `confirm` on your newly-created `User` instance._
<img width="1455" alt="Screen Shot 2020-10-22 at 4 56 19 PM" src="https://user-images.githubusercontent.com/6921610/96943782-f5b29d80-148d-11eb-87b8-8a09051b2ccc.png">

4. Once your user has been confirmed, try logging in as the new Forem creator/admin:
<img width="1455" alt="Screen Shot 2020-10-22 at 4 56 48 PM" src="https://user-images.githubusercontent.com/6921610/96943867-2eeb0d80-148e-11eb-838a-ec4af21b1991.png">

_You should be able to log in successfully and be sent to the _normal_ user onboarding (for now!):_
<img width="1455" alt="Screen Shot 2020-10-22 at 4 56 59 PM" src="https://user-images.githubusercontent.com/6921610/96943874-327e9480-148e-11eb-99ce-c32638809062.png">

5. Log out, and then go back to the log in screen `/enter`. You should no longer see the new Forem creator onboarding form/flow; instead it should look like the "normal" user sign in form:
<img width="1415" alt="Screen Shot 2020-10-22 at 4 57 33 PM" src="https://user-images.githubusercontent.com/6921610/96943937-5e9a1580-148e-11eb-87b9-9c23b36d52b3.png">


## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] ~docs.forem.com~ inline docs and comments where necessary
- [ ] readme
- [ ] no documentation needed

## Are there any post deployment tasks we need to perform?
Because this is hidden behind a feature flag, we should be safe to deploy this to production without any actual users running into it 🎉 

## What gif best describes this PR or how it makes you feel?

![beyonce feeling the flow](https://media0.giphy.com/media/l3V0mcUKWL45mAo24/giphy.webp?cid=5a38a5a28ks2um9enwry61tmv78367y55nth08bs789echyo&rid=giphy.webp)
