### PR TITLE
Return video_source_url in API V0 Videos index (#6299)

### DIFF
--- a/app/controllers/api/v0/videos_controller.rb
+++ b/app/controllers/api/v0/videos_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :set_cache_control_headers, only: %i[index]
 
       INDEX_ATTRIBUTES_FOR_SERIALIZATION = %i[
-        id video path title video_thumbnail_url user_id video_duration_in_seconds
+        id video path title video_thumbnail_url user_id video_duration_in_seconds video_source_url
       ].freeze
       private_constant :INDEX_ATTRIBUTES_FOR_SERIALIZATION
 

--- a/app/views/api/v0/videos/index.json.jbuilder
+++ b/app/views/api/v0/videos/index.json.jbuilder
@@ -9,6 +9,7 @@ json.array! @video_articles do |video_article|
     :title,
     :user_id,
     :video_duration_in_minutes,
+    :video_source_url,
   )
 
   json.user do

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -579,6 +579,7 @@ components:
         - title
         - user_id
         - video_duration_in_minutes
+        - video_source_url
         - user
       properties:
         type_of:
@@ -603,6 +604,9 @@ components:
 
             If the video duration is below 1 hour, the format will be `mm:ss`,
             if it's 1 hour or above the format will be `h:mm:ss`.
+          type: string
+        video_source_url:
+          format: url
           type: string
         user:
           type: object
@@ -1316,6 +1320,7 @@ components:
           title: 'BaseCS: Depth First Search Implementing'
           user_id: 2882
           video_duration_in_minutes: '11:47'
+          video_source_url: 'https://dw71fyauz7yz9.cloudfront.net/123/123.m3u8'
           user:
             name: Vaidehi Joshi
 

--- a/spec/requests/api/v0/videos_spec.rb
+++ b/spec/requests/api/v0/videos_spec.rb
@@ -51,10 +51,11 @@ RSpec.describe "Api::V0::Videos", type: :request do
       get api_videos_path
 
       response_video = response.parsed_body.first
-      expected_keys = %w[type_of id path cloudinary_video_url title user_id video_duration_in_minutes user]
+      expected_keys = %w[type_of id path cloudinary_video_url title user_id video_duration_in_minutes video_source_url
+                         user]
       expect(response_video.keys).to match_array(expected_keys)
 
-      %w[id path cloudinary_video_url title user_id video_duration_in_minutes].each do |attr|
+      %w[id path cloudinary_video_url title user_id video_duration_in_minutes video_source_url].each do |attr|
         expect(response_video[attr]).to eq(video_article.public_send(attr))
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It adds `video_source_url` attribute in API V0 videos index.

## Related Tickets & Documents

Closes #6299

## QA Instructions, Screenshots, Recordings

Go to http://localhost:3000/api/videos and check if `video_source_url` is returned.

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help
