### PR TITLE
Don't use instantclick for registration links

### DIFF
--- a/app/views/shared/_authentication_actions.html.erb
+++ b/app/views/shared/_authentication_actions.html.erb
@@ -1,4 +1,4 @@
-<a href="<%= sign_up_path(state: "new-user") %>" class="crayons-btn" aria-label="Create new account">
+<a href="<%= sign_up_path(state: "new-user") %>" class="crayons-btn" aria-label="Create new account" data-no-instant>
   Create new account
 </a>
 <a href="<%= sign_up_path %>" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">

--- a/app/views/shared/_authentication_actions.html.erb
+++ b/app/views/shared/_authentication_actions.html.erb
@@ -1,4 +1,4 @@
-<a href="<%= sign_up_path(state: "new-user") %>" class="crayons-btn" aria-label="Create new account" data-no-instant>
+<a href="<%= sign_up_path(state: "new-user") %>" class="crayons-btn" aria-label="Create new account">
   Create new account
 </a>
 <a href="<%= sign_up_path %>" class="crayons-btn crayons-btn--ghost-brand" aria-label="Log in">

--- a/app/views/shared/authentication/_providers_registration_form.html.erb
+++ b/app/views/shared/authentication/_providers_registration_form.html.erb
@@ -10,7 +10,7 @@
   <% end %>
   <% if params[:state] == "new-user" && SiteConfig.allow_email_password_registration %>
     <%= link_to "#{inline_svg_tag('email.svg', aria: true, class: 'crayons-icon', title: 'email')}Sign up with Email".html_safe,
-                request.params.merge(state: "email_signup"),
+                request.params.merge(state: "email_signup").except("i"),
                 class: "crayons-btn crayons-btn--l crayons-btn--brand-email crayons-btn--icon-left whitespace-nowrap",
                 data: { no_instant: "" } %>
   <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where navigating to the registration page `/users/signup` via InstantClick (clicking the link itself) passes along the InstantClick param `?i=i`, which in turn breaks CSS for the email signup link.

**So the biggest thing to consider is whether we want that InstantClick navigation feeling still when clicking from the homepage to the "Create New Account" registration page.** I think it's a good touch but it is also prone to causing problems with the rest of our sign up links.

## QA Instructions, Screenshots, Recordings
1. Add the two changed lines to your respective files, probably easier than pulling this PR and checking out via Git.
2. Have email registration enabled via /admin/config, Authentication section
3. Log out or open an incognito/private window
4. Go to the homepage
5. Click the Create New Account link
6. Click the Sign up with email link
7. See that the CSS renders properly

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![A dude weighs his options in his mind, using his hands to gesture like he's considering two options.](https://media.giphy.com/media/l41YyrtIMFcxYayDS/giphy.gif)
