### PR TITLE
Expand cropping options for Imgproxy

### DIFF
--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -38,9 +38,18 @@ module Images
     }.freeze
 
     def self.imgproxy(img_src, **kwargs)
-      options = DEFAULT_IMGPROXY_OPTIONS.merge(kwargs).reject { |_, v| v.blank? }
+      translated_options = translate_cloudinary_options(kwargs)
+      options = DEFAULT_IMGPROXY_OPTIONS.merge(translated_options).reject { |_, v| v.blank? }
       Imgproxy.config.endpoint ||= get_imgproxy_endpoint
       Imgproxy.url_for(img_src, options)
+    end
+
+    def self.translate_cloudinary_options(options)
+      if options[:crop] == "fill"
+        options[:resizing_type] = "fill"
+      end
+
+      options
     end
 
     def self.imgproxy_enabled?

--- a/lib/data_update_scripts/20201026155851_resave_to_bust_cache_for_imgproxy.rb
+++ b/lib/data_update_scripts/20201026155851_resave_to_bust_cache_for_imgproxy.rb
@@ -1,0 +1,18 @@
+module DataUpdateScripts
+  class ResaveToBustCacheForImgproxy
+    def run
+      return unless ENV["FOREM_CONTEXT"] == "forem_cloud"
+
+      User.find_each do |user|
+        CacheBuster.bust_user(user)
+      end
+
+      Organization.find_each do |organization|
+        CacheBuster.bust_organization(organization, organization.slug)
+      end
+
+      Article.find_each(&:save)
+      Comment.find_each(&:save)
+    end
+  end
+end

--- a/spec/services/images/optimizer_spec.rb
+++ b/spec/services/images/optimizer_spec.rb
@@ -77,4 +77,11 @@ RSpec.describe Images::Optimizer, type: :service do
       expect(imgproxy_url).to match(%r{/s:500:500/aHR0cHM6Ly9pLmlt/Z3VyLmNvbS9mS1lL/Z280LnBuZw})
     end
   end
+
+  describe "#translate_cloudinary_options" do
+    it "Set resizing_type to fill if crop: fill is provided" do
+      options = { width: 100, height: 100, crop: "fill" }
+      expect(described_class.translate_cloudinary_options(options)).to include(resizing_type: "fill")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix

## Description
This is to fix the distorted profile image in some Forem community. Please take a look at https://github.com/forem/InternalProjectPlanning/issues/215

## Related Tickets & Documents
Resolves https://github.com/forem/InternalProjectPlanning/issues/215
## QA Instructions, Screenshots, Recordings
(I'm including a simple imgproxy setup for this QA, if you already know how to set it up please ignore first 2 steps)
1. Install imgproxy (`-> brew install imgproxy`) and start it up (`-> imgproxy`)
1. Just for this demo, please change `app/services/images/optimizer.rb:6` to `if true`, we're forcing the app to use imgproxy.
1. Choose a rectangular image of your choice, or use [this picture](https://magazine.northeast.aaa.com/wp-content/uploads/2018/05/banff-national-park-1-640x423.jpg).
1. Start up a rails console and enter the following `Images::Profile.call(your-url-goes-here.com, length: "320")`
1. Visit the url imgproxy generated, your image should look now look square. If the domain is missing, use `localhost:8080`

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Only on the Forem cloud, we either need to purge cache or bust some user's page.
