### PR TITLE
Copy username to search_fields

### DIFF
--- a/config/elasticsearch/mappings/users.json
+++ b/config/elasticsearch/mappings/users.json
@@ -58,7 +58,8 @@
       "type": "text"
     },
     "username": {
-      "type": "keyword"
+      "type": "keyword",
+      "copy_to": "search_fields"
     },
     "profile_fields": {
       "type": "nested",

--- a/lib/data_update_scripts/20200914042434_reindex_users_for_profiles.rb
+++ b/lib/data_update_scripts/20200914042434_reindex_users_for_profiles.rb
@@ -1,9 +1,9 @@
 module DataUpdateScripts
   class ReindexUsersForProfiles
     def run
-      User.select(:id).in_batches(of: 200) do |batch|
-        Search::BulkIndexWorker.set(queue: :default).perform_async("User", batch.ids)
-      end
+      # User.select(:id).in_batches(of: 200) do |batch|
+      #   Search::BulkIndexWorker.set(queue: :default).perform_async("User", batch.ids)
+      # end
     end
   end
 end

--- a/lib/data_update_scripts/20201030134117_reindex_users_for_username_search.rb
+++ b/lib/data_update_scripts/20201030134117_reindex_users_for_username_search.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class ReindexUsersForUsernameSearch
+    def run
+      User.select(:id).in_batches(of: 200) do |batch|
+        Search::BulkIndexWorker.set(queue: :default).perform_async("User", batch.ids)
+      end
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/reindex_users_for_username_search_spec.rb
+++ b/spec/lib/data_update_scripts/reindex_users_for_username_search_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+require Rails.root.join("lib/data_update_scripts/20201030134117_reindex_users_for_username_search.rb")
+
+describe DataUpdateScripts::ReindexUsersForUsernameSearch do
+  let(:user) { create :user }
+
+  it "reindexes users" do
+    sidekiq_assert_enqueued_with(job: Search::BulkIndexWorker, args: ["User", [user.id]], queue: "default") do
+      described_class.new.run
+    end
+  end
+end

--- a/spec/services/search/user_spec.rb
+++ b/spec/services/search/user_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe Search::User, type: :service do
         doc_ids = user_docs.map { |t| t["id"] }
         expect(doc_ids).to include(user1.id, user2.id)
       end
+
+      it "searches by a username" do
+        allow(user1).to receive(:username).and_return("kyloren")
+        index_documents([user1])
+        query_params = { size: 5, search_fields: "kyloren" }
+
+        user_docs = described_class.search_documents(params: query_params)
+        expect(user_docs.count).to eq(1)
+        doc_ids = user_docs.map { |t| t["id"] }
+        expect(doc_ids).to include(user1.id)
+      end
     end
 
     context "with a filter" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR enabled searching a user by username with wildcard. E.g. when a user is `krzysiek1507`, it finds by the whole username but also by a part of it: `krzysiek`, `krzysiek15`. Since the pattern is: `word*`, it won't find by a substring from the middle or the end of the username.

## Related Tickets & Documents

Closes #10967

## QA Instructions, Screenshots, Recordings

1. Try to find by a username (NOTE: to fail it, the username cannot be equal or be part of first or last name)
2. Run:
```ruby
Search::User.update_mappings
User.all.each(&:touch) # if your db is small
```
3. Search again for the username

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

1. Mappings for User have to be updated.
2. Users have to be reindexed.