### PR TITLE
Renamed internal.js pack file to admin.js

### DIFF
--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -1,6 +1,9 @@
 import { Application } from 'stimulus';
 import { definitionsFromContext } from 'stimulus/webpack-helpers';
 
+// This loads all the Stimulus controllers at the same time for the admin
+// section of the application.
+
 const application = Application.start();
 const context = require.context('admin/controllers', true, /.js$/);
 application.load(definitionsFromContext(context));

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -12,7 +12,7 @@
   <title><%= controller_name.titleize %></title>
 
   <!-- StimulusJS -->
-  <%= javascript_packs_with_chunks_tag "internal", defer: true %>
+  <%= javascript_packs_with_chunks_tag "admin", defer: true %>
 
   <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
 

--- a/docs/admin/admin-user-interface.md
+++ b/docs/admin/admin-user-interface.md
@@ -33,8 +33,10 @@ Stimulus is a modest frontend framework; its primary purpose is manipulating
 HTML. It does not provide templating features.
 
 In the Forem application, [Webpacker](/frontend/webpacker/) is used to load
-Stimulus controllers. Ideally, controllers serve as an abstraction for shared
-functionality between views.
+Stimulus controllers via the `app/javascript/packs/admin.js`
+[pack file](https://github.com/rails/webpacker/blob/master/docs/folder-structure.md#packs-aka-webpack-entries).
+Ideally, controllers serve as an abstraction for shared functionality between
+views.
 
 New controllers can be added in `/app/javascript/admin/controllers`. Unit tests
 should exist for each controller in the adjacent


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It's not really obvious where all the administration frontend controllers get bootstrapped. This file rename helps with that.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

The pack file has been renamed, so the admin section of the application should behave the same.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [x] docs.forem.com
- [ ] readme
- [ ] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Someone in a t-rex costume waving](https://media.giphy.com/media/xTk9ZY0C9ZWM2NgmCA/giphy.gif)
