### PR TITLE
Remove duplicated nav in sidebar_nav

### DIFF
--- a/app/views/articles/_sidebar_nav.html.erb
+++ b/app/views/articles/_sidebar_nav.html.erb
@@ -45,7 +45,6 @@
 </nav>
 
 <nav class="mb-6" aria-label="Secondary sidebar nav">
-<nav class="mb-6" aria-label="Secondary sidebar nav">
   <% if user_signed_in? && current_user.following_tags_count.positive? %>
     <header class="p-2 pr-0 flex items-center justify-between">
       <h3 class="crayons-subtitle-3">My Tags</h3>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

[This](https://github.com/forem/forem/commit/8fb1a3824a92942f1c05524d0ede5c27c4b6d90f#diff-60389f4530eeb06208f463974e7bb70cfc9d00d9e85affa395004dff9cfdffdaR48) commit duplicated the `nav` starting element.

## Related Tickets & Documents



## QA Instructions, Screenshots, Recordings

Test if the nav works.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed
