### PR TITLE
Render followed tags only if container available

### DIFF
--- a/app/javascript/packs/homePage.jsx
+++ b/app/javascript/packs/homePage.jsx
@@ -89,7 +89,12 @@ if (!document.getElementById('featured-story-marker')) {
           renderFeed(changedFeedTimeFrame);
         });
       });
-      renderTagsFollowed(document.getElementById('sidebar-nav-followed-tags'));
+
+      const tagsFollowedContainer = document.getElementById(
+        'sidebar-nav-followed-tags',
+      );
+
+      if (tagsFollowedContainer) renderTagsFollowed(tagsFollowedContainer);
     }
   }, 2);
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If a user doesn't follow any tags, then on the homepage instead of `My tags` section, the `Explore` section is rendered and we can see in the console:
```js
Uncaught TypeError: Cannot read property 'firstElementChild' of null
    at renderTagsFollowed (homePage.jsx?a167:53)
    at dataLoadedCheck (homePage.jsx?a167:92)
    at fn.___hb (base.js:7708)
    at base.js:8141
```

This PR changes the code to render followed tags only if the container is present.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

1. Check if there is no warning in the console when `Explore` section visible.
2. Check if the followed tags are rendered is any followed.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed