### PR TITLE
Truncate long tags in sidebar

### DIFF
--- a/app/assets/stylesheets/widgets.scss
+++ b/app/assets/stylesheets/widgets.scss
@@ -291,6 +291,13 @@
 .sidebar-nav-element {
   display: block;
   position: relative;
+
+  a {
+    display: block;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+  }
+
   @media screen and (min-width: $breakpoint-m) {
     .sidebar-nav-link-follow {
       display: none;


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A popular tag with a long name causes a horizontal scrollbar in the sidebar
<img width="268" alt="Sidebar with long popular tag and horizontal scrollbars" src="https://user-images.githubusercontent.com/5287128/97098517-dc9a2e80-16d1-11eb-88c1-8a24cf0ae48c.png">

This PR truncates long tags and shows ellipses on text overflow.

## Related Tickets & Documents
Resolves https://github.com/forem/forem/issues/10990

## QA Instructions, Screenshots, Recordings
- In `rails console` create a new tag. Tags must be marked as `supported` to appear in the sidebar. Eg:
```rb
Tag.create!(name: 'longnamethatcausesoverflow', supported: true)
```
- If you have more than 30 tags you may need to change the new tag's `hotness_score` so that it appears in the list. 
For reference: Here's the query that generates the popular tag list
https://github.com/forem/forem/blob/4dde307a43b5d6c901bd4550d122accd86ce587e/app/views/articles/_sidebar_nav.html.erb#L81
- Navigate to `/`

Sidebar after changes
<img width="277" alt="Forem sidebar with long tag truncated with ellipses" src="https://user-images.githubusercontent.com/5287128/97098432-fa1ac880-16d0-11eb-80a3-ef65bc1a4ae2.png">

## Added tests?

- [ ] yes
- [x] no, because they aren't needed (I think?)
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

