### PR TITLE
Bug Fix:Only Require Timemachine for Testing envs

### DIFF
--- a/app/assets/javascripts/initializers/initializeTimemachine.js.erb
+++ b/app/assets/javascripts/initializers/initializeTimemachine.js.erb
@@ -1,6 +1,6 @@
-//= require timemachine.js
-
 <% if Rails.env.test? %>
+  //= require timemachine.js
+
   // Ensure that locale time in JavaScript matches the Timezone on
   // our server during testing
   timemachine.config({


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
If we always try to require timemachine.js then we end up with this production error bc it is not packaged for production.
```
Sprockets::FileNotFound: couldn't find file 'timemachine.js' with type 'application/javascript'
```
This ensures we only require it for testing
