### PR TITLE
Optimization:Remove more_tag_weight_experiment From Feed Tests and Rebalance

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -3,7 +3,6 @@ module Stories
     respond_to :json
 
     VARIANTS = {
-      "more_tag_weight_experiment" => :more_tag_weight_experiment,
       "more_tag_weight_more_random_experiment" => :more_tag_weight_more_random_experiment,
       "more_comments_experiment" => :more_comments_experiment,
       "more_experience_level_weight_experiment" => :more_experience_level_weight_experiment,

--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -60,13 +60,6 @@ module Articles
         stories
       end
 
-      # Test variation: tags make bigger impact
-      def more_tag_weight_experiment
-        @tag_weight = 2
-        _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
-        stories
-      end
-
       def more_tag_weight_more_random_experiment
         @tag_weight = 2
         @randomness = 7
@@ -102,26 +95,24 @@ module Articles
       end
 
       def mix_of_everything_experiment
-        case rand(10)
+        case rand(9)
         when 0
           default_home_feed(user_signed_in: true)
         when 1
-          more_tag_weight_experiment
-        when 2
           more_tag_weight_more_random_experiment
-        when 3
+        when 2
           more_comments_experiment
-        when 4
+        when 3
           more_experience_level_weight_experiment
-        when 5
+        when 4
           more_tag_weight_randomized_at_end_experiment
-        when 6
+        when 5
           more_experience_level_weight_randomized_at_end_experiment
-        when 7
+        when 6
           more_comments_randomized_at_end_experiment
-        when 8
+        when 7
           more_comments_medium_weight_randomized_at_end_experiment
-        when 9
+        when 8
           more_comments_minimal_weight_randomized_at_end_experiment
         else
           default_home_feed(user_signed_in: true)
@@ -135,7 +126,8 @@ module Articles
 
       def more_tag_weight_randomized_at_end_experiment
         @randomness = 0
-        results = more_tag_weight_experiment
+        @tag_weight = 2
+        _featured_story, results = default_home_feed_and_featured_story(user_signed_in: true)
         first_half(results).shuffle + last_half(results)
       end
 

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -2,7 +2,6 @@ experiments:
   user_home_feed: # Home feed collection for logged in user
     variants:
       - base
-      - more_tag_weight_experiment
       - more_tag_weight_more_random_experiment
       - more_comments_experiment
       - more_experience_level_weight_experiment
@@ -13,17 +12,16 @@ experiments:
       - more_comments_medium_weight_randomized_at_end_experiment
       - more_comments_minimal_weight_randomized_at_end_experiment
     weights:
-      - 10
-      - 10
-      - 10
       - 5
       - 5
       - 10
       - 10
-      - 5
-      - 25
-      - 5
-      - 5
+      - 10
+      - 10
+      - 10
+      - 20
+      - 10
+      - 10
     goals:
       - user_creates_comment
       - user_creates_reaction

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 NON_DEFAULT_EXPERIMENTS = %i[
-  more_tag_weight_experiment
   more_tag_weight_more_random_experiment
   more_comments_experiment
   more_experience_level_weight_experiment


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Continuing to close the loop on these Feed experiments. After removing a couple of them last week I re-evaluated the remaining ones and it's pretty clear the `more_tag_weight_experiment` alone is not going to be a winner based on the [AB test dashboard](https://dev.to/abtests/). I also took this opportunity to rebalance the weights a little towards the experiments that appear to be more successful to give them a better chance of standing out and maybe "winning"
![Screen Shot 2020-10-26 at 11 29 16 AM](https://user-images.githubusercontent.com/1813380/97197532-c2b52600-177b-11eb-8e3e-dd761bb53ed8.png)
![Screen Shot 2020-10-26 at 11 29 25 AM](https://user-images.githubusercontent.com/1813380/97197536-c34dbc80-177b-11eb-84a5-406f496c36a4.png)
![Screen Shot 2020-10-26 at 11 29 33 AM](https://user-images.githubusercontent.com/1813380/97197540-c3e65300-177b-11eb-8340-764880ef3fca.png)

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-47841833

## Added tests?
- [x] no, because they aren't needed bc we are removing code!


![alt_text](https://media1.tenor.com/images/00b2c6f9f54e5e8e8e65764a4a0702c3/tenor.gif?itemid=13719641)
