### PR TITLE
Add admin shortcut to tag page

### DIFF
--- a/app/assets/javascripts/initializers/initializeAllTagEditButtons.js
+++ b/app/assets/javascripts/initializers/initializeAllTagEditButtons.js
@@ -4,7 +4,7 @@ function initializeAllTagEditButtons() {
   var tagEditButton = document.getElementById('tag-edit-button');
   var tagAdminButton = document.getElementById('tag-admin-button');
   var user = userData();
-  if (user.admin) {
+  if (user.admin && tagAdminButton) {
     tagAdminButton.style.display = 'inline-block';
     document.getElementById('tag-admin-button').style.display = 'inline-block';
   }

--- a/app/assets/javascripts/initializers/initializeAllTagEditButtons.js
+++ b/app/assets/javascripts/initializers/initializeAllTagEditButtons.js
@@ -2,11 +2,16 @@
 
 function initializeAllTagEditButtons() {
   var tagEditButton = document.getElementById('tag-edit-button');
+  var tagAdminButton = document.getElementById('tag-admin-button');
   var user = userData();
+  if (user.admin) {
+    tagAdminButton.style.display = 'inline-block';
+    document.getElementById('tag-admin-button').style.display = 'inline-block';
+  }
   if (
     user &&
     tagEditButton &&
-    user.moderator_for_tags.indexOf(tagEditButton.dataset.tag) > -1
+    (user.moderator_for_tags.indexOf(tagEditButton.dataset.tag) > -1 || user.admin)
   ) {
     tagEditButton.style.display = 'inline-block';
     document.getElementById('tag-mod-button').style.display = 'inline-block';

--- a/app/assets/stylesheets/sidebar-data.scss
+++ b/app/assets/stylesheets/sidebar-data.scss
@@ -9,13 +9,6 @@
   padding: 16px;
   @include themeable(color, theme-secondary-color, $dark-medium-gray);
   color: var(--card-color-tertiary);
-  .mod-action-button {
-    padding: 2px 9px;
-    font-size: 1.2em;
-    display: block;
-    margin-top: 5px;
-    border-radius: 3px;
-  }
   hr {
     opacity: 0.3;
     margin: 25px 0px 15px;

--- a/app/views/articles/tags/_sidebar.html.erb
+++ b/app/views/articles/tags/_sidebar.html.erb
@@ -70,11 +70,11 @@
             <a style="display:none;" id="tag-edit-button" data-tag="<%= @tag_model.name %>" class="crayons-btn crayons-btn--outlined mod-action-button fs-s" href="<%= tag_url(@tag_model, @page) %>/edit" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
               Edit
             </a>
-            <a style="display:none;" id="tag-mod-button" data-tag="<%= @tag_model.name %>" class="crayons-btn crayons-btn--outlined mod-action-button fs-s" href="/mod/<%= @tag_model.name %>" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
-              Moderate
-            </a>
             <a style="display:none;" id="tag-admin-button" data-tag="<%= @tag_model.name %>" class="crayons-btn crayons-btn--outlined mod-action-button fs-s" href="/admin/tags/<%= @tag_model.id %>" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>" data-no-instant>
               Admin
+            </a>
+            <a style="display:none;" id="tag-mod-button" data-tag="<%= @tag_model.name %>" class="crayons-btn crayons-btn--outlined mod-action-button fs-s" href="/mod/<%= @tag_model.name %>" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
+              Moderate
             </a>
           </div>
         <% else %>

--- a/app/views/articles/tags/_sidebar.html.erb
+++ b/app/views/articles/tags/_sidebar.html.erb
@@ -66,16 +66,17 @@
           <%= pluralize @num_published_articles, "Post" %> Published
         </div>
         <% if user_signed_in? %>
-          <span style="display:none;" id="tag-edit-button" data-tag="<%= @tag_model.name %>">
-            <a class="crayons-btn crayons-btn--secondary mod-action-button" href="<%= tag_url(@tag_model, @page) %>/edit" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
+          <div class="crayons-btn-group mt-3">
+            <a style="display:none;" id="tag-edit-button" data-tag="<%= @tag_model.name %>" class="crayons-btn crayons-btn--outlined mod-action-button fs-s" href="<%= tag_url(@tag_model, @page) %>/edit" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
               Edit
             </a>
-          </span>
-          <span style="display:none;" id="tag-mod-button" data-tag="<%= @tag_model.name %>">
-            <a class="crayons-btn mod-action-button" href="/mod/<%= @tag_model.name %>" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
+            <a style="display:none;" id="tag-mod-button" data-tag="<%= @tag_model.name %>" class="crayons-btn crayons-btn--outlined mod-action-button fs-s" href="/mod/<%= @tag_model.name %>" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
               Moderate
             </a>
-          </span>
+            <a style="display:none;" id="tag-admin-button" data-tag="<%= @tag_model.name %>" class="crayons-btn crayons-btn--outlined mod-action-button fs-s" href="/admin/tags/<%= @tag_model.id %>" style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>" data-no-instant>
+              Admin
+            </a>
+          </div>
         <% else %>
           <% number_of_pages = @num_published_articles / @number_of_articles %>
           <% range = number_of_pages < 10 || @page < 4 ? 1..[number_of_pages, 9].min : [@page - 3, 1].max..[@page + 5, number_of_pages].min %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,12 +1,12 @@
 <% title "Tags on #{community_name}" %>
 
 <%= content_for :page_meta do %>
-  <link rel="canonical" href="<%= app_url("/about") %>" />
+  <link rel="canonical" href="<%= app_url("/tags") %>" />
   <meta name="description" content="Tags to follow on <%= community_name %>">
   <%= meta_keywords_default %>
 
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="<%= app_url("/about") %>" />
+  <meta property="og:url" content="<%= app_url("/tags") %>" />
   <meta property="og:title" content="Tags to follow on <%= community_name %>" />
   <meta property="og:image" content="<%= SiteConfig.main_social_image %>" />
   <meta property="og:description" content="<%= community_qualified_name %> is great!" />

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe "StoriesIndex", type: :request do
 
       it "has mod-action-button" do
         get "/t/#{tag.name}"
-        expect(response.body).to include('<a class="crayons-btn mod-action-button"')
+        expect(response.body).to include('class="crayons-btn crayons-btn--outlined mod-action-button fs-s"')
       end
 
       it "does not render pagination" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The problem that this is solving is that setting any admin-only functionality lacks intuitive ergonomics for admins. If they recognize that a tag needs to be adjusted or elevated, it's a pain to get to the proper admin dashboard. This adds an admin button alongside mod buttons. Also made a style adjustment.

Old:

<img width="291" alt="Screen Shot 2020-10-26 at 11 59 40 AM" src="https://user-images.githubusercontent.com/3102842/97196377-c8fad080-1782-11eb-9567-3890b3c475d4.png">

New:

<img width="270" alt="Screen Shot 2020-10-26 at 11 53 18 AM" src="https://user-images.githubusercontent.com/3102842/97195529-d9f71200-1781-11eb-9332-ef3488b38bcc.png">

This creates a button a shortcut to admin, alongside moderation to allow admins to more easily modify admin-level tag decisions.
