### PR TITLE
Optimization:Limit Tags Searched For Follow Suggestions

### DIFF
--- a/app/services/suggester/users/recent.rb
+++ b/app/services/suggester/users/recent.rb
@@ -22,7 +22,7 @@ module Suggester
 
       def tagged_article_user_ids(num_weeks = 1)
         Article.published
-          .tagged_with(user.decorate.cached_followed_tag_names, any: true)
+          .tagged_with(user.decorate.cached_followed_tag_names.sample(5), any: true)
           .where("score > ? AND published_at > ?", article_reaction_count, num_weeks.weeks.ago)
           .pluck(:user_id)
           .each_with_object(Hash.new(0)) { |value, counts| counts[value] += 1 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Was recently looking at some slow traces on Honeycomb when I came across one that had a 1 second SQL query in it. Upon further investigation, I noticed that the query was trying to suggest users to follow and was using the current user's followed tags. This particular user had 20 tags they were following which made the query pretty intense with 20 `OR` tagging statements. To save us some process time and power I decided a good solution would be to limit the number of tags when suggesting users to follow. 


## Added tests?
- [x] No, overall behavior has remained the same so current tests should be sufficient 

## Added to documentation?
- [x] No documentation needed


![alt_text](https://media1.tenor.com/images/85fc489ec84fa2f906c4a847a95754e9/tenor.gif?itemid=5688674)
