### PR TITLE
Refactor Admin Events Index

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -4,7 +4,7 @@ module Admin
     include ApplicationHelper
 
     def index
-      @events = Event.all.order(starts_at: :desc).page(params[:page]).per(20)
+      @events = Event.order(starts_at: :desc).page(params[:page]).per(20)
     end
 
     def new

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -4,12 +4,15 @@ module Admin
     include ApplicationHelper
 
     def index
-      @event = Event.new(
-        location_name: "#{URL.domain}/live",
-        location_url: app_url,
-        description_markdown: "*Description* *Pre-requisites:* *Bio*",
-      )
-      @events = Event.order(starts_at: :desc)
+      @events = Event.all.order(starts_at: :desc)
+    end
+
+    def new
+      @event = Event.new
+    end
+
+    def edit
+      @event = Event.find(params[:id])
     end
 
     def create
@@ -17,22 +20,21 @@ module Admin
       @events = Event.order(starts_at: :desc)
       if @event.save
         flash[:success] = "Successfully created event: #{@event.title}"
-        redirect_to(action: :index)
+        redirect_to admin_events_path
       else
         flash[:danger] = @event.errors.full_messages
-        render "index.html.erb"
+        render new_admin_event_path
       end
     end
 
     def update
       @event = Event.find(params[:id])
-      @events = Event.order(starts_at: :desc)
       if @event.update(event_params)
         flash[:success] = "#{@event.title} was successfully updated"
-        redirect_to "/admin/events"
+        redirect_to admin_event_path
       else
         flash[:danger] = @event.errors.full_messages
-        render "index.html.erb"
+        render :edit
       end
     end
 

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -4,7 +4,7 @@ module Admin
     include ApplicationHelper
 
     def index
-      @events = Event.all.order(starts_at: :desc)
+      @events = Event.all.order(starts_at: :desc).page(params[:page]).per(20)
     end
 
     def new

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -8,7 +8,11 @@ module Admin
     end
 
     def new
-      @event = Event.new
+      @event = Event.new(
+        location_name: "#{URL.domain}/live",
+        location_url: app_url,
+        description_markdown: "*Description* *Pre-requisites:* *Bio*",
+      )
     end
 
     def edit
@@ -17,7 +21,6 @@ module Admin
 
     def create
       @event = Event.new(event_params)
-      @events = Event.order(starts_at: :desc)
       if @event.save
         flash[:success] = "Successfully created event: #{@event.title}"
         redirect_to admin_events_path
@@ -31,7 +34,7 @@ module Admin
       @event = Event.find(params[:id])
       if @event.update(event_params)
         flash[:success] = "#{@event.title} was successfully updated"
-        redirect_to admin_event_path
+        redirect_to admin_events_path
       else
         flash[:danger] = @event.errors.full_messages
         render :edit

--- a/app/views/admin/events/_event_form.html.erb
+++ b/app/views/admin/events/_event_form.html.erb
@@ -1,50 +1,54 @@
-<div class="form-group">
-  <%= f.label :cover_image %>:
-  <%= f.file_field :cover_image, class: "form-control" %>
+<div class="crayons-card p-6">
+  <%= form_for [:admin, @event] do |f| %>
+    <div class="form-group">
+      <%= f.label :cover_image %>:
+      <%= f.file_field :cover_image, class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= f.label :profile_image %> (for live notification):
+      <%= f.file_field :profile_image, class: "form-control" %>
+      <img src="<%= @event.profile_image_url %>" style="width: 25%;" alt="event profile image">
+    </div>
+    <div class="form-group">
+      <%= f.label :title %>
+      <%= f.text_field :title, maxlength: 90, size: 40, required: true, class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= f.label :host_name %>
+      <%= f.text_field :host_name, size: 40, required: true, class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= f.label :category %>
+      <%= f.select :category, ["AMA", "Workshop", "Talk", "Town Hall"], required: true %>
+    </div>
+    <div class="form-group">
+      <%= f.label :starts_at %>
+      <%= f.datetime_select :starts_at, required: true, include_blank: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "form-control" %> UTC Time Only (4 hours ahead of eastern time)
+    </div>
+    <div class="form-group">
+      <%= f.label :ends_at %>
+      <%= f.datetime_select :ends_at, required: true, include_blank: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "form-control" %> UTC Time Only (4 hours ahead of eastern time)
+    </div>
+    <div class="form-group">
+      <%= f.label :location_name %>
+      <%= f.text_field :location_name, required: true, class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= f.label :location_url %>
+      <%= f.text_field :location_url, required: true, class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= f.label :description_markdown %>
+      <%= f.text_area :description_markdown, size: "45x10", required: true, class: "form-control" %>
+    </div>
+    <div class="form-group">
+      <%= f.label :published %>
+      <%= f.check_box :published %>
+    </div>
+    <div class="form-group">
+      <%= f.label :live_now %>
+      <%= f.check_box :live_now %>
+    </div>
+    <%= f.submit class: "btn btn-primary" %>
+  <% end %>
 </div>
-<div class="form-group">
-  <%= f.label :profile_image %> (for live notification):
-  <%= f.file_field :profile_image, class: "form-control" %>
-  <img src="<%= event.profile_image_url %>" style="width: 25%;" alt="event profile image">
-</div>
-<div class="form-group">
-  <%= f.label :title %>
-  <%= f.text_field :title, maxlength: 90, size: 40, required: true, class: "form-control" %>
-</div>
-<div class="form-group">
-  <%= f.label :host_name %>
-  <%= f.text_field :host_name, size: 40, required: true, class: "form-control" %>
-</div>
-<div class="form-group">
-  <%= f.label :category %>
-  <%= f.select :category, ["AMA", "Workshop", "Talk", "Town Hall"], required: true %>
-</div>
-<div class="form-group">
-  <%= f.label :starts_at %>
-  <%= f.datetime_select :starts_at, required: true, include_blank: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "form-control" %> UTC Time Only (4 hours ahead of eastern time)
-</div>
-<div class="form-group">
-  <%= f.label :ends_at %>
-  <%= f.datetime_select :ends_at, required: true, include_blank: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "form-control" %> UTC Time Only (4 hours ahead of eastern time)
-</div>
-<div class="form-group">
-  <%= f.label :location_name %>
-  <%= f.text_field :location_name, required: true, class: "form-control" %>
-</div>
-<div class="form-group">
-  <%= f.label :location_url %>
-  <%= f.text_field :location_url, required: true, class: "form-control" %>
-</div>
-<div class="form-group">
-  <%= f.label :description_markdown %>
-  <%= f.text_area :description_markdown, size: "45x10", required: true, class: "form-control" %>
-</div>
-<div class="form-group">
-  <%= f.label :published %>
-  <%= f.check_box :published %>
-</div>
-<div class="form-group">
-  <%= f.label :live_now %>
-  <%= f.check_box :live_now %>
-</div>
-<%= f.submit class: "btn btn-primary" %>

--- a/app/views/admin/events/_event_form.html.erb
+++ b/app/views/admin/events/_event_form.html.erb
@@ -1,54 +1,54 @@
 <div class="crayons-card p-6">
   <%= form_for [:admin, @event] do |f| %>
-    <div class="form-group">
-      <%= f.label :cover_image %>:
-      <%= f.file_field :cover_image, class: "form-control" %>
+    <div class="crayons-field">
+      <%= f.label :cover_image, class: "crayons-field__label" %>
+      <%= f.file_field :cover_image, class: "crayons-field" %>
     </div>
-    <div class="form-group">
-      <%= f.label :profile_image %> (for live notification):
-      <%= f.file_field :profile_image, class: "form-control" %>
+    <div class="crayons-field">
+      <%= f.label :profile_image, class: "crayons-field__label" %> (for live notification):
+      <%= f.file_field :profile_image, class: "crayons-field" %>
       <img src="<%= @event.profile_image_url %>" style="width: 25%;" alt="event profile image">
     </div>
-    <div class="form-group">
-      <%= f.label :title %>
-      <%= f.text_field :title, maxlength: 90, size: 40, required: true, class: "form-control" %>
+    <div class="crayons-field">
+      <%= f.label :title, class: "crayons-field__label" %>
+      <%= f.text_field :title, maxlength: 90, size: 40, required: true, class: "crayons-textfield" %>
     </div>
-    <div class="form-group">
-      <%= f.label :host_name %>
-      <%= f.text_field :host_name, size: 40, required: true, class: "form-control" %>
+    <div class="crayons-field">
+      <%= f.label :host_name, class: "crayons-field__label" %>
+      <%= f.text_field :host_name, size: 40, required: true, class: "crayons-textfield" %>
     </div>
-    <div class="form-group">
-      <%= f.label :category %>
-      <%= f.select :category, ["AMA", "Workshop", "Talk", "Town Hall"], required: true %>
+    <div class="crayons-field">
+      <%= f.label :category, class: "crayons-field__label" %>
+      <%= f.select :category, ["AMA", "Workshop", "Talk", "Town Hall"], required: true, class: "crayons-select" %>
     </div>
-    <div class="form-group">
-      <%= f.label :starts_at %>
-      <%= f.datetime_select :starts_at, required: true, include_blank: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "form-control" %> UTC Time Only (4 hours ahead of eastern time)
+    <div class="crayons-field">
+      <%= f.label :starts_at, class: "crayons-field__label" %>
+      <%= f.datetime_select :starts_at, required: true, include_blank: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "crayons-select" %> UTC Time Only (4 hours ahead of eastern time)
     </div>
-    <div class="form-group">
-      <%= f.label :ends_at %>
-      <%= f.datetime_select :ends_at, required: true, include_blank: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "form-control" %> UTC Time Only (4 hours ahead of eastern time)
+    <div class="crayons-field">
+      <%= f.label :ends_at, class: "crayons-field__label" %>
+      <%= f.datetime_select :ends_at, required: true, include_blank: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "crayons-select" %> UTC Time Only (4 hours ahead of eastern time)
     </div>
-    <div class="form-group">
-      <%= f.label :location_name %>
-      <%= f.text_field :location_name, required: true, class: "form-control" %>
+    <div class="crayons-field">
+      <%= f.label :location_name, class: "crayons-field__label" %>
+      <%= f.text_field :location_name, required: true, class: "crayons-textfield" %>
     </div>
-    <div class="form-group">
-      <%= f.label :location_url %>
-      <%= f.text_field :location_url, required: true, class: "form-control" %>
+    <div class="crayons-field">
+      <%= f.label :location_url, class: "crayons-field__label" %>
+      <%= f.text_field :location_url, required: true, class: "crayons-textfield" %>
     </div>
-    <div class="form-group">
-      <%= f.label :description_markdown %>
-      <%= f.text_area :description_markdown, size: "45x10", required: true, class: "form-control" %>
+    <div class="crayons-field">
+      <%= f.label :description_markdown, class: "crayons-field__label" %>
+      <%= f.text_area :description_markdown, size: "45x10", required: true, class: "crayons-textfield" %>
     </div>
-    <div class="form-group">
-      <%= f.label :published %>
-      <%= f.check_box :published %>
+    <div class="crayons-field">
+      <%= f.label :published, class: "crayons-field__label" %>
+      <%= f.check_box :published, class: "crayons-checkbox" %>
     </div>
-    <div class="form-group">
-      <%= f.label :live_now %>
-      <%= f.check_box :live_now %>
+    <div class="crayons-field">
+      <%= f.label :live_now, class: "crayons-field__label" %>
+      <%= f.check_box :live_now, class: "crayons-checkbox" %>
     </div>
-    <%= f.submit class: "btn btn-primary" %>
+    <%= f.submit class: "crayons-btn" %>
   <% end %>
 </div>

--- a/app/views/admin/events/edit.html.erb
+++ b/app/views/admin/events/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="crayons-card p-6 mb-6">
-  <h2 class="crayons-title mb-6">Create New Event</h2>
+  <h2 class="crayons-title mb-6">Edit Event: <%= @event.title.to_s %></h2>
 
   <%= form_for @event, url: { controller: "events", action: "create" } do |f| %>
     <%= render "event_form", f: f, event: @event %>

--- a/app/views/admin/events/edit.html.erb
+++ b/app/views/admin/events/edit.html.erb
@@ -1,7 +1,4 @@
 <div class="crayons-card p-6 mb-6">
   <h2 class="crayons-title mb-6">Edit Event: <%= @event.title.to_s %></h2>
-
-  <%= form_for @event, url: { controller: "events", action: "create" } do |f| %>
-    <%= render "event_form", f: f, event: @event %>
-  <% end %>
+    <%= render "event_form" %>
 </div>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,17 +1,36 @@
-<div class="crayons-card p-6 mb-6">
-  <h2 class="crayons-title mb-6">Upcoming Events</h2>
+<header class="flex items-center mb-6">
+  <h2 class="crayons-title">Events</h2>
+  <%= link_to "New Event", new_admin_event_path, class: "ml-auto crayons-btn crayons-btn--s" %>
+</header>
+<br>
+
+<div class="crayons-card p-6 pages__table">
+  <h3>Upcoming Events</h3>
   <% @events.each do |event| %>
     <% if event.starts_at.future? %>
-      <img src="<%= event.cover_image_url %>" alt="event cover image">
+      <div class="flex py-2 items-center">
+        <%= event.title %>
+        <% if event.cover_image_url.present? %>
+          <img class="mx-auto mt-3" width="40" height="40" src="<%= event.cover_image_url %>" alt="event cover image">
+        <% end %>
+        <%= link_to "Edit", edit_admin_event_path(event.id), class: "ml-auto crayons-btn crayons-btn--s crayons-btn--secondary" %>
+      </div>
     <% end %>
   <% end %>
 </div>
+<br>
 
-<div class="crayons-card p-6 mb-6">
-  <h2 class="crayons-title mb-6">Past Events</h2>
+<div class="crayons-card p-6 pages__table">
+<h3>Past Events</h3>
   <% @events.each do |event| %>
     <% if !event.starts_at.future? %>
-      <img src="<%= event.cover_image_url %>" alt="event cover image">
+      <div class="flex py-2 items-center">
+        <%= event.title %>
+        <% if event.cover_image_url.present? %>
+          <img class="mx-auto mt-3 justify-content-center" width="50" height="50" src="<%= event.cover_image_url %>" alt="event cover image">
+        <% end %>
+        <%= link_to "Edit", edit_admin_event_path(event.id), class: "ml-auto crayons-btn crayons-btn--s crayons-btn--secondary" %>
+      </div>
     <% end %>
   <% end %>
 </div>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -27,7 +27,7 @@
       <div class="flex py-2 items-center">
         <%= event.title %>
         <% if event.cover_image_url.present? %>
-          <img class="mx-auto mt-3 justify-content-center" width="50" height="50" src="<%= event.cover_image_url %>" alt="event cover image">
+          <img class="mx-auto mt-3 justify-content-center" width="40" height="40" src="<%= event.cover_image_url %>" alt="event cover image">
         <% end %>
         <%= link_to "Edit", edit_admin_event_path(event.id), class: "ml-auto crayons-btn crayons-btn--s crayons-btn--secondary" %>
       </div>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,19 +1,8 @@
 <div class="crayons-card p-6 mb-6">
-  <h2 class="crayons-title mb-6">Create New Event</h2>
-
-  <%= form_for @event, url: { controller: "events", action: "create" } do |f| %>
-    <%= render "event_form", f: f, event: @event %>
-  <% end %>
-</div>
-
-<div class="crayons-card p-6 mb-6">
   <h2 class="crayons-title mb-6">Upcoming Events</h2>
   <% @events.each do |event| %>
     <% if event.starts_at.future? %>
       <img src="<%= event.cover_image_url %>" alt="event cover image">
-      <%= form_for [:admin, event] do |f| %>
-        <%= render "event_form", f: f, event: event %>
-      <% end %>
     <% end %>
   <% end %>
 </div>
@@ -23,9 +12,6 @@
   <% @events.each do |event| %>
     <% if !event.starts_at.future? %>
       <img src="<%= event.cover_image_url %>" alt="event cover image">
-      <%= form_for [:admin, event] do |f| %>
-        <%= render "event_form", f: f, event: event %>
-      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -15,6 +15,7 @@
         <% end %>
         <%= link_to "Edit", edit_admin_event_path(event.id), class: "ml-auto crayons-btn crayons-btn--s crayons-btn--secondary" %>
       </div>
+      <hr>
     <% end %>
   <% end %>
 </div>
@@ -31,6 +32,7 @@
         <% end %>
         <%= link_to "Edit", edit_admin_event_path(event.id), class: "ml-auto crayons-btn crayons-btn--s crayons-btn--secondary" %>
       </div>
+      <hr>
     <% end %>
   <% end %>
 </div>

--- a/app/views/admin/events/new.html.erb
+++ b/app/views/admin/events/new.html.erb
@@ -1,7 +1,4 @@
 <div class="crayons-card p-6 mb-6">
   <h2 class="crayons-title mb-6">Create New Event</h2>
-
-  <%= form_for @event, url: { controller: "events", action: "create" } do |f| %>
-    <%= render "event_form", f: f, event: @event %>
-  <% end %>
+    <%= render "event_form" %>
 </div>

--- a/app/views/admin/pages/index.html.erb
+++ b/app/views/admin/pages/index.html.erb
@@ -16,7 +16,7 @@
 
 <div class="mt-8 pages__override_defaults">
   <div class="my-6">
-    <% if !@code_of_conduct || !@privacy || !@terms%>
+    <% if !@code_of_conduct || !@privacy || !@terms %>
       <h2 class="mb-4 crayons-title">Override defaults</h2>
       <div class="crayons-notice mb-4 crayons-notice--warning">
         <strong>Note: Proceed with caution. When you edit any of the following pages, it will diverge from the original Forem version and you will no longer receive updates. You will see your updated version in the section above.</strong>
@@ -31,7 +31,7 @@
         <% if !@privacy %>
           <div class="flex py-2 items-center">
               <%= link_to "Privacy Policy", privacy_path %>
-              <%= link_to "Override", new_admin_page_path(slug: "privacy"), class: "ml-auto crayons-btn crayons-btn--s crayons-btn--danger"  %>
+              <%= link_to "Override", new_admin_page_path(slug: "privacy"), class: "ml-auto crayons-btn crayons-btn--s crayons-btn--danger" %>
           </div>
         <% end %>
         <% if !@terms %>
@@ -47,6 +47,4 @@
       </div>
     <% end %>
   </div>
-
-
 </div>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -80,14 +80,14 @@
       <span class="location"><%= event.location_url %></span>
       <span class="alarm_reminder">15</span>
       <span class="description">
-        <%= event.description_html.html_safe %>
+        <%= event.description_html&.html_safe %>
         ------
         Link to attend - <%= event.location_url %>
       </span>
     </div>
   </div>
   <div class="event-description">
-    <%= event.description_html.html_safe %>
+    <%= event.description_html&.html_safe %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,7 @@ Rails.application.routes.draw do
                                               destroy], path: "listings/categories"
 
       resources :comments, only: [:index]
-      resources :events, only: %i[index create update]
+      resources :events, except: %i[destroy]
       resources :feedback_messages, only: %i[index show]
       resources :invitations, only: %i[index new create destroy]
       resources :pages, only: %i[index new create edit update destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,7 @@ Rails.application.routes.draw do
                                               destroy], path: "listings/categories"
 
       resources :comments, only: [:index]
-      resources :events, except: %i[destroy]
+      resources :events, only: %i[index create update new edit]
       resources :feedback_messages, only: %i[index show]
       resources :invitations, only: %i[index new create destroy]
       resources :pages, only: %i[index new create edit update destroy]

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -1,8 +1,19 @@
 require "rails_helper"
 
 RSpec.describe "/admin/events", type: :request do
-  let(:event) { create(:event) }
+  let(:event) { create(:event, title: "Hey") }
   let(:admin) { create(:user, :super_admin) }
+  let(:params) do
+    {
+      event: {
+        title: "Hello, world!",
+        description_markdown: "This is an event",
+        starts_at: Time.current,
+        ends_at: 3660.seconds.from_now,
+        category: "Talk"
+      }
+    }
+  end
 
   describe "PUT admin/events" do
     before do
@@ -18,6 +29,24 @@ RSpec.describe "/admin/events", type: :request do
     it "marks an event as live now" do
       patch "/admin/events/#{event.id}", params: { event: { live_now: "1" } }
       expect(event.reload.live_now).to eq true
+    end
+
+    it "successfully updates the event title" do
+      expect do
+        patch "/admin/events/#{event.id}", params: params
+      end.to change { event.reload.title }.to("Hello, world!")
+    end
+  end
+
+  describe "POST /admin/events" do
+    let(:post_resource) { post "/admin/events", params: params }
+
+    before { sign_in admin }
+
+    it "successfully creates an event" do
+      expect do
+        post_resource
+      end.to change { Event.all.count }.by(1)
     end
   end
 end

--- a/spec/system/admin/admin_creates_new_event_spec.rb
+++ b/spec/system/admin/admin_creates_new_event_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Admin creates new event", type: :system do
 
   before do
     sign_in admin
-    visit "/admin/events"
+    visit "/admin/events/new"
   end
 
   def select_date_and_time(year, month, date, hour, min, field_name)
@@ -26,7 +26,7 @@ RSpec.describe "Admin creates new event", type: :system do
   end
 
   it "loads /admin/events" do
-    expect(page).to have_content("Create New Event")
+    expect(page).to have_content("New Event")
   end
 
   it "loads published events on /events" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
**The issue**:
> As a Forem admin setting up events, it's pretty unwieldy to open /admin/events because everything is on one page. That includes past events, future events, the event creation page, etc. 

**The solution**:
This PR refactors the `/admin/events` index page by removing the event creation and event edit forms from the index into their own views and by cleaning up the `/admin/events` UI by separating out "Upcoming Events" and "Past Events" by use of a crayons table. Additionally, this PR adds a "New Event" button to the top of the `/admin/events` index and inline "Edit" buttons next to each event for easy editing. This PR also refactors the `Admin::EventsController`, Admin event-related forms, and Admin event-related specs. It also adds additional actions to the `Admin::EventsController` and additional routes to `routes.rb` (`#edit`, `#new`, and `#update`) and adds and refactors tests around creating and updating events.

## Related Tickets & Documents
Closes https://github.com/forem/InternalProjectPlanning/issues/208

## QA Instructions, Screenshots, Recordings
**To QA this PR, first ensure that you have an `admin` role, and then please do the following**:

- Navigate to `/admin/events` to see the new, Pages-inspired index page:
![Screen Shot 2020-10-26 at 2 28 51 PM](https://user-images.githubusercontent.com/32834804/97224981-93acad80-1797-11eb-95c8-95ed6bf1690d.png)

- Click on "New Event" to create a new event. After filling out the form, click "Create Event" to create your new event. **Note**: an image should only appear in the `/admin/events` index if you upload one, otherwise, no image should display in the table (see final QA screenshot to see what that looks like):
![Screen Shot 2020-10-26 at 2 31 08 PM](https://user-images.githubusercontent.com/32834804/97225161-e5553800-1797-11eb-9082-e1b5fb4d1f05.png)

- You should be redirected back to `/admin/events` upon the successful creation of an event. You should see a flash message indicating that the creation was successful and you should also see your event under the correct heading, "Upcoming Events" or "Past Events," depending on when your event takes place:
![Screen Shot 2020-10-26 at 2 34 04 PM](https://user-images.githubusercontent.com/32834804/97225466-4da41980-1798-11eb-8c5a-6b10a3b51cdc.png)

- Click the "Edit" button next to your newly created event to edit the event and edit one or all of the fields. Upon a successful update, you should be redirected back to `/admin/events` and you should see a flash message indicating that the update was successful:
![Screen Shot 2020-10-26 at 2 35 32 PM](https://user-images.githubusercontent.com/32834804/97225640-8217d580-1798-11eb-825e-944e5fd4fdc9.png)

- After creating and updating multiple events, your `/admin/events` index should look something like this, with the events properly sorted under the correct headers, "Upcoming Events" and "Past Events":
![Screen Shot 2020-10-26 at 2 25 10 PM](https://user-images.githubusercontent.com/32834804/97224649-108b5780-1797-11eb-8e2a-9fc75ffe5d74.png)

- Any published events can be seen on `/events`:
![Screen Shot 2020-10-26 at 2 49 24 PM](https://user-images.githubusercontent.com/32834804/97227271-dcb23100-179a-11eb-9434-ac7a6e9526af.png)

- Try to break things! ⚒️ 

## Added tests?

- [x] Yes, and updated existing specs
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
None that I can think of!

## [optional] What gif best describes this PR or how it makes you feel?

![The word "event" in various fonts](https://media.giphy.com/media/ekY8JdlX7FqQTbteE7/giphy.gif)