### PR TITLE
Removing email prop and fixing test

### DIFF
--- a/app/javascript/chat/ChatChannelSettings/ModFaqSection.jsx
+++ b/app/javascript/chat/ChatChannelSettings/ModFaqSection.jsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import PropTypes from 'prop-types';
 
-const ModFaqSection = ({ email, currentMembershipRole }) => {
+const ModFaqSection = ({ currentMembershipRole }) => {
   if (currentMembershipRole === 'member') {
     return null;
   }
@@ -24,7 +24,6 @@ const ModFaqSection = ({ email, currentMembershipRole }) => {
 };
 
 ModFaqSection.propTypes = {
-  email: PropTypes.string.isRequired,
   currentMembershipRole: PropTypes.string.isRequired,
 };
 

--- a/app/javascript/chat/__tests__/modFaqSection.test.jsx
+++ b/app/javascript/chat/__tests__/modFaqSection.test.jsx
@@ -5,18 +5,9 @@ import ModFaqSection from '../ChatChannelSettings/ModFaqSection';
 
 describe('<ChannelDescriptionSection />', () => {
   it('should have no a11y violations', async () => {
-    const { container } = render(<ModFaqSection email="jane@doe.com" />);
+    const { container } = render(<ModFaqSection />);
     const results = await axe(container);
 
     expect(results).toHaveNoViolations();
-  });
-
-  it('should render', () => {
-    const { queryByText } = render(<ModFaqSection email="jane@doe.com" />);
-
-    expect(
-      queryByText(/^Questions about Connect Channel moderation\? Contact/),
-    ).toBeDefined();
-    expect(queryByText('jane@doe.com')).toBeDefined();
   });
 });

--- a/app/javascript/chat/__tests__/modFaqSection.test.jsx
+++ b/app/javascript/chat/__tests__/modFaqSection.test.jsx
@@ -10,4 +10,12 @@ describe('<ChannelDescriptionSection />', () => {
 
     expect(results).toHaveNoViolations();
   });
+
+  it('should render', () => {
+    const { queryByText } = render(<ModFaqSection />);
+
+    expect(
+      queryByText(/^Questions about Connect Channel moderation\? Contact/),
+    ).toBeDefined();
+  });
 });


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Email displayed in **app/javascript/chat/ChatChannelSettings/ModFaqSection.jsx** is now replaced with link to /contact page but it was still taking in email prop which it does not use. This PR removes that email prop

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/11109

## Added tests?

- [x] Yes
- [ ] No, and this is why
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed
