### PR TITLE
Autoresize on comment textarea + comment submit on `CMD/CTRL+Return`

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -179,6 +179,11 @@ function handleCommentSubmit(event) {
   event.preventDefault();
   var form = event.target;
   form.classList.add('submitting');
+  var textarea = form.getElementsByClassName('comment-textarea')[0];
+  if (textarea) {
+    textarea.style.height = null;
+    textarea.blur();
+  }
   var parentComment = document.getElementById("comment-node-" + event.target.dataset.commentId);
 
   var body = JSON.stringify({
@@ -392,7 +397,8 @@ function handleFormClose(event) {
 
 function handleSizeChange(event) {
   var textarea = event.target;
-  textarea.style.height = textarea.scrollHeight + "px";
+  var oldHeight = parseInt(textarea.style.height.replace('px',''));
+  textarea.style.height = textarea.scrollHeight + (textarea.scrollHeight > oldHeight ? 15 : 0) + "px";
 }
 
 function handleButtonsActivation(event) {

--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -341,7 +341,7 @@ function replaceSelectedText(textArea, text) {
 
     // IE 8-10
     else if(document.selection) {
-      t ieRange = document.selection.createRange();
+      const ieRange = document.selection.createRange();
       ieRange.text = text;
 
       // Move cursor after the inserted text

--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -126,6 +126,7 @@ function initializeCommentsPage() {
               commentWrapper = event.target.closest('.inner-comment');
               commentWrapper.classList.add("replying");
               commentWrapper.innerHTML += buildCommentFormHTML(commentableId, commentableType, parentId);
+              initializeCommentsPage();
               
               setTimeout(function () {
                 commentWrapper.getElementsByTagName('textarea')[0].focus();
@@ -221,8 +222,7 @@ function handleCommentSubmit(event) {
           else if (mainCommentsForm) {
             var mainCommentsForm = document.getElementById("new_comment");
             mainCommentsForm.classList.remove("submitting");
-            const textArea = document.getElementById("text-area");
-            textArea.classList.remove('embiggened-max', 'embiggened-more', 'embiggened');
+            const textArea = form.querySelector(".comment-textarea");
             textArea.closest('.comment-form').classList.remove('comment-form--initiated');
             textArea.value = newComment.comment_template || "";
             var preview = document.getElementById("preview-div");
@@ -275,15 +275,6 @@ function handleFocus(event) {
   }
 }
 
-function handleBlur(event) {
-  setTimeout(function () {
-    var el = document.getElementById('text-area');
-    if (el.value.length == 0) {
-      el.classList.remove('embiggened-max', 'embiggened-more', 'embiggened');
-    }
-  }, 100);
-}
-
 function handleKeyUp(event) {
   handleSizeChange(event);
   handleButtonsActivation(event);
@@ -299,10 +290,7 @@ function handleSubmit(event) {
 
   var codeOfConduct = user.checked_code_of_conduct;
   if (codeOfConduct && event.target.value.trim() !== '') {
-    // get a reference to the submit button for the text area (first level comment vs. reply comment)
-    var parentFormId = event.target.parentElement.parentElement.id || event.target.parentElement.id;
-    var submitButton = document.querySelector('#' + parentFormId + ' button[type="submit"].comment-action-button');
-    submitButton.click();
+    event.target.closest('form').querySelector('button[type="submit"]').click();
   }
 }
 
@@ -353,7 +341,7 @@ function replaceSelectedText(textArea, text) {
 
     // IE 8-10
     else if(document.selection) {
-      const ieRange = document.selection.createRange();
+      t ieRange = document.selection.createRange();
       ieRange.text = text;
 
       // Move cursor after the inserted text
@@ -403,19 +391,8 @@ function handleFormClose(event) {
 }
 
 function handleSizeChange(event) {
-  var lines = event.target.value.split(/\r*\n/);
   var textarea = event.target;
-  var lineCount = lines.length;
-  if (lineCount > 10) {
-    textarea.classList.add('embiggened-max');
-    textarea.classList.remove('embiggened-more', 'embiggened');
-  } else if (lineCount > 3) {
-    textarea.classList.add('embiggened-more');
-    textarea.classList.remove('embiggened-max', 'embiggened');
-  } else {
-    textarea.classList.add('embiggened');
-    textarea.classList.remove('embiggened-more', 'embiggened-max');
-  }
+  textarea.style.height = textarea.scrollHeight + "px";
 }
 
 function handleButtonsActivation(event) {
@@ -431,8 +408,9 @@ function handleButtonsActivation(event) {
 }
 
 function validateField(event) {
-  if (document.getElementById('text-area')) {
-    var commentField = document.getElementById('text-area').value;
+  var textarea = event.target.closest('.comment-form').querySelector('.comment-textarea');
+  if (textarea) {
+    var commentField = textarea.value;
     if (commentField == '') {
       event.preventDefault();
     }

--- a/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
@@ -18,7 +18,7 @@ function buildCommentFormHTML(commentableId, commentableType, parentId) {
       <input value="${parentId}" type="hidden" name="comment[parent_id]" id="comment_parent_id" />
       <div class="comment-form__inner">
         <div class="comment-form__field">
-          <textarea id="textarea-for-${parentId}" class="crayons-textfield crayons-textfield--ghost comment-textarea" name="comment[body_markdown]" id="comment_body_markdown" placeholder="Reply..." required onkeydown="handleKeyDown.bind(this)(event)" onfocus="handleFocus.bind(this)(event)" oninput="handleChange.bind(this)(event)"></textarea>
+          <textarea id="textarea-for-${parentId}" class="crayons-textfield crayons-textfield--ghost comment-textarea" name="comment[body_markdown]" placeholder="Reply..." required="required" onkeydown="handleKeyDown(event)" onfocus="handleFocus(event)" oninput="handleChange(event)" onkeykup="handleSizeChange(event)"></textarea>
           <div class="comment-form__toolbar">
             <div class="editor-image-upload">
               <input type="file" id="image-upload-${randomIdNumber}"  name="file" accept="image/*" style="display:none">

--- a/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
@@ -18,7 +18,7 @@ function buildCommentFormHTML(commentableId, commentableType, parentId) {
       <input value="${parentId}" type="hidden" name="comment[parent_id]" id="comment_parent_id" />
       <div class="comment-form__inner">
         <div class="comment-form__field">
-          <textarea id="textarea-for-${parentId}" class="crayons-textfield crayons-textfield--ghost comment-textarea" name="comment[body_markdown]" placeholder="Reply..." required="required" onkeydown="handleKeyDown(event)" onfocus="handleFocus(event)" oninput="handleChange(event)" onkeykup="handleSizeChange(event)"></textarea>
+          <textarea id="textarea-for-${parentId}" class="crayons-textfield crayons-textfield--ghost comment-textarea" name="comment[body_markdown]" placeholder="Reply..." required="required" onkeydown="handleKeyDown(event)" onfocus="handleFocus(event)" oninput="handleChange(event)" onkeykup="handleKeyUp(event)"></textarea>
           <div class="comment-form__toolbar">
             <div class="editor-image-upload">
               <input type="file" id="image-upload-${randomIdNumber}"  name="file" accept="image/*" style="display:none">

--- a/app/assets/stylesheets/views/comments.scss
+++ b/app/assets/stylesheets/views/comments.scss
@@ -30,16 +30,7 @@
   .comment-textarea {
     resize: vertical;
     padding: 0.5em;
-
-    &.embiggened {
-      height: 96px;
-    }
-    &.embiggened-more {
-      height: 256px;
-    }
-    &.embiggened-max {
-      height: 384px;
-    }
+    max-height: 40vh;
   }
 
   &__toolbar,
@@ -49,7 +40,7 @@
 
   &--initiated {
     .comment-textarea {
-      height: 96px;
+      height: 128px;
     }
   }
 

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -36,12 +36,10 @@
       <%= f.text_area :body_markdown,
                       placeholder: "Add to the discussion",
                       onfocus: "handleFocus(event)",
-                      onblur: "handleBlur(event)",
                       onkeyup: "handleKeyUp(event)",
                       onkeydown: "handleKeyDown(event)",
                       oninput: "handleChange(event)",
                       id: "text-area",
-                      # autofocus: @comment.persisted?,
                       required: true,
                       class: "crayons-textfield comment-textarea crayons-textfield--ghost",
                       'aria-label': "Add a comment to the discussion" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR does two things:

1. Improves autoresizing when writing a comment (not sure why it doesn't work on replying comment form but it also doesn't work currently so at least I'm not breaking it :D...) 
2. Brings back possibility to to hit CMD+Return to submit a comment.

## Related Tickets & Documents

- Closes #10829 
- Closes #11086 

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] Yes
- [x] Not needed.
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed
