### PR TITLE
A11y: Add shortcut to bookmark an article

### DIFF
--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -237,7 +237,9 @@ function buildArticleHTML(article) {
     var saveButton = '';
     if (article.class_name === 'Article') {
       saveButton =
-        '<button type="button" class="crayons-btn crayons-btn--secondary crayons-btn--s bookmark-button" data-reactable-id="' +
+        '<button type="button" id="article-save-button-' +
+        article.id +
+        '" class="crayons-btn crayons-btn--secondary crayons-btn--s bookmark-button" data-reactable-id="' +
         article.id +
         '">\
                       <span class="bm-initial">Save</span>\

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -197,6 +197,7 @@ Object {
                     class="crayons-btn crayons-btn--s crayons-btn--secondary"
                     data-initial-feed="true"
                     data-reactable-id="62407"
+                    id="article-save-button-62407"
                     type="button"
                   >
                     Save
@@ -402,6 +403,7 @@ Object {
                   class="crayons-btn crayons-btn--s crayons-btn--secondary"
                   data-initial-feed="true"
                   data-reactable-id="62407"
+                  id="article-save-button-62407"
                   type="button"
                 >
                   Save

--- a/app/javascript/articles/components/SaveButton.jsx
+++ b/app/javascript/articles/components/SaveButton.jsx
@@ -37,6 +37,7 @@ export class SaveButton extends Component {
       return (
         <button
           type="button"
+          id={`article-save-button-${article.id}`}
           className={`crayons-btn crayons-btn--s ${
             isBookmarked ? 'crayons-btn--ghost' : 'crayons-btn--secondary'
           }`}

--- a/app/javascript/packs/homePageFeed.jsx
+++ b/app/javascript/packs/homePageFeed.jsx
@@ -82,7 +82,7 @@ export const renderFeed = (timeFrame) => {
 
         const [featuredStory, ...subStories] = feedItems;
         const feedStyle = JSON.parse(document.body.dataset.user).feed_style;
-        if(featuredStory) {
+        if (featuredStory) {
           sendFeaturedArticleAnalytics(featuredStory.id);
         }
 
@@ -91,14 +91,15 @@ export const renderFeed = (timeFrame) => {
         // 3. Rest of the stories for the feed
         return (
           <div>
-            {featuredStory && 
-            <Article
-              {...commonProps}
-              article={featuredStory}
-              isFeatured
-              feedStyle={feedStyle}
-              isBookmarked={bookmarkedFeedItems.has(featuredStory.id)}
-            />}
+            {featuredStory && (
+              <Article
+                {...commonProps}
+                article={featuredStory}
+                isFeatured
+                feedStyle={feedStyle}
+                isBookmarked={bookmarkedFeedItems.has(featuredStory.id)}
+              />
+            )}
             {podcastEpisodes.length > 0 && (
               <PodcastEpisodes episodes={podcastEpisodes} />
             )}

--- a/app/javascript/packs/homePageFeedShortcuts.jsx
+++ b/app/javascript/packs/homePageFeedShortcuts.jsx
@@ -1,0 +1,21 @@
+import { h, render } from 'preact';
+import { KeyboardShortcuts } from '../shared/components/useKeyboardShortcuts';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.querySelector('#articles-list');
+
+  render(
+    <KeyboardShortcuts
+      shortcuts={{
+        b: (event) => {
+          const article = event.target?.closest('.crayons-story');
+
+          if (!article) return;
+
+          article.querySelector('button[id^=article-save-button-]')?.click();
+        },
+      }}
+    />,
+    root,
+  );
+});

--- a/app/javascript/packs/signupModalShortcuts.jsx
+++ b/app/javascript/packs/signupModalShortcuts.jsx
@@ -1,0 +1,18 @@
+import { h, render } from 'preact';
+import { KeyboardShortcuts } from '../shared/components/useKeyboardShortcuts';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.querySelector('#global-signup-modal');
+
+  render(
+    <KeyboardShortcuts
+      shortcuts={{
+        Escape() {
+          const modal = document.querySelector('#global-signup-modal');
+          modal?.classList.add('hidden');
+        },
+      }}
+    />,
+    root,
+  );
+});

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -86,7 +86,7 @@
           <small class="crayons-story__tertiary fs-xs mr-2">
             <%= story.reading_time < 1 ? 1 : story.reading_time %> min read
           </small>
-          <button type="button" class="crayons-btn crayons-btn--secondary crayons-btn--s bookmark-button" data-reactable-id="<%= story.id %>" aria-label="Save to reading list" title="Save to reading list">
+          <button type="button" id="article-save-button-<%= story.id %>" class="crayons-btn crayons-btn--secondary crayons-btn--s bookmark-button" data-reactable-id="<%= story.id %>" aria-label="Save to reading list" title="Save to reading list">
             <span class="bm-initial">Save</span>
             <span class="bm-success">Saved</span>
           </button>

--- a/app/views/layouts/_signup_modal.html.erb
+++ b/app/views/layouts/_signup_modal.html.erb
@@ -42,3 +42,5 @@
   </div>
   <div class="crayons-modal__overlay"></div>
 </div>
+
+<%= javascript_packs_with_chunks_tag "signupModalShortcuts", defer: true %>

--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -19,3 +19,5 @@
     <div class="single-article-small-pic" id="article-index-hidden-div" style="display:none"></div>
   <% end %>
 </div>
+
+<%= javascript_packs_with_chunks_tag "homePageFeedShortcuts", defer: true %>


### PR DESCRIPTION
##  What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a shortcut on `b` (for now?) to save an article as long as the user is focused somewhere inside the article.

Also adds a shortcut on the signup modal to close it on `Escape` keypress. It helps to keep the navigation mouseless after pressing `b`.

This will be more useful once #10468 is merged, but it can live on its own.

Also, `b` is to discuss here. Other options have been discussed such as `ctrl+s`.

## Related Tickets & Documents

Closes #11018 

## QA Instructions, Screenshots, Recordings

1. Focus on article (anywhere inside)
2. Press `b`
3. Article is saved/unsaved
    - Logged in: actually saves it
    - Logged out: Opens the signup modal

## Added tests?

- [ ] Yes
- [x] No, and this is why: not needed
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/pOKrXLf9N5g76/giphy.gif)
