### PR TITLE
Remove the hardcoded /future redirect + add the redirect back to only Forem as a pre/post deployment task

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -99,7 +99,6 @@
       '/embed/',               // Don't fetch for embeded content.
       '/enter',                // Don't run on registration.
       '/feed',                 // Skip the RSS feed
-      '/future',               // Skip for /future.
       '/i/',                   // Ignore locally stored image path
       '/images/',              // Ignore nginx proxy path
       '/internal',             // redirects

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -357,8 +357,6 @@ Rails.application.routes.draw do
     get "/async_info/base_data", controller: "async_info#base_data", defaults: { format: :json }
     get "/async_info/shell_version", controller: "async_info#shell_version", defaults: { format: :json }
 
-    get "/future", to: redirect("devteam/the-future-of-dev-160n")
-
     # Settings
     post "users/update_language_settings" => "users#update_language_settings"
     post "users/join_org" => "users#join_org"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Some Forems may want to use the /future url as part of their forems, hence we want to make /future available to all Forems, whilst keeping it reserved on DEV to redirect to the necessary post. 

## Related Tickets & Documents
We did the same thing for route /forem https://github.com/forem/forem/pull/11083

## QA Instructions, Screenshots, Recordings
After pulling down this PR the route should no longer redirect to the hardcoded link.

## Added tests?

- [ ] Yes
- [x] No, because we're simply removing a route here that was not tested previously.
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
This can be done pre deployment.

We still want this to work on DEV so we want to create Page that will create the redirect on DEV. It can  be done through the interface of the console. See below:
```
Page.create(
 title: "Future Redirect",
 body_html: "<script>window.location.href = 'https://dev.to/devteam/the-future-of-dev-160n'</script>",
 slug: "future",
 description: "Redirect the future link to an article written on DEV",
 template: "contained",
 is_top_level_path: true
)
```

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/Nm8ZPAGOwZUQM/giphy.gif)
