### PR TITLE
Updated gitdocs.json links to `https`

### DIFF
--- a/docs/.gitdocs.json
+++ b/docs/.gitdocs.json
@@ -18,13 +18,13 @@
     },
     {
       "title": "Ruby doc",
-      "href": "http://docs.forem.com/ruby-doc",
+      "href": "https://docs.forem.com/ruby-doc",
       "target": "_blank",
       "rel": "noopener noreferrer nofollow"
     },
     {
       "title": "API doc",
-      "href": "http://docs.forem.com/api",
+      "href": "https://docs.forem.com/api",
       "target": "_blank",
       "rel": "noopener noreferrer nofollow"
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ X ] Documentation Update

## Description
Updated gitdocs.json links to `https`
The links for `ruby` and `api` on the [docs](https://docs.dev.to/) had an insecure http link.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] Yes
- [X] No, and this is why: Not needed
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [X] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![https gif](https://media.giphy.com/media/KZYTMerDWCEKK9sV4Q/giphy.gif)
