### PR TITLE
Updating theme dynamically without manual refresh

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -1,3 +1,5 @@
+//= require jquery
+//= require jquery_ujs
 //= require_tree ./initializers
 //= require_tree ./utilities
 //= require lib/xss

--- a/app/assets/javascripts/utilities/updateStyles.js
+++ b/app/assets/javascripts/utilities/updateStyles.js
@@ -1,0 +1,6 @@
+async function updateStyles(theme) {
+  const css = await fetch(`https://dev.to/assets/themes/${theme}.css`);
+
+  let string = await css.text();
+  document.getElementById('body-styles').innerHTML = `<style>${string}</style>`;
+}

--- a/app/views/users/_ux.html.erb
+++ b/app/views/users/_ux.html.erb
@@ -62,3 +62,19 @@
     <button class="crayons-btn" type="submit">Save</button>
   </div>
 <% end %>
+<script>
+  document.getElementById("user_config_theme_default").onclick = function() {
+    updateStyles("minimal");
+  };
+  var config_themes = ["night", "minimal_light", "pink", "ten_x_hacker"];
+  for( let theme of config_themes){
+    document.getElementById(`user_config_theme_${theme}_theme`).onclick = function() {
+      if (theme === "ten_x_hacker"){
+        theme = "hacker";
+      } else if( theme === "minimal_light" ) {
+        theme = "minimal";
+      }
+      updateStyles(theme);
+    };
+  }
+</script>

--- a/app/views/users/_ux.html.erb
+++ b/app/views/users/_ux.html.erb
@@ -1,6 +1,6 @@
 <%= javascript_packs_with_chunks_tag "stickySaveFooter", defer: true %>
 
-<%= form_for @user, html: { id: "ux-customization-form", class: "sticky-footer-form grid gap-6" } do |f| %>
+<%= form_for @user, remote: true, authenticity_token: true, html: { id: "ux-customization-form", class: "sticky-footer-form grid gap-6" } do |f| %>
   <div class="crayons-card crayons-card--content-rows">
     <h2>Style Customization</h2>
 

--- a/app/views/users/update.js.erb
+++ b/app/views/users/update.js.erb
@@ -1,0 +1,6 @@
+var selected_theme = "<%= @user.decorate.config_body_class %>";
+localStorage.setItem(
+  'config_body_class',
+  selected_theme
+);
+window.location.reload();


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Instead of manually refreshing the page after saving the theme. This ticket fixes it and changes the theme dynamically on save. 

## Related Tickets & Documents
Closes #3613

## QA Instructions, Screenshots, Recordings
- Go to User's Settings page.
- Navigate to UX tab, select some theme.
- Theme should get updated website wide.
- [Loom Recording](https://www.loom.com/share/2503b9e5c9d5457692bfbfee861e393c)
## Added tests?

- [ ] Yes
- [x] Its a bug fix which doesn't need test case.
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed

