### PR TITLE
Add default for main_social_image

### DIFF
--- a/app/controllers/concerns/verify_setup_completed.rb
+++ b/app/controllers/concerns/verify_setup_completed.rb
@@ -7,7 +7,6 @@ module VerifySetupCompleted
     community_name
     community_description
 
-    main_social_image
     logo_png
     logo_svg
 

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -60,11 +60,12 @@ module URL
     nil
   end
 
-  # Creatres an Image URL - a shortcut for the .image_url helper
+  # Creates an Image URL - a shortcut for the .image_url helper
   #
   # @param image_name [String] the image file name
-  def self.local_image(image_name)
-    host = ActionController::Base.asset_host ||= url(nil)
+  # @param host [String] (optional) the host for the image URL you'd like to use
+  def self.local_image(image_name, host: nil)
+    host ||= ActionController::Base.asset_host || url(nil)
     ActionController::Base.helpers.image_url(image_name, host: host)
   end
 

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -7,7 +7,11 @@ module URL
   end
 
   def self.domain
-    SiteConfig.respond_to?(:app_domain) ? SiteConfig.app_domain : ApplicationConfig["APP_DOMAIN"]
+    if Rails.application&.initialized? && SiteConfig.respond_to?(:app_domain)
+      SiteConfig.app_domain
+    else
+      ApplicationConfig["APP_DOMAIN"]
+    end
   end
 
   def self.url(uri = nil)

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -7,7 +7,7 @@ module URL
   end
 
   def self.domain
-    Rails.application&.initialized? ? SiteConfig.app_domain : ApplicationConfig["APP_DOMAIN"]
+    SiteConfig.respond_to?(:app_domain) ? SiteConfig.app_domain : ApplicationConfig["APP_DOMAIN"]
   end
 
   def self.url(uri = nil)
@@ -60,7 +60,8 @@ module URL
   #
   # @param image_name [String] the image file name
   def self.local_image(image_name)
-    ActionController::Base.helpers.image_url(image_name)
+    host = ActionController::Base.asset_host ||= url(nil)
+    ActionController::Base.helpers.image_url(image_name, host: host)
   end
 
   def self.organization(organization)

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -7,7 +7,7 @@ module URL
   end
 
   def self.domain
-    SiteConfig.respond_to?(:app_domain) ? SiteConfig.app_domain : ApplicationConfig["APP_DOMAIN"]
+    Rails.application&.initialized? ? SiteConfig.app_domain : ApplicationConfig["APP_DOMAIN"]
   end
 
   def self.url(uri = nil)
@@ -56,11 +56,11 @@ module URL
     nil
   end
 
-  # Creates an Image URL - a shortcut for the .image_url helper
+  # Creatres an Image URL - a shortcut for the .image_url helper
   #
   # @param image_name [String] the image file name
   def self.local_image(image_name)
-    host = ActionController::Base.asset_host ||= url(nil)
+    host = ActionController::Base.asset_host ||= "#{protocol}#{ENV['APP_DOMAIN']}"
     ActionController::Base.helpers.image_url(image_name, host: host)
   end
 

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -60,7 +60,7 @@ module URL
   #
   # @param image_name [String] the image file name
   def self.local_image(image_name)
-    host = ActionController::Base.asset_host ||= "#{protocol}#{ENV['APP_DOMAIN']}"
+    host = ActionController::Base.asset_host ||= "#{protocol}#{ApplicationConfig['APP_DOMAIN']}"
     ActionController::Base.helpers.image_url(image_name, host: host)
   end
 

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -56,6 +56,13 @@ module URL
     nil
   end
 
+  # Creatres an Image URL - a shortcut for the .image_url helper
+  #
+  # @param image_name [String] the image file name
+  def self.local_image(image_name)
+    ActionController::Base.helpers.image_url(image_name)
+  end
+
   def self.organization(organization)
     url(organization.slug)
   end

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -7,7 +7,7 @@ module URL
   end
 
   def self.domain
-    Rails.application&.initialized? ? SiteConfig.app_domain : ApplicationConfig["APP_DOMAIN"]
+    SiteConfig.respond_to?(:app_domain) ? SiteConfig.app_domain : ApplicationConfig["APP_DOMAIN"]
   end
 
   def self.url(uri = nil)
@@ -60,7 +60,7 @@ module URL
   #
   # @param image_name [String] the image file name
   def self.local_image(image_name)
-    host = ActionController::Base.asset_host ||= "#{protocol}#{ApplicationConfig['APP_DOMAIN']}"
+    host = ActionController::Base.asset_host ||= url(nil)
     ActionController::Base.helpers.image_url(image_name, host: host)
   end
 

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -56,7 +56,7 @@ module URL
     nil
   end
 
-  # Creatres an Image URL - a shortcut for the .image_url helper
+  # Creates an Image URL - a shortcut for the .image_url helper
   #
   # @param image_name [String] the image file name
   def self.local_image(image_name)

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -12,6 +12,7 @@ class SiteConfig < RailsSettings::Base
 
   STACK_ICON = File.read(Rails.root.join("app/assets/images/stack.svg")).freeze
   LIGHTNING_ICON = File.read(Rails.root.join("app/assets/images/lightning.svg")).freeze
+  MAIN_SOCIAL_IMAGE = File.read(Rails.root.join("app/assets/images/social-media-cover.png")).freeze
 
   # Meta
   field :admin_action_taken_at, type: :datetime, default: Time.current
@@ -84,7 +85,7 @@ class SiteConfig < RailsSettings::Base
   field :recaptcha_secret_key, type: :string, default: ApplicationConfig["RECAPTCHA_SECRET"]
 
   # Images
-  field :main_social_image, type: :string
+  field :main_social_image, type: :string, default: MAIN_SOCIAL_IMAGE
   field :favicon_url, type: :string, default: "favicon.ico"
   field :logo_png, type: :string
   field :logo_svg, type: :string

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -12,7 +12,7 @@ class SiteConfig < RailsSettings::Base
 
   STACK_ICON = File.read(Rails.root.join("app/assets/images/stack.svg")).freeze
   LIGHTNING_ICON = File.read(Rails.root.join("app/assets/images/lightning.svg")).freeze
-  MAIN_SOCIAL_IMAGE = File.read(Rails.root.join("app/assets/images/social-media-cover.png")).freeze
+  MAIN_SOCIAL_IMAGE = ActionController::Base.helpers.image_url("social-media-cover.png").freeze
 
   # Meta
   field :admin_action_taken_at, type: :datetime, default: Time.current

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -12,7 +12,7 @@ class SiteConfig < RailsSettings::Base
 
   STACK_ICON = File.read(Rails.root.join("app/assets/images/stack.svg")).freeze
   LIGHTNING_ICON = File.read(Rails.root.join("app/assets/images/lightning.svg")).freeze
-  MAIN_SOCIAL_IMAGE = ActionController::Base.helpers.image_url("social-media-cover.png").freeze
+  MAIN_SOCIAL_IMAGE = URL.local_image("social-media-cover.png").freeze
 
   # Meta
   field :admin_action_taken_at, type: :datetime, default: Time.current

--- a/spec/lib/url_spec.rb
+++ b/spec/lib/url_spec.rb
@@ -95,4 +95,49 @@ RSpec.describe URL, type: :lib do
       expect(described_class.tag(tag, 2)).to eq("https://dev.to/t/#{tag.name}/page/2")
     end
   end
+
+  describe ".local_image" do
+    let(:image_name) { "social-media-cover" }
+    let(:image_extension) { ".png" }
+    let(:image_file) { image_name + image_extension }
+    let(:test_host) { "https://test-host.com" }
+
+    # Rails "fingerprints" the assets so /social-media-cover.png is actually
+    # /social-media-cover-a1b2c3.png. Therefore, we use regex to match the file
+    # names in these specs.
+    it "returns the correct URL for an image name with no host" do
+      image_url_regex = %r{
+        #{ApplicationConfig["APP_PROTOCOL"]} # https://
+        #{SiteConfig.app_domain}/            # dev.to
+        assets/                              # assets/ directory
+        #{image_name}-                       # social-media-cover
+        [a-f0-9]*                            # letters and numbers
+        #{image_extension}                   # .png
+      }x
+      expect(described_class.local_image(image_file)).to match(image_url_regex)
+    end
+
+    it "returns the correct URL for an image when a host is provided" do
+      image_url_regex = %r{
+        #{test_host}/      # https://test-host.com
+        assets/            # assets/ directory
+        #{image_name}-     # social-media-cover
+        [a-f0-9]*          # letters and numbers
+        #{image_extension} # .png
+      }x
+      expect(described_class.local_image(image_file, host: test_host)).to match(image_url_regex)
+    end
+
+    it "returns the correct URL for an image when an asset_host is defined" do
+      allow(ActionController::Base).to receive(:asset_host).and_return(test_host)
+      image_url_regex = %r{
+        #{test_host}/      # https://test-host.com
+        assets/            # assets/ directory
+        #{image_name}-     # social-media-cover
+        [a-f0-9]*          # letters and numbers
+        #{image_extension} # .png
+      }x
+      expect(described_class.local_image(image_file)).to match(image_url_regex)
+    end
+  end
 end

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe "/admin/config", type: :request do
 
       describe "Images" do
         it "updates main_social_image" do
-          expected_default_image_url = ActionController::Base.helpers.image_url("social-media-cover.png")
+          expected_default_image_url = URL.local_image("social-media-cover.png")
           expect(SiteConfig.main_social_image).to eq(expected_default_image_url)
 
           expected_image_url = "https://dummyimage.com/300x300"

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -213,6 +213,9 @@ RSpec.describe "/admin/config", type: :request do
 
       describe "Images" do
         it "updates main_social_image" do
+          expected_default_image_url = ActionController::Base.helpers.image_url("social-media-cover.png")
+          expect(SiteConfig.main_social_image).to eq(expected_default_image_url)
+
           expected_image_url = "https://dummyimage.com/300x300"
           post "/admin/config", params: { site_config: { main_social_image: expected_image_url },
                                           confirmation: confirmation_message }

--- a/spec/system/admin/admin_manages_configuration_spec.rb
+++ b/spec/system/admin/admin_manages_configuration_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Admin manages configuration", type: :system do
       allow(SiteConfig).to receive(:suggested_users).and_return(nil)
       allow(SiteConfig).to receive(:suggested_tags).and_return(nil)
       visit root_path
-      expect(page.body).to match(/Setup not completed yet, missing(.*)main social image(.*), and others/)
+      expect(page.body).to match(/Setup not completed yet, missing(.*)logo png(.*), and others/)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This PR makes setting the `main_social_image` optional when setting up a Forem by setting a default value in the `SiteConfig`. This is part of @forem/creator-onboarding's efforts to reduce the amount of required configs as much as impossible and follows up on https://github.com/forem/forem/pull/11005 and https://github.com/forem/forem/pull/9747

## Related Tickets & Documents
Closes https://github.com/forem/InternalProjectPlanning/issues/93

## QA Instructions, Screenshots, Recordings
1. Fire up the app locally and navigate to [http://localhost:3000/admin/config](http://localhost:3000/admin/config).
2. Verify that under **Get Started** you no longer see a **Main social image** field.
3. Verify that under **Images** you see the default value set for **Main social image**
![Screen Shot 2020-10-27 at 4 37 07 PM](https://user-images.githubusercontent.com/15987080/97359355-0474c800-1873-11eb-8b00-642e5d1f6298.png)

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![unsure_gif](https://media.giphy.com/media/5t9wJjyHAOxvnxcPNk/giphy.gif)
