### PR TITLE
Grab email for existing Twitter users if previous email was blank

### DIFF
--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -130,6 +130,9 @@ module Authentication
       user.tap do |model|
         user.unlock_access! if user.access_locked?
         user.assign_attributes(provider.existing_user_data)
+        if user.email.blank? && provider.name == "twitter"
+          user.update_column(:email, provider.get_email)
+        end
 
         update_profile_updated_at(model)
 

--- a/app/services/authentication/providers/twitter.rb
+++ b/app/services/authentication/providers/twitter.rb
@@ -28,6 +28,10 @@ module Authentication
         }
       end
 
+      def get_email
+        info.email.to_s
+      end
+
       def self.settings_url
         SETTINGS_URL
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
So there's an edge case where Forems that did not enable the correct permissions for getting the user's email address through the Twitter OAuth process were not able to get the user's email.

This PR fixes it, but it may not be the _best_ way to do so. First, it's a monkey patch specific for Twitter as opposed to other providers, and I don't think it's good practice to have code or solutions like this. For this to resolve the problem, users will need to sign in through Twitter again, and the email should pull in properly now. Unfortunately, we can't do anything until they've accepted the new forem-specific Twitter OAuth app's permissions.

## Added tests?
- [x] No, and this is why: it's a monkey patch and sort of a PoC

## Added to documentation?
- [x] No documentation needed