### PR TITLE
Show "Flag user" and "Unpublish Article" button for moderators always

### DIFF
--- a/app/javascript/actionsPanel/actionsPanel.js
+++ b/app/javascript/actionsPanel/actionsPanel.js
@@ -18,8 +18,7 @@ export function addCloseListener() {
 
 export function initializeHeight() {
   document.documentElement.style.height = '100%';
-  document.body.style.cssText =
-    'height: 100%; margin: 0; padding-top: 0; overflow-y: hidden';
+  document.body.style.cssText = 'height: 100%; margin: 0; padding-top: 0;';
   document.getElementById('page-content').style.cssText =
     'margin-top: 0 !important; margin-bottom: 0;';
 }


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

"Flag user" and "Unpublish" button was not always visible but showed up refresh. This PR fixes that and make sure they always show up for moderators in right panel

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/11134

## QA Instructions, Screenshots, Recordings
1. Go to article
2. Open moderator panel
3. "Flag user" and "Unpublish Article" button will showup the first time without refresh

## Added tests?

- [ ] Yes
- [x] No, and this is why: Test is not needed in this case
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed
