### PR TITLE
Encode domain name in pusher channels

### DIFF
--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -64,7 +64,7 @@ export default class Chat extends Component {
     );
 
     this.state = {
-      appName: document.body.dataset.appName,
+      appDomain: document.body.dataset.appDomain,
       messages: [],
       scrolled: false,
       showAlert: false,
@@ -116,7 +116,7 @@ export default class Chat extends Component {
       isMobileDevice,
       channelPaginationNum,
       currentUserId,
-      appName,
+      appDomain,
       messageOffset,
     } = this.state;
 
@@ -127,13 +127,13 @@ export default class Chat extends Component {
     );
     this.subscribeChannelsToPusher(
       channelsForPusherSub,
-      (channel) => `open-channel--${appName}-${channel.chat_channel_id}`,
+      (channel) => `open-channel--${appDomain}-${channel.chat_channel_id}`,
     );
 
     setupObserver(this.observerCallback);
 
     this.subscribePusher(
-      `private-message-notifications--${appName}-${currentUserId}`,
+      `private-message-notifications--${appDomain}-${currentUserId}`,
     );
 
     if (activeChannelId) {
@@ -236,7 +236,7 @@ export default class Chat extends Component {
   messageOpened = () => {};
 
   loadChannels = (channels, query) => {
-    const { activeChannelId, appName } = this.state;
+    const { activeChannelId, appDomain } = this.state;
     const activeChannel =
       this.state.activeChannel ||
       channels.filter(
@@ -285,11 +285,11 @@ export default class Chat extends Component {
     }
     this.subscribeChannelsToPusher(
       channels.filter(this.channelTypeFilterFn('open')),
-      (channel) => `open-channel--${appName}-${channel.chat_channel_id}`,
+      (channel) => `open-channel--${appDomain}-${channel.chat_channel_id}`,
     );
     this.subscribeChannelsToPusher(
       channels.filter(this.channelTypeFilterFn('invite_only')),
-      (channel) => `private-channel--${appName}-${channel.chat_channel_id}`,
+      (channel) => `private-channel--${appDomain}-${channel.chat_channel_id}`,
     );
     const chatChannelsList = document.getElementById(
       'chatchannels__channelslist',
@@ -346,7 +346,7 @@ export default class Chat extends Component {
   };
 
   setupChannel = (channelId) => {
-    const { messages, messageOffset, activeChannel, appName } = this.state;
+    const { messages, messageOffset, activeChannel, appDomain } = this.state;
     if (
       !messages[channelId] ||
       messages[channelId].length === 0 ||
@@ -361,9 +361,9 @@ export default class Chat extends Component {
         null,
       );
       if (activeChannel.channel_type === 'open')
-        this.subscribePusher(`open-channel--${appName}-${channelId}`);
+        this.subscribePusher(`open-channel--${appDomain}-${channelId}`);
     }
-    this.subscribePusher(`private-channel--${appName}-${channelId}`);
+    this.subscribePusher(`private-channel--${appDomain}-${channelId}`);
   };
 
   setOpenChannelUsers = (res) => {

--- a/app/javascript/utilities/connect/getUnopenedChannels.jsx
+++ b/app/javascript/utilities/connect/getUnopenedChannels.jsx
@@ -23,9 +23,9 @@ class UnopenedChannelNotice extends Component {
 
   componentDidMount() {
     const { pusherKey } = this.props;
-    const appName = document.body.dataset.appName;
+    const appDomain = document.body.dataset.appDomain;
     setupPusher(pusherKey, {
-      channelId: `private-message-notifications--${appName}-${window.currentUser.id}`,
+      channelId: `private-message-notifications--${appDomain}-${window.currentUser.id}`,
       messageCreated: this.receiveNewMessage,
       messageDeleted: this.removeMessage,
       messageEdited: this.updateMessage,

--- a/app/javascript/utilities/connect/getUnopenedChannels.jsx
+++ b/app/javascript/utilities/connect/getUnopenedChannels.jsx
@@ -23,7 +23,7 @@ class UnopenedChannelNotice extends Component {
 
   componentDidMount() {
     const { pusherKey } = this.props;
-    const appDomain = document.body.dataset.appDomain;
+    const { appDomain } = document.body.dataset;
     setupPusher(pusherKey, {
       channelId: `private-message-notifications--${appDomain}-${window.currentUser.id}`,
       messageCreated: this.receiveNewMessage,

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -114,9 +114,9 @@ class ChatChannel < ApplicationRecord
   def pusher_channels
     # TODO: use something more unique here (uuid?) rather than just id.
     if invite_only?
-      "private-channel--#{ChatChannel.pusher_valid_app_domain}-#{id}"
+      "private-channel--#{ChatChannel.urlsafe_encoded_app_domain}-#{id}"
     elsif open?
-      "open-channel--#{ChatChannel.pusher_valid_app_domain}-#{id}"
+      "open-channel--#{ChatChannel.urlsafe_encoded_app_domain}-#{id}"
     else
       chat_channel_memberships.pluck(:user_id).map { |id| ChatChannel.pm_notifications_channel(id) }
     end
@@ -166,11 +166,11 @@ class ChatChannel < ApplicationRecord
   end
 
   def self.pm_notifications_channel(user_id)
-    "private-message-notifications--#{pusher_valid_app_domain}-#{user_id}"
+    "private-message-notifications--#{urlsafe_encoded_app_domain}-#{user_id}"
   end
 
-  def self.pusher_valid_app_domain
-    Base64.strict_encoding64(ApplicationConfig["APP_DOMAIN"])
+  def self.urlsafe_encoded_app_domain
+    Base64.urlsafe_encode64(ApplicationConfig["APP_DOMAIN"])
   end
 
   private

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -170,8 +170,7 @@ class ChatChannel < ApplicationRecord
   end
 
   def self.pusher_valid_app_domain
-    # as of 10/27/2020 this is /[^A-Za-z0-9_\-=@,.;]/
-    ApplicationConfig["APP_DOMAIN"].gsub(Pusher::Channel::INVALID_CHANNEL_REGEX, "")
+    Base64.strict_encoding64(ApplicationConfig["APP_DOMAIN"])
   end
 
   private

--- a/app/models/chat_channel.rb
+++ b/app/models/chat_channel.rb
@@ -114,9 +114,9 @@ class ChatChannel < ApplicationRecord
   def pusher_channels
     # TODO: use something more unique here (uuid?) rather than just id.
     if invite_only?
-      "private-channel--#{ApplicationConfig['APP_DOMAIN']}-#{id}"
+      "private-channel--#{ChatChannel.pusher_valid_app_domain}-#{id}"
     elsif open?
-      "open-channel--#{ApplicationConfig['APP_DOMAIN']}-#{id}"
+      "open-channel--#{ChatChannel.pusher_valid_app_domain}-#{id}"
     else
       chat_channel_memberships.pluck(:user_id).map { |id| ChatChannel.pm_notifications_channel(id) }
     end
@@ -166,7 +166,12 @@ class ChatChannel < ApplicationRecord
   end
 
   def self.pm_notifications_channel(user_id)
-    "private-message-notifications--#{ApplicationConfig['APP_DOMAIN']}-#{user_id}"
+    "private-message-notifications--#{pusher_valid_app_domain}-#{user_id}"
+  end
+
+  def self.pusher_valid_app_domain
+    # as of 10/27/2020 this is /[^A-Za-z0-9_\-=@,.;]/
+    ApplicationConfig["APP_DOMAIN"].gsub(Pusher::Channel::INVALID_CHANNEL_REGEX, "")
   end
 
   private

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -58,7 +58,7 @@
         data-user-status="<%= user_logged_in_status %>"
         class="<%= SiteConfig.default_font.tr("_", "-") %>-article-body default-header"
         data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>"
-        data-app-name="<%= ApplicationConfig["APP_DOMAIN"] %>"
+        data-app-name="<%= ChatChannel.pusher_valid_app_domain %>"
         data-honeybadger-key="<%= ApplicationConfig["HONEYBADGER_JS_API_KEY"] %>"
         data-release-footprint="<%= ApplicationConfig["RELEASE_FOOTPRINT"] %>"
         data-ga-tracking="<%= SiteConfig.ga_tracking_id %>">

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -58,7 +58,7 @@
         data-user-status="<%= user_logged_in_status %>"
         class="<%= SiteConfig.default_font.tr("_", "-") %>-article-body default-header"
         data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>"
-        data-app-name="<%= ChatChannel.pusher_valid_app_domain %>"
+        data-app-name="<%= ChatChannel.urlsafe_encoded_app_domain %>"
         data-honeybadger-key="<%= ApplicationConfig["HONEYBADGER_JS_API_KEY"] %>"
         data-release-footprint="<%= ApplicationConfig["RELEASE_FOOTPRINT"] %>"
         data-ga-tracking="<%= SiteConfig.ga_tracking_id %>">

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -58,7 +58,7 @@
         data-user-status="<%= user_logged_in_status %>"
         class="<%= SiteConfig.default_font.tr("_", "-") %>-article-body default-header"
         data-pusher-key="<%= ApplicationConfig["PUSHER_KEY"] %>"
-        data-app-name="<%= ChatChannel.urlsafe_encoded_app_domain %>"
+        data-app-domain="<%= ChatChannel.urlsafe_encoded_app_domain %>"
         data-honeybadger-key="<%= ApplicationConfig["HONEYBADGER_JS_API_KEY"] %>"
         data-release-footprint="<%= ApplicationConfig["RELEASE_FOOTPRINT"] %>"
         data-ga-tracking="<%= SiteConfig.ga_tracking_id %>">

--- a/spec/models/chat_channel_spec.rb
+++ b/spec/models/chat_channel_spec.rb
@@ -80,4 +80,13 @@ RSpec.describe ChatChannel, type: :model do
       expect(chat_channel.private_org_channel?).to be(false)
     end
   end
+
+  describe "::urlsafe_encoded_app_domain" do
+    it "uses urlsafe base64 encoding" do
+      domain_name = "community.snyk.io"
+      allow(ApplicationConfig).to receive(:[]).with("APP_DOMAIN").and_return(domain_name)
+      encoded_domain_name = described_class.urlsafe_encoded_app_domain
+      expect(Base64.urlsafe_decode64(encoded_domain_name)).to eq(domain_name)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] (development) Bug Fix

## Description
https://github.com/forem/forem/pull/11029 fixed a production issue but broke development.`localhost:3000` is not a valid pusher channel name because Pusher [channel specification](https://github.com/pusher/pusher-http-ruby/blob/master/lib/pusher/channel.rb#L11) doesn't allow colon. I was receiving the following error in development and test:

```
Pusher::Error:
       Illegal channel name 'private-message-notifications--localhost:3000-25'
```

This feature encodes the domain name, which would fix this issue but also provide the added benefit of obfuscating channel names.


## Related Tickets & Documents
This is an additional update to https://github.com/forem/forem/pull/11029

## QA Instructions, Screenshots, Recordings
Prior to this fix you probably can't _send a message and see it appear immediately_ in development.

1. Bootup the app locally and make sure you are logged in.
1. Open up the Rails console. Find the first user and take note of their username ie `User.first.username`.
1. Change their inbox type to open `User.first.update(inbox_type: "open")`
1. Navigate to their profile page (ie `localhost:3000/{User.first.username}`) and click `chat` on the right side of their profile banner.
1. You should be able to see and send messages without issue.

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
nope
