### PR TITLE
Refactor: Run Display Ad Events Controller in all Envs

### DIFF
--- a/app/controllers/display_ad_events_controller.rb
+++ b/app/controllers/display_ad_events_controller.rb
@@ -15,7 +15,7 @@ class DisplayAdEventsController < ApplicationMetalController
   private
 
   def update_display_ads_data
-    return if Rails.env.production? && rand(20) != 1 # We need to do this operation only once in a while.
+    return if skip_ad_update?
 
     @display_ad = DisplayAd.find(display_ad_event_params[:display_ad_id])
 
@@ -32,5 +32,10 @@ class DisplayAdEventsController < ApplicationMetalController
 
   def display_ad_event_params
     params[:display_ad_event].slice(:context_type, :category, :display_ad_id)
+  end
+
+  def skip_ad_update?
+    # We need to do this operation only once in a while.
+    rand(20) != 1
   end
 end

--- a/spec/requests/display_ad_events_spec.rb
+++ b/spec/requests/display_ad_events_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe "DisplayAdEvents", type: :request do
     context "when user signed in" do
       before do
         sign_in user
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(DisplayAdEventsController).to receive(:skip_ad_update?).and_return(false)
+        # rubocop:enable RSpec/AnyInstance
       end
 
       it "creates a display ad click event" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
[This controller was added to help us determine the success of DEV shop ads](https://github.com/forem/forem/pull/3589). I think the `Rails.env.production?` was merely added bc this doesn't have a lot of value locally. However, we should get in the habit of setting up our code so that it runs in all environments. This ensures that we don't miss things bc code paths were not run in test or development. 

## Added tests?
- [x] No bc they already exist and are sufficient 


![alt_text](https://media.tenor.com/images/e02b895afafc7a272b612d2f8583338f/tenor.gif)
