### PR TITLE
Feature:Deploy Forem to DEV on every merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,5 +91,3 @@ jobs:
         api_key: '$HEROKU_AUTH_TOKEN'
         app:
           master: practicaldev
-        on:
-          condition: $TRAVIS_COMMIT_MESSAGE =~ \[deploy\]

--- a/docs/maintainers/deploying.md
+++ b/docs/maintainers/deploying.md
@@ -5,30 +5,23 @@ title: Deployment Guide
 # Deploying Forem
 
 Anyone with the ability to merge PRs on GitHub can deploy the application.
-Remember that this is a shared responsibility, so everyone should deploy code
-occasionally.
+Whenever a PR is merged the code is deployed. When deploying complex code, be
+sure that other team members are around to help if something goes wrong.
 
-If the application needs to be deployed when the code is merged, appending
-`[deploy]` to the merge commit's message will trigger a deploy.
-
-When deploying complex code, be sure that other team members are around to help
-if something goes wrong.
-
-Generally, it's a good idea to keep the SRE team in the loop on any deploys.
-However, deployments are our collective responsibility, so it's important to
-monitor your deploys. You can see deployment status on Travis-ci.com and in the
-#deployment-pipeline channel on Slack. Be prepared to rollback or push a fix for
-any deployment!
+Generally, it's a good idea to keep the SRE team in the loop on high risk
+deploys. However, deployments are our collective responsibility, so it's
+important to monitor your deploys. You can see deployment status on
+Travis-ci.com and in the #deployment-pipeline channel on Slack. Be prepared to
+rollback or push a fix for any deployment!
 
 # Deployment and CI/CD Process
 
 ## Overview
 
 Forem relies on GitHub and Travis to deploy continuously to Heroku. If a Pull
-Request is merged with a `[deploy]` in its title, it will be automatically
-deployed to production once the build steps complete successfully. The process
-currently takes about 20 minutes to complete and will need a few additional
-minutes before the change goes live.
+Request is merged it will automatically be deployed to production once the build
+steps complete successfully. The process currently takes about 20 minutes to
+complete and will need a few additional minutes before the change goes live.
 
 ## Travis Stages
 
@@ -38,8 +31,7 @@ The following stages can be explored in our
 process consists of 2 stages.
 
 1. Running our test suite in 3 parallel jobs.
-2. Deploying the application if we have merged with the master branch and the
-   `[deploy]` flag is present in the merge commit.
+2. Deploying the application.
 
 ### Stage 1: Running Tests
 
@@ -61,9 +53,9 @@ If all of the jobs pass then we move on to Stage 2 of the Travis CI process.
 ### Stage 2: Deploying
 
 If the build was kicked off from a pull request being created or updated this
-stage will do nothing. If the branch has been merged into master with the
-`[deploy]` flag, then this stage will kick off a deploy. The deploy will run in
-its own job deploying our application to Heroku.
+stage will do nothing. If the branch has been merged into master, then this
+stage will kick off a deploy. The deploy will run in its own job deploying our
+application to Heroku.
 
 Prior to deploying the code, Heroku will run database migrations, Elasticsearch
 updates, and do some final checks (more information on that below) to make sure

--- a/docs/maintainers/deploying.md
+++ b/docs/maintainers/deploying.md
@@ -5,8 +5,8 @@ title: Deployment Guide
 # Deploying Forem
 
 Anyone with the ability to merge PRs on GitHub can deploy the application.
-Whenever a PR is merged the code is deployed. When deploying complex code, be
-sure that other team members are around to help if something goes wrong.
+**Whenever a PR is merged the code is deployed. When deploying complex code, be
+sure that other team members are around to help if something goes wrong.**
 
 Generally, it's a good idea to keep the SRE team in the loop on high risk
 deploys. However, deployments are our collective responsibility, so it's


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR is in response to [a great internal team discussion around our deploy strategies](https://forem.team/vaidehijoshi/responsibilities-around-code-deployment-3mdh). Since many people on the team seem to be in favor of a continuous deploy setup I went ahead and created this PR. However, feel free to jump in if you have differing opinions on this! I simply wanted to get a step ahead.

When I first joined, one of the reasons we never went with a full continuous deploy strategy was because Travis did not have the ability to cancel multiple builds. The build and deploy were also one and the same which meant if you wanted to cancel a deploy you had to cancel the CI build which meant not testing the new code. Now that those problems have been fixed thanks to Travis new "Auto Cancel" feature and our new flow of 3 jobs for CI and a separate job for Deploying, I think we can safely turn on continuous deployment and allow Travis help us handle the concurrency when multiple things are merged at once. 

NOTE: This will only deploy continuously to DEV currently. Hooking up Forem deploys will be a whole separate system that we will create.

## PRE Deployment Tasks
* Turn ON Auto-Cancellation in Travis

## POST Deployment Tasks
* Update internal team deploy documentation(or maybe delete it since we have it in our standard docs...) 

![alt_text](https://media.tenor.com/images/6d896d00367f153033e4d135283b1588/tenor.gif)
