### PR TITLE
Add feature flag for profile admin section

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -3,41 +3,6 @@ module Admin
     before_action :authorize_admin
     after_action :verify_authorized
 
-    # This is used in app/views/admin/shared/_navbar.html.erb to build the
-    # side navbar in alphabetical order.
-    MENU_ITEMS = [
-      { name: "articles",              controller: "articles" },
-      { name: "broadcasts",            controller: "broadcasts" },
-      { name: "badges",                controller: "badges" },
-      { name: "badge_achievements",    controller: "badge_achievements" },
-      { name: "chat_channels",         controller: "chat_channels" },
-      { name: "comments",              controller: "comments" },
-      { name: "config",                controller: "config" },
-      { name: "display_ads",           controller: "display_ads" },
-      { name: "events",                controller: "events" },
-      { name: "growth",                controller: "growth" },
-      { name: "html_variants",         controller: "html_variants" },
-      { name: "listings",              controller: "listings" },
-      { name: "moderator_actions",     controller: "moderator_actions" },
-      { name: "mods",                  controller: "mods" },
-      { name: "navigation_links",      controller: "navigation_links" },
-      { name: "privileged_reactions",  controller: "privileged_reactions" },
-      { name: "organizations",         controller: "organizations" },
-      { name: "pages",                 controller: "pages" },
-      { name: "permissions",           controller: "permissions" },
-      { name: "podcasts",              controller: "podcasts" },
-      { name: "config: profile setup", controller: "profile_fields" },
-      { name: "reports",               controller: "reports" },
-      { name: "response_templates",    controller: "response_templates" },
-      { name: "sponsorships",          controller: "sponsorships" },
-      { name: "tags",                  controller: "tags" },
-      { name: "tools",                 controller: "tools" },
-      { name: "users",                 controller: "users" },
-      { name: "vault secrets",         controller: "secrets" },
-      { name: "webhooks",              controller: "webhook_endpoints" },
-      { name: "welcome",               controller: "welcome" },
-    ].sort_by { |menu_item| menu_item[:name] }.freeze
-
     private
 
     def authorization_resource

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -2,6 +2,8 @@ module AdminHelper
   # This is used in app/views/admin/shared/_navbar.html.erb to build the
   # side navbar in alphabetical order. It's also used to display the "menu"
   # in app/vews/admin/admin_portals/index.html.erb.
+  # If you add an item before "config", please update the insert call in
+  # admin_menu_items below.
   MENU_ITEMS = [
     { name: "articles",              controller: "articles" },
     { name: "broadcasts",            controller: "broadcasts" },
@@ -32,16 +34,13 @@ module AdminHelper
     { name: "vault secrets",         controller: "secrets" },
     { name: "webhooks",              controller: "webhook_endpoints" },
     { name: "welcome",               controller: "welcome" },
-  ].freeze
+  ].sort_by { |menu_item| menu_item[:name] }
 
   PROFILE_ADMIN = { name: "config: profile setup", controller: "profile_fields" }.freeze
 
   def admin_menu_items
-    menu_items = if Flipper.enabled?(:profile_admin)
-                   MENU_ITEMS.dup << PROFILE_ADMIN
-                 else
-                   MENU_ITEMS
-                 end
-    menu_items.sort_by { |menu_item| menu_item[:name] }
+    return MENU_ITEMS unless Flipper.enabled?(:profile_admin)
+
+    MENU_ITEMS.dup.insert(7, PROFILE_ADMIN)
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,47 @@
+module AdminHelper
+  # This is used in app/views/admin/shared/_navbar.html.erb to build the
+  # side navbar in alphabetical order It's also used to display the "menu"
+  # in app/views/admin/admin_portals/index.html.erb.
+  MENU_ITEMS = [
+    { name: "articles",              controller: "articles" },
+    { name: "broadcasts",            controller: "broadcasts" },
+    { name: "badges",                controller: "badges" },
+    { name: "badge_achievements",    controller: "badge_achievements" },
+    { name: "chat_channels",         controller: "chat_channels" },
+    { name: "comments",              controller: "comments" },
+    { name: "config",                controller: "config" },
+    { name: "display_ads",           controller: "display_ads" },
+    { name: "events",                controller: "events" },
+    { name: "growth",                controller: "growth" },
+    { name: "html_variants",         controller: "html_variants" },
+    { name: "listings",              controller: "listings" },
+    { name: "moderator_actions",     controller: "moderator_actions" },
+    { name: "mods",                  controller: "mods" },
+    { name: "navigation_links",      controller: "navigation_links" },
+    { name: "privileged_reactions",  controller: "privileged_reactions" },
+    { name: "organizations",         controller: "organizations" },
+    { name: "pages",                 controller: "pages" },
+    { name: "permissions",           controller: "permissions" },
+    { name: "podcasts",              controller: "podcasts" },
+    { name: "reports",               controller: "reports" },
+    { name: "response_templates",    controller: "response_templates" },
+    { name: "sponsorships",          controller: "sponsorships" },
+    { name: "tags",                  controller: "tags" },
+    { name: "tools",                 controller: "tools" },
+    { name: "users",                 controller: "users" },
+    { name: "vault secrets",         controller: "secrets" },
+    { name: "webhooks",              controller: "webhook_endpoints" },
+    { name: "welcome",               controller: "welcome" },
+  ].freeze
+
+  PROFILE_ADMIN = { name: "config: profile setup", controller: "profile_fields" }.freeze
+
+  def admin_menu_items
+    menu_items = if Flipper.enabled?(:profile_admin)
+                   MENU_ITEMS.dup << PROFILE_ADMIN
+                 else
+                   MENU_ITEMS
+                 end
+    menu_items.sort_by { |menu_item| menu_item[:name] }
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,7 +1,7 @@
 module AdminHelper
   # This is used in app/views/admin/shared/_navbar.html.erb to build the
-  # side navbar in alphabetical order It's also used to display the "menu"
-  # in app/views/admin/admin_portals/index.html.erb.
+  # side navbar in alphabetical order. It's also used to display the "menu"
+  # in app/vews/admin/admin_portals/index.html.erb.
   MENU_ITEMS = [
     { name: "articles",              controller: "articles" },
     { name: "broadcasts",            controller: "broadcasts" },

--- a/app/views/admin/admin_portals/index.html.erb
+++ b/app/views/admin/admin_portals/index.html.erb
@@ -1,5 +1,12 @@
   <div class="grid gap-2 m:gap-4 l:gap-6 m:grid-cols-2 l:grid-cols-3 px-2 m:px-0">
-    <% Admin::ApplicationController::MENU_ITEMS.each do |menu_item| %>
+    <%# Temporary code while we use a feature flag for the profile admin. %>
+    <% menu_items = Admin::ApplicationController::MENU_ITEMS.dup %>
+    <% unless Flipper.enabled?(:profile_admin) %>
+      <% index = menu_items.find_index { |item| item[:name] == "config: profile setup" } %>
+      <% menu_items.delete_at(index) %>
+    <% end %>
+
+    <% menu_items.each do |menu_item| %>
       <div class="tag-card crayons-card branded-4 p-4 m:p-6 m:pt-4 flex flex-col relative">
         <h3 class="crayons-tag crayons-tag--l mb-2">
           <a href="/admin/<%= menu_item[:controller] %>" class="crayons-link">

--- a/app/views/admin/admin_portals/index.html.erb
+++ b/app/views/admin/admin_portals/index.html.erb
@@ -1,12 +1,5 @@
   <div class="grid gap-2 m:gap-4 l:gap-6 m:grid-cols-2 l:grid-cols-3 px-2 m:px-0">
-    <%# Temporary code while we use a feature flag for the profile admin. %>
-    <% menu_items = Admin::ApplicationController::MENU_ITEMS.dup %>
-    <% unless Flipper.enabled?(:profile_admin) %>
-      <% index = menu_items.find_index { |item| item[:name] == "config: profile setup" } %>
-      <% menu_items.delete_at(index) %>
-    <% end %>
-
-    <% menu_items.each do |menu_item| %>
+    <% admin_menu_items.each do |menu_item| %>
       <div class="tag-card crayons-card branded-4 p-4 m:p-6 m:pt-4 flex flex-col relative">
         <h3 class="crayons-tag crayons-tag--l mb-2">
           <a href="/admin/<%= menu_item[:controller] %>" class="crayons-link">

--- a/app/views/admin/shared/_navbar.html.erb
+++ b/app/views/admin/shared/_navbar.html.erb
@@ -1,4 +1,4 @@
-<% Admin::ApplicationController::MENU_ITEMS.each do |menu_item| %>
+<% admin_menu_items.each do |menu_item| %>
   <a class="crayons-link crayons-link--block <%= "crayons-link--current" if request.path.split("/")[2].match?(menu_item[:controller]) %>" href="/admin/<%= menu_item[:controller] %>">
     <%= menu_item[:name].to_s.titleize %>
   </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,14 +83,12 @@ Rails.application.routes.draw do
         end
       end
 
-      # NOTE: @citizen428 The next two routes have temporary constraint while
-      # this feature is WIP
-      resources :profile_field_groups,
-                only: %i[update create destroy],
-                constraints: -> { Flipper.enabled?(:profile_admin) }
-      resources :profile_fields,
-                only: %i[index update create destroy],
-                constraints: -> { Flipper.enabled?(:profile_admin) }
+      # NOTE: @citizen428 The next two resources have a temporary constraint
+      # while profile generalization is still WIP
+      constraints(->(_request) { Flipper.enabled?(:profile_admin) }) do
+        resources :profile_field_groups, only: %i[update create destroy]
+        resources :profile_fields, only: %i[index update create destroy]
+      end
       resources :reactions, only: [:update]
       resources :response_templates, only: %i[index new edit create update destroy]
       resources :chat_channels, only: %i[index create update destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,8 +83,14 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :profile_field_groups, only: %i[update create destroy]
-      resources :profile_fields, only: %i[index update create destroy]
+      # NOTE: @citizen428 The next two routes have temporary constraint while
+      # this feature is WIP
+      resources :profile_field_groups,
+                only: %i[update create destroy],
+                constraints: -> { Flipper.enabled?(:profile_admin) }
+      resources :profile_fields,
+                only: %i[index update create destroy],
+                constraints: -> { Flipper.enabled?(:profile_admin) }
       resources :reactions, only: [:update]
       resources :response_templates, only: %i[index new edit create update destroy]
       resources :chat_channels, only: %i[index create update destroy] do

--- a/spec/models/profile_field_group_spec.rb
+++ b/spec/models/profile_field_group_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe ProfileFieldGroup, type: :model do
   subject { group }
 
+  before do
+    allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
+  end
+
   let!(:group) { create(:profile_field_group) }
 
   it { is_expected.to have_many(:profile_fields).dependent(:nullify) }

--- a/spec/requests/admin/admin_portals_spec.rb
+++ b/spec/requests/admin/admin_portals_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "/admin", type: :request do
       expect(response.body).to include("Config: Profile Setup")
     end
 
-    it "does shows the option when the feature flag is enabled" do
+    it "does not show the option when the feature flag is disabled" do
       allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(false)
 
       get admin_path

--- a/spec/requests/admin/admin_portals_spec.rb
+++ b/spec/requests/admin/admin_portals_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "/admin", type: :request do
+  let(:super_admin) { create(:user, :super_admin) }
+
+  before { sign_in super_admin }
+
+  describe "profile admin feature flag" do
+    it "shows the option when the feature flag is enabled" do
+      allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
+
+      get admin_path
+
+      expect(response.body).to include("Config: Profile Setup")
+    end
+
+    it "does shows the option when the feature flag is enabled" do
+      allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(false)
+
+      get admin_path
+
+      expect(response.body).not_to include("Config: Profile Setup")
+    end
+  end
+end

--- a/spec/requests/admin/profile_field_groups_spec.rb
+++ b/spec/requests/admin/profile_field_groups_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "/admin/profile_field_groups", type: :request do
 
   before do
     sign_in admin
+    allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
   end
 
   describe "POST /admin/profile_field_groups" do

--- a/spec/requests/admin/profile_fields_spec.rb
+++ b/spec/requests/admin/profile_fields_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "/admin/profile_fields", type: :request do
 
   before do
     sign_in admin
+    allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
   end
 
   describe "GET /admin/profile_fields" do

--- a/spec/requests/admin/sidebar_spec.rb
+++ b/spec/requests/admin/sidebar_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "admin sidebar", type: :request do
+  let(:super_admin) { create(:user, :super_admin) }
+
+  before { sign_in super_admin }
+
+  describe "profile admin feature flag" do
+    it "shows the option in the sidebar when the feature flag is enabled" do
+      allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
+
+      get admin_articles_path
+
+      expect(response.body).to include("Config: Profile Setup")
+    end
+
+    it "does not show the option in the sidebar when the feature flag is disabled" do
+      allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(false)
+
+      get admin_articles_path
+
+      expect(response.body).not_to include("Config: Profile Setup")
+    end
+  end
+end

--- a/spec/routing/profile_admin_routes_spec.rb
+++ b/spec/routing/profile_admin_routes_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Profile admin routes", type: :routing do
-  let(:user) { create(:super_admin) }
-
   it "renders the profile admin route if the feature flag is enabled" do
     allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
 

--- a/spec/routing/profile_admin_routes_spec.rb
+++ b/spec/routing/profile_admin_routes_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe "Profile admin routes", type: :routing do
+  let(:user) { create(:super_admin) }
+
+  it "renders the profile admin route if the feature flag is enabled" do
+    allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
+
+    expect(get: admin_profile_fields_path).to route_to(
+      controller: "admin/profile_fields",
+      action: "index",
+      locale: nil,
+    )
+  end
+
+  it "does not render the profile admin route if the feature flag is disabled" do
+    allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(false)
+
+    expect(get: admin_profile_fields_path).not_to route_to(
+      controller: "admin/profile_fields",
+      action: "index",
+      locale: nil,
+    )
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a feature flag `:profile_admin` which removes the menu item from the admin index and sidebar and also disables the routes. 

Anyone should feel free to merge this, it has tests for all scenarios.

## Related Tickets & Documents

https://github.com/forem/InternalProjectPlanning/issues/147

## QA Instructions, Screenshots, Recordings

### Admin index:

0. Ensure the feature flag is disabled.
1. Go to `/admin`
2. Ensure that you don't see the profile admin link (it would be right after "Config")
    <img width="1289" alt="Screen Shot 2020-10-29 at 10 15 24" src="https://user-images.githubusercontent.com/47985/97521218-ac070d00-19cf-11eb-8314-ec6c56f648e3.png">
3. Enable the feature flag in the Rails console:
    ```ruby
    Flipper.enable(:profile_admin)
    ```
4. Reload `/admin`, you should now see a "Config: Profile Setup" option:
    <img width="1270" alt="Admin_Portals" src="https://user-images.githubusercontent.com/47985/97521336-eec8e500-19cf-11eb-9adb-4b9302ee277a.png">


### Admin sidebar menu:

0. Ensure the feature flag is disabled.
1. Go an admin page, e.g. `/admin/articles`
2. Ensure that you don't see the profile admin link (it would be right under "Config")
    <img width="319" alt="Screen Shot 2020-10-30 at 11 31 52" src="https://user-images.githubusercontent.com/47985/97660234-851a0b00-1aa3-11eb-9aaf-1c4d26d2eec1.png">
3. Enable the feature flag in the Rails console:
    ```ruby
    Flipper.enable(:profile_admin)
    ```
4. Reload the page, you should now see a "Config: Profile Setup" option:
    <img width="293" alt="Articles" src="https://user-images.githubusercontent.com/47985/97660316-bd214e00-1aa3-11eb-8ff0-8aa932932244.png">

### Routing constraint

0. Ensure the feature flag is disabled.
1. Go to `/admin/profile_fields`
2. You should be redirected to our root route.
3. Enable the feature flag in the Rails console:
    ```ruby
    Flipper.enable(:profile_admin)
    ```
4. Going to `/admin/profile_fields` should now render the profile admin page.

## Added tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [X] No documentation needed
