### PR TITLE
Automatically mark tag supported when adding mod

### DIFF
--- a/app/labor/assign_tag_moderator.rb
+++ b/app/labor/assign_tag_moderator.rb
@@ -17,6 +17,7 @@ module AssignTagModerator
       add_tag_mod_role(user, tag)
       add_trusted_role(user)
       add_to_chat_channels(user, tag)
+      tag.update(supported: true) unless tag.supported?
 
       NotifyMailer.with(user: user, tag: tag, channel_slug: chat_channel_slug(tag))
         .tag_moderator_confirmation_email

--- a/lib/data_update_scripts/20201030015634_make_tags_with_mods_supported.rb
+++ b/lib/data_update_scripts/20201030015634_make_tags_with_mods_supported.rb
@@ -1,0 +1,25 @@
+module DataUpdateScripts
+  class MakeTagsWithModsSupported
+    def run
+      ActiveRecord::Base.connection.execute(<<~SQL.squish)
+        WITH unsupported_tags_with_mods_ids AS (
+          SELECT
+            tags.id
+          FROM
+            tags
+            JOIN roles ON (roles.name = 'tag_moderator'
+                AND resource_id = tags.id)
+          WHERE
+            supported = FALSE)
+        UPDATE
+          tags
+        SET
+          supported = TRUE
+        FROM
+          unsupported_tags_with_mods_ids AS cte
+        WHERE
+          tags.id = cte.id;
+      SQL
+    end
+  end
+end

--- a/spec/labor/assign_tag_moderator_spec.rb
+++ b/spec/labor/assign_tag_moderator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AssignTagModerator, type: :labor do
   let(:user_two) { create(:user) }
   let(:mod_relator) { create(:user) }
   let(:tag_one) { create(:tag) }
-  let(:tag_two) { create(:tag) }
+  let(:tag_two) { create(:tag, supported: false) }
   let!(:channel) do
     create(:chat_channel,
            slug: "tag-moderators",
@@ -66,5 +66,11 @@ RSpec.describe AssignTagModerator, type: :labor do
     it "doesn't raise a NoMethodError error" do
       expect { add_tag_moderators }.not_to raise_error(NoMethodError)
     end
+  end
+
+  it "marks tags as supported if they aren't already" do
+    expect do
+      add_tag_moderators
+    end.to change { tag_two.reload.supported? }.from(false).to(true)
   end
 end

--- a/spec/lib/data_update_scripts/make_tags_with_mods_supported_spec.rb
+++ b/spec/lib/data_update_scripts/make_tags_with_mods_supported_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20201030015634_make_tags_with_mods_supported.rb",
+)
+
+describe DataUpdateScripts::MakeTagsWithModsSupported do
+  let!(:tag1) { create(:tag, name: "Test1", supported: false) }
+  let!(:tag2) { create(:tag, name: "Test2", supported: false) }
+  let!(:user) { create(:user) }
+
+  it "sets tags with moderators to supported", :aggregate_failures do
+    user.add_role(:tag_moderator, tag1)
+
+    expect do
+      described_class.new.run
+    end.to change { tag1.reload.supported? }.from(false).to(true)
+    expect(tag2.reload.supported).to be false
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR automatcally marks tags as supported when a tag mod is added. This removes the burden from admins to manually mark the tag. 

## Related Tickets & Documents

Closes #11140 

## QA Instructions, Screenshots, Recordings

1. Create a tag: `tag = Tag.create(name: "admintest")`
2. Check that it isn't supported: `tag.supported? #=> false`
3. Assign a tag moderator: `AssignTagModerator.add_tag_moderators([User.last.id], [tag.id])`
4. Ensure the tag is now supported: `tag.reload.supported? #=> true`

## Added tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [X] No documentation needed
