### PR TITLE
Refactor:Remove Rails Env Prod Check when Setting Shell Version

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -30,7 +30,7 @@ class AsyncInfoController < ApplicationController
     # shell_version will change on every deploy.
     # *Technically* could be only on changes to assets and shell, but this is more fool-proof.
     shell_version = ApplicationConfig["RELEASE_FOOTPRINT"]
-    render json: { version: Rails.env.production? ? shell_version : rand(1000) }.to_json
+    render json: { version: shell_version }.to_json
   end
 
   def broadcast_data


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Removed another unnecessary `Rails.env.production?` check for shell_version. Locally we are not caching the shell_version so this version being unique is not needed. If we do ever implement surrogate header caching locally that will force us to update this shell_version which I think is a good thing as it is pushing us closer to a production like env. 

## Added tests?
- [x] No, bc no new functionality is being added

![alt_text](https://media2.giphy.com/media/8rXWheJaSY0ak/giphy.gif)
