### PR TITLE
Refactor:Remove Production Conditional for Page View Updates

### DIFF
--- a/app/controllers/page_views_controller.rb
+++ b/app/controllers/page_views_controller.rb
@@ -32,7 +32,7 @@ class PageViewsController < ApplicationMetalController
   private
 
   def update_article_page_views
-    return if Rails.env.production? && rand(15) != 1 # We don't need to update the article page views every time.
+    return if skip_page_view_update?
 
     @article = Article.find(page_view_params[:article_id])
     new_page_views_count = @article.page_views.sum(:counts_for_number_of_views)
@@ -46,7 +46,7 @@ class PageViewsController < ApplicationMetalController
   end
 
   def update_organic_page_views
-    return if Rails.env.production? && rand(100) != 1 # We need to do this operation only once in a while.
+    return if skip_organic_page_view_update?
 
     page_views_from_google_com = @article.page_views.where(referrer: "https://www.google.com/")
 
@@ -63,5 +63,15 @@ class PageViewsController < ApplicationMetalController
     organic_count_past_month_count = page_views_from_google_com
       .where("created_at > ?", 1.month.ago).sum(:counts_for_number_of_views)
     @article.update_column(:organic_page_views_past_month_count, organic_count_past_month_count)
+  end
+
+  def skip_page_view_update?
+    # We don't need to update the article page views every time.
+    rand(15) != 1
+  end
+
+  def skip_organic_page_view_update?
+    # We need to do this operation only once in a while.
+    rand(100) != 1
   end
 end

--- a/spec/requests/page_views_spec.rb
+++ b/spec/requests/page_views_spec.rb
@@ -4,6 +4,13 @@ RSpec.describe "PageViews", type: :request do
   let(:user) { create(:user, :trusted) }
   let(:article) { create(:article) }
 
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(PageViewsController).to receive(:skip_page_view_update?).and_return(false)
+    allow_any_instance_of(PageViewsController).to receive(:skip_organic_page_view_update?).and_return(false)
+    # rubocop:enable RSpec/AnyInstance
+  end
+
   describe "POST /page_views" do
     context "when user signed in" do
       before do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Just like #11144 this PR removes a couple more `Rails.env.production?` checks. There is really no reason why we can't run these locally so why not. As stated in the other PR, the more we can make development like production the better. 

## Added tests?
- [x] No, be there is no new functionality


![alt_text](https://media4.giphy.com/media/O7o2mWVFb5wo8/giphy.gif)
