### PR TITLE
Remove social icons from comment liquid tag

### DIFF
--- a/app/views/comments/_liquid.html.erb
+++ b/app/views/comments/_liquid.html.erb
@@ -7,16 +7,6 @@
       <a href="/<%= comment.user.username %>">
         <span class="comment-username"><%= comment.user.name %></span>
       </a>
-      <% if comment.user.twitter_username.present? %>
-        <a href="https://twitter.com/<%= comment.user.twitter_username %>">
-          <img src="/assets/twitter-logo.svg" class="icon-img" alt="twitter" />
-        </a>
-      <% end %>
-      <% if comment.user.github_username.present? %>
-        <a href="https://github.com/<%= comment.user.github_username %>">
-          <img src="/assets/github-logo.svg" class="icon-img" alt="github" />
-        </a>
-      <% end %>
       <%= render "comments/comment_date", decorated_comment: comment.decorate %>
     </div>
     <div class="body">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Design change

## Description
Following the footstep of https://github.com/forem/forem/pull/10977 and removing social icon from comment liquid tag.

## Related Tickets & Documents
n/a
## QA Instructions, Screenshots, Recordings
You should be able to use the comment liquid tag and not see the social icon attached for the user.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a