### PR TITLE
Filter by a few other roles when adding potential mods

### DIFF
--- a/app/queries/admin/moderators_query.rb
+++ b/app/queries/admin/moderators_query.rb
@@ -4,7 +4,7 @@ module Admin
       state: :trusted
     }.with_indifferent_access.freeze
 
-    NAMES_FOR_POTENTIAL = %i[banned warned trusted comment_banned].freeze
+    VALID_ROLES = %i[banned warned trusted comment_banned].freeze
 
     def self.call(relation: User.all, options: {})
       options = DEFAULT_OPTIONS.merge(options)

--- a/app/queries/admin/moderators_query.rb
+++ b/app/queries/admin/moderators_query.rb
@@ -26,7 +26,7 @@ module Admin
     end
 
     def self.potential_role_ids
-      Role.where(name: NAMES_FOR_POTENTIAL).select(:id)
+      @potential_role_ids ||= Role.where(name: VALID_ROLES).select(:id)
     end
 
     def self.search_relation(relation, search)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
This updates the potential tag mod page `/admin/mods?state=potential` (used for finding and adding new mods) to not show `warned` and `comment_banned` users. Also refactors it a bit.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/248

## QA Instructions, Screenshots, Recordings
1. In Rails console, ban a user `User.first.add_role :banned`
2. Visit `/admin/mods?state=potential`
3. Ensure that user with ID 1 does not appear

## Added tests?
- [x] No, and this is why: _there are already tests for this_

## Added to documentation?
- [x] No documentation needed


## [optional] What gif best describes this PR or how it makes you feel?

![A detective from Scooby Doo uses a magnifying lens, and covers his whole face with it so you only see a blinking eye.](https://media.giphy.com/media/2kXLNQypdX9O1A3zxX/giphy.gif)
