### PR TITLE
Set email registration to default: false

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -28,7 +28,7 @@ class SiteConfig < RailsSettings::Base
   field :video_encoder_key, type: :string
 
   # Authentication
-  field :allow_email_password_registration, type: :boolean, default: true
+  field :allow_email_password_registration, type: :boolean, default: false
   field :allow_email_password_login, type: :boolean, default: true
   field :allow_both_email_signup_and_login, type: :boolean, default: true
   field :require_captcha_for_email_password_registration, type: :boolean, default: false


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Sets the email registration config to default: false.