### PR TITLE
Update comments label in widget

### DIFF
--- a/app/views/articles/_widget_list_item.html.erb
+++ b/app/views/articles/_widget_list_item.html.erb
@@ -2,10 +2,8 @@
   <%= plucked_article[1] %>
   <% if show_comment_count %>
     <div class="crayons-link__secondary">
-      <% if plucked_article[2] == 1 %>
-        <%= plucked_article[2] %> comment
-      <% elsif plucked_article[2] > 1 %>
-        <%= plucked_article[2] %> comments
+      <% if plucked_article[2] > 0 %>
+        <%= pluralize(plucked_article[2], "comment") %>
       <% else %>
         <span class="crayons-indicator crayons-indicator--accent">New</span>
       <% end %>

--- a/app/views/articles/_widget_list_item.html.erb
+++ b/app/views/articles/_widget_list_item.html.erb
@@ -2,8 +2,10 @@
   <%= plucked_article[1] %>
   <% if show_comment_count %>
     <div class="crayons-link__secondary">
-      <% if plucked_article[2] > 0 %>
-        Comments: <%= plucked_article[2] %>
+      <% if plucked_article[2] == 1 %>
+        <%= plucked_article[2] %> comment
+      <% elsif plucked_article[2] > 1 %>
+        <%= plucked_article[2] %> comments
       <% else %>
         <span class="crayons-indicator crayons-indicator--accent">New</span>
       <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description
In the widgets container, update the "comments" string so that the format is `3 comments` instead of `Comments: 3`.

This format uses more human-friendly language.

## QA Instructions, Screenshots, Recordings

![Screen Shot 2020-10-30 at 1 07 10 PM](https://user-images.githubusercontent.com/816402/97752503-599e1d00-1ab1-11eb-95de-f49ddfdfcd13.png)
![Screen Shot 2020-10-30 at 1 07 27 PM](https://user-images.githubusercontent.com/816402/97752508-5a36b380-1ab1-11eb-8887-aadfedffd31f.png)
![Screen Shot 2020-10-30 at 1 07 42 PM](https://user-images.githubusercontent.com/816402/97752511-5acf4a00-1ab1-11eb-9dab-d280a3e4e487.png)


_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] Yes
- [x] No, and this is why: it doesn't seem necessary
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [ ] No documentation needed

