### PR TITLE
Refactor:Show Same Number of Articles for all Envs

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -12,7 +12,7 @@ class StoriesController < ApplicationController
     ]
   }.freeze
 
-  SIGNED_OUT_RECORD_COUNT = (Rails.env.production? ? 60 : 10).freeze
+  SIGNED_OUT_RECORD_COUNT = 60
 
   before_action :authenticate_user!, except: %i[index search show]
   before_action :set_cache_control_headers, only: %i[index search show]

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -434,7 +434,8 @@ RSpec.describe "StoriesIndex", type: :request do
         expect(response.body).not_to include('<span class="olderposts-pagenumber">')
       end
 
-      it "does not render pagination even with many posts" do
+      it "renders pagination with many posts" do
+        stub_const("StoriesController::SIGNED_OUT_RECORD_COUNT", 10)
         create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
         get "/t/#{tag.name}"
         expect(response.body).to include('<span class="olderposts-pagenumber">')
@@ -459,6 +460,7 @@ RSpec.describe "StoriesIndex", type: :request do
       end
 
       it "does not include current page link" do
+        stub_const("StoriesController::SIGNED_OUT_RECORD_COUNT", 10)
         create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
         get "/t/#{tag.name}/page/2"
         expect(response.body).to include('<span class="olderposts-pagenumber">2')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
There is no reason we can't load the same amount of articles for the feed in development and test as we do in production. 

## Added tests?
- [x] No, minor implementation detail change but I did update some and fixed some descriptions!


![alt_text](https://media1.tenor.com/images/f774f9f71f743d04d5d5ebe183786fa6/tenor.gif?itemid=15471799)
