### PR TITLE
Refactor:Always Load Last 24 Hour Podcasts

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -344,11 +344,10 @@ class StoriesController < ApplicationController
   def assign_podcasts
     return unless user_signed_in?
 
-    num_hours = Rails.env.production? ? 24 : 2400
     @podcast_episodes = PodcastEpisode
       .includes(:podcast)
       .order(published_at: :desc)
-      .where("published_at > ?", num_hours.hours.ago)
+      .where("published_at > ?", 24.hours.ago)
       .select(:slug, :title, :podcast_id, :image)
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
There is not really a good reason to treat production any different when showing recent podcasts. If devs want to mimic this behavior locally they can always go in and update podcast published dates to be within a day. 

## Added tests?
- [x] No, minor implementation change


![alt_text](https://thumbs.gfycat.com/FineIndelibleIntermediateegret-size_restricted.gif)
