### PR TITLE
Fix header and drawer overlap in profiles

### DIFF
--- a/app/assets/stylesheets/config/_variables.scss
+++ b/app/assets/stylesheets/config/_variables.scss
@@ -101,7 +101,7 @@
 
   --z-negative: -1; // to hide something behind everything else
   --z-elevate: 1; // to elevate something, just a little, in relation to its sibling
-  --z-sticky: 100; // header, mobile actions bar
+  --z-sticky: 250; // header, mobile actions bar
   --z-drawer: 200; // sidebar sliding nav drawers
   --z-modal: 300; // modals ¯\_(ツ)_/¯
   --z-dropdown: 400; // all kinds of dropdowns


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This fixes the header and drawer overlapping in user profiles by increasing the `z-sticky` css variable to `250` (should be greater than the `z-drawer`, which is `200`).

## Related Tickets & Documents
References/Closes/Fixes/Resolves #11202 

## QA Instructions, Screenshots, Recordings
Go to any user profile and scroll down to the bottom.

![header-overlap-screencast](https://user-images.githubusercontent.com/42511917/97774386-00d98d80-1b60-11eb-825b-0dffb006f4dc.gif)

## Added tests?

- [ ] Yes
- [x] No, and this is why: css change
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed

