### PR TITLE
fix for code fullscreen action on comment page

### DIFF
--- a/app/javascript/packs/fullScreenModeControl.js
+++ b/app/javascript/packs/fullScreenModeControl.js
@@ -1,0 +1,11 @@
+import addFullScreenModeControl from '../utilities/codeFullscreenModeSwitcher';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const fullscreenActionElements = document.querySelectorAll(
+    '.js-fullscreen-code-action',
+  );
+
+  if (fullscreenActionElements) {
+    addFullScreenModeControl(fullscreenActionElements);
+  }
+});

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -77,7 +77,7 @@
      data-commentable-type="<%= @commentable.class.name %>">
   <% if @root_comment %>
     <div id="response-templates-data"></div>
-    <%= javascript_packs_with_chunks_tag "responseTemplates", defer: true %>
+    <%= javascript_packs_with_chunks_tag "responseTemplates", "fullScreenModeControl", defer: true %>
     <div class="top-level-actions">
       <h3>re: <%= @commentable.title %> <a href="<%= @commentable.path %>">VIEW POST</a></h3>
       <span class="comment-action-buttons">
@@ -127,6 +127,8 @@
 <% if has_vid?(@commentable) %>
   <%= render "articles/fitvids" %>
 <% end %>
+
+<div class="fullscreen-code js-fullscreen-code"></div>
 
 <script async>
   <%== TweetTag.script %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes #10979 

## QA Instructions, Screenshots, Recordings

This fix makes fullscreen functionality for code highlight blocks available on comment page. 

When you open comment page by clicking on 'permalink' from comment menu, you will see url contains **/comment/**. 

If comments contain code highlight block in comments page, on hover you will see fullscreen button.

Currently It won't respond to click events in Production version. 

This PR fixes this issue, making fullscreen block clickable.

## Added tests?

- [ ] Yes
- [x] No, and this is why: _probably it should be added separately. For fullscreen screen mode functionality and for markup_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed
