### PR TITLE
Spec Fix:Remove Extra Space From Single Number Dates in Spec

### DIFF
--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Views an article", type: :system do
     # here
     it "shows the readable publish date" do
       visit article.path
-      expect(page).to have_selector("article time", text: article.readable_publish_date)
+      expect(page).to have_selector("article time", text: article.readable_publish_date.gsub("  ", " "))
     end
 
     it "embeds the published timestamp" do
@@ -61,11 +61,13 @@ RSpec.describe "Views an article", type: :system do
       # here
       it "shows the identical readable publish dates in each page" do
         visit first_article.path
-        expect(page).to have_selector("article time", text: first_article.readable_publish_date)
-        expect(page).to have_selector(".crayons-card--secondary time", text: first_article.readable_publish_date)
+        expect(page).to have_selector("article time", text: first_article.readable_publish_date.gsub("  ", " "))
+        expect(page).to have_selector(".crayons-card--secondary time",
+                                      text: first_article.readable_publish_date.gsub("  ", " "))
         visit second_article.path
-        expect(page).to have_selector("article time", text: second_article.readable_publish_date)
-        expect(page).to have_selector(".crayons-card--secondary time", text: second_article.readable_publish_date)
+        expect(page).to have_selector("article time", text: second_article.readable_publish_date.gsub("  ", " "))
+        expect(page).to have_selector(".crayons-card--secondary time",
+                                      text: second_article.readable_publish_date.gsub("  ", " "))
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Spec Fix

## Description
Remove the extra white space that occurs when a published_at day is a single number in the specs

This PR can be merged by any core team member. 

![alt_text](https://media1.tenor.com/images/f81890bb9544b29eedd02c32b1a793ad/tenor.gif?itemid=8273061)
