### PR TITLE
Fix buggy z-index for header / sticky elements

### DIFF
--- a/app/assets/stylesheets/config/_variables.scss
+++ b/app/assets/stylesheets/config/_variables.scss
@@ -101,9 +101,9 @@
 
   --z-negative: -1; // to hide something behind everything else
   --z-elevate: 1; // to elevate something, just a little, in relation to its sibling
-  --z-sticky: 100; // header, mobile actions bar
   --z-drawer: 200; // sidebar sliding nav drawers
   --z-modal: 300; // modals ¯\_(ツ)_/¯
   --z-dropdown: 400; // all kinds of dropdowns
   --z-popover: 500; // tooltips, snackbars, etc.
+  --z-sticky: 600; // header, mobile actions bar
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Since z-index cleanup (#11157), frontend is buggy. 
The reason is the following code:

```scss
  --z-negative: -1; // to hide something behind everything else
  --z-elevate: 1; // to elevate something, just a little, in relation to its sibling
  --z-sticky: 100; // header, mobile actions bar  <--------------- BUG because less than `z-drawer`
  --z-drawer: 200; // sidebar sliding nav drawers
  --z-modal: 300; // modals ¯\_(ツ)_/¯
  --z-dropdown: 400; // all kinds of dropdowns
  --z-popover: 500; // tooltips, snackbars, etc.
```

## Related Tickets & Documents
#11157 (the culprit 😉)

## QA Instructions, Screenshots, Recordings
![image](https://user-images.githubusercontent.com/5319267/97852491-18974a00-1cf7-11eb-88e5-0cfc1dd0d62b.png)

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] Yes
- [X] No, and this is why: Not needed
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [X] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Nope! 👍 

## [optional] What gif best describes this PR or how it makes you feel?
![css](https://media1.tenor.com/images/a606cd1865670e21c21ab5948d3014db/tenor.gif?itemid=4792065)
