### PR TITLE
Refactor:Implement Carrierwave Monkeypatch in all Envs

### DIFF
--- a/config/initializers/carrierwave_monkeypatch.rb
+++ b/config/initializers/carrierwave_monkeypatch.rb
@@ -3,15 +3,13 @@
 # We also force this to use the SiteConfig instead of APP_DOMAIN because the value
 # could change after initial boot.
 
-if Rails.env.production?
-  module CarrierWave
-    module Storage
-      class Fog < Abstract
-        class File
-          include CarrierWave::Utilities::Uri
-          def url
-            public_url.gsub(ApplicationConfig["APP_DOMAIN"], SiteConfig.app_domain)
-          end
+module CarrierWave
+  module Storage
+    class Fog < Abstract
+      class File
+        include CarrierWave::Utilities::Uri
+        def url
+          public_url.gsub(ApplicationConfig["APP_DOMAIN"], SiteConfig.app_domain)
         end
       end
     end

--- a/spec/initializers/carrierwave_monkeypatch_spec.rb
+++ b/spec/initializers/carrierwave_monkeypatch_spec.rb
@@ -1,0 +1,18 @@
+# rubocop:disable RSpec/FilePath
+require "rails_helper"
+
+describe CarrierWave::Storage::Fog::File do
+  it "replaces ApplicationConfig APP_DOMAIN with SiteConfig.app_domain" do
+    CarrierWave::Uploader::Base.fog_credentials = {
+      provider: "AWS", aws_access_key_id: "foo", aws_secret_access_key: "bar"
+    }
+    allow(ApplicationConfig).to receive(:[]).with("APP_DOMAIN").and_return("s3.amazonaws.com")
+    allow(SiteConfig).to receive(:app_domain).and_return("forem.com")
+    file_url = described_class.new(
+      CarrierWave::Uploader::Base, nil, "/a/path"
+    ).url
+
+    expect(file_url).to include("forem.com")
+  end
+end
+# rubocop:enable RSpec/FilePath


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Having patches like this in the code that are only applied in Production can be risky. The reason it is risky is bc if a problem comes up with the patch say because of a gem upgrade we won't have any indication of it(at this point down the road with some more intricate testing strategies we likely will) until the code is in use by users. With the guard removed, there is a chance we can catch issues before then. 

I also added a test for this patch so if the patch is removed accidentally, the test will break as a warning. 

I tested this locally and everything works as expected and with the tests passing **I dont think** there is any reason why we need this guard clause. 
 
## Added tests?
- [x] YES


![alt_text](https://media2.giphy.com/media/t0AJF1JhZdjji/200.gif)
