### PR TITLE
Feature:Default Rails Consoles to Readonly

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -139,6 +139,13 @@ Rails.application.configure do
     config.middleware.use Rack::HostRedirect,
                           ENV["HEROKU_APP_URL"] => ENV["APP_DOMAIN"]
   end
+
+  # If we are opening a rails console without WRITE_CONSOLE set and a BLAZER_DATABASE_URL
+  # is present, use that url as our DATABASE_URL. BLAZER_DATABASE_URL by default is readonly
+  # and this will ensure the console is readonly as well
+  if ENV["WRITE_CONSOLE"].nil? && Rails.const_defined?("Console") && ENV["BLAZER_DATABASE_URL"].present?
+    ENV["DATABASE_URL"] = ENV["BLAZER_DATABASE_URL"]
+  end
 end
 # rubocop:enable Metrics/BlockLength
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Opening a production console is always a bit scary because you want to be extra careful you don't change anything you shouldn't. With this PR, if we have a BLAZER_DATABASE_URL present such as on Heroku, the console will connect to the database with that URL instead. The advantage here is that the BLAZER_DATABASE_URL is read-only and shields user sensitive data. 

## Added tests?
- [x] No, bc this is a production only feature. 

![alt_text](gif_link)
