### PR TITLE
Feature:Continuous Deploy to Benhalpern Community

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ notifications:
 
 jobs:
   include:
-    - stage: Deploy
+    - stage: Deploy DEV
       if: type != pull_request
       script: skip
       after_script: skip
@@ -91,3 +91,12 @@ jobs:
         api_key: '$HEROKU_AUTH_TOKEN'
         app:
           master: practicaldev
+    - stage: Deploy BenHalpern
+      if: type != pull_request
+      script: skip
+      after_script: skip
+      deploy:
+        provider: heroku
+        api_key: '$HEROKU_AUTH_TOKEN'
+        app:
+          master: benhalpern-community


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Continuous deploy to the benhalpern-community on Heroku. The plan here is to give everyone full access to the benhalpern-community via Heroku and admin. The community is configured the same as DEV and will give engineers the ability to view and interact with our Heroku infrastructure via the Heroku UI and console. The goal is to do the same for a couple of new Forem communities that I will be working with @jdoss to spin up and give full access to. 

I choose to use 2 jobs here instead of serially deploying since that would cause the job to take up to 25 min. This also will ensure that if a deploy to one app fails the other is not affected. 

We are hoping this can help alleviate some of the access and visibility frustrations many people have been having. Access is still an ongoing conversation but I think this is a step in the right direction.  


## Added tests?
- [x] No, bc this is part of our CI process

![alt_text](gif_link)
