### PR TITLE
Add --spec option for data_update generator

### DIFF
--- a/docs/backend/data-update-scripts.md
+++ b/docs/backend/data-update-scripts.md
@@ -40,6 +40,26 @@ module DataUpdateScripts
 end
 ```
 
+The generator will also automatically create the corresponding spec file.
+
+```ruby
+require "rails_helper"
+require Rails.root.join(
+  "20201103042915_backfill_column_for_articles.rb",
+)
+
+describe DataUpdateScripts::BackfillColumnForArticles do
+  pending "add some examples to (or delete) #{__FILE__}"
+end
+```
+
+While we encourage adding tests for data update scripts, you can skip spec
+creation by adding the `--no-spec` option to the `rails generate` command:
+
+```
+rails generate data_update BackfillColumnForArticles --no-spec
+```
+
 Once your script is in place then you can either run `rails data_updates:run`
 manually or you can let our setup script handle it. In our local
 [bin/setup](https://github.com/forem/forem/blob/master/bin/setup) script you

--- a/lib/generators/data_update/data_update_generator.rb
+++ b/lib/generators/data_update/data_update_generator.rb
@@ -1,11 +1,22 @@
 class DataUpdateGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("templates", __dir__)
+  class_option :spec, type: :boolean, default: true
 
   def create_data_update_file
     template(
       "data_update.rb.tt",
-      File.join("lib", "data_update_scripts", class_path,
-                "#{Time.current.utc.strftime('%Y%m%d%H%M%S')}_#{file_name}.rb"),
+      File.join("lib", "data_update_scripts", class_path, script_name),
     )
+
+    return unless options["spec"]
+
+    template(
+      "data_update_spec.rb.tt",
+      File.join("spec", "lib", "data_update_scripts", class_path, "#{file_name}_spec.rb"),
+    )
+  end
+
+  def script_name
+    @script_name ||= "#{Time.current.utc.strftime('%Y%m%d%H%M%S')}_#{file_name}.rb"
   end
 end

--- a/lib/generators/data_update/templates/data_update_spec.rb.tt
+++ b/lib/generators/data_update/templates/data_update_spec.rb.tt
@@ -1,0 +1,8 @@
+require "rails_helper"
+require Rails.root.join(
+  "<%= script_name %>",
+)
+
+describe DataUpdateScripts::<%= class_name %> do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

During my recent profile generalization work, I had to write quite a few data update scripts and got tired of adding the corresponding specs manually. I decided to add `--spec` / `--no-spec`options to the generator, with `--spec` being the deafault:

```
❯ rails generate data_update -h
Usage:
  rails generate data_update NAME [options]

Options:
  [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)
  [--spec], [--no-spec]                      # Indicates when to generate spec
                                             # Default: true
[output snipped]
```

The generated specs are simple and follow our current conventions. The included message is borrowed from Rails' default generators:

```ruby
require "rails_helper"
require Rails.root.join(
  "20201103044008_do_the_thing.rb",
)

describe DataUpdateScripts::DoTheThing do
  pending "add some examples to (or delete) #{__FILE__}"
end
```

I also noticed that our generator doesn't play nicely with `rails destroy data_update`: since we prepend the timestamp to the filename during runtime it will yield a different value on `destroy` vs `generate` and the file won't actually get removed. It works for the newly added specs though, as those use stable filenames. I made a mental note of looking into this during the next downtime, the Rails migration generator should have clues on how to handle this case properly.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

1. Run `rails generate data_update DoSomething` and verify that the script and spec were created and have the right content.
2. Run `rails generate data_update DoSomethingElse --no-spec` and verify that the script gets created as expected but the spec doesn't.

## Added tests?

- [ ] Yes
- [X] No, and this is why: we didn't have any tests for this yet and I want to go back to writing the actual data update script that prompted this. I did make a mental note to add specs for the whole generator during the next cooldown period.
- [ ] I need help with writing tests

## Added to documentation?

- [X] Docs.forem.com
- [ ] README
- [ ] No documentation needed
