### PR TITLE
Prepare for profile column drop

### DIFF
--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -11,7 +11,8 @@ class ProfileField < ApplicationRecord
 
   enum display_area: {
     header: 0,
-    left_sidebar: 1
+    left_sidebar: 1,
+    settings_only: 2
   }
 
   belongs_to :profile_field_group, optional: true

--- a/app/services/profile_fields/field_definition.rb
+++ b/app/services/profile_fields/field_definition.rb
@@ -32,7 +32,7 @@ module ProfileFields
     end
 
     def add_fields
-      self.class.fields.each { |field| ProfileField.create(field) }
+      self.class.fields.each { |field| ProfileField.find_or_create_by(field) }
     end
   end
 end

--- a/app/services/profile_fields/import_from_csv.rb
+++ b/app/services/profile_fields/import_from_csv.rb
@@ -1,6 +1,6 @@
 module ProfileFields
   class ImportFromCsv
-    HEADERS = %i[label input_type placeholder_text description group].freeze
+    HEADERS = %i[label input_type placeholder_text description group display_area].freeze
 
     def self.call(file)
       CSV.foreach(file, headers: HEADERS, skip_blanks: true) do |row|

--- a/lib/data/dev_profile_fields.csv
+++ b/lib/data/dev_profile_fields.csv
@@ -1,29 +1,29 @@
-Display email on profile,check_box,,,Basic
-Name,text_field,John Doe,,Basic
-Website URL,text_field,https://yoursite.com,,Basic
-Summary,text_area,A short bio...,,Basic
-Location,text_field,"Halifax, Nova Scotia",,Basic
-Facebook URL,text_field,https://facebook.com/...,,Links
-Youtube URL,text_field,https://www.youtube.com/channel/...,,Links
-StackOverflow URL,text_field,https://stackoverflow.com/users/...,,Links
-LinkedIn URL,text_field,https://www.linkedin.com/in/...,,Links
-Behance URL,text_field,https://www.behance.net/...,,Links
-Dribbble URL,text_field,https://dribbble.com/...,,Links
-Medium URL,text_field,https://medium.com/@...,,Links
-GitLab URL,text_field,https://gitlab.com/...,,Links
-Instagram URL,text_field,https://www.instagram.com/...,,Links
-Mastodon URL,text_field,https://...,,Links
-Twitch URL,text_field,https://www.twitch.tv/...,,Links
-Education,text_field,,,Work
-Employer name,text_field,Acme Inc.,,Work
-Employer URL,text_field,https://dev.com,,Work
-Employment title,text_field,Junior Frontend Engineer,,Work
-Looking for work,check_box,,,Work
-"Display ""looking for work"" on profile",check_box,,,Work
-Recruiters can contact me about job opportunities,check_box,,,Work
-Skills/Languages,text_area,,What tools and languages are you most experienced with? Are you specialized or more of a generalist?,Coding
-Currently learning,text_area,,"What are you learning right now? What are the new tools and languages you're picking up right now?",Coding
-Currently hacking on,text_area,,What projects are currently occupying most of your time?,Coding
-Available for,text_area,,"What kinds of collaborations or discussions are you available for? What's a good reason to say Hey! to you these days?",Coding
-Brand color 1,color_field,#000000,"Used for backgrounds, borders etc.",Branding
-Brand color 2,color_field,#000000,Used for texts (usually put on Brand color 1).,Branding
+Display email on profile,check_box,,,Basic,settings_only
+Name,text_field,John Doe,,Basic,header
+Website URL,text_field,https://yoursite.com,,Basic,header
+Summary,text_area,A short bio...,,Basic,header
+Location,text_field,"Halifax, Nova Scotia",,Basic,header
+Facebook URL,text_field,https://facebook.com/...,,Links,header
+Youtube URL,text_field,https://www.youtube.com/channel/...,,Links,header
+StackOverflow URL,text_field,https://stackoverflow.com/users/...,,Links,header
+LinkedIn URL,text_field,https://www.linkedin.com/in/...,,Links,header
+Behance URL,text_field,https://www.behance.net/...,,Links,header
+Dribbble URL,text_field,https://dribbble.com/...,,Links,header
+Medium URL,text_field,https://medium.com/@...,,Links,header
+GitLab URL,text_field,https://gitlab.com/...,,Links,header
+Instagram URL,text_field,https://www.instagram.com/...,,Links,header
+Mastodon URL,text_field,https://...,,Links,header
+Twitch URL,text_field,https://www.twitch.tv/...,,Links,header
+Education,text_field,,,Work,header
+Employer name,text_field,Acme Inc.,,Work,header
+Employer URL,text_field,https://dev.com,,Work,header
+Employment title,text_field,Junior Frontend Engineer,,Work,header
+Looking for work,check_box,,,Work,settings_only
+"Display ""looking for work"" on profile",check_box,,,Work,settings_only
+Recruiters can contact me about job opportunities,check_box,,,Work,settings_only
+Skills/Languages,text_area,,What tools and languages are you most experienced with? Are you specialized or more of a generalist?,Coding,left_sidebar
+Currently learning,text_area,,"What are you learning right now? What are the new tools and languages you're picking up right now?",Coding,left_sidebar
+Currently hacking on,text_area,,What projects are currently occupying most of your time?,Coding,left_sidebar
+Available for,text_area,,"What kinds of collaborations or discussions are you available for? What's a good reason to say Hey! to you these days?",Coding,left_sidebar
+Brand color 1,color_field,#000000,"Used for backgrounds, borders etc.",Branding,settings_only
+Brand color 2,color_field,#000000,Used for texts (usually put on Brand color 1).,Branding,settings_only

--- a/lib/data_update_scripts/20201103050112_prepare_for_profile_column_drop.rb
+++ b/lib/data_update_scripts/20201103050112_prepare_for_profile_column_drop.rb
@@ -12,7 +12,7 @@ module DataUpdateScripts
       User.includes(:profile).find_each do |user|
         profile = user.profile
         user_data = Profiles::ExtractData.call(user)
-        profile.update(data: profile.data.merge(user_data))
+        profile.update(data: profile.data.merge(user_data.compact))
       end
     end
   end

--- a/lib/data_update_scripts/20201103050112_prepare_for_profile_column_drop.rb
+++ b/lib/data_update_scripts/20201103050112_prepare_for_profile_column_drop.rb
@@ -1,0 +1,19 @@
+module DataUpdateScripts
+  class PrepareForProfileColumnDrop
+    def run
+      # Make sure all current DEV profile fields exist. The import task is
+      # idempotent so we don't need further checkes here.
+      dev_fields_csv = Rails.root.join("lib/data/dev_profile_fields.csv")
+      ProfileFields::ImportFromCsv.call(dev_fields_csv)
+
+      # Make sure all current profile data is migrated before we remove the
+      # column from User. Also ensure we don't lose any data for custom fields,
+      # even if these got temporarily disabled by a feature flag.
+      User.includes(:profile).find_each do |user|
+        profile = user.profile
+        user_data = Profiles::ExtractData.call(user)
+        profile.update(data: profile.data.merge(user_data))
+      end
+    end
+  end
+end

--- a/lib/tasks/forem.rake
+++ b/lib/tasks/forem.rake
@@ -2,8 +2,6 @@ namespace :forem do
   desc "Performs basic setup for new Forem instances"
   task setup: :environment do
     puts "\n== Setting up profile fields =="
-    # TODO: [@forem/oss] Remove the destroy_all call
-    ProfileField.destroy_all
     ProfileFields::AddBaseFields.call
   end
 

--- a/spec/fixtures/files/profile_fields.csv
+++ b/spec/fixtures/files/profile_fields.csv
@@ -1,4 +1,4 @@
-Name,text_field,John Doe,,Basic
-Skills/Languages,text_area,,Programming languages,Coding
+Name,text_field,John Doe,,Basic,header
+Skills/Languages,text_area,,Programming languages,Coding,left_sidebar
 
-Color,color_field,#000000,"Used for backgrounds, borders etc.",Branding
+Color,color_field,#000000,"Used for backgrounds, borders etc.",Branding,settings_only

--- a/spec/lib/data_update_scripts/prepare_for_profile_column_drop_spec.rb
+++ b/spec/lib/data_update_scripts/prepare_for_profile_column_drop_spec.rb
@@ -5,12 +5,13 @@ require Rails.root.join(
 
 describe DataUpdateScripts::PrepareForProfileColumnDrop do
   context "when using only DEV profile fields" do
-    it "migrates data from the user to the profile" do
-      user = create(:user)
+    it "migrates data from the user to the profile", :aggregate_failures do
+      summary = "I hack on profiles a lot"
+      user = create(:user, summary: summary)
 
-      expect do
-        described_class.new.run
-      end.to change { user.profile.reload.data.keys.size }.to(30)
+      expect(user.profile).not_to respond_to(:summary)
+      described_class.new.run
+      expect(user.profile.reload.summary).to eq(summary)
     end
   end
 

--- a/spec/lib/data_update_scripts/prepare_for_profile_column_drop_spec.rb
+++ b/spec/lib/data_update_scripts/prepare_for_profile_column_drop_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20201103050112_prepare_for_profile_column_drop.rb",
+)
+
+describe DataUpdateScripts::PrepareForProfileColumnDrop do
+  context "when using only DEV profile fields" do
+    it "migrates data from the user to the profile" do
+      user = create(:user)
+
+      expect do
+        described_class.new.run
+      end.to change { user.profile.reload.data.keys.size }.to(30)
+    end
+  end
+
+  context "when a Forem used additional profile fields" do
+    let!(:user) { create(:user) }
+
+    before do
+      create(:profile_field, label: "Doge Test")
+      Profile.refresh_attributes!
+      user.profile.update(doge_test: "Such update, much wow!")
+    end
+
+    it "migrates data and keeps existing data intact", :aggregate_failures do
+      described_class.new.run
+      expect(user.profile.reload.data.keys.size).to eq(31)
+      expect(user.profile.data).to have_key("doge_test")
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR came out of a discussion (see [conclusion](https://github.com/forem/forem/pull/10707#issuecomment-719141336) in #10707 and some work done in the closed #11110 branch.

1. Adds a new `:settings_only` option to the `display_area` enum.
2. Updates the CSV importer and the DEV profile fields CSV file to add `display_area` .
3. Adds a data update script for ensuring that all DEV fields are current and profiles are really up to date before starting to ignore the columns in the next PR.

## Related Tickets & Documents

#6994 

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [X] No documentation needed
