### PR TITLE
Fixing tags in listing modal

### DIFF
--- a/app/javascript/listings/singleListing/Header.jsx
+++ b/app/javascript/listings/singleListing/Header.jsx
@@ -31,7 +31,7 @@ const Header = ({ listing, currentUserId, onTitleClick, onAddTag }) => {
         </a>
       </h2>
       <DateTime dateTime={listingDate} className="single-listing__date" />
-      <TagLinks tags={listing.tags} onClick={onAddTag} />
+      <TagLinks tags={listing.tags || listing.tag_list} onClick={onAddTag} />
 
       <DropdownMenu listing={listing} isOwner={currentUserId === userId} />
     </header>


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR makes sure the tags always show up in listing modal

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/11231

## QA Instructions, Screenshots, Recordings
1. Go to /listings
2. Click on a listing with tags. It will open up a modal and it will show the tags
3. Now refresh the page
4. The modal will show up but with tags

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [x] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed
