### PR TITLE
Add expectation to ensure on edit comment page

### DIFF
--- a/spec/system/comments/user_edits_a_comment_spec.rb
+++ b/spec/system/comments/user_edits_a_comment_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Editing A Comment", type: :system, js: true do
 
   def assert_updated
     expect(page).to have_css("textarea")
+    expect(page).to have_text("Editing comment")
     fill_in "text-area", with: new_comment_text
     click_button("Submit")
     expect(page).to have_text(new_comment_text)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a flaky test where the test sometimes doesn't click through to the edit comment page properly.

I'm not really sure why `expect(page).to have_text("Editing comment")` would change anything honestly. But 50/50 runs locally made me believe otherwise...

## [optional] What gif best describes this PR or how it makes you feel?

![Alan Rickman or Snape shrugs.](https://media.giphy.com/media/fKk2I5iiWGN0I/giphy.gif)