### PR TITLE
Conditionally hide onboarding task card

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -38,7 +38,7 @@
     <%# BEGIN Feed menu bar %>
     <main class="articles-list crayons-layout__content" id="articles-list" role="main">
       <h1 class="visually-hidden-header">Articles</h1>
-      <%= render(partial: "onboardings/task_card") if user_signed_in? && current_user.saw_onboarding %>
+      <%= render(partial: "onboardings/task_card") if user_signed_in? && current_user.saw_onboarding? %>
 
       <header class="flex items-center p-2 m:p-0 m:pb-2" id="on-page-nav-controls">
         <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--icon mr-2 inline-block m:hidden" id="on-page-nav-butt-left" aria-label="nav-button-left">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -38,7 +38,6 @@
     <%# BEGIN Feed menu bar %>
     <main class="articles-list crayons-layout__content" id="articles-list" role="main">
       <h1 class="visually-hidden-header">Articles</h1>
-
       <%= render(partial: "onboardings/task_card") if user_signed_in? && current_user.saw_onboarding %>
 
       <header class="flex items-center p-2 m:p-0 m:pb-2" id="on-page-nav-controls">

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -38,7 +38,8 @@
     <%# BEGIN Feed menu bar %>
     <main class="articles-list crayons-layout__content" id="articles-list" role="main">
       <h1 class="visually-hidden-header">Articles</h1>
-      <%= render(partial: "onboardings/task_card") if user_signed_in? %>
+
+      <%= render(partial: "onboardings/task_card") if user_signed_in? && current_user.saw_onboarding %>
 
       <header class="flex items-center p-2 m:p-0 m:pb-2" id="on-page-nav-controls">
         <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--icon mr-2 inline-block m:hidden" id="on-page-nav-butt-left" aria-label="nav-button-left">

--- a/app/views/onboardings/_task_card.html.erb
+++ b/app/views/onboardings/_task_card.html.erb
@@ -1,7 +1,7 @@
 <script>
   /**
    * This script corresponds to initializeOnboardingTaskCard() which will display the task card
-   */
+  */
 
   function closeTaskCard() {
     var taskCard = document.getElementsByClassName("onboarding-task-card")[0];
@@ -17,7 +17,7 @@
 </style>
 
 <div class="onboarding-task-card" role="dialog" aria-labelledby="task-card-title" aria-describedby="task-card-subtitle">
-  <button class="close" onclick="closeTaskCard()" aria-label="Close Welcome message">
+  <button class="close" onclick="closeTaskCard()" aria-label="Close Welcome Message">
     <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M6.99974 5.58623L11.9497 0.63623L13.3637 2.05023L8.41374 7.00023L13.3637 11.9502L11.9497 13.3642L6.99974 8.41423L2.04974 13.3642L0.635742 11.9502L5.58574 7.00023L0.635742 2.05023L2.04974 0.63623L6.99974 5.58623Z" fill="white" />
     </svg>

--- a/app/views/onboardings/_task_card.html.erb
+++ b/app/views/onboardings/_task_card.html.erb
@@ -1,7 +1,7 @@
 <script>
   /**
    * This script corresponds to initializeOnboardingTaskCard() which will display the task card
-  */
+   */
 
   function closeTaskCard() {
     var taskCard = document.getElementsByClassName("onboarding-task-card")[0];

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
     end
   end
 
-  context "when signed out", type: :sytem, js: true do
+  context "when signed out", type: :system, js: true do
     before { visit article_with_user_subscription_tag.path }
 
     it "prompts a user to sign in when they're signed out", type: :system, js: true do

--- a/spec/system/authentication/redirects_using_referer_spec.rb
+++ b/spec/system/authentication/redirects_using_referer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Redirects authentication using Referer", type: :system do
   let(:article) { build(:article) }
   let(:user) do
-    create(:user, :with_identity, identities: [:twitter], saw_onboarding: true)
+    create(:user, :with_identity, identities: [:twitter])
   end
 
   let(:login_link) { "Log in" }

--- a/spec/system/authentication/user_logs_in_with_email_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_email_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Authenticating with Email" do
   end
 
   context "when a user is new" do
-    let(:user) { build(:user) }
+    let(:user) { build(:user, saw_onboarding: false) }
 
     context "when using valid credentials" do
       it "creates a new user", js: true do

--- a/spec/system/authentication/user_logs_in_with_email_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_email_spec.rb
@@ -80,6 +80,16 @@ RSpec.describe "Authenticating with Email" do
 
         expect(page).to have_current_path("/?signin=true")
       end
+
+      it "logs in and redirects to onboarding if it hasn't been seen" do
+        user.update(saw_onboarding: false)
+
+        visit sign_up_path
+        log_in_user(user)
+
+        expect(page).to have_current_path("/onboarding", ignore_query: true)
+        expect(page.html).to include("onboarding-container")
+      end
     end
 
     context "when already signed in" do

--- a/spec/system/onboardings/user_completes_onboarding_spec.rb
+++ b/spec/system/onboardings/user_completes_onboarding_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe "Completing Onboarding", type: :system, js: true do
+  let(:password) { Faker::Internet.password(min_length: 8) }
+  let(:user) { create(:user, password: password, password_confirmation: password, saw_onboarding: false) }
+
+  after do
+    sign_out user
+  end
+
+  context "when the user hasn't seen onboarding" do
+    before do
+      visit sign_up_path
+      log_in_user(user)
+    end
+
+    it "logs in and redirects to onboarding if it hasn't been seen" do
+      expect(page).to have_current_path("/onboarding", ignore_query: true)
+      expect(page.html).to include("onboarding-container")
+    end
+
+    it "does not render the onboarding task card on the feed" do
+      visit "/"
+
+      # Explicitly test that the task card element HTML is not on the page.
+      expect(page.html).not_to include("onboarding-task-card")
+    end
+  end
+
+  context "when the user has seen onboarding" do
+    before do
+      user.update(saw_onboarding: true)
+
+      visit sign_up_path
+      log_in_user(user)
+    end
+
+    it "logs in and renders the feed" do
+      expect(page).to have_current_path("/?signin=true")
+      expect(page.html).not_to include("onboarding-container")
+    end
+
+    it "renders the feed and onboarding task card" do
+      visit "/"
+
+      wait_for_javascript
+      expect(page).to have_css(".onboarding-task-card")
+    end
+
+    it "can dismiss the onboarding task card" do
+      visit "/"
+
+      wait_for_javascript
+      expect(page).to have_css(".onboarding-task-card")
+
+      find(".onboarding-task-card .close").click
+      expect(page).not_to have_css(".onboarding-task-card")
+    end
+  end
+
+  # TODO: Vaidehi Joshi - Extract this into a reusable helper
+  def log_in_user(user)
+    fill_in("user_email", with: user.email)
+    fill_in("user_password", with: user.password)
+    click_button("Continue", match: :first)
+  end
+end

--- a/spec/system/user/user_edits_integrations_spec.rb
+++ b/spec/system/user/user_edits_integrations_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "User edits their integrations", type: :system, js: true do
-  let(:user) { create(:user, saw_onboarding: true) }
+  let(:user) { create(:user) }
   let(:github_response_body) do
     [
       {

--- a/spec/system/user/user_edits_profile_spec.rb
+++ b/spec/system/user/user_edits_profile_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "User edits their profile", type: :system do
-  let(:user) { create(:user, saw_onboarding: true) }
+  let(:user) { create(:user) }
 
   before do
     sign_in user

--- a/spec/system/user/user_edits_ux_spec.rb
+++ b/spec/system/user/user_edits_ux_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "User edits their UX settings", type: :system do
-  let(:user) { create(:user, saw_onboarding: true) }
+  let(:user) { create(:user) }
 
   before do
     sign_in user

--- a/spec/system/user/user_self_destroy_spec.rb
+++ b/spec/system/user/user_self_destroy_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "User destroys their profile", type: :system, js: true do
-  let(:user) { create(:user, saw_onboarding: true) }
+  let(:user) { create(:user) }
 
   before do
     sign_in user


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As a part of the ✨ NEW CREATOR ONBOARDING FLOW ✨, we need to change how we deal with the onboarding code. There is a lot to untangle, since we currently force _all_ users to go through that flow.

**There will be more PRs that touch onboarding-related code, but in an attempt to make these PRs easy to review + QA, I am attempting to keep them small and encapsulated around incremental changes.**

This PR conditionally renders the onboarding task card by checking that a user `saw_onboarding` before rendering the card. On a practical level, this check doesn't do anything for _current Forems_, because every single user is going to be _forced_ through onboarding. So really, this check is redundant, currently.

HOWEVER! I have more code in the pipeline that assumes that Forem creators will _not_ be going through the "usual onboarding flow", located at `/onboarding`. To that end, we need to change the logic where we assume that every user will have seen onboarding -- for Forem creators, `saw_onboarding` will be `false`, as they will have their own concept of "creator onboarding".

Specifically, this PR:

- [x] Checks that the `current_user.saw_onboarding` before rendering the task card.
- [x] Improves upon and adds new tests around our onboarding flow (which I will use in future PRs when I add specs around the creator onboarding flow).
- [x] Removes a bunch of redundant `saw_onboarding: true` checks from test `user`s in our `/spec` files.
- [x] Fixes some typos + capitalization issues that I found in related files.

## Related Tickets & Documents

A step towards completing https://github.com/forem/InternalProjectPlanning/issues/81.

## QA Instructions, Screenshots, Recordings

**To QA this, please ensure that the onboarding flow continues to work as it _currently does_.**

Here's what you'll want to test:
1. Go through the sign up + sign in process for your local Forem instance. Ensure that you see the onboarding task card, and that you can close it:
<img width="1174" alt="Screen_Shot_2020-11-03_at_3_31_14_PM" src="https://user-images.githubusercontent.com/6921610/98052198-6d67bd00-1dea-11eb-8450-7d6b701cf529.png">
2. When you close the task card, it should not appear again:
<img width="1164" alt="Screen Shot 2020-11-03 at 3 20 05 PM" src="https://user-images.githubusercontent.com/6921610/98052236-88d2c800-1dea-11eb-9f10-363174d63ae1.png">
3. Delete the `task-card-closed` key from your local storage: 
<img width="612" alt="Screen_Shot_2020-11-03_at_3_20_34_PM" src="https://user-images.githubusercontent.com/6921610/98052257-91c39980-1dea-11eb-9fff-0eb8baf9c33f.png">
4. Ensure that the task card renders again 😸 
<img width="1176" alt="Screen Shot 2020-11-03 at 3 19 55 PM" src="https://user-images.githubusercontent.com/6921610/98052282-a4d66980-1dea-11eb-838b-68b6d496eedd.png">


## Added tests?

- [x] Yes: _I added more robust tests for when the task card partial should and should not render. I also added a test to the email login specs, which currently don't test the onboarding redirect the way that the other authentication specs do!_
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [ ] No documentation needed
- [x] Inline documentation, as needed

## Are there any post deployment tasks we need to perform?
Nope! :) 

## What gif best describes this PR or how it makes you feel?

![dancing kermit](https://media3.giphy.com/media/8m4R4pvViWtRzbloJ1/giphy.gif?cid=5a38a5a2xl19ff8vwqrtqyl5utahp7cgnextb9ecs8xhjjwg&rid=giphy.gif)
