### PR TITLE
Fixing date in listing modal

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -3,7 +3,8 @@ class ListingsController < ApplicationController
 
   INDEX_JSON_OPTIONS = {
     only: %i[
-      title processed_html tag_list category id user_id slug contact_via_connect location
+      title processed_html tag_list category id user_id slug contact_via_connect location bumped_at
+      originally_published_at
     ],
     include: {
       author: { only: %i[username name], methods: %i[username profile_image_90] },

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "/listings", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "has correct keys in the response" do
+    it "listings have correct keys" do
       get "/listings"
 
       parsed_response = Nokogiri.HTML(response.body)

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "nokogiri"
 
 RSpec.describe "/listings", type: :request do
   let(:user) { create(:user) }
@@ -35,12 +36,29 @@ RSpec.describe "/listings", type: :request do
     before do
       sign_in user
       create_list(:credit, 25, user: user)
+      listing_params[:listing][:post_as_organization] = "1"
+      post "/listings", params: listing_params
     end
 
     it "returns text/html and has status 200" do
       get "/listings"
       expect(response.media_type).to eq("text/html")
       expect(response).to have_http_status(:ok)
+    end
+
+    it "has correct keys in the response" do
+      get "/listings"
+
+      parsed_response = Nokogiri.HTML(response.body)
+
+      listings = JSON.parse(parsed_response.xpath("//*[@id='listings-index-container']")[0]["data-listings"])
+
+      index_keys = %w[
+        title processed_html tag_list id user_id slug contact_via_connect location bumped_at
+        originally_published_at author user
+      ]
+
+      expect(listings.first.keys).to match_array index_keys
     end
 
     context "when the user has no params" do


### PR DESCRIPTION
##  What type of PR is this? 

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When listing modal is refreshed the date does not appear this PR fixes that.

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/11261

## QA Instructions, Screenshots, Recordings

1. Go to /listings
2. Click on a listing with date. It will open up a modal and it will show the date
3. Now refresh the page
4. The modal will show up but with date

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [x] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed
