### PR TITLE
Data update script generator: Use full path instead of filename for require

### DIFF
--- a/docs/backend/data-update-scripts.md
+++ b/docs/backend/data-update-scripts.md
@@ -45,7 +45,7 @@ The generator will also automatically create the corresponding spec file.
 ```ruby
 require "rails_helper"
 require Rails.root.join(
-  "20201103042915_backfill_column_for_articles.rb",
+  "lib/data_updates/20201103042915_backfill_column_for_articles.rb",
 )
 
 describe DataUpdateScripts::BackfillColumnForArticles do

--- a/lib/generators/data_update/data_update_generator.rb
+++ b/lib/generators/data_update/data_update_generator.rb
@@ -3,10 +3,7 @@ class DataUpdateGenerator < Rails::Generators::NamedBase
   class_option :spec, type: :boolean, default: true
 
   def create_data_update_file
-    template(
-      "data_update.rb.tt",
-      File.join("lib", "data_update_scripts", class_path, script_name),
-    )
+    template("data_update.rb.tt", script_path)
 
     return unless options["spec"]
 
@@ -16,7 +13,10 @@ class DataUpdateGenerator < Rails::Generators::NamedBase
     )
   end
 
-  def script_name
-    @script_name ||= "#{Time.current.utc.strftime('%Y%m%d%H%M%S')}_#{file_name}.rb"
+  def script_path
+    @script_path ||= begin
+      script_name = "#{Time.current.utc.strftime('%Y%m%d%H%M%S')}_#{file_name}.rb"
+      File.join("lib", "data_update_scripts", class_path, script_name)
+    end
   end
 end

--- a/lib/generators/data_update/templates/data_update_spec.rb.tt
+++ b/lib/generators/data_update/templates/data_update_spec.rb.tt
@@ -1,6 +1,6 @@
 require "rails_helper"
 require Rails.root.join(
-  "<%= script_name %>",
+  "<%= script_path %>",
 )
 
 describe DataUpdateScripts::<%= class_name %> do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Quick follow up to #11245 from yesterday, we need the full path for the require, not just the script name.

```diff
-  "20201103042915_backfill_column_for_articles.rb",
+ "lib/data_updates/20201103042915_backfill_column_for_articles.rb",
```

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

* Run the generator and make sure the generated spec requires the full script path (`lib/data_updates/<timestamp_<scriptname>`).

## Added tests?

- [ ] Yes
- [X] No, and this is why: This is still on my downtime todo list.
- [ ] I need help with writing tests

## Added to documentation?

- [X] Docs.forem.com
- [ ] README
- [ ] No documentation needed
