### PR TITLE
Exclude code highlight panel markup from RSS description 

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -386,6 +386,11 @@ class Article < ApplicationRecord
     self.co_author_ids = list_of_co_author_ids.split(",").map(&:strip)
   end
 
+  def plain_html
+    doc = Nokogiri::HTML.fragment(processed_html)
+    doc.search("highlight__panel").each(&:remove).to_html
+  end
+
   private
 
   def search_score

--- a/app/views/articles/feed.rss.builder
+++ b/app/views/articles/feed.rss.builder
@@ -24,7 +24,7 @@ xml.rss version: "2.0" do
         xml.pubDate article.published_at.to_s(:rfc822) if article.published_at
         xml.link app_url(article.path)
         xml.guid app_url(article.path)
-        xml.description sanitize(article.processed_html, tags: allowed_tags, attributes: allowed_attributes)
+        xml.description sanitize(article.plain_html, tags: allowed_tags, attributes: allowed_attributes)
         article.tag_list.each do |tag_name|
           xml.category tag_name
         end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -980,4 +980,10 @@ RSpec.describe Article, type: :model do
       expect(article.co_author_ids).to match_array([co_author1.id, co_author2.id])
     end
   end
+
+  describe "#plain_html" do
+    it "doesn't include js panel markup" do
+      expect(article.plain_html).not_to include("Enter fullscreen mode")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Based on #10927 requirements this PR introduces a new Article method that sanitizes `processed_html` output with Nokogiri

## Related Tickets & Documents

Closes #10927 

## QA Instructions, Screenshots, Recordings

Open http://localhost:3000/feed/username, resulting XML markup doesn't have `highlight__panel` tags anymore

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed