### PR TITLE
Fix rails db:seed error

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -450,9 +450,16 @@ seeder.create_if_none(FeedbackMessage) do
   )
 
   3.times do
+    article_id = Article
+      .left_joins(:reactions)
+      .where.not(articles: { id: Reaction.article_vomits.pluck(:reactable_id) })
+      .order(Arel.sql("RANDOM()"))
+      .first
+      .id
+
     Reaction.create!(
       category: "vomit",
-      reactable_id: Article.order(Arel.sql("RANDOM()")).first.id,
+      reactable_id: article_id,
       reactable_type: "Article",
       user_id: mod.id,
     )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`rails db:setup` or `rails db:seed` commands sometimes fail. This is because in `db/seeds.rb`, 3 'vomit' reactions are created for 3 randomly selected articles (on a total of 25).

```rb
3.times.do
  Reaction.create!(
    category: "vomit",
    reactable_id: Article.order(Arel.sql("RANDOM()")).first.id,
    reactable_id: article_id,
    reactable_type: "Article",
    user_id: mod.id,
  )
end
```

If the same article is picked 2 times, the creation of the reaction will crash because according to the validations, it is not allowed to create 2 'vomit' reactions for the same article.

With these changes, we make sure to select an article that does not already have a vomit reaction. 

## Related Tickets & Documents

Closes #11271 

## QA Instructions, Screenshots, Recordings

In `db/seeds.rb` on line 188, change `num_articles` to `3`. It is then very likely that `rails db:setup` command will fail on master.
It won't fail with those changes.

## Added tests?

- [ ] Yes
- [x] No, and this is why: seeds are not tested
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![First forem contribution !](https://media.giphy.com/media/BrB6VyTMD1qyQ/giphy.gif)
First forem contribution !