### PR TITLE
Revert "Deploy In Parallel to Heroku Apps"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,16 +82,21 @@ notifications:
 
 jobs:
   include:
-    - stage: Deploy
+    - stage: Deploy DEV
       if: type != pull_request
       script: skip
       after_script: skip
       deploy:
-        - provider: heroku
-          api_key: '$HEROKU_AUTH_TOKEN'
-          app:
-            master: practicaldev
-        - provider: heroku
-          api_key: '$HEROKU_AUTH_TOKEN'
-          app:
-            master: benhalpern-community
+        provider: heroku
+        api_key: '$HEROKU_AUTH_TOKEN'
+        app:
+          master: practicaldev
+    - stage: Deploy BenHalpern
+      if: type != pull_request
+      script: skip
+      after_script: skip
+      deploy:
+        provider: heroku
+        api_key: '$HEROKU_AUTH_TOKEN'
+        app:
+          master: benhalpern-community


### PR DESCRIPTION
Reverts forem/forem#11258 since it deploys I think(waiting to see what happens) the 2 apps in a single job. I would rather have 2 individual sequential jobs then the jobs combined since if one of them fails its harder to tell which one if the deploys are grouped. 