### PR TITLE
Refactor:Enable Datadog When DD_API_KEY is Present

### DIFF
--- a/config/initializers/datadog_apm.rb
+++ b/config/initializers/datadog_apm.rb
@@ -1,6 +1,6 @@
 Datadog.configure do |c|
   c.tracer env: Rails.env
-  c.tracer enabled: Rails.env.production?
+  c.tracer enabled: ENV["DD_API_KEY"].present?
   c.tracer partial_flush: true
   c.tracer priority_sampling: true
   c.use :elasticsearch


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
I am noticing a lot of little Datadog trace errors and warnings coming from a Forem that is missing a DD_API_KEY. I think this might be due to trying to enable Datadog in the code but then not having a key present for sending the logs to Datadog. This updates the code to only enable Datadog tracing if a DD_API_KEY is present. This also eliminates the need for it to be a production environment to enable Datadog. This could be useful if you want to use a personal Datadog account to test something locally. 

## Added tests?
- [x] No, updated a gem configuration which is not our responsibility to test. 


![alt_text](https://media1.giphy.com/media/TI46fnNHSTJUevmwwe/200.gif)
