### PR TITLE
Refactor Completing Onboarding spec for flakiness

### DIFF
--- a/spec/system/onboardings/user_completes_onboarding_spec.rb
+++ b/spec/system/onboardings/user_completes_onboarding_spec.rb
@@ -2,19 +2,21 @@ require "rails_helper"
 
 RSpec.describe "Completing Onboarding", type: :system, js: true do
   let(:password) { Faker::Internet.password(min_length: 8) }
-  let(:user) { create(:user, password: password, password_confirmation: password, saw_onboarding: false) }
 
-  after do
-    sign_out user
+  before do
+    allow(SiteConfig).to receive(:allow_email_password_registration).and_return(true)
+    allow(SiteConfig).to receive(:allow_email_password_login).and_return(true)
   end
 
   context "when the user hasn't seen onboarding" do
+    let(:user) { create(:user, password: password, password_confirmation: password, saw_onboarding: false) }
+
     before do
       visit sign_up_path
       log_in_user(user)
     end
 
-    xit "logs in and redirects to onboarding if it hasn't been seen" do
+    it "logs in and redirects to onboarding if it hasn't been seen" do
       expect(page).to have_current_path("/onboarding", ignore_query: true)
       expect(page.html).to include("onboarding-container")
     end
@@ -28,26 +30,19 @@ RSpec.describe "Completing Onboarding", type: :system, js: true do
   end
 
   context "when the user has seen onboarding" do
-    before do
-      user.update(saw_onboarding: true)
+    let(:user) { create(:user, password: password, password_confirmation: password) }
 
+    before do
       visit sign_up_path
       log_in_user(user)
     end
 
-    xit "logs in and renders the feed" do
+    it "logs in and renders the feed" do
       expect(page).to have_current_path("/?signin=true")
       expect(page.html).not_to include("onboarding-container")
     end
 
-    it "renders the feed and onboarding task card" do
-      visit "/"
-
-      wait_for_javascript
-      expect(page).to have_css(".onboarding-task-card")
-    end
-
-    it "can dismiss the onboarding task card" do
+    it "renders and can dismiss the onboarding task card" do
       visit "/"
 
       wait_for_javascript

--- a/spec/system/onboardings/user_completes_onboarding_spec.rb
+++ b/spec/system/onboardings/user_completes_onboarding_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Completing Onboarding", type: :system, js: true do
   end
 
   context "when the user has seen onboarding" do
-    let(:user) { create(:user, password: password, password_confirmation: password) }
+    let(:user) { create(:user, password: password, password_confirmation: password, saw_onboarding: true) }
 
     before do
       visit sign_up_path


### PR DESCRIPTION
What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In https://github.com/forem/forem/pull/11259, I added some specs that later on, caused flakiness in some CI builds.

@mstruve noticed these and was able to repro them locally (which, confusingly, never was an issue for me on the original PR 🤔), and went ahead and commented them out temporarily in https://github.com/forem/forem/pull/11277.

I did some investigating, and wasn't actually able to find a specific _line_ or issue that was causing these flaky specs. However, noticed some things that I missed in the spec the first time around that could be refactored. Notably, I also realized that I never mocked the `SiteConfig` variables, `allow_email_password_registration` + `allow_email_password_login`. I'm not _entirely_ sure why the spec would have failed in the way it did in when it became flaky, but it seems like adding these mocks in and refactoring the file has resulted in the test file passing consistently for me when running it locally 🤷 

## Related Tickets & Documents

Fixes commented out flaky specs in https://github.com/forem/forem/pull/11277.

## QA Instructions, Screenshots, Recordings

Check out this branch, and run `rspec ./spec/system/onboardings/user_completes_onboarding_spec.rb` locally. You should be able to re-run it a few times and it should continue to pass.

_If it doesn't pass for you, please let me know! It's hard to QA and fix flaky specs as they are not consistently reproducible. 😕_

## Added tests?

- [ ] Yes
- [x] No, and this is why: _this refactors a preexisting spec file, and doesn't add any other, new code_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed

