### PR TITLE
Use OPENRESTY_URL over protocol + domain

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -33,7 +33,7 @@ export REDIS_SIDEKIQ_URL="redis://localhost:6379"
 # Elasticsearch
 export ELASTICSEARCH_URL="http://localhost:9200"
 
-# Openresty
+# OpenResty
 export OPENRESTY_URL=""
 
 # SSL config

--- a/.env_sample
+++ b/.env_sample
@@ -6,10 +6,6 @@ export APP_DOMAIN="localhost:3000"
 export APP_PROTOCOL="http://"
 export FOREM_OWNER_SECRET="secret"
 
-# Openresty domain + Protocol setting for development
-export OPENRESTY_DOMAIN=""
-export OPENRESTY_PROTOCOL=""
-
 # Community Related Variables
 export COMMUNITY_NAME="DEV(local)"
 
@@ -36,6 +32,9 @@ export REDIS_SIDEKIQ_URL="redis://localhost:6379"
 
 # Elasticsearch
 export ELASTICSEARCH_URL="http://localhost:9200"
+
+# Openresty
+export OPENRESTY_URL=""
 
 # SSL config
 export FORCE_SSL_IN_RAILS="not applicable in dev"

--- a/app/services/edge_cache/bust.rb
+++ b/app/services/edge_cache/bust.rb
@@ -44,7 +44,7 @@ module EdgeCache
     end
 
     def nginx_enabled?
-      ApplicationConfig["OPENRESTY_PROTOCOL"].present? && ApplicationConfig["OPENRESTY_DOMAIN"].present?
+      ApplicationConfig["OPENRESTY_URL"].present?
     end
   end
 end

--- a/app/services/edge_cache/bust/nginx.rb
+++ b/app/services/edge_cache/bust/nginx.rb
@@ -26,9 +26,9 @@ module EdgeCache
 
         return true if response.is_a?(Net::HTTPSuccess)
       rescue StandardError
-        # If we can't connect to Openresty, alert ourselves that
+        # If we can't connect to OpenResty, alert ourselves that
         # it is unavailable and return false.
-        Rails.logger.error("Could not connect to Openresty via #{ApplicationConfig['OPENRESTY_URL']}!")
+        Rails.logger.error("Could not connect to OpenResty via #{ApplicationConfig['OPENRESTY_URL']}!")
         DatadogStatsClient.increment("edgecache_bust.service_unavailable",
                                      tags: ["path:#{ApplicationConfig['OPENRESTY_URL']}"])
         false

--- a/app/services/edge_cache/bust/nginx.rb
+++ b/app/services/edge_cache/bust/nginx.rb
@@ -4,17 +4,13 @@ module EdgeCache
       def self.call(path)
         return unless nginx_available?
 
-        uri = URI.parse("#{openresty_path}#{path}")
+        uri = URI.parse("#{ApplicationConfig['OPENRESTY_URL']}#{path}")
         http = Net::HTTP.new(uri.host, uri.port)
         response = http.request Net::HTTP::Purge.new(uri.request_uri)
 
         raise StandardError, "Nginx Purge request failed: #{response.body}" unless response.is_a?(Net::HTTPSuccess)
 
         response.body
-      end
-
-      def self.openresty_path
-        "#{ApplicationConfig['OPENRESTY_PROTOCOL']}#{ApplicationConfig['OPENRESTY_DOMAIN']}"
       end
 
       def self.nginx_available?
@@ -24,7 +20,7 @@ module EdgeCache
         # available just once, and persist it on the class with @provider_available?.
         # Then, we could allow for an array of @paths = [] to be passed in,
         # and on single bust instance could bust multiple paths in order.
-        uri = URI.parse(openresty_path)
+        uri = URI.parse(ApplicationConfig["OPENRESTY_URL"])
         http = Net::HTTP.new(uri.host, uri.port)
         response = http.get(uri.request_uri)
 
@@ -32,8 +28,9 @@ module EdgeCache
       rescue StandardError
         # If we can't connect to Openresty, alert ourselves that
         # it is unavailable and return false.
-        Rails.logger.error("Could not connect to Openresty via #{openresty_path}!")
-        DatadogStatsClient.increment("edgecache_bust.service_unavailable", tags: ["path:#{openresty_path}"])
+        Rails.logger.error("Could not connect to Openresty via #{ApplicationConfig['OPENRESTY_URL']}!")
+        DatadogStatsClient.increment("edgecache_bust.service_unavailable",
+                                     tags: ["path:#{ApplicationConfig['OPENRESTY_URL']}"])
         false
       end
     end

--- a/spec/services/edge_cache/bust_spec.rb
+++ b/spec/services/edge_cache/bust_spec.rb
@@ -97,8 +97,7 @@ RSpec.describe EdgeCache::Bust, type: :service do
   end
 
   def stub_nginx
-    allow(ApplicationConfig).to receive(:[]).with("OPENRESTY_PROTOCOL").and_return(nil)
-    allow(ApplicationConfig).to receive(:[]).with("OPENRESTY_DOMAIN").and_return(nil)
+    allow(ApplicationConfig).to receive(:[]).with("OPENRESTY_URL").and_return(nil)
   end
 
   def configure_fastly
@@ -108,7 +107,6 @@ RSpec.describe EdgeCache::Bust, type: :service do
   end
 
   def configure_nginx
-    allow(ApplicationConfig).to receive(:[]).with("OPENRESTY_PROTOCOL").and_return("http://")
-    allow(ApplicationConfig).to receive(:[]).with("OPENRESTY_DOMAIN").and_return("localhost:9090")
+    allow(ApplicationConfig).to receive(:[]).with("OPENRESTY_URL").and_return("http://localhost:9090")
   end
 end

--- a/spec/services/edge_cache/bust_spec.rb
+++ b/spec/services/edge_cache/bust_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe EdgeCache::Bust, type: :service do
       stub_fastly
     end
 
-    context "when openresty is not configured" do
+    context "when OpenResty is not configured" do
       before do
         stub_nginx
       end
@@ -74,7 +74,7 @@ RSpec.describe EdgeCache::Bust, type: :service do
       end
     end
 
-    context "when openresty is configured and available" do
+    context "when OpenResty is configured and available" do
       before do
         configure_nginx
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR goes along with https://github.com/forem/infra/pull/62, which extracts the concept of `openresty_domain` and `openresty_protocol` (currently hard-coded) into a single variable: `openresty_url`. 

This PR uses that new variable in place of the two variables we were using previously.

## Related Tickets & Documents

https://github.com/forem/infra/pull/62

## QA Instructions, Screenshots, Recordings

Ensure that Nginx still works with caching/busting with this ENV var, and ensure that the tests pass. 

## Added tests?

- [ ] Yes
- [x] No, and this is why: _updated pre-existing tests_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed

