### PR TITLE
Refactor comment dropdown menu functionality

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -46,50 +46,6 @@ function addRelevantButtonsToArticle(user) {
   }
 }
 
-function addRelevantButtonsToComments(user) {
-  if (document.getElementById('comments-container')) {
-    // buttons are actually <span>'s
-    var settingsButts = document.getElementsByClassName('comment-actions');
-
-    for (let i = 0; i < settingsButts.length; i += 1) {
-      let butt = settingsButts[i];
-      const { action, commentableUserId, userId } = butt.dataset;
-      if (parseInt(userId, 10) === user.id && action === 'settings-button') {
-        butt.innerHTML =
-          '<a href="' +
-          butt.dataset.path +
-          '" rel="nofollow" class="crayons-link crayons-link--block" data-no-instant>Settings</a>';
-        butt.classList.remove('hidden');
-        butt.classList.add('block');
-      }
-
-      if (
-        action === 'hide-button' &&
-        parseInt(commentableUserId, 10) === user.id
-      ) {
-        butt.classList.remove('hidden');
-        butt.classList.add('block');
-      }
-    }
-
-    if (user.trusted) {
-      var modButts = document.getElementsByClassName('mod-actions');
-      for (let i = 0; i < modButts.length; i += 1) {
-        let butt = modButts[i];
-        if (butt.classList.contains('mod-actions-comment-button')) {
-          butt.innerHTML =
-            '<a href="' +
-            butt.dataset.path +
-            '" rel="nofollow" class="crayons-link crayons-link--block">Moderate</a>';
-        }
-        butt.className = 'mod-actions';
-        butt.classList.remove('hidden');
-        butt.classList.add('block');
-      }
-    }
-  }
-}
-
 function setCurrentUserToNavBar(user) {
   const userNavLink = document.getElementById('first-nav-link');
   userNavLink.href = `/${user.username}`;
@@ -109,5 +65,9 @@ function initializeBaseUserData() {
   initializeUserSidebar(user);
   initializeProfileImage(user);
   addRelevantButtonsToArticle(user);
-  addRelevantButtonsToComments(user);
+
+}
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
 }

--- a/app/assets/javascripts/initializers/initializeCommentDropdown.js
+++ b/app/assets/javascripts/initializers/initializeCommentDropdown.js
@@ -131,5 +131,5 @@ function initializeCommentDropdown() {
 
   setTimeout(function addListeners() {
     getAllByClassName('dropbtn').forEach(addDropdownListener);
-  }, 100);
+  }, 200);
 }

--- a/app/assets/javascripts/initializers/initializeCommentsPage.js
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js
@@ -162,10 +162,10 @@ function addCommentDropdownFunctionality(user) {
       let shellData = shell.dataset
       let hideHTML = '';
       let hideAction = '';
-      if (user) {
-        if (user.id === shellData.commentableUserId && shellData.hidden === 'false') {
+      if (user && user.id === shellData.commentableUserId) {
+        if (shellData.hidden === 'false') {
           hideAction = 'hide'
-        } else if (user.id === shellData.commentableUserId) {
+        } else {
           hideAction = 'unhide'
         }  
         hideHTML = `<a href="#" class="crayons-link crayons-link--block hide-comment" data-hide-type="${hideAction}" data-comment-id="${shellData.commentId}">${capitalizeFirstLetter(hideAction)}</a>`

--- a/app/assets/javascripts/initializers/initializeCommentsPage.js
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js
@@ -1,6 +1,5 @@
 function initializeCommentsPage() {
   if (document.getElementById('comments-container')) {
-    toggleCodeOfConduct();
     var commentableId = document.getElementById('comments-container').dataset.commentableId;
     var commentableType = document.getElementById('comments-container').dataset.commentableType;
     commentableIdList = commentableId.split(",");
@@ -150,20 +149,40 @@ function initializeCommentsPage() {
     }
   }
   listenForDetailsToggle();
+  const user = userData();
+  addCommentDropdownFunctionality(user);
 }
 
-function toggleCodeOfConduct() {
-  var user = userData();
-  if (!user) {
-    return;
-  }
-  var codeOfConduct = user.checked_code_of_conduct
-  var checkboxWrapper = document.getElementById('toggle-code-of-conduct-checkbox');
-  if (checkboxWrapper && !codeOfConduct) {
-    checkboxWrapper.innerHTML = '<input type="checkbox" name="checked_code_of_conduct" class="checkbox" required/>\
-                                  <label for="checked_code_of_conduct">I\'ve read the <a href="/code-of-conduct">code of conduct</a></label>'
+function addCommentDropdownFunctionality(user) {
+  if (document.getElementById('comments-container')) {
+    var commentDropdowns = document.getElementsByClassName('comment-dropdown-shell');
+
+    for (let i = 0; i < commentDropdowns.length; i += 1) {
+      let shell = commentDropdowns[i];
+      let shellData = shell.dataset
+      let hideHTML = '';
+      let hideAction = '';
+      if (user) {
+        if (user.id === shellData.commentableUserId && shellData.hidden === 'false') {
+          hideAction = 'hide'
+        } else if (user.id === shellData.commentableUserId) {
+          hideAction = 'unhide'
+        }  
+        hideHTML = `<a href="#" class="crayons-link crayons-link--block hide-comment" data-hide-type="${hideAction}" data-comment-id="${shellData.commentId}">${capitalizeFirstLetter(hideAction)}</a>`
+      }
+      shell.innerHTML = `<div class="crayons-dropdown p-1 right-1 left-1 s:right-0 s:left-auto fs-base">
+        <a href="${shellData.commentPath}" class="crayons-link crayons-link--block">Permalink</a>
+        ${user && user.id === shellData.commentUserId ?
+          `<a href="${shellData.commentPath}/settings" rel="nofollow" class="crayons-link crayons-link--block" data-no-instant>Settings</a>` : ''}
+        ${hideHTML}
+        </span>
+        <span class="mod-actions hidden mod-actions-comment-button" data-path="${shellData.commentPath}/mod"></span>
+        <span class="report-abuse-link-wrapper" data-path="/report-abuse?url=${window.location.origin + shellData.commentPath}"></span>
+      </div>`
+    }
   }
 }
+
 
 function replaceActionButts(el) {
   var loggedInActionButts = "";

--- a/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildCommentFormHTML.js.erb
@@ -1,13 +1,6 @@
 function buildCommentFormHTML(commentableId, commentableType, parentId) {
   var authToken = document.querySelector("meta[name='csrf-token']").getAttribute('content');
   var user = userData();
-  var codeOfConductHTML = ""
-  if (user && !user.codeOfConduct && user.commentCount < 1){
-    codeOfConductHTML =   '<div class="code-of-conduct sub-comment-code-of-conduct" style="display:block" id="toggle-code-of-conduct-checkbox">\
-                            <input class="checkbox" type="checkbox" name="checked_code_of_conduct" required />\
-                            <label for="checked_code_of_conduct">I\'ve read the <a href="/code-of-conduct">code of conduct</a></label>\
-                          </div>'
-  }
   var randomIdNumber = Math.floor(Math.random() * 1991);
 
   return `<form class="comment-form pt-4" onsubmit="handleCommentSubmit.bind(this)(event)" id="new-comment-${parentId}" action="/comments" accept-charset="UTF-8" method="post" data-comment-id="${parentId}">

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -49,20 +49,12 @@
         <button class="dropbtn" aria-label="Toggle dropdown menu">
           <%= inline_svg_tag("overflow-horizontal.svg", aria: true, class: "dropdown-icon", title: "Dropdown menu") %>
         </button>
-        <div class="dropdown">
-          <div class="crayons-dropdown p-1 right-1 left-1 s:right-0 s:left-auto fs-base">
-            <a href="<%= comment.path %>" class="crayons-link crayons-link--block">Permalink</a>
-            <span class="comment-actions hidden" data-user-id="<%= comment.user_id %>" data-action="settings-button" data-path="<%= comment.path %>/settings">
-            </span>
-            <% action = comment.hidden_by_commentable_user ? "Unhide" : "Hide" %>
-            <span class="comment-actions hidden" data-action="hide-button" data-commentable-user-id="<%= commentable.user_id %>" data-user-id="<%= comment.user_id %>" style="display: none; width: 100%;">
-              <a href="#" class="crayons-link crayons-link--block hide-comment" data-hide-type="<%= action.downcase %>" data-comment-id="<%= comment.id %>">
-                <%= action %>
-              </a>
-            </span>
-            <span class="mod-actions hidden mod-actions-comment-button" data-path="<%= comment.path %>/mod"></span>
-            <span class="report-abuse-link-wrapper" data-path="/report-abuse?url=<%= comment_url(comment) %>"></span>
-          </div>
+        <div class="dropdown comment-dropdown-shell"
+          data-comment-id="<%= comment.id %>"
+          data-user-id="<%= comment.user_id %>"
+          data-comment-path="<%= comment.path %>"
+          data-commentable-user-id="<%= commentable.user_id %>"
+          data-hidden="<%= comment.hidden_by_commentable_user %>">
         </div>
       </div>
       <div class="body <%= "low-quality-comment" if decorated_comment.low_quality %>">

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -95,8 +95,6 @@
       <a href="<%= @comment.path %>" class="crayons-btn crayons-btn--ghost js-btn-dismiss hidden">Dismiss</a>
     </div>
   </div>
-
-  <div class="code-of-conduct" id="toggle-code-of-conduct-checkbox"></div>
 <% end %>
 
 <% if @comment.persisted? %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This is a refactor which should not affect user functionality, but it does have nice positive impacts.

- IMO it cleans up the code a bit.
- It saves a good deal of bandwidth. Every comment dropdown at the moment is about 800 characters. I'm not sure how it shakes up after gzipping etc, but this is definitely an improvement for overall file size. A page with 50 comments currently uses 4,000 characters just to render these dropdown menus. 😱
- SEO will enjoy slightly smaller pages. It is also good SEO practice to strip away sections that do not serve the page's content and important navigation, where appropriate, so this should be a solid benefit in that regard. 

I also removed a bit of dead code along the way.