### PR TITLE
Render op markers for coauthors

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -16,7 +16,7 @@ module CommentsHelper
       [
         commentable.user_id,
         commentable.co_author_ids,
-      ].any? { |id| id == comment.user_id }
+      ].flatten.any? { |id| id == comment.user_id }
   end
 
   def get_ama_or_op_banner(commentable)

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
       with_title { true }
       with_collection { nil }
     end
+    co_author_ids { [] }
     association :user, factory: :user, strategy: :create
     description { Faker::Hipster.paragraph(sentence_count: 1)[0..100] }
     main_image    { with_main_image ? Faker::Avatar.image : nil }

--- a/spec/system/user_visits_a_comments_page_spec.rb
+++ b/spec/system/user_visits_a_comments_page_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe "Views an article", type: :system, js: true do
   let(:user) { create(:user) }
-  let(:article) { create(:article, user: user) }
+  let(:co_author) { create(:user) }
+  let(:article) { create(:article, user: user, co_author_ids: [co_author.id]) }
+  let(:ama_article) { create(:article, user: user, tags: "ama") }
 
   let!(:comment) { create(:comment, commentable: article) }
   let!(:child_comment) { create(:comment, parent: comment, commentable: article) }
@@ -12,6 +14,22 @@ RSpec.describe "Views an article", type: :system, js: true do
     visit "#{article.path}/comments"
 
     expect(page).to have_selector(".single-comment-node", visible: :visible, count: 3)
+    expect(page).not_to have_selector(".op-marker")
+  end
+
+  it "shows op marker on author and co-author comments" do
+    create(:comment, user: user, commentable: article)
+    create(:comment, user: co_author, commentable: article)
+    visit "#{article.path}/comments"
+
+    expect(page).to have_selector(".op-marker", visible: :visible, text: "Author", count: 2)
+  end
+
+  it "shows special op marker on ama articles" do
+    create(:comment, user: user, commentable: ama_article)
+    visit "#{ama_article.path}/comments"
+
+    expect(page).to have_selector(".op-marker", visible: :visible, text: "Ask Me Anything")
   end
 
   it "shows a thread" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We weren't rendering "OP markers" (author identifying flair) on coauthors. This change fixes that!

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/11128

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed
