### PR TITLE
Fix hidden progress bar

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -229,7 +229,7 @@
   position: fixed;
   top: 0;
   background: var(--accent-brand);
-  z-index: var(--popover);
+  z-index: var(--z-popover);
   height: var(--su-1);
   width: 0;
   &.showing {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes hidden progress bar by replacing `--popover` with `--z-popover`

## Related Tickets & Documents

Fix #11293

## QA Instructions, Screenshots, Recordings

1. Simulate slow connection on devtools
2. Go to any page with devtools is opened
3. Progress bar should be displayed while next page is loading

![201106151733](https://user-images.githubusercontent.com/33394747/98344172-71434b80-2045-11eb-85e9-ef45c57d67dc.gif)

## Added tests?

- [ ] Yes
- [X] No, not needed
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [X] No documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![cross fingers](https://user-images.githubusercontent.com/33394747/98343884-11e53b80-2045-11eb-9c8f-45fbb035a915.gif)