### PR TITLE
Validate Image URLs in SiteConfig

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -142,7 +142,7 @@ module Admin
         onboarding_taskcard_image
       ].freeze
 
-    VALID_URL = %r{\A(http|https)://([/|.|\w|\s|-])*.[a-z]{2,5}(:[0-9]{1,5})?(/.*)?$}.freeze
+    VALID_URL = %r{\A(http|https)://([/|.|\w|\s|-])*.[a-z]{2,5}(:[0-9]{1,5})?(/.*)\z}.freeze
 
     layout "admin"
 

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -133,6 +133,7 @@ module Admin
 
     before_action :extra_authorization_and_confirmation, only: [:create]
     before_action :validate_inputs, only: [:create]
+    before_action :validate_image_urls, only: [:create]
     after_action :bust_content_change_caches, only: [:create]
 
     def show
@@ -202,6 +203,12 @@ module Admin
       redirect_to admin_config_path, alert: "😭 #{errors.join(',')}" if errors.any?
     end
 
+    def validate_image_urls
+      errors = []
+      errors << "Image URL must be a valid URL" unless valid_image_url
+      redirect_to admin_config_path, alert: "😭 #{errors.join(',')}" if errors.any?
+    end
+
     def clean_up_params
       config = params[:site_config]
       return unless config
@@ -232,6 +239,14 @@ module Admin
     def brand_color_not_hex
       hex = params.dig(:site_config, :primary_brand_color_hex)
       hex.present? && !hex.match?(/\A#(\h{6}|\h{3})\z/)
+    end
+
+    def valid_image_url
+      image_url = params.dig(:site_config, :main_social_image) ||
+        params.dig(:site_config, :logo_png) ||
+        params.dig(:site_config, :secondary_logo_url)
+      valid_url = %r{\A(https:)//([/|.|\w|\s|-])*\.(?:jpg|gif|png)/}
+      image_url.present? && image_url.match?(valid_url)
     end
   end
 end

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -244,7 +244,13 @@ module Admin
     def valid_image_url
       image_url = params.dig(:site_config, :main_social_image) ||
         params.dig(:site_config, :logo_png) ||
-        params.dig(:site_config, :secondary_logo_url)
+        params.dig(:site_config, :secondary_logo_url) ||
+        params.dig(:site_config, :campaign_sidebar_image) ||
+        params.dig(:site_config, :mascot_image_url) ||
+        params.dig(:site_config, :mascot_footer_image_url) ||
+        params.dig(:site_config, :onboarding_logo_image) ||
+        params.dig(:site_config, :onboarding_background_image) ||
+        params.dig(:site_config, :onboarding_taskcard_image)
       valid_url = %r{\A(https:)//([/|.|\w|\s|-])*\.(?:jpg|gif|png)/}
       image_url.present? && image_url.match?(valid_url)
     end

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -129,7 +129,7 @@ module Admin
         home_feed_minimum_score
       ].freeze
 
-    VALID_IMAGE_URLS =
+    IMAGE_FIELDS =
       %i[
         logo_png
         secondary_logo_url

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -129,28 +129,23 @@ module Admin
         home_feed_minimum_score
       ].freeze
 
-    # VALID_IMAGE_URLS =
-    #   %i[
-    #     logo_png
-    #     secondary_logo_url
-    #     mascot_image_url
-    #     mascot_footer_image_url
-    #     campaign_sidebar_image
-    #     onboarding_logo_image
-    #     onboarding_background_image
-    #     onboarding_taskcard_image
-    #   ].freeze
+    VALID_IMAGE_URLS =
+      %i[
+        logo_png
+        secondary_logo_url
+        mascot_image_url
+        mascot_footer_image_url
+        campaign_sidebar_image
+        onboarding_logo_image
+        onboarding_background_image
+        onboarding_taskcard_image
+      ].freeze
 
     layout "admin"
 
     before_action :extra_authorization_and_confirmation, only: [:create]
     before_action :validate_inputs, only: [:create]
-    after_action :validate_image_urls, only: [:create]
-    # before_action :validate_image_urls, only: [:valid_image_url]
-    # before_action :validate_image_urls, if: :valid_image_url, only: [:create]
-    # before_action :validate_image_urls, only: [:valid_image_url], if: -> { :VALID_IMAGE_URLS }
-    # before_save :validate_image_urls
-    # before_action :validate_image_urls, only: [:valid_image_url]
+    before_action :validate_image_urls, only: [:create], if: -> { VALID_IMAGE_URLS.present? }
     after_action :bust_content_change_caches, only: [:create]
 
     def show
@@ -159,7 +154,6 @@ module Admin
 
     def create
       clean_up_params
-      # validate_image_urls
 
       config_params.each do |key, value|
         if value.is_a?(Array)
@@ -271,7 +265,6 @@ module Admin
         params.dig(:site_config, :onboarding_taskcard_image)
       valid_url = %r{\A(https:)//([/|.|\w|\s|-])*\.(?:jpg|gif|png)/}
       image_url.present? && image_url.match?(valid_url)
-      # VALID_IMAGE_URLS.present? && VALID_IMAGE_URLS.match?(valid_url)
     end
   end
 end

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -129,11 +129,28 @@ module Admin
         home_feed_minimum_score
       ].freeze
 
+    VALID_IMAGE_URLS =
+      %i[
+        logo_png
+        secondary_logo_url
+        mascot_image_url
+        mascot_footer_image_url
+        campaign_sidebar_image
+        onboarding_logo_image
+        onboarding_background_image
+        onboarding_taskcard_image
+      ].freeze
+
     layout "admin"
 
     before_action :extra_authorization_and_confirmation, only: [:create]
     before_action :validate_inputs, only: [:create]
-    before_action :validate_image_urls, only: [:create]
+    after_action :validate_image_urls, only: [:create]
+    # before_action :validate_image_urls, only: [:valid_image_url]
+    # before_action :validate_image_urls, if: :valid_image_url, only: [:create]
+    # before_action :validate_image_urls, only: [:valid_image_url], if: -> { :VALID_IMAGE_URLS }
+    # before_save :validate_image_urls
+    # before_action :validate_image_urls, only: [:valid_image_url]
     after_action :bust_content_change_caches, only: [:create]
 
     def show
@@ -142,6 +159,7 @@ module Admin
 
     def create
       clean_up_params
+      # validate_image_urls
 
       config_params.each do |key, value|
         if value.is_a?(Array)
@@ -253,6 +271,7 @@ module Admin
         params.dig(:site_config, :onboarding_taskcard_image)
       valid_url = %r{\A(https:)//([/|.|\w|\s|-])*\.(?:jpg|gif|png)/}
       image_url.present? && image_url.match?(valid_url)
+      # VALID_IMAGE_URLS.present? && VALID_IMAGE_URLS.match?(valid_url)
     end
   end
 end

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -131,11 +131,12 @@ module Admin
 
     IMAGE_FIELDS =
       %i[
+        main_social_image
         logo_png
         secondary_logo_url
+        campaign_sidebar_image
         mascot_image_url
         mascot_footer_image_url
-        campaign_sidebar_image
         onboarding_logo_image
         onboarding_background_image
         onboarding_taskcard_image
@@ -145,7 +146,7 @@ module Admin
 
     before_action :extra_authorization_and_confirmation, only: [:create]
     before_action :validate_inputs, only: [:create]
-    before_action :validate_image_urls, only: [:create], if: -> { VALID_IMAGE_URLS.present? }
+    before_action :validate_image_urls, only: [:create], if: -> { params[:site_config].key?(IMAGE_FIELDS) }
     after_action :bust_content_change_caches, only: [:create]
 
     def show

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -129,17 +129,17 @@ module Admin
         home_feed_minimum_score
       ].freeze
 
-    VALID_IMAGE_URLS =
-      %i[
-        logo_png
-        secondary_logo_url
-        mascot_image_url
-        mascot_footer_image_url
-        campaign_sidebar_image
-        onboarding_logo_image
-        onboarding_background_image
-        onboarding_taskcard_image
-      ].freeze
+    # VALID_IMAGE_URLS =
+    #   %i[
+    #     logo_png
+    #     secondary_logo_url
+    #     mascot_image_url
+    #     mascot_footer_image_url
+    #     campaign_sidebar_image
+    #     onboarding_logo_image
+    #     onboarding_background_image
+    #     onboarding_taskcard_image
+    #   ].freeze
 
     layout "admin"
 

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -142,7 +142,7 @@ module Admin
         onboarding_taskcard_image
       ].freeze
 
-    VALID_URL = %r{\A(http|https)://([/|.|\w|\s|-])*.[a-z]{2,5}(:[0-9]{1,5})?(/.*)\z}.freeze
+    VALID_URL = %r{\A(http|https)://([/|.|\w|\s|-])*.[a-z]{2,5}(:[0-9]{1,5})?(/.*)?\z}.freeze
 
     layout "admin"
 

--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -142,7 +142,7 @@ module Admin
         onboarding_taskcard_image
       ].freeze
 
-    VALID_URL = %r{\A(http|https)://([/|.|\w|\s|-])*.(?:jpg|gif|png)}.freeze
+    VALID_URL = %r{\A(http|https)://([/|.|\w|\s|-])*.[a-z]{2,5}(:[0-9]{1,5})?(/.*)?$}.freeze
 
     layout "admin"
 

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -238,9 +238,9 @@ RSpec.describe "/admin/config", type: :request do
         end
 
         it "only updates the main_social_image if given a valid image URL" do
-          expected_image_url = "![logo_lowres]https://dummyimage.com/300x300"
+          invalid_image_url = "![logo_lowres]https://dummyimage.com/300x300"
           expect do
-            post "/admin/config", params: { site_config: { main_social_image: expected_image_url },
+            post "/admin/config", params: { site_config: { main_social_image: invalid_image_url },
                                             confirmation: confirmation_message }
           end.not_to change(SiteConfig, :main_social_image)
         end
@@ -250,14 +250,6 @@ RSpec.describe "/admin/config", type: :request do
           post "/admin/config", params: { site_config: { favicon_url: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.favicon_url).to eq(expected_image_url)
-        end
-
-        it "only updates the favicon_url if given a valid image URL" do
-          expected_image_url = "![logo_lowres]https://dummyimage.com/300x300"
-          expect do
-            post "/admin/config", params: { site_config: { favicon_url: expected_image_url },
-                                            confirmation: confirmation_message }
-          end.not_to change(SiteConfig, :favicon_url)
         end
 
         it "updates logo_png" do
@@ -270,9 +262,9 @@ RSpec.describe "/admin/config", type: :request do
         end
 
         it "only updates the logo_png if given a valid image URL" do
-          expected_image_url = "![logo_lowres]https://dummyimage.com/300x300"
+          invalid_image_url = "![logo_lowres]https://dummyimage.com/300x300"
           expect do
-            post "/admin/config", params: { site_config: { logo_png: expected_image_url },
+            post "/admin/config", params: { site_config: { logo_png: invalid_image_url },
                                             confirmation: confirmation_message }
           end.not_to change(SiteConfig, :logo_png)
         end
@@ -292,9 +284,9 @@ RSpec.describe "/admin/config", type: :request do
         end
 
         it "only updates the secondary_logo_url if given a valid image URL" do
-          expected_image_url = "![logo_lowres]https://dummyimage.com/300x300"
+          invalid_image_url = "![logo_lowres]https://dummyimage.com/300x300"
           expect do
-            post "/admin/config", params: { site_config: { secondary_logo_url: expected_image_url },
+            post "/admin/config", params: { site_config: { secondary_logo_url: invalid_image_url },
                                             confirmation: confirmation_message }
           end.not_to change(SiteConfig, :secondary_logo_url)
         end

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -237,11 +237,29 @@ RSpec.describe "/admin/config", type: :request do
           expect(SiteConfig.main_social_image).to eq(expected_image_url)
         end
 
+        it "only updates the main_social_image if given a valid image URL" do
+          expected_image_url = "![logo_lowres]https://dummyimage.com/300x300"
+          expect do
+            post "/admin/config", params: { site_config: { main_social_image: expected_image_url },
+                                            confirmation: confirmation_message }
+            # expect(SiteConfig.main_social_image).not_to eq(expected_image_url)
+          end.not_to change(SiteConfig, :main_social_image)
+        end
+
         it "updates favicon_url" do
           expected_image_url = "https://dummyimage.com/300x300"
           post "/admin/config", params: { site_config: { favicon_url: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.favicon_url).to eq(expected_image_url)
+        end
+
+        it "only updates the favicon_url if given a valid image URL" do
+          expected_image_url = "![logo_lowres]https://dummyimage.com/300x300"
+          expect do
+            post "/admin/config", params: { site_config: { favicon_url: expected_image_url },
+                                            confirmation: confirmation_message }
+            # expect(SiteConfig.main_social_image).not_to eq(expected_image_url)
+          end.not_to change(SiteConfig, :favicon_url)
         end
 
         it "updates logo_png" do
@@ -251,6 +269,15 @@ RSpec.describe "/admin/config", type: :request do
             post "/admin/config", params: { site_config: { logo_png: expected_image_url },
                                             confirmation: confirmation_message }
           end.to change(SiteConfig, :logo_png).from(expected_default_image_url).to(expected_image_url)
+        end
+
+        it "only updates the logo_png if given a valid image URL" do
+          expected_image_url = "![logo_lowres]https://dummyimage.com/300x300"
+          expect do
+            post "/admin/config", params: { site_config: { logo_png: expected_image_url },
+                                            confirmation: confirmation_message }
+            # expect(SiteConfig.main_social_image).not_to eq(expected_image_url)
+          end.not_to change(SiteConfig, :logo_png)
         end
 
         it "updates logo_svg" do
@@ -265,6 +292,15 @@ RSpec.describe "/admin/config", type: :request do
           post "/admin/config", params: { site_config: { secondary_logo_url: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.secondary_logo_url).to eq(expected_image_url)
+        end
+
+        it "only updates the secondary_logo_url if given a valid image URL" do
+          expected_image_url = "![logo_lowres]https://dummyimage.com/300x300"
+          expect do
+            post "/admin/config", params: { site_config: { secondary_logo_url: expected_image_url },
+                                            confirmation: confirmation_message }
+            # expect(SiteConfig.main_social_image).not_to eq(expected_image_url)
+          end.not_to change(SiteConfig, :secondary_logo_url)
         end
 
         it "updates left_navbar_svg_icon" do

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "/admin/config", type: :request do
       end
 
       it "does not allow user to update config if they have proper confirmation" do
-        expected_image_url = "https://dummyimage.com/300x300"
+        expected_image_url = "https://dummyimage.com/300x300.png"
         expect do
           post "/admin/config", params: { site_config: { favicon_url: expected_image_url },
                                           confirmation: confirmation_message }
@@ -34,7 +34,7 @@ RSpec.describe "/admin/config", type: :request do
       end
 
       it "does not allow user to update config if they do not have proper confirmation" do
-        expected_image_url = "https://dummyimage.com/300x300"
+        expected_image_url = "https://dummyimage.com/300x300.png"
         expect do
           post "/admin/config", params: { site_config: { favicon_url: expected_image_url },
                                           confirmation: "Not proper" }
@@ -231,7 +231,7 @@ RSpec.describe "/admin/config", type: :request do
           expected_default_image_url = URL.local_image("social-media-cover.png")
           expect(SiteConfig.main_social_image).to eq(expected_default_image_url)
 
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           post "/admin/config", params: { site_config: { main_social_image: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.main_social_image).to eq(expected_image_url)
@@ -246,7 +246,7 @@ RSpec.describe "/admin/config", type: :request do
         end
 
         it "updates favicon_url" do
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           post "/admin/config", params: { site_config: { favicon_url: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.favicon_url).to eq(expected_image_url)
@@ -254,7 +254,7 @@ RSpec.describe "/admin/config", type: :request do
 
         it "updates logo_png" do
           expected_default_image_url = URL.local_image("icon.png")
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           expect do
             post "/admin/config", params: { site_config: { logo_png: expected_image_url },
                                             confirmation: confirmation_message }
@@ -262,7 +262,7 @@ RSpec.describe "/admin/config", type: :request do
         end
 
         it "only updates the logo_png if given a valid image URL" do
-          invalid_image_url = "![logo_lowres]https://dummyimage.com/300x300"
+          invalid_image_url = "![logo_lowres]https://dummyimage.com/300x300.png"
           expect do
             post "/admin/config", params: { site_config: { logo_png: invalid_image_url },
                                             confirmation: confirmation_message }
@@ -270,21 +270,21 @@ RSpec.describe "/admin/config", type: :request do
         end
 
         it "updates logo_svg" do
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           post "/admin/config", params: { site_config: { logo_svg: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.logo_svg).to eq(expected_image_url)
         end
 
         it "updates secondary_logo_url" do
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           post "/admin/config", params: { site_config: { secondary_logo_url: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.secondary_logo_url).to eq(expected_image_url)
         end
 
         it "only updates the secondary_logo_url if given a valid image URL" do
-          invalid_image_url = "![logo_lowres]https://dummyimage.com/300x300"
+          invalid_image_url = "![logo_lowres]https://dummyimage.com/300x300.png"
           expect do
             post "/admin/config", params: { site_config: { secondary_logo_url: invalid_image_url },
                                             confirmation: confirmation_message }
@@ -308,7 +308,7 @@ RSpec.describe "/admin/config", type: :request do
         end
 
         it "rejects update without proper confirmation" do
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           expect do
             post "/admin/config", params: { site_config: { logo_svg: expected_image_url },
                                             confirmation: "Incorrect yo!" }
@@ -316,7 +316,7 @@ RSpec.describe "/admin/config", type: :request do
         end
 
         it "rejects update without any confirmation" do
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           expect do
             post "/admin/config", params: { site_config: { logo_svg: expected_image_url },
                                             confirmation: "" }
@@ -334,7 +334,7 @@ RSpec.describe "/admin/config", type: :request do
 
         it "updates mascot_image_url" do
           expected_default_image_url = URL.local_image("mascot.png")
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           expect do
             post "/admin/config", params: { site_config: { mascot_image_url: expected_image_url },
                                             confirmation: confirmation_message }
@@ -342,7 +342,7 @@ RSpec.describe "/admin/config", type: :request do
         end
 
         it "updates mascot_footer_image_url" do
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           post "/admin/config", params: { site_config: { mascot_footer_image_url: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.mascot_footer_image_url).to eq(expected_image_url)
@@ -473,21 +473,21 @@ RSpec.describe "/admin/config", type: :request do
 
       describe "Onboarding" do
         it "updates onboarding_taskcard_image" do
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           post "/admin/config", params: { site_config: { onboarding_taskcard_image: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.onboarding_taskcard_image).to eq(expected_image_url)
         end
 
         it "updates onboarding_logo_image" do
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           post "/admin/config", params: { site_config: { onboarding_logo_image: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.onboarding_logo_image).to eq(expected_image_url)
         end
 
         it "updates onboarding_background_image" do
-          expected_image_url = "https://dummyimage.com/300x300"
+          expected_image_url = "https://dummyimage.com/300x300.png"
           post "/admin/config", params: { site_config: { onboarding_background_image: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.onboarding_background_image).to eq(expected_image_url)

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -237,6 +237,13 @@ RSpec.describe "/admin/config", type: :request do
           expect(SiteConfig.main_social_image).to eq(expected_image_url)
         end
 
+        it "updates main_social_image with a valid image" do
+          expected_image = "https://dummyimage.com/300x300"
+          post "/admin/config", params: { site_config: { main_social_image: expected_image },
+                                          confirmation: confirmation_message }
+          expect(SiteConfig.main_social_image).to eq(expected_image)
+        end
+
         it "only updates the main_social_image if given a valid image URL" do
           invalid_image_url = "![logo_lowres]https://dummyimage.com/300x300"
           expect do
@@ -261,6 +268,13 @@ RSpec.describe "/admin/config", type: :request do
           end.to change(SiteConfig, :logo_png).from(expected_default_image_url).to(expected_image_url)
         end
 
+        it "updates logo_png with a valid image" do
+          expected_image = "https://dummyimage.com/300x300"
+          post "/admin/config", params: { site_config: { logo_png: expected_image },
+                                          confirmation: confirmation_message }
+          expect(SiteConfig.logo_png).to eq(expected_image)
+        end
+
         it "only updates the logo_png if given a valid image URL" do
           invalid_image_url = "![logo_lowres]https://dummyimage.com/300x300.png"
           expect do
@@ -281,6 +295,13 @@ RSpec.describe "/admin/config", type: :request do
           post "/admin/config", params: { site_config: { secondary_logo_url: expected_image_url },
                                           confirmation: confirmation_message }
           expect(SiteConfig.secondary_logo_url).to eq(expected_image_url)
+        end
+
+        it "updates secondary_logo_url with a valid image" do
+          expected_image = "https://dummyimage.com/300x300"
+          post "/admin/config", params: { site_config: { secondary_logo_url: expected_image },
+                                          confirmation: confirmation_message }
+          expect(SiteConfig.secondary_logo_url).to eq(expected_image)
         end
 
         it "only updates the secondary_logo_url if given a valid image URL" do

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -242,7 +242,6 @@ RSpec.describe "/admin/config", type: :request do
           expect do
             post "/admin/config", params: { site_config: { main_social_image: expected_image_url },
                                             confirmation: confirmation_message }
-            # expect(SiteConfig.main_social_image).not_to eq(expected_image_url)
           end.not_to change(SiteConfig, :main_social_image)
         end
 
@@ -258,7 +257,6 @@ RSpec.describe "/admin/config", type: :request do
           expect do
             post "/admin/config", params: { site_config: { favicon_url: expected_image_url },
                                             confirmation: confirmation_message }
-            # expect(SiteConfig.main_social_image).not_to eq(expected_image_url)
           end.not_to change(SiteConfig, :favicon_url)
         end
 
@@ -276,7 +274,6 @@ RSpec.describe "/admin/config", type: :request do
           expect do
             post "/admin/config", params: { site_config: { logo_png: expected_image_url },
                                             confirmation: confirmation_message }
-            # expect(SiteConfig.main_social_image).not_to eq(expected_image_url)
           end.not_to change(SiteConfig, :logo_png)
         end
 
@@ -299,7 +296,6 @@ RSpec.describe "/admin/config", type: :request do
           expect do
             post "/admin/config", params: { site_config: { secondary_logo_url: expected_image_url },
                                             confirmation: confirmation_message }
-            # expect(SiteConfig.main_social_image).not_to eq(expected_image_url)
           end.not_to change(SiteConfig, :secondary_logo_url)
         end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
**The issue**:
> As a Forem Admin, I might make a mistake and add erroneous info into the image URL field. This shouldn't break the site.

**The solution**:
This PR adds validations to the `Admin::ConfigsController` that check an image's URL against some regexp to ensure that the image URL is valid before saving the changes to the SiteConfig.

## Related Tickets & Documents
Closes https://github.com/forem/InternalProjectPlanning/issues/249

## QA Instructions, Screenshots, Recordings
**To QA this PR, first ensure that you have an admin role, and then please do the following**:

- Navigate to `/admin/config`:
![Screen Shot 2020-11-06 at 3 02 09 PM](https://user-images.githubusercontent.com/32834804/98418867-13ad0000-2041-11eb-951a-52cecfb49255.png)

- Navigate to the "Images" section and attempt to update an image with an invalid image URL, such as `![low_res]https://fjhkfhwk.png`. You should be shown an error message: "😭  Image URL must be a valid URL":
![Screen Shot 2020-11-06 at 3 03 30 PM](https://user-images.githubusercontent.com/32834804/98418996-5a9af580-2041-11eb-884e-3e6caa5235ff.png)
![Screen Shot 2020-11-06 at 3 04 04 PM](https://user-images.githubusercontent.com/32834804/98419026-68e91180-2041-11eb-957a-2a7528a0c75d.png)

- Navigate back to the "Images" section and update the form with a valid image URL--you should be shown a success message upon update:
<img width="1336" alt="Screen Shot 2020-11-10 at 3 44 08 PM" src="https://user-images.githubusercontent.com/32834804/98742413-afa17900-236b-11eb-8669-5a61e35771a9.png">
<img width="1358" alt="Screen Shot 2020-11-10 at 3 43 32 PM" src="https://user-images.githubusercontent.com/32834804/98742417-b16b3c80-236b-11eb-9e8a-a074cd832b5b.png">

- Attempt to update the SiteConfig with invalid image URLs in other sections where images can be uploaded (Mascot, Onboarding, etc.) and ensure that it fails with the error message and redirect _back_ to the `admin_config_path`:
![Screen Shot 2020-11-06 at 3 06 10 PM](https://user-images.githubusercontent.com/32834804/98419140-a6e63580-2041-11eb-8a70-778708e7ceea.png)
![Screen Shot 2020-11-06 at 3 04 04 PM](https://user-images.githubusercontent.com/32834804/98419160-b1083400-2041-11eb-96d9-7870b79d3570.png)

- Try to break things! 🔨 

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
Nope!

## [optional] What gif best describes this PR or how it makes you feel?

![Upload Button](https://media.giphy.com/media/zSAXyipHKtoZ2/giphy.gif)
