### PR TITLE
Correctly set constant in including modules

### DIFF
--- a/app/models/concerns/acts_as_profile_field.rb
+++ b/app/models/concerns/acts_as_profile_field.rb
@@ -1,9 +1,11 @@
 # Used for sharing behavior between ProfileField and CustomProfileField
-concern :ActsAsProfileField do
+module ActsAsProfileField
+  extend ActiveSupport::Concern
+
+  WORD_REGEX = /\w+/.freeze
+
   included do
     before_create :generate_attribute_name
-
-    WORD_REGEX = /\w+/.freeze # rubocop:disable Lint/ConstantDefinitionInBlock
 
     validates :label, presence: true, uniqueness: { case_sensitive: false }
     validates :attribute_name, presence: true, on: :update


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

When I extracted the `ActsAsProfileField` concern I was a bit sloppy and just popped a `rubocop:disable` on the end of the constant definition. However, when eager loading the app in production you'll see two warnings like this:

```
/home/travis/build/forem/forem/app/models/concerns/acts_as_profile_field.rb:6: warning: already initialized constant WORD_REGEX

/home/travis/build/forem/forem/app/models/concerns/acts_as_profile_field.rb:6: warning: previous definition of WORD_REGEX was here
```

This PR addresses this by making the concern a "traditional" module (not using the `concern ... do` shorthand) and pulling the constant out of the `included` block.

The alternative would have been to change `included` like this:

```ruby
included do |base|
  base.const_set(:WORD_REGEX, /\w+/.freeze)
end
```

This added complexity somewhat defeats the purpose of using a shorthand, so I chose the option mentioned above.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

On `master` (or any other branch that is not this one):

1. Start a Rails console: `rails c`
2. Load profile fields: `ProfileField`
3. Load custom profile fields: `CustomProfileField`. You should see something like the following:

```ruby
[2] forem(main)> CustomProfileField
/Users/xxx/src/work/forem/app/models/concerns/acts_as_profile_field.rb:6: warning: already initialized constant WORD_REGEX
/Users/xxx/src/work/forem/app/models/concerns/acts_as_profile_field.rb:6: warning: previous definition of WORD_REGEX was here
class CustomProfileField < ApplicationRecord {
```

Repeat the above 3 steps on this branch, you should not see the warnings.

## Added tests?

- [ ] Yes
- [ ] No, and this is why: no behavior change, current specs still cover this
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [X] No documentation needed
