### PR TITLE
Refactor:Remove more_experience_level_weight_experiment From Feed Tests

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -5,10 +5,7 @@ module Stories
     VARIANTS = {
       "more_tag_weight_more_random_experiment" => :more_tag_weight_more_random_experiment,
       "more_comments_experiment" => :more_comments_experiment,
-      "more_experience_level_weight_experiment" => :more_experience_level_weight_experiment,
       "more_tag_weight_randomized_at_end_experiment" => :more_tag_weight_randomized_at_end_experiment,
-      "more_experience_level_weight_randomized_at_end_experiment" =>
-        :more_experience_level_weight_randomized_at_end_experiment,
       "more_comments_randomized_at_end_experiment" => :more_comments_randomized_at_end_experiment,
       "more_comments_medium_weight_randomized_at_end_experiment" =>
         :more_comments_medium_weight_randomized_at_end_experiment,

--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -88,14 +88,8 @@ module Articles
         stories
       end
 
-      def more_experience_level_weight_experiment
-        @experience_level_weight = 3
-        _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
-        stories
-      end
-
       def mix_of_everything_experiment
-        case rand(9)
+        case rand(7)
         when 0
           default_home_feed(user_signed_in: true)
         when 1
@@ -103,16 +97,12 @@ module Articles
         when 2
           more_comments_experiment
         when 3
-          more_experience_level_weight_experiment
-        when 4
           more_tag_weight_randomized_at_end_experiment
-        when 5
-          more_experience_level_weight_randomized_at_end_experiment
-        when 6
+        when 4
           more_comments_randomized_at_end_experiment
-        when 7
+        when 5
           more_comments_medium_weight_randomized_at_end_experiment
-        when 8
+        when 6
           more_comments_minimal_weight_randomized_at_end_experiment
         else
           default_home_feed(user_signed_in: true)
@@ -128,12 +118,6 @@ module Articles
         @randomness = 0
         @tag_weight = 2
         _featured_story, results = default_home_feed_and_featured_story(user_signed_in: true)
-        first_half(results).shuffle + last_half(results)
-      end
-
-      def more_experience_level_weight_randomized_at_end_experiment
-        @randomness = 0
-        results = more_experience_level_weight_experiment
         first_half(results).shuffle + last_half(results)
       end
 

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -4,21 +4,17 @@ experiments:
       - base
       - more_tag_weight_more_random_experiment
       - more_comments_experiment
-      - more_experience_level_weight_experiment
       - mix_of_everything_experiment
       - more_tag_weight_randomized_at_end_experiment
-      - more_experience_level_weight_randomized_at_end_experiment
       - more_comments_randomized_at_end_experiment
       - more_comments_medium_weight_randomized_at_end_experiment
       - more_comments_minimal_weight_randomized_at_end_experiment
     weights:
-      - 5
-      - 5
+      - 10
+      - 15
       - 10
       - 10
-      - 10
-      - 10
-      - 10
+      - 15
       - 20
       - 10
       - 10

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -3,9 +3,7 @@ require "rails_helper"
 NON_DEFAULT_EXPERIMENTS = %i[
   more_tag_weight_more_random_experiment
   more_comments_experiment
-  more_experience_level_weight_experiment
   more_tag_weight_randomized_at_end_experiment
-  more_experience_level_weight_randomized_at_end_experiment
   more_comments_randomized_at_end_experiment
   more_comments_medium_weight_randomized_at_end_experiment
   more_comments_minimal_weight_randomized_at_end_experiment


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
When looking at the results from our feed experiments, I noticed that the experience level weighting is by far the lowest performer so I decided it was time to remove those ones. You can see the results below. Meanwhile, the tag experiments seem to be doing well so I moved some of the weight from the removed experiments to the tag ones. 
![Screen Shot 2020-11-09 at 9 43 33 AM](https://user-images.githubusercontent.com/1813380/98555720-e4c4a300-2267-11eb-9dc2-ef351a6aa651.png)
![Screen Shot 2020-11-09 at 9 43 40 AM](https://user-images.githubusercontent.com/1813380/98555724-e55d3980-2267-11eb-9f14-543634016e56.png)
![Screen Shot 2020-11-09 at 9 43 59 AM](https://user-images.githubusercontent.com/1813380/98555725-e5f5d000-2267-11eb-8bbc-ca7e108dc436.png)
![Screen Shot 2020-11-09 at 9 44 07 AM](https://user-images.githubusercontent.com/1813380/98555727-e68e6680-2267-11eb-90d6-bd13a128baba.png)


## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-48726981

## Added tests?
- [x] No, bc this is removing code :) 



![alt_text](https://media1.tenor.com/images/9457abecfec23b1d9440cd1920e1af19/tenor.gif?itemid=17557409)
