### PR TITLE
Update shell version when admin action taken

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -17,6 +17,7 @@ module Admin
       CacheBuster.bust("/tags/onboarding") # Needs to change when suggested_tags is edited.
       CacheBuster.bust("/shell_top") # Cached at edge, sent to service worker.
       CacheBuster.bust("/shell_bottom") # Cached at edge, sent to service worker.
+      CacheBuster.bust("/async_info/shell_version") # Checks if current users should be busted..
       CacheBuster.bust("/onboarding") # Page is cached at edge.
       CacheBuster.bust("/") # Page is cached at edge.
       SiteConfig.admin_action_taken_at = Time.current # Used as cache key

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -17,7 +17,7 @@ module Admin
       CacheBuster.bust("/tags/onboarding") # Needs to change when suggested_tags is edited.
       CacheBuster.bust("/shell_top") # Cached at edge, sent to service worker.
       CacheBuster.bust("/shell_bottom") # Cached at edge, sent to service worker.
-      CacheBuster.bust("/async_info/shell_version") # Checks if current users should be busted..
+      CacheBuster.bust("/async_info/shell_version") # Checks if current users should be busted.
       CacheBuster.bust("/onboarding") # Page is cached at edge.
       CacheBuster.bust("/") # Page is cached at edge.
       SiteConfig.admin_action_taken_at = Time.current # Used as cache key

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -29,7 +29,7 @@ class AsyncInfoController < ApplicationController
     set_surrogate_key_header "shell-version-endpoint"
     # shell_version will change on every deploy.
     # *Technically* could be only on changes to assets and shell, but this is more fool-proof.
-    shell_version = ApplicationConfig["RELEASE_FOOTPRINT"]
+    shell_version = ApplicationConfig["RELEASE_FOOTPRINT"] + SiteConfig.admin_action_taken_at.to_s
     render json: { version: shell_version }.to_json
   end
 

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -42,7 +42,6 @@
       <link href="<%= optimized_image_url(SiteConfig.logo_png, width: 128, fetch_format: "png") %>" rel="icon" sizes="128x128" />
       <meta name="apple-mobile-web-app-title" content="<%= SiteConfig.app_domain %>">
       <meta name="application-name" content="<%= SiteConfig.app_domain %>">
-      <meta property="fb:pages" content="568966383279687" />
       <meta name="theme-color" content="#000000" />
       <link rel="manifest" href="/manifest.json" />
       <link rel="search" href="<%= URL.url("open-search.xml") %>" type="application/opensearchdescription+xml" title="<%= community_qualified_name %>" />


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When an admin makes a change, it will be immediately reflected across the site in general, but for existing users with a cached shell top (cached by service workers) will not immediately get the update.

This makes appropriate changes such that a config change will ensure users fetch the new shell. This will help admin UX because they will see the new stuff right away and not think of this as a bug, as it would now with their own page not clearing the cache right away.

Unrelated line I fixed: Removed an old `fb:pages` hardcoded meta tag we no longer user or need. (If for some reason we still need this, we can add it back in as _generalized_ via config, rather than the hardcoded DEV version).