### PR TITLE
Update data update script

### DIFF
--- a/lib/data_update_scripts/20201103050112_prepare_for_profile_column_drop.rb
+++ b/lib/data_update_scripts/20201103050112_prepare_for_profile_column_drop.rb
@@ -1,5 +1,7 @@
 module DataUpdateScripts
   class PrepareForProfileColumnDrop
+    HONEYCOMB_PREFIX = "data_update_20201103050112".freeze
+
     def run
       # Make sure all current DEV profile fields exist. The import task is
       # idempotent so we don't need further checkes here.
@@ -9,10 +11,17 @@ module DataUpdateScripts
       # Make sure all current profile data is migrated before we remove the
       # column from User. Also ensure we don't lose any data for custom fields,
       # even if these got temporarily disabled by a feature flag.
-      User.includes(:profile).find_each do |user|
+      User.includes(:profile).order(:id).find_each do |user|
         profile = user.profile
         user_data = Profiles::ExtractData.call(user)
-        profile.update(data: profile.data.merge(user_data.compact))
+        profile.update(data: profile.data.merge(user_data).compact)
+      rescue StandardError => e
+        Honeycomb.add_field("#{HONEYCOMB_PREFIX}.class", e.class)
+        Honeycomb.add_field("#{HONEYCOMB_PREFIX}.message", e.message)
+        Honeycomb.add_field("#{HONEYCOMB_PREFIX}.user_id", e.user_id)
+        next
+      ensure
+        Rails.cache.write(HONEYCOMB_PREFIX, user.id, expires_in: 48.hours)
       end
     end
   end

--- a/spec/lib/data_update_scripts/prepare_for_profile_column_drop_spec.rb
+++ b/spec/lib/data_update_scripts/prepare_for_profile_column_drop_spec.rb
@@ -26,7 +26,7 @@ describe DataUpdateScripts::PrepareForProfileColumnDrop do
 
     it "migrates data and keeps existing data intact", :aggregate_failures do
       described_class.new.run
-      expect(user.profile.reload.data.keys.size).to eq(31)
+      expect(user.profile.reload.data.keys.size).to eq(11)
       expect(user.profile.data).to have_key("doge_test")
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Bug Fix

## Description

In #11246 I added a data update script to do two things:

1. Ensure all current DEV profile fields are present so we can drop the columns from `User` and rely on delegation.
2. Migrate the data one more time just in case and compact it (remove `nil` values) while doing so.

The second point wasn't strictly necessary, but it felt better to do this before we drop columns and data is gone for good. Alas the process errored out without any exception **and** the call to `compact` was in the wrong place, so it isn't even easy to see which records were process already. Yeah, me! 👏 🙄 

This PR does the following:

1. Puts the call to `compact` in the correct place. 
2. Explicitly logs errors to Honeycomb and continues after an error.
3. Stores the last processed user id in the Rails cache so if things terrminate again we know how far we got.

## Related Tickets & Documents

#6994 

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [X] Yes, updating the existing one. Looking back I should have noticed that the `compact` was in the wrong place.

## Added to documentation?

- [X] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

No, but there is a pre-deployment task. To ensure the data update script can run again, remove its entry from any Forem instance where you want to run the script again:

```ruby
DataUpdateScript.delete_by(file_name: "20201103050112_prepare_for_profile_column_drop")
```

## What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/47985/98628416-24af8700-2349-11eb-9cd4-2c20978f630b.png)

