### PR TITLE
Refactor:Remove Duplicate from Onboarding Specs

### DIFF
--- a/spec/system/onboardings/user_completes_onboarding_spec.rb
+++ b/spec/system/onboardings/user_completes_onboarding_spec.rb
@@ -9,17 +9,8 @@ RSpec.describe "Completing Onboarding", type: :system, js: true do
   end
 
   context "when the user hasn't seen onboarding" do
-    before do
-      visit sign_up_path
-      log_in_user(user)
-    end
-
-    xit "logs in and redirects to onboarding if it hasn't been seen" do
-      expect(page).to have_current_path("/onboarding", ignore_query: true)
-      expect(page.html).to include("onboarding-container")
-    end
-
-    xit "does not render the onboarding task card on the feed" do
+    it "does not render the onboarding task card on the feed" do
+      sign_in(user)
       visit "/"
 
       # Explicitly test that the task card element HTML is not on the page.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Small cleanup here. We had one spec that was commented out that I found was a [duplicate to another log in spec](https://github.com/forem/forem/blob/master/spec/system/authentication/user_logs_in_with_email_spec.rb#L84) so I went ahead and removed it. I also switched to using the Warden sign_in helper for the other spec since there is no need to test the actual login flow and we will see if that makes it more reliable 

## Added tests?
- [x] No, removed one bc its a duplicate


![alt_text](https://media1.tenor.com/images/055aa1493333c64e86a3f5a3602e0629/tenor.gif?itemid=17542641)
