### PR TITLE
Add admin guide to "added to docs?" section of PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@ as any relevant images for UI changes._
 
 ## Added to documentation?
 
-- [ ] Docs.forem.com
+- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
 - [ ] README
 - [ ] No documentation needed
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Template update

## Description
I'm linking to the GitBook generated version (https://forem.gitbook.io/forem-admin-guide/) and not the GitHub repo (https://github.com/forem/forem-admin-guide) but I could see the opposite being better.  Open to suggestions.

This will help us keep the [Forem Admin Guide](https://forem.gitbook.io/forem-admin-guide/) more up-to-date as we make changes.