### PR TITLE
Change from stylesheet_url to stylesheet_path

### DIFF
--- a/app/views/layouts/_asset_reconciliation.html.erb
+++ b/app/views/layouts/_asset_reconciliation.html.erb
@@ -1,8 +1,8 @@
 <meta name="page-cached-at" content="<%= Time.current.to_i %>">
 
-<meta name="proper-stylesheet-crayons" content="<%= stylesheet_url "crayons" %>">
-<meta name="proper-stylesheet-views" content="<%= stylesheet_url "views" %>">
-<meta name="proper-stylesheet-minimal" content="<%= stylesheet_url "minimal" %>">
+<meta name="proper-stylesheet-crayons" content="<%= stylesheet_path "crayons" %>">
+<meta name="proper-stylesheet-views" content="<%= stylesheet_path "views" %>">
+<meta name="proper-stylesheet-minimal" content="<%= stylesheet_path "minimal" %>">
 
 <script async>
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In Heroku, `stylesheet_url` and `stylesheet_path` are the same because of the way asset urls work. In Forem Cloud, the `stylesheet_tag` uses the _path_ variation. So this needs to work as such to work properly in Forem Cloud.