### PR TITLE
Bust caches at different intervals on restart

### DIFF
--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -2,9 +2,12 @@ namespace :cache do
   desc "Enqueue BustCachePathWorker"
   task enqueue_path_bust_workers: :environment do
     # Trigger cache purges for globally-cached endpoints that could have changed
-    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/shell_top")
-    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/shell_bottom")
-    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/onboarding")
-    BustCachePathWorker.set(queue: :high_priority).perform_in(10.minutes, "/async_info/shell_version")
+    [30, 180, 600].each do |n|
+      BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, "/")
+      BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, "/shell_top")
+      BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, "/shell_bottom")
+      BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, "/onboarding")
+      BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, "/async_info/shell_version")
+    end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The purpose of this file is to bust the caches of some key semi-static pages when we redeploy the app. Once it is re-fetched it will be cached globally for everyone.

Currently we wait ten minutes, which is good to wait for Heroku's asynchronous restart, but I think waiting that long isn't ideal for Forem Cloud. I created a new version which runs these commands at three intervals: 30 seconds, 3 minutes, and 10 minutes.

The impact of a few extra cache busts will be minimal, but it will help us better deal with cache inconsistencies. If the new site is up in 30 seconds to receive the cache bust on the lastest, that's great. If it's not up and running the new code, we'll try again a couple more times.

I also added the home page bust to ensure we see the latest there quickly on new deployments.