### PR TITLE
Refactor:Remove Deprecated SENDGRID_API_KEY From production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -123,14 +123,13 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
-  sendgrid_api_key_present = ENV["SENDGRID_API_KEY"].present?
   config.action_mailer.default_url_options = { host: protocol + ENV["APP_DOMAIN"].to_s }
   ActionMailer::Base.smtp_settings = {
     address: "smtp.sendgrid.net",
     port: "587",
     authentication: :plain,
-    user_name: sendgrid_api_key_present ? "apikey" : ENV["SENDGRID_USERNAME_ACCEL"],
-    password: sendgrid_api_key_present ? ENV["SENDGRID_API_KEY"] : ENV["SENDGRID_PASSWORD_ACCEL"],
+    user_name: ENV["SENDGRID_USERNAME_ACCEL"],
+    password: ENV["SENDGRID_PASSWORD_ACCEL"],
     domain: ENV["APP_DOMAIN"],
     enable_starttls_auto: true
   }


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
From SendGrid:
> We are emailing to inform you of an upcoming requirement to update your authentication method with Twilio SendGrid to API keys exclusively by December 10th, 2020 in order to ensure uninterrupted service and improve the security of your account. Our records show that one or more users with this email address used basic authentication with username and password for one or more of your SendGrid API requests in the last 30 days. If you do not take action, those API requests will be rejected on December 10th, 2020.
--



## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [ ] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
