### PR TITLE
Bug Fix:Remove Deprecated SENDGRID_USERNAME and SENDGRID_PASSWORD from production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -123,14 +123,13 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
-  sendgrid_api_key_present = ENV["SENDGRID_API_KEY"].present?
   config.action_mailer.default_url_options = { host: protocol + ENV["APP_DOMAIN"].to_s }
   ActionMailer::Base.smtp_settings = {
     address: "smtp.sendgrid.net",
     port: "587",
     authentication: :plain,
-    user_name: sendgrid_api_key_present ? "apikey" : ENV["SENDGRID_USERNAME_ACCEL"],
-    password: sendgrid_api_key_present ? ENV["SENDGRID_API_KEY"] : ENV["SENDGRID_PASSWORD_ACCEL"],
+    user_name: "apikey",
+    password: ENV["SENDGRID_API_KEY"],
     domain: ENV["APP_DOMAIN"],
     enable_starttls_auto: true
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
From SendGrid
> We are emailing to inform you of an upcoming requirement to update your authentication method with Twilio SendGrid to API keys exclusively by December 10th, 2020 in order to ensure uninterrupted service and improve the security of your account. 

This removes the SENDGRID_USERNAME and SENDGRID_PASSWORD ENV variables and only uses the API key. I have updated all Heroku Forems (practicaldev, benhalpern-community, aechive, and cluster-employment) to use API keys. @andygeorge confirmed that there are not usernames or passwords for SENDGRID in the Forem infra inventory so all AWS Forems should be good to go. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-49106309

## Added tests?
- [x] No, bc this is only used in production

![alt_text](https://media2.giphy.com/media/l3vRhDQrmQ6Rj4Y4E/giphy.gif)
