### PR TITLE
feat: Preload links on focus

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -245,6 +245,25 @@ var instantClick
     getImageForLink(a);
   }
 
+  function focusListener(e) {
+    var a = getLinkTarget(e.target)
+
+    if (!a || !isPreloadable(a)) {
+      return
+    }
+
+    a.removeEventListener('focus', focusListener)
+
+    if (!$delayBeforePreload) {
+      preload(a.href)
+    }
+    else {
+      $urlToPreload = a.href
+      $preloadTimer = setTimeout(preload, $delayBeforePreload)
+    }
+    getImageForLink(a);
+  }
+
   function clickListener(e) {
     try{
       var a = getLinkTarget(e.target)
@@ -368,10 +387,10 @@ var instantClick
     var docBody = document.body;
     if (docBody) {
       document.body.addEventListener('touchstart', touchstartListener, true)
+      document.body.addEventListener('focus', focusListener, true)
       if ($preloadOnMousedown) {
         document.body.addEventListener('mousedown', mousedownListener, true)
-      }
-      else {
+      } else {
         document.body.addEventListener('mouseover', mouseoverListener, true)
       }
       document.body.addEventListener('click', clickListener, true)

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -245,6 +245,9 @@ var instantClick
     getImageForLink(a);
   }
 
+  // If a link is focused, it is preloaded just like on mousover.
+  // It also covers the issue where a user needs to press <return> twice
+  // in order to follow a focused link.
   function focusListener(e) {
     var a = getLinkTarget(e.target)
 

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -255,8 +255,6 @@ var instantClick
       return
     }
 
-    a.removeEventListener('focus', focusListener)
-
     if (!$delayBeforePreload) {
       preload(a.href)
     }

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -246,8 +246,8 @@ var instantClick
   }
 
   // If a link is focused, it is preloaded just like on mousover.
-  // It also covers the issue where a user needs to press <return> twice
-  // in order to follow a focused link.
+  // It also covers the issue where a user needs to press <return>
+  // twice in order to follow a focused link.
   function focusListener(e) {
     var a = getLinkTarget(e.target)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Links are currently preloaded on mouse hover.

This adds the same functionality but for keyboard focus.

Fixes some issues with links needing 2 hits on return in order to work.

## Related Tickets & Documents

Closes #11372 

## QA Instructions, Screenshots, Recordings

1. Navigate any link using the keyboard
2. Press return
3. Link is followed without delay or the need to press return again

## Added tests?

- [ ] Yes
- [x] No, and this is why: not needed
- [ ] I need help with writing tests

## Added to documentation?

- [ ] Docs.forem.com
- [ ] README
- [x] No documentation needed