### PR TITLE
Feature:Send Alerts for Failed DataUpdateScripts to Datadog

### DIFF
--- a/app/workers/metrics/check_data_update_script_statuses.rb
+++ b/app/workers/metrics/check_data_update_script_statuses.rb
@@ -1,0 +1,16 @@
+module Metrics
+  class CheckDataUpdateScriptStatuses
+    include Sidekiq::Worker
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform
+      DataUpdateScript.failed.find_each do |script|
+        DatadogStatsClient.count(
+          "data_update_scripts.failures",
+          1,
+          tags: ["file_name:#{script.file_name}"],
+        )
+      end
+    end
+  end
+end

--- a/app/workers/metrics/check_data_update_script_statuses.rb
+++ b/app/workers/metrics/check_data_update_script_statuses.rb
@@ -4,7 +4,8 @@ module Metrics
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform
-      DataUpdateScript.failed.find_each do |script|
+      failed_scripts = DataUpdateScript.failed.where(created_at: 1.week.ago..Time.current)
+      failed_scripts.find_each do |script|
         DatadogStatsClient.count(
           "data_update_scripts.failures",
           1,

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -16,6 +16,9 @@ record_daily_notifications:
 record_data_counts:
   cron: "10 * * * *" # every hour, 10 min after the hour
   class: "Metrics::RecordDataCountsWorker"
+check_data_update_script_statuses:
+  cron: "30 * * * *" # 30 min after every hour
+  class: "Metrics::CheckDataUpdateScriptStatuses"
 award_yearly_club_badges:
   cron: "0 0 * * *" # daily at 12 am UTC
   class: "BadgeAchievements::BadgeAwardWorker"

--- a/spec/factories/data_update_script.rb
+++ b/spec/factories/data_update_script.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :data_update_script do
-    file_name { "20200214151804_data_update_test_script" }
+    file_name { |n| "20200214151804_data_update_test_script#{n}" }
   end
 end

--- a/spec/workers/metrics/check_data_update_script_statuses_spec.rb
+++ b/spec/workers/metrics/check_data_update_script_statuses_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Metrics::CheckDataUpdateScriptStatuses, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "low_priority", 1
+
+  describe "#perform" do
+    it "logs failed script" do
+      create(:data_update_script)
+      failed_script = create(:data_update_script, status: :failed)
+      allow(DatadogStatsClient).to receive(:count)
+      described_class.new.perform
+
+      expect(DatadogStatsClient).to have_received(:count).once
+      expect(
+        DatadogStatsClient,
+      ).to have_received(:count).with(
+        "data_update_scripts.failures", 1, { tags: ["file_name:#{failed_script.file_name}"] }
+      ).at_least(1)
+    end
+  end
+end

--- a/spec/workers/metrics/check_data_update_script_statuses_spec.rb
+++ b/spec/workers/metrics/check_data_update_script_statuses_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe Metrics::CheckDataUpdateScriptStatuses, type: :worker do
   include_examples "#enqueues_on_correct_queue", "low_priority", 1
 
   describe "#perform" do
-    it "logs failed script" do
+    it "logs recently failed script" do
       create(:data_update_script)
+      create(:data_update_script, status: :failed, created_at: 1.month.ago)
       failed_script = create(:data_update_script, status: :failed)
       allow(DatadogStatsClient).to receive(:count)
       described_class.new.perform


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
I was [recently asked to check all of our Forems](https://github.com/forem/forem/pull/11350#issuecomment-725164177) to see if a DataUpdateScript had succeeded. Since we have 10+ Forems the idea of having to annoy @forem/systems to let me access every single one seemed a bit daunting and unideal. Rather than check each manually I choose to create a scheduled job that will do it for us. This job will run every hour, 30 minutes after the house, and report any failed DataUpdateScripts. It is then our job to look into them and fix them. 

I think after the initial check we could shrink the time limit down even more to a couple of hours to limit the number of scripts we check, but right now I want to make sure the script in question(run on Monday) is included in the first run. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-49151524

## Added tests?
- [x] Yes

![alt_text](https://media4.giphy.com/media/3ohuPwtVfPsxaMp0QM/200.gif)
