### PR TITLE
Replace calls to Flipper with FeatureFlag

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -39,7 +39,7 @@ module AdminHelper
   PROFILE_ADMIN = { name: "config: profile setup", controller: "profile_fields" }.freeze
 
   def admin_menu_items
-    return MENU_ITEMS unless Flipper.enabled?(:profile_admin)
+    return MENU_ITEMS unless FeatureFlag.enabled?(:profile_admin)
 
     MENU_ITEMS.dup.insert(7, PROFILE_ADMIN)
   end

--- a/app/helpers/authentication_helper.rb
+++ b/app/helpers/authentication_helper.rb
@@ -30,7 +30,7 @@ module AuthenticationHelper
   end
 
   def forem_creator_flow_enabled?
-    Flipper.enabled?(:creator_onboarding) && waiting_on_first_user?
+    FeatureFlag.enabled?(:creator_onboarding) && waiting_on_first_user?
   end
 
   def waiting_on_first_user?

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,6 @@
 module FeatureFlag
   class << self
-    delegate :enabled?, :exist?, to: Flipper
+    delegate :enable, :enabled?, :exist?, to: Flipper
 
     def accessible?(feature_flag_name, *args)
       feature_flag_name.blank? || !exist?(feature_flag_name) || enabled?(feature_flag_name, *args)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,7 +85,7 @@ Rails.application.routes.draw do
 
       # NOTE: @citizen428 The next two resources have a temporary constraint
       # while profile generalization is still WIP
-      constraints(->(_request) { Flipper.enabled?(:profile_admin) }) do
+      constraints(->(_request) { FeatureFlag.enabled?(:profile_admin) }) do
         resources :profile_field_groups, only: %i[update create destroy]
         resources :profile_fields, only: %i[index update create destroy]
       end

--- a/spec/models/profile_field_group_spec.rb
+++ b/spec/models/profile_field_group_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ProfileFieldGroup, type: :model do
   subject { group }
 
   before do
-    allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
+    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
   end
 
   let!(:group) { create(:profile_field_group) }

--- a/spec/requests/admin/admin_portals_spec.rb
+++ b/spec/requests/admin/admin_portals_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "/admin", type: :request do
 
   describe "profile admin feature flag" do
     it "shows the option when the feature flag is enabled" do
-      allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
+      allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
 
       get admin_path
 
@@ -15,7 +15,7 @@ RSpec.describe "/admin", type: :request do
     end
 
     it "does not show the option when the feature flag is disabled" do
-      allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(false)
+      allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(false)
 
       get admin_path
 

--- a/spec/requests/admin/profile_field_groups_spec.rb
+++ b/spec/requests/admin/profile_field_groups_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "/admin/profile_field_groups", type: :request do
 
   before do
     sign_in admin
-    allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
+    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
   end
 
   describe "POST /admin/profile_field_groups" do

--- a/spec/requests/admin/profile_fields_spec.rb
+++ b/spec/requests/admin/profile_fields_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "/admin/profile_fields", type: :request do
 
   before do
     sign_in admin
-    allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
+    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
   end
 
   describe "GET /admin/profile_fields" do

--- a/spec/requests/admin/sidebar_spec.rb
+++ b/spec/requests/admin/sidebar_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "admin sidebar", type: :request do
 
   describe "profile admin feature flag" do
     it "shows the option in the sidebar when the feature flag is enabled" do
-      allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
+      allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
 
       get admin_articles_path
 
@@ -15,7 +15,7 @@ RSpec.describe "admin sidebar", type: :request do
     end
 
     it "does not show the option in the sidebar when the feature flag is disabled" do
-      allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(false)
+      allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(false)
 
       get admin_articles_path
 

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -111,12 +111,8 @@ RSpec.describe "Registrations", type: :request do
 
     context "with the creator_onboarding feature flag" do
       before do
-        Flipper.enable(:creator_onboarding)
+        allow(FeatureFlag).to receive(:enabled?).with(:creator_onboarding).and_return(true)
         allow(SiteConfig).to receive(:waiting_on_first_user).and_return(true)
-      end
-
-      after do
-        Flipper.disable(:creator_onboarding)
       end
 
       it "renders the creator onboarding form" do
@@ -176,7 +172,7 @@ RSpec.describe "Registrations", type: :request do
       end
 
       it "does not raise disallowed if community is set to allow email" do
-        expect { post "/users" }.not_to raise_error Pundit::NotAuthorizedError
+        expect { post "/users" }.not_to raise_error
       end
 
       it "does not create user with invalid params" do
@@ -269,7 +265,7 @@ RSpec.describe "Registrations", type: :request do
       end
 
       it "does not raise disallowed" do
-        expect { post "/users" }.not_to raise_error Pundit::NotAuthorizedError
+        expect { post "/users" }.not_to raise_error
       end
 
       it "creates user with valid params passed" do
@@ -323,12 +319,8 @@ RSpec.describe "Registrations", type: :request do
 
     context "with the creator_onboarding feature flag" do
       before do
-        Flipper.enable(:creator_onboarding)
+        allow(FeatureFlag).to receive(:enabled?).with(:creator_onboarding).and_return(true)
         allow(SiteConfig).to receive(:waiting_on_first_user).and_return(true)
-      end
-
-      after do
-        Flipper.disable(:creator_onboarding)
       end
 
       it "creates user with valid params passed" do

--- a/spec/routing/profile_admin_routes_spec.rb
+++ b/spec/routing/profile_admin_routes_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Profile admin routes", type: :routing do
   it "renders the profile admin route if the feature flag is enabled" do
-    allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(true)
+    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
 
     expect(get: admin_profile_fields_path).to route_to(
       controller: "admin/profile_fields",
@@ -12,7 +12,7 @@ RSpec.describe "Profile admin routes", type: :routing do
   end
 
   it "does not render the profile admin route if the feature flag is disabled" do
-    allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(false)
+    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(false)
 
     expect(get: admin_profile_fields_path).not_to route_to(
       controller: "admin/profile_fields",

--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -2,7 +2,23 @@ require "rails_helper"
 
 UserStruct = Struct.new(:flipper_id)
 
-describe FeatureFlag, type: :helper do
+describe FeatureFlag, type: :service do
+  describe ".enable" do
+    it "calls Flipper's enable method" do
+      allow(Flipper).to receive(:enable).with("foo")
+
+      described_class.enable("foo")
+
+      expect(Flipper).to have_received(:enable).with("foo")
+    end
+
+    it "enables the feature" do
+      described_class.enable("foo")
+
+      expect(described_class.enabled?("foo")).to be(true)
+    end
+  end
+
   describe ".enabled?" do
     it "calls Flipper's enabled? method" do
       allow(Flipper).to receive(:enabled?).with("foo")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

As we introduced the `FeatureFlag` wrapper in https://github.com/forem/forem/pull/8149 we should try to use that around the code instead of directly accessing Flipper. This will help us if we ever have to switch feature flag framework, would also enable us to add metrics on feature flag calls (eg. "how many times do we access flagged features?") and so on.

Note: the API is the same, just use `FeatureFlag` instead of `Flipper` and if anything missing is needed, add it to the wrapper module.

## Related Tickets & Documents

#8149

## QA Instructions, Screenshots, Recordings

1. Load the console, try `FeatureFlag.enable(:foobar)` and check with `Flipper.enabled?(:foobar)` that is indeed enabled
1. Do nothing as this is already tested automatically

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
