### PR TITLE
Fixed the scroll bar problem in Safari

### DIFF
--- a/app/assets/stylesheets/components/modals.scss
+++ b/app/assets/stylesheets/components/modals.scss
@@ -56,7 +56,6 @@
     width: 100%;
     height: 100%;
     pointer-events: auto;
-    overflow: hidden;
 
     @media (min-width: $breakpoint-s) {
       @include generate-box(
@@ -76,7 +75,8 @@
       align-items: center;
       justify-content: space-between;
       padding: var(--modal-header-padding);
-
+      flex-shrink: 0;
+      
       &__title {
         font-size: var(--modal-header-font-size);
       }

--- a/app/assets/stylesheets/components/modals.scss
+++ b/app/assets/stylesheets/components/modals.scss
@@ -56,6 +56,7 @@
     width: 100%;
     height: 100%;
     pointer-events: auto;
+    overflow: hidden;
 
     @media (min-width: $breakpoint-s) {
       @include generate-box(


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As you guys know, while editing a new post, there is a modal box used for demonstrating markdown formats and liquid tags. In Safari, I realized that the scroll bar is overflowing at the bottom of the modal as shown in Screenshot no.1. So, adding "overflow: hidden;" to the class of that modal, which is "crayons-modal__box", fixed the problem. 

I've also checked it on Firefox and Google Chrome and they do not have any bug like this.(Screenshot no.2 and Screenshot no.3)

## Related Tickets & Documents

**Folder location:** `forem/app/assets/stylesheets/components/modal.scss`

## QA Instructions, Screenshots, Recordings

  <img width="1440" alt="safari" src="https://user-images.githubusercontent.com/24878421/98940387-f45c1a00-24fb-11eb-891d-0338eb8c8f9f.png">
<p align="center">Screenshot no.1 - Problem in Safari</p>

<img width="1440" alt="firefox" src="https://user-images.githubusercontent.com/24878421/98941134-2b7efb00-24fd-11eb-941d-dfe7167fbca4.png">
<p align="center">Screenshot no.2 - Firefox</p>

<img width="1440" alt="google_chrome" src="https://user-images.githubusercontent.com/24878421/98941194-418cbb80-24fd-11eb-8cae-828f1abb6b7a.png">
<p align="center">Screenshot no.3 - Google Chrome</p>

_You may test the changes by entering to "write a new post page" and clicking on Markdown or Liquid Tags link found in the right section._

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [x] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## What gif best describes this PR or how it makes you feel?

![like a cat](https://media.giphy.com/media/BzyTuYCmvSORqs1ABM/giphy.gif)
