### PR TITLE
Hotfix: Remove mascot from JS template for modals

### DIFF
--- a/app/assets/javascripts/utilities/showUserAlertModal.js
+++ b/app/assets/javascripts/utilities/showUserAlertModal.js
@@ -64,7 +64,7 @@ const getModalHtml = (
 ) => `<div id="${modalId}" data-testid="modal-container" class="crayons-modal crayons-modal--m hidden">
     <div role="dialog" aria-modal="true" class="crayons-modal__box">
       <div class="crayons-modal__box__header border-b-0 justify-end">
-          <button class="crayons-btn crayons-btn--ghost crayons-btn--icon" type="button" 
+          <button class="crayons-btn crayons-btn--ghost crayons-btn--icon" type="button"
               onClick="toggleUserAlertModal();" aria-label="Close">
             <svg width="24" height="24" viewBox="0 0 24 24" class="crayons-icon"
               xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="714d29e78a3867c79b07f310e075e824">
@@ -87,11 +87,6 @@ const getModalHtml = (
             ${confirm_text}
           </button>
         </div>
-        <% if SiteConfig.mascot_image_url.present? %>
-          <figure class="w-25">
-            <img src="<%= SiteConfig.mascot_image_url %>" class="w-100" />
-          </figure>
-        <% end %>
       </div>
     </div>
     <div data-testid="modal-overlay" class="crayons-modal__overlay"></div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Right now the app is not booting locally because `showUserAlertModal.js.erb` requires `SiteConfig` which is not accessible when the app compiles that template on boot. 

This is just an interim solution, we can find a better way to show the mascot in the modal in a separate PR

cc @lisasy @maestromac @nickytonline 

## Related Tickets & Documents

#11344 
