### PR TITLE
Filter by tags of reading list items not tags you follow

### DIFF
--- a/app/javascript/packs/readingList.jsx
+++ b/app/javascript/packs/readingList.jsx
@@ -1,23 +1,14 @@
 import { h, render } from 'preact';
-import { getUserDataAndCsrfToken } from '../chat/util';
 import { ReadingList } from '../readingList/readingList';
 
 function loadElement() {
-  getUserDataAndCsrfToken().then(({ currentUser }) => {
-    const followedTagNames = JSON.parse(currentUser.followed_tags).map(
-      (t) => t.name,
+  const root = document.getElementById('reading-list');
+  if (root) {
+    render(
+      <ReadingList availableTags={[]} statusView={root.dataset.view} />,
+      root,
     );
-    const root = document.getElementById('reading-list');
-    if (root) {
-      render(
-        <ReadingList
-          availableTags={followedTagNames}
-          statusView={root.dataset.view}
-        />,
-        root,
-      );
-    }
-  });
+  }
 }
 
 window.InstantClick.on('change', () => {

--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -36,8 +36,8 @@ export class ReadingList extends Component {
   constructor(props) {
     super(props);
 
-    const { availableTags, statusView } = this.props;
-    this.state = defaultState({ availableTags, archiving: false, statusView });
+    const { statusView } = this.props;
+    this.state = defaultState({ archiving: false, statusView });
 
     // bind and initialize all shared functions
     this.onSearchBoxType = debounceAction(onSearchBoxType.bind(this), {

--- a/app/javascript/searchableItemList/searchableItemList.js
+++ b/app/javascript/searchableItemList/searchableItemList.js
@@ -77,7 +77,7 @@ export function performInitialSearch({ searchOptions = {} }) {
     const reactions = response.result;
     const availableTags = [
       ...new Set(reactions.flatMap((rxn) => rxn.reactable.tag_list)),
-    ];
+    ].sort();
     component.setState({
       page: 0,
       items: reactions,

--- a/app/javascript/searchableItemList/searchableItemList.js
+++ b/app/javascript/searchableItemList/searchableItemList.js
@@ -75,12 +75,16 @@ export function performInitialSearch({ searchOptions = {} }) {
   const responsePromise = fetchSearch('reactions', dataHash);
   return responsePromise.then((response) => {
     const reactions = response.result;
+    const availableTags = [
+      ...new Set(reactions.flatMap((rxn) => rxn.reactable.tag_list)),
+    ];
     component.setState({
       page: 0,
       items: reactions,
       itemsLoaded: true,
       totalCount: response.total,
       showLoadMoreButton: hitsPerPage < response.total,
+      availableTags,
     });
   });
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature
- [x] Optimization

## Description
This updates the reading list to get the tags of the articles in your reading list as opposed to filtering by the tags you follow. General consensus among the team was that we should make this change, since the current version (tags you follow) was not really intuitive.

## Related Tickets & Documents
Closes https://github.com/forem/InternalProjectPlanning/issues/240

## QA Instructions, Screenshots, Recordings
1. Save some articles from the home page: localhost:3000
2. Go to your reading list: localhost:3000/readinglist
3. See that the proper tags are displayed, and that there are no duplicates

## Added tests?
- [x] No, and this is why: We don't test for the `state` of the `readingList` component at all, so I didn't feel the need to add one. Happy to though, if I should!

## Added to documentation?
- [x] No documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Lisa Simpson says, "That was too easy," and has a skeptical look on her face.](https://media.giphy.com/media/3o6MbkWQI5OazCn8cM/giphy.gif)
