### PR TITLE
Remove wrong metric from Feeds::Import

### DIFF
--- a/app/services/feeds/import.rb
+++ b/app/services/feeds/import.rb
@@ -39,7 +39,6 @@ module Feeds
             create_articles_from_user_feed(user, feed)
           end
         end
-        DatadogStatsClient.count("feeds::import::parse_feeds.count", articles.length)
 
         total_articles_count += articles.length
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is already collected here https://github.com/forem/forem/blob/de5122cb52983c24ac92f091e21889a383e89c7d/app/services/feeds/import.rb#L29

This statement is just incorrect :-( 

