### PR TITLE
Bug Fix:Update Remove Draft Articles Scripts to not use Squish

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -664,6 +664,9 @@ Rails/SkipsModelValidations:
   Reference: 'https://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
   Enabled: false
 
+Rails/SquishedSQLHeredocs:
+  Enabled: false
+
 Rails/WhereExists:
   Description: 'Prefer `exists?(...)` over `where(...).exists?`.'
   Enabled: true

--- a/lib/data_update_scripts/20200901085230_remove_draft_articles_with_duplicate_canonical_url.rb
+++ b/lib/data_update_scripts/20200901085230_remove_draft_articles_with_duplicate_canonical_url.rb
@@ -6,7 +6,7 @@ module DataUpdateScripts
       # This statement deletes all draft articles in excess found to be duplicate over canonical_url,
       # excluding those whose body_markdown is different from the other duplicate occurrences
       result = ActiveRecord::Base.connection.execute(
-        <<~SQL.squish,
+        <<-SQL # rubocop:disable Style/TrailingCommaInArguments
           WITH duplicates_draft_articles AS
               (SELECT id
                FROM
@@ -42,7 +42,7 @@ module DataUpdateScripts
       # with different bodies.
       # We thus select the oldest for removal preserving the most recent one
       result = ActiveRecord::Base.connection.execute(
-        <<~SQL.squish,
+        <<-SQL,
           WITH duplicates_draft_articles AS
               (SELECT id
                FROM

--- a/lib/data_update_scripts/20200901085230_remove_draft_articles_with_duplicate_canonical_url.rb
+++ b/lib/data_update_scripts/20200901085230_remove_draft_articles_with_duplicate_canonical_url.rb
@@ -6,7 +6,7 @@ module DataUpdateScripts
       # This statement deletes all draft articles in excess found to be duplicate over canonical_url,
       # excluding those whose body_markdown is different from the other duplicate occurrences
       result = ActiveRecord::Base.connection.execute(
-        <<-SQL # rubocop:disable Style/TrailingCommaInArguments
+        <<-SQL,
           WITH duplicates_draft_articles AS
               (SELECT id
                FROM

--- a/lib/data_update_scripts/20200904132553_remove_draft_articles_with_duplicate_feed_source_url.rb
+++ b/lib/data_update_scripts/20200904132553_remove_draft_articles_with_duplicate_feed_source_url.rb
@@ -6,7 +6,7 @@ module DataUpdateScripts
       # This statement deletes all draft articles in excess found to be duplicate over feed_source_url,
       # excluding those whose body_markdown is different from the other duplicate occurrences
       result_same_body = ActiveRecord::Base.connection.execute(
-        <<-SQL # rubocop:disable Style/TrailingCommaInArguments
+        <<-SQL,
           WITH duplicates_draft_articles AS
               (SELECT id
                FROM

--- a/lib/data_update_scripts/20200904132553_remove_draft_articles_with_duplicate_feed_source_url.rb
+++ b/lib/data_update_scripts/20200904132553_remove_draft_articles_with_duplicate_feed_source_url.rb
@@ -6,7 +6,7 @@ module DataUpdateScripts
       # This statement deletes all draft articles in excess found to be duplicate over feed_source_url,
       # excluding those whose body_markdown is different from the other duplicate occurrences
       result_same_body = ActiveRecord::Base.connection.execute(
-        <<~SQL.squish,
+        <<-SQL # rubocop:disable Style/TrailingCommaInArguments
           WITH duplicates_draft_articles AS
               (SELECT id
                FROM
@@ -33,7 +33,7 @@ module DataUpdateScripts
       # with different bodies.
       # We thus select the oldest for removal preserving the most recent one
       result_different_bodies = ActiveRecord::Base.connection.execute(
-        <<~SQL.squish,
+        <<-SQL,
           WITH duplicates_draft_articles AS
               (SELECT id
                FROM

--- a/lib/data_update_scripts/20200910135958_remove_draft_articles_with_duplicate_user_id_title_body_markdown.rb
+++ b/lib/data_update_scripts/20200910135958_remove_draft_articles_with_duplicate_user_id_title_body_markdown.rb
@@ -5,7 +5,7 @@ module DataUpdateScripts
 
       # This statement deletes all draft articles in excess found to be duplicate over those three columns
       ActiveRecord::Base.connection.execute(
-        <<~SQL.squish,
+        <<-SQL # rubocop:disable Style/TrailingCommaInArguments
           WITH duplicates_draft_articles AS
               (SELECT id
                FROM

--- a/lib/data_update_scripts/20200910135958_remove_draft_articles_with_duplicate_user_id_title_body_markdown.rb
+++ b/lib/data_update_scripts/20200910135958_remove_draft_articles_with_duplicate_user_id_title_body_markdown.rb
@@ -5,7 +5,7 @@ module DataUpdateScripts
 
       # This statement deletes all draft articles in excess found to be duplicate over those three columns
       ActiveRecord::Base.connection.execute(
-        <<-SQL # rubocop:disable Style/TrailingCommaInArguments
+        <<-SQL,
           WITH duplicates_draft_articles AS
               (SELECT id
                FROM


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Some of our SQL scripts do not play nice with `.squish` so I went ahead and removed `.squish` from all the scripts that were failing because of it. I also turned off the Rubocop that enforces its use. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-49457249

## QA Instructions, Screenshots, Recordings
Copy and paste the SQL commands into a console and watch them run successfully. 

## Added tests?
- [x] No, bc I just tweaked some formatting 

![alt_text](https://media3.giphy.com/media/wZlfTifod44XS/200.gif)
