### PR TITLE
Refactor: Remove more_tag_weight_more_random_experiment

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -3,7 +3,6 @@ module Stories
     respond_to :json
 
     VARIANTS = {
-      "more_tag_weight_more_random_experiment" => :more_tag_weight_more_random_experiment,
       "more_comments_experiment" => :more_comments_experiment,
       "more_tag_weight_randomized_at_end_experiment" => :more_tag_weight_randomized_at_end_experiment,
       "more_comments_randomized_at_end_experiment" => :more_comments_randomized_at_end_experiment,

--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -60,13 +60,6 @@ module Articles
         stories
       end
 
-      def more_tag_weight_more_random_experiment
-        @tag_weight = 2
-        @randomness = 7
-        _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
-        stories
-      end
-
       # Test variation: the more comments a post has, the higher it's rated!
       def more_comments_experiment
         @comment_weight = 2
@@ -89,20 +82,18 @@ module Articles
       end
 
       def mix_of_everything_experiment
-        case rand(7)
+        case rand(6)
         when 0
           default_home_feed(user_signed_in: true)
         when 1
-          more_tag_weight_more_random_experiment
-        when 2
           more_comments_experiment
-        when 3
+        when 2
           more_tag_weight_randomized_at_end_experiment
-        when 4
+        when 3
           more_comments_randomized_at_end_experiment
-        when 5
+        when 4
           more_comments_medium_weight_randomized_at_end_experiment
-        when 6
+        when 5
           more_comments_minimal_weight_randomized_at_end_experiment
         else
           default_home_feed(user_signed_in: true)

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -2,7 +2,6 @@ experiments:
   user_home_feed: # Home feed collection for logged in user
     variants:
       - base
-      - more_tag_weight_more_random_experiment
       - more_comments_experiment
       - mix_of_everything_experiment
       - more_tag_weight_randomized_at_end_experiment
@@ -10,10 +9,9 @@ experiments:
       - more_comments_medium_weight_randomized_at_end_experiment
       - more_comments_minimal_weight_randomized_at_end_experiment
     weights:
-      - 10
       - 15
-      - 10
-      - 10
+      - 15
+      - 15
       - 15
       - 20
       - 10

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 NON_DEFAULT_EXPERIMENTS = %i[
-  more_tag_weight_more_random_experiment
   more_comments_experiment
   more_tag_weight_randomized_at_end_experiment
   more_comments_randomized_at_end_experiment


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
This has been the most recent underperforming experiment in our group so I am removing it and redistributing the weight to other more successful experiments. 
![Screen Shot 2020-11-16 at 2 33 12 PM](https://user-images.githubusercontent.com/1813380/99299088-54123800-2810-11eb-9526-179d839e065c.png)
![Screen Shot 2020-11-16 at 2 33 20 PM](https://user-images.githubusercontent.com/1813380/99299089-55dbfb80-2810-11eb-9b19-13b34df08ef8.png)

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-48726981

## QA Instructions, Screenshots, Recordings
Make sure the Feed page still loads :) 

## Added tests?
- [x] No, bc we are removing functionality 

![alt_text](https://thumbs.gfycat.com/BelovedSnappyAfricanelephant-size_restricted.gif)
