### PR TITLE
Optimization:Only Check Past Day for DataUpdateScript failures

### DIFF
--- a/app/workers/metrics/check_data_update_script_statuses.rb
+++ b/app/workers/metrics/check_data_update_script_statuses.rb
@@ -4,7 +4,7 @@ module Metrics
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform
-      failed_scripts = DataUpdateScript.failed.where(created_at: 1.week.ago..Time.current)
+      failed_scripts = DataUpdateScript.failed.where(created_at: 1.day.ago..Time.current)
       failed_scripts.find_each do |script|
         DatadogStatsClient.count(
           "data_update_scripts.failures",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
As described in #11381, I originally set this at 1 week to figure out if a particular DataUpdateScript had failed. Turns out it did not so now we can set this to something a little shorter. I choose 1 day even though we check every hour so that in the event say Sidekiq goes down or for some reason, the check job doesn't run we can still get alerted of the failure for a while after. 
 
## Added tests?
- [x] No, already has a test that tests failure creation date

![alt_text](https://media3.giphy.com/media/WwFEQbYYJkVNe/giphy.gif)
