### PR TITLE
Add community_emoji to SiteConfig

### DIFF
--- a/app/controllers/admin/configs_controller.rb
+++ b/app/controllers/admin/configs_controller.rb
@@ -14,6 +14,7 @@ module Admin
     COMMUNITY_PARAMS =
       %i[
         community_name
+        community_emoji
         collective_noun
         collective_noun_disabled
         community_description

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,7 +45,7 @@ module ApplicationHelper
     derived_title = if page_title.include?(community_name)
                       page_title
                     elsif user_signed_in?
-                      "#{page_title} - #{community_qualified_name} 👩‍💻👨‍💻"
+                      "#{page_title} - #{community_qualified_name} #{community_emoji}"
                     else
                       "#{page_title} - #{community_name}"
                     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -185,6 +185,10 @@ module ApplicationHelper
     @community_name ||= SiteConfig.community_name
   end
 
+  def community_emoji
+    @community_emoji ||= SiteConfig.community_emoji
+  end
+
   def community_qualified_name
     return "#{community_name} #{SiteConfig.collective_noun}" unless SiteConfig.collective_noun_disabled
 

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -53,6 +53,10 @@ module Constants
         description: "Used in meta description tags etc.",
         placeholder: "A fabulous community of kind and welcoming people."
       },
+      community_emoji: {
+        description: "Used in the title tags across the site alongside the community name",
+        placeholder: ""
+      },
       community_member_label: {
         description: "Used to determine what a member will be called e.g developer, hobbyist etc.",
         placeholder: "user"

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -48,6 +48,7 @@ class SiteConfig < RailsSettings::Base
 
   # Community Content
   field :community_name, type: :string, default: ApplicationConfig["COMMUNITY_NAME"] || "New Forem"
+  field :community_emoji, type: :string, default: "🌱"
   field :collective_noun, type: :string, default: "Community"
   field :collective_noun_disabled, type: :boolean, default: false
   field :community_description, type: :string

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -426,6 +426,15 @@
                 </div>
 
                 <div class="crayons-field">
+                  <%= admin_config_label :community_emoji %>
+                  <%= admin_config_description Constants::SiteConfig::DETAILS[:community_emoji][:description] %>
+                  <%= f.text_field :community_emoji,
+                                   class: "crayons-textfield",
+                                   value: SiteConfig.community_emoji,
+                                   placeholder: Constants::SiteConfig::DETAILS[:community_emoji][:placeholder] %>
+                </div>
+
+                <div class="crayons-field">
                   <%= admin_config_label :tagline %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:tagline][:description] %>
                   <%= f.text_field :tagline,

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for :page_meta do %>
   <% title_with_timeframe(
-       page_title: "#{community_qualified_name} 👩‍💻👨‍💻",
+       page_title: "#{community_qualified_name} #{community_emoji}",
        timeframe: params[:timeframe],
        content_for: true,
      ) %>

--- a/app/views/chat_channels/index.html.erb
+++ b/app/views/chat_channels/index.html.erb
@@ -1,4 +1,4 @@
-<% title("#{community_name} Connect 👩‍💻💬👨‍💻") %>
+<% title("#{community_name} Connect") %>
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url(connect_path) %>" />
   <meta name="description" content="<%= community_name %> Connect">

--- a/spec/liquid_tags/tweet_tag_spec.rb
+++ b/spec/liquid_tags/tweet_tag_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe TweetTag, type: :liquid_tag do
   let(:twitter_id) { "1018911886862057472" }
   let(:handle) { "thepracticaldev" }
-  let(:name) { "DEV Community 👩‍💻👨‍💻" }
+  let(:name) { "DEV Community" }
   let(:body) { "When GitHub goes down" }
 
   setup { Liquid::Template.register_tag("tweet", described_class) }

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -124,6 +124,14 @@ RSpec.describe "/admin/config", type: :request do
           expect(SiteConfig.community_description).to eq(description)
         end
 
+        it "updates the community_emoji" do
+          allow(SiteConfig).to receive(:community_emoji).and_call_original
+          emoji = "🥐"
+          post "/admin/config", params: { site_config: { community_emoji: emoji },
+                                          confirmation: confirmation_message }
+          expect(SiteConfig.community_emoji).to eq(emoji)
+        end
+
         it "updates the community_name" do
           name_magoo = "Hey hey #{rand(100)}"
           post "/admin/config", params: { site_config: { community_name: name_magoo },

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -124,12 +124,21 @@ RSpec.describe "/admin/config", type: :request do
           expect(SiteConfig.community_description).to eq(description)
         end
 
-        it "updates the community_emoji" do
+        it "updates the community_emoji if valid" do
           allow(SiteConfig).to receive(:community_emoji).and_call_original
           emoji = "🥐"
           post "/admin/config", params: { site_config: { community_emoji: emoji },
                                           confirmation: confirmation_message }
           expect(SiteConfig.community_emoji).to eq(emoji)
+        end
+
+        it "does not update the community_emoji if invalid" do
+          allow(SiteConfig).to receive(:community_emoji).and_call_original
+          not_an_emoji = "i love croissants"
+          expect do
+            post "/admin/config", params: { site_config: { community_emoji: not_an_emoji },
+                                            confirmation: confirmation_message }
+          end.not_to change(SiteConfig, :community_emoji)
         end
 
         it "updates the community_name" do

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -21,11 +21,13 @@ RSpec.describe "StoriesShow", type: :request do
 
     ## Title tag
     it "renders signed-in title tag for signed-in user" do
+      allow(SiteConfig).to receive(:community_emoji).and_return("🌱")
+
       sign_in user
       get article.path
 
-      expected_title = "<title>#{CGI.escapeHTML(article.title)} - #{community_qualified_name} 👩‍💻👨‍💻</title>"
-      expect(response.body).to include(expected_title)
+      title = "<title>#{CGI.escapeHTML(article.title)} - #{community_qualified_name} #{community_emoji}</title>"
+      expect(response.body).to include(title)
     end
 
     it "renders signed-out title tag for signed-out user" do
@@ -44,12 +46,14 @@ RSpec.describe "StoriesShow", type: :request do
     end
 
     it "does not render title tag with search_optimized_title_preamble if set and not signed in" do
+      allow(SiteConfig).to receive(:community_emoji).and_return("🌱")
+
       sign_in user
       article.update_column(:search_optimized_title_preamble, "Hey this is a test")
       get article.path
 
-      expected_title = "<title>#{CGI.escapeHTML(article.title)} - #{community_qualified_name} 👩‍💻👨‍💻</title>"
-      expect(response.body).to include(expected_title)
+      title = "<title>#{CGI.escapeHTML(article.title)} - #{community_qualified_name} #{community_emoji}</title>"
+      expect(response.body).to include(title)
     end
 
     it "does not render preamble with search_optimized_title_preamble not signed in but not set" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As mentioned in https://github.com/forem/forem/issues/11449, we currently hardcode some emojis in the `<title>` tags of our site, but that locks in other Forem creators to the hardcoded emojis that we chose 😕 

Instead, we want to allow Forem creators to choose _their own_ emojis to associate with the site (or to not have an emoji at all!). This PR removes the hardcoded emojis and add an optional `community_emoji` field to `SiteConfig`, which can be blank or which a Forem creator can override with their own choice of emoji.

It also removes a hardcoded emoji on the `/connect` page, since associating an emoji with a specific _page_ is a much larger feature and seems like it deserves a product discussion.

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/11449.

## QA Instructions, Screenshots, Recordings

Starting with a fresh Forem/SiteConfig:
1. Head to `/admin/config`. You should see the default emoji in the `community_emoji` field within `Community Content`:
<img width="897" alt="one" src="https://user-images.githubusercontent.com/6921610/99321041-c3445800-2821-11eb-965c-97732f04a556.png">
2. Try clearing out the emoji entirely -- you should be able to do it with no problems since it is _not_ a required field:
<img width="888" alt="two" src="https://user-images.githubusercontent.com/6921610/99321043-c5a6b200-2821-11eb-8227-2bf94400f790.png">
3. Try adding some 🥐s for emojis. You should be able to update the SiteConfig without any issues:
<img width="933" alt="three" src="https://user-images.githubusercontent.com/6921610/99321099-ed961580-2821-11eb-9a35-399721fd6d67.png">
4. Check the `<title>` tag on the articles index page. You should see your community emojis reflected in the DOM!

## Added tests?

- [x] Yes (added a new test and updated preexisting tests!)
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## Are there any post deployment tasks we need to perform?

**We will need to add `👩‍💻👨‍💻` as the `community_emoji` on DEV. We should also add them to forem.team and forem.dev if we want something _other than_ the default `🌱`.**

## What ~gif~ EMOJI best describes this PR or how it makes you feel?
🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐🥐
