### PR TITLE
Add username to profile more info button

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -150,7 +150,7 @@
         <%= render "users/metadata" %>
 
         <div class="p-3 pt-0 block m:hidden js-user-info-trigger-wrapper">
-          <button type="button" class="crayons-btn crayons-btn--outlined w-100 js-user-info-trigger">More info about user...</button>
+          <button type="button" class="crayons-btn crayons-btn--outlined w-100 js-user-info-trigger">More info about @<%= @user.username %></button>
         </div>
 
         <div class="crayons-modal align-left hidden">

--- a/docs/technical-overview/architecture.md
+++ b/docs/technical-overview/architecture.md
@@ -133,6 +133,9 @@ infinitely branching threads.
 The user is the authorization/identity component of logging into the app. It is
 also the public profile/authorship/etc. belonging to the people who use the app.
 
+While "user" is a perfectly good technical name, it is a fairly cold way to refer
+to humans, so we should prefer labeling people as members, or by their name/username.
+
 ## Tags
 
 Tags are used to organize user generated content. Each tag has a set of rules

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe "UserProfiles", type: :request do
       expect(response.body).to include "Pinned"
     end
 
+    it "calls user by their username in the 'more info' area" do
+      get "/#{user.username}"
+      expect(response.body).to include "More info about @#{user.username}"
+    end
+
+
     it "does not render pins if they don't exist" do
       get "/#{user.username}"
       expect(response.body).not_to include "Pinned"

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe "UserProfiles", type: :request do
       expect(response.body).to include "More info about @#{user.username}"
     end
 
-
     it "does not render pins if they don't exist" do
       get "/#{user.username}"
       expect(response.body).not_to include "Pinned"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Small adjustment.

We recently shipped this button which just said "user", but I think adding the user's name here is more human.

It's a small thing and totally cool that we shipped the first copy as something we could later improve on.

## QA Instructions, Screenshots, Recordings

<img width="498" alt="Screen Shot 2020-11-16 at 6 48 17 PM" src="https://user-images.githubusercontent.com/3102842/99321799-a79a7b00-283c-11eb-9fc6-cd6fccc6b1d0.png">

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [x] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [ ] No documentation needed


![human](https://media.giphy.com/media/2shBNJSPTrpWvoXfpD/giphy.gif)
