### PR TITLE
Fix broken article feed keyboard navigation

### DIFF
--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -267,10 +267,21 @@ function buildArticleHTML(article) {
         '</div></a>';
     }
 
+    var navigationLink = `
+      <a
+        href="${article.path}"
+        aria-labelledby="article-link-${article.id}"
+        class="crayons-story__hidden-navigation-link"
+      >
+        ${article.title}
+      </a>
+    `;
+
     return `<article class="crayons-story"
       data-article-path="${article.path}"
       id="article-${article.id}"
       data-content-user-id="${article.user_id}">\
+        ${navigationLink}\
         <div role="presentation">\
           ${videoHTML}\
           <div class="crayons-story__body">\


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As mentioned in #11463, [this commit](https://github.com/forem/forem/commit/449cf89737) removed the hidden navigation link from the article HTML. This PR adds it back.

## Related Tickets & Documents

- Keyboard feed navigation: #10468
- No ticket for the bug yet

## QA Instructions, Screenshots, Recordings

Navigate the feed up and down with `j` and `k`. It should reach the end of the feed.

## Added tests?

- [ ] Yes
- [x] No, and this is why: This is a quick fix. Tests should be added to the file. See #11461
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed
