### PR TITLE
Add article cachebust backoff update script

### DIFF
--- a/lib/data_update_scripts/20201118141822_gradual_article_cache_bust.rb
+++ b/lib/data_update_scripts/20201118141822_gradual_article_cache_bust.rb
@@ -8,13 +8,16 @@ module DataUpdateScripts
       # This uses exponential backoff in order to bust the caches of more recent articles first, but not
       # bust everything in too short a period, so that the edge cache can gradually re-heat without everything
       # going cold at once. Articles with high "hotness score" (e.g. more recent) are the ones most in need of busting.
+
+      # It only busts the "?i=i" variant of the path which is the "internal nav" version, aka the page when swapped
+      # with internal navigation, not the one landed on directly (which wouldn't have cache mismatches)
       Article.published.order("hotness_score DESC").limit(2000).each_with_index do |article, index|
         n = index + 300 # + 300 gives the server time to boot up
-        BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, article.path)
+        BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, "#{article.path}?i=i")
       end
       Article.published.order("hotness_score DESC").offset(2500).limit(5000).each_with_index do |article, index|
         n = (index * 3) + 450
-        BustCachePathWorker.set(queue: :medium_priority).perform_in(n.seconds, article.path)
+        BustCachePathWorker.set(queue: :medium_priority).perform_in(n.seconds, "#{article.path}?i=i")
       end
     end
   end

--- a/lib/data_update_scripts/20201118141822_gradual_article_cache_bust.rb
+++ b/lib/data_update_scripts/20201118141822_gradual_article_cache_bust.rb
@@ -1,0 +1,21 @@
+module DataUpdateScripts
+  class GradualArticleCacheBust
+    def run
+      # This script is designed to bust the cache on article pages sufficient such that significant changes to
+      # CSS will not create meaningful visual regressions for most users.
+      # All articles have their caches naturally recycle once per day to finalize the transition.
+
+      # This uses exponential backoff in order to bust the caches of more recent articles first, but not
+      # bust everything in too short a period, so that the edge cache can gradually re-heat without everything
+      # going cold at once. Articles with high "hotness score" (e.g. more recent) are the ones most in need of busting.
+      Article.published.order("hotness_score DESC").limit(2000).each_with_index do |article, index|
+        n = index + 300 # + 300 gives the server time to boot up
+        BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, article.path)
+      end
+      Article.published.order("hotness_score DESC").offset(2500).limit(5000).each_with_index do |article, index|
+        n = (index * 3) + 450
+        BustCachePathWorker.set(queue: :medium_priority).perform_in(n.seconds, article.path)
+      end
+    end
+  end
+end

--- a/lib/data_update_scripts/20201118141822_gradual_article_cache_bust.rb
+++ b/lib/data_update_scripts/20201118141822_gradual_article_cache_bust.rb
@@ -11,11 +11,11 @@ module DataUpdateScripts
 
       # It only busts the "?i=i" variant of the path which is the "internal nav" version, aka the page when swapped
       # with internal navigation, not the one landed on directly (which wouldn't have cache mismatches)
-      Article.published.order("hotness_score DESC").limit(1500).each_with_index do |article, index|
+      Article.published.order("hotness_score DESC").limit(1500).select(:path).each_with_index do |article, index|
         n = index + 300 # + 300 gives the server time to boot up
         BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, "#{article.path}?i=i")
       end
-      Article.published.order("hotness_score DESC").offset(1500).limit(3000).each_with_index do |article, index|
+      Article.published.order("hotness_score DESC").offset(1500).limit(3000).select(:path).each_with_index do |article, index|
         n = (index * 3) + 450
         BustCachePathWorker.set(queue: :medium_priority).perform_in(n.seconds, "#{article.path}?i=i")
       end

--- a/lib/data_update_scripts/20201118141822_gradual_article_cache_bust.rb
+++ b/lib/data_update_scripts/20201118141822_gradual_article_cache_bust.rb
@@ -11,11 +11,11 @@ module DataUpdateScripts
 
       # It only busts the "?i=i" variant of the path which is the "internal nav" version, aka the page when swapped
       # with internal navigation, not the one landed on directly (which wouldn't have cache mismatches)
-      Article.published.order("hotness_score DESC").limit(2000).each_with_index do |article, index|
+      Article.published.order("hotness_score DESC").limit(1500).each_with_index do |article, index|
         n = index + 300 # + 300 gives the server time to boot up
         BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, "#{article.path}?i=i")
       end
-      Article.published.order("hotness_score DESC").offset(2500).limit(5000).each_with_index do |article, index|
+      Article.published.order("hotness_score DESC").offset(1500).limit(3000).each_with_index do |article, index|
         n = (index * 3) + 450
         BustCachePathWorker.set(queue: :medium_priority).perform_in(n.seconds, "#{article.path}?i=i")
       end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a script proposed to be paired with https://github.com/forem/forem/pull/11283

That PR makes pretty significant changes which could cause inconsistencies in navigation if we do not pair it with a cache-busting approach.

We cannot bust all the site at once, but when we go to merge that I think we need some kind of gradual cachebust.

This would create lots of short running jobs that would gradually run gradually more spaced out over time and be done in a few hours.

This script should be abundantly safe with small communities, but we need something or else there could be stale cache issues. With DEV I think it's a script similar to the manual steps we've taken in the past in similar situations.