### PR TITLE
Remove boolean checks for validate_inclusion_of in specs

### DIFF
--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Follow, type: :model do
     subject { user.follow(user_2) }
 
     it { is_expected.to validate_inclusion_of(:subscription_status).in_array(%w[all_articles none]) }
-    it { is_expected.to validate_inclusion_of(:blocked).in_array([true, false]) }
     it { is_expected.to validate_presence_of(:followable_id) }
     it { is_expected.to validate_presence_of(:followable_type) }
     it { is_expected.to validate_presence_of(:follower_id) }

--- a/spec/models/profile_field_spec.rb
+++ b/spec/models/profile_field_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe ProfileField, type: :model do
 
       it { is_expected.to validate_presence_of(:display_area) }
       it { is_expected.to validate_presence_of(:input_type) }
-      it { is_expected.to validate_inclusion_of(:show_in_onboarding).in_array([true, false]) }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -180,9 +180,7 @@ RSpec.describe User, type: :model do
       it { is_expected.not_to allow_value("AcMe_1%").for(:username) }
       it { is_expected.to allow_value("AcMe_1").for(:username) }
 
-      it { is_expected.to validate_inclusion_of(:email_digest_periodic).in_array([true, false]) }
       it { is_expected.to validate_inclusion_of(:inbox_type).in_array(%w[open private]) }
-      it { is_expected.to validate_inclusion_of(:welcome_notifications).in_array([true, false]) }
 
       it { is_expected.to validate_length_of(:email).is_at_most(50).allow_nil }
       it { is_expected.to validate_length_of(:inbox_guidelines).is_at_most(250).allow_nil }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

If you run `spec/models/user_spec.rb` or any of the other files in this PR you'll notice the following warning:

> Warning from shoulda-matchers:
> 
> You are using `validate_inclusion_of` to assert that a boolean column
> allows boolean values and disallows non-boolean ones. Be aware that it
> is not possible to fully test this, as boolean columns will
> automatically convert non-boolean values to boolean ones. Hence, you
> should consider removing this test.

Thus I'm removing those explicit checks

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
