### PR TITLE
Feature:Backend Username Search Endpoint for Mention Completion

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,5 @@
 class SearchController < ApplicationController
-  before_action :authenticate_user!, only: %i[tags chat_channels reactions]
+  before_action :authenticate_user!, only: %i[tags chat_channels reactions usernames]
   before_action :format_integer_params
   before_action :sanitize_params, only: %i[listings reactions feed_content]
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -82,6 +82,14 @@ class SearchController < ApplicationController
     render json: { result: user_search }
   end
 
+  def usernames
+    usernames = Search::User.search_usernames(params[:username])
+
+    render json: { result: usernames }
+  rescue Search::Errors::Transport::BadRequest
+    render json: { result: [] }
+  end
+
   def feed_content
     feed_docs = if params[:class_name].blank?
                   # If we are in the main feed and not filtering by type return

--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -7,7 +7,26 @@ module Search
     DEFAULT_PER_PAGE = 20
 
     class << self
+      def search_usernames(username)
+        results = search(body: username_query(username))
+        results.dig("hits", "hits").map do |doc|
+          doc.dig("_source", "username")
+        end
+      end
+
       private
+
+      def username_query(username)
+        {
+          query: {
+            query_string: {
+              query: "username:#{username}*",
+              analyze_wildcard: true,
+              allow_leading_wildcard: false
+            }
+          }
+        }
+      end
 
       def prepare_doc(hit)
         source = hit["_source"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -310,6 +310,7 @@ Rails.application.routes.draw do
     get "/search/chat_channels" => "search#chat_channels"
     get "/search/listings" => "search#listings"
     get "/search/users" => "search#users"
+    get "/search/usernames" => "search#usernames"
     get "/search/feed_content" => "search#feed_content"
     get "/search/reactions" => "search#reactions"
     get "/chat_channel_memberships/find_by_chat_channel_id" => "chat_channel_memberships#find_by_chat_channel_id"

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -66,6 +66,18 @@ RSpec.describe "Search", type: :request, proper_status: true do
     end
   end
 
+  describe "GET /search/usernames" do
+    let(:names) { ["username"] }
+
+    it "returns json" do
+      allow(Search::User).to receive(:search_usernames).and_return(
+        names,
+      )
+      get "/search/usernames"
+      expect(response.parsed_body).to eq("result" => names)
+    end
+  end
+
   describe "GET /search/feed_content" do
     let(:mock_documents) { [{ "title" => "article1" }] }
 

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -67,9 +67,11 @@ RSpec.describe "Search", type: :request, proper_status: true do
   end
 
   describe "GET /search/usernames" do
+    let(:authorized_user) { create(:user) }
     let(:names) { ["username"] }
 
     it "returns json" do
+      sign_in authorized_user
       allow(Search::User).to receive(:search_usernames).and_return(
         names,
       )


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
For a while many have been asking for an autocomplete functionality for mentions. This provides the backend endpoint to get the job done. When given a username or part of a username it will pass that to Elasticsearch, run a search, and then return all matching usernames in an array.

## Related Tickets & Documents
https://github.com/forem/forem/issues/354

## Added tests?
- [x] Yes 💪 


![alt_text](https://www.reactiongifs.us/wp-content/uploads/2018/01/kvUU7.gif)
