### PR TITLE
Replace podcast bar helpers with image_tag

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,22 +62,6 @@ module ApplicationHelper
     content_for ? title(title_text) : title_text
   end
 
-  def icon(name, pixels = "20")
-    image_tag(icon_url(name), alt: name, class: "icon-img", height: pixels, width: pixels)
-  end
-
-  def icon_url(name)
-    postfix = {
-      "twitter" => "v1456342401/twitter-logo-silhouette_1_letrqc.png",
-      "github" => "v1456342401/github-logo_m841aq.png",
-      "link" => "v1456342401/link-symbol_apfbll.png",
-      "volume" => "v1461589297/technology_1_aefet2.png",
-      "volume-mute" => "v1461589297/technology_jiugwb.png"
-    }.fetch(name, "v1456342953/star-in-black-of-five-points-shape_sor40l.png")
-
-    "https://res.cloudinary.com/#{ApplicationConfig['CLOUDINARY_CLOUD_NAME']}/image/upload/#{postfix}"
-  end
-
   def optimized_image_url(url, width: 500, quality: 80, fetch_format: "auto", random_fallback: true)
     fallback_image = asset_path("#{rand(1..40)}.png") if random_fallback
 

--- a/app/views/podcast_episodes/_podcast_bar.html.erb
+++ b/app/views/podcast_episodes/_podcast_bar.html.erb
@@ -16,12 +16,16 @@
     </span>
     <span id="volume">
       <span id="volumeindicator" class="volume-icon-wrapper showing">
-        <span id="volbutt"><%= icon("volume", 16) %></span>
+        <span id="volbutt">
+          <%= image_tag("volume.png", alt: "volume", class: "icon-img", height: 16, width: 16) %>
+        </span>
         <span class="range-wrapper">
           <input type="range" name="points" id="volumeslider" value="50" min="0" max="100" data-show-value="true">
         </span>
       </span>
-      <span id="mutebutt" class="volume-icon-wrapper hidden"><%= icon("volume-mute", 16) %></span>
+      <span id="mutebutt" class="volume-icon-wrapper hidden">
+        <%= image_tag("volume-mute.png", alt: "volume-mute", class: "icon-img", height: 16, width: 16) %>
+      </span>
       <span class="speed" id="speed" data-speed=1>1x</span>
     </span>
     <span class="buffer-wrapper" id="bufferwrapper">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix for Forem

## Description
We were generating assets path ourselves instead of using `image_tag` with the asset that's already in our asset folder. This is broken in Forem because we don't use Cloudinary there.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
0. Pull down this PR and boot up the app locally.
1. Make sure you have podcasts locally. You need to have developing caching enabled and running sidekiq. 
2. Navigate to any podcast episodes and press play.
3. You should be able to see the volume and volume mute icon.

![image](https://user-images.githubusercontent.com/15793250/99710986-37277000-2a6f-11eb-8ced-acbf3b2b0212.png)
![image](https://user-images.githubusercontent.com/15793250/99711029-44dcf580-2a6f-11eb-8064-a1477062f4f8.png)

### UI accessibility concerns?
n/a

## Added tests?
- [x] No, and this is why: I would normally include a view spec but this partials' render is very straight forward.

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
