### PR TITLE
Update Trusted User Email Copy

### DIFF
--- a/app/views/mailers/notify_mailer/trusted_role_email.html.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.html.erb
@@ -2,17 +2,33 @@
   Hey <%= @user.name %>!
 </p>
 <p>
-  We are happy to let you know that your <%= community_name %> account has just been upgraded to "trusted" status.
+  We are happy to let you know that you've been granted "trusted" status on <%= community_name %>.
 </p>
 <p>
-  This gives you the power to privately downvote content which is low quality or spam and harassment, alongside a bit of additional functionality to help ensure the success of the community. Anywhere you now see a shield on the site indicates a place you can go to join our community's crowd-sourced moderation initiative.
+  This update allows you to make use of a few extra features — each of which furthers our goal of cultivating a welcoming and constructive community.
 </p>
 <p>
-  You may occasionally receive notifications about optional moderation actions, but you can  <a href="<%= app_url(user_settings_path(:notifications)) %>">unsubscribe</a> if you do not want to receive these notices.
+  Here's an overview of your new abilities:
+  <ul>
+    <li>Use reactions (👎, 👍, 🤢) to moderate content</li>
+    <li>Quickly flag rule-breaking behavior to <%= community_name %> staff</li>
+    <li>Rate the experience level of a post</li>
+  </ul>
 </p>
 <p>
-  <b><a href="<%= app_url("/community-moderation") %>">Click here for full details about what you can do with the trusted role.</b></a>
+  <b>For details on all available features and how to access them, visit our <a href="<%= app_url("/community-moderation") %>"><%= community_name %> Trusted User Guide.</b></a>
 </p>
 <p>
-  - <%= community_name %> Team
+  Note that you may occasionally receive notifications about optional moderation actions, please <a href="<%= app_url(user_settings_path(:notifications)) %>">unsubscribe</a> if you do not want to receive these notices.
+</p>
+<p>
+  If you have any questions or feedback for us, please write to <%= SiteConfig.email_addresses[:default] %> and share your thoughts.
+</p>
+
+<p>
+  Thanks for being such an awesome member of the community!
+</p>
+
+<p>
+  <%= community_name %> Team
 </p>

--- a/app/views/mailers/notify_mailer/trusted_role_email.html.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.html.erb
@@ -10,8 +10,8 @@
 <p>
   Here's an overview of your new abilities:
   <ul>
-    <li>Use reactions (👎, 👍, 🤢) to moderate content</li>
-    <li>Quickly flag rule-breaking behavior to <%= community_name %> staff</li>
+    <li>Use reactions (👎, 👍) to moderate content</li>
+    <li>Quickly flag rule-breaking behavior with 🤢 to <%= community_name %> staff</li>
     <li>Rate the experience level of a post</li>
   </ul>
 </p>

--- a/app/views/mailers/notify_mailer/trusted_role_email.html.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.html.erb
@@ -5,7 +5,7 @@
   We are happy to let you know that you've been granted "trusted" status on <%= community_name %>.
 </p>
 <p>
-  This update allows you to make use of a few extra features — each of which furthers our goal of cultivating a welcoming and constructive community.
+  This update allows you to make use of a few extra features—all of which further our goal of cultivating a welcoming and constructive community.
 </p>
 <p>
   Here's an overview of your new abilities:
@@ -16,10 +16,10 @@
   </ul>
 </p>
 <p>
-  <b>For details on all available features and how to access them, visit our <a href="<%= app_url("/community-moderation") %>"><%= community_name %> Trusted User Guide.</b></a>
+  <b>For details on all available features and how to access them, visit our <a href="<%= app_url("/community-moderation") %>"><%= community_name %> Trusted User Guide</a>.</b>
 </p>
 <p>
-  Note that you may occasionally receive notifications about optional moderation actions, please <a href="<%= app_url(user_settings_path(:notifications)) %>">unsubscribe</a> if you do not want to receive these notices.
+  You may occasionally receive notifications about optional moderation actions; please <a href="<%= app_url(user_settings_path(:notifications)) %>">unsubscribe</a> if you do not want to receive these updates.
 </p>
 <p>
   If you have any questions or feedback for us, please write to <%= SiteConfig.email_addresses[:default] %> and share your thoughts.

--- a/app/views/mailers/notify_mailer/trusted_role_email.text.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.text.erb
@@ -2,7 +2,7 @@ Hey <%= @user.name %>!
 
 We are happy to let you know that you've been granted "trusted" status on <%= community_name %>.
 
-This update allows you to make use of a few extra features — each of which furthers our goal of cultivating a welcoming and constructive community.
+This update allows you to make use of a few extra features—all of which further our goal of cultivating a welcoming and constructive community.
 
 Here's an overview of your new abilities:
 
@@ -10,7 +10,7 @@ Here's an overview of your new abilities:
 - Quickly flag rule-breaking behavior with 🤢 to <%= community_name %> staff
 - Rate the experience level of a post
 
-Note that you may occasionally receive notifications about optional moderation actions, please unsubscribe (<%= app_url(user_settings_path(:notifications)) %>) if you do not want to receive these notices.
+You may occasionally receive notifications about optional moderation actions; please unsubscribe (<%= app_url(user_settings_path(:notifications)) %>) if you do not want to receive these updates.
 
 For details on all available features and how to access them, visit our <%= community_name %> Trusted User Guide: <%= app_url("/community-moderation") %>
 

--- a/app/views/mailers/notify_mailer/trusted_role_email.text.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.text.erb
@@ -6,8 +6,8 @@ This update allows you to make use of a few extra features — each of which fur
 
 Here's an overview of your new abilities:
 
-- Use reactions (👎, 👍, 🤢) to moderate content
-- Quickly flag rule-breaking behavior to <%= community_name %> staff
+- Use reactions (👎, 👍) to moderate content
+- Quickly flag rule-breaking behavior with 🤢 to <%= community_name %> staff
 - Rate the experience level of a post
 
 Note that you may occasionally receive notifications about optional moderation actions, please unsubscribe (<%= app_url(user_settings_path(:notifications)) %>) if you do not want to receive these notices.

--- a/app/views/mailers/notify_mailer/trusted_role_email.text.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.text.erb
@@ -1,11 +1,21 @@
 Hey <%= @user.name %>!
 
-We are happy to let you know that your <%= community_name %> account has just been upgraded to "trusted" status.
+We are happy to let you know that you've been granted "trusted" status on <%= community_name %>.
 
-This gives you the power to privately downvote content which is low quality or spam and harassment, alongside a bit of additional functionality to help ensure the success of the community. Anywhere you now see a shield on the site indicates a place you can go to join our community's crowd-sourced moderation initiative. 
+This update allows you to make use of a few extra features — each of which furthers our goal of cultivating a welcoming and constructive community.
 
-You may occasionally receive notifications about optional moderation actions, but you can unsubscribe (<%= app_url(user_settings_path(:notifications)) %>) if you do not want to receive these notices.
+Here's an overview of your new abilities:
 
-For more information about what you can do as a "trusted" user, check out this page: <%= app_url("/community-moderation") %>
+- Use reactions (👎, 👍, 🤢) to moderate content
+- Quickly flag rule-breaking behavior to <%= community_name %> staff
+- Rate the experience level of a post
 
-- <%= community_name %> Team
+Note that you may occasionally receive notifications about optional moderation actions, please unsubscribe (<%= app_url(user_settings_path(:notifications)) %>) if you do not want to receive these notices.
+
+For details on all available features and how to access them, visit our <%= community_name %> Trusted User Guide: <%= app_url("/community-moderation") %>
+
+If you have any questions or feedback for us, please write to <%= SiteConfig.email_addresses[:default] %> and share your thoughts.
+
+Thanks for being such an awesome member of the community!
+
+<%= community_name %> Team


### PR DESCRIPTION
closes https://github.com/forem/InternalProjectPlanning/issues/345

Update trusted user email copy to enable us to successfully onboard more trusted users. Here are the email previews:
Plain text:
![Screen Shot 2020-11-19 at 3 10 27 PM](https://user-images.githubusercontent.com/1813380/99718884-31cb2500-2a71-11eb-8d2b-1b6429f226a8.png)

HTML
![Screen Shot 2020-11-19 at 3 12 07 PM](https://user-images.githubusercontent.com/1813380/99718910-3b548d00-2a71-11eb-9e86-ddc12479ffd0.png)
