### PR TITLE
API: Endpoint to get an organization's users

### DIFF
--- a/app/controllers/api/v0/organizations_controller.rb
+++ b/app/controllers/api/v0/organizations_controller.rb
@@ -9,14 +9,15 @@ module Api
       ].freeze
       private_constant :SHOW_ATTRIBUTES_FOR_SERIALIZATION
 
-      ORG_USERS_FOR_SERIALIZATION = %i[
-        id username name twitter_username github_username profile_image website_url
+      USERS_FOR_SERIALIZATION = %i[
+        id username name twitter_username github_username
+        profile_image website_url location summary created_at
       ].freeze
-      private_constant :ORG_USERS_FOR_SERIALIZATION
+      private_constant :USERS_FOR_SERIALIZATION
 
       def show
         @organization = Organization.select(SHOW_ATTRIBUTES_FOR_SERIALIZATION)
-          .find_by!(username: params[:org_username])
+          .find_by!(username: params[:username])
       end
 
       def users
@@ -24,13 +25,13 @@ module Api
         num = [per_page, 1000].min
         page = params[:page] || 1
 
-        @users = @organization.users.select(ORG_USERS_FOR_SERIALIZATION).page(page).per(num)
+        @users = @organization.users.select(USERS_FOR_SERIALIZATION).page(page).per(num)
       end
 
       private
 
       def find_organization
-        @organization = Organization.find_by!(username: params[:org_username])
+        @organization = Organization.find_by!(username: params[:organization_username])
       end
     end
   end

--- a/app/controllers/api/v0/organizations_controller.rb
+++ b/app/controllers/api/v0/organizations_controller.rb
@@ -1,15 +1,36 @@
 module Api
   module V0
     class OrganizationsController < ApiController
+      before_action :find_organization, only: %i[users]
+
       SHOW_ATTRIBUTES_FOR_SERIALIZATION = %i[
         username name summary twitter_username github_username url
         location created_at profile_image tech_stack tag_line story
       ].freeze
       private_constant :SHOW_ATTRIBUTES_FOR_SERIALIZATION
 
+      ORG_USERS_FOR_SERIALIZATION = %i[
+        id username name twitter_username github_username profile_image website_url
+      ].freeze
+      private_constant :ORG_USERS_FOR_SERIALIZATION
+
       def show
         @organization = Organization.select(SHOW_ATTRIBUTES_FOR_SERIALIZATION)
           .find_by!(username: params[:org_username])
+      end
+
+      def users
+        per_page = (params[:per_page] || 30).to_i
+        num = [per_page, 1000].min
+        page = params[:page] || 1
+
+        @users = @organization.users.select(ORG_USERS_FOR_SERIALIZATION).page(page).per(num)
+      end
+
+      private
+
+      def find_organization
+        @organization = Organization.find_by!(username: params[:org_username])
       end
     end
   end

--- a/app/views/api/v0/organizations/users.json.jbuilder
+++ b/app/views/api/v0/organizations/users.json.jbuilder
@@ -1,7 +1,3 @@
 json.array! @users do |user|
-  json.type_of "org_user"
-  json.extract!(user, :name, :username, :twitter_username, :github_username)
-
-  json.website_url user.processed_website_url
-  json.profile_image Images::Profile.call(user.profile_image_url, length: 320)
+  json.partial! "api/v0/shared/user_show", user: user
 end

--- a/app/views/api/v0/organizations/users.json.jbuilder
+++ b/app/views/api/v0/organizations/users.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @users do |user|
+  json.type_of "org_user"
+  json.extract!(user, :name, :username, :twitter_username, :github_username)
+
+  json.website_url user.processed_website_url
+  json.profile_image Images::Profile.call(user.profile_image_url, length: 320)
+end

--- a/app/views/api/v0/shared/_user_show.json.jbuilder
+++ b/app/views/api/v0/shared/_user_show.json.jbuilder
@@ -1,0 +1,16 @@
+json.type_of "user"
+
+json.extract!(
+  user,
+  :id,
+  :username,
+  :name,
+  :summary,
+  :twitter_username,
+  :github_username,
+  :website_url,
+  :location,
+)
+
+json.joined_at     user.created_at.strftime("%b %e, %Y")
+json.profile_image Images::Profile.call(user.profile_image_url, length: 320)

--- a/app/views/api/v0/users/show.json.jbuilder
+++ b/app/views/api/v0/users/show.json.jbuilder
@@ -1,16 +1,1 @@
-json.type_of "user"
-
-json.extract!(
-  @user,
-  :id,
-  :username,
-  :name,
-  :summary,
-  :twitter_username,
-  :github_username,
-  :website_url,
-  :location,
-)
-
-json.joined_at     @user.created_at.strftime("%b %e, %Y")
-json.profile_image Images::Profile.call(@user.profile_image_url, length: 320)
+json.partial! "api/v0/shared/user_show", user: user

--- a/app/views/api/v0/users/show.json.jbuilder
+++ b/app/views/api/v0/users/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! "api/v0/shared/user_show", user: user
+json.partial! "api/v0/shared/user_show", user: @user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,11 +201,8 @@ Rails.application.routes.draw do
         end
 
         resources :profile_images, only: %i[show], param: :username
-        resources :organizations, only: [] do
-          collection do
-            get "/:org_username", to: "organizations#show"
-            get "/:org_username/users", to: "organizations#users"
-          end
+        resources :organizations, only: [:show], param: :username do
+          resources :users, only: [:index], to: "organizations#users"
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,7 @@ Rails.application.routes.draw do
         resources :organizations, only: [] do
           collection do
             get "/:org_username", to: "organizations#show"
+            get "/:org_username/users", to: "organizations#users"
           end
         end
       end

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -17,7 +17,7 @@ info:
     Dates and date times, unless otherwise specified, must be in
     the [RFC 3339](https://tools.ietf.org/html/rfc3339) format.
 
-  version: "0.9.2"
+  version: "0.9.3"
   termsOfService: https://dev.to/terms
   contact:
     name: DEV Team
@@ -1147,6 +1147,30 @@ components:
           description: Profile image (640x640)
           format: url
 
+    OrgUser:
+      description: Org user
+      type: object
+      properties:
+        type_of:
+          type: string
+        username:
+          type: string
+        name:
+          type: string
+        twitter_username:
+          type: string
+          nullable: true
+        github_username:
+          type: string
+          nullable: true
+        website_url:
+          type: string
+          format: url
+        profile_image:
+          type: string
+          description: Profile image (640x640)
+          format: url
+
   examples:
     ErrorBadRequest:
       value:
@@ -1725,6 +1749,16 @@ components:
         tag_line: 
         story:
         profile_image: https://res.cloudinary.com/...jpeg
+
+    OrgUser:
+      value:
+        - type_of: org_user
+          username: miltonwaddams
+          name: Milton Waddams
+          twitter_username: stapler
+          github_username: stapler
+          website_url: https://stapler.internet
+          profile_image: https://res.cloudinary.com/...jpeg
 
 tags:
   - name: articles
@@ -3022,6 +3056,54 @@ paths:
           label: curl
           source: |
             curl https://dev.to/api/organizations/ecorp
+
+  /organizations/{org_username}/users:
+    get:
+      operationId: getOrgUsers
+      summary: Organization's users
+      description: |
+        This endpoint allows the client to retrieve a list of an organization's users
+
+        It supports pagination, each page will contain `30` users by default.
+      tags:
+        - organizations
+      parameters:
+        - name: org_username
+          in: path
+          required: true
+          description: |
+            Username of the organization
+          schema:
+            type: string
+          example: "ecorp"
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/perPageParam30to1000'
+      responses:
+        "200":
+          description: A list of an organization's users
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/OrgUser"
+              examples:
+                user-success:
+                  $ref: "#/components/examples/OrgUser"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/APIError"
+              examples:
+                user-not-found:
+                  $ref: "#/components/examples/ErrorNotFound"
+      x-code-samples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl https://dev.to/api/organizations/ecorp/users
 
   /podcast_episodes:
     get:

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -1147,30 +1147,6 @@ components:
           description: Profile image (640x640)
           format: url
 
-    OrgUser:
-      description: Org user
-      type: object
-      properties:
-        type_of:
-          type: string
-        username:
-          type: string
-        name:
-          type: string
-        twitter_username:
-          type: string
-          nullable: true
-        github_username:
-          type: string
-          nullable: true
-        website_url:
-          type: string
-          format: url
-        profile_image:
-          type: string
-          description: Profile image (640x640)
-          format: url
-
   examples:
     ErrorBadRequest:
       value:
@@ -1702,6 +1678,20 @@ components:
         joined_at: Jan 1, 2017
         profile_image: https://res.cloudinary.com/...jpeg
 
+    Users:
+      value:
+        - type_of: user
+          id: 1234
+          username: bob
+          name: bob
+          summary: Hello, world
+          twitter_username: bob
+          github_username: bob
+          website_url:
+          location: New York
+          joined_at: Jan 1, 2017
+          profile_image: https://res.cloudinary.com/...jpeg
+
     WebhookCreate:
       value:
         webhook_endpoint:
@@ -1749,16 +1739,6 @@ components:
         tag_line: 
         story:
         profile_image: https://res.cloudinary.com/...jpeg
-
-    OrgUser:
-      value:
-        - type_of: org_user
-          username: miltonwaddams
-          name: Milton Waddams
-          twitter_username: stapler
-          github_username: stapler
-          website_url: https://stapler.internet
-          profile_image: https://res.cloudinary.com/...jpeg
 
 tags:
   - name: articles
@@ -3015,7 +2995,7 @@ paths:
           source: |
             curl -H "api-key: API_KEY" https://dev.to/api/readinglist
 
-  /organizations/{org_username}:
+  /organizations/{username}:
     get:
       operationId: getOrganization
       summary: An organization
@@ -3024,7 +3004,7 @@ paths:
       tags:
         - organizations
       parameters:
-        - name: org_username
+        - name: username
           in: path
           required: true
           description: |
@@ -3057,18 +3037,18 @@ paths:
           source: |
             curl https://dev.to/api/organizations/ecorp
 
-  /organizations/{org_username}/users:
+  /organizations/{username}/users:
     get:
       operationId: getOrgUsers
       summary: Organization's users
       description: |
-        This endpoint allows the client to retrieve a list of an organization's users
+        This endpoint allows the client to retrieve a list of users belonging to the organization
 
         It supports pagination, each page will contain `30` users by default.
       tags:
         - organizations
       parameters:
-        - name: org_username
+        - name: username
           in: path
           required: true
           description: |
@@ -3080,16 +3060,16 @@ paths:
         - $ref: '#/components/parameters/perPageParam30to1000'
       responses:
         "200":
-          description: A list of an organization's users
+          description: A list of users belonging to the organization
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/OrgUser"
+                  $ref: "#/components/schemas/User"
               examples:
                 user-success:
-                  $ref: "#/components/examples/OrgUser"
+                  $ref: "#/components/examples/Users"
         "404":
           description: Resource not found
           content:

--- a/spec/requests/api/v0/organizations_spec.rb
+++ b/spec/requests/api/v0/organizations_spec.rb
@@ -25,4 +25,41 @@ RSpec.describe "Api::V0::Organizations", type: :request do
       expect(response_organization["joined_at"]).to eq(organization.created_at.utc.iso8601)
     end
   end
+
+  describe "GET /api/organizations/:username/users" do
+    let!(:org_user) { create(:user, :org_member) }
+    let(:organization) { org_user.organizations.first }
+
+    it "returns 404 if the organizations username is not found" do
+      get "/api/organizations/invalid-username/users"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "supports pagination" do
+      create(:organization_membership, user: create(:user), organization: organization)
+
+      get "/api/organizations/#{organization.username}/users", params: { page: 1, per_page: 1 }
+      expect(response.parsed_body.length).to eq(1)
+
+      get "/api/organizations/#{organization.username}/users", params: { page: 2, per_page: 1 }
+      expect(response.parsed_body.length).to eq(1)
+
+      get "/api/organizations/#{organization.username}/users", params: { page: 3, per_page: 1 }
+      expect(response.parsed_body.length).to eq(0)
+    end
+
+    it "returns the correct json representation of the organizations users", :aggregate_failures do
+      get "/api/organizations/#{organization.username}/users"
+
+      response_org_users = response.parsed_body
+
+      %w[
+        username name twitter_username github_username website_url
+      ].each do |attr|
+        expect(response_org_users.first[attr]).to eq(org_user.public_send(attr))
+      end
+
+      expect(response_org_users.first["profile_image_url"]).to eq(org_user["profile_image_url"])
+    end
+  end
 end


### PR DESCRIPTION
<!--


     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This would provide an api endpoint `dev.to/api/organizations/{org_username}/users` to get a list of an organization's users.
As discussed in issue 9212, This is the 2nd of 4 related endpoints that will include:
```
dev.to/api/organizations/{org_username}/articles
dev.to/api/organizations/{org_username}/listings
```

## Related Tickets & Documents
#9212  #10931

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [x] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [ ] No documentation needed

