### PR TITLE
Update trusted role email Subject

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -135,7 +135,7 @@ class NotifyMailer < ApplicationMailer
   def trusted_role_email
     @user = params[:user]
 
-    subject = "You've been upgraded to #{SiteConfig.community_name} Community mod status!"
+    subject = "Congrats! You're now a \"trusted\" user on #{SiteConfig.community_name}!"
     mail(to: @user.email, subject: subject)
   end
 

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe NotifyMailer, type: :mailer do
     let(:email) { described_class.with(user: user).trusted_role_email }
 
     it "renders proper subject" do
-      expected_subject = "You've been upgraded to #{SiteConfig.community_name} Community mod status!"
+      expected_subject = "Congrats! You're now a \"trusted\" user on #{SiteConfig.community_name}!"
       expect(email.subject).to eq(expected_subject)
     end
 


### PR DESCRIPTION
Quick Subject line update for the Trusted Mod Email to make the wording and copy more clear and and consistent