### PR TITLE
Suppress Postcss warnings & Re-enable Benhalpern deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,13 +92,13 @@ jobs:
         api_key: '$HEROKU_AUTH_TOKEN'
         app:
           master: practicaldev
-    # - stage: Deploy
-    #   name: Deploy BenHalpern
-    #   if: type != pull_request
-    #   script: skip
-    #   after_script: skip
-    #   deploy:
-    #     provider: heroku
-    #     api_key: '$HEROKU_AUTH_TOKEN'
-    #     app:
-    #       master: benhalpern-community
+    - stage: Deploy
+      name: Deploy BenHalpern
+      if: type != pull_request
+      script: skip
+      after_script: skip
+      deploy:
+        provider: heroku
+        api_key: '$HEROKU_AUTH_TOKEN'
+        app:
+          master: benhalpern-community

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pretest": "npm run lint:frontend",
     "test": "jest app/javascript/ bin/ --coverage",
     "test:watch": "jest app/javascript/ bin/ --watch",
-    "postcss": "postcss public/assets/*.css -d public/assets 2> err.log"
+    "postcss": "postcss public/assets/*.css -d public/assets 2> postcss_error.log"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pretest": "npm run lint:frontend",
     "test": "jest app/javascript/ bin/ --coverage",
     "test:watch": "jest app/javascript/ bin/ --watch",
-    "postcss": "postcss public/assets/*.css -d public/assets"
+    "postcss": "postcss public/assets/*.css -d public/assets 2> err.log"
   },
   "husky": {
     "hooks": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -8,11 +8,6 @@ module.exports = {
         flexbox: 'no-2009',
       },
       stage: 3,
-      features: {
-        customProperties: {
-          warnings: false,
-        },
-      },
     }),
   ],
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We've been getting by log flood from `postcss-custom-properties` which is messing up our Travis build. Because that tool no longer provides warning suppression, this PR will suppress it via bash and output it to a file name `err.log` for future debugging.

## Related Tickets & Documents
Resolves https://github.com/forem/forem/issues/11490

Previous attempts
https://github.com/forem/forem/pull/11518
https://github.com/forem/forem/pull/11520

## QA Instructions, Screenshots, Recordings
Run `bin/rails assets:precompile` locally and you should not see any warning.

### UI accessibility concerns?
n/a

## Added tests?
- [x] No, and this is why: This is a CI change

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a

