### PR TITLE
Update aspect ratio of images on the Admin's config page

### DIFF
--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -170,7 +170,7 @@ module Constants
         placeholder: SVG_PLACEHOLDER
       },
       logo_png: {
-        description: "Used as a fallback to the SVG. Recommended minimum of 192x192px for PWA support",
+        description: "Used as a fallback to the SVG. Recommended minimum of 512x512px for PWA support",
         placeholder: IMAGE_PLACEHOLDER
       },
       logo_svg: {

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -170,7 +170,7 @@ module Constants
         placeholder: SVG_PLACEHOLDER
       },
       logo_png: {
-        description: "Minimum 1024px, used for PWA etc.",
+        description: "Minimum 192x192px, used for PWA etc.",
         placeholder: IMAGE_PLACEHOLDER
       },
       logo_svg: {

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -170,7 +170,7 @@ module Constants
         placeholder: SVG_PLACEHOLDER
       },
       logo_png: {
-        description: "Minimum 192x192px, used for PWA etc.",
+        description: "Used as a fallback to the SVG. Recommended minimum of 192x192px for PWA support",
         placeholder: IMAGE_PLACEHOLDER
       },
       logo_svg: {

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -178,7 +178,7 @@ module Constants
         placeholder: SVG_PLACEHOLDER
       },
       main_social_image: {
-        description: "Used as the main image in social networks and OpenGraph",
+        description: "Used as the main image in social networks and OpenGraph. Recommended aspect ratio of 16:9 (600x337px,1200x675px)",
         placeholder: IMAGE_PLACEHOLDER
       },
       mailchimp_api_key: {

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -89,7 +89,7 @@ class SiteConfig < RailsSettings::Base
   # Images
   field :main_social_image, type: :string, default: proc { URL.local_image("social-media-cover.png") }
 
-  field :favicon_url, type: :string, default: "favicon.ico"
+  field :favicon_url, type: :string, default: proc { URL.local_image("favicon.ico") }
   field :logo_png, type: :string, default: proc { URL.local_image("icon.png") }
 
   field :logo_svg, type: :string

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -200,9 +200,9 @@
                           <%= admin_config_label :allowed_registration_email_domains, "Allowed email domains" %>
                           <%= admin_config_description Constants::SiteConfig::DETAILS[:allowed_registration_email_domains][:description] %>
                           <%= f.text_field :allowed_registration_email_domains,
-                                            class: "crayons-textfield",
-                                            value: SiteConfig.allowed_registration_email_domains.join(","),
-                                            placeholder: Constants::SiteConfig::DETAILS[:allowed_registration_email_domains][:placeholder] %>
+                                           class: "crayons-textfield",
+                                           value: SiteConfig.allowed_registration_email_domains.join(","),
+                                           placeholder: Constants::SiteConfig::DETAILS[:allowed_registration_email_domains][:placeholder] %>
                         </div>
                         <div class="crayons-field--checkbox">
                           <%= f.check_box :display_email_domain_allow_list_publicly,
@@ -722,7 +722,7 @@
                                    value: SiteConfig.main_social_image,
                                    placeholder: Constants::SiteConfig::DETAILS[:main_social_image][:placeholder] %>
                   <% if SiteConfig.main_social_image.present? %>
-                    <img alt="main social image" class="img-fluid" src="<%= SiteConfig.main_social_image %>" />
+                    <img alt="main social image" class="img-fluid" src="<%= SiteConfig.main_social_image %>" width="600px" height="337px" />
                   <% end %>
                 </div>
 
@@ -1043,7 +1043,7 @@
                                    placeholder: Constants::SiteConfig::DETAILS[:onboarding_logo_image][:placeholder] %>
                   <div class="row mt-2">
                     <div class="col-12">
-                      <img alt="main social image" class="img-fluid" src="<%= SiteConfig.onboarding_logo_image %>" />
+                      <img alt="main social image" class="img-fluid" src="<%= SiteConfig.onboarding_logo_image %>" width="600px" height="337px" />
                     </div>
                   </div>
                 </div>

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -744,7 +744,7 @@
                                    value: SiteConfig.logo_png,
                                    placeholder: Constants::SiteConfig::DETAILS[:logo_png][:placeholder] %>
                   <% if SiteConfig.logo_png.present? %>
-                    <img src="<%= Images::Optimizer.call(SiteConfig.logo_png, width: 256) %>" width="128" height="128" />
+                    <img src="<%= Images::Optimizer.call(SiteConfig.logo_png, width: 128) %>" width="128px" height="128px" />
                   <% end %>
                 </div>
 
@@ -771,7 +771,7 @@
                                    value: SiteConfig.secondary_logo_url,
                                    placeholder: Constants::SiteConfig::DETAILS[:secondary_logo_url][:placeholder] %>
                   <% if SiteConfig.secondary_logo_url.present? %>
-                    <img alt="secondary logo image" class="img-fluid" src="<%= Images::Optimizer.call(SiteConfig.secondary_logo_url, width: 256) %>" />
+                    <img alt="secondary logo image" class="img-fluid" src="<%= Images::Optimizer.call(SiteConfig.secondary_logo_url, width: 256) %>" width="128px" height="128px" />
                   <% end %>
                 </div>
 

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -733,7 +733,7 @@
                                    class: "form-control",
                                    value: SiteConfig.favicon_url,
                                    placeholder: Constants::SiteConfig::DETAILS[:favicon_url][:placeholder] %>
-                  <img alt="favicon" class="preview" src="<%= Images::Optimizer.call(SiteConfig.favicon_url, width: 32) %>" />
+                  <img alt="favicon" class="preview" src="<%= Images::Optimizer.call(SiteConfig.favicon_url, width: 32) %>" width="32px" height="32px" />
                 </div>
 
                 <div class="crayons-field">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The img tags used in the config page doesn't have proper width and height specified. This PR addresses that and change some of the descriptions.

Please feel free to commit to this PR directly.

## Related Tickets & Documents
Resolves https://github.com/forem/InternalProjectPlanning/issues/293

## QA Instructions, Screenshots, Recordings
0. Pull down this PR, set add the following role to your own local account `me.role(:single_resource_admin, Config)`
1. Start up the server, navigate to `/admin/config`
2. Click on the 'Images' dropdown.
3. All the images there shouldn't look out of proportion. Nothing should look too big or distorted.

### UI accessibility concerns?
I don't think there should be any concern here as I'm just changing the css.

## Added tests?
- [x] No, and this is why: this is mostly a css change

## Added to documentation?
I'll update the docs as soon as we come to an agreement

- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [ ] No documentation

## [optional] Are there any post deployment tasks we need to perform?
n/a