### PR TITLE
Include core assets in serviceworker cache

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -137,6 +137,22 @@
       return;
     }
 
+    // Fetch and/or JS and CSS assets for better persistence than memory cache.
+    if (url.pathname.startsWith("/assets/") || url.pathname.startsWith("/packs/")) {
+      event.respondWith(
+        caches.open(staticCacheName).then(function (cache) {
+          return cache.match(event.request).then(function (response) {
+            return (
+              response ||
+              fetch(event.request).then(function (response) {
+                cache.put(event.request, response.clone());
+                return response;
+              })
+            );
+          });
+        })
+      );
+    }
     if (url.origin === location.origin) {
       if (event.clientId === "" && // Not fetched via AJAX after page load.
         event.request.method == "GET" && // Don't fetch on POST, DELETE, etc.
@@ -187,6 +203,22 @@
             "/shell_bottom",
           ]));
       }
+
+      // Periodically delete assets when they pile up
+      if (Math.random() > 0.97) {
+        caches.open(staticCacheName).then(function(cache) {
+          cache.keys().then(function(keys) {
+            if (keys.length > 100) {
+              keys.forEach(function(r) {
+                if (r.url.includes("/assets/") || r.url.includes("/packs/")) {
+                  cache.delete(r);
+                };
+              });
+            }
+          });
+        });
+      }
+
     }
   });
 <% end %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Currently when we deploy Forem Cloud we do not retain assets for old versions of the platform, and service workers do not seem to reliably retain the in-memory cached version of assets, so we sometimes get flashes of unstyled content and other frontend issues.

This adds more static assets to the serviceworker cache, and also adds functionality to _periodically_ flush that component of the serviceworker cache to make sure we don't over-cache.

## QA Instructions, Screenshots, Recordings

Things should _continue to work as normal_. If you open up the application tab of chrome tools and view Cache Storage you'll see static 1.2 cache including a bunch of assets.