### PR TITLE
Bug Fix:User >= when filtering by SiteConfig.home_feed_minimum_score

### DIFF
--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -186,7 +186,7 @@ module Articles
 
       def globally_hot_articles(user_signed_in)
         hot_stories = published_articles_by_tag
-          .where("score > ? OR featured = ?", SiteConfig.home_feed_minimum_score, true)
+          .where("score >= ? OR featured = ?", SiteConfig.home_feed_minimum_score, true)
           .order(hotness_score: :desc)
         featured_story = hot_stories.where.not(main_image: nil).first
         if user_signed_in

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -61,21 +61,18 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
     let(:default_feed) { feed.default_home_feed_and_featured_story }
     let(:featured_story) { default_feed.first }
     let(:stories) { default_feed.second }
+    let!(:min_score_article) { create(:article, score: 0) }
 
-    before { article.update(published_at: 1.week.ago) }
+    before do
+      article.update(published_at: 1.week.ago)
+      allow(SiteConfig).to receive(:home_feed_minimum_score).and_return(0)
+    end
 
-    it "returns a featured article and array of other articles" do
-      expect(featured_story).to be_a(Article)
+    it "returns a featured article and correctly scored other articles", :aggregate_failures do
       expect(stories).to be_a(Array)
-      expect(stories.first).to be_a(Article)
-    end
-
-    it "chooses a featured story with a main image" do
       expect(featured_story).to eq hot_story
-    end
-
-    it "doesn't include low scoring stories" do
       expect(stories).not_to include(low_scoring_article)
+      expect(stories).to include(min_score_article)
     end
 
     context "when user logged in" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Include Articles WITH the `SiteConfig.home_feed_minimum_score` in the Feed

## Related Tickets & Documents
Closes: https://github.com/forem/InternalProjectPlanning/issues/347

## Added tests?
- [x] Yes

![alt_text](https://media.giphy.com/media/xT5LMSczEm0NtjNoGI/giphy.gif)
