### PR TITLE
Reword "Public" Checkbox Warning Message in the SiteConfig

### DIFF
--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -200,9 +200,9 @@
                           <%= admin_config_label :allowed_registration_email_domains, "Allowed email domains" %>
                           <%= admin_config_description Constants::SiteConfig::DETAILS[:allowed_registration_email_domains][:description] %>
                           <%= f.text_field :allowed_registration_email_domains,
-                                            class: "crayons-textfield",
-                                            value: SiteConfig.allowed_registration_email_domains.join(","),
-                                            placeholder: Constants::SiteConfig::DETAILS[:allowed_registration_email_domains][:placeholder] %>
+                                           class: "crayons-textfield",
+                                           value: SiteConfig.allowed_registration_email_domains.join(","),
+                                           placeholder: Constants::SiteConfig::DETAILS[:allowed_registration_email_domains][:placeholder] %>
                         </div>
                         <div class="crayons-field--checkbox">
                           <%= f.check_box :display_email_domain_allow_list_publicly,
@@ -1301,7 +1301,7 @@
                   <div class="mt-0">
                     <%= admin_config_label :public %>
                     <p class="crayons-field__description">
-                      Are most of the site pages (e.g. posts, profiles) public? <strong>Be very cautious about changing thing.</strong>
+                      Are most of the site pages (e.g. posts, profiles) public? <strong>Please take precaution when changing this setting.</strong>
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR rewords the bolded warning message below the "Public" checkbox in the SiteConfig, which I stumbled upon while working on something else.

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings
**Before**:
<img width="952" alt="Screen Shot 2020-11-23 at 11 02 22 AM" src="https://user-images.githubusercontent.com/32834804/99998096-5f6ae380-2d7b-11eb-86ae-4612b58933ab.png">

**After**:
<img width="963" alt="Screen Shot 2020-11-23 at 11 01 09 AM" src="https://user-images.githubusercontent.com/32834804/99997993-35192600-2d7b-11eb-9e96-466ec6aba60a.png">

### UI accessibility concerns?
N/A

## Added tests?

- [ ] Yes
- [x] No, and this is why: because the SiteConfig is already tested and this is merely a rewording of text.
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Hamilton the Musical](https://media.giphy.com/media/jwXZGkR5raCuMtN7fS/giphy.gif)
