### PR TITLE
[EOY 2020] Replace "ban" with "suspend" in Admin

### DIFF
--- a/app/controllers/chat_channels_controller.rb
+++ b/app/controllers/chat_channels_controller.rb
@@ -103,7 +103,7 @@ class ChatChannelsController < ApplicationController
       else
         render json: {
           status: "error",
-          message: "Ban failed. user with username '#{username}' not found in this channel."
+          message: "Suspend failed. user with username '#{username}' not found in this channel."
         }, status: :bad_request
       end
     when "/unban"
@@ -114,7 +114,7 @@ class ChatChannelsController < ApplicationController
       else
         render json: {
           status: "error",
-          message: "Unban failed. User with username '#{username}' not found in this channel."
+          message: "Unsuspend failed. User with username '#{username}' not found in this channel."
         }, status: :bad_request
       end
     when "/clearchannel"

--- a/app/lib/constants/role.rb
+++ b/app/lib/constants/role.rb
@@ -1,8 +1,8 @@
 module Constants
   module Role
     BASE_ROLES = ["Warn",
-                  "Comment Ban",
-                  "Ban",
+                  "Comment Suspend",
+                  "Suspend",
                   "Regular Member",
                   "Trusted",
                   "Pro"].freeze

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -699,8 +699,8 @@ class Article < ApplicationRecord
       author_id: SiteConfig.mascot_user_id,
       noteable_id: user_id,
       noteable_type: "User",
-      reason: "automatic_ban",
-      content: "User banned for too many spammy articles, triggered by autovomit.",
+      reason: "automatic_suspend",
+      content: "User suspended for too many spammy articles, triggered by autovomit.",
     )
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -272,8 +272,8 @@ class Comment < ApplicationRecord
       author_id: SiteConfig.mascot_user_id,
       noteable_id: user_id,
       noteable_type: "User",
-      reason: "automatic_ban",
-      content: "User banned for too many spammy articles, triggered by autovomit.",
+      reason: "automatic_suspend",
+      content: "User suspended for too many spammy articles, triggered by autovomit.",
     )
   end
 

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -14,7 +14,7 @@ module Moderator
       BanishedUser.create(username: user.username, banished_by: admin)
       user.unsubscribe_from_newsletters if user.email?
       remove_profile_info
-      handle_user_status("Ban", "spam account")
+      handle_user_status("Suspend", "spam account")
       delete_user_activity
       delete_comments
       delete_articles

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -57,12 +57,12 @@ module Moderator
 
     def handle_user_status(role, note)
       case role
-      when "Ban" || "Spammer"
+      when "Suspend" || "Spammer"
         user.add_role :banned
         remove_privileges
       when "Warn"
         warned
-      when "Comment Ban"
+      when "Comment Suspend"
         comment_banned
       when "Regular Member"
         regular_member

--- a/app/views/admin/users/_activity.html.erb
+++ b/app/views/admin/users/_activity.html.erb
@@ -15,7 +15,7 @@
     <p>(view full history in notes below)</p>
     <ul>
       <% @user.roles.each do |role| %>
-        <% if role.name === "banned" %>
+        <% if role.name == "banned" %>
           <li>suspended</li>
         <% else %>
           <li><%= role.name %> <em><%= role.resource_name.to_s %></em></li>

--- a/app/views/admin/users/_activity.html.erb
+++ b/app/views/admin/users/_activity.html.erb
@@ -15,7 +15,11 @@
     <p>(view full history in notes below)</p>
     <ul>
       <% @user.roles.each do |role| %>
-        <li><%= role.name %> <em><%= role.resource_name.to_s %></em></li>
+        <% if role.name === "banned" %>
+          <li>suspended</li>
+        <% else %>
+          <li><%= role.name %> <em><%= role.resource_name.to_s %></em></li>
+        <% end %>
       <% end %>
     </ul>
   </div>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -24,7 +24,7 @@
         <% elsif @user.warned %>
           <span class="badge badge-warning">Member is Warned</span>
         <% elsif @user.comment_banned %>
-          <span class="badge badge-warning">Member is Comment Banned</span>
+          <span class="badge badge-warning">Member is Comment Suspended</span>
         <% elsif @user.trusted %>
           <span class="badge badge-success">Member is Trusted</span>
         <% else %>

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -798,13 +798,13 @@ RSpec.describe Article, type: :model do
         expect(Reaction.last.user_id).to eq(user.id)
       end
 
-      it "does not ban user if only single vomit" do
+      it "does not suspend user if only single vomit" do
         article.body_markdown = article.body_markdown.gsub(article.title, "This post is about Yahoomagoo gogo")
         article.save
         expect(article.user.banned).to be false
       end
 
-      it "bans user with 3 comment vomits" do
+      it "suspends user with 3 comment vomits" do
         second_article = create(:article, user: article.user)
         third_article = create(:article, user: article.user)
         article.body_markdown = article.body_markdown.gsub(article.title, "This post is about Yahoomagoo gogo")
@@ -815,7 +815,7 @@ RSpec.describe Article, type: :model do
         second_article.save
         third_article.save
         expect(article.user.banned).to be true
-        expect(Note.last.reason).to eq "automatic_ban"
+        expect(Note.last.reason).to eq "automatic_suspend"
       end
 
       it "does not create vomit reaction if does not have matching title" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -410,13 +410,13 @@ RSpec.describe Comment, type: :model do
       expect(Reaction.last.user_id).to eq(user.id)
     end
 
-    it "does not ban user if only single vomit" do
+    it "does no suspend user if only single vomit" do
       comment.body_markdown = "This post is about Yahoomagoo gogo"
       comment.save
       expect(comment.user.banned).to be false
     end
 
-    it "bans user with 3 comment vomits" do
+    it "suspends user with 3 comment vomits" do
       comment.body_markdown = "This post is about Yahoomagoo gogo"
       second_comment = create(:comment, user: comment.user, body_markdown: "This post is about Yahoomagoo gogo")
       third_comment = create(:comment, user: comment.user, body_markdown: "This post is about Yahoomagoo gogo")
@@ -425,7 +425,7 @@ RSpec.describe Comment, type: :model do
       second_comment.save
       third_comment.save
       expect(comment.user.banned).to be true
-      expect(Note.last.reason).to eq "automatic_ban"
+      expect(Note.last.reason).to eq "automatic_suspend"
     end
 
     it "does not create vomit reaction if user is established in this context" do

--- a/spec/requests/admin/users_manage_spec.rb
+++ b/spec/requests/admin/users_manage_spec.rb
@@ -113,19 +113,19 @@ RSpec.describe "Admin::Users", type: :request do
   end
 
   context "when managing activity and roles" do
-    it "adds comment ban role" do
-      params = { user: { user_status: "Comment Ban", note_for_current_role: "comment ban this user" } }
+    it "adds comment suspend role" do
+      params = { user: { user_status: "Comment Suspend", note_for_current_role: "comment suspend this user" } }
       patch "/admin/users/#{user.id}/user_status", params: params
 
       expect(user.roles.first.name).to eq("comment_banned")
-      expect(Note.first.content).to eq("comment ban this user")
+      expect(Note.first.content).to eq("comment suspend this user")
     end
 
     it "selects new role for user" do
       user.add_role :trusted
       user.reload
 
-      params = { user: { user_status: "Comment Ban", note_for_current_role: "comment ban this user" } }
+      params = { user: { user_status: "Comment Suspend", note_for_current_role: "comment suspend this user" } }
       patch "/admin/users/#{user.id}/user_status", params: params
 
       expect(user.roles.count).to eq(1)

--- a/spec/system/admin/admin_bans_or_warns_user_spec.rb
+++ b/spec/system/admin/admin_bans_or_warns_user_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe "Admin bans user", type: :system do
     visit edit_admin_user_path(user.id)
   end
 
-  def ban_user
+  def suspend_user
     visit "/admin/users/#{user.id}/edit"
-    select("Ban", from: "user_user_status")
+    select("Suspend", from: "user_user_status")
     fill_in("user_note_for_current_role", with: "something")
     click_button("Update User Status")
     expect(page).to have_content("User has been updated")
@@ -30,7 +30,7 @@ RSpec.describe "Admin bans user", type: :system do
     user.add_role :tag_moderator, tag
   end
 
-  def unban_user
+  def unsuspend_user
     visit "/admin/users/#{user.id}/edit"
     select("Regular Member", from: "user_user_status")
     fill_in("user_note_for_current_role", with: "good user")
@@ -49,16 +49,16 @@ RSpec.describe "Admin bans user", type: :system do
   end
 
   # to-do: add spec for invalid bans
-  it "checks that the user is banned and has note" do
-    ban_user
+  it "checks that the user is suspended and has note" do
+    suspend_user
     expect(user.banned).to eq(true)
-    expect(Note.last.reason).to eq "Ban"
+    expect(Note.last.reason).to eq "Suspend"
   end
 
-  it "removes other roles if user is banned" do
+  it "removes other roles if user is suspended" do
     user.add_role :trusted
     add_tag_moderator_role
-    ban_user
+    suspend_user
 
     expect(user.banned).to eq(true)
     expect(user.trusted).to eq(false)
@@ -68,7 +68,7 @@ RSpec.describe "Admin bans user", type: :system do
 
   it "unbans user" do
     user.add_role :banned
-    unban_user
+    unsuspend_user
 
     expect(user.has_role?(:banned)).to eq(false)
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Renames "ban" to "suspend" throughout the `/admin/` space.
closes https://github.com/forem/InternalProjectPlanning/issues/298

#### NOTE: 👇🏽
I stopped short of changing `banned` and `comment_banned` to `suspended` and `comment_suspended` (respectively) within `app > models > role.rb`, as I am not sure how that move will affect current role assignments in production. I welcome feedback/corrections on my decision. :pray:


## QA Instructions, Screenshots, Recordings
1. Navigate to `localhost:xxxx/admin/users` as a `super_admin` role
2. Edit any user and give them either `Suspend` or `Comment Suspend` roles
3. Check that their show page reflects the role changes made

https://www.loom.com/share/6c764ef0ff724b8e8c73433681a2edf1


### UI accessibility concerns?
Changes were made just to certain text, depending on the user's role; there are no UI accessibility concerns introduced, in my humble opinion


## Added tests?

- [X] Yes, tests were modified according to code changes made
- [ ] No, and this is why:
- [ ] I need help with writing tests

## Added to documentation?

- [X] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
https://app.gitbook.com/@forem/s/forem-admin-guide/admin/users/user-roles
- [ ] README
- [ ] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
None

## [optional] What gif best describes this PR or how it makes you feel?

![Get It Dance](https://media.giphy.com/media/U5U8gZy0PlrcLY46NC/giphy-downsized.gif)
