### PR TITLE
Make Images::Optimizer nil-safe

### DIFF
--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -1,7 +1,7 @@
 module Images
   module Optimizer
     def self.call(img_src, **kwargs)
-      return img_src if img_src.starts_with?("/")
+      return img_src if img_src.blank? || img_src.starts_with?("/")
 
       if imgproxy_enabled?
         imgproxy(img_src, kwargs)

--- a/spec/services/images/optimizer_spec.rb
+++ b/spec/services/images/optimizer_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Images::Optimizer, type: :service do
       expect(described_class.call(relative_asset_path)).to eq relative_asset_path
     end
 
+    it "does nothing when given nil" do
+      expect(described_class.call(nil)).to eq nil
+    end
+
     it "calls cloudinary if imgproxy is not enabled" do
       allow(described_class).to receive(:imgproxy_enabled?).and_return(false)
       described_class.call(image_url)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Instead of breaking an entire page because of one missing image, `Images::Optimizer` should ignore the empty/missing image and pass it back as is so at the very least we can see the culprit.

## Related Tickets & Documents
Debugging-aid for https://github.com/forem/InternalProjectPlanning/issues/348

## QA Instructions, Screenshots, Recordings
- All image should still be rendered normally.

## Added tests?
- [x] Yes

## Added to documentation?
[x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a