### PR TITLE
Fix email messages link in admin's user page

### DIFF
--- a/app/views/admin/users/_email_tools.html.erb
+++ b/app/views/admin/users/_email_tools.html.erb
@@ -25,7 +25,10 @@
     <h3>Recent Emails</h3>
     <div class="list-group-flush">
       <% @user.email_messages.order(sent_at: :desc).limit(50).each do |email| %>
-        <a href="/admin/email_messages/<%= email.id %>" class="list-group-item list-group-item-action">
+        <a href="<%= resource_admin_email_message_path(email.id) %>"
+           class="list-group-item list-group-item-action"
+           rel="noopener noreferer"
+           target="_blank">
           <%= email.subject %>
           <em> - <%= email.sent_at&.strftime("%b %e '%y") %></em>
         </a>

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe "admin/users", type: :request do
         expect(response.body).to include("Current Roles")
       end
     end
+
+    context "when a user has been sent an email" do
+      it "renders a link to the user email on the Resource Admin" do
+        email = create(:email_message, user: user, to: user.email)
+        get admin_user_path(user.id)
+
+        expect(response.body).to include(resource_admin_email_message_path(email.id))
+      end
+    end
   end
 
   describe "GET /admin/users/:id/edit" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Email messages point to the wrong path in the admin's user page

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/11578

## QA Instructions, Screenshots, Recordings

1. log in the admin
1. select a user, send them an email, refresh the page
1. verify that the link under "recent emails" works 

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
