### PR TITLE
Bug Fix:Remove Score Filter From Tag Mod Index

### DIFF
--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -13,7 +13,6 @@ class ModerationsController < ApplicationController
     return unless current_user&.trusted
 
     articles = Article.published
-      .where("score > -5 AND score < 5")
       .order(published_at: :desc).limit(70)
     articles = articles.cached_tagged_with(params[:tag]) if params[:tag].present?
     if params[:state] == "new-authors"

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -130,11 +130,8 @@ RSpec.describe "Moderations", type: :request do
       get "#{article.path}/actions_panel"
     end
 
-    it "shows the admin add tag option if the article has room for a tag" do
+    it "shows the admin tag options", :aggregate_failures do
       expect(response.body).to include "admin-add-tag"
-    end
-
-    it "shows the option to remove tags" do
       expect(response.body).to include "circle centered-icon adjustment-icon subtract"
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Remove score filter for articles for the moderator's article index so they can view all articles. 

## Related Tickets & Documents
Closes https://github.com/forem/tech-private/issues/420

## Added tests?
- [x] No, they already exist


![alt_text](https://media2.giphy.com/media/MWdOAxxPDEhNKyzXVK/200.gif)
