### PR TITLE
Refactor/Optimization:Use more_comments_minimal_weight_randomized_at_end for Signed In Feed

### DIFF
--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -42,6 +42,11 @@ module Articles
           .order(score: :desc).page(@page).per(@number_of_articles)
       end
 
+      def default_home_feed(user_signed_in: false)
+        _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: user_signed_in, ranking: true)
+        stories
+      end
+
       def latest_feed
         published_articles_by_tag.order(published_at: :desc)
           .where("score > ?", MINIMUM_SCORE_LATEST_FEED)
@@ -54,79 +59,15 @@ module Articles
         [featured_story, hot_stories]
       end
 
-      # Test variation: Base
-      def default_home_feed(user_signed_in: false)
-        _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: user_signed_in, ranking: true)
-        stories
-      end
-
-      # Test variation: the more comments a post has, the higher it's rated!
-      def more_comments_experiment
-        @comment_weight = 2
-        _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
-        stories
-      end
-
-      # Test variation: the more comments a post has, the higher it's rated!
-      def more_comments_medium_weight_experiment
-        @comment_weight = 0.5
-        _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
-        stories
-      end
-
-      # Test variation: the more comments a post has, the higher it's rated!
-      def more_comments_minimal_weight_experiment
+      def more_comments_minimal_weight
         @comment_weight = 0.2
         _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: true)
         stories
       end
 
-      def mix_of_everything_experiment
-        case rand(6)
-        when 0
-          default_home_feed(user_signed_in: true)
-        when 1
-          more_comments_experiment
-        when 2
-          more_tag_weight_randomized_at_end_experiment
-        when 3
-          more_comments_randomized_at_end_experiment
-        when 4
-          more_comments_medium_weight_randomized_at_end_experiment
-        when 5
-          more_comments_minimal_weight_randomized_at_end_experiment
-        else
-          default_home_feed(user_signed_in: true)
-        end
-      end
-
-      # Randomized at end group for next three experiments
-      # Rather than randomizing *during* the ranking, rank solely by quality/match
-      # and randomize the top half of the ranked results.
-      # Resulting in more relevance and still more freshness.
-
-      def more_tag_weight_randomized_at_end_experiment
+      def more_comments_minimal_weight_randomized_at_end
         @randomness = 0
-        @tag_weight = 2
-        _featured_story, results = default_home_feed_and_featured_story(user_signed_in: true)
-        first_half(results).shuffle + last_half(results)
-      end
-
-      def more_comments_randomized_at_end_experiment
-        @randomness = 0
-        results = more_comments_experiment
-        first_half(results).shuffle + last_half(results)
-      end
-
-      def more_comments_medium_weight_randomized_at_end_experiment
-        @randomness = 0
-        results = more_comments_medium_weight_experiment
-        first_half(results).shuffle + last_half(results)
-      end
-
-      def more_comments_minimal_weight_randomized_at_end_experiment
-        @randomness = 0
-        results = more_comments_minimal_weight_experiment
+        results = more_comments_minimal_weight
         first_half(results).shuffle + last_half(results)
       end
 

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -1,21 +1,9 @@
 experiments:
   user_home_feed: # Home feed collection for logged in user
     variants:
-      - base
-      - more_comments_experiment
-      - mix_of_everything_experiment
-      - more_tag_weight_randomized_at_end_experiment
-      - more_comments_randomized_at_end_experiment
-      - more_comments_medium_weight_randomized_at_end_experiment
-      - more_comments_minimal_weight_randomized_at_end_experiment
+      - more_comments_minimal_weight_randomized_at_end
     weights:
-      - 15
-      - 15
-      - 15
-      - 15
-      - 20
-      - 10
-      - 10
+      - 100
     goals:
       - user_creates_comment
       - user_creates_reaction

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -1,14 +1,5 @@
 require "rails_helper"
 
-NON_DEFAULT_EXPERIMENTS = %i[
-  more_comments_experiment
-  more_tag_weight_randomized_at_end_experiment
-  more_comments_randomized_at_end_experiment
-  more_comments_medium_weight_randomized_at_end_experiment
-  more_comments_minimal_weight_randomized_at_end_experiment
-  mix_of_everything_experiment
-].freeze
-
 RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
   let(:user) { create(:user) }
   let!(:feed) { described_class.new(user: user, number_of_articles: 100, page: 1) }
@@ -137,33 +128,12 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
     end
   end
 
-  describe "all non-default experiments" do
-    it "returns articles for all experiments" do
+  describe "more_comments_minimal_weight_randomized_at_end" do
+    it "returns articles" do
       new_story = create(:article, published_at: 10.minutes.ago, score: 10)
-      NON_DEFAULT_EXPERIMENTS.each do |method|
-        stories = feed.public_send(method)
-        expect(stories).to include(old_story)
-        expect(stories).to include(new_story)
-      end
-    end
-  end
-
-  describe "#more_comments_experiment" do
-    let(:article_with_one_comment) { create(:article) }
-    let(:article_with_five_comments) { create(:article) }
-    let(:stories) { feed.more_comments_experiment }
-
-    before do
-      create(:comment, user: user, commentable: article_with_one_comment)
-      create_list(:comment, 5, user: user, commentable: article_with_five_comments)
-      article_with_one_comment.update_score
-      article_with_five_comments.update_score
-      article_with_one_comment.reload
-      article_with_five_comments.reload
-    end
-
-    it "ranks articles with more comments higher" do
-      expect(stories[0]).to eq article_with_five_comments
+      stories = feed.more_comments_minimal_weight_randomized_at_end
+      expect(stories).to include(old_story)
+      expect(stories).to include(new_story)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description
Based [on our data](https://dev.to/abtests/) we have decided to go with the `more_comments_minimal_weight_randomized_at_end` path for the large experimental feed. By choosing a single path here we will not allow ourselves to turn other knobs and pull different levers to try and further improve our feed experience. For this reason I left the AB testing framework in place so we can get a settled baseline to compare future changes to such as #11513 
![Screen Shot 2020-11-24 at 3 15 25 PM](https://user-images.githubusercontent.com/1813380/100146489-9c100b00-2e5f-11eb-995a-2a45021721af.png)
![Screen Shot 2020-11-24 at 3 15 32 PM](https://user-images.githubusercontent.com/1813380/100146493-9d413800-2e5f-11eb-935f-f71f9f5e4071.png)

## Related Issues/Tasks
https://github.com/orgs/forem/projects/6#card-48726981

## Added tests?
- [x] No, removing code


![alt_text](https://media0.giphy.com/media/zCME2Cd20Czvy/giphy.gif)
