### PR TITLE
Don't do serviceworker asset caching in development

### DIFF
--- a/app/views/service_worker/index.js.erb
+++ b/app/views/service_worker/index.js.erb
@@ -137,22 +137,27 @@
       return;
     }
 
-    // Fetch and/or JS and CSS assets for better persistence than memory cache.
-    if (url.pathname.startsWith("/assets/") || url.pathname.startsWith("/packs/")) {
-      event.respondWith(
-        caches.open(staticCacheName).then(function (cache) {
-          return cache.match(event.request).then(function (response) {
-            return (
-              response ||
-              fetch(event.request).then(function (response) {
-                cache.put(event.request, response.clone());
-                return response;
-              })
-            );
-          });
-        })
-      );
-    }
+    <% if Rails.env.production? %>
+      // We should generally not run this in development
+      // Because the assets will not have cache-busting fingerprints.
+      // Fetch and/or JS and CSS assets for better persistence than memory cache.
+      if (url.pathname.startsWith("/assets/") || url.pathname.startsWith("/packs/")) {
+        event.respondWith(
+          caches.open(staticCacheName).then(function (cache) {
+            return cache.match(event.request).then(function (response) {
+              return (
+                response ||
+                fetch(event.request).then(function (response) {
+                  cache.put(event.request, response.clone());
+                  return response;
+                })
+              );
+            });
+          })
+        );
+      }
+    <% end %>
+
     if (url.origin === location.origin) {
       if (event.clientId === "" && // Not fetched via AJAX after page load.
         event.request.method == "GET" && // Don't fetch on POST, DELETE, etc.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We recently added caching of core assets into the serviceworker cache in addition to the general in-memory cache because we have more control over eviction, etc.

However, since locally we do not _fingerprint_ assets, we can't rely on that as a cachebusting mechanism like we can in prod. This makes that that code will not run in development. This is a `.erb` file so we can access Rails where appropriate.

This is kind of a hot fix, but we could re-evaluate for a cleaner approach in the future.

We do not need to adjust other cache eviction logic because if the cache is not accumulating, the eviction logic should be fine if the cache is empty.