### PR TITLE
Restore fieldsets in Settings/Customization

### DIFF
--- a/app/views/users/_customization.html.erb
+++ b/app/views/users/_customization.html.erb
@@ -61,7 +61,10 @@
           <%= render partial: "experience_selector", locals: { f: f, exp: exp, i: i, label: user_experience_labels } %>
         <% end %>
       </div>
-      <p>This will not be displayed on your profile or anywhere publicly. It helps gently determine what content you are shown along with tags you follow etc.</p>
+      <p>
+        This will not be displayed on your profile or anywhere publicly. It helps gently determine what content you are
+        shown along with tags you follow etc.
+      </p>
     </div>
   </div>
 
@@ -80,15 +83,17 @@
       </p>
     </header>
 
-    <div class="crayons-field crayons-field--checkbox">
-      <%= f.check_box :display_sponsors, class: "crayons-checkbox" %>
-      <%= f.label :display_sponsors, "Display Sponsors (When browsing)", class: "crayons-field__label" %>
-    </div>
+    <fieldset class="grid gap-4">
+      <div class="crayons-field crayons-field--checkbox">
+        <%= f.check_box :display_sponsors, class: "crayons-checkbox" %>
+        <%= f.label :display_sponsors, "Display Sponsors (When browsing)", class: "crayons-field__label" %>
+      </div>
 
-    <div class="crayons-field crayons-field--checkbox">
-      <%= f.check_box :permit_adjacent_sponsors, class: "crayons-checkbox" %>
-      <%= f.label :permit_adjacent_sponsors, "Permit Nearby Sponsors (When publishing)", class: "crayons-field__label" %>
-    </div>
+      <div class="crayons-field crayons-field--checkbox">
+        <%= f.check_box :permit_adjacent_sponsors, class: "crayons-checkbox" %>
+        <%= f.label :permit_adjacent_sponsors, "Permit Nearby Sponsors (When publishing)", class: "crayons-field__label" %>
+      </div>
+    </fieldset>
   </div>
 
   <div class="crayons-card crayons-card--content-rows">
@@ -102,10 +107,12 @@
       </p>
     </header>
 
-    <div class="crayons-field crayons-field--checkbox">
-      <%= f.check_box :display_announcements, class: "crayons-checkbox" %>
-      <%= f.label :display_announcements, "Display Announcements (When browsing)", class: "crayons-field__label" %>
-    </div>
+    <fieldset class="grid gap-4">
+      <div class="crayons-field crayons-field--checkbox">
+        <%= f.check_box :display_announcements, class: "crayons-checkbox" %>
+        <%= f.label :display_announcements, "Display Announcements (When browsing)", class: "crayons-field__label" %>
+      </div>
+    </fieldset>
   </div>
 
   <div class="save-footer crayons-card crayons-card--content-rows">

--- a/app/views/users/_language_settings.html.erb
+++ b/app/views/users/_language_settings.html.erb
@@ -15,12 +15,14 @@
     </p>
   </header>
 
-  <% Languages::LIST.each do |code, name| %>
-    <label class="crayons-field crayons-field--checkbox">
-      <%= check_box_tag "user[preferred_languages][]",
-                        code, @user.preferred_languages_array&.include?(code),
-                        class: "crayons-checkbox" %>
-      <div class="crayons-field__label"><%= name %></div>
-    </label>
-  <% end %>
+  <fieldset class="grid gap-4">
+    <% Languages::LIST.each do |code, name| %>
+      <label class="crayons-field crayons-field--checkbox">
+        <%= check_box_tag "user[preferred_languages][]",
+                          code, @user.preferred_languages_array&.include?(code),
+                          class: "crayons-checkbox" %>
+        <div class="crayons-field__label"><%= name %></div>
+      </label>
+    <% end %>
+  </fieldset>
 </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the hotfix https://github.com/forem/forem/pull/11615 we left out the `grid gap-4` containers while removing nested forms. This puts them back as `<fieldset>`. 

Thanks to @nickytonline for the help: https://github.com/forem/forem/pull/11615/files#r530371789

## Related Tickets & Documents

#11615 

## Added tests?

- [ ] Yes
- [x]  No, and this is why: visual aids, leftovers
- [ ] I need help with writing tests
