### PR TITLE
Add contact email to SiteConfig and replace default where appropriate

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -55,7 +55,7 @@ module Admin
       user = User.find(params[:id])
       send_to_admin = params[:send_to_admin].to_boolean
       if send_to_admin
-        email = SiteConfig.email_addresses[:default]
+        email = SiteConfig.email_addresses[:contact]
         receiver = "admin"
       else
         email = user.email

--- a/app/controllers/api_secrets_controller.rb
+++ b/app/controllers/api_secrets_controller.rb
@@ -23,7 +23,7 @@ class ApiSecretsController < ApplicationController
     if @secret.destroy
       flash[:notice] = "Your API Key has been revoked."
     else
-      flash[:error] = "An error occurred. Please try again or send an email to: #{SiteConfig.email_addresses[:default]}"
+      flash[:error] = "An error occurred. Please try again or send an email to: #{SiteConfig.email_addresses[:contact]}"
     end
 
     redirect_back(fallback_location: root_path)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -57,7 +57,7 @@ class OrganizationsController < ApplicationController
       redirect_to user_settings_path(:organization)
     else
       flash[:settings_notice] = "#{organization.errors.full_messages.to_sentence}.
-        Please email #{SiteConfig.email_addresses['default']} for assistance."
+        Please email #{SiteConfig.email_addresses[:contact]} for assistance."
       redirect_to user_settings_path(:organization, id: organization.id)
     end
   rescue Pundit::NotAuthorizedError
@@ -71,7 +71,7 @@ class OrganizationsController < ApplicationController
     @organization.secret = @organization.generated_random_secret
     @organization.save
     flash[:settings_notice] = "Your org secret was updated"
-    redirect_to "/settings/organization"
+    redirect_to user_settings_path(:organization)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -113,7 +113,7 @@ class UsersController < ApplicationController
   def remove_identity
     set_current_tab("account")
 
-    error_message = "An error occurred. Please try again or send an email to: #{SiteConfig.email_addresses[:default]}"
+    error_message = "An error occurred. Please try again or send an email to: #{SiteConfig.email_addresses[:contact]}"
     unless Authentication::Providers.enabled?(params[:provider])
       flash[:error] = error_message
       redirect_to user_settings_path(@tab)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -202,10 +202,10 @@ module ApplicationHelper
     link_to body, collection.path, **kwargs
   end
 
-  def email_link(type = :default, text: nil, additional_info: nil)
-    # The allowed types for type is :default, :business, :privacy, and members.
-    # These options can be found in field :email_addresses of models/site_config.rb
-    email = SiteConfig.email_addresses[type] || SiteConfig.email_addresses[:default]
+  def email_link(type = :contact, text: nil, additional_info: nil)
+    # The allowed types for type are the keys of `SiteConfig.email_addresses`
+    # :default, :contact, :business, :privacy, :members
+    email = SiteConfig.email_addresses[type] || SiteConfig.email_addresses[:contact]
     mail_to email, text || email, additional_info
   end
 

--- a/app/labor/error_message_cleaner.rb
+++ b/app/labor/error_message_cleaner.rb
@@ -8,7 +8,7 @@ class ErrorMessageCleaner
   def clean
     if error_message.include?("expected key while parsing a block mapping at line")
       "There was a problem parsing the front-matter YAML. Perhaps you need to escape a quote " \
-      "or a colon or something. Email #{SiteConfig.email_addresses[:default]} if you are having trouble."
+      "or a colon or something. Email #{SiteConfig.email_addresses[:contact]} if you are having trouble."
     else
       error_message
     end

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -66,6 +66,7 @@ class SiteConfig < RailsSettings::Base
   # Emails
   field :email_addresses, type: :hash, default: {
     default: ApplicationConfig["DEFAULT_EMAIL"],
+    contact: ApplicationConfig["DEFAULT_EMAIL"],
     business: ApplicationConfig["DEFAULT_EMAIL"],
     privacy: ApplicationConfig["DEFAULT_EMAIL"],
     members: ApplicationConfig["DEFAULT_EMAIL"]

--- a/app/views/admin/users/_data_export.html.erb
+++ b/app/views/admin/users/_data_export.html.erb
@@ -11,7 +11,9 @@
       You have the option of exporting to your admin account to send to the user, or exporting to the user directly.
     </p>
     <p>
-      Exporting the data to your admin account will send it to your default admin email (<%= SiteConfig.email_addresses[:default] %>), and exporting to the user will send it to their email (<%= @user.email %>).
+      Exporting the data to your admin account will send it to your contact
+      admin email (<%= SiteConfig.email_addresses[:contact] %>),
+      and exporting to the user will send it to their email (<%= @user.email %>).
     </p>
     <div style="display: flex;">
       <%= button_to "Export to Admin", export_data_admin_user_path(@user.id), data: { confirm: "Are you sure you want to export this user's content to the ADMIN?" }, class: "crayons-btn", params: { send_to_admin: true }, style: "margin-right: 8px;" %>

--- a/app/views/mailers/notify_mailer/account_deleted_email.text.erb
+++ b/app/views/mailers/notify_mailer/account_deleted_email.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @name %>, your account has been successfully deleted.
 
-Contact us at <%= SiteConfig.email_addresses[:default] %> if there is anything more we can help with.
+Contact us at <%= SiteConfig.email_addresses[:contact] %> if there is anything more we can help with.
 
 Thanks,
 The <%= community_name %> Team

--- a/app/views/mailers/notify_mailer/tag_moderator_confirmation_email.html.erb
+++ b/app/views/mailers/notify_mailer/tag_moderator_confirmation_email.html.erb
@@ -44,7 +44,7 @@
 
 <p>
   Tag moderation is something we're continuously iterating on, so you can expect adjustments and expanding features over time as we receive feedback. We regularly send out a biweekly Mod Newsletter to keep mods up to date on these changes, so look out for it!
-  Of course, don't hesitate to reach out to us at any moment if you have any feedback — feel free to write to <%= SiteConfig.email_addresses[:default] %> and share your thoughts.
+  Of course, don't hesitate to reach out to us at any moment if you have any feedback — feel free to write to <%= email_link %> and share your thoughts.
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/tag_moderator_confirmation_email.text.erb
+++ b/app/views/mailers/notify_mailer/tag_moderator_confirmation_email.text.erb
@@ -20,7 +20,7 @@ When in doubt about how to exercise your new privileges, please ask! If these Co
 
 Tag moderation is something we're continuously iterating on, so you can expect adjustments and expanding features over time as we receive feedback.
 We regularly send out a biweekly Mod Newsletter to keep mods up to date on these changes, so look out for it!
-Of course, don't hesitate to reach out to us at any moment if you have any feedback — feel free to write to <%= SiteConfig.email_addresses[:default] %> and share your thoughts.
+Of course, don't hesitate to reach out to us at any moment if you have any feedback — feel free to write to <%= SiteConfig.email_addresses[:contact] %> and share your thoughts.
 
 Thanks so much for volunteering your time to benefit the <%= community_qualified_name %>. We sincerely appreciate your help!
 

--- a/app/views/mailers/notify_mailer/trusted_role_email.html.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.html.erb
@@ -22,7 +22,7 @@
   You may occasionally receive notifications about optional moderation actions; please <a href="<%= app_url(user_settings_path(:notifications)) %>">unsubscribe</a> if you do not want to receive these updates.
 </p>
 <p>
-  If you have any questions or feedback for us, please write to <%= SiteConfig.email_addresses[:default] %> and share your thoughts.
+  If you have any questions or feedback for us, please write to <%= email_link %> and share your thoughts.
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/trusted_role_email.text.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.text.erb
@@ -14,7 +14,7 @@ You may occasionally receive notifications about optional moderation actions; pl
 
 For details on all available features and how to access them, visit our <%= community_name %> Trusted User Guide: <%= app_url("/community-moderation") %>
 
-If you have any questions or feedback for us, please write to <%= SiteConfig.email_addresses[:default] %> and share your thoughts.
+If you have any questions or feedback for us, please write to <%= SiteConfig.email_addresses[:contact] %> and share your thoughts.
 
 Thanks for being such an awesome member of the community!
 

--- a/app/views/moderations/_mod_sidebar_left.html.erb
+++ b/app/views/moderations/_mod_sidebar_left.html.erb
@@ -71,7 +71,7 @@
       Have feedback to improve your Mod experience?
     </span>
     <span>
-      Please email <%= SiteConfig.email_addresses[:default] %>!
+      Please email <%= SiteConfig.email_addresses[:contact] %>!
     </span>
   </div>
 </aside>

--- a/app/views/open_search/show.xml.erb
+++ b/app/views/open_search/show.xml.erb
@@ -3,7 +3,6 @@
  <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
    <ShortName><%= helper.community_name %> Search</ShortName>
    <Description>Find posts from the <%= helper.community_qualified_name %>.</Description>
-   <Contact><%= SiteConfig.email_addresses[:default] %></Contact>
-   <Url type="text/html" 
-     template="<%= URL.url("search") %>?q={searchTerms}"/>
+   <Contact><%= SiteConfig.email_addresses[:contact] %></Contact>
+   <Url type="text/html" template="<%= URL.url("search") %>?q={searchTerms}" />
  </OpenSearchDescription>

--- a/app/views/users/_org_admin.html.erb
+++ b/app/views/users/_org_admin.html.erb
@@ -231,7 +231,7 @@
       <% end %>
       <p>
         Questions? Email us at
-        <a href="<%= SiteConfig.email_addresses[:default] %>"><%= SiteConfig.email_addresses[:default] %></a>
+        <a href="<%= SiteConfig.email_addresses[:contact] %>"><%= SiteConfig.email_addresses[:contact] %></a>
         for help.
       </p>
     </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -148,10 +148,13 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#email_link" do
+    let(:contact_email) { "contact@dev.to" }
+
     before do
       allow(SiteConfig).to receive(:email_addresses).and_return(
         {
           default: "hi@dev.to",
+          contact: contact_email,
           business: "business@dev.to",
           privacy: "privacy@dev.to",
           members: "members@dev.to"
@@ -164,17 +167,17 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
 
     it "sets the correct href" do
-      expect(helper.email_link).to have_link(href: "mailto:hi@dev.to")
+      expect(helper.email_link).to have_link(href: "mailto:#{contact_email}")
       expect(helper.email_link(:business)).to have_link(href: "mailto:business@dev.to")
     end
 
     it "has the correct text in the a tag" do
       expect(helper.email_link(text: "Link Name")).to have_text("Link Name")
-      expect(helper.email_link).to have_text("hi@dev.to")
+      expect(helper.email_link).to have_text(contact_email)
     end
 
     it "returns the default email if it doesn't understand the type parameter" do
-      expect(helper.email_link(:nonsense)).to have_link(href: "mailto:hi@dev.to")
+      expect(helper.email_link(:nonsense)).to have_link(href: "mailto:#{contact_email}")
     end
 
     it "returns an href with additional_info parameters" do
@@ -183,7 +186,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         body: "This is a longer body with a question mark ? \n and a newline"
       }
 
-      link = "<a href=\"mailto:hi@dev.to?body=This%20is%20a%20longer%20body%20with%20a%20" \
+      link = "<a href=\"mailto:#{contact_email}?body=This%20is%20a%20longer%20body%20with%20a%20" \
         "question%20mark%20%3F%20%0A%20and%20a%20newline&amp;subject=This%20is%20a%20long%20subject\">text</a>"
       expect(email_link(text: "text", additional_info: additional_info)).to eq(link)
     end

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -229,6 +229,7 @@ RSpec.describe "/admin/config", type: :request do
             confirmation: confirmation_message
           }
 
+          expect(SiteConfig.email_addresses[:contact]).to eq("contact@example.com")
           expect(SiteConfig.email_addresses[:business]).to eq("partners@example.com")
           expect(SiteConfig.email_addresses[:privacy]).to eq("privacy@example.com")
           expect(SiteConfig.email_addresses[:members]).to eq("members@example.com")

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -218,16 +218,29 @@ RSpec.describe "/admin/config", type: :request do
       describe "Emails" do
         it "updates email_addresses" do
           expected_email_addresses = {
+            contact: "contact@example.com",
             business: "partners@example.com",
             privacy: "privacy@example.com",
             members: "members@example.com"
           }
-          post "/admin/config", params: { site_config: { email_addresses: expected_email_addresses },
-                                          confirmation: confirmation_message }
-          expect(SiteConfig.email_addresses[:privacy]).to eq("privacy@example.com")
+
+          post admin_config_path, params: {
+            site_config: { email_addresses: expected_email_addresses },
+            confirmation: confirmation_message
+          }
+
           expect(SiteConfig.email_addresses[:business]).to eq("partners@example.com")
+          expect(SiteConfig.email_addresses[:privacy]).to eq("privacy@example.com")
           expect(SiteConfig.email_addresses[:members]).to eq("members@example.com")
-          expect(SiteConfig.email_addresses[:default]).to eq(ApplicationConfig["DEFAULT_EMAIL"])
+        end
+
+        it "does not update the default email address" do
+          post admin_config_path, params: {
+            site_config: { email_addresses: { default: "random@example.com" } },
+            confirmation: confirmation_message
+          }
+
+          expect(SiteConfig.email_addresses[:default]).not_to eq("random@example.com")
         end
       end
 

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -411,7 +411,7 @@ RSpec.describe "UserSettings", type: :request do
         delete "/users/remove_identity", params: { provider: provider }
         expect(response).to redirect_to("/settings/account")
 
-        error = "An error occurred. Please try again or send an email to: #{SiteConfig.email_addresses[:default]}"
+        error = "An error occurred. Please try again or send an email to: #{SiteConfig.email_addresses[:contact]}"
         expect(flash[:error]).to eq(error)
       end
 
@@ -433,21 +433,21 @@ RSpec.describe "UserSettings", type: :request do
       end
 
       it "sets the proper flash error message" do
-        delete "/users/remove_identity", params: { provider: provider }
+        delete users_remove_identity_path, params: { provider: provider }
 
-        error = "An error occurred. Please try again or send an email to: #{SiteConfig.email_addresses[:default]}"
+        error = "An error occurred. Please try again or send an email to: #{SiteConfig.email_addresses[:contact]}"
         expect(flash[:error]).to eq(error)
       end
 
       it "does not delete any identities" do
         expect do
-          delete "/users/remove_identity", params: { provider: provider }
+          delete users_remove_identity_path, params: { provider: provider }
         end.not_to change(user.identities, :count)
       end
 
-      it "redirects successfully to /settings/account" do
-        delete "/users/remove_identity", params: { provider: provider }
-        expect(response).to redirect_to("/settings/account")
+      it "redirects successfully to the Settings-Account page" do
+        delete users_remove_identity_path, params: { provider: provider }
+        expect(response).to redirect_to(user_settings_path(:account))
       end
     end
   end

--- a/spec/services/exporter/service_spec.rb
+++ b/spec/services/exporter/service_spec.rb
@@ -92,9 +92,9 @@ RSpec.describe Exporter::Service, type: :service do
     end
 
     context "when emailing an admin" do
-      it "delivers one email to the default admin email" do
+      it "delivers one email to the contact admin email" do
         admin_email = "admin@example.com"
-        allow(SiteConfig).to receive(:email_addresses).and_return({ default: admin_email })
+        allow(SiteConfig).to receive(:email_addresses).and_return({ contact: admin_email })
         service = valid_instance(article.user)
         service.export(admin_email)
         expect(ActionMailer::Base.deliveries.last.to.first).to eq admin_email


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We're adding a new `:contact` email to replace the transactional `noreply` default email across all Forems. 

## Related Tickets & Documents

Closes https://github.com/forem/InternalProjectPlanning/issues/198

## QA Instructions, Screenshots, Recordings

1. Go to http://localhost:3000/admin/config
1. Change the contact email
1. Click around and see it changed

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

We might need to notify Forem admins to change this ASAP from the default.
