### PR TITLE
fix(api): add tags to the parameter wrapper in article api endpoints

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -11,6 +11,11 @@ module Api
 
       skip_before_action :verify_authenticity_token, only: %i[create update]
 
+      wrap_parameters :article, include: %i[
+        title body_markdown published series main_image
+        canonical_url description tags
+      ]
+
       INDEX_ATTRIBUTES_FOR_SERIALIZATION = %i[
         id user_id organization_id collection_id
         title description main_image published_at crossposted_at social_image

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1271,7 +1271,7 @@ ActiveRecord::Schema.define(version: 2020_11_14_151157) do
     t.datetime "last_article_at", default: "2017-01-01 05:00:00"
     t.datetime "last_comment_at", default: "2017-01-01 05:00:00"
     t.datetime "last_followed_at"
-    t.datetime "last_moderation_notification", default: "2017-01-01 05:00:00"
+    t.datetime "last_moderation_notification", default: "2016-12-31 18:30:00"
     t.datetime "last_notification_activity"
     t.string "last_onboarding_page"
     t.datetime "last_reacted_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1271,7 +1271,7 @@ ActiveRecord::Schema.define(version: 2020_11_14_151157) do
     t.datetime "last_article_at", default: "2017-01-01 05:00:00"
     t.datetime "last_comment_at", default: "2017-01-01 05:00:00"
     t.datetime "last_followed_at"
-    t.datetime "last_moderation_notification", default: "2016-12-31 18:30:00"
+    t.datetime "last_moderation_notification", default: "2017-01-01 05:00:00"
     t.datetime "last_notification_activity"
     t.string "last_onboarding_page"
     t.datetime "last_reacted_at"

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -692,6 +692,17 @@ RSpec.describe "Api::V0::Articles", type: :request do
         expect(Article.find(response.parsed_body["id"]).cached_tag_list).to eq(tags.join(", "))
       end
 
+      it "creates an article with a title, body and a list of tags when request is made without article property" do
+        tags = %w[meta discussion]
+        expect do
+          headers = { "api-key" => api_secret.secret, "content-type" => "application/json" }
+          params = { "title" => Faker::Book.title, "body_markdown" => "Yo ho ho", "tags" => tags }
+          post api_articles_path, params: params.to_json, headers: headers
+          expect(response).to have_http_status(:created)
+        end.to change(Article, :count).by(1)
+        expect(Article.find(response.parsed_body["id"]).cached_tag_list).to eq(tags.join(", "))
+      end
+
       it "creates an unpublished article with the front matter in the body" do
         body_markdown = file_fixture("article_unpublished.txt").read
         expect do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
### The issue
When I try to create an article using the `/articles` endpoint with the following payload.
```
{
        "title": "A test post again",
        "description": "Testing article creation bug again",
        "body_markdown": "## Some content",
        "tags": ["javascript"]
}
```

The article gets created but there are no tags in it.

However when I access the same endpoint using the following payload. 
```
{
  article: {
        "title": "A test post again",
        "description": "Testing article creation bug again",
        "body_markdown": "## Some content",
        "tags": ["javascript"]
  }
}
```

There is no such issue.

### The cause
Btw, according to documentation, there should be an `article` property in which all the article properties are present. But not adding the `article` property doesn't result in an error in the response but there is a little bug as mentioned above. 

This is because of the parameter wrapper by rails defined here.
https://github.com/forem/forem/blob/65110550d8c2231f73ff99ae305a46b7b0bcb4f9/config/initializers/wrap_parameters.rb#L7-L9

When a request is received to the articles endpoint without the `article` property it automatically creates one and the final `params` variable has the following value.
```
{"title"=>"A test post again", "description"=>"Testing article creation bug again", "body_markdown"=>"## Some content", "tags"=>["javascript"], "locale"=>nil, "article"=>{"title"=>"A test post again", "body_markdown"=>"## Some content", "description"=>"Testing article creation bug again"}}
```

It can be seen that it wrapped everything except the `tags` probably because it's an array.

### The solution implemented
So, I manually defined the parameters that should be wrapped in the `ArticlesController`.

### Alternative solution
If not this, we can disable the wrap_parameters globally (or maybe in this controller only) too, so that there's an error when the user doesn't wrap the article body in `article` property in the post/put request.

## Related Tickets & Documents
Fixes #11516 

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how accessibility is impacted and tested. For more info, check out the [Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/YODE9YaCC6dws/giphy.gif)
