### PR TITLE
Add blocking option to Report Abuse form

### DIFF
--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -1,4 +1,8 @@
 class FeedbackMessagesController < ApplicationController
+  ALLOWED_PARAMS = %i[
+    message feedback_type category reported_url block_reported_user
+  ].freeze
+
   # No authorization required for entirely public controller
   skip_before_action :verify_authenticity_token
 
@@ -40,7 +44,6 @@ class FeedbackMessagesController < ApplicationController
   end
 
   def feedback_message_params
-    allowed_params = %i[message feedback_type category reported_url]
-    params.require(:feedback_message).permit(allowed_params)
+    params.require(:feedback_message).permit(ALLOWED_PARAMS)
   end
 end

--- a/app/models/feedback_message.rb
+++ b/app/models/feedback_message.rb
@@ -1,6 +1,8 @@
 class FeedbackMessage < ApplicationRecord
   resourcify
 
+  attr_accessor :block_reported_user
+
   belongs_to :offender, class_name: "User", optional: true, inverse_of: :offender_feedback_messages
   belongs_to :reporter, class_name: "User", optional: true, inverse_of: :reporter_feedback_messages
   belongs_to :affected, class_name: "User", optional: true, inverse_of: :affected_feedback_messages

--- a/app/views/feedback_messages/_form.html.erb
+++ b/app/views/feedback_messages/_form.html.erb
@@ -67,6 +67,13 @@
     <%= f.text_area :message, class: "crayons-textfield", placeholder: "...", value: @previous_message, required: true %>
   </div>
 
+  <div class="crayons-field crayons-field--checkbox">
+    <%= f.check_box :block_reported_user, class: "crayons-checkbox" %>
+    <label class="crayons-field__label" for="feedback_message_block_reported_user">
+      Also block the reported user
+    </label>
+  </div>
+
 <% if SiteConfig.recaptcha_secret_key.present? && SiteConfig.recaptcha_site_key.present? %>
   <div class="recaptcha-tag-container">
     <%= recaptcha_tags site_key: SiteConfig.recaptcha_site_key %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

This PR adds an option for blocking the offending user directly to the Report Abuse form to streamline this process for the reporter.

![Screen_Shot_2020-11-27_at_09_03_31](https://user-images.githubusercontent.com/47985/100406751-49ba2e80-3099-11eb-8bb7-7d140028ccc2.png)


## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how accessibility is impacted and tested. For more info, check out the [Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [ ] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
