### PR TITLE
Move LogWorkerQueueStats from labor to services

### DIFF
--- a/app/workers/metrics/record_background_queue_stats_worker.rb
+++ b/app/workers/metrics/record_background_queue_stats_worker.rb
@@ -4,7 +4,7 @@ module Metrics
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform
-      Loggers::LogWorkerQueueStats.run
+      Loggers::LogWorkerQueueStats.call
     end
   end
 end

--- a/spec/services/loggers/log_worker_queue_stats_spec.rb
+++ b/spec/services/loggers/log_worker_queue_stats_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
-describe Loggers::LogWorkerQueueStats do
+describe Loggers::LogWorkerQueueStats, type: :service do
   it "logs totals" do
     allow(described_class).to receive(:record_totals)
-    described_class.run
+    described_class.call
     expect(described_class).to have_received(:record_totals)
   end
 
   it "logs queue stats" do
     allow(described_class).to receive(:record_queue_stats)
-    described_class.run
+    described_class.call
     expect(described_class).to have_received(:record_queue_stats)
   end
 end

--- a/spec/workers/metrics/record_background_queue_stats_worker_spec.rb
+++ b/spec/workers/metrics/record_background_queue_stats_worker_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Metrics::RecordBackgroundQueueStatsWorker, type: :worker do
 
   describe "#perform" do
     it "logs estimated counts in Datadog" do
-      allow(Loggers::LogWorkerQueueStats).to receive(:run)
+      allow(Loggers::LogWorkerQueueStats).to receive(:call)
       described_class.new.perform
 
-      expect(Loggers::LogWorkerQueueStats).to have_received(:run)
+      expect(Loggers::LogWorkerQueueStats).to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR moves `app/labor/loggers/log_worker_queue_stats.rb` to `app/services/loggers/log_worker_queue_stats.rb` and updates specs and code accordingly.

## Related Tickets & Documents

https://github.com/forem/InternalProjectPlanning/issues/271

## Added tests?

- [X] Moved existing ones

## Added to documentation?

- [X] No documentation needed
