### PR TITLE
Bug Fix:Remove nil cached_tag_lists when Collecting Tags

### DIFF
--- a/app/workers/follows/update_points_worker.rb
+++ b/app/workers/follows/update_points_worker.rb
@@ -34,7 +34,7 @@ module Follows
       tags = articles.pluck(:cached_tag_list).compact.flat_map { |list| list.split(", ") }
       occurrences = tags.count(tag.name)
       bonus = inverse_popularity_bonus(tag)
-      Math.log(occurrences + bonus + 1) # +1 is purelt to avoid log(0) => -infinity
+      Math.log(occurrences + bonus + 1) # +1 is purely to avoid log(0) => -infinity
     end
 
     def adjust_other_tag_follows_of_user(user_id)

--- a/app/workers/follows/update_points_worker.rb
+++ b/app/workers/follows/update_points_worker.rb
@@ -31,7 +31,7 @@ module Follows
       last_100_long_page_view_article_ids = user.page_views.where(time_tracked_in_seconds: 45..)
         .pluck(:article_id).last(100)
       articles = Article.where(id: last_100_reactable_ids + last_100_long_page_view_article_ids)
-      tags = articles.pluck(:cached_tag_list).flat_map { |list| list.split(", ") }
+      tags = articles.pluck(:cached_tag_list).compact.flat_map { |list| list.split(", ") }
       occurrences = tags.count(tag.name)
       bonus = inverse_popularity_bonus(tag)
       Math.log(occurrences + bonus + 1) # +1 is purelt to avoid log(0) => -infinity


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
There is a chance the `cached_tag_list` for an article is nil, in that case we want to make sure we remove it from our array when we are gathering up tags. 

Fixes: https://app.honeybadger.io/fault/66984/8942c036047ae64eb2372bbcf65e8dc6

## Added tests?
- [x] No, minor implementation change for an edge case I dont think is worth testing


![alt_text](https://media3.giphy.com/media/ncMOpLZlqHKVi/giphy.gif)
