### PR TITLE
Bugfix: Remove focus from avatars in notifications for better keyboard navigation

### DIFF
--- a/app/views/notifications/_aggregated_reactions.html.erb
+++ b/app/views/notifications/_aggregated_reactions.html.erb
@@ -4,14 +4,14 @@
 
 <div class="relative shrink-0 self-start">
   <% if actors.size == 1 %>
-    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l m:crayons-avatar--xl" tabindex="-1">
+    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l m:crayons-avatar--xl" aria-hidden="true" tabindex="-1">
       <img src="<%= actors.first["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= actors.first["username"] %>'s profile" width="48" height="48">
     </a>
   <% else %>
-    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l mr-4" tabindex="-1">
+    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l mr-4" aria-hidden="true" tabindex="-1">
       <img src="<%= actors.first["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= actors.first["username"] %>'s profile" width="48" height="48">
     </a>
-    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l absolute -right-1 -bottom-3 border-solid border-2 border-base-inverted" tabindex="-1">
+    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l absolute -right-1 -bottom-3 border-solid border-2 border-base-inverted" aria-hidden="true" tabindex="-1">
       <img src="<%= actors.last["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= actors.last["username"] %>'s profile" width="48" height="48">
     </a>
   <% end %>

--- a/app/views/notifications/_aggregated_reactions.html.erb
+++ b/app/views/notifications/_aggregated_reactions.html.erb
@@ -4,14 +4,14 @@
 
 <div class="relative shrink-0 self-start">
   <% if actors.size == 1 %>
-    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l m:crayons-avatar--xl">
+    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l m:crayons-avatar--xl" tabindex="-1">
       <img src="<%= actors.first["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= actors.first["username"] %>'s profile" width="48" height="48">
     </a>
   <% else %>
-    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l mr-4">
+    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l mr-4" tabindex="-1">
       <img src="<%= actors.first["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= actors.first["username"] %>'s profile" width="48" height="48">
     </a>
-    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l absolute -right-1 -bottom-3 border-solid border-2 border-base-inverted">
+    <a href="<%= actors.first["path"] %>" class="crayons-avatar crayons-avatar--l absolute -right-1 -bottom-3 border-solid border-2 border-base-inverted" tabindex="-1">
       <img src="<%= actors.last["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= actors.last["username"] %>'s profile" width="48" height="48">
     </a>
   <% end %>

--- a/app/views/notifications/_follow.html.erb
+++ b/app/views/notifications/_follow.html.erb
@@ -18,7 +18,7 @@
     <% json_data_array = notification["json_data"]["aggregated_siblings"] %>
     <div class="flex mb-3">
       <% notification.json_data["aggregated_siblings"][0..10].each do |sibling| %>
-        <a href="<%= sibling["path"] %>" class="crayons-avatar crayons-avatar--l shrink-0 mx-1" tabindex="-1" aria-hidden="true">
+        <a href="<%= sibling["path"] %>" class="crayons-avatar crayons-avatar--l shrink-0 mx-1" <% if sibling["id"] == json_data_array.first["id"] %> tabindex="-1" aria-hidden="true"<% end %>>
           <img src="<%= sibling["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= sibling["name"] %>'s profile" width="32" height="32">
         </a>
       <% end %>

--- a/app/views/notifications/_follow.html.erb
+++ b/app/views/notifications/_follow.html.erb
@@ -2,7 +2,7 @@
   <% if notification.json_data["aggregated_siblings"].length == 1 %>
     <% first_notification = notification.json_data["aggregated_siblings"].first %>
     <% cache "activity-profile-pic-#{first_notification['id']}-#{first_notification['profile_image_90']}" do %>
-      <a href="<%= first_notification["path"] %>" class="crayons-avatar crayons-avatar--l <% if notification.json_data["aggregated_siblings"].length == 1 %>m:crayons-avatar--xl<% end %> shrink-0">
+      <a href="<%= first_notification["path"] %>" class="crayons-avatar crayons-avatar--l <% if notification.json_data["aggregated_siblings"].length == 1 %>m:crayons-avatar--xl<% end %> shrink-0" tabindex="-1">
         <img src="<%= first_notification["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= first_notification["username"] %>'s profile" width="48" height="48">
       </a>
     <% end %>
@@ -18,7 +18,7 @@
     <% json_data_array = notification["json_data"]["aggregated_siblings"] %>
     <div class="flex mb-3">
       <% notification.json_data["aggregated_siblings"][0..10].each do |sibling| %>
-        <a href="<%= sibling["path"] %>" class="crayons-avatar crayons-avatar--l shrink-0 mx-1">
+        <a href="<%= sibling["path"] %>" class="crayons-avatar crayons-avatar--l shrink-0 mx-1" tabindex="-1">
           <img src="<%= sibling["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= sibling["name"] %>'s profile" width="32" height="32">
         </a>
       <% end %>

--- a/app/views/notifications/_follow.html.erb
+++ b/app/views/notifications/_follow.html.erb
@@ -2,7 +2,7 @@
   <% if notification.json_data["aggregated_siblings"].length == 1 %>
     <% first_notification = notification.json_data["aggregated_siblings"].first %>
     <% cache "activity-profile-pic-#{first_notification['id']}-#{first_notification['profile_image_90']}" do %>
-      <a href="<%= first_notification["path"] %>" class="crayons-avatar crayons-avatar--l <% if notification.json_data["aggregated_siblings"].length == 1 %>m:crayons-avatar--xl<% end %> shrink-0" tabindex="-1">
+      <a href="<%= first_notification["path"] %>" class="crayons-avatar crayons-avatar--l <% if notification.json_data["aggregated_siblings"].length == 1 %>m:crayons-avatar--xl<% end %> shrink-0" tabindex="-1" aria-hidden="true">
         <img src="<%= first_notification["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= first_notification["username"] %>'s profile" width="48" height="48">
       </a>
     <% end %>
@@ -18,7 +18,7 @@
     <% json_data_array = notification["json_data"]["aggregated_siblings"] %>
     <div class="flex mb-3">
       <% notification.json_data["aggregated_siblings"][0..10].each do |sibling| %>
-        <a href="<%= sibling["path"] %>" class="crayons-avatar crayons-avatar--l shrink-0 mx-1" tabindex="-1">
+        <a href="<%= sibling["path"] %>" class="crayons-avatar crayons-avatar--l shrink-0 mx-1" tabindex="-1" aria-hidden="true">
           <img src="<%= sibling["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= sibling["name"] %>'s profile" width="32" height="32">
         </a>
       <% end %>

--- a/app/views/notifications/shared/_profile_pic.html.erb
+++ b/app/views/notifications/shared/_profile_pic.html.erb
@@ -1,10 +1,10 @@
 <div class="relative self-start">
   <% if json_data["organization"] %>
-    <a class="crayons-logo crayons-logo--l m:crayons-logo--xl" href="<%= json_data["organization"]["path"] %>">
+    <a class="crayons-logo crayons-logo--l m:crayons-logo--xl" href="<%= json_data["organization"]["path"] %>" tabindex="-1">
       <img alt="<%= json_data["organization"]["name"] %> logo" class="crayons-logo__image" src="<%= json_data["organization"]["profile_image_90"] %>" width="48" height="48">
     </a>
   <% end %>
-  <a href="<%= json_data["user"]["path"] %>" class="crayons-avatar <% if json_data["organization"] %> crayons-avatar--l absolute -right-2 -bottom-2 border-solid border-2 border-base-inverted <% else %> crayons-avatar--l m:crayons-avatar--xl <% end %>">
+  <a href="<%= json_data["user"]["path"] %>" class="crayons-avatar <% if json_data["organization"] %> crayons-avatar--l absolute -right-2 -bottom-2 border-solid border-2 border-base-inverted <% else %> crayons-avatar--l m:crayons-avatar--xl <% end %>" tabindex="-1">
     <img src="<%= json_data["user"]["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= json_data["user"]["username"] %>'s profile" width="48" height="48">
   </a>
 </div>

--- a/app/views/notifications/shared/_profile_pic.html.erb
+++ b/app/views/notifications/shared/_profile_pic.html.erb
@@ -1,10 +1,10 @@
 <div class="relative self-start">
   <% if json_data["organization"] %>
-    <a class="crayons-logo crayons-logo--l m:crayons-logo--xl" href="<%= json_data["organization"]["path"] %>" tabindex="-1">
+    <a class="crayons-logo crayons-logo--l m:crayons-logo--xl" href="<%= json_data["organization"]["path"] %>" tabindex="-1" aria-hidden="true">
       <img alt="<%= json_data["organization"]["name"] %> logo" class="crayons-logo__image" src="<%= json_data["organization"]["profile_image_90"] %>" width="48" height="48">
     </a>
   <% end %>
-  <a href="<%= json_data["user"]["path"] %>" class="crayons-avatar <% if json_data["organization"] %> crayons-avatar--l absolute -right-2 -bottom-2 border-solid border-2 border-base-inverted <% else %> crayons-avatar--l m:crayons-avatar--xl <% end %>" tabindex="-1">
+  <a href="<%= json_data["user"]["path"] %>" class="crayons-avatar <% if json_data["organization"] %> crayons-avatar--l absolute -right-2 -bottom-2 border-solid border-2 border-base-inverted <% else %> crayons-avatar--l m:crayons-avatar--xl <% end %>" tabindex="-1" aria-hidden="true">
     <img src="<%= json_data["user"]["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= json_data["user"]["username"] %>'s profile" width="48" height="48">
   </a>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR removes notifications' user- and organisation avatars from tab-order and accessibility tree, as the same info can be found textually right after the avatars. 

With the case of multiple followers, I decided to go with [@nickytonline 's suggestion](https://github.com/forem/forem/issues/11403#issuecomment-735402472). This solution can be a bit confusing as sighted keyboard users can see that the first avatar on followers list doesn't get focus, and it can be unclear that the first avatar belongs to the user whose name is mentioned, but on the other hand, it saves a keystroke (which could potentially be really painful for some, so this helps them. Also, one tab less for all who use keyboard for navigation.).  Another option I was considering was to keep all of the avatars in the tab order, so there would have been one extra tab in these cases, but it would have potentially been less confusing. So if there are any ideas for that, I'm happy to refactor 😊 

## Related Tickets & Documents

Closes #11403 

## QA Instructions, Screenshots, Recordings

Testing: 
1. Open notifications and have some notifications with user avatar(s)
2. Tab trough the notifications, and notice that the avatars in the notifications are not tabbable. 
3. If testing with a screen reader, pull up the list of links on the notifications page, and see that the avatars (with alt text "*username*'s profile") are not on the list.


![Visual demonstration of the tabbing order with this PR](https://user-images.githubusercontent.com/28345294/100534642-e4417b80-3219-11eb-93a8-594f715d05fa.gif)


## Added tests?

- [ ] Yes
- [x] No, and this is why: I think I didn't touch any code, that had tests attached.
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

