### PR TITLE
Small optimization: Don't include --active variation on button for non-logged-in traffic

### DIFF
--- a/app/views/articles/_reaction_button.html.erb
+++ b/app/views/articles/_reaction_button.html.erb
@@ -7,8 +7,10 @@
   <span class="crayons-reaction__icon crayons-reaction__icon--inactive">
     <%= inline_svg_tag(image_path, aria: true, class: "crayons-icon", title: description) %>
   </span>
+  <% if user_signed_in? # We cannot trigger the action state unless the user is signed in, so no need to render. %>
   <span class="crayons-reaction__icon crayons-reaction__icon--active">
     <%= inline_svg_tag(image_active_path, aria: true, class: "crayons-icon", title: description) %>
   </span>
+  <% end %>
   <span class="crayons-reaction__count" id="reaction-number-<%= category %>" alt="count"><span class="bg-base-40 opacity-25 p-2 inline-block radius-default"></span></span>
 </button>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This is a small optimization of not shipping the "hidden" SVGs in contexts where there is no scenario that we would add the parent class that would make these visible.

It saves the bandwidth from all the characters involved in rendering the SVGs. It's not the hugest optimization, but since it applies to our most trafficked page template, every fractional kb saved in one request amounts to a lot of total bandwidth, and for SEO purposes, the less we ask Google to crawl through, the better, even if it's small things.