### PR TITLE
Redirect old settings routes to new ones

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -436,6 +436,12 @@ Rails.application.routes.draw do
       end
     end
 
+    # Redirect previous settings changed after https://github.com/forem/forem/pull/11347
+    get "/settings/integrations", to: redirect("/settings/extensions")
+    get "/settings/misc", to: redirect("/settings")
+    get "/settings/publishing-from-rss", to: redirect("/settings/extensions")
+    get "/settings/ux", to: redirect("/settings/customization")
+
     get "/settings/(:tab)" => "users#edit", :as => :user_settings
     get "/settings/:tab/:org_id" => "users#edit", :constraints => { tab: /organization/ }
     get "/settings/:tab/:id" => "users#edit", :constraints => { tab: /response-templates/ }

--- a/spec/routing/all_routes_spec.rb
+++ b/spec/routing/all_routes_spec.rb
@@ -42,5 +42,29 @@ RSpec.describe "all routes", type: :routing do
 
       expect(response).to redirect_to(SiteConfig.shop_url)
     end
+
+    it "redirects /settings/integrations to /settings/extensions" do
+      get user_settings_path(:integrations)
+
+      expect(response).to redirect_to(user_settings_path(:extensions))
+    end
+
+    it "redirects /settings/misc to /settings" do
+      get user_settings_path(:misc)
+
+      expect(response).to redirect_to(user_settings_path)
+    end
+
+    it "redirects /settings/publishing-from-rss to /settings/extensions" do
+      get user_settings_path("publishing-from-rss")
+
+      expect(response).to redirect_to(user_settings_path(:extensions))
+    end
+
+    it "redirects /settings/ux to /settings/customization" do
+      get user_settings_path(:ux)
+
+      expect(response).to redirect_to(user_settings_path(:customization))
+    end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Some of the old settings paths have hardcoded links in articles and in general it's a good idea to redirect old to new.

## Related Tickets & Documents

https://github.com/forem/forem/pull/11347

## QA Instructions, Screenshots, Recordings

1. load the app
1. go to the old path and see you're redirected to the new one

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
