### PR TITLE
Improve error message of User Subscriptions

### DIFF
--- a/app/models/user_subscription.rb
+++ b/app/models/user_subscription.rb
@@ -90,6 +90,6 @@ class UserSubscription < ApplicationRecord
 
     return if source_active
 
-    errors.add(:base, "Source not found.")
+    errors.add(:base, "Source not found. Please make sure your #{user_subscription_sourceable_type} is active!")
   end
 end

--- a/spec/models/user_subscription_spec.rb
+++ b/spec/models/user_subscription_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe UserSubscription, type: :model do
                                                                                    published: false)
       user_subscription = described_class.build(source: unpublished_source, subscriber: subscriber)
       expect(user_subscription).not_to be_valid
-      expect(user_subscription.errors[:base]).to include "Source not found."
+      expect(user_subscription.errors[:base]).to include "Source not found. Please make sure your Article is active!"
     end
 
     it "validates the tag is enabled in the source" do

--- a/spec/requests/user_subscriptions_spec.rb
+++ b/spec/requests/user_subscriptions_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "UserSubscriptions", type: :request do
       end.to change(UserSubscription, :count).by(0)
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.parsed_body["error"]).to include("Source not found.")
+      expect(response.parsed_body["error"]).to include("Source not found. Please make sure your Article is active!")
     end
 
     it "returns an error for a source that doesn't have the UserSubscription liquid tag enabled" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Currently, you can only use the user subscription feature on an "active" source, aka a published article or a comment that hasn't been deleted. If you try to test out this feature on a source that _isn't_ active, then you'll get an error message about "the Source not being found":
![image](https://user-images.githubusercontent.com/6921610/100685541-6ec8ce80-3331-11eb-9d39-2cc6cb628f6e.png)

While a user _might_ be able to guess what this means, we could be a little more clear in this message I think! I've updated the message to be a bit more specific :) 

## Related Tickets & Documents

Inspired by [this Slack thread](https://dev-internal.slack.com/archives/C7GE84DEJ/p1606784386377500).

## QA Instructions, Screenshots, Recordings

To QA this feature, pull down this branch locally, and make sure the user you are logged in as has the `:restricted_liquid_tag` role. Once you have the role, create a new article that includes the user subscription liquid tag in the markdown (see the [relevant docs here](https://app.gitbook.com/@forem/s/team-handbook/tech/user-subscription-liquid-tag)):

```
{% user_subscription I love llamas, click here to subscribe to top-notch llama content!! %}
```

You should see an error message that reads: `Source not found. Please make sure your Article is active!`

### UI accessibility concerns?

Since this just changes the content of an error message, it should be a copy change only and not affect accessibility at all :) 

## Added tests?

- [x] ~Yes~ Updated pre-existing tests! 😉 
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## Are there any post deployment tasks we need to perform?

Nope!