### PR TITLE
Fix invalid feed error display in settings

### DIFF
--- a/app/views/users/_publishing_from_rss.html.erb
+++ b/app/views/users/_publishing_from_rss.html.erb
@@ -51,7 +51,7 @@
     </div>
 
     <%= f.hidden_field :tab, value: @tab %>
-    <% button_text = @user.feed_url.present? ? "Save" : "Submit" %>
+    <% button_text = @user.feed_url.present? ? "Save Feed Settings" : "Submit Feed Settings" %>
     <div><button class="crayons-btn" type="submit"><%= button_text %></button></div>
   <% end %>
 

--- a/app/views/users/_response_templates.html.erb
+++ b/app/views/users/_response_templates.html.erb
@@ -33,7 +33,7 @@
 
   <%= form_with model: @response_template do |f| %>
     <section class="flex flex-col gap-3">
-      <% if @response_template.persisted? %>
+      <% if @response_template&.persisted? %>
         <% title = params[:previous_title] || @response_template.title %>
         <% content = params[:previous_content] || @response_template.content %>
         <h3 class="crayons-subtitle-3">

--- a/spec/system/user/user_edits_extensions_spec.rb
+++ b/spec/system/user/user_edits_extensions_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe "User edits their extensions", type: :system, js: true do
       .to_return(status: 200, body: github_response_body.to_json, headers: { "Content-Type" => "application/json" })
   end
 
-  describe "via visiting /settings" do
+  describe "Stackbit" do
     before do
-      visit "/settings"
+      visit user_settings_path
     end
 
     it "has connect-to-stackbit prompt" do
@@ -35,6 +35,22 @@ RSpec.describe "User edits their extensions", type: :system, js: true do
 
       click_link "Extensions"
       expect(page).to have_text("Connected to Stackbit")
+    end
+  end
+
+  describe "Feed" do
+    before do
+      visit user_settings_path(:extensions)
+    end
+
+    it "fails if the feed URL is invalid" do
+      stub_request(:get, "https://medium.com/feed/alkdmksadksa")
+        .to_return(status: 200, body: "not an xml feed")
+
+      fill_in "user[feed_url]", with: "https://medium.com/feed/alkdmksadksa"
+      click_on "Submit Feed Settings"
+
+      expect(page).to have_text("Feed url is not a valid RSS/Atom feed")
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When an invalid feed is submitted in the "Extensions" page, one of the various templates rendered there breaks with a 500 error, ths is the fix for that.

## QA Instructions, Screenshots, Recordings

1. go to dev.to/settings/extensions and add a URL that's not a feed
1. press save/submit
1. witness the finality of the error
1. do the same with this branch and see the actual error message

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
