### PR TITLE
Ensure first user of a Forem has a trusted role

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -45,6 +45,7 @@ class RegistrationsController < Devise::RegistrationsController
 
     resource.add_role(:super_admin)
     resource.add_role(:single_resource_admin, Config)
+    resource.add_role(:trusted)
     SiteConfig.waiting_on_first_user = false
     Users::CreateMascotAccount.call
   end

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -333,6 +333,7 @@ RSpec.describe "Registrations", type: :request do
                     password_confirmation: "PaSSw0rd_yo000" } }
         expect(User.first.has_role?(:super_admin)).to be true
         expect(User.first.has_role?(:single_resource_admin, Config)).to be true
+        expect(User.first.has_role?(:trusted)).to be true
       end
 
       it "creates mascot user" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The first user (the Forem creator) has a `super_admin` role and a `single_resource_admin` role for the `Config`, but they aren't `trusted` by default. This means an extra step they have to go through in order to moderate the first content that is submitted to their Forem instance. We should grant them the `trusted` role by default.

Ultimately, I think we probably need to do something more far-reaching in order to give _every_ superadmin the benefits of being a trusted user (as described in https://github.com/forem/forem/issues/11569), but I didn't want to go through the whole codebase adding a bunch of conditionals without thinking through other alternatives first. In the meantime, adding trusted as a role for all new Forem creators will be helpful for bizdev + @pkfrank.

## Related Tickets & Documents
Addresses part of https://github.com/forem/forem/issues/11569.

## QA Instructions, Screenshots, Recordings

1. Reset your database and seed using the "STARTER" mode (`MODE=STARTER rails db:reset`).
2. Sign up as the first user of the Forem.
3. In the rails console, check that the user you just signed up as has the `trusted` role (in addition to `single_resource_admin` and `super_admin`).

### UI accessibility concerns?

Nope, this is a backend change.

## Added tests?

- [x] ~Yes~ Updated preexisting tests :) 
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

_Note: we'll want to update the Admin Guide once we've actually closed out this ticket and figured out the second half of what needs to be done here!_

## Are there any post deployment tasks we need to perform?
Nope!
