### PR TITLE
Removed ambiguity when multiple profile fields and groups exist in test

### DIFF
--- a/spec/system/admin/admin_manages_profile_fields_spec.rb
+++ b/spec/system/admin/admin_manages_profile_fields_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe "Admin manages profile fields", type: :system do
   end
 
   it "adds a profile field" do
-    click_on "Add Field"
+    all(:button, "Add Field").last.click
     first("input#profile_field_label", visible: true).set("Example field")
     click_on "Create Profile field"
     expect(page).to have_text("Profile field Example field created")
   end
 
   it "deletes a profile_field_group" do
-    click_button "Delete Group"
+    all(:button, "Delete Group").last.click
     expect(page).to have_text("Group #{profile_field_group.name} deleted")
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<details><summary>Flaky spec log</summary>
<p>

```ruby
Failures:
1551
1552
  1) Admin manages profile fields adds a profile field
1553
     Failure/Error: click_on "Add Field"
1554
1555
     Capybara::Ambiguous:
1556
       Ambiguous match, found 4 elements matching visible link or button "Add Field"
1557
1558
1559
1560
     # ./spec/system/admin/admin_manages_profile_fields_spec.rb:26:in `block (2 levels) in <top (required)>'
1561
     # ./spec/rails_helper.rb:135:in `block (3 levels) in <top (required)>'
1562
     # ./spec/rails_helper.rb:135:in `block (2 levels) in <top (required)>'
1563
1564
  2) Admin manages profile fields deletes a profile_field_group
1565
     Failure/Error: click_button "Delete Group"
1566
1567
     Capybara::Ambiguous:
1568
       Ambiguous match, found 4 elements matching visible button "Delete Group" that is not disabled
1569
1570
1571
1572
     # ./spec/system/admin/admin_manages_profile_fields_spec.rb:33:in `block (2 levels) in <top (required)>'
1573
     # ./spec/rails_helper.rb:135:in `block (3 levels) in <top (required)>'
1574
     # ./spec/rails_helper.rb:135:in `block (2 levels) in <top (required)>'
1575
1576
Finished in 8 minutes 32 seconds
1529
2309 examples, 2 failures, 2 pending
```

</p>
</details>

## Added tests?

- [ ] Yes
- [x] No, and this is why: It's a fix of an existing spec
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![i will try to fix you](https://media.giphy.com/media/LMi1bb2S0UXFbZs3Uq/giphy.gif)
