### PR TITLE
Bug Fix: First Published Post Not Showing Properly in the Feed

### DIFF
--- a/app/javascript/articles/Feed.jsx
+++ b/app/javascript/articles/Feed.jsx
@@ -33,7 +33,8 @@ export const Feed = ({ timeFrame, renderFeed }) => {
 
         // Remove that first one from the array.
         const index = feedItems.indexOf(featuredStory);
-        feedItems.splice(index, 1);
+        const deleteCount = featuredStory ? 1 : 0;
+        feedItems.splice(index, deleteCount);
         const subStories = feedItems;
         const organizedFeedItems = [featuredStory, subStories].flat();
 

--- a/app/javascript/articles/Feed.jsx
+++ b/app/javascript/articles/Feed.jsx
@@ -27,11 +27,15 @@ export const Feed = ({ timeFrame, renderFeed }) => {
         const feedItems = await getFeedItems(timeFrame);
 
         // Ensure first article is one with a main_image
+        // This is important because the featuredStory will
+        // appear at the top of the feed, with a larger
+        // main_image than any of the stories or feed elements.
         const featuredStory = feedItems.find(
           (story) => story.main_image !== null,
         );
 
-        // Remove that first one from the array.
+        // Remove that first story from the array to
+        // prevent it from rendering twice in the feed.
         const index = feedItems.indexOf(featuredStory);
         const deleteCount = featuredStory ? 1 : 0;
         feedItems.splice(index, deleteCount);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR resolves a bug that occurs when the first published post on a Forem does _not_ contain a `main_image`, resulting in the post not being "featured." Prior to these changes, if the first, published post on a Forem did not have a cover image, resulting in the post not being considered "featured," the post would not display in the feed until it was updated to contain a `main_image`, was set as `featured: true`, or another post was published _in addition to_ the first published post.

To resolve the bug, a ternary operator was added to `app/javascript/articles/Feed.jsx` to determine where the splicing of the  `feedItems` array (which separates out `featuredStories` from `subStories`) should occur. This proved necessary because when the first published post _does not_ have a `main_image`, it results in an empty array. This then results in a `splice` that removes the _last_ element in the array, ultimately causing no posts to show in the feed because we've removed the posts from the `feedItems` array. 

An alternative approach to resolving this bug would be to add a conditional to lines `29`-`31` in `Feed.jsx` that provides a fallback for when the first published post does _not_ contain a cover image. If my reviewers feel that that approach is more appropriate, I am happy to explore that option!

## Related Tickets & Documents
Closes https://github.com/forem/InternalProjectPlanning/issues/155

## QA Instructions, Screenshots, Recordings
**To QA this PR, please do the following**:
- Navigate to `localhost` on your `main` branch and delete all of the posts that you currently have in a rails console:
```
Article.destroy_all
```
- Now that you've deleted all of your posts, create a _new_ post without a `main_image` and publish it:
![Screen Shot 2020-12-02 at 12 52 26 PM](https://user-images.githubusercontent.com/32834804/100923975-3d6d1180-349d-11eb-9762-17c5aeceb45b.png)
![Screen Shot 2020-12-02 at 12 52 47 PM](https://user-images.githubusercontent.com/32834804/100924091-64c3de80-349d-11eb-9840-c5fad06fd69d.png)

- Observe that the post does _not_ show in the feed:
![Screen Shot 2020-12-02 at 12 54 35 PM](https://user-images.githubusercontent.com/32834804/100924202-891fbb00-349d-11eb-903d-b7171e7d200e.png)

- Switch from your `main` branch to my branch and observe that the post now shows in the feed:
![Screen Shot 2020-12-02 at 12 55 00 PM](https://user-images.githubusercontent.com/32834804/100924287-a5235c80-349d-11eb-9f03-06d948719f3c.png)

- Try to break things! 🛠️ 

### UI accessibility concerns?
N/A

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
- [x] Question: it looks like the best place to test this would be in `app/javascript/articles/_tests_/Article.test.jsx`, is that correct? If so, I would assume that I might need to add a new test because the existing spec did not catch this bug, but we already test that both an Article and a Featured Article render in the feed... 🤔 

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![The Office: Erin and Kelly looking at a computer](https://media.giphy.com/media/3o7TKW61qfGrQpw44E/giphy.gif)
