### PR TITLE
Display message from the back end when leaving a channel

### DIFF
--- a/app/javascript/chat/ChatChannelSettings/ChatChannelSettings.jsx
+++ b/app/javascript/chat/ChatChannelSettings/ChatChannelSettings.jsx
@@ -308,7 +308,12 @@ export default class ChatChannelSettings extends Component {
     const { currentMembership } = this.state;
     if (actionStatus) {
       const response = await leaveChatChannelMembership(currentMembership.id);
+      const { message } = response;
       if (response.success) {
+        this.setState({
+          successMessages: response.message,
+          errorMessages: null,
+        });
         this.props.handleLeavingChannel(currentMembership.id);
       } else {
         this.setState({
@@ -316,6 +321,7 @@ export default class ChatChannelSettings extends Component {
           errorMessages: response.message,
         });
       }
+      addSnackbarItem({ message });
     }
   };
 

--- a/app/javascript/chat/ChatChannelSettings/ChatChannelSettings.jsx
+++ b/app/javascript/chat/ChatChannelSettings/ChatChannelSettings.jsx
@@ -311,7 +311,7 @@ export default class ChatChannelSettings extends Component {
       const { message } = response;
       if (response.success) {
         this.setState({
-          successMessages: response.message,
+          successMessages: message,
           errorMessages: null,
         });
         this.props.handleLeavingChannel(currentMembership.id);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

_Supersedes: https://github.com/forem/forem/pull/9870 (@jacobherrington)_

The messages passed from the back end to the front end when leaving a chat channel are never displayed, this PR addresses that.

## Related Tickets & Documents

I intended to fix this together with #9502, which got fixed by #9804.

## QA Instructions, Screenshots, Recordings

Leave a chat channel and see a snackbar notification appear.

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.forem.com
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

Nope.

## [optional] What gif best describes this PR or how it makes you feel?

![Adjustment GIF](https://media.giphy.com/media/26gN12uxpyl82bgju/giphy.gif)
