### PR TITLE
Remove unused index_notifications_on_json_data

### DIFF
--- a/db/migrate/20201203063435_remove_index_notifications_on_json_data_from_notifications.rb
+++ b/db/migrate/20201203063435_remove_index_notifications_on_json_data_from_notifications.rb
@@ -1,0 +1,15 @@
+class RemoveIndexNotificationsOnJsonDataFromNotifications < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    return unless index_exists?(:notifications, :json_data)
+
+    remove_index :notifications, column: :json_data, algorithm: :concurrently
+  end
+
+  def down
+    return if index_exists?(:notifications, :json_data)
+
+    add_index :notifications, :json_data, algorithm: :concurrently, using: :gin
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+ActiveRecord::Schema.define(version: 2020_12_03_063435) do
 
-ActiveRecord::Schema.define(version: 2020_11_19_153512) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -715,7 +715,6 @@ ActiveRecord::Schema.define(version: 2020_11_19_153512) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["created_at"], name: "index_notifications_on_created_at"
-    t.index ["json_data"], name: "index_notifications_on_json_data", using: :gin
     t.index ["notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_notifiable_id_notifiable_type_and_action"
     t.index ["notifiable_type"], name: "index_notifications_on_notifiable_type"
     t.index ["notified_at"], name: "index_notifications_on_notified_at"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR removes the unused (0 index scans according to `pg_catalog.pg_stat_user_indexes`) index `index_notifications_on_json_data` from `notifications`. This index currently weighs in at 15GB. The migration is written in a fully reversible way because that's how I like them, even if it makes them a bit more verbose.

## Related Tickets & Documents

n/a

## Added tests?

- [X] No, and this is why: they are not necessary

## Added to documentation?

- [X] No documentation needed
