### PR TITLE
Change profile header cache key to purge headers

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,8 @@
     <%= @user_json_ld.to_json.html_safe %>
   </script>
 <% end %>
-<% cache "main-user-profile-header-area-#{@user.id}-#{@user.profile_updated_at}-#{user_signed_in?}", expires_in: 10.days do %>
+
+<% cache "user-profile-header-area-#{@user.id}-#{@user.profile_updated_at}-#{user_signed_in?}", expires_in: 10.days do %>
   <style>
     :root {
       --profile-brand-color: <%= HexComparer.new([user_colors(@user)[:bg], user_colors(@user)[:text]]).brightness(0.88) %>;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We recently shipped a [profile fields overhaul](https://github.com/forem/forem/pull/10707) which resulted in a bug (dumb Ruby and the fact that it treats empty string as `truthy` 🤣 ).

We fixed it in https://github.com/forem/forem/pull/11730 but unfortunately the HTML is cached for 10 days. 

The quickest solution is to change the cache key. This will have a performance hit on DEV and possibly other Forems

## Related Tickets & Documents

#10707
#11730 

## Added tests?

- [ ] Yes
- [x] No, and this is why: caching keys aren't tested
- [ ] I need help with writing tests

## [optional] Are there any pre deployment tasks we need to perform?

Possibly the capacity of the DEV web server needs to be upped a bit before we deploy this
