### PR TITLE
Add first time admin login to FAQs

### DIFF
--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -4,6 +4,20 @@ title: FAQs
 
 # Frequently Asked Questions
 
+## How do I log in after starting up Forem for the first time?
+
+Seeding the database create an admin user (see
+[Database](/getting-started/db/#default-admin-user)) with the following
+credentials:
+
+```
+email: admin@forem.local
+password: password
+```
+
+Once logged in as this admin user, you can turn on any authentication methods
+you'd like (see [Authentication](/backend/authentication/))
+
 ## How do I build my local copy of the Ruby source code documentation?
 
 ```shell

--- a/docs/getting-started/start-app.md
+++ b/docs/getting-started/start-app.md
@@ -17,7 +17,9 @@ bin/startup
 (This just runs `foreman start -f Procfile.dev`, for notes on how to install
 Foreman, please see [Other Tools](/installation/others/))
 
-Then point your browser to http://localhost:3000/ to view the site.
+Then point your browser to http://localhost:3000/ to view the site. To log in
+use the admin account created by default (see
+[Database](/getting-started/db/#default-admin-user))
 
 If you run into issues while trying to run `bin/setup` and the error message
 isn't helpful, try running `bin/rails s -p 3000`. For example, you may need to


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Adds a FAQ about how to log into Forem the first time it starts up: information about the default admin account has been hard to find in the current Database section.

## Added to documentation?

- [x] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [ ] No documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/xT5LMDOHiRGBeA6HIs/giphy.gif)
