### PR TITLE
Improve user subscription UX flow when latency is high

### DIFF
--- a/app/liquid_tags/user_subscription_tag.rb
+++ b/app/liquid_tags/user_subscription_tag.rb
@@ -13,11 +13,13 @@ class UserSubscriptionTag < LiquidTagBase
     }
 
     // Hiding/showing elements
+    // If clearSubscribeButton is false, we will not clear out the subscription-signed-in area,
+    // which will allow users to re-submit their subscription if they see any error messages.
     // ***************************************
-    function clearSubscriptionArea() {
-      const subscriptionSignedIn = document.getElementById('subscription-signed-in');
-      if (subscriptionSignedIn) {
-        subscriptionSignedIn.classList.add("hidden");
+    function clearSubscriptionArea({ clearSubscribeButton = true } = {}) {
+      if (!clearSubscribeButton) {
+        // Allow users to try submitting again if they see an error.
+        hideSubscriptionSignedIn();
       }
 
       const subscriptionSignedOut = document.getElementById('subscription-signed-out');
@@ -25,10 +27,7 @@ class UserSubscriptionTag < LiquidTagBase
         subscriptionSignedOut.classList.add("hidden");
       }
 
-      const responseMessage = document.getElementById('response-message');
-      if (responseMessage) {
-        responseMessage.classList.add("hidden");
-      }
+      hideResponseMessage();
 
       const subscriberAppleAuth = document.getElementById('subscriber-apple-auth');
       if (subscriberAppleAuth) {
@@ -36,6 +35,15 @@ class UserSubscriptionTag < LiquidTagBase
       }
 
       hideConfirmationModal();
+    }
+
+    // Hides the response message (which displays success/error messages) if it exists.
+    // ***************************************
+    function hideResponseMessage() {
+      const responseMessage = document.getElementById('response-message');
+      if (responseMessage) {
+        responseMessage.classList.add("hidden");
+      }
     }
 
     function showSignedIn() {
@@ -73,12 +81,20 @@ class UserSubscriptionTag < LiquidTagBase
     }
 
     function showResponseMessage(noticeType, msg) {
-      clearSubscriptionArea();
+      clearSubscriptionArea(clearSubscribeButton = false);
+
       const responseMessage = document.getElementById('response-message');
       if (responseMessage) {
         responseMessage.classList.remove("hidden");
         responseMessage.classList.add(`crayons-notice--${noticeType}`);
         responseMessage.textContent = msg;
+
+        if (noticeType === 'danger') {
+          // Allow users to try resubscribing if they see an error message.
+          const subscribeBtn = document.getElementById('subscribe-btn');
+          subscribeBtn.textContent = "Submit";
+          subscribeBtn.disabled = false;
+        }
       }
     }
 
@@ -96,6 +112,7 @@ class UserSubscriptionTag < LiquidTagBase
     }
 
     function showSubscribed() {
+      hideSubscriptionSignedIn();
       updateSubscriberData();
       const authorUsername = document.getElementById('user-subscription-tag')?.dataset.authorUsername;
       const alreadySubscribedMsg = `You are already subscribed.`;
@@ -144,6 +161,13 @@ class UserSubscriptionTag < LiquidTagBase
       });
     }
 
+    function hideSubscriptionSignedIn() {
+      const subscriptionSignedIn = document.getElementById('subscription-signed-in');
+      if (subscriptionSignedIn) {
+        subscriptionSignedIn.classList.add("hidden");
+      }
+    }
+
     // Adding event listeners for 'click'
     // ***************************************
     function addSignInClickHandler() {
@@ -190,6 +214,13 @@ class UserSubscriptionTag < LiquidTagBase
     // API calls
     // ***************************************
     function submitSubscription() {
+      // Hide any error messages previously rendered.
+      hideResponseMessage();
+
+      const subscribeBtn = document.getElementById('subscribe-btn');
+      subscribeBtn.textContent = "Submitting...";
+      subscribeBtn.disabled = true;
+
       const headers = {
         Accept: 'application/json',
         'X-CSRF-Token': window.csrfToken,
@@ -251,12 +282,15 @@ class UserSubscriptionTag < LiquidTagBase
     // Handle API responses
     // ***************************************
     function handleSubscription() {
+      hideConfirmationModal(); // Close the modal once the user has confirmed.
+
       submitSubscription().then(function(response) {
         if (response.success) {
           const userSubscriptionTag = document.getElementById('user-subscription-tag');
           const authorUsername = (userSubscriptionTag ? userSubscriptionTag.dataset.authorUsername : null);
           const successMsg = `You are now subscribed and may receive emails from ${authorUsername}`;
           showResponseMessage('success', successMsg);
+          hideSubscriptionSignedIn();
         } else {
           showResponseMessage('danger', response.error);
         }

--- a/app/liquid_tags/user_subscription_tag.rb
+++ b/app/liquid_tags/user_subscription_tag.rb
@@ -8,6 +8,8 @@ class UserSubscriptionTag < LiquidTagBase
   ].freeze
 
   SCRIPT = <<~JAVASCRIPT.freeze
+    const subscribeBtn = document.getElementById('subscribe-btn');
+
     function isUserSignedIn() {
       return document.head.querySelector('meta[name="user-signed-in"][content="true"]') !== null;
     }
@@ -91,7 +93,6 @@ class UserSubscriptionTag < LiquidTagBase
 
         if (noticeType === 'danger') {
           // Allow users to try resubscribing if they see an error message.
-          const subscribeBtn = document.getElementById('subscribe-btn');
           subscribeBtn.textContent = "Submit";
           subscribeBtn.disabled = false;
         }
@@ -182,7 +183,6 @@ class UserSubscriptionTag < LiquidTagBase
     }
 
     function addConfirmationModalClickHandlers() {
-      const subscribeBtn = document.getElementById('subscribe-btn');
       if (subscribeBtn) {
         subscribeBtn.addEventListener('click', function(e) {
           showConfirmationModal();
@@ -217,7 +217,6 @@ class UserSubscriptionTag < LiquidTagBase
       // Hide any error messages previously rendered.
       hideResponseMessage();
 
-      const subscribeBtn = document.getElementById('subscribe-btn');
       subscribeBtn.textContent = "Submitting...";
       subscribeBtn.disabled = true;
 

--- a/app/views/liquids/_user_subscription.html.erb
+++ b/app/views/liquids/_user_subscription.html.erb
@@ -33,7 +33,7 @@
           <button class="crayons-btn mb-4" id="subscribe-btn">
             Subscribe
           </button>
-          <div class="fs-s" id="logged-in-text">
+          <div class="fs-s mb-3" id="logged-in-text">
             You'll subscribe with
             <span class="ltag__user-subscription-tag__subscriber-email"></span>
             the email address associated with your DEV account. To use a

--- a/spec/liquid_tags/user_subscription_tag_spec.rb
+++ b/spec/liquid_tags/user_subscription_tag_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
       expect(page).to have_css("#user-subscription-confirmation-modal", visible: :visible)
     end
 
-    it "displays a sucess mesage when a subscription is created" do
+    it "displays a sucess message when a subscription is created" do
       expect(page).to have_css("#subscription-signed-out", visible: :hidden)
       expect(page).to have_css("#subscriber-apple-auth", visible: :hidden)
       expect(page).to have_css("#response-message", visible: :hidden)
@@ -94,7 +94,9 @@ RSpec.describe UserSubscriptionTag, type: :liquid_tag do
       expect(page).to have_css("#subscription-signed-in", visible: :visible)
       click_button("Subscribe", id: "subscribe-btn")
       click_button("Confirm subscription", id: "confirmation-btn")
-      expect(page).to have_css("#subscription-signed-in", visible: :hidden)
+
+      # User should be able see the error and should be able to resubscribe.
+      expect(page).to have_css("#subscription-signed-in", visible: :visible)
       expect(page).to have_css("#response-message.crayons-notice--danger", visible: :visible)
 
       within "#response-message" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We ran into some latency + UX issues today around the user subscription tag. This PR improves on the issues that many users ran into by doing the following:

- [x] Disabling the `Subscribe` button while a request is submitting
- [x] Rendering errors alongside the `Subscribe` button so that users can try re-subscribing
- [x] Changing the text of the subscribe button to `Subscribing...` while the request is submitting

## Related Tickets & Documents

[This DEV post](https://dev.to/devteam/how-to-claim-your-hacktoberfest-completion-badge-3l2h) and related discussions in our support channel.

## QA Instructions, Screenshots, Recordings

To QA this feature, pull down this branch locally, and make sure the user you are logged in as has the `:restricted_liquid_tag` role. Once you have the role, create a new article that includes the user subscription liquid tag in the markdown (see the [relevant docs here](https://app.gitbook.com/@forem/s/team-handbook/tech/user-subscription-liquid-tag)):

```
{% user_subscription I love llamas, click here to subscribe to top-notch llama content!! %}
```

To test my changes, you will want to first make some changes to the `UserSubscriptionsController`. You can mock latency by adding a `sleep 10` (or any other number of seconds) to the controller. You can mock errors by just commenting out the code and forcing an error. For example:

<img width="1009" alt="Screen Shot 2020-12-03 at 11 02 26 AM" src="https://user-images.githubusercontent.com/6921610/101075600-18d57000-3557-11eb-85dc-a8da12a48104.png">

Now, go to the article with the user subscription tag that you just created. You should see a button to subscribe:

<img width="745" alt="Screen Shot 2020-12-03 at 10 57 27 AM" src="https://user-images.githubusercontent.com/6921610/101075334-ba0ff680-3556-11eb-85e8-b9ecc2e26921.png">

Click the button, and click the "confirm" button in the modal (the modal should automatically close once you confirm that you want to subscribe). Look for the disabled button and the `Submitting...` button text:
<img width="751" alt="Screen Shot 2020-12-03 at 10 57 37 AM" src="https://user-images.githubusercontent.com/6921610/101075779-54703a00-3557-11eb-98db-c43198dc1495.png">

It should take some time for the request to submit, and you should be able to test that you _cannot_ make multiple requests (the button should be disabled, so clicking it many times shouldn't do anything!)

You should see your "mock" error rendered on the user subscription box:
<img width="732" alt="Screen Shot 2020-12-03 at 10 57 49 AM" src="https://user-images.githubusercontent.com/6921610/101075913-7ec1f780-3557-11eb-949d-5c7e952df62a.png">

Now, go back to the `UserSubscriptionsController` and revert those changes. Try re-submitting by clicking the button to try to re-subscribe again. You should see the `Submitting...` text appear again:
<img width="705" alt="Screen Shot 2020-12-03 at 10 58 21 AM" src="https://user-images.githubusercontent.com/6921610/101075973-94cfb800-3557-11eb-8f6e-7f60803b6ceb.png">

...but this time, the request should be successful, and you should see your _success_ message. The subscribe button should have disappeared now:
<img width="732" alt="Screen Shot 2020-12-03 at 10 58 31 AM" src="https://user-images.githubusercontent.com/6921610/101075979-97321200-3557-11eb-977d-e8c2b7414208.png">

Finally, try refreshing the page entirely. You should still see a slightly different success message telling you that you are already subscribed, and the subscribe button should disappear:
<img width="738" alt="Screen Shot 2020-12-03 at 10 58 57 AM" src="https://user-images.githubusercontent.com/6921610/101076118-c8aadd80-3557-11eb-86c4-b25f1d017b0a.png">


### UI accessibility concerns?

None that I'm aware of -- the only UI change here is changing the text and adding the `disabled` attribute to a button that should have already had it :) 

## Added tests?

- [x] ~Yes~ Updated pre-existing tests!
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## Are there any post deployment tasks we need to perform?
None!
