### PR TITLE
Return from method if env called in boot up not available

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -25,6 +25,7 @@ class Profile < ApplicationRecord
 
   # Generates typed accessors for all currently defined profile fields.
   def self.refresh_attributes!
+    return if ENV["ENV_AVAILABLE"] == "false"
     return unless Database.table_exists?("profiles")
 
     ProfileField.find_each do |field|


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This is a code path that is hit during `rake assets:precompile` when the database is not available. We have the `ENV["ENV_AVAILABLE"] == "false"` indication to check here.

We can't access the database during assets precompile outside the container (as it is built in Forem Cloud) so this doesn't break Heroku but breaks FSS.

@jdoss is also going to enable GitHub checks for this so we'll catch it sooner.