### PR TITLE
Fix wikipedia tag z-index

### DIFF
--- a/app/assets/stylesheets/ltags/WikipediaTag.scss
+++ b/app/assets/stylesheets/ltags/WikipediaTag.scss
@@ -39,7 +39,7 @@
   }
   .ltag__wikipedia--btn--container {
     padding: 0.1em 0 1.15em;
-    z-index: 100;
+    z-index: var(--z-elevate);
     text-align: center;
     position: relative;
     box-shadow: 0px 0px 60px 42px #fff;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Quick fix for this:

<img width="313" alt="Screen Shot 2020-12-03 at 2 30 30 PM" src="https://user-images.githubusercontent.com/3102842/101078424-28af7d00-3574-11eb-9d72-b223d184d2f2.png">

The variable-based z-index is the thing we want to be using anywhere we can, so this cleans things up effectively here.

The failing "build-containers" is not related to this change.