### PR TITLE
Generalize social image path and clean up code

### DIFF
--- a/app/services/images/generate_social_image.rb
+++ b/app/services/images/generate_social_image.rb
@@ -1,5 +1,16 @@
 module Images
   class GenerateSocialImage
+    OPTIMIZER_OPTIONS = {
+      height: 400,
+      width: 800,
+      gravity: "north",
+      crop: "fill",
+      type: "url2png",
+      flags: nil,
+      quality: nil,
+      fetch_format: nil
+    }.freeze
+
     def self.call(resource)
       new(resource).call
     end
@@ -34,18 +45,7 @@ module Images
     end
 
     def optimize_image(path)
-      options = {
-        height: 400,
-        width: 800,
-        gravity: "north",
-        crop: "fill",
-        type: "url2png",
-        flags: nil,
-        quality: nil,
-        fetch_format: nil
-      }
-
-      Images::Optimizer.call("https://dev.to/social_previews#{path}", options)
+      Images::Optimizer.call("#{URL.url}/social_previews#{path}", OPTIMIZER_OPTIONS)
     end
   end
 end

--- a/spec/services/images/generate_social_image_spec.rb
+++ b/spec/services/images/generate_social_image_spec.rb
@@ -32,4 +32,17 @@ RSpec.describe Images::GenerateSocialImage, type: :labor do
       expect(described_class.call(article).include?(article.title)).to eq(true)
     end
   end
+
+  it "creates optimized images" do
+    allow(SiteConfig).to receive(:app_domain).and_return("example.com")
+    allow(Images::Optimizer).to receive(:call)
+
+    described_class.call(user)
+
+    expected_url = 
+      "http://example.com/social_previews/user/#{user.id}?bust=#{user.profile_image_url}"
+    
+    expect(Images::Optimizer).to \
+      have_received(:call).with(expected_url, Images::GenerateSocialImage::OPTIMIZER_OPTIONS)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This code [recently moved from `app/labor` to `app/services`](https://github.com/forem/forem/pull/11691). In that PR @leewynne spotted a hardcoded dev.to URL, which this PR addresses. It also moves the options hash into a constant. 

## Added tests?

- [X] Yes

## Added to documentation?

- [X] No documentation needed
