### PR TITLE
Change logic for checking for database on boot.

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -25,12 +25,13 @@ class Profile < ApplicationRecord
 
   # Generates typed accessors for all currently defined profile fields.
   def self.refresh_attributes!
-    return if ENV["ENV_AVAILABLE"] == "false"
     return unless Database.table_exists?("profiles")
 
     ProfileField.find_each do |field|
       store_attribute :data, field.attribute_name.to_sym, field.type
     end
+  rescue PG::ConnectionBad
+    puts "No database connections available. Assumed to be running assets:precompile."
   end
 
   # Returns an array of all currently defined `store_attribute`s on `data`.

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -30,7 +30,7 @@ class Profile < ApplicationRecord
     ProfileField.find_each do |field|
       store_attribute :data, field.attribute_name.to_sym, field.type
     end
-  rescue PG::ConnectionBad
+  rescue PG::ConnectionBad # This method may run before the database is available.
     puts "No database connections available. Assumed to be running assets:precompile."
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This code may run while `ENV["ENV_AVAILABLE"]` is still false, but not only in `assets:precompile` mode.

`ENV["ENV_AVAILABLE"]` is designed to check whether environment variables are present. And I'm thinking that it might be the case that environment variables are not present yet when this code runs, even in the "real" boot.... Which doesn't entirely makes sense to me, but maybe this runs before the `ENV` object is working properly?

This is fairly one-off type of behavior, as described here:

```ruby
  # NOTE: @citizen428 We want to have a current list of profile attributes the
  # moment the application loads. I wish Rails had a hook for code to run after
  # the app started...
  refresh_attributes!
```

At least this shouldn't break anything further I'm pretty sure and might be worth trying?