### PR TITLE
Revert "Bump husky from 4.3.0 to 4.3.4 (#11764)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "eslint-plugin-react": "^7.21.5",
     "faker": "^5.1.0",
     "gitdocs": "^2.0.0",
-    "husky": "^4.3.4",
+    "husky": "^4.3.0",
     "ibm-openapi-validator": "0.31.1",
     "jest": "26.6.3",
     "jest-axe": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9891,10 +9891,10 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-husky@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.4.tgz#676275a10ec5be2e893bd6ff71113bb829cc1f5b"
-  integrity sha512-wykHsss5kQtmbFrjQv0R7YyW1uFd7fv7gT1sA54potoDYmOTENJtBC/X1/AyoSAi1obp8CiGODOIdOGnPxSmFg==
+husky@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.0.tgz#0b2ec1d66424e9219d359e26a51c58ec5278f0de"
+  integrity sha512-tTMeLCLqSBqnflBZnlVDhpaIMucSGaYyX6855jM4AguGeWCeSzNdb1mfyWduTZ3pe3SJVvVWGL0jO1iKZVPfTA==
   dependencies:
     chalk "^4.0.0"
     ci-info "^2.0.0"


### PR DESCRIPTION
This reverts commit c9a289efed49965fa58ec2f2aa3cd9d671c5c501.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Husky 4.3.4, albeit correctly, doesn't silently ignore the fact that it requires `Git >= 2.13.0` and on Heroku we run 2.7, as we haven't update our Heroku images yet, see [Ubuntu Packages on Heroku Stacks](https://devcenter.heroku.com/articles/stack-packages), we have two options:

- add the env `HUSKY_SKIP_INSTALL=1` to simply skip installation on deployment
- revert Husky to what it was before until we upgrade Heroku stack images from Heroku 16 to Heroku 20

See also the error message in one of the failed builds - https://travis-ci.com/github/forem/forem/jobs/455297246#L563:

>        Husky requires Git >=2.13.0. Got v2.7.4.
>        husky > Failed to install