### PR TITLE
Add bust_article service

### DIFF
--- a/app/services/edge_cache/bust.rb
+++ b/app/services/edge_cache/bust.rb
@@ -1,10 +1,10 @@
 module EdgeCache
   class Bust
     TIMEFRAMES = [
-      [1.week.ago, "week"],
-      [1.month.ago, "month"],
-      [1.year.ago, "year"],
-      [5.years.ago, "infinity"],
+      [-> { 1.week.ago }, "week"],
+      [-> { 1.month.ago }, "month"],
+      [-> { 1.year.ago }, "year"],
+      [-> { 5.years.ago }, "infinity"],
     ].freeze
 
     def self.call(path)

--- a/app/services/edge_cache/bust.rb
+++ b/app/services/edge_cache/bust.rb
@@ -1,5 +1,12 @@
 module EdgeCache
   class Bust
+    TIMEFRAMES = [
+      [1.week.ago, "week"],
+      [1.month.ago, "month"],
+      [1.year.ago, "year"],
+      [5.years.ago, "infinity"],
+    ].freeze
+
     def self.call(path)
       bust(path)
     end

--- a/app/services/edge_cache/bust_article.rb
+++ b/app/services/edge_cache/bust_article.rb
@@ -37,7 +37,7 @@ module EdgeCache
       end
 
       TIMEFRAMES.each do |timestamp, interval|
-        next unless Article.published.where("published_at > ?", timestamp)
+        next unless Article.published.where("published_at > ?", timestamp.call)
           .order(public_reactions_count: :desc).limit(3).ids.include?(article.id)
 
         bust("/top/#{interval}")
@@ -65,7 +65,7 @@ module EdgeCache
         end
 
         TIMEFRAMES.each do |timestamp, interval|
-          next unless Article.published.where("published_at > ?", timestamp).tagged_with(tag)
+          next unless Article.published.where("published_at > ?", timestamp.call).tagged_with(tag)
             .order(public_reactions_count: :desc).limit(3).ids.include?(article.id)
 
           bust("/top/#{interval}")

--- a/app/services/edge_cache/bust_article.rb
+++ b/app/services/edge_cache/bust_article.rb
@@ -1,0 +1,90 @@
+module EdgeCache
+  class BustArticle < Bust
+    def self.call(article)
+      return unless article
+
+      article.purge
+
+      bust(article.path)
+      bust("/#{article.user.username}")
+      bust("#{article.path}/")
+      bust("#{article.path}?i=i")
+      bust("#{article.path}/?i=i")
+      bust("#{article.path}/comments")
+      bust("#{article.path}?preview=#{article.password}")
+      bust("#{article.path}?preview=#{article.password}&i=i")
+      bust("/#{article.organization.slug}") if article.organization.present?
+      bust_home_pages(article)
+      bust_tag_pages(article)
+      bust("/api/articles/#{article.id}")
+
+      return unless article.collection_id
+
+      article.collection&.articles&.find_each do |collection_article|
+        bust(collection_article.path)
+      end
+    end
+
+    def self.bust_home_pages(article)
+      if article.featured_number.to_i > Time.current.to_i
+        bust("/")
+        bust("?i=i")
+      end
+
+      if article.video.present? && article.featured_number.to_i > 10.days.ago.to_i
+        bust("/videos")
+        bust("/videos?i=i")
+      end
+
+      TIMEFRAMES.each do |timestamp, interval|
+        next unless Article.published.where("published_at > ?", timestamp)
+          .order(public_reactions_count: :desc).limit(3).ids.include?(article.id)
+
+        bust("/top/#{interval}")
+        bust("/top/#{interval}?i=i")
+        bust("/top/#{interval}/?i=i")
+      end
+
+      if article.published && article.published_at > 1.hour.ago
+        bust("/latest")
+        bust("/latest?i=i")
+      end
+
+      bust("/") if Article.published.order(hotness_score: :desc).limit(4).ids.include?(article.id)
+    end
+
+    private_class_method :bust_home_pages
+
+    def self.bust_tag_pages(article)
+      return unless article.published
+
+      article.tag_list.each do |tag|
+        if article.published_at.to_i > 2.minutes.ago.to_i
+          bust("/t/#{tag}/latest")
+          bust("/t/#{tag}/latest?i=i")
+        end
+
+        TIMEFRAMES.each do |timestamp, interval|
+          next unless Article.published.where("published_at > ?", timestamp).tagged_with(tag)
+            .order(public_reactions_count: :desc).limit(3).ids.include?(article.id)
+
+          bust("/top/#{interval}")
+          bust("/top/#{interval}?i=i")
+          bust("/top/#{interval}/?i=i")
+          12.times do |i|
+            bust("/api/articles?tag=#{tag}&top=#{i}")
+          end
+        end
+
+        next unless rand(2) == 1 &&
+          Article.published.tagged_with(tag)
+            .order(hotness_score: :desc).limit(2).ids.include?(article.id)
+
+        bust("/t/#{tag}")
+        bust("/t/#{tag}?i=i")
+      end
+    end
+
+    private_class_method :bust_tag_pages
+  end
+end

--- a/app/services/edge_cache/bust_article.rb
+++ b/app/services/edge_cache/bust_article.rb
@@ -20,7 +20,7 @@ module EdgeCache
 
       return unless article.collection_id
 
-      article.collection&.articles&.find_each do |collection_article|
+      article.collection.articles.find_each do |collection_article|
         bust(collection_article.path)
       end
     end

--- a/spec/services/edge_cache/bust_article_spec.rb
+++ b/spec/services/edge_cache/bust_article_spec.rb
@@ -6,11 +6,26 @@ RSpec.describe EdgeCache::BustArticle, type: :service do
   before do
     allow(article).to receive(:purge)
     allow(described_class).to receive(:bust)
+    allow(described_class).to receive(:bust_home_pages)
+    allow(described_class).to receive(:bust_tag_pages)
   end
 
   it "busts the cache" do
     described_class.call(article)
     expect(article).to have_received(:purge).once
+    expect(described_class).to have_received(:bust).exactly(9).times
     expect(described_class).to have_received(:bust).with(article.path).once
+    expect(described_class).to have_received(:bust_home_pages).with(article).once
+    expect(described_class).to have_received(:bust_tag_pages).with(article).once
+  end
+
+  context "when an article is part of an organization" do
+    it "busts the organization slug" do
+      organization = create(:organization)
+      article.organization = organization
+
+      described_class.call(article)
+      expect(described_class).to have_received(:bust).with("/#{article.organization.slug}").once
+    end
   end
 end

--- a/spec/services/edge_cache/bust_article_spec.rb
+++ b/spec/services/edge_cache/bust_article_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe EdgeCache::BustArticle, type: :service do
+  let(:article) { create(:article) }
+
+  before do
+    allow(article).to receive(:purge)
+    allow(described_class).to receive(:bust)
+  end
+
+  it "busts the cache" do
+    described_class.call(article)
+    expect(article).to have_received(:purge).once
+    expect(described_class).to have_received(:bust).with(article.path).once
+  end
+end

--- a/spec/services/edge_cache/bust_spec.rb
+++ b/spec/services/edge_cache/bust_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe EdgeCache::Bust, type: :service do
     expect(described_class.const_defined?(:TIMEFRAMES)).to be true
   end
 
+  it "adjusts TIMEFRAMES according to the current time" do
+    current_year = Time.current.year
+
+    Timecop.freeze(3.years.ago) do
+      timestamp, _interval = described_class::TIMEFRAMES.first
+      expect(timestamp.call.year).to be <= current_year - 3
+    end
+  end
+
   describe "#bust_fastly_cache" do
     let(:fastly_provider_class) { EdgeCache::Bust::Fastly }
 

--- a/spec/services/edge_cache/bust_spec.rb
+++ b/spec/services/edge_cache/bust_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe EdgeCache::Bust, type: :service do
   let(:user) { create(:user) }
   let(:path) { "/#{user.username}" }
 
+  it "defines TIMEFRAMES" do
+    expect(described_class.const_defined?(:TIMEFRAMES)).to be true
+  end
+
   describe "#bust_fastly_cache" do
     let(:fastly_provider_class) { EdgeCache::Bust::Fastly }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method I turn into a service. Once all methods are refactored into services, I'll then PR for each reference to the old `CacheBuster` to the new service. By "making the transition" one PR at a time, it will be easier to debug. Once all references to the old `CacheBuster` are updated, I'll delete that as well.

Here are the methods:
- [ ] bust_page
- [ ] bust_tag
- [ ] bust_events
- [ ] bust_podcast
- [ ] bust_organization
- [ ] bust_podcast_episode
- [ ] bust_listings
- [ ] bust_user
- [x] bust_tag_pages
- [x] bust_home_pages
- [x] bust_article
- [x] bust_article_comment
- [x] bust_comment

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Nothing to really QA since we aren't referencing this new code, yet!

## Added tests?
- [x] Yes - I'm open to ideas on how to provide better test coverage!

## Added to documentation?
- [x] No documentation needed

![ucf_volleyball_spike_setup](https://media.giphy.com/media/1BhEyeZst1bOFHeiyZ/giphy.gif)
