### PR TITLE
GitHub workflow for /ci trigger

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,11 @@
      - ✅ Provide tests for your changes.
      - 📝 Use descriptive commit messages.
      - 📗 Update any related documentation and include any relevant screenshots.
+
+     NOTE: Pull Requests from forked repositories will need to be reviewed by
+     a Forem Team member before any CI builds will run. Once your PR is approved
+     with a `/ci` reply to the PR, it will be allowed run subsequent builds without
+     manual approval.
 -->
 
 ## What type of PR is this? (check all applicable)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 
      NOTE: Pull Requests from forked repositories will need to be reviewed by
      a Forem Team member before any CI builds will run. Once your PR is approved
-     with a `/ci` reply to the PR, it will be allowed run subsequent builds without
+     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
      manual approval.
 -->
 

--- a/.github/workflows/buildkite.yml
+++ b/.github/workflows/buildkite.yml
@@ -1,0 +1,28 @@
+name: Approve PR for running Buildkite  pipelines
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  add_ci_label:
+    name: "Add CI label to PR"
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/ci') && github.event.comment.author_association == 'MEMBER'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          labels: ci
+  build_containers:
+    name: "Run Buildkite forem/build-containers pipeline"
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/ci') && github.event.comment.author_association == 'MEMBER'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jdoss/trigger-pipeline-action@c1c77c83b3c16b03b474bc2e1ce6eb36dbde7f3d
+        env:
+          BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.buildkite_api_access_token }}
+          PIPELINE: "forem/build-containers"
+          PULL_REQUEST_ID: ${{github.event.issue.number}

--- a/.github/workflows/buildkite.yml
+++ b/.github/workflows/buildkite.yml
@@ -1,4 +1,4 @@
-name: Approve PR for running Buildkite  pipelines
+name: Approve PR for running Buildkite pipelines
 
 on:
   issue_comment:
@@ -15,6 +15,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           labels: ci
+
   build_containers:
     name: "Run Buildkite forem/build-containers pipeline"
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/ci') && github.event.comment.author_association == 'MEMBER'

--- a/.github/workflows/buildkite.yml
+++ b/.github/workflows/buildkite.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   add_ci_label:
     name: "Add CI label to PR"
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/ci') && github.event.comment.author_association == 'MEMBER'
+    if: github.event.issue.pull_request != '' &&
+      startsWith(github.event.comment.body, '/ci') &&
+      (github.event.comment.author_association == 'MEMBER' ||
+      github.event.comment.author_association == 'OWNER')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -18,7 +21,10 @@ jobs:
 
   build_containers:
     name: "Run Buildkite forem/build-containers pipeline"
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/ci') && github.event.comment.author_association == 'MEMBER'
+    if: github.event.issue.pull_request != '' &&
+      startsWith(github.event.comment.body, '/ci') &&
+      (github.event.comment.author_association == 'MEMBER' ||
+      github.event.comment.author_association == 'OWNER')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,23 @@
+name: Comment on PR
+
+on:
+  pull_request_target:
+
+jobs:
+  if: github.repository != 'forem/forem'
+  pull_request_comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add comment to PR if coming from third-party fork
+        uses: mshick/add-pr-comment@v1
+        with:
+          message: |
+            Thank you for opening this PR! We appreciate you!
+
+            For all pull requests coming from third-party forks we will need to
+            review the PR before we can process it through our CI pipelines.
+
+            A Forem Team member will review this contribution and get back with
+            you as soon as possible!
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token-user-login: 'github-actions[bot]'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
             For all pull requests coming from third-party forks we will need to
             review the PR before we can process it through our CI pipelines.
 
-            A Forem Team member will review this contribution and get back with
+            A Forem Team member will review this contribution and get back to
             you as soon as possible!
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add in GitHub workflow for adding the `ci` label to the PR and running Buildkite pipeline(s).

The `ci` label will allow the PR to be built on push without having to continuously issue the `/ci` trigger from a Forem team member.

```
build.pull_request.repository.fork != true || build.pull_request.labels includes "ci"
```

Also using the `/ci` trigger will run the initial pipeline builds too.

## [optional] What gif best describes this PR or how it makes you feel?

![punch myself in the faceeeeeeeee](https://media.giphy.com/media/TxgA1aho46CWc/giphy.gif)
