### PR TITLE
Invalidate cache for all org users' profiles

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -36,6 +36,7 @@ class OrganizationsController < ApplicationController
     end
 
     if @organization.update(organization_params.merge(profile_updated_at: Time.current))
+      @organization.users.touch_all(:organization_info_updated_at)
       flash[:settings_notice] = "Your organization was successfully updated."
       redirect_to "/settings/organization"
     else


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This uses the [`touch_all` method](https://blog.saeloun.com/2019/08/27/rails-6-touch_all-method.html) to bust a cache key in a user's profile organization section. Specifically, [this key](https://github.com/forem/forem/blob/19a048ecec30363b61db3891001808b3ea9b37c5/app/views/users/_sidebar.html.erb):
```ruby
  <% cache "user-profile-sidebar-additional-#{@user.id}-#{@user.github_repos_updated_at}-#{@user.badge_achievements_count}-#{@user.organization_info_updated_at}", expires_in: 2.days do %>
```

## Related Tickets & Documents
Closes #11790

## QA Instructions, Screenshots, Recordings
1. Enable caching in development `rails dev:cache`
2. Make an organization: /settings/organization/new
3. Update your organization's **name and slug**
4. Visit your profile page
5. See that your org's name is proper
6. See that your org's link sends you to the new slug

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

### UI accessibility concerns?
Nope.

## Added tests?
- [x] No, and this is why: I don't think we test for cache changes like this?

## Added to documentation?
- [x] No documentation needed