### PR TITLE
Create services for busting pages, tags, events, and podcasts

### DIFF
--- a/app/services/edge_cache/bust_events.rb
+++ b/app/services/edge_cache/bust_events.rb
@@ -1,0 +1,8 @@
+module EdgeCache
+  class BustEvents < Bust
+    def self.call
+      bust("/events")
+      bust("/events?i=i")
+    end
+  end
+end

--- a/app/services/edge_cache/bust_page.rb
+++ b/app/services/edge_cache/bust_page.rb
@@ -1,0 +1,12 @@
+module EdgeCache
+  class BustPage < Bust
+    def self.call(slug)
+      return unless slug
+
+      bust("/page/#{slug}")
+      bust("/page/#{slug}?i=i")
+      bust("/#{slug}")
+      bust("/#{slug}?i=i")
+    end
+  end
+end

--- a/app/services/edge_cache/bust_podcast.rb
+++ b/app/services/edge_cache/bust_podcast.rb
@@ -1,0 +1,9 @@
+module EdgeCache
+  class BustPodcast < Bust
+    def self.call(path)
+      return unless path
+
+      bust("/#{path}")
+    end
+  end
+end

--- a/app/services/edge_cache/bust_tag.rb
+++ b/app/services/edge_cache/bust_tag.rb
@@ -1,0 +1,15 @@
+module EdgeCache
+  class BustTag < Bust
+    def self.call(tag)
+      return unless tag
+
+      tag.purge
+
+      bust("/t/#{tag.name}")
+      bust("/t/#{tag.name}?i=i")
+      bust("/t/#{tag.name}/?i=i")
+      bust("/t/#{tag.name}/")
+      bust("/tags")
+    end
+  end
+end

--- a/spec/services/edge_cache/bust_events_spec.rb
+++ b/spec/services/edge_cache/bust_events_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe EdgeCache::BustEvents, type: :service do
+  let(:paths) do
+    [
+      "/events",
+      "/events?i=i",
+    ]
+  end
+
+  before do
+    paths.each do |path|
+      allow(described_class).to receive(:bust).with(path).once
+    end
+  end
+
+  it "busts the cache" do
+    described_class.call
+
+    paths.each do |path|
+      expect(described_class).to have_received(:bust).with(path).once
+    end
+  end
+end

--- a/spec/services/edge_cache/bust_page_spec.rb
+++ b/spec/services/edge_cache/bust_page_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe EdgeCache::BustPage, type: :service do
+  let(:slug) { "slug" }
+  let(:paths) do
+    [
+      "/page/#{slug}",
+      "/page/#{slug}?i=i",
+      "/#{slug}",
+      "/#{slug}?i=i",
+    ]
+  end
+
+  before do
+    paths.each do |path|
+      allow(described_class).to receive(:bust).with(path)
+    end
+  end
+
+  it "busts the cache" do
+    described_class.call(slug)
+
+    paths.each do |path|
+      expect(described_class).to have_received(:bust).with(path).once
+    end
+  end
+end

--- a/spec/services/edge_cache/bust_page_spec.rb
+++ b/spec/services/edge_cache/bust_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe EdgeCache::BustPage, type: :service do
 
   before do
     paths.each do |path|
-      allow(described_class).to receive(:bust).with(path)
+      allow(described_class).to receive(:bust).with(path).once
     end
   end
 

--- a/spec/services/edge_cache/bust_podcast_spec.rb
+++ b/spec/services/edge_cache/bust_podcast_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe EdgeCache::BustPodcast, type: :service do
+  let(:podcast_path) { "podcast_path" }
+  let(:paths) do
+    [
+      "/#{podcast_path}",
+    ]
+  end
+
+  before do
+    paths.each do |path|
+      allow(described_class).to receive(:bust).with(path).once
+    end
+  end
+
+  it "busts the cache" do
+    described_class.call(podcast_path)
+
+    paths.each do |path|
+      expect(described_class).to have_received(:bust).with(path).once
+    end
+  end
+end

--- a/spec/services/edge_cache/bust_tag_spec.rb
+++ b/spec/services/edge_cache/bust_tag_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe EdgeCache::BustTag, type: :service do
+  let(:tag) { create(:tag) }
+  let(:paths) do
+    [
+      "/t/#{tag.name}",
+      "/t/#{tag.name}?i=i",
+      "/t/#{tag.name}/?i=i",
+      "/t/#{tag.name}/",
+      "/tags",
+    ]
+  end
+
+  before do
+    paths.each do |path|
+      allow(described_class).to receive(:bust).with(path).once
+    end
+
+    allow(tag).to receive(:purge).once
+  end
+
+  it "busts the cache" do
+    described_class.call(tag)
+
+    paths.each do |path|
+      expect(described_class).to have_received(:bust).with(path).once
+    end
+
+    expect(tag).to have_received(:purge).once
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
_I'm choosing to refactor a handful of methods/services at once in this PR since they're simpler and similar._

As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method I turn into a service. Once all methods are refactored into services, I'll then PR for each reference to the old `CacheBuster` to the new service. By "making the transition" one PR at a time, it will be easier to debug. Once all references to the old `CacheBuster` are updated, I'll delete that as well.

Here are the methods:
- [x] bust_page
- [x] bust_tag
- [x] bust_events
- [x] bust_podcast
- [ ] bust_organization
- [ ] bust_podcast_episode
- [ ] bust_listings
- [ ] bust_user
- [x] bust_tag_pages
- [x] bust_home_pages
- [x] bust_article
- [x] bust_article_comment
- [x] bust_comment

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Nothing to really QA since we aren't referencing this new code, yet!

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![lil_waybe_moving_along_gif](https://media.giphy.com/media/s45IR6QzWLDj2/giphy.gif)
