### PR TITLE
Scope PR workflow only run when the PR is opened.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,6 +2,7 @@ name: Comment on PR
 
 on:
   pull_request_target:
+    types: [opened]
 
 jobs:
   pull_request_comment:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This will scope the PR workflow to only run when the pull request is initially opened to avoid late comments like this:

https://github.com/forem/forem/pull/11039#issuecomment-741631685

## [optional] What gif best describes this PR or how it makes you feel?

![Finding out I had to keep working on GitHub Actions more today...](https://media.giphy.com/media/irPxRRzMTMFd6/giphy.gif)
