### PR TITLE
Create services for busting organizations, podcast episodes, listings, and users

### DIFF
--- a/app/services/edge_cache/bust_listings.rb
+++ b/app/services/edge_cache/bust_listings.rb
@@ -1,0 +1,16 @@
+module EdgeCache
+  class BustListings < Bust
+    def self.call(listing)
+      return unless listing
+
+      # we purge all listings as it's the wanted behavior with the following URL purging
+      listing.purge_all
+
+      bust("/listings")
+      bust("/listings?i=i")
+      bust("/listings/#{listing.category}/#{listing.slug}")
+      bust("/listings/#{listing.category}/#{listing.slug}?i=i")
+      bust("/listings/#{listing.category}")
+    end
+  end
+end

--- a/app/services/edge_cache/bust_organization.rb
+++ b/app/services/edge_cache/bust_organization.rb
@@ -1,0 +1,17 @@
+module EdgeCache
+  class BustOrganization < Bust
+    def self.call(organization, slug)
+      return unless organization && slug
+
+      bust("/#{slug}")
+
+      begin
+        organization.articles.find_each do |article|
+          bust(article.path)
+        end
+      rescue StandardError => e
+        Rails.logger.error("Tag issue: #{e}")
+      end
+    end
+  end
+end

--- a/app/services/edge_cache/bust_podcast_episode.rb
+++ b/app/services/edge_cache/bust_podcast_episode.rb
@@ -1,0 +1,18 @@
+module EdgeCache
+  class BustPodcastEpisode < Bust
+    def self.call(podcast_episode, path, podcast_slug)
+      return unless podcast_episode && path && podcast_slug
+
+      podcast_episode.purge
+      podcast_episode.purge_all
+
+      begin
+        bust(path)
+        bust("/#{podcast_slug}")
+        bust("/pod")
+      rescue StandardError => e
+        Rails.logger.warn(e)
+      end
+    end
+  end
+end

--- a/app/services/edge_cache/bust_user.rb
+++ b/app/services/edge_cache/bust_user.rb
@@ -1,0 +1,22 @@
+module EdgeCache
+  class BustUser < Bust
+    def self.call(user)
+      return unless user
+
+      username = user.username
+
+      paths = [
+        "/#{username}",
+        "/#{username}?i=i",
+        "/#{username}/comments",
+        "/#{username}/comments?i=i",
+        "/#{username}/comments/?i=i",
+        "/live/#{username}",
+        "/live/#{username}?i=i",
+        "/feed/#{username}",
+      ]
+
+      paths.each { |path| bust(path) }
+    end
+  end
+end

--- a/spec/services/edge_cache/bust_listings_spec.rb
+++ b/spec/services/edge_cache/bust_listings_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe EdgeCache::BustListings, type: :service do
+  let(:listing) { create(:listing) }
+
+  let(:paths) do
+    [
+      "/listings",
+      "/listings?i=i",
+      "/listings/#{listing.category}/#{listing.slug}",
+      "/listings/#{listing.category}/#{listing.slug}?i=i",
+      "/listings/#{listing.category}",
+    ]
+  end
+
+  before do
+    allow(listing).to receive(:purge_all)
+
+    paths.each do |path|
+      allow(described_class).to receive(:bust).with(path).once
+    end
+  end
+
+  it "busts the cache" do
+    described_class.call(listing)
+
+    expect(listing).to have_received(:purge_all)
+
+    paths.each do |path|
+      expect(described_class).to have_received(:bust).with(path).once
+    end
+  end
+end

--- a/spec/services/edge_cache/bust_organization_spec.rb
+++ b/spec/services/edge_cache/bust_organization_spec.rb
@@ -16,4 +16,11 @@ RSpec.describe EdgeCache::BustOrganization, type: :service do
     expect(described_class).to have_received(:bust).with("/#{slug}").once
     expect(described_class).to have_received(:bust).with(article.path).once
   end
+
+  it "logs an error" do
+    allow(described_class).to receive(:bust).with("/5").once
+    allow(Rails.logger).to receive(:error)
+    described_class.call(4, 5)
+    expect(Rails.logger).to have_received(:error).once
+  end
 end

--- a/spec/services/edge_cache/bust_organization_spec.rb
+++ b/spec/services/edge_cache/bust_organization_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe EdgeCache::BustOrganization, type: :service do
+  let(:organization) { create(:organization) }
+  let(:article) { create(:article, organization: organization) }
+  let(:slug) { "slug" }
+
+  before do
+    allow(described_class).to receive(:bust).with("/#{slug}").once
+    allow(described_class).to receive(:bust).with(article.path).once
+  end
+
+  it "busts the cache" do
+    described_class.call(organization, slug)
+
+    expect(described_class).to have_received(:bust).with("/#{slug}").once
+    expect(described_class).to have_received(:bust).with(article.path).once
+  end
+end

--- a/spec/services/edge_cache/bust_podcast_episode_spec.rb
+++ b/spec/services/edge_cache/bust_podcast_episode_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe EdgeCache::BustPodcastEpisode, type: :service do
+  let(:podcast) { create(:podcast) }
+  let(:podcast_episode) { create(:podcast_episode, podcast_id: podcast.id) }
+  let(:podcast_path) { "/cfp" }
+  let(:podcast_slug) { "-007" }
+
+  let(:paths) do
+    [
+      podcast_path,
+      "/#{podcast_slug}",
+      "/pod",
+    ]
+  end
+
+  before do
+    paths.each do |path|
+      allow(described_class).to receive(:bust).with(path).once
+    end
+
+    allow(podcast_episode).to receive(:purge)
+    allow(podcast_episode).to receive(:purge_all)
+  end
+
+  it "busts the cache" do
+    described_class.call(podcast_episode, podcast_path, podcast_slug)
+
+    paths.each do |path|
+      expect(described_class).to have_received(:bust).with(path).once
+    end
+
+    expect(podcast_episode).to have_received(:purge)
+    expect(podcast_episode).to have_received(:purge_all)
+  end
+
+  it "logs an error" do
+    allow(Rails.logger).to receive(:warn)
+    allow(described_class).to receive(:bust).and_raise(StandardError)
+    described_class.call(podcast_episode, 12, podcast_slug)
+    expect(Rails.logger).to have_received(:warn).once
+  end
+end

--- a/spec/services/edge_cache/bust_user_spec.rb
+++ b/spec/services/edge_cache/bust_user_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe EdgeCache::BustUser, type: :service do
+  let(:user) { create(:user) }
+
+  let(:paths) do
+    username = user.username
+
+    [
+      "/#{username}",
+      "/#{username}?i=i",
+      "/#{username}/comments",
+      "/#{username}/comments?i=i",
+      "/#{username}/comments/?i=i",
+      "/live/#{username}",
+      "/live/#{username}?i=i",
+      "/feed/#{username}",
+    ]
+  end
+
+  before do
+    paths.each do |path|
+      allow(described_class).to receive(:bust).with(path).once
+    end
+  end
+
+  it "busts the cache" do
+    described_class.call(user)
+
+    paths.each do |path|
+      expect(described_class).to have_received(:bust).with(path).once
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
_I'm choosing to refactor a handful of methods/services at once in this PR since they're similar._

As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method I turn into a service. Once all methods are refactored into services, I'll then PR for each reference to the old `CacheBuster` to the new service. By "making the transition" one PR at a time, it will be easier to debug. Once all references to the old `CacheBuster` are updated, I'll delete that as well.

Here are the methods:
- [x] bust_page
- [x] bust_tag
- [x] bust_events
- [x] bust_podcast
- [x] bust_organization
- [x] bust_podcast_episode
- [x] bust_listings
- [x] bust_user
- [x] bust_tag_pages
- [x] bust_home_pages
- [x] bust_article
- [x] bust_article_comment
- [x] bust_comment

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Nothing to really QA since we aren't referencing this new code, yet!

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![jersey_shore_moving_on_gif](https://media.giphy.com/media/W1TTs7a4A7TaSrFGl8/giphy.gif)