### PR TITLE
Refactor:Remove old teams from CODEOWNERS and update general teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,12 +3,10 @@
 # for further details
 
 /*.md                                               @forem/oss
-/app/controllers/articles_controller.rb             @forem/hells-bells
+/app/assets/                                        @forem/frontend
 /app/controllers/async_info_controller.rb           @forem/sre
-/app/controllers/stories_controller.rb              @forem/hells-bells
+/app/javascript/                                    @forem/frontend
 /app/services/search/                               @forem/sre
-/app/views/articles/                                @forem/hells-bells
-/app/views/stories/                                 @forem/hells-bells
 /app/workers/                                       @forem/sre
 /config/                                            @forem/sre
 /db/                                                @forem/sre
@@ -24,7 +22,7 @@ docker-compose.yml                                  @forem/systems
 Dockerfile                                          @forem/systems
 Gemfile                                             @forem/sre    @forem/oss
 Gemfile.lock                                        @forem/sre    @forem/oss
-package.json                                        @forem/oss    @nickytonline
+package.json                                        @forem/oss    @forem/frontend
 podman-compose.yml                                  @forem/systems
 scripts/                                            @forem/systems
-yarn.lock                                           @forem/oss    @nickytonline
+yarn.lock                                           @forem/oss    @forem/frontend


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Removed the old hells-bells team from the CODEOWNERS file and replaced @nickytonline with the frontend team. I think we could lean even more into this and add the backend team to here but wasn't sure how people felt about that yet so I am holding off. 

![alt_text](https://media.tenor.com/images/d69ecc2e568974d043795615b9db4a31/tenor.gif)
