### PR TITLE
Make mod button only show up for trusted user

### DIFF
--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -32,7 +32,7 @@
       <% if user_signed_in? %>
         <a href="<%= new_path %>" class="crayons-btn hidden mr-2 whitespace-nowrap m:block ml-auto">Write a post</a>
 
-        <a id="moderation-link" class="crayons-header__link crayons-btn crayons-btn--ghost crayons-btn--icon-rounded hidden m:flex" aria-label="Moderation" href="<%= mod_path %>">
+        <a id="moderation-link" class="crayons-header__link crayons-btn crayons-btn--ghost crayons-btn--icon-rounded trusted-visible-block m:flex" aria-label="Moderation" href="<%= mod_path %>">
           <%= inline_svg_tag("mod.svg", aria: true, class: "crayons-icon", title: "Moderation") %>
         </a>
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There is a current bug which is having the mod action button in the nav bar be _always_ present. There is one missing class we use to toggle this based on stuff we store client side about the user.

## QA Instructions, Screenshots, Recordings

Manually change the `config_body_class` in `user_decorator` to verify that this is showing up properly or not. You'll probably need to refresh twice to see the change.

## Tests

We _just_ implemented end-to-end testing with cypress and I think to get this hot fix in we should just ship, but this is the kind of thing that could warrant a regression test in the future.