### PR TITLE
Make followers notification overflow-hidden

### DIFF
--- a/app/views/notifications/_follow.html.erb
+++ b/app/views/notifications/_follow.html.erb
@@ -16,7 +16,7 @@
     </div>
   <% else %>
     <% json_data_array = notification["json_data"]["aggregated_siblings"] %>
-    <div class="flex mb-3">
+    <div class="flex mb-3 max-w-100 overflow-x-hidden">
       <% notification.json_data["aggregated_siblings"][0..10].each do |sibling| %>
         <a href="<%= sibling["path"] %>" class="crayons-avatar crayons-avatar--l shrink-0 mx-1" <% if sibling["id"] == json_data_array.first["id"] %> tabindex="-1" aria-hidden="true"<% end %>>
           <img src="<%= sibling["profile_image_90"] %>" class="crayons-avatar__image" alt="link to <%= sibling["name"] %>'s profile" width="32" height="32">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the event that the new follower box overflows, it's better that it be hidden vs escape the box.

<img width="136" alt="Screen Shot 2020-12-11 at 4 16 08 PM" src="https://user-images.githubusercontent.com/3102842/101955635-31cfc800-3bcc-11eb-8a7c-8a9a0ac213bf.png">

There are alternatives to fixing this, maybe it spans multiple lines, but I think this hot fix is better than leaving the problem as it is.

