### PR TITLE
Fix feed navigation shortcuts when first article is not 100% visible

### DIFF
--- a/app/javascript/shared/components/useListNavigation.js
+++ b/app/javascript/shared/components/useListNavigation.js
@@ -152,7 +152,7 @@ function navigate(
   const nextFocusable = nextContainer?.querySelector(focusableSelector);
   if (nextFocusable) {
     nextFocusable.focus();
-    if (!isInViewport(nextFocusable, 64)) {
+    if (!isInViewport({ element: nextFocusable, offsetTop: 64 })) {
       window.scrollTo({ top: nextContainer.offsetTop - 64 });
     }
   }
@@ -211,7 +211,9 @@ function getPreviousElement(
 }
 
 /**
- * Gets the first visible element that matches a selector
+ * Checks if the first completely visible element is present that matches a selector and returns if it is available
+ * If that isn't visible, it looks for the partially visible element that is present and returns that
+ * If no elements visible(like the banner case which could cover the entire viewport), we select the first element from the list
  *
  * @param {string} selector - The CSS selector
  *
@@ -219,7 +221,19 @@ function getPreviousElement(
  */
 function getFirstVisibleElement(selector) {
   const elements = document.querySelectorAll(selector);
-  return Array.prototype.find.call(elements, (element) =>
-    isInViewport(element),
+  const completelyVisibleFirstElement = Array.prototype.find.call(
+    elements,
+    (element) => isInViewport({ element }),
   );
+  if (completelyVisibleFirstElement) {
+    return completelyVisibleFirstElement;
+  }
+  const partiallyVisibleFirstElement = Array.prototype.find.call(
+    elements,
+    (element) => isInViewport({ element, allowPartialVisibility: true }),
+  );
+  if (partiallyVisibleFirstElement) {
+    return partiallyVisibleFirstElement;
+  }
+  return elements && elements[0];
 }

--- a/app/javascript/shared/components/useListNavigation.js
+++ b/app/javascript/shared/components/useListNavigation.js
@@ -220,20 +220,18 @@ function getPreviousElement(
  * @returns {object} The first visible element
  */
 function getFirstVisibleElement(selector) {
-  const elements = document.querySelectorAll(selector);
-  const completelyVisibleFirstElement = Array.prototype.find.call(
-    elements,
-    (element) => isInViewport({ element }),
+  const elements = [...document.querySelectorAll(selector)];
+  const completelyVisibleFirstElement = elements.find((element) =>
+    isInViewport({ element }),
   );
   if (completelyVisibleFirstElement) {
     return completelyVisibleFirstElement;
   }
-  const partiallyVisibleFirstElement = Array.prototype.find.call(
-    elements,
-    (element) => isInViewport({ element, allowPartialVisibility: true }),
+  const partiallyVisibleFirstElement = elements.find((element) =>
+    isInViewport({ element, allowPartialVisibility: true }),
   );
   if (partiallyVisibleFirstElement) {
     return partiallyVisibleFirstElement;
   }
-  return elements && elements[0];
+  return elements[0];
 }

--- a/app/javascript/utilities/viewport.js
+++ b/app/javascript/utilities/viewport.js
@@ -3,22 +3,45 @@
  *
  * @example
  * const element = document.getElementById('element');
- * isInViewport(element); // true or false
+ * isInViewport({element, allowPartialVisibility = true}); // true or false
  *
  * @param {object} element - The HTML element to check
  * @param {number} [offsetTop=0] - Part of the screen to ignore counting from the top
- *
+ * @param {boolean} [allowPartialVisibility=false] - A boolean to flip the check between partial or completely visible in the viewport
  * @returns {boolean} isInViewport - true if the element is visible in the viewport
  */
-export function isInViewport(element, offsetTop = 0) {
+export function isInViewport({
+  element,
+  offsetTop = 0,
+  allowPartialVisibility = false,
+}) {
   const boundingRect = element.getBoundingClientRect();
   const clientHeight =
     window.innerHeight || document.documentElement.clientHeight;
   const clientWidth = window.innerWidth || document.documentElement.clientWidth;
+  const topIsInViewport =
+    boundingRect.top <= clientHeight && boundingRect.top >= offsetTop;
+  const rightIsInViewport =
+    boundingRect.right >= 0 && boundingRect.right <= clientWidth;
+  const bottomIsInViewport =
+    boundingRect.bottom >= offsetTop && boundingRect.bottom <= clientHeight;
+  const leftIsInViewport =
+    boundingRect.left <= clientWidth && boundingRect.left >= 0;
+  const topIsOutOfViewport = boundingRect.top <= offsetTop;
+  const bottomIsOutOfViewport = boundingRect.bottom >= clientHeight;
+  const elementSpansEntireViewport =
+    topIsOutOfViewport && bottomIsOutOfViewport;
+
+  if (allowPartialVisibility) {
+    return (
+      (topIsInViewport || bottomIsInViewport || elementSpansEntireViewport) &&
+      (leftIsInViewport || rightIsInViewport)
+    );
+  }
   return (
-    boundingRect.top >= offsetTop &&
-    boundingRect.left >= 0 &&
-    boundingRect.bottom <= clientHeight &&
-    boundingRect.right <= clientWidth
+    topIsInViewport &&
+    bottomIsInViewport &&
+    leftIsInViewport &&
+    rightIsInViewport
   );
 }

--- a/app/javascript/utilities/viewport.js
+++ b/app/javascript/utilities/viewport.js
@@ -5,7 +5,7 @@
  * const element = document.getElementById('element');
  * isInViewport({element, allowPartialVisibility = true}); // true or false
  *
- * @param {object} element - The HTML element to check
+ * @param {HTMLElement} element - The HTML element to check
  * @param {number} [offsetTop=0] - Part of the screen to ignore counting from the top
  * @param {boolean} [allowPartialVisibility=false] - A boolean to flip the check between partial or completely visible in the viewport
  * @returns {boolean} isInViewport - true if the element is visible in the viewport


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x]  Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
 The feature was introduced to navigate between articles using the keyboard commands j and k. Previously we were looking for the completely visible first element. There could be cases where we may have partially visible elements, but no completely visible element. 

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/11566

## QA Instructions, Screenshots, Recordings

### To reproduce

* Navigate to /top/infinity
* Make sure your browser's window is not big enough to fit the entire first article
* Try to initialize the article feed navigation (pressing j and k)
* Notice nothing is happening

### Expected behavior

When no article is focused on, the first article that is visible should be focused on.

We might want to have similar behavior to the current one: we look for the first article that is fully visible and then fall back to any that is partially visible if nothing is found. 

### UI accessibility concerns?

It helps improves accessibility by responding to keyboard events to navigate between articles 

## Added tests?

- [ ] Yes
- [ ] No, and this is why:
- [x] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

