### PR TITLE
Move back from after_initialize to explicit call

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -25,8 +25,6 @@ class Profile < ApplicationRecord
   }.with_indifferent_access.freeze
 
   # Generates typed accessors for all currently defined profile fields.
-  # This is also used in config/application.rb to initialize profiles on app
-  # boot in the after_initialize hook.
   def self.refresh_attributes!
     return if ENV["ENV_AVAILABLE"] == "false"
     return unless Database.table_exists?("profiles")
@@ -35,6 +33,10 @@ class Profile < ApplicationRecord
       store_attribute :data, field.attribute_name.to_sym, field.type
     end
   end
+
+  # Set up all profile attributes when this class loads so all store_attribute
+  # accessors get defined immediately.
+  refresh_attributes!
 
   # Returns an array of all currently defined `store_attribute`s on `data`.
   def self.attributes

--- a/config/application.rb
+++ b/config/application.rb
@@ -85,9 +85,6 @@ module PracticalDeveloper
         top_routes << route
       end
       ReservedWords.all = [ReservedWords::BASE_WORDS + top_routes].flatten.compact.uniq
-
-      # Set up all profile attributes when the app starts
-      Profile.refresh_attributes!
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this?

- [X] Refactor

## Description

Context:

1. We somewhat recently [merged a PR](https://github.com/forem/forem/pull/10707) that starts ignoring profile columns on  `User` and delegates them to `Profile` instead. This is supposed to be a temporary workaround so we can take our time to with updating existing app code to not rely on certain profile fields directly. This PR was open for a long time, because it was thoroughly tested by 
2. As part of this PR, @rhymes ]suggested an `after_initialize` hook](https://github.com/forem/forem/pull/10707#discussion_r535016233).
3. I [had my reservations](https://github.com/forem/forem/pull/10707#discussion_r535042360), but then decided to [implement the suggestion anyway](https://github.com/forem/forem/pull/11783).
4. Random bug reports about missing methods started showing up in various places which I found confusing due to the extensive testing mentioned in 1.
5. 

What I believe is happening:

1. The previous solution with an explicit `refresh_attributes!` in `Profile`'s class body made sure all accessors defined via `store_accessor` are available as soon as the class is loaded.
2. I suspect using `after_initialize` for `Profile.refresh_attributes` is too late, since at this point we already loaded `User` which set up delegation to methods that didn't exist yet.
3. I'm not entirely convinced by this explanation, as Ruby's late binding nature usually means things like this work. Here's a small example:
    ```ruby
    class TestProfile; end

   class TestUser
      attr_reader :profile

      def initialize
        @profile = TestProfile.new
      end
     
      delegate :a_method, to: :profile, allow_nil: true
    end

    tu = TestUser.new
    tu.a_method
    #=> NoMethodError: undefined method `a_method' for #<Profile:0x000056071b4fa4c0>

    class TestProfile; def a_method; 42; end ; end
    tu.a_method
    #=> 42
    ```
4. That said, there may be other more subtle effects in play here (classes being cached by Rails, user objects being cached by our application code) that I'm not taking into consideration and I want to eliminate one unknown: the original PR was tested with the explicit `refresh_attributes!` call in `Profile` so I'd prefer moving back to this even if it doesn't solve all our issues as it's also semantically closer to what we want. This isn't a "do this after the app is loaded" scenario, but a "do this while the `Profile` class is loading" one instead.
5. @rhymes' suggestion of using `after_initialize` was absolutely sensible, it was my original comment/explanation that was misleading.

## Related Tickets & Documents

#6994, #11855, https://github.com/forem/InternalProjectPlanning/issues/379

## Added tests?

- [X] No, and this is why:  existing ones should cover this and still be green.

## Added to documentation?

- [X] No documentation needed
