### PR TITLE
Update bust_comment to BustComment

### DIFF
--- a/app/services/users/delete_articles.rb
+++ b/app/services/users/delete_articles.rb
@@ -11,7 +11,7 @@ module Users
         article.buffer_updates.delete_all
         article.comments.includes(:user).find_each do |comment|
           comment.reactions.delete_all
-          cache_buster.bust_comment(comment.commentable)
+          EdgeCache::BustComment.call(comment.commentable)
           cache_buster.bust_user(comment.user)
           comment.remove_from_elasticsearch
           comment.delete

--- a/app/services/users/delete_comments.rb
+++ b/app/services/users/delete_comments.rb
@@ -7,7 +7,7 @@ module Users
 
       user.comments.find_each do |comment|
         comment.reactions.delete_all
-        cache_buster.bust_comment(comment.commentable)
+        EdgeCache::BustComment.call(comment.commentable)
         comment.remove_notifications
         comment.remove_from_elasticsearch
         comment.delete

--- a/spec/services/users/delete_articles_spec.rb
+++ b/spec/services/users/delete_articles_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Users::DeleteArticles, type: :service do
     let(:buster) { double }
 
     before do
-      allow(buster).to receive(:bust_comment)
+      allow(EdgeCache::BustComment).to receive(:call)
       allow(buster).to receive(:bust_article)
       allow(buster).to receive(:bust_user)
 
@@ -48,7 +48,7 @@ RSpec.describe Users::DeleteArticles, type: :service do
 
     it "busts cache" do
       described_class.call(user, buster)
-      expect(buster).to have_received(:bust_comment).with(article).twice
+      expect(EdgeCache::BustComment).to have_received(:call).with(article).twice
       expect(buster).to have_received(:bust_user).with(user2).at_least(:once)
       expect(buster).to have_received(:bust_article).with(article)
     end

--- a/spec/services/users/delete_comments_spec.rb
+++ b/spec/services/users/delete_comments_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Users::DeleteComments, type: :service do
   before do
     create_list(:comment, 2, commentable: article, user: user)
 
-    allow(buster).to receive(:bust_comment)
+    allow(EdgeCache::BustComment).to receive(:call)
     allow(buster).to receive(:bust_user)
   end
 
@@ -30,7 +30,7 @@ RSpec.describe Users::DeleteComments, type: :service do
 
   it "busts cache" do
     described_class.call(user, buster)
-    expect(buster).to have_received(:bust_comment).with(article).at_least(:once)
+    expect(EdgeCache::BustComment).to have_received(:call).with(article).at_least(:once)
     expect(buster).to have_received(:bust_user).with(user)
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This PR updates references for busting comment cache from `CacheBuster` to a new, dedicated service `EdgeCache::BustComment`.

As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method so we can test each piece of cache-busting manually in production after we deploy it. Once all method references are updated, I'll remove the legacy `CacheBuster`. We don't want to remove it preemptively either because there could always be jobs in the queue referencing it. So removing it will be its own PR at the very end when code is no longer referencing it.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Can't really QA this outside of production.


## Are there any post deployment tasks we need to perform?
**Yes** - once this PR deploys, we need to test cache busting. We can do this by posting a comment in production and then updating said comment. If the comment updates and displays correctly as expected without having to hard refresh, that means it should be working correctly.

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![the_office_shocked_gif](https://media.giphy.com/media/D51g1LqVdMF0I/giphy.gif)