### PR TITLE
Fix gitdocs's syntax error

### DIFF
--- a/docs/frontend/readme.md
+++ b/docs/frontend/readme.md
@@ -1,18 +1,17 @@
 ---
-
-title: Frontend Guide items:
-
-- plain-js.md
-- webpacker.md
-- preact.md
-- instant-click.md
-- dynamic-imports.md
-- styles.md
-- linting-formatting.md
-- liquid-tags.md
-- debugging.md
-- tracking.md
-- accessibility.md
-- tips.md
+title: Frontend Guide
+items:
+  - plain-js.md
+  - webpacker.md
+  - preact.md
+  - instant-click.md
+  - dynamic-imports.md
+  - styles.md
+  - linting-formatting.md
+  - liquid-tags.md
+  - debugging.md
+  - tracking.md
+  - accessibility.md
+  - tips.md
 
 # Frontend Guide


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] bug

## Description
This syntax error has broken our doc deployment for roughly a week now.

## Related Tickets & Documents
n/a
## QA Instructions, Screenshots, Recordings
1. cd into `/docs`
1. you should be able to run `make` without issue.

Or you can check to see that all Github's checks on this PR.
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a