### PR TITLE
Make social preview color a color field

### DIFF
--- a/app/views/admin/listing_categories/_form.html.erb
+++ b/app/views/admin/listing_categories/_form.html.erb
@@ -19,8 +19,8 @@
 </div>
 
 <div class="form-group">
-  <%= label_tag :social_preview_color, "Color hex" %>
-  <%= text_field_tag :social_preview_color, @listing_category.social_preview_color, class: "form-control" %>
+  <%= label_tag :social_preview_color, "Social preview color" %>
+  <%= color_field_tag :social_preview_color, @listing_category.social_preview_color, class: "form-control" %>
 </div>
 
 <div class="form-group">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR changes the social preview color in the listings category admin from a text field to an actual color input. It also changes the label from "Color hex" to "Social preview color".

## Related Tickets & Documents

Closes #11898 

## QA Instructions, Screenshots, Recordings

![image](https://user-images.githubusercontent.com/47985/102181471-356d9280-3edd-11eb-83b7-cc14fb21fa47.png)

## Added tests?

- [X] No, and this is why: existing specs should cover this

## Added to documentation?

- [X] No documentation needed

