### PR TITLE
Fix html variant image prefix logic

### DIFF
--- a/app/models/html_variant.rb
+++ b/app/models/html_variant.rb
@@ -75,6 +75,6 @@ class HtmlVariant < ApplicationRecord
   end
 
   def allowed_image_host?(src)
-    src.start_with?("https://res.cloudinary.com/") || src.start_with?("https://#{SiteConfig.app_domain}/")
+    src.start_with?("https://res.cloudinary.com/") || src.start_with?(URL.url)
   end
 end

--- a/app/models/html_variant.rb
+++ b/app/models/html_variant.rb
@@ -75,6 +75,6 @@ class HtmlVariant < ApplicationRecord
   end
 
   def allowed_image_host?(src)
-    src.start_with?("https://res.cloudinary.com/") || src.start_with?(URL.url)
+    src.start_with?("https://res.cloudinary.com/") || src.start_with?(Images::Optimizer.get_imgproxy_endpoint)
   end
 end

--- a/app/models/html_variant.rb
+++ b/app/models/html_variant.rb
@@ -75,6 +75,6 @@ class HtmlVariant < ApplicationRecord
   end
 
   def allowed_image_host?(src)
-    src.start_with?("https://res.cloudinary.com/")
+    src.start_with?("https://res.cloudinary.com/") || src.start_with?("https://#{SiteConfig.app_domain}/")
   end
 end

--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -66,7 +66,7 @@ module Images
         # On other environments, rely on ApplicationConfig for a
         # more flexible configuration
         # ie. default imgproxy endpoint is localhost:8080
-        ApplicationConfig["IMGPROXY_ENDPOINT"]
+        ApplicationConfig["IMGPROXY_ENDPOINT"] || "http://localhost:8080"
       end
     end
   end

--- a/spec/models/html_variant_spec.rb
+++ b/spec/models/html_variant_spec.rb
@@ -57,14 +57,17 @@ RSpec.describe HtmlVariant, type: :model do
   end
 
   it "does not add prefix if it already starts with cloudinary" do
-    html = "<div><img src='https://res.cloudinary.com/image.jpg' /></div>"
+    allow(Images::Optimizer).to receive(:call)
+    html = %(<img src="https://res.cloudinary.com/image.jpg">)
     html_variant.update(approved: false, html: html)
-    expect(html_variant.html).to include("https://res.cloudinary.com/image.jpg")
+    expect(Images::Optimizer).not_to have_received(:call)
   end
 
   it "does not add prefix if already on site root" do
-    html = "<div><img src='https://#{SiteConfig.app_domain}/image.jpg' /></div>"
+    allow(Images::Optimizer).to receive(:call)
+    html = "<img src=\"#{Images::Optimizer.get_imgproxy_endpoint}/image.jpg\">"
     html_variant.update(approved: false, html: html)
-    expect(html_variant.html).to include("https://#{SiteConfig.app_domain}/image.jpg")
+    html_variant.save
+    expect(Images::Optimizer).not_to have_received(:call)
   end
 end

--- a/spec/models/html_variant_spec.rb
+++ b/spec/models/html_variant_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe HtmlVariant, type: :model do
     expect(html_variant.html).to include(cloudinary_string)
   end
 
-  it "does not add prefix if cloudinary already start" do
+  it "does not add prefix if it already starts with cloudinary" do
     html = "<div><img src='https://res.cloudinary.com/image.jpg' /></div>"
     html_variant.update(approved: false, html: html)
     expect(html_variant.html).to include("https://res.cloudinary.com/image.jpg")

--- a/spec/models/html_variant_spec.rb
+++ b/spec/models/html_variant_spec.rb
@@ -55,4 +55,16 @@ RSpec.describe HtmlVariant, type: :model do
     cloudinary_string = "/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_420/https://devimages.com/image.jpg"
     expect(html_variant.html).to include(cloudinary_string)
   end
+
+  it "does not add prefix if cloudinary already start" do
+    html = "<div><img src='https://res.cloudinary.com/image.jpg' /></div>"
+    html_variant.update(approved: false, html: html)
+    expect(html_variant.html).to include("https://res.cloudinary.com/image.jpg")
+  end
+
+  it "does not add prefix if already on site root" do
+    html = "<div><img src='https://#{SiteConfig.app_domain}/image.jpg' /></div>"
+    html_variant.update(approved: false, html: html)
+    expect(html_variant.html).to include("https://#{SiteConfig.app_domain}/image.jpg")
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The current naive prefix logic for images here was only accounting for the cloudinary version. This modifies the logic such that it will also work for the imgproxy way.

Currently if an admin edits this file, they'll keep adding prefixes to infinity. This should aolve the issue.

This is a simple hotfix, but added regression test to ensure things are imrpved for the cases we care about.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
