### PR TITLE
Update bust_article to BustArticle

### DIFF
--- a/app/controllers/admin/tools_controller.rb
+++ b/app/controllers/admin/tools_controller.rb
@@ -36,7 +36,7 @@ module Admin
     def handle_article_cache
       article = Article.find(params[:bust_article].to_i)
       article.touch(:last_commented_at)
-      CacheBuster.bust_article(article)
+      EdgeCache::BustArticle.call(article)
     end
 
     def bust_link(link)

--- a/app/services/users/delete_articles.rb
+++ b/app/services/users/delete_articles.rb
@@ -21,7 +21,7 @@ module Users
         article.purge
       end
       virtual_articles.each do |article|
-        cache_buster.bust_article(article)
+        EdgeCache::BustArticle.call(article)
       end
     end
   end

--- a/app/workers/articles/bust_cache_worker.rb
+++ b/app/workers/articles/bust_cache_worker.rb
@@ -1,9 +1,11 @@
 module Articles
   class BustCacheWorker < BustCacheBaseWorker
-    def perform(article_id, cache_buster = "CacheBuster")
+    def perform(article_id)
       article = Article.find_by(id: article_id)
 
-      cache_buster.constantize.bust_article(article) if article
+      return unless article
+
+      EdgeCache::BustArticle.call(article)
     end
   end
 end

--- a/spec/services/users/delete_articles_spec.rb
+++ b/spec/services/users/delete_articles_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Users::DeleteArticles, type: :service do
 
     before do
       allow(EdgeCache::BustComment).to receive(:call)
-      allow(buster).to receive(:bust_article)
+      allow(EdgeCache::BustArticle).to receive(:call)
       allow(buster).to receive(:bust_user)
 
       create_list(:comment, 2, commentable: article, user: user2)
@@ -50,7 +50,7 @@ RSpec.describe Users::DeleteArticles, type: :service do
       described_class.call(user, buster)
       expect(EdgeCache::BustComment).to have_received(:call).with(article).twice
       expect(buster).to have_received(:bust_user).with(user2).at_least(:once)
-      expect(buster).to have_received(:bust_article).with(article)
+      expect(EdgeCache::BustArticle).to have_received(:call).with(article)
     end
 
     it "removes comments from Elasticsearch", :aggregate_failures do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This PR updates references for busting article cache from `CacheBuster` to a new, dedicated service `EdgeCache::BustArticle`.

As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method so we can test each piece of cache-busting manually in production after we deploy it. Once all method references are updated, I'll remove the legacy `CacheBuster`. We don't want to remove it preemptively either because there could always be jobs in the queue referencing it. So removing it will be its own PR at the very end when code is no longer referencing it.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Can't really QA this outside of production.


## Are there any post deployment tasks we need to perform?
**Yes** - once this PR deploys, we need to test cache-busting. We can do this by posting an article in production and then updating the said article. If the article updates and displays correctly as expected without having to hard refresh, that means it should be working correctly.

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![goat_slowly_but_surely_gif](https://media.giphy.com/media/Y3G8Mgonb9eIQn8z1A/giphy.gif)