### PR TITLE
Remove GitHub repositories when GitHub identity is removed

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -133,6 +133,11 @@ class UsersController < ApplicationController
         :profile_updated_at => Time.current,
       )
 
+      # GitHub repositories are tied with the existence of the GitHub identity
+      # as we use the user's GitHub token to fetch them from the API.
+      # We should delete them when a user unlinks their GitHub account.
+      @user.github_repos.destroy_all if provider.provider_name == :github
+
       flash[:settings_notice] = "Your #{provider.official_name} account was successfully removed."
     else
       flash[:error] = error_message

--- a/app/views/users/_integrations_github_repositories.html.erb
+++ b/app/views/users/_integrations_github_repositories.html.erb
@@ -5,7 +5,10 @@
         GitHub
       </h2>
       <p class="color-base-70">
-        Pin your GitHub repositories to your profile
+        Pin your GitHub repositories to your profile.
+      </p>
+      <p class="color-base-70">
+        <em>Repositories will be disappear from your profile if you remove the OAuth association with GitHub.</em>
       </p>
     </header>
 

--- a/lib/data_update_scripts/20201217162454_cleanup_orphan_git_hub_repositories.rb
+++ b/lib/data_update_scripts/20201217162454_cleanup_orphan_git_hub_repositories.rb
@@ -1,0 +1,22 @@
+module DataUpdateScripts
+  class CleanupOrphanGitHubRepositories
+    def run
+      # load orphan GithubRepo ids
+      rows = ActiveRecord::Base.connection.execute(
+        <<-SQL,
+          SELECT id FROM github_repos
+          WHERE user_id NOT IN (
+            SELECT users.id FROM users
+            JOIN identities ON users.id = identities.user_id
+            WHERE provider = 'github'
+          )
+        SQL
+      )
+
+      github_repos_ids = rows.map { |row| row["id"] }
+
+      # load them in batches and delete them from AR so that we can trigger the after_destroy callbacks
+      GithubRepo.where(id: github_repos_ids).find_each(&:destroy)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/cleanup_orphan_git_hub_repositories_spec.rb
+++ b/spec/lib/data_update_scripts/cleanup_orphan_git_hub_repositories_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20201217162454_cleanup_orphan_git_hub_repositories.rb",
+)
+
+describe DataUpdateScripts::CleanupOrphanGitHubRepositories do
+  let(:user) { create(:user, :with_identity, identities: [:github]) }
+
+  before do
+    omniauth_mock_providers_payload
+    create(:github_repo, user: user)
+  end
+
+  it "does not delete a repository if the user has a GitHub identity" do
+    expect do
+      described_class.new.run
+    end.not_to change(user.github_repos, :count)
+  end
+
+  it "deletes a repository if the user does not have a GitHub identity" do
+    github_identity = user.identities.github.first
+    github_identity.destroy
+
+    expect do
+      described_class.new.run
+    end.to change(user.github_repos, :count).by(-user.github_repos.size)
+  end
+end

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -138,16 +138,53 @@ RSpec.describe "admin/users", type: :request do
   end
 
   describe "DELETE /admin/users/:id/remove_identity" do
+    let(:provider) { Authentication::Providers.available.first }
+    let(:user) do
+      omniauth_mock_providers_payload
+      create(:user, :with_identity)
+    end
+
+    before do
+      omniauth_mock_providers_payload
+      allow(SiteConfig).to receive(:authentication_providers).and_return(Authentication::Providers.available)
+    end
+
     it "removes the given identity" do
       identity = user.identities.first
-      delete "/admin/users/#{user.id}/remove_identity", params: { user: { identity_id: identity.id } }
-      expect { identity.reload }.to raise_error ActiveRecord::RecordNotFound
+
+      delete remove_identity_admin_user_path(user.id), params: { user: { identity_id: identity.id } }
+
+      expect { identity.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "updates their social account's username to nil" do
       identity = user.identities.first
-      delete "/admin/users/#{user.id}/remove_identity", params: { user: { identity_id: identity.id } }
-      expect(user.reload.github_username).to eq nil
+
+      delete remove_identity_admin_user_path(user.id), params: { user: { identity_id: identity.id } }
+
+      expect(user.public_send("#{identity.provider}_username")).to be(nil)
+    end
+
+    it "does not remove GitHub repositories if the removed identity is not GitHub" do
+      create(:github_repo, user: user)
+
+      identity = user.identities.twitter.first
+
+      expect do
+        delete remove_identity_admin_user_path(user.id), params: { user: { identity_id: identity.id } }
+      end.not_to change(user.github_repos, :count)
+    end
+
+    it "removes GitHub repositories if the removed identity is GitHub" do
+      repo = create(:github_repo, user: user)
+
+      identity = user.identities.github.first
+
+      expect do
+        delete remove_identity_admin_user_path(user.id), params: { user: { identity_id: identity.id } }
+      end.to change(user.github_repos, :count).by(-1)
+
+      expect(GithubRepo.exists?(id: repo.id)).to be(false)
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently we need and use the GitHub user's token to fetch GitHub repositories for a user's profile. 
If they unlink their GitHub identity from Forem, the repositories remain but the user can't remove them. In addition, the server will keep not keep them updated because the authentication key has been deleted.

Now, if a user severes the connection between Forem and GitHub, their repositories will be removed as well.

I also added a data update script to remove existing orphan repositories in the `github_repos` table.

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/11918

## QA Instructions, Screenshots, Recordings

1. open the admin and enable GitHub authentication at localhost:3000/admin/config or load the console and add both `:github` and `:twitter` to the `SiteConfig.available_providers` array (you also need to configure the global authentication keys in the `.env` file)
2. sign in with GitHub
3. connect Twitter as well from http://localhost:3000/settings/account
3. go to http://localhost:3000/settings/extensions and pin one or more repositories
4. go to your profile and make sure they are there
5. go to http://localhost:3000/settings/account and remove the GitHub identity
6. make sure your profile doesn't show GitHub repositories anymore

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed
