### PR TITLE
Update bust_tag to EdgeCache::BustTag

### DIFF
--- a/app/workers/tags/bust_cache_worker.rb
+++ b/app/workers/tags/bust_cache_worker.rb
@@ -4,7 +4,7 @@ module Tags
       tag = Tag.find_by(name: tag_name)
       return unless tag
 
-      CacheBuster.bust_tag(tag)
+      EdgeCache::BustTag.call(tag)
     end
   end
 end

--- a/spec/workers/tags/bust_cache_worker_spec.rb
+++ b/spec/workers/tags/bust_cache_worker_spec.rb
@@ -3,26 +3,26 @@ require "rails_helper"
 RSpec.describe Tags::BustCacheWorker, type: :worker do
   let(:worker) { subject }
 
-  before { allow(CacheBuster).to receive(:bust_tag) }
-
   # Passing in random tag
   include_examples "#enqueues_on_correct_queue", "high_priority", ["php"]
 
   describe "#perform_now" do
     it "busts cache" do
       tag = create(:tag)
+      allow(EdgeCache::BustTag).to receive(:call).with(tag)
 
       worker.perform(tag.name)
 
-      expect(CacheBuster).to have_received(:bust_tag).with(tag)
+      expect(EdgeCache::BustTag).to have_received(:call).with(tag)
     end
 
     it "doesn't call the cache buster if the tag does not exist" do
+      allow(EdgeCache::BustTag).to receive(:call)
       tag_name = "definitelyatagthatdoesnotexist"
 
       worker.perform(tag_name)
 
-      expect(CacheBuster).not_to have_received(:bust_tag)
+      expect(EdgeCache::BustTag).not_to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This PR updates references for busting tag cache from `CacheBuster` to a new, dedicated service `EdgeCache::BustTag`.

As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method so we can test each piece of cache-busting manually in production after we deploy it. Once all method references are updated, I'll remove the legacy `CacheBuster`. We don't want to remove it preemptively either because there could always be jobs in the queue referencing it. So removing it will be its own PR at the very end when code is no longer referencing it.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Can't really QA this outside of production.

## Are there any post deployment tasks we need to perform?
**Yes** - once this PR deploys, we need to test cache-busting. We can do this by creating a tag in production and then updating the said tag. If the tag updates and displays correctly as expected without having to hard refresh, that means it should be working correctly.

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![goat_slowly_but_surely_gif](https://media.giphy.com/media/Y3G8Mgonb9eIQn8z1A/giphy.gif)