### PR TITLE
Update bust_events to EdgeCache::BustEvents

### DIFF
--- a/app/workers/events/bust_cache_worker.rb
+++ b/app/workers/events/bust_cache_worker.rb
@@ -3,7 +3,7 @@ module Events
     sidekiq_options queue: :low_priority
 
     def perform
-      CacheBuster.bust_events
+      EdgeCache::BustEvents.call
     end
   end
 end

--- a/spec/workers/events/bust_cache_worker_spec.rb
+++ b/spec/workers/events/bust_cache_worker_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe Events::BustCacheWorker do
 
   describe "#perform" do
     it "busts cache" do
-      allow(CacheBuster).to receive(:bust_events)
+      allow(EdgeCache::BustEvents).to receive(:call)
       described_class.new.perform
-      expect(CacheBuster).to have_received(:bust_events)
+      expect(EdgeCache::BustEvents).to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This PR updates references for busting events cache from `CacheBuster` to a new, dedicated service `EdgeCache::BustEvents`.

As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method so we can test each piece of cache-busting manually in production after we deploy it. Once all method references are updated, I'll remove the legacy `CacheBuster`. We don't want to remove it preemptively either because there could always be jobs in the queue referencing it. So removing it will be its own PR at the very end when code is no longer referencing it.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Can't really QA this outside of production.

## Are there any post deployment tasks we need to perform?
**Yes** - once this PR deploys, we need to test cache-busting. We can do this by creating an event in production and then updating the said event. If the event updates and displays correctly as expected without having to hard refresh, that means it should be working correctly.

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![goat_slowly_but_surely_gif](https://media.giphy.com/media/Y3G8Mgonb9eIQn8z1A/giphy.gif)