### PR TITLE
Add missing default social image (and remove DEV version) from /pod and /events

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -9,9 +9,11 @@
   <meta property="og:title" content="<%= community_name %> Events" />
   <meta property="og:description" content="Community events." />
   <meta property="og:site_name" content="<%= community_qualified_name %>" />
+  <meta property="og:image" content="<%= SiteConfig.main_social_image %>">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@<%= SiteConfig.social_media_handles["twitter"] %>">
   <meta name="twitter:title" content="<%= community_name %> Events">
+  <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
 <% end %>
 
 <script type="text/javascript" src="https://addevent.com/libs/atc/1.6.1/atc.min.js" async defer></script>

--- a/app/views/podcast_episodes/_meta.html.erb
+++ b/app/views/podcast_episodes/_meta.html.erb
@@ -9,7 +9,7 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="<%= app_url(@podcast.slug) %>" />
     <meta property="og:title" content="<%= @podcast.title %>" />
-    <meta property="og:image" content="https://res.cloudinary.com/practicaldev/image/fetch/c_scale,h_300,w_300,r_max/u_listennow_kjml1x,y_45/<%= optimized_image_url(@podcast.image_url, width: 300) %>">
+    <meta property="og:image" content="<%= SiteConfig.main_social_image %>">
 
     <meta property="og:description" content="<%= @podcast.description %>" />
     <meta property="og:site_name" content="<%= community_qualified_name %>" />
@@ -19,7 +19,7 @@
     <meta name="twitter:creator" content="@<%= @podcast.twitter_username %>">
     <meta name="twitter:title" content="<%= @podcast.title %>">
     <meta name="twitter:description" content="<%= @podcast.description %>" />
-    <meta name="twitter:image:src" content="https://res.cloudinary.com/practicaldev/image/fetch/c_scale,h_300,w_300,r_max/u_listennow_kjml1x,y_45/<%= optimized_image_url(@podcast.image_url, width: 300) %>">
+    <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
   <% end %>
 <% else %>
   <% title "Podcasts" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes the issue where there is an outdated DEV social image for `/pod` and `/events`... These are both secondary pages on the site and given current patterns, using the default social image makes sense.

Closes https://github.com/forem/forem/issues/11708