### PR TITLE
Fix the way we check for AndroidBridge global

### DIFF
--- a/app/assets/javascripts/initializers/runtime.js
+++ b/app/assets/javascripts/initializers/runtime.js
@@ -41,7 +41,7 @@ class Runtime {
   static isNativeAndroid(namespace = null) {
     const nativeCheck =
       /DEV-Native-android|ForemWebView/i.test(navigator.userAgent) &&
-      typeof AndroidBridge === 'function';
+      typeof AndroidBridge !== 'undefined';
 
     let namespaceCheck = true;
     if (nativeCheck && namespace) {

--- a/app/assets/javascripts/initializers/runtime.js
+++ b/app/assets/javascripts/initializers/runtime.js
@@ -41,7 +41,7 @@ class Runtime {
   static isNativeAndroid(namespace = null) {
     const nativeCheck =
       /DEV-Native-android|ForemWebView/i.test(navigator.userAgent) &&
-      AndroidBridge != undefined;
+      typeof AndroidBridge === 'function';
 
     let namespaceCheck = true;
     if (nativeCheck && namespace) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Turns out that when using the `ForemWebView` user agent the `AndroidBridge != undefined` check is raising an exception. It didn't appear before because the user agent check now is shared by both Android and iOS, causing the exception to be raised (because `AndroidBridge` is not defined in the iOS ForemWebView context).

This PR changes the check for this global so it works well on all platforms

## QA Instructions, Screenshots, Recordings

Open your local environment and try to click on the ellipses (three dots) on any Article. It should open the modal/pop-up with the options to share the article (meaning that it doesn't break).

If you try out in Dev Tools console run these two lines:

```js
// Will likely raise an exception
AndroidBridge != undefined;

// Should return `false` unless AndroidBridge global is available
typeof AndroidBridge === 'function';
```

If you have an iPhone/iPad running on iOS:
1. Install the DEV app from the App Store
2. Open any Article and try to click on the ellipses (three dots) option to share
3. It fails for me. This PR fixes the problem

### UI accessibility concerns?

None. This will fix a UI feature in iOS

## Added tests?

- [ ] Yes
- [x] No, and this is why: This only happens in clients using `ForemWebView` user agent. There may be a way to test this using Cypress but it feels a little too early for implementing those e2e tests right now. I'm open for ideas to approach testing this and other mobile situations
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![uuummmm](https://media.giphy.com/media/9JwWxcR0SUSC195IWL/giphy.gif)
