### PR TITLE
Remove collective_noun and collective_noun_disabled from the Config

### DIFF
--- a/lib/data_update_scripts/20201218173445_remove_collective_noun_from_config.rb
+++ b/lib/data_update_scripts/20201218173445_remove_collective_noun_from_config.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class RemoveCollectiveNounFromConfig
+    def run
+      SiteConfig.where(var: %w[collective_noun collective_noun_disabled]).destroy_all
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR contains a `data_update` script that removes `collective_noun` and `collective_noun_disabled` from the SiteConfig.

## Related Tickets & Documents
Relates to PR #11846 

## QA Instructions, Screenshots, Recordings
Ensure that all of the checks pass! ♻️ Additionally, you can run the `data_update` script manually to ensure that upon running it, `collective_noun` and `collective_noun_disabled` are deleted.

### UI accessibility concerns?
N/A

## Added tests?

- [ ] Yes
- [x] No, and this is why: my previous PR, #11846 , includes the necessary tests for changes related to the removal of `collective_noun` and `collective_noun_disabled`
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [ ] No documentation needed
- [x] I have removed the "Collective Noun" section from the Admin Guide and have added some further details to the "Community Name" section, but have not yet merged the changes. To view these changes and suggest edits, please take a look at my proposed changes: https://app.gitbook.com/@forem/s/forem-admin-guide/~/drafts/-MOr2aA_SCj61eSjxPLG/admin/config/community-content

## [optional] Are there any post-deployment tasks we need to perform?
We will need to ensure that this `data_update` script runs!

## [optional] What gif best describes this PR or how it makes you feel?

![Beyonce Single Ladies Waving Bye](https://media.giphy.com/media/cIVHCtsVJX7gJGQJpa/giphy.gif)
