### PR TITLE
Declare winner in update points worker

### DIFF
--- a/app/workers/follows/update_points_worker.rb
+++ b/app/workers/follows/update_points_worker.rb
@@ -35,7 +35,7 @@ module Follows
       tags = articles.pluck(:cached_tag_list).compact.flat_map { |list| list.split(", ") }
       occurrences = tags.count(tag.name)
       bonus = inverse_popularity_bonus(tag)
-      finalized_points(occurrences, bonus, user)
+      finalized_points(occurrences, bonus)
     end
 
     def adjust_other_tag_follows_of_user(user_id)
@@ -64,7 +64,7 @@ module Follows
       top_100_tag_names.index(tag.name) || (top_100_tag_names.size * 1.5)
     end
 
-    def finalized_points(occurrences, bonus, user)
+    def finalized_points(occurrences, bonus)
       Math.log(occurrences + bonus + 1) # + 1 in all cases is to avoid log(0) => -infinity
     end
 

--- a/app/workers/follows/update_points_worker.rb
+++ b/app/workers/follows/update_points_worker.rb
@@ -65,21 +65,7 @@ module Follows
     end
 
     def finalized_points(occurrences, bonus, user)
-      test_variant = field_test(:follow_implicit_points, participant: user)
-      case test_variant
-      when "no_implicit_score"
-        0
-      when "half_weight_after_log"
-        Math.log(occurrences + bonus + 1) * 0.5
-      when "double_weight_after_log"
-        Math.log(occurrences + bonus + 1) * 2.0
-      when "double_bonus_before_log"
-        Math.log(occurrences + (bonus * 2) + 1)
-      when "without_weighting_bonus"
-        Math.log(occurrences + 1)
-      else # base - Our current "default" implementation
-        Math.log(occurrences + bonus + 1) # + 1 in all cases is to avoid log(0) => -infinity
-      end
+      Math.log(occurrences + bonus + 1) # + 1 in all cases is to avoid log(0) => -infinity
     end
 
     def cached_app_wide_top_tag_names

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -1,9 +1,22 @@
 experiments:
   follow_implicit_points: # Points given for implicit tag weights
-    # Implemented here: app/workers/follows/update_points_worker.rb
+    # TEST FINISHED
     # Hypotheses: Weighting tags based on implied preference will lead
     # to more repeat engagement.
     # Recommended duration: 4 weeks (ending at start of January)
+
+    # OUTCOME:
+    # It was observed that "base" has been consistently ahead in comments and
+    # "four hours of article reads in day" by 10% to 20% over no_implicit_score
+    # but over time this began regressing towards the mean and seeming more random.
+    # In inspecting the ways we are measuring goals here, anything with a low barrier
+    # will eventually be reached (aka leave one reaction) by most users, so over time
+    # these goals demonstrate less value.
+    # So this test is being cut off on the observation of a clear winner early on
+    # with the note that we need tests which can map better to the duration of the test.
+
+    # This experiment is no longer running in production, but can remain configured here
+    # while there are no other experiments running.
     variants:
       - base
       - no_implicit_score

--- a/spec/workers/follows/update_points_worker_spec.rb
+++ b/spec/workers/follows/update_points_worker_spec.rb
@@ -82,36 +82,5 @@ RSpec.describe Follows::UpdatePointsWorker, type: :worker do
 
       expect(follow.reload.points).to be > original_points # should be higher because tag is now less popular
     end
-
-    context "with field tests in place" do
-      # regressions testing a few field test scenarios
-      it "returns zero if no_implicit_score field test" do
-        create(:field_test_membership,
-               experiment: :follow_implicit_points, variant: "no_implicit_score", participant_id: user.id)
-        follow = Follow.last
-        follow.update_column(:explicit_points, 2.2)
-        worker.perform(reaction.reactable_id, reaction.user_id)
-        follow.reload
-        expect(follow.implicit_points).to eq 0
-      end
-
-      it "returns double if double_weight_after_log field test" do
-        create(:field_test_membership,
-               experiment: :follow_implicit_points, variant: "double_weight_after_log", participant_id: user.id)
-        follow = Follow.last
-        worker.perform(reaction.reactable_id, reaction.user_id)
-        follow.reload
-        expect(follow.implicit_points).to be_within(0.9).of(2)
-      end
-
-      it "returns double if half_weight_after_log field test" do
-        create(:field_test_membership,
-               experiment: :follow_implicit_points, variant: "half_weight_after_log", participant_id: user.id)
-        follow = Follow.last
-        worker.perform(reaction.reactable_id, reaction.user_id)
-        follow.reload
-        expect(follow.implicit_points).to be_within(0.7).of(0.5)
-      end
-    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

In this PR https://github.com/forem/forem/pull/11675 we added a/b tests to see if any variant was a clear winner.

The results right now don't really show a clear winner (https://dev.to/abtests) however, I believe that there is a clear winner, but that this test was set up with a few flaws.

About a week into the test, "base" (which is the original _new_ feature) _was_ the clear winner across almost all the tests. It was winning by 10% to 20%.... But as the test has gone on, the results have become closer and seemed random. In inspecting the essence of what we are testing for to see success, this is just not a test that is built to run as long as this one.

Because our success metrics deem success if someone reaches some of these criteria _just once_ results become a little too random over time. If we want to measure success over a 4 week span, we need something that is a little more likely to differentiate than these one-off successes.

Based on logging in to observe every day since we started this, it's clear to me that "base" is the winner, and that the way the results have become more close over time is a symptom of the way the test was set up.

All else equal we want to finish tests when we can in order to reduce extra code paths, and this is a good time to do so.

I believe this test showed "base" to be successful, even if the parameters of the test lasting 4 weeks didn't really align with the way we were measuring.

Because we basically modify and re-use field test classes when setting up tests, I think we can keep the current classes around and change them for the next test. (I have another test in mind already)

<img width="689" alt="Screen Shot 2020-12-20 at 5 47 23 PM" src="https://user-images.githubusercontent.com/3102842/102726277-71449580-42eb-11eb-9744-9b9696597055.png">

PR https://github.com/forem/forem/pull/11982 will remove the remnants of this current test in part of a refactor of the overall functionality for better re-use.

## Added tests?

- [x] Yes - removed tests actually.
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

Once we remove this test I will create a blog post to sum up these findings.
