### PR TITLE
Reenable End to End Testing... Again 😄

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,12 +69,12 @@ script:
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "1" ]; then bundle exec bundle-audit check --update --ignore CVE-2015-9284; fi
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "1" ]; then yarn build-storybook; fi
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "2" ]; then bin/test-console-check; fi
-  # - export FOREM_OWNER_SECRET="secret"
-  # - yarn e2e:ci
-  # # Dropping and recreating the database for Capybara/rspecs
-  # - bundle exec rails db:drop
-  # - bundle exec rails db:create
-  # - bundle exec rails db:schema:load
+  - export FOREM_OWNER_SECRET="secret"
+  - yarn e2e:ci
+  # Dropping and recreating the database for Capybara/rspecs
+  - bundle exec rails db:drop
+  - bundle exec rails db:create
+  - bundle exec rails db:schema:load
   - 'bin/knapsack_pro_rspec'
   - '[ ! -f .approvals ] || bundle exec approvals verify --ask false'
 after_script:

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,9 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
+  # See https://github.com/rails/rails/issues/40613#issuecomment-727283155
+  config.action_view.cache_template_loading = true
+
   # NOTE: [Rails 6] this is the default store in testing,
   # as we haven't enabled Rails 6.0 defaults in config/application.rb,
   # we need to keep this explicit, for now


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I've rerun the build 4 times for this PR and it's passed every time. I also created a forked branch PR as I noticed @Ridhwana's PR that ran into e2e issues was from a forked repo. I reran the build 4 times on #11978, and everytime it passed.

This potentially appears to be a rails 6 issue when `RAILS_ENV=test`. See https://github.com/rails/rails/issues/40613.

We have the following set in config/environments/test.rb

```
  # The test environment is used exclusively to run your application's
  # test suite. You never need to work with it otherwise. Remember that
  # your test database is "scratch space" for the test suite and is wiped
  # and recreated between test runs. Don't rely on the data there!
  config.cache_classes = true
```

When `config.cache_classes = true` is set to true, apparently it will implicitly set `config.action_view.cache_template_loading` to true as well. The above mentioned Rails issue talks about that and also references [3.10 Configuring Action View](https://guides.rubyonrails.org/configuring.html#configuring-action-view) from the Rails documentation.

Having said that, the issue references a Rails 4.2 spec for testing this and I came across the [same tests in master](https://github.com/rails/rails/blob/master/railties/test/application/configuration_test.rb#L1251-L1291) for the Rails repository and the similar tests only seem to test for this when in development mode which is why I have explicitly set `config.action_view.cache_template_loading = true` for test.rb.

I don't know if this is the actual fix as I do not have enough Rails experience, but it does appear to fix the issue in the CI/CD pipeline.

## Related Tickets & Documents

- #11978
- #382
- https://github.com/rails/rails/issues/40613

## QA Instructions, Screenshots, Recordings

N/A

### UI accessibility concerns?

N/A

## Added tests?

- [ ] Yes
- [x] No, and this is why: This is test infrastructure
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Johnny Rose from Shitt's Creek saying "Possibly"](https://media.giphy.com/media/kEoOCToX1VeJWDCPSk/giphy-downsized-large.gif)
