### PR TITLE
Improve date/time picker on admin/events/new

### DIFF
--- a/app/views/admin/events/_event_form.html.erb
+++ b/app/views/admin/events/_event_form.html.erb
@@ -23,11 +23,15 @@
     </div>
     <div class="crayons-field">
       <%= f.label :starts_at, class: "crayons-field__label" %>
+      <fieldset>
       <%= f.datetime_select :starts_at, required: true, include_blank: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "crayons-select" %> UTC Time Only (4 hours ahead of eastern time)
+      </fieldset>
     </div>
     <div class="crayons-field">
       <%= f.label :ends_at, class: "crayons-field__label" %>
+      <fieldset>
       <%= f.datetime_select :ends_at, required: true, include_blank: true, start_year: Time.current.year, end_year: Time.current.year + 2, class: "crayons-select" %> UTC Time Only (4 hours ahead of eastern time)
+      </fieldset>
     </div>
     <div class="crayons-field">
       <%= f.label :location_name, class: "crayons-field__label" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change makes the date-time picker significantly nicer.

The `datetime_select` elements are now placed within `fieldset` elements, this means the `fieldset` element is the child element in the flexbox column used by `crayons-field` rather than each `select` element.

There may be some additional padding needed on some of the elements.

## Related Tickets & Documents

Closes #11392 

## QA Instructions, Screenshots, Recordings

![2020-12-18 21 31 48 localhost 71d785e654ea](https://user-images.githubusercontent.com/26224873/102663307-7c2ae900-4178-11eb-9bd1-33d65e2629dc.png)


### UI accessibility concerns?

There is an issue: Select elements should have an accessible name. 

![2020-12-18 21 34 33 localhost e1b10e93b9f5](https://user-images.githubusercontent.com/26224873/102663473-d75cdb80-4178-11eb-8d4d-6f36ff4ed93e.png)

I think this an issue with the `datetime_select` component not being accessible out of the box, this is also to be found on other pages, e.g. `admin/sponsorships/:id/edit`. This should probably be dealt with as a separate issue.

## Added tests?

- [ ] Yes
- [x] No, I have visually inspected the change and run the Axe accessibility tool, see above.
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed


