### PR TITLE
Fix API's broken organization image

### DIFF
--- a/app/controllers/api/v0/organizations_controller.rb
+++ b/app/controllers/api/v0/organizations_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :find_organization, only: %i[users listings]
 
       SHOW_ATTRIBUTES_FOR_SERIALIZATION = %i[
-        username name summary twitter_username github_username url
+        id username name summary twitter_username github_username url
         location created_at profile_image tech_stack tag_line story
       ].freeze
       private_constant :SHOW_ATTRIBUTES_FOR_SERIALIZATION

--- a/spec/requests/api/v0/organizations_spec.rb
+++ b/spec/requests/api/v0/organizations_spec.rb
@@ -13,16 +13,19 @@ RSpec.describe "Api::V0::Organizations", type: :request do
       get api_organization_path(organization.username)
 
       response_organization = response.parsed_body
-
-      expect(response_organization["type_of"]).to eq("organization")
+      expect(response_organization).to include(
+        {
+          "profile_image" => organization.profile_image_url,
+          "type_of" => "organization",
+          "joined_at" => organization.created_at.utc.iso8601
+        },
+      )
 
       %w[
         username name summary twitter_username github_username url location tech_stack tag_line story
       ].each do |attr|
         expect(response_organization[attr]).to eq(organization.public_send(attr))
       end
-
-      expect(response_organization["joined_at"]).to eq(organization.created_at.utc.iso8601)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Missing `id` in the organization API controller `SHOW_ATTRIBUTES_FOR_SERIALIZATION` prevented Carrierwave from being able to generate the proper image route. 

## Related Tickets & Documents
Resolves https://github.com/forem/forem/issues/11937

## QA Instructions, Screenshots, Recordings
The test should sufficiently provide that it's working but to manually see that it's working,
1. Pull down this PR and start up the Rails server.
2. Obtain an organization's name. An easy way to do that is to run `Organization.first.path` in Rails' console.
3. Access that organization via the API, ie  `http://localhost:3000/api/organizations/the-org-of-your-choice`
4. You should see a profile image URL listed. Prepend `localhost:3000` to it and it should provide you a proper image.

### UI accessibility concerns?
n/a

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
