### PR TITLE
Add rel noopener to footer links

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -20,9 +20,9 @@
     <p class="fs-s crayons-footer__description"><a href="/" aria-label="<%= community_name %> Home" class="crayons-link"><%= community_qualified_name %></a> – <%= SiteConfig.community_description %></p>
     <div class="m:-mb-4 crayons-footer__description">
       <%# The following copy is necessary for compatability with the Forem AGPL licence which requires instances to link back to the source. %>
-      <p class="fs-s">Built on <a href="https://www.forem.com" class="crayons-link" target="_blank">Forem</a> — the <a href="https://dev.to/t/opensource" class="crayons-link">open source</a> software that powers <a href="https://dev.to" class="crayons-link">DEV</a> and other inclusive communities.</p>
-      <p class="fs-s">Made with love and <a href="https://dev.to/t/rails" class="crayons-link">Ruby on Rails</a>. <%= community_qualified_name %> <span title="copyright">&copy;</span> <%= copyright_notice %>.</p>
-      <div><a href="https://www.forem.com" target="_blank" class="inline-block mt-4"><%= inline_svg_tag("logo-forem.svg", aria: true, class: "crayons-icon crayons-icon--default", title: "Forem logo") %></a></div>
+      <p class="fs-s">Built on <a href="https://www.forem.com" class="crayons-link" target="_blank" rel="noopener">Forem</a> — the <a href="https://dev.to/t/opensource" target="_blank" rel="noopener" class="crayons-link">open source</a> software that powers <a href="https://dev.to" target="_blank" rel="noopener" class="crayons-link">DEV</a> and other inclusive communities.</p>
+      <p class="fs-s">Made with love and <a href="https://dev.to/t/rails" target="_blank" rel="noopener" class="crayons-link">Ruby on Rails</a>. <%= community_qualified_name %> <span title="copyright">&copy;</span> <%= copyright_notice %>.</p>
+      <div><a href="https://www.forem.com" target="_blank" rel="noopener" class="inline-block mt-4"><%= inline_svg_tag("logo-forem.svg", aria: true, class: "crayons-icon crayons-icon--default", title: "Forem logo") %></a></div>
     </div>
   </div>
   <% if SiteConfig.mascot_footer_image_url.present? %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Footer links in the "Built on Forem" section should all open in a new tab and use `rel="nopener"`.

Currently some open in the same window and some open in a new tab but do not have the attribute.

## QA Instructions, Screenshots, Recordings

1. load the PR
2. make sure the links open in a new tab

## Added tests?

- [ ] Yes
- [x] No, and this is why: I didn't add a test because we don't seem to have a proper footer test and this is a minor change related to web security, also the links we link to are of Forem property
- [ ] I need help with writing tests
