### PR TITLE
Use default social image on /listings

### DIFF
--- a/app/views/listings/index.html.erb
+++ b/app/views/listings/index.html.erb
@@ -18,10 +18,10 @@
   <% else %>
     <meta property="og:title" content="Listings" />
     <meta property="og:description" content="<%= SiteConfig.community_description %>" />
-    <meta property="og:image" content="https://thepracticaldev.s3.amazonaws.com/i/sa3xjflbtvt9zw0xpan5.png">
+    <meta property="og:image" content="<%= SiteConfig.main_social_image %>">
     <meta name="twitter:title" content="Listings">
     <meta name="twitter:description" content="<%= SiteConfig.community_description %>">
-    <meta name="twitter:image:src" content="https://thepracticaldev.s3.amazonaws.com/i/sa3xjflbtvt9zw0xpan5.png">
+    <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
   <% end %>
   <meta name="twitter:site" content="@<%= SiteConfig.social_media_handles["twitter"] %>">
   <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Small generalization update

## Description

Following pattern from https://github.com/forem/forem/pull/11961 to generalize the social image on `/listings`

## Related Tickets & Documents

https://github.com/forem/forem/pull/11961

## Added tests?

- [ ] Yes
- [x] No, and this is why: not needed
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed
