### PR TITLE
Bust sidebar when display ad is updated

### DIFF
--- a/app/controllers/admin/display_ads_controller.rb
+++ b/app/controllers/admin/display_ads_controller.rb
@@ -2,6 +2,8 @@ module Admin
   class DisplayAdsController < Admin::ApplicationController
     layout "admin"
 
+    after_action :bust_ad_caches, only: %i[create update destroy]
+
     def index
       @display_ads = DisplayAd.order(id: :desc)
         .joins(:organization)
@@ -65,6 +67,10 @@ module Admin
 
     def authorize_admin
       authorize DisplayAd, :access?, policy_class: InternalPolicy
+    end
+
+    def bust_ad_caches
+      EdgeCache::BustSidebar.call
     end
   end
 end

--- a/spec/requests/admin/display_ads_spec.rb
+++ b/spec/requests/admin/display_ads_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe "/admin/display_ads", type: :request do
           post_resource
         end.to change { DisplayAd.all.count }.by(1)
       end
+
+      it "busts sidebar" do
+        post_resource
+        expect(EdgeCache::BustSidebar).to have_received(:call).once
+      end
     end
 
     describe "PUT /admin/display_ads" do

--- a/spec/requests/admin/display_ads_spec.rb
+++ b/spec/requests/admin/display_ads_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "/admin/display_ads", type: :request do
       end
 
       it "busts sidebar" do
+        allow(EdgeCache::BustSidebar).to receive(:call)
         post_resource
         expect(EdgeCache::BustSidebar).to have_received(:call).once
       end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This calls to bust the sidebar when an admin modifies an ad, to help the ad show up more quickly if relevant.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

