### PR TITLE
Only runs front-end tests related to changes in a PR now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
   - bundle exec rails db:schema:load
   - bundle exec rails webpacker:compile
   - './cc-test-reporter before-build'
-  - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "0" ]; then yarn test --colors; fi
+  - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "0" ]; then yarn test:ci; fi
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "0" ]; then ./cc-test-reporter format-coverage -t lcov -o coverage/codeclimate.lcov.json; fi
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "1" ]; then bundle exec bundle-audit check --update --ignore CVE-2015-9284; fi
   - if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "1" ]; then yarn build-storybook; fi

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -1644,7 +1644,7 @@ export default class Chat extends Component {
 
   handleMention = (e) => {
     const { activeChannel } = this.state;
-    const mention = e.keyCode === 63;
+    const mention = e.keyCode === 64;
     if (mention && activeChannel.channel_type !== 'direct') {
       const memberListElement = document.getElementById('mentionList');
       memberListElement.focus();

--- a/app/javascript/chat/chat.jsx
+++ b/app/javascript/chat/chat.jsx
@@ -1644,7 +1644,7 @@ export default class Chat extends Component {
 
   handleMention = (e) => {
     const { activeChannel } = this.state;
-    const mention = e.keyCode === 64;
+    const mention = e.keyCode === 63;
     if (mention && activeChannel.channel_type !== 'direct') {
       const memberListElement = document.getElementById('mentionList');
       memberListElement.focus();

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:frontend": "eslint app/assets/javascripts/**/*.js app/javascript/**/*.jsx app/javascript/**/*.js",
     "pretest": "yarn run lint:frontend",
     "test": "jest app/javascript/ bin/ --coverage",
-    "test:ci": "jest --colors --changedSince=origin/master --maxWorkers=4",
+    "test:ci": "jest --colors --changedSince=origin/master --maxWorkers=4 --ci",
     "test:watch": "jest app/javascript/ bin/ --watch",
     "postcss": "postcss public/assets/*.css -d public/assets 2> postcss_error.log",
     "e2e": "cypress open",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint:frontend": "eslint app/assets/javascripts/**/*.js app/javascript/**/*.jsx app/javascript/**/*.js",
     "pretest": "yarn run lint:frontend",
     "test": "jest app/javascript/ bin/ --coverage",
+    "test:ci": "jest --colors --changedSince=origin/master --maxWorkers=4",
     "test:watch": "jest app/javascript/ bin/ --watch",
     "postcss": "postcss public/assets/*.css -d public/assets 2> postcss_error.log",
     "e2e": "cypress open",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] CI/CD Optimization
- [ ] Documentation Update

## Description

This is a proof of concept meant to speed up the CI/CD pipeline in regards to front-end tests (unit and integration). Inspired by a conversation with Sunil Pai on Twitter, https://twitter.com/threepointone/status/1342108210900176897

Here's my test where only the file I changed in the PR gets associated tests run for it.

```bash
$ if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "0" ]; then yarn test:ci; fi

yarn run v1.22.5

$ jest --colors --changedSince=origin/master --maxWorkers=4

 PASS  app/javascript/chat/__tests__/chat.test.jsx (6.799 s)

  <Chat />

    ✓ should have no a11y violations (583 ms)

    ✓ should render expanded (58 ms)

    ✓ should collapse and expand chat channels properly (30 ms)

    ✓ should show mention pop-up on keyUp @ (23 ms)

Test Suites: 1 passed, 1 total

Tests:       4 passed, 4 total

Snapshots:   0 total

Time:        7.332 s

Ran all test suites related to changed files.

Done in 9.51s.

The command "if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "0" ]; then yarn test:ci; fi" exited with 0.
```

Compare the test run of `9.51s` to compared to a typical one of, `~60s` + the coverage report time (See https://travis-ci.com/github/forem/forem/jobs/464671828)

Currently this works, but then the coverage report fails as we no longer generate it

```bash
$ if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "0" ]; then ./cc-test-reporter format-coverage -t lcov -o coverage/codeclimate.lcov.json; fi

time="2020-12-24T18:56:25Z" level=error msg="could not find coverage file \ncould not find any files in search paths for lcov. search paths were: , coverage/lcov.info" 

Error: could not find any files in search paths for lcov. search paths were: , coverage/lcov.info

Usage:

  cc-test-reporter format-coverage [coverage file] [flags]

Flags:

      --add-prefix string   add this prefix to file paths

  -t, --input-type string   type of input source to use [clover, cobertura, coverage.py, excoveralls, gcov, gocov, jacoco, lcov, lcov-json, simplecov, xccov]

  -o, --output string       output path (default "coverage/codeclimate.json")

  -p, --prefix string       the root directory where the coverage analysis was performed (default "/home/travis/build/forem/forem")

Global Flags:

  -d, --debug   run in debug mode

The command "if [ "$KNAPSACK_PRO_CI_NODE_INDEX" == "0" ]; then ./cc-test-reporter format-coverage -t lcov -o coverage/codeclimate.lcov.json; fi" exited with 255.
```

It doesn't make sense to run the coverage report if we're running only a small subset of the tests.

## Related Tickets & Documents

https://twitter.com/threepointone/status/1342108210900176897

## QA Instructions, Screenshots, Recordings

Tests should pass as  this is just a testing infrastructure change.

### UI accessibility concerns?

N/A This is testing infrastructure.

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [ ] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
