### PR TITLE
Update bust_organization to EdgeCache::BustOrganization

### DIFF
--- a/app/workers/organizations/bust_cache_worker.rb
+++ b/app/workers/organizations/bust_cache_worker.rb
@@ -1,9 +1,11 @@
 module Organizations
   class BustCacheWorker < BustCacheBaseWorker
     def perform(organization_id, slug)
+      return unless organization_id && slug
+
       organization = Organization.find_by(id: organization_id)
 
-      return unless organization && slug
+      return unless organization
 
       EdgeCache::BustOrganization.call(organization, slug)
     end

--- a/app/workers/organizations/bust_cache_worker.rb
+++ b/app/workers/organizations/bust_cache_worker.rb
@@ -3,9 +3,9 @@ module Organizations
     def perform(organization_id, slug)
       organization = Organization.find_by(id: organization_id)
 
-      return unless organization
+      return unless organization && slug
 
-      CacheBuster.bust_organization(organization, slug)
+      EdgeCache::BustOrganization.call(organization, slug)
     end
   end
 end

--- a/lib/data_update_scripts/20201026155851_resave_to_bust_cache_for_imgproxy.rb
+++ b/lib/data_update_scripts/20201026155851_resave_to_bust_cache_for_imgproxy.rb
@@ -8,7 +8,7 @@ module DataUpdateScripts
       end
 
       Organization.find_each do |organization|
-        CacheBuster.bust_organization(organization, organization.slug)
+        EdgeCache::BustOrganization.call(organization, organization.slug)
       end
 
       Article.find_each(&:save)

--- a/spec/workers/organizations/bust_cache_worker_spec.rb
+++ b/spec/workers/organizations/bust_cache_worker_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe Organizations::BustCacheWorker, type: :worker do
       end
     end
 
+    describe "when no slug is found" do
+      it "doest not call the service" do
+        worker.perform(organization.id, nil)
+        expect(EdgeCache::BustOrganization).not_to have_received(:call)
+      end
+    end
+
     it "busts cache" do
       worker.perform(organization.id, "SlUg")
       expect(EdgeCache::BustOrganization).to have_received(:call).with(organization, "SlUg")

--- a/spec/workers/organizations/bust_cache_worker_spec.rb
+++ b/spec/workers/organizations/bust_cache_worker_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe Organizations::BustCacheWorker, type: :worker do
     let(:worker) { subject }
 
     before do
-      allow(CacheBuster).to receive(:bust_organization)
+      allow(EdgeCache::BustOrganization).to receive(:call)
     end
 
     describe "when no organization is found" do
       it "doest not call the service" do
         allow(Organization).to receive(:find_by).and_return(nil)
         worker.perform(789, "SlUg")
-        expect(CacheBuster).not_to have_received(:bust_organization)
+        expect(EdgeCache::BustOrganization).not_to have_received(:call)
       end
     end
 
     it "busts cache" do
       worker.perform(organization.id, "SlUg")
-      expect(CacheBuster).to have_received(:bust_organization).with(organization, "SlUg")
+      expect(EdgeCache::BustOrganization).to have_received(:call).with(organization, "SlUg")
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This PR updates references for busting the organization cache from `CacheBuster` to a new, dedicated service `EdgeCache::BustOrganization`.

As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method so we can test each piece of cache-busting manually in production after we deploy it. Once all method references are updated, I'll remove the legacy `CacheBuster`. We don't want to remove it preemptively either because there could always be jobs in the queue referencing it. So removing it will be its own PR at the very end when code is no longer referencing it.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Can't really QA this outside of production.

## Are there any post deployment tasks we need to perform?
**Yes** - once this PR deploys, we need to test cache-busting. We can do this by updating an organization in production. If the organization updates and displays correctly as expected without having to hard refresh, that means it should be working correctly.

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![goat_slowly_but_surely_gif](https://media.giphy.com/media/Y3G8Mgonb9eIQn8z1A/giphy.gif)