### PR TITLE
Update bust_user to EdgeCache::BustUser

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -53,7 +53,7 @@ class OrganizationsController < ApplicationController
     authorize organization
     if organization.destroy
       current_user.touch(:organization_info_updated_at)
-      CacheBuster.bust_user(current_user)
+      EdgeCache::BustUser.call(current_user)
       flash[:settings_notice] = "Your organization: \"#{organization.name}\" was successfully deleted."
       redirect_to user_settings_path(:organization)
     else

--- a/app/services/users/delete_articles.rb
+++ b/app/services/users/delete_articles.rb
@@ -2,7 +2,7 @@ module Users
   module DeleteArticles
     module_function
 
-    def call(user, cache_buster = CacheBuster)
+    def call(user)
       return if user.articles.blank?
 
       virtual_articles = user.articles.map { |article| Article.new(article.attributes) }
@@ -12,7 +12,7 @@ module Users
         article.comments.includes(:user).find_each do |comment|
           comment.reactions.delete_all
           EdgeCache::BustComment.call(comment.commentable)
-          cache_buster.bust_user(comment.user)
+          EdgeCache::BustUser.call(comment.user)
           comment.remove_from_elasticsearch
           comment.delete
         end

--- a/app/services/users/delete_comments.rb
+++ b/app/services/users/delete_comments.rb
@@ -2,7 +2,7 @@ module Users
   module DeleteComments
     module_function
 
-    def call(user, cache_buster = CacheBuster)
+    def call(user)
       return unless user.comments.any?
 
       user.comments.find_each do |comment|
@@ -12,7 +12,7 @@ module Users
         comment.remove_from_elasticsearch
         comment.delete
       end
-      cache_buster.bust_user(user)
+      EdgeCache::BustUser.call(user)
     end
   end
 end

--- a/lib/data_update_scripts/20201026155851_resave_to_bust_cache_for_imgproxy.rb
+++ b/lib/data_update_scripts/20201026155851_resave_to_bust_cache_for_imgproxy.rb
@@ -4,7 +4,7 @@ module DataUpdateScripts
       return unless ENV["FOREM_CONTEXT"] == "forem_cloud"
 
       User.find_each do |user|
-        CacheBuster.bust_user(user)
+        EdgeCache::BustUser.call(user)
       end
 
       Organization.find_each do |organization|

--- a/spec/services/users/delete_articles_spec.rb
+++ b/spec/services/users/delete_articles_spec.rb
@@ -23,12 +23,10 @@ RSpec.describe Users::DeleteArticles, type: :service do
   end
 
   context "with comments" do
-    let(:buster) { double }
-
     before do
       allow(EdgeCache::BustComment).to receive(:call)
       allow(EdgeCache::BustArticle).to receive(:call)
-      allow(buster).to receive(:bust_user)
+      allow(EdgeCache::BustUser).to receive(:call)
 
       create_list(:comment, 2, commentable: article, user: user2)
     end
@@ -47,9 +45,9 @@ RSpec.describe Users::DeleteArticles, type: :service do
     end
 
     it "busts cache" do
-      described_class.call(user, buster)
+      described_class.call(user)
       expect(EdgeCache::BustComment).to have_received(:call).with(article).twice
-      expect(buster).to have_received(:bust_user).with(user2).at_least(:once)
+      expect(EdgeCache::BustUser).to have_received(:call).with(user2).at_least(:once)
       expect(EdgeCache::BustArticle).to have_received(:call).with(article)
     end
 

--- a/spec/services/users/delete_comments_spec.rb
+++ b/spec/services/users/delete_comments_spec.rb
@@ -5,18 +5,17 @@ RSpec.describe Users::DeleteComments, type: :service do
   let(:trusted_user) { create(:user, :trusted) }
   let(:article) { create(:article) }
   let(:comment) { create(:comment, user: user, commentable: article) }
-  let(:buster) { double }
 
   before do
     create_list(:comment, 2, commentable: article, user: user)
 
     allow(EdgeCache::BustComment).to receive(:call)
-    allow(buster).to receive(:bust_user)
+    allow(EdgeCache::BustUser).to receive(:call)
   end
 
   it "destroys user comments" do
     comment
-    described_class.call(user, buster)
+    described_class.call(user)
     expect(Comment.where(user_id: user.id).any?).to be false
   end
 
@@ -24,19 +23,19 @@ RSpec.describe Users::DeleteComments, type: :service do
     comment
     sidekiq_perform_enqueued_jobs
     expect(comment.elasticsearch_doc).not_to be_nil
-    sidekiq_perform_enqueued_jobs { described_class.call(user, buster) }
+    sidekiq_perform_enqueued_jobs { described_class.call(user) }
     expect { comment.elasticsearch_doc }.to raise_error(Search::Errors::Transport::NotFound)
   end
 
   it "busts cache" do
-    described_class.call(user, buster)
+    described_class.call(user)
     expect(EdgeCache::BustComment).to have_received(:call).with(article).at_least(:once)
-    expect(buster).to have_received(:bust_user).with(user)
+    expect(EdgeCache::BustUser).to have_received(:call).with(user)
   end
 
   it "destroys moderation notifications properly" do
     create(:notification, notifiable: comment, action: "Moderation", user: trusted_user)
-    described_class.call(user, buster)
+    described_class.call(user)
     expect(Notification.count).to eq 0
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This PR updates references for busting a user cache from `CacheBuster` to a new, dedicated service `EdgeCache::BustUser`.

As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method so we can test each piece of cache-busting manually in production after we deploy it. Once all method references are updated, I'll remove the legacy `CacheBuster`. We don't want to remove it preemptively either because there could always be jobs in the queue referencing it. So removing it will be its own PR at the very end when code is no longer referencing it.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Can't really QA this outside of production.

## Are there any post deployment tasks we need to perform?
**Yes** - once this PR deploys, we need to test cache-busting. We can do this by updating a user in production. If the user updates and displays correctly as expected without having to hard refresh, that means it should be working correctly.

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![goat_slowly_but_surely_gif](https://media.giphy.com/media/Y3G8Mgonb9eIQn8z1A/giphy.gif)