### PR TITLE
Update bust to EdgeCache::Bust

### DIFF
--- a/app/controllers/admin/tools_controller.rb
+++ b/app/controllers/admin/tools_controller.rb
@@ -43,10 +43,10 @@ module Admin
       if link.starts_with?(URL.url)
         link.sub!(URL.url, "")
       end
-      CacheBuster.bust(link)
-      CacheBuster.bust("#{link}/")
-      CacheBuster.bust("#{link}?i=i")
-      CacheBuster.bust("#{link}/?i=i")
+      EdgeCache::Bust.call(link)
+      EdgeCache::Bust.call("#{link}/")
+      EdgeCache::Bust.call("#{link}?i=i")
+      EdgeCache::Bust.call("#{link}/?i=i")
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -178,12 +178,12 @@ class ApplicationController < ActionController::Base
   end
 
   def bust_content_change_caches
-    CacheBuster.bust("/tags/onboarding") # Needs to change when suggested_tags is edited.
-    CacheBuster.bust("/shell_top") # Cached at edge, sent to service worker.
-    CacheBuster.bust("/shell_bottom") # Cached at edge, sent to service worker.
-    CacheBuster.bust("/async_info/shell_version") # Checks if current users should be busted.
-    CacheBuster.bust("/onboarding") # Page is cached at edge.
-    CacheBuster.bust("/") # Page is cached at edge.
+    EdgeCache::Bust.call("/tags/onboarding") # Needs to change when suggested_tags is edited.
+    EdgeCache::Bust.call("/shell_top") # Cached at edge, sent to service worker.
+    EdgeCache::Bust.call("/shell_bottom") # Cached at edge, sent to service worker.
+    EdgeCache::Bust.call("/async_info/shell_version") # Checks if current users should be busted.
+    EdgeCache::Bust.call("/onboarding") # Page is cached at edge.
+    EdgeCache::Bust.call("/") # Page is cached at edge.
     SiteConfig.admin_action_taken_at = Time.current # Used as cache key
   end
 

--- a/app/controllers/profile_pins_controller.rb
+++ b/app/controllers/profile_pins_controller.rb
@@ -31,7 +31,7 @@ class ProfilePinsController < ApplicationController
   end
 
   def bust_user_profile
-    CacheBuster.bust(current_user.path)
-    CacheBuster.bust("#{current_user.path}?i=i")
+    EdgeCache::Bust.call(current_user.path)
+    EdgeCache::Bust.call("#{current_user.path}?i=i")
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -665,9 +665,9 @@ class Article < ApplicationRecord
   end
 
   def bust_cache
-    CacheBuster.bust(path)
-    CacheBuster.bust("#{path}?i=i")
-    CacheBuster.bust("#{path}?preview=#{password}")
+    EdgeCache::Bust.call(path)
+    EdgeCache::Bust.call("#{path}?i=i")
+    EdgeCache::Bust.call("#{path}?preview=#{password}")
     async_bust
   end
 

--- a/app/models/badge.rb
+++ b/app/models/badge.rb
@@ -29,7 +29,7 @@ class Badge < ApplicationRecord
   end
 
   def bust_path
-    CacheBuster.bust(path)
-    CacheBuster.bust("#{path}?i=i")
+    EdgeCache::Bust.call(path)
+    EdgeCache::Bust.call("#{path}?i=i")
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -238,7 +238,7 @@ class Comment < ApplicationRecord
   def synchronous_bust
     commentable.touch(:last_comment_at) if commentable.respond_to?(:last_comment_at)
     user.touch(:last_comment_at)
-    CacheBuster.bust(commentable.path.to_s) if commentable
+    EdgeCache::Bust.call(commentable.path.to_s) if commentable
     expire_root_fragment
   end
 

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -38,8 +38,8 @@ class GithubRepo < ApplicationRecord
     return if user.blank?
 
     user.touch
-    CacheBuster.bust(user.path)
-    CacheBuster.bust("#{user.path}?i=i")
-    CacheBuster.bust("#{user.path}/?i=i")
+    EdgeCache::Bust.call(user.path)
+    EdgeCache::Bust.call("#{user.path}?i=i")
+    EdgeCache::Bust.call("#{user.path}/?i=i")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -489,8 +489,8 @@ class User < ApplicationRecord
   def resave_articles
     articles.find_each do |article|
       if article.path
-        CacheBuster.bust(article.path)
-        CacheBuster.bust("#{article.path}?i=i")
+        EdgeCache::Bust.call(article.path)
+        EdgeCache::Bust.call("#{article.path}?i=i")
       end
       article.save
     end

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -37,7 +37,7 @@ module Moderator
       end
       user.update_columns(name: new_name, username: new_username, old_username: user.username,
                           profile_updated_at: Time.current)
-      CacheBuster.bust("/#{user.old_username}")
+      EdgeCache::Bust.call("/#{user.old_username}")
     end
 
     def remove_profile_info

--- a/app/services/moderator/merge_user.rb
+++ b/app/services/moderator/merge_user.rb
@@ -25,7 +25,7 @@ module Moderator
       @keep_user.touch(:profile_updated_at)
       Users::MergeSyncWorker.perform_async(@keep_user.id)
 
-      CacheBuster.bust("/#{@keep_user.username}")
+      EdgeCache::Bust.call("/#{@keep_user.username}")
     end
 
     private

--- a/app/services/users/delete.rb
+++ b/app/services/users/delete.rb
@@ -9,7 +9,7 @@ module Users
       delete_articles
       delete_user_activity
       user.unsubscribe_from_newsletters
-      CacheBuster.bust("/#{user.username}")
+      EdgeCache::Bust.call("/#{user.username}")
       user.destroy
       Rails.cache.delete("user-destroy-token-#{user.id}")
     end

--- a/app/workers/articles/bust_multiple_caches_worker.rb
+++ b/app/workers/articles/bust_multiple_caches_worker.rb
@@ -5,8 +5,8 @@ module Articles
 
     def perform(article_ids)
       Article.select(:id, :path).where(id: article_ids).find_each do |article|
-        CacheBuster.bust(article.path)
-        CacheBuster.bust("#{article.path}?i=i")
+        EdgeCache::Bust.call(article.path)
+        EdgeCache::Bust.call("#{article.path}?i=i")
       end
     end
   end

--- a/app/workers/bust_cache_path_worker.rb
+++ b/app/workers/bust_cache_path_worker.rb
@@ -1,5 +1,5 @@
 class BustCachePathWorker < BustCacheBaseWorker
   def perform(path)
-    CacheBuster.bust(path)
+    EdgeCache::Bust.call(path)
   end
 end

--- a/app/workers/reactions/bust_homepage_cache_worker.rb
+++ b/app/workers/reactions/bust_homepage_cache_worker.rb
@@ -5,7 +5,6 @@ module Reactions
     sidekiq_options queue: :high_priority, retry: 10
 
     def perform(reaction_id)
-      cache_buster = CacheBuster
       reaction = Reaction.find_by(id: reaction_id, reactable_type: "Article")
       return unless reaction&.reactable
 
@@ -13,10 +12,10 @@ module Reactions
       return unless featured_articles_ids.include?(reaction.reactable_id)
 
       reaction.reactable.touch
-      cache_buster.bust("/")
-      cache_buster.bust("/")
-      cache_buster.bust("/?i=i")
-      cache_buster.bust("?i=i")
+      EdgeCache::Bust.call("/")
+      EdgeCache::Bust.call("/")
+      EdgeCache::Bust.call("/?i=i")
+      EdgeCache::Bust.call("?i=i")
     end
   end
 end

--- a/app/workers/reactions/bust_reactable_cache_worker.rb
+++ b/app/workers/reactions/bust_reactable_cache_worker.rb
@@ -8,14 +8,14 @@ module Reactions
       reaction = Reaction.find_by(id: reaction_id)
       return unless reaction&.reactable
 
-      CacheBuster.bust(reaction.user.path)
+      EdgeCache::Bust.call(reaction.user.path)
       case reaction.reactable_type
       when "Article"
-        CacheBuster.bust("/reactions?article_id=#{reaction.reactable_id}")
+        EdgeCache::Bust.call("/reactions?article_id=#{reaction.reactable_id}")
       when "Comment"
         path = "/reactions?commentable_id=#{reaction.reactable.commentable_id}&" \
           "commentable_type=#{reaction.reactable.commentable_type}"
-        CacheBuster.bust(path)
+        EdgeCache::Bust.call(path)
       end
     end
   end

--- a/spec/models/badge_spec.rb
+++ b/spec/models/badge_spec.rb
@@ -35,19 +35,19 @@ RSpec.describe Badge, type: :model do
 
     describe "cache busting" do
       before do
-        allow(CacheBuster).to receive(:bust)
+        allow(EdgeCache::Bust).to receive(:bust)
       end
 
       it "calls the cache buster with the path" do
         badge.save
 
-        expect(CacheBuster).to have_received(:bust).with(badge.path)
+        expect(EdgeCache::Bust).to have_received(:bust).with(badge.path)
       end
 
       it "calls the cache buster with the internal path" do
         badge.save
 
-        expect(CacheBuster).to have_received(:bust).with("#{badge.path}?i=i")
+        expect(EdgeCache::Bust).to have_received(:bust).with("#{badge.path}?i=i")
       end
     end
   end

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe GithubRepo, type: :model do
       end
 
       it "busts the correct caches" do
-        allow(CacheBuster).to receive(:bust)
+        allow(EdgeCache::Bust).to receive(:call)
 
         repo.save
 
-        expect(CacheBuster).to have_received(:bust).with(user.path)
-        expect(CacheBuster).to have_received(:bust).with("#{user.path}?i=i")
-        expect(CacheBuster).to have_received(:bust).with("#{user.path}/?i=i")
+        expect(EdgeCache::Bust).to have_received(:call).with(user.path)
+        expect(EdgeCache::Bust).to have_received(:call).with("#{user.path}?i=i")
+        expect(EdgeCache::Bust).to have_received(:call).with("#{user.path}/?i=i")
       end
     end
   end

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Users::Delete, type: :service do
   end
 
   it "busts user profile page" do
-    allow(CacheBuster).to receive(:bust)
+    allow(EdgeCache::Bust).to receive(:call).with("/#{user.username}")
     described_class.new(user).call
-    expect(CacheBuster).to have_received(:bust).with("/#{user.username}")
+    expect(EdgeCache::Bust).to have_received(:call).with("/#{user.username}")
   end
 
   it "deletes user's follows" do

--- a/spec/workers/articles/bust_multiple_caches_worker_spec.rb
+++ b/spec/workers/articles/bust_multiple_caches_worker_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Articles::BustMultipleCachesWorker, type: :worker do
     let(:worker) { subject }
 
     it "busts cache" do
-      allow(CacheBuster).to receive(:bust)
+      allow(EdgeCache::Bust).to receive(:call)
 
       worker.perform([article.id])
 
-      expect(CacheBuster).to have_received(:bust).with(path).once
-      expect(CacheBuster).to have_received(:bust).with("#{path}?i=i").once
+      expect(EdgeCache::Bust).to have_received(:call).with(path).once
+      expect(EdgeCache::Bust).to have_received(:call).with("#{path}?i=i").once
     end
   end
 end

--- a/spec/workers/bust_cache_path_worker_spec.rb
+++ b/spec/workers/bust_cache_path_worker_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe BustCachePathWorker, type: :worker do
   include_examples "#enqueues_on_correct_queue", "high_priority"
 
   describe "#perform" do
+    let(:path) { "/foo" }
+
     it "busts cache for given path" do
-      allow(CacheBuster).to receive(:bust)
-      worker.perform("/foo")
-      expect(CacheBuster).to have_received(:bust).with("/foo")
+      allow(EdgeCache::Bust).to receive(:call).with(path)
+      worker.perform(path)
+      expect(EdgeCache::Bust).to have_received(:call).with(path)
     end
   end
 end

--- a/spec/workers/reactions/bust_homepage_cache_worker_spec.rb
+++ b/spec/workers/reactions/bust_homepage_cache_worker_spec.rb
@@ -8,21 +8,21 @@ RSpec.describe Reactions::BustHomepageCacheWorker, type: :worker do
 
     it "busts the homepage cache when reactable is an Article" do
       reaction = create(:reaction, reactable: article, user: user)
-      allow(CacheBuster).to receive(:bust)
+      allow(EdgeCache::Bust).to receive(:call)
 
       worker.perform(reaction.id)
 
-      expect(CacheBuster).to have_received(:bust).exactly(4)
+      expect(EdgeCache::Bust).to have_received(:call).exactly(4)
     end
 
     it "doesn't bust the homepage cache when reactable is a Comment" do
       comment = create(:comment, commentable: article)
       comment_reaction = create(:reaction, reactable: comment, user: user)
-      allow(CacheBuster).to receive(:bust)
+      allow(EdgeCache::Bust).to receive(:call)
 
       worker.perform(comment_reaction.id)
 
-      expect(CacheBuster).not_to have_received(:bust)
+      expect(EdgeCache::Bust).not_to have_received(:call)
     end
 
     it "doesn't fail if a reaction doesn't exist" do

--- a/spec/workers/reactions/bust_reactable_cache_worker_spec.rb
+++ b/spec/workers/reactions/bust_reactable_cache_worker_spec.rb
@@ -10,20 +10,20 @@ RSpec.describe Reactions::BustReactableCacheWorker, type: :worker do
     let(:worker) { subject }
 
     before do
-      allow(CacheBuster).to receive(:bust)
+      allow(EdgeCache::Bust).to receive(:call)
     end
 
     it "busts the reactable article cache" do
       worker.perform(reaction.id)
-      expect(CacheBuster).to have_received(:bust).with(user.path).once
-      expect(CacheBuster).to have_received(:bust).with("/reactions?article_id=#{article.id}").once
+      expect(EdgeCache::Bust).to have_received(:call).with(user.path).once
+      expect(EdgeCache::Bust).to have_received(:call).with("/reactions?article_id=#{article.id}").once
     end
 
     it "busts the reactable comment cache" do
       worker.perform(comment_reaction.id)
-      expect(CacheBuster).to have_received(:bust).with(user.path).once
+      expect(EdgeCache::Bust).to have_received(:call).with(user.path).once
       param = "/reactions?commentable_id=#{article.id}&commentable_type=Article"
-      expect(CacheBuster).to have_received(:bust).with(param).once
+      expect(EdgeCache::Bust).to have_received(:call).with(param).once
     end
 
     it "doesn't fail if a reaction doesn't exist" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This PR updates references for busting cache from `CacheBuster` to a new, dedicated service `EdgeCache::Bust`.

As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method so we can test each piece of cache-busting manually in production after we deploy it. Once all method references are updated, I'll remove the legacy `CacheBuster`. We don't want to remove it preemptively either because there could always be jobs in the queue referencing it. So removing it will be its own PR at the very end when code is no longer referencing it.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Can't really QA this outside of production.

## Are there any post deployment tasks we need to perform?
**Yes** - once this PR deploys, we need to test cache-busting. We can do this by updating an article in production. If the article updates and displays correctly as expected without having to hard refresh, that means it should be working correctly.

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![goat_slowly_but_surely_gif](https://media.giphy.com/media/Y3G8Mgonb9eIQn8z1A/giphy.gif)