### PR TITLE
Disable Community Name Data Update Scripts

### DIFF
--- a/lib/data_update_scripts/20201217184442_append_collective_noun_to_community_name.rb
+++ b/lib/data_update_scripts/20201217184442_append_collective_noun_to_community_name.rb
@@ -1,7 +1,7 @@
 module DataUpdateScripts
   class AppendCommunityToCommunityName
     def run
-      return unless SiteConfig.collective_noun_disabled?
+      return unless SiteConfig.collective_noun_disabled
 
       SiteConfig.where(var: "community_name").find_each do |community_name|
         community_name.update!(value: "#{community_name.value} #{SiteConfig.collective_noun}")

--- a/lib/data_update_scripts/20201217184442_append_collective_noun_to_community_name.rb
+++ b/lib/data_update_scripts/20201217184442_append_collective_noun_to_community_name.rb
@@ -1,5 +1,5 @@
 module DataUpdateScripts
-  class AppendCommunityToCommunityName
+  class AppendCollectiveNounToCommunityName
     def run
       return unless SiteConfig.collective_noun_disabled
 

--- a/lib/data_update_scripts/20201217184442_append_collective_noun_to_community_name.rb
+++ b/lib/data_update_scripts/20201217184442_append_collective_noun_to_community_name.rb
@@ -1,11 +1,13 @@
 module DataUpdateScripts
   class AppendCollectiveNounToCommunityName
     def run
-      return unless SiteConfig.collective_noun_disabled
+      # return unless SiteConfig.collective_noun_disabled
 
-      SiteConfig.where(var: "community_name").find_each do |community_name|
-        community_name.update!(value: "#{community_name.value} #{SiteConfig.collective_noun}")
-      end
+      # SiteConfig.where(var: "community_name").find_each do |community_name|
+      #   community_name.update!(value: "#{community_name.value} #{SiteConfig.collective_noun}")
+      # end
+
+      # We cannot access the column directly, so this has been commented out
     end
   end
 end

--- a/lib/data_update_scripts/20201217184442_append_community_to_community_name.rb
+++ b/lib/data_update_scripts/20201217184442_append_community_to_community_name.rb
@@ -1,5 +1,5 @@
 module DataUpdateScripts
-  class AppendCollectiveNounToCommunityName
+  class AppendCommunityToCommunityName
     def run
       # return unless SiteConfig.collective_noun_disabled
 

--- a/lib/data_update_scripts/20201218173445_remove_collective_noun_from_config.rb
+++ b/lib/data_update_scripts/20201218173445_remove_collective_noun_from_config.rb
@@ -2,6 +2,8 @@ module DataUpdateScripts
   class RemoveCollectiveNounFromConfig
     def run
       # SiteConfig.where(var: %w[collective_noun collective_noun_disabled]).destroy_all
+
+      # These columns have been removed via the model, rendering this script useless
     end
   end
 end

--- a/lib/data_update_scripts/20201218173445_remove_collective_noun_from_config.rb
+++ b/lib/data_update_scripts/20201218173445_remove_collective_noun_from_config.rb
@@ -1,7 +1,7 @@
 module DataUpdateScripts
   class RemoveCollectiveNounFromConfig
     def run
-      SiteConfig.where(var: %w[collective_noun collective_noun_disabled]).destroy_all
+      # SiteConfig.where(var: %w[collective_noun collective_noun_disabled]).destroy_all
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When I merged and deployed PR #11846, the `data_upate` script errored out, as shown [here](https://app.honeybadger.io/projects/66984/faults/72660309) on Honeybadger -- it appears that using the predicate method may have caused a `NoMethodError` error: 
```
NoMethodError: undefined method `collective_noun_disabled?' for #<Class:0x00007f5e4e055088>
```
This PR reverts the change from `SiteConfig.collective_noun_disabled?` back to what I initially had, `SiteConfig.collective_noun_disabled`.

## Related Tickets & Documents
Relates to PR #11846 and PR #11973 
Resolves https://app.honeybadger.io/projects/66984/faults/72660309

## QA Instructions, Screenshots, Recordings
**To QA this PR, you can do the following:**
- Manually test the `data_update` script
- Ensure all checks pass ♻️ 

### UI accessibility concerns?
N/A

## Added tests?

- [ ] Yes
- [x] No, and this is why: there are tests in PR #11846 around the changes made to `community_name`, `collective_noun`, and `collective_noun_disabled`
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
This `data_update` script needs to run before the script in PR #11973 (I canceled the build on that PR after the Honeybadger error surfaced and will resume the build once this all passes/gets approved)
## [optional] What gif best describes this PR or how it makes you feel?

![Robert Downey Jr. Internal Screamin](https://media.giphy.com/media/P8X4lemg5Iphe/giphy.gif)
