### PR TITLE
Adds collective_noun Fields Back to SiteConfig Model

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -55,6 +55,8 @@ class SiteConfig < RailsSettings::Base
   # Community Content
   field :community_name, type: :string, default: ApplicationConfig["COMMUNITY_NAME"] || "New Forem"
   field :community_emoji, type: :string, default: "🌱"
+  # collective_noun and collective_noun_disabled have been added back temporarily for
+  # a data_update script, but will be removed in a future PR!
   field :collective_noun, type: :string, default: "Community"
   field :collective_noun_disabled, type: :boolean, default: false
   field :community_description, type: :string

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -55,6 +55,8 @@ class SiteConfig < RailsSettings::Base
   # Community Content
   field :community_name, type: :string, default: ApplicationConfig["COMMUNITY_NAME"] || "New Forem"
   field :community_emoji, type: :string, default: "🌱"
+  field :collective_noun, type: :string, default: "Community"
+  field :collective_noun_disabled, type: :boolean, default: false
   field :community_description, type: :string
   field :community_member_label, type: :string, default: "user"
   field :tagline, type: :string

--- a/lib/data_update_scripts/20201228194641_append_collective_noun_to_community_name.rb
+++ b/lib/data_update_scripts/20201228194641_append_collective_noun_to_community_name.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class AppendCollectiveNounToCommunityName
+    def run
+      return "#{SiteConfig.community_name} #{SiteConfig.collective_noun}" unless SiteConfig.collective_noun_disabled?
+    end
+  end
+end

--- a/lib/data_update_scripts/20201228194641_append_collective_noun_to_community_name.rb
+++ b/lib/data_update_scripts/20201228194641_append_collective_noun_to_community_name.rb
@@ -1,11 +1,9 @@
 module DataUpdateScripts
   class AppendCollectiveNounToCommunityName
     def run
-      if SiteConfig.collective_noun_disabled
-        SiteConfig.community_name
-      else
-        SiteConfig.community_name = "#{SiteConfig.community_name} #{SiteConfig.collective_noun}"
-      end
+      return if SiteConfig.collective_noun_disabled
+
+      SiteConfig.community_name = "#{SiteConfig.community_name} #{SiteConfig.collective_noun}"
     end
   end
 end

--- a/lib/data_update_scripts/20201228194641_append_collective_noun_to_community_name.rb
+++ b/lib/data_update_scripts/20201228194641_append_collective_noun_to_community_name.rb
@@ -1,7 +1,11 @@
 module DataUpdateScripts
   class AppendCollectiveNounToCommunityName
     def run
-      return "#{SiteConfig.community_name} #{SiteConfig.collective_noun}" unless SiteConfig.collective_noun_disabled?
+      if SiteConfig.collective_noun_disabled
+        SiteConfig.community_name
+      else
+        SiteConfig.community_name = "#{SiteConfig.community_name} #{SiteConfig.collective_noun}"
+      end
     end
   end
 end

--- a/lib/data_update_scripts/20201228194641_append_collective_noun_to_community_name.rb
+++ b/lib/data_update_scripts/20201228194641_append_collective_noun_to_community_name.rb
@@ -1,7 +1,7 @@
 module DataUpdateScripts
   class AppendCollectiveNounToCommunityName
     def run
-      return if SiteConfig.collective_noun_disabled
+      return if SiteConfig.collective_noun_disabled || SiteConfig.collective_noun.blank?
 
       SiteConfig.community_name = "#{SiteConfig.community_name} #{SiteConfig.collective_noun}"
     end

--- a/spec/lib/data_update_scripts/append_collective_noun_to_community_name_spec.rb
+++ b/spec/lib/data_update_scripts/append_collective_noun_to_community_name_spec.rb
@@ -6,7 +6,7 @@ require Rails.root.join(
 describe DataUpdateScripts::AppendCollectiveNounToCommunityName do
   context "when collective_noun_disabled is false" do
     it "appends the collective_noun to the community_name" do
-      SiteConfig.collective_noun = "Club"
+      allow(SiteConfig).to receive(:collective_noun).and_return("Club")
       described_class.new.run
       expect(SiteConfig.collective_noun_disabled).to eq(false)
       expect(SiteConfig.community_name).to eq("DEV(local) Club")
@@ -15,9 +15,8 @@ describe DataUpdateScripts::AppendCollectiveNounToCommunityName do
 
   context "when collective_noun_disabled is true" do
     it "does not append the collective_noun to the community_name" do
-      SiteConfig.collective_noun_disabled = true
+      allow(SiteConfig).to receive(:collective_noun_disabled).and_return(true)
       described_class.new.run
-      expect(SiteConfig.collective_noun_disabled).to eq(true)
       expect(SiteConfig.community_name).to eq("DEV(local)")
     end
   end

--- a/spec/lib/data_update_scripts/append_collective_noun_to_community_name_spec.rb
+++ b/spec/lib/data_update_scripts/append_collective_noun_to_community_name_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20201228194641_append_collective_noun_to_community_name.rb",
+)
+
+describe DataUpdateScripts::AppendCollectiveNounToCommunityName do
+  context "when collective_noun_disabled is false" do
+    it "appends the collective_noun to the community_name" do
+      described_class.new.run
+      expect(SiteConfig.collective_noun_disabled).to eq(false)
+      expect(SiteConfig.community_name).to eq("DEV(local) Community")
+    end
+  end
+
+  context "when collective_noun_disabled is true" do
+    it "does not append the collective_noun to the community_name" do
+      SiteConfig.collective_noun_disabled = true
+      described_class.new.run
+      expect(SiteConfig.collective_noun_disabled).to eq(true)
+      expect(SiteConfig.community_name).to eq("DEV(local)")
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/append_collective_noun_to_community_name_spec.rb
+++ b/spec/lib/data_update_scripts/append_collective_noun_to_community_name_spec.rb
@@ -6,9 +6,10 @@ require Rails.root.join(
 describe DataUpdateScripts::AppendCollectiveNounToCommunityName do
   context "when collective_noun_disabled is false" do
     it "appends the collective_noun to the community_name" do
+      SiteConfig.collective_noun = "Club"
       described_class.new.run
       expect(SiteConfig.collective_noun_disabled).to eq(false)
-      expect(SiteConfig.community_name).to eq("DEV(local) Community")
+      expect(SiteConfig.community_name).to eq("DEV(local) Club")
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds the `collective_noun` and `collective_noun_disabled` columns back to the `SiteConfig` model after running into a `data_update` script failure in another PR. This is necessary so that when running the `data_update` script responsible for updating the `community_name`, we have access to the `collective_noun` and `collective_noun_disabled` methods. Additionally, this PR adds a `data_update` script that conditionally updates `SiteConfig.community_name` _if_ `SiteConfig.collective_noun_disabled` returns `false`. If, however, the forem has `collective_noun_disabled` set to `true`, then the `community_name` will remain as-is and untouched.

## Related Tickets & Documents
Relates to PRs #11846 , PR #11973 , and PR #12054 

## QA Instructions, Screenshots, Recordings
**To QA these changes, first ensure that all checks pass and the Travis build is green, then**:
- Run the `data_update` script manually and ensure that your Community's name updates accordingly

### UI accessibility concerns?
N/A

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
The `data_update` script included in this PR needs to successfully run!

## [optional] What gif best describes this PR or how it makes you feel?

![The Office: Days of Nonsense](https://media.giphy.com/media/E5mkciTEaBLNK/giphy.gif)