### PR TITLE
Fix broken link to configuring environment variables page

### DIFF
--- a/docs/backend/configuration.md
+++ b/docs/backend/configuration.md
@@ -20,8 +20,8 @@ environments. Examples:
 - `STRIPE_SECRET_KEY`
 
 Settings managed via your ENV can be found in
-[Configuring Environment Variables](../getting-started/config-env.md)) and
-viewed at `/admin/config` (see [the Admin guide](/admin)):
+[Configuring Environment Variables](/getting-started/config-env)) and viewed at
+`/admin/config` (see [the Admin guide](/admin)):
 
 ![Screenshot of env variable admin interface](https://user-images.githubusercontent.com/47985/73627243-67d41f80-467e-11ea-9121-221275ff8a89.png)
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
I fixed `Configuring Environment Variables` link on [this page](https://docs.forem.com/backend/configuration/) that shows `Page Not Found!` when clicking.