### PR TITLE
Cleanup bust_user

### DIFF
--- a/app/workers/users/bust_cache_worker.rb
+++ b/app/workers/users/bust_cache_worker.rb
@@ -4,7 +4,7 @@ module Users
       user = User.find_by(id: user_id)
       return unless user
 
-      CacheBuster.bust_user(user)
+      EdgeCache::BustUser.call(user)
     end
   end
 end

--- a/spec/workers/users/bust_cache_worker_spec.rb
+++ b/spec/workers/users/bust_cache_worker_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Users::BustCacheWorker, type: :worker do
     let(:worker) { subject }
 
     it "busts cache" do
-      allow(CacheBuster).to receive(:bust_user)
+      allow(EdgeCache::BustUser).to receive(:call).with(user)
 
       worker.perform(user.id)
-      expect(CacheBuster).to have_received(:bust_user).with(user)
+      expect(EdgeCache::BustUser).to have_received(:call).with(user)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
In https://github.com/forem/forem/pull/12051 I believe I missed a reference to `bust_user`. This PR updates references for busting a user cache from `CacheBuster` to a new, dedicated service `EdgeCache::BustUser`.

As part of our efforts to move legacy code from `/labor` to `/services` (https://github.com/forem/InternalProjectPlanning/issues/271), we want to move [`CacheBuster`](https://github.com/forem/forem/blob/master/app/labor/cache_buster.rb), into `/services` and re-factor the logic at the same time.

More specifically, we want to break up the methods in `CacheBuster` (i.e. `bust_comments`, `bust_article`, etc.) into their own services (i.e. `BustComment`, `BustArticle`, etc.). More on this approach can be found in [this comment](https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929) from @citizen428.

My gameplan is to PR for each method so we can test each piece of cache-busting manually in production after we deploy it. Once all method references are updated, I'll remove the legacy `CacheBuster`. We don't want to remove it preemptively either because there could always be jobs in the queue referencing it. So removing it will be its own PR at the very end when code is no longer referencing it.

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/271
https://github.com/forem/InternalProjectPlanning/issues/271#issuecomment-733416929

## QA Instructions, Screenshots, Recordings
Can't really QA this outside of production.

## Are there any post deployment tasks we need to perform?
**Yes** - once this PR deploys, we need to test cache-busting. We can do this by updating a user in production. If the user updates and displays correctly as expected without having to hard refresh, that means it should be working correctly.

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

![goat_slowly_but_surely_gif](https://media.giphy.com/media/Y3G8Mgonb9eIQn8z1A/giphy.gif)