### PR TITLE
Override specified line break behaviour on the ID column

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -176,3 +176,7 @@ label {
     padding: 0;
   }
 }
+
+.mod-actions__data {
+  max-width: 300px;
+}

--- a/app/views/admin/badge_achievements/index.html.erb
+++ b/app/views/admin/badge_achievements/index.html.erb
@@ -29,7 +29,7 @@
   <tbody class="crayons-card">
    <% @badge_achievements.each do |badge_achievement| %>
     <tr>
-      <td><%= badge_achievement.user.id %></td>
+      <td class="whitespace-nowrap"><%= badge_achievement.user.id %></td>
       <td><%= badge_achievement.user.username %></td>
       <td><%= badge_achievement.badge.title %></td>
       <h5>

--- a/app/views/admin/badge_achievements/index.html.erb
+++ b/app/views/admin/badge_achievements/index.html.erb
@@ -29,7 +29,7 @@
   <tbody class="crayons-card">
    <% @badge_achievements.each do |badge_achievement| %>
     <tr>
-      <td class="whitespace-nowrap"><%= badge_achievement.user.id %></td>
+      <td><%= badge_achievement.user.id %></td>
       <td><%= badge_achievement.user.username %></td>
       <td><%= badge_achievement.badge.title %></td>
       <h5>

--- a/app/views/admin/moderator_actions/index.html.erb
+++ b/app/views/admin/moderator_actions/index.html.erb
@@ -23,7 +23,7 @@
   <tbody class="crayons-card">
     <% @moderator_actions.each do |action| %>
       <tr>
-        <td class="whitespace-nowrap"><%= action.id %></td>
+        <td><%= action.id %></td>
         <td><%= link_to(action.user.username, admin_user_path(action.user_id)) if action.user %></td>
         <td><%= "#{action.data['action'].humanize} #{action.data['controller'].humanize.singularize.titleize}" if action.data.present? %></td>
         <td><%= action.data %></td>

--- a/app/views/admin/moderator_actions/index.html.erb
+++ b/app/views/admin/moderator_actions/index.html.erb
@@ -23,7 +23,7 @@
   <tbody class="crayons-card">
     <% @moderator_actions.each do |action| %>
       <tr>
-        <td><%= action.id %></td>
+        <td class="whitespace-nowrap"><%= action.id %></td>
         <td><%= link_to(action.user.username, admin_user_path(action.user_id)) if action.user %></td>
         <td><%= "#{action.data['action'].humanize} #{action.data['controller'].humanize.singularize.titleize}" if action.data.present? %></td>
         <td><%= action.data %></td>

--- a/app/views/admin/moderator_actions/index.html.erb
+++ b/app/views/admin/moderator_actions/index.html.erb
@@ -26,7 +26,7 @@
         <td class="whitespace-nowrap"><%= action.id %></td>
         <td><%= link_to(action.user.username, admin_user_path(action.user_id)) if action.user %></td>
         <td><%= "#{action.data['action'].humanize} #{action.data['controller'].humanize.singularize.titleize}" if action.data.present? %></td>
-        <td><%= action.data %></td>
+        <td class="mod-actions__data"><%= action.data %></td>
         <td><%= action.created_at %></td>
       </tr>
     <% end %>

--- a/app/views/admin/mods/index.html.erb
+++ b/app/views/admin/mods/index.html.erb
@@ -40,7 +40,7 @@
     <tbody class="crayons-card">
       <% @mods.each do |mod| %>
         <tr>
-          <td><%= mod.id %></td>
+          <td class="whitespace-nowrap"><%= mod.id %></td>
           <td><%= link_to mod.username, admin_user_path(mod.id) %></td>
           <td><%= mod.comments_count %></td>
           <td><%= mod.badge_achievements_count %></td>

--- a/app/views/admin/mods/index.html.erb
+++ b/app/views/admin/mods/index.html.erb
@@ -40,7 +40,7 @@
     <tbody class="crayons-card">
       <% @mods.each do |mod| %>
         <tr>
-          <td class="whitespace-nowrap"><%= mod.id %></td>
+          <td><%= mod.id %></td>
           <td><%= link_to mod.username, admin_user_path(mod.id) %></td>
           <td><%= mod.comments_count %></td>
           <td><%= mod.badge_achievements_count %></td>

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -23,7 +23,7 @@
     <% @organizations.each do |organization| %>
       <tr>
         <td><%= link_to "@#{organization.name}", admin_organization_path(organization.id) %></td>
-        <td><%= organization.id %></td>
+        <td class="whitespace-nowrap"><%= organization.id %></td>
         <% if organization.twitter_username %>
           <td><%= link_to organization.twitter_username, "https://twitter.com/#{organization.twitter_username}" %></td>
         <% else %>

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -23,7 +23,7 @@
     <% @organizations.each do |organization| %>
       <tr>
         <td><%= link_to "@#{organization.name}", admin_organization_path(organization.id) %></td>
-        <td class="whitespace-nowrap"><%= organization.id %></td>
+        <td><%= organization.id %></td>
         <% if organization.twitter_username %>
           <td><%= link_to organization.twitter_username, "https://twitter.com/#{organization.twitter_username}" %></td>
         <% else %>

--- a/app/views/admin/permissions/index.html.erb
+++ b/app/views/admin/permissions/index.html.erb
@@ -13,7 +13,7 @@
   <tbody class="crayons-card">
     <% @users.each do |user| %>
       <tr>
-        <td class="align-top"><%= user.id %></td>
+        <td class="align-top whitespace-nowrap"><%= user.id %></td>
         <td class="align-top"><%= link_to "@#{user.username}", user.path %></td>
         <td>
           <ul>

--- a/app/views/admin/podcasts/index.html.erb
+++ b/app/views/admin/podcasts/index.html.erb
@@ -23,7 +23,7 @@
   <tbody class="crayons-card">
     <% @podcasts.each do |podcast| %>
       <tr>
-        <td><%= podcast.id %></td>
+        <td class="whitespace-nowrap"><%= podcast.id %></td>
         <td><%= link_to podcast.title, edit_admin_podcast_path(podcast) %></td>
         <td><%= link_to podcast.feed_url, podcast.feed_url %></td>
         <td><%= podcast.episodes_count %></td>

--- a/app/views/admin/podcasts/index.html.erb
+++ b/app/views/admin/podcasts/index.html.erb
@@ -23,7 +23,7 @@
   <tbody class="crayons-card">
     <% @podcasts.each do |podcast| %>
       <tr>
-        <td class="whitespace-nowrap"><%= podcast.id %></td>
+        <td><%= podcast.id %></td>
         <td><%= link_to podcast.title, edit_admin_podcast_path(podcast) %></td>
         <td><%= link_to podcast.feed_url, podcast.feed_url %></td>
         <td><%= podcast.episodes_count %></td>

--- a/app/views/admin/privileged_reactions/index.html.erb
+++ b/app/views/admin/privileged_reactions/index.html.erb
@@ -34,7 +34,7 @@
       <tr>
         <td class="whitespace-nowrap"><%= reaction.id %></td>
         <td><%= link_to reaction.user.username, admin_user_path(reaction.user_id) %></td>
-        <td><%= reaction.reactable_type %></td>
+        <td class="whitespace-nowrap"><%= reaction.reactable_type %></td>
         <td><%= reaction.category %></td>
         <td>
           <% if reaction.reactable_type == "Article" %>

--- a/app/views/admin/privileged_reactions/index.html.erb
+++ b/app/views/admin/privileged_reactions/index.html.erb
@@ -32,7 +32,7 @@
   <tbody class="crayons-card">
     <% @privileged_reactions.each do |reaction| %>
       <tr>
-        <td><%= reaction.id %></td>
+        <td class="whitespace-nowrap"><%= reaction.id %></td>
         <td><%= link_to reaction.user.username, admin_user_path(reaction.user_id) %></td>
         <td><%= reaction.reactable_type %></td>
         <td><%= reaction.category %></td>

--- a/app/views/admin/privileged_reactions/index.html.erb
+++ b/app/views/admin/privileged_reactions/index.html.erb
@@ -32,7 +32,7 @@
   <tbody class="crayons-card">
     <% @privileged_reactions.each do |reaction| %>
       <tr>
-        <td class="whitespace-nowrap"><%= reaction.id %></td>
+        <td><%= reaction.id %></td>
         <td><%= link_to reaction.user.username, admin_user_path(reaction.user_id) %></td>
         <td><%= reaction.reactable_type %></td>
         <td><%= reaction.category %></td>

--- a/app/views/admin/sponsorships/index.html.erb
+++ b/app/views/admin/sponsorships/index.html.erb
@@ -32,7 +32,7 @@
     <% @sponsorships.each do |sponsorship| %>
       <tr>
         <td><%= link_to sponsorship.id, edit_admin_sponsorship_path(sponsorship) %></td>
-        <td><%= sponsorship.level %></td>
+        <td class="whitespace-nowrap"><%= sponsorship.level %></td>
         <td><%= sponsorship.status %></td>
         <td><%= sponsorship.expires_at&.strftime("%d %B %Y %H:%M UTC") %></td>
         <td>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -17,7 +17,7 @@
     <% @users.each do |user| %>
     <tr>
       <td><%= link_to user.username, admin_user_path(user) %></td>
-      <td><%= user.id %></td>
+      <td class="whitespace-nowrap"><%= user.id %></td>
       <td><%= user.name %></td>
       <td><%= user_twitter_link(user) %></td>
       <td><%= user_github_link(user) %></td>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -17,7 +17,7 @@
     <% @users.each do |user| %>
     <tr>
       <td><%= link_to user.username, admin_user_path(user) %></td>
-      <td class="whitespace-nowrap"><%= user.id %></td>
+      <td><%= user.id %></td>
       <td><%= user.name %></td>
       <td><%= user_twitter_link(user) %></td>
       <td><%= user_github_link(user) %></td>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There are some formatting issues on some of the tables on the admin page. These include:
- ID's that are overflowing on two lines (see /admin/users)
- Columns that are taking up too much space causing words to wrap unnecessarily
- and more... 

I've attached screenshots in the relevant sections. 

### Some other solutions that I considered:

I was tempted to change the css from 

```
.crayons-card {
 overflow-wrap: anywhere;
}
```
to 

```
.crayons-card {
 overflow-wrap: break-word;
}
```
since this solves some of the formatting issues outlined. However, it also causes the table to exceed the width of the screen, whereas ` overflow-wrap: anywhere;` ensures that the overflow is managed in such a way that the table does not exceed the width of the viewport width. 

_Hence, I went with overriding the specific columns that we don't want to line breaks on (using `whitespace-nowrap`), specifically the ID numbers.  In addition, I also added a max width on a column that I knew would be very long since it contains json data. This solves the most obvious problems but some usernames and url's will still need to overflow_ 

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/207

## QA Instructions, Screenshots, Recordings

Note: these are screenshots on a 1024px width screen. 

### BEFORE:

- <img width="1027" alt="Screenshot 2020-12-30 at 12 23 22" src="https://user-images.githubusercontent.com/2786819/103346382-84e6bd80-4a9c-11eb-8bb7-eadfa89f3e99.png">
- <img width="1030" alt="Screenshot 2020-12-30 at 12 25 06" src="https://user-images.githubusercontent.com/2786819/103346387-8912db00-4a9c-11eb-95e8-4a864f086b3c.png">
- <img width="1025" alt="Screenshot 2020-12-30 at 12 25 24" src="https://user-images.githubusercontent.com/2786819/103346389-89ab7180-4a9c-11eb-8a29-cf5a7f31f4eb.png">
- <img width="1027" alt="Screenshot 2020-12-30 at 12 25 55" src="https://user-images.githubusercontent.com/2786819/103346392-8adc9e80-4a9c-11eb-8675-0d906f457dd9.png">

### AFTER:

- <img width="1025" alt="Screenshot 2020-12-30 at 12 46 47" src="https://user-images.githubusercontent.com/2786819/103346667-5ddcbb80-4a9d-11eb-937f-4e5abddf30ee.png">
- <img width="1024" alt="Screenshot 2020-12-30 at 12 48 01" src="https://user-images.githubusercontent.com/2786819/103346767-abf1bf00-4a9d-11eb-8d3e-95c495552c11.png">
- <img width="1029" alt="Screenshot 2020-12-30 at 12 50 45" src="https://user-images.githubusercontent.com/2786819/103346774-b0b67300-4a9d-11eb-84b9-dc63e3a1d5ed.png">
- <img width="1051" alt="Screenshot 2020-12-30 at 12 53 04" src="https://user-images.githubusercontent.com/2786819/103346864-025efd80-4a9e-11eb-8613-2f05850f80f7.png">

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [ ] Yes
- [x] No, these were superficial UI changes.
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
