### PR TITLE
Optimization: Convert tags/_main_feed and widget_list_item partial loads to collections

### DIFF
--- a/app/views/articles/tags/_main_feed.html.erb
+++ b/app/views/articles/tags/_main_feed.html.erb
@@ -1,6 +1,4 @@
-<% @stories.each_with_index do |story, i| %>
-  <%= render "articles/single_story", story: story, featured: false %>
-<% end %>
+<%= render partial: "articles/single_story", collection: @stories, as: :story, locals: { featured: false } %>
 <% if @stories.size > 1 %>
   <div class="placeholder-div"></div>
 <% end %>

--- a/app/views/articles/tags/_sidebar_additional.html.erb
+++ b/app/views/articles/tags/_sidebar_additional.html.erb
@@ -10,9 +10,7 @@
           </header>
           <div class="widget-body">
             <div class="widget-link-list">
-              <% active_threads.each do |plucked_article| %>
-                <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
-              <% end %>
+              <%= render partial: "articles/widget_list_item", collection: active_threads, as: :plucked_article, locals: { show_comment_count: true } %>
             </div>
           </div>
         </div>
@@ -31,9 +29,7 @@
               </header>
               <div class="widget-body">
                 <div class="widget-link-list">
-                  <% boostable_posts.each do |plucked_article| %>
-                    <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: false %>
-                  <% end %>
+                  <%= render partial: "articles/widget_list_item", collection: boostable_posts, as: :plucked_article, locals: { show_comment_count: false } %>
                 </div>
               </div>
             </div>
@@ -46,9 +42,7 @@
               </header>
               <div class="widget-body">
                 <div class="widget-link-list">
-                  <% recent_preamble_optimized_posts.each do |plucked_article| %>
-                    <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: false %>
-                  <% end %>
+                  <%= render partial: "articles/widget_list_item", collection: recent_preamble_optimized_posts, as: :plucked_article, locals: { show_comment_count: false } %>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Rather than iterating over articles and creating each partial individually, [Rails allows us to load them as a collection](https://guides.rubyonrails.org/layouts_and_rendering.html#rendering-collections) which can [speed up load time](https://medium.com/@coorasse/partial-rendering-performance-in-rails-101fdfb6ffb9). We do this in quite a few places in the code. This just addresses 2 places where I noticed it initially. 

## Related Tickets & Documents
https://github.com/forem/InternalProjectPlanning/issues/273

## QA Instructions, Screenshots, Recordings
* Load tag pages and note that you will see the following log instead of 10 separate partial loads
```
Rendered collection of articles/_widget_list_item.html.erb [10 times]
```

## Added tests?
- [x] No, and this is an implementation change, as long as all current tests pass we should be good.

![alt_text](https://thumbs.gfycat.com/GloomyTintedCrownofthornsstarfish-max-1mb.gif)
