### PR TITLE
Bug Fix:Update dev.to check to use DEV Community

### DIFF
--- a/app/services/email_digest.rb
+++ b/app/services/email_digest.rb
@@ -13,7 +13,7 @@ class EmailDigest
         # Temporary
         # @sre:mstruve This is temporary until we have an efficient way to handle this job
         # for our large DEV community. Smaller Forems should be able to handle it no problem
-        if SiteConfig.community_name == "DEV"
+        if SiteConfig.community_name == "DEV Community"
           Emails::SendUserDigestWorker.new.perform(user.id)
         else
           Emails::SendUserDigestWorker.perform_async(user.id)

--- a/app/workers/articles/rss_reader_worker.rb
+++ b/app/workers/articles/rss_reader_worker.rb
@@ -8,7 +8,7 @@ module Articles
       # Temporary
       # @sre:mstruve This is temporary until we have an efficient way to handle this job
       # for our large DEV community. Smaller Forems should be able to handle it no problem
-      return if SiteConfig.community_name == "DEV"
+      return if SiteConfig.community_name == "DEV Community"
 
       if FeatureFlag.enabled?(:feeds_import)
         ::Feeds::ImportArticlesWorker.perform_async

--- a/app/workers/emails/enqueue_digest_worker.rb
+++ b/app/workers/emails/enqueue_digest_worker.rb
@@ -8,7 +8,7 @@ module Emails
       # Temporary
       # @sre:mstruve This is temporary until we have an efficient way to handle this job
       # for our large DEV community. Smaller Forems should be able to handle it no problem
-      return if SiteConfig.community_name == "DEV"
+      return if SiteConfig.community_name == "DEV Community"
 
       EmailDigest.send_periodic_digest_email
     end

--- a/spec/services/email_digest_spec.rb
+++ b/spec/services/email_digest_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe EmailDigest, type: :service do
     end
 
     it "performs job inline if community is DEV" do
-      allow(SiteConfig).to receive(:community_name).and_return("DEV")
+      allow(SiteConfig).to receive(:community_name).and_return("DEV Community")
       user = create(:user, email_digest_periodic: true)
       worker = Emails::SendUserDigestWorker.new
       allow(worker).to receive(:perform)

--- a/spec/workers/articles/rss_reader_worker_spec.rb
+++ b/spec/workers/articles/rss_reader_worker_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Articles::RssReaderWorker, type: :worker do
     end
 
     it "short circuits if it's running on DEV" do
-      allow(SiteConfig).to receive(:community_name).and_return("DEV")
+      allow(SiteConfig).to receive(:community_name).and_return("DEV Community")
       allow(RssReader).to receive(:get_all_articles)
       allow(FeatureFlag).to receive(:enabled?)
 


### PR DESCRIPTION
Recently we changed our site name on dev.to from DEV to DEV Community. This is used in our code in a couple of places and needs to be updated. From a prod console
```
irb(main):002:0> SiteConfig.community_name == "DEV Community"
=> true
```