### PR TITLE
Add format to image optimizer

### DIFF
--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -34,6 +34,8 @@ module Images
     DEFAULT_IMGPROXY_OPTIONS = {
       height: nil,
       width: nil,
+      format: nil,
+      max_bytes: 500_000, # Keep everything under half of one MB.
       resizing_type: nil
     }.freeze
 
@@ -48,7 +50,7 @@ module Images
       if options[:crop] == "fill"
         options[:resizing_type] = "fill"
       end
-
+      options[:format] = options[:fetch_format] == "auto" ? nil : options[:fetch_format]
       options
     end
 

--- a/app/view_objects/cloud_cover_url.rb
+++ b/app/view_objects/cloud_cover_url.rb
@@ -12,7 +12,7 @@ class CloudCoverUrl
     width = 1000
     img_src = url_without_prefix_nesting(url, width)
 
-    Images::Optimizer.call(img_src, width: width, height: 420, crop: "imagga_scale")
+    Images::Optimizer.call(img_src, width: width, height: 420, crop: "imagga_scale", fetch_format: "webp")
   end
 
   private

--- a/spec/services/images/optimizer_spec.rb
+++ b/spec/services/images/optimizer_spec.rb
@@ -86,9 +86,21 @@ RSpec.describe Images::Optimizer, type: :service do
   end
 
   describe "#translate_cloudinary_options" do
-    it "Set resizing_type to fill if crop: fill is provided" do
+    it "sets resizing_type to fill if crop: fill is provided" do
       options = { width: 100, height: 100, crop: "fill" }
       expect(described_class.translate_cloudinary_options(options)).to include(resizing_type: "fill")
+    end
+
+    it "sets format to nil if fetch_format is auto" do
+      options = { width: 100, height: 100, fetch_format: "auto" }
+      expect(described_class.translate_cloudinary_options(options)).to include(format: nil)
+    end
+
+    it "sets format to format if fetch_format is given specific format" do
+      options = { width: 100, height: 100, fetch_format: "webp" }
+      expect(described_class.translate_cloudinary_options(options)).to include(format: "webp")
+      options = { width: 100, height: 100, fetch_format: "jpg" }
+      expect(described_class.translate_cloudinary_options(options)).to include(format: "jpg")
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR applies the format of webp to cover images on posts. imgproxy does not have "auto" format, which we use on Cloudinary, but we should be using webp wherever possible. Only about 0.75% of all DEV traffic is from browsers that are not compatible with webp, and this is dropping quickly as more people move to Safari 14. And this number is much lower on authenticated traffic.

I think there is still too much traffic from these browsers to entirely drop support, but I think removing support for old Safari browsers _only for cover images_ is okay. This one image won't render properly for a very small number of users, but the gains are that the rest of the traffic will benefit from the far smaller webp images in their feed.

In a matter of months we may be able to consider applying the format of webp more broadly.

Apple ecosystem tends to have really healthy update cycles and I think we can start stepping into the webp universe.

<img width="1349" alt="Screen Shot 2020-12-31 at 6 48 48 PM" src="https://user-images.githubusercontent.com/3102842/103431092-d5434580-4b98-11eb-9c4c-06b2061860dd.png">

**Edit:** It looks like we _can_ auto-detect webp support directly within imgproxy. 

https://docs.imgproxy.net/#/configuration?id=webp-support-detection

We should probably try this and use webp everywhere I'd think.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed
