### PR TITLE
Use anchor tag instead of button for edit/delete links

### DIFF
--- a/app/javascript/listings/__tests__/ListingDashboard.test.jsx
+++ b/app/javascript/listings/__tests__/ListingDashboard.test.jsx
@@ -262,10 +262,12 @@ describe('<ListingDashboard />', () => {
     // edit and delete buttons
     const editButton = getByText('Edit', listing1GetByTextOptions);
 
+    expect(editButton.nodeName).toEqual('A');
     expect(editButton.getAttribute('href')).toEqual('/listings/23/edit');
 
     const deleteButton = getByText('Delete', listing1GetByTextOptions);
 
+    expect(deleteButton.nodeName).toEqual('A');
     expect(deleteButton.getAttribute('href')).toEqual(
       '/listings/cfp/asdfasdf-2ea8/delete_confirm',
     );

--- a/app/javascript/listings/dashboard/rowElements/actionButtons.jsx
+++ b/app/javascript/listings/dashboard/rowElements/actionButtons.jsx
@@ -6,16 +6,25 @@ const ActionButtons = ({ isDraft, editUrl, deleteConfirmUrl }) => {
   return (
     <div className="listing-row-actions">
       {isDraft && (
-        <Button href={editUrl} className="dashboard-listing-edit-button">
+        <Button
+          tagName="a"
+          url={editUrl}
+          className="dashboard-listing-edit-button"
+        >
           View draft
         </Button>
       )}
-      <Button href={editUrl} className="dashboard-listing-edit-button">
+      <Button
+        tagName="a"
+        url={editUrl}
+        className="dashboard-listing-edit-button"
+      >
         Edit
       </Button>
       <Button
         variant="danger"
-        href={deleteConfirmUrl}
+        tagName="a"
+        url={deleteConfirmUrl}
         className="dashboard-listing-delete-button"
       >
         Delete

--- a/app/javascript/listings/dashboard/rowElements/actionButtons.jsx
+++ b/app/javascript/listings/dashboard/rowElements/actionButtons.jsx
@@ -6,27 +6,14 @@ const ActionButtons = ({ isDraft, editUrl, deleteConfirmUrl }) => {
   return (
     <div className="listing-row-actions">
       {isDraft && (
-        <Button
-          tagName="a"
-          url={editUrl}
-          className="dashboard-listing-edit-button"
-        >
+        <Button tagName="a" url={editUrl}>
           View draft
         </Button>
       )}
-      <Button
-        tagName="a"
-        url={editUrl}
-        className="dashboard-listing-edit-button"
-      >
+      <Button tagName="a" url={editUrl}>
         Edit
       </Button>
-      <Button
-        variant="danger"
-        tagName="a"
-        url={deleteConfirmUrl}
-        className="dashboard-listing-delete-button"
-      >
+      <Button variant="danger" tagName="a" url={deleteConfirmUrl}>
         Delete
       </Button>
     </div>

--- a/app/views/listings/delete_confirm.html.erb
+++ b/app/views/listings/delete_confirm.html.erb
@@ -17,7 +17,7 @@
     <%= form_tag "/listings/#{@listing.id}", method: :delete do %>
       <button class="crayons-btn crayons-btn--danger">Delete</button>
       <a data-no-instant href="/listings/<%= @listing.id %>/edit" class="crayons-btn crayons-btn--secondary">
-        <%= @article.published ? "Unpublish" : "Edit" %>
+        <%= @listing.published ? "Unpublish" : "Edit" %>
       </a>
     <% end %>
   </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where in the listings dashboard, a listing's edit and delete buttons were HTML `<button>` tags, when they should be `<a>` tags that link to the proper page.

## Related Tickets & Documents
Closes #10937

## QA Instructions, Screenshots, Recordings
1. Make a listing: http://localhost:3000/listings/new
2. Go to your listings dashboard: http://localhost:3000/listings/dashboard
3. Click the edit button and see that it routes properly
4. Click the delete button and see that it routes to `/:listing_slug/delete_confirm`

### UI accessibility concerns?
Don't think so! Just changed it to a regular link.

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?
Can't load Giphy today :(
