### PR TITLE
Bug Fix:Update Article Cached Org and Docs When Org is Deleted

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -610,13 +610,8 @@ class Article < ApplicationRecord
   end
 
   def update_cached_user
-    if organization
-      self.cached_organization = Articles::CachedEntity.from_object(organization)
-    end
-
-    return unless user
-
-    self.cached_user = Articles::CachedEntity.from_object(user)
+    self.cached_organization = organization ? Articles::CachedEntity.from_object(organization) : nil
+    self.cached_user = user ? Articles::CachedEntity.from_object(user) : nil
   end
 
   def set_all_dates

--- a/spec/lib/data_update_scripts/update_articles_cached_entities_spec.rb
+++ b/spec/lib/data_update_scripts/update_articles_cached_entities_spec.rb
@@ -15,8 +15,9 @@ describe DataUpdateScripts::UpdateArticlesCachedEntities do
   end
 
   it "changes cached organizations from OpenStructs to Structs" do
-    cached_org = make_ostruct(create(:organization))
-    article = create(:article, cached_organization: cached_org)
+    org = create(:organization)
+    article = create(:article, organization: org)
+    article.update_column(:cached_organization, make_ostruct(org))
 
     expect do
       described_class.new.run

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -81,15 +81,14 @@ RSpec.describe Organization, type: :model do
       expect(article.elasticsearch_doc.dig("_source", "organization", "name")).to eq(new_org_name)
     end
 
-    # TODO: This will be fixed by @mstruve
-    # https://github.com/forem/forem/pull/10707#pullrequestreview-538071192
-    xit "on destroy removes data from elasticsearch" do
+    it "on destroy updates related article data" do
       article = create(:article, organization: organization)
-      sidekiq_perform_enqueued_jobs
+      drain_all_sidekiq_jobs
       expect(article.elasticsearch_doc.dig("_source", "organization", "id")).to eq(organization.id)
       organization.destroy
       sidekiq_perform_enqueued_jobs
       expect(article.elasticsearch_doc.dig("_source", "organization")).to be_nil
+      expect(article.reload.cached_organization).to be_nil
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We had a couple of bugs showing up here.
1. When an organization is deleted we were not updating the associate article Elasticsearch documents.
2. Upon finding 1, I also discovered we were not updating the `cached_organization` on articles when an organization was removed. 

Why didn't we notice this sooner? 
We didn't notice this sooner bc technically we will not destroy an organization if it has any associated articles according to our organization policy.
```ruby
  def destroyable?
    organization_memberships.count == 1 && articles.count.zero?
  end
```
Regardless, I still think having these in place would be a good idea in the event we remove that requirement one day OR in the event someone manually removes an organization from a console. Ideally, you don't want that to happen but this ensures we are covered if it does. 

## Related Tickets & Documents
Stole this from the [SRE project board](https://github.com/orgs/forem/projects/6)
https://github.com/orgs/forem/projects/18#card-52095568

## Added tests?
- [x] Yes

![alt_text](https://media.tenor.com/images/251c250b6e962c4ffa78fce64c4aacac/tenor.gif)
