### PR TITLE
Use wait-retry-interval parameter for dockerize

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       APP_DOMAIN: rails
     volumes:
       - .:/opt/apps/forem:delegated
-    entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "http://elasticsearch:9200", "-wait", "tcp://redis:6379", "-wait", "file:///opt/apps/forem/vendor/bundle/.bundle_finished", "-timeout", "2700s"]
+    entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "http://elasticsearch:9200", "-wait", "tcp://redis:6379", "-wait", "file:///opt/apps/forem/vendor/bundle/.bundle_finished", "-timeout", "2700s", "-wait-retry-interval", "10s"]
     command: [ "bash", "-c", "./scripts/entrypoint.sh bootstrap && bundle exec rails server -b 0.0.0.0 -p 3000"]
 
   bundle:
@@ -75,7 +75,7 @@ services:
       ELASTICSEARCH_URL: http://elasticsearch:9200
     volumes:
       - .:/opt/apps/forem:delegated
-    entrypoint: ["dockerize", "-wait", "file:///opt/apps/forem/node_modules/.bin/webpack-dev-server", "-wait", "file:///opt/apps/forem/vendor/bundle/.bundle_finished", "-timeout", "2700s"]
+    entrypoint: ["dockerize", "-wait", "file:///opt/apps/forem/node_modules/.bin/webpack-dev-server", "-wait", "file:///opt/apps/forem/vendor/bundle/.bundle_finished", "-timeout", "2700s", "-wait-retry-interval", "10s"]
     command: ["./bin/webpack-dev-server"]
 
   seed:
@@ -96,7 +96,7 @@ services:
       ELASTICSEARCH_URL: http://elasticsearch:9200
     volumes:
       - .:/opt/apps/forem:delegated
-    entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "http://elasticsearch:9200", "-wait", "tcp://redis:6379", "-wait", "http://rails:3000", "-timeout", "2700s"]
+    entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "http://elasticsearch:9200", "-wait", "tcp://redis:6379", "-wait", "http://rails:3000", "-timeout", "2700s", "-wait-retry-interval", "20s"]
     command: ["bundle", "exec", "rake","db:seed"]
 
   sidekiq:
@@ -117,7 +117,7 @@ services:
       ELASTICSEARCH_URL: http://elasticsearch:9200
     volumes:
       - .:/opt/apps/forem:delegated
-    entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "http://elasticsearch:9200", "-wait", "tcp://redis:6379", "-wait", "http://rails:3000", "-timeout", "2700s"]
+    entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "http://elasticsearch:9200", "-wait", "tcp://redis:6379", "-wait", "http://rails:3000", "-timeout", "2700s", "-wait-retry-interval", "20s"]
     command: ["bundle", "exec", "sidekiq","-c","2"]
 
   db:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The default retry interval for dockerize when using the `wait`
parameter is 1s. Because it takes several seconds, at least, to boot
up elasticsearch and bundler, the `rails` and `webpacker` services
generate a number of retry messages.

The `seed` and `sidekiq` services both wait for `rails` service to be
up and running. That takes time as well, and these two generate a
sometimes overwhelming level of output.

This change sets the retry interval for dockerize to 10s for `rails`
and `webpacker` and 20s for `seed` and `sidekiq`. These choices are
fairly arbitrary, but aim to strike a balance between keeping the
output readable as services start and not excessively delaying start
times.

With bad luck, this could delay start up on the order of 30s. However,
the increased awareness of where the various services are in their
startup process is hopefully a worthwhile tradeoff.

## Related Tickets & Documents

Closes #12099

## QA Instructions, Screenshots, Recordings

Start the docker compose setup with `./bin/container-setup` and notice the decrease in output messages.

### UI accessibility concerns?
N/A

## Added tests?

- [ ] Yes
- [x] No, and this is why: I don't believe automated tests would be helpful here, but if they are, I need some pointers.
- [x] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

Not that I am aware of.

## [optional] What gif best describes this PR or how it makes you feel?

![LEGO Batman first try](https://media.tenor.com/images/fd01c8055500984d9e2858eb480b62c9/tenor.png)
