### PR TITLE
Add `max_bytes` to imgproxy.

### DIFF
--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -34,6 +34,8 @@ module Images
     DEFAULT_IMGPROXY_OPTIONS = {
       height: nil,
       width: nil,
+      format: nil,
+      max_bytes: 500_000, # Keep everything under half of one MB.
       resizing_type: nil
     }.freeze
 
@@ -48,7 +50,7 @@ module Images
       if options[:crop] == "fill"
         options[:resizing_type] = "fill"
       end
-
+      options[:format] = options[:fetch_format] == "auto" ? nil : options[:fetch_format]
       options
     end
 

--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -34,7 +34,6 @@ module Images
     DEFAULT_IMGPROXY_OPTIONS = {
       height: nil,
       width: nil,
-      format: nil,
       max_bytes: 500_000, # Keep everything under half of one MB.
       resizing_type: nil
     }.freeze
@@ -50,7 +49,7 @@ module Images
       if options[:crop] == "fill"
         options[:resizing_type] = "fill"
       end
-      options[:format] = options[:fetch_format] == "auto" ? nil : options[:fetch_format]
+
       options
     end
 

--- a/app/view_objects/cloud_cover_url.rb
+++ b/app/view_objects/cloud_cover_url.rb
@@ -12,7 +12,7 @@ class CloudCoverUrl
     width = 1000
     img_src = url_without_prefix_nesting(url, width)
 
-    Images::Optimizer.call(img_src, width: width, height: 420, crop: "imagga_scale")
+    Images::Optimizer.call(img_src, width: width, height: 420, crop: "imagga_scale", fetch_format: "webp")
   end
 
   private

--- a/app/view_objects/cloud_cover_url.rb
+++ b/app/view_objects/cloud_cover_url.rb
@@ -12,7 +12,7 @@ class CloudCoverUrl
     width = 1000
     img_src = url_without_prefix_nesting(url, width)
 
-    Images::Optimizer.call(img_src, width: width, height: 420, crop: "imagga_scale", fetch_format: "webp")
+    Images::Optimizer.call(img_src, width: width, height: 420, crop: "imagga_scale")
   end
 
   private

--- a/spec/services/images/optimizer_spec.rb
+++ b/spec/services/images/optimizer_spec.rb
@@ -86,9 +86,21 @@ RSpec.describe Images::Optimizer, type: :service do
   end
 
   describe "#translate_cloudinary_options" do
-    it "Set resizing_type to fill if crop: fill is provided" do
+    it "sets resizing_type to fill if crop: fill is provided" do
       options = { width: 100, height: 100, crop: "fill" }
       expect(described_class.translate_cloudinary_options(options)).to include(resizing_type: "fill")
+    end
+
+    it "sets format to nil if fetch_format is auto" do
+      options = { width: 100, height: 100, fetch_format: "auto" }
+      expect(described_class.translate_cloudinary_options(options)).to include(format: nil)
+    end
+
+    it "sets format to format if fetch_format is given specific format" do
+      options = { width: 100, height: 100, fetch_format: "webp" }
+      expect(described_class.translate_cloudinary_options(options)).to include(format: "webp")
+      options = { width: 100, height: 100, fetch_format: "jpg" }
+      expect(described_class.translate_cloudinary_options(options)).to include(format: "jpg")
     end
   end
 end

--- a/spec/services/images/optimizer_spec.rb
+++ b/spec/services/images/optimizer_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Images::Optimizer, type: :service do
     it "works" do
       allow(described_class).to receive(:imgproxy_enabled?).and_return(true)
       imgproxy_url = described_class.imgproxy(image_url, service: :imgproxy, width: 500, height: 500)
-      expect(imgproxy_url).to match(%r{/s:500:500/aHR0cHM6Ly9pLmlt/Z3VyLmNvbS9mS1lL/Z280LnBuZw})
+      expect(imgproxy_url).to match(%r{/s:500:500/mb:500000/aHR0cHM6Ly9pLmlt/Z3VyLmNvbS9mS1lL/Z280LnBuZw})
     end
   end
 
@@ -89,18 +89,6 @@ RSpec.describe Images::Optimizer, type: :service do
     it "sets resizing_type to fill if crop: fill is provided" do
       options = { width: 100, height: 100, crop: "fill" }
       expect(described_class.translate_cloudinary_options(options)).to include(resizing_type: "fill")
-    end
-
-    it "sets format to nil if fetch_format is auto" do
-      options = { width: 100, height: 100, fetch_format: "auto" }
-      expect(described_class.translate_cloudinary_options(options)).to include(format: nil)
-    end
-
-    it "sets format to format if fetch_format is given specific format" do
-      options = { width: 100, height: 100, fetch_format: "webp" }
-      expect(described_class.translate_cloudinary_options(options)).to include(format: "webp")
-      options = { width: 100, height: 100, fetch_format: "jpg" }
-      expect(described_class.translate_cloudinary_options(options)).to include(format: "jpg")
     end
   end
 end

--- a/spec/views/dashboards/show.html.erb_spec.rb
+++ b/spec/views/dashboards/show.html.erb_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "dashboards/show.html.erb", type: :view do
       assign(:user, create(:user))
       assign(:articles, [])
       render
-      expect(rendered).to match(%r{/w:300/aHR0cHM6Ly9pLmlt/Z3VyLmNvbS9mS1lL/Z280LnBuZw})
+      expect(rendered).to match(%r{/w:300/mb:500000/aHR0cHM6Ly9pLmlt/Z3VyLmNvbS9mS1lL/Z280LnBuZw})
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This feature adds the `max_bytes` default option to help reduce the size of overly big images. This will automatically add optimization only where it is most needed... On the most over-sized images.

## Related Tickets & Documents

This is related to this PR: https://github.com/forem/forem/pull/12089

But as noted, some of that is better implemented with imgproxy ENV vars. But this one seems appropriate.

## Added tests?

- [x] Yes - Adjusted existing test to check for this variable.
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
