### PR TITLE
Small clean ups in post form

### DIFF
--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -335,7 +335,7 @@ class Tags extends Component {
       // updates searchResults array according to what is being typed by user
       // allows user to choose a tag when they've typed the partial or whole word
       this.setState({
-        searchResults: response.result,
+        searchResults: response.result.filter((t) => !this.selected.includes(t.name)),
       });
     });
   }

--- a/app/views/articles/_v2_form.html.erb
+++ b/app/views/articles/_v2_form.html.erb
@@ -83,35 +83,10 @@
             </button>
           </div>
           <div class="crayons-article-form__title">
-            <textarea class="crayons-textfield crayons-textfield--ghost fs-3xl s:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight" type="text" id="article-form-title" placeholder="New post title here..." autocomplete="off" style="height: 60px; "><%= article.title %></textarea>
-          </div>
-          <div class="crayons-article-form__tagsfield">
-            <input type="text" class="crayons-textfield crayons-textfield--ghost ff-monospace" placeholder="Add up to 4 tags..." name="tags" value="<%= article.cached_tag_list %>" />
+            <textarea class="crayons-textfield crayons-textfield--ghost fs-3xl s:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight" type="text" id="article-form-title" placeholder="New post title here..." autocomplete="off"><%= article.title %></textarea>
           </div>
         </div>
       <% end %>
-      <div class="crayons-article-form__body text-padding">
-        <div class="crayons-article-form__toolbar">
-          <button class="crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon-left fw-normal" type="button">
-            <%= ("#{inline_svg_tag('image.svg', aria: true, class: 'crayons-icon', title: 'Image')}Upload image").delete!("\n").html_safe %>
-            <input type="file" id="image-upload-field" class="w-100 h-100 absolute left-0 right-0 top-0 bottom-0 overflow-hidden opacity-0 cursor-pointer" multiple accept="image/*" data-max-file-size-mb="25" />
-          </button>
-        </div>
-        <textarea class="crayons-article-form__body__field crayons-textfield crayons-textfield--ghost" id="article_body_markdown" placeholder="Write your post content here..." name="body_markdown"><%= article.body_markdown %></textarea>
-      </div>
-    </div>
-    <div class="crayons-article-form__aside"></div>
-
-    <div class="crayons-article-form__aside"></div>
-
-    <div class="crayons-article-form__footer">
-      <button class="crayons-btn mr-2" type="button">Publish</button>
-      <button class="crayons-btn crayons-btn--secondary mr-2" type="button">Save draft</button>
-      <div class="relative">
-        <button class="crayons-btn crayons-btn--ghost crayons-btn--icon" type="button" title="Post options">
-          <%= inline_svg_tag("cog.svg", aria: true, class: "crayons-icon", title: "Options") %>
-        </button>
-      </div>
     </div>
   </form>
 </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a couple low-hanging fruit to fix some behavior in the "write a post" form.

This prevents the "jump" between the server rendered and client rendered view... It does this by eliminating some of what gets rendered on the server. It replaces it with more of a blank canvas until the rest of the form is rendered. The "jump" is most jarring on mobile. I think this will particularly improve that context.

The other small thing is to not render the row in the tag dropdown if that value has already been searched for. So if you type `j` in the tag bar, and select `java`, the next `j` you add will _not_ have `java` in the list.

These are a few low-hanging fruit for usability and code cleanliness.