### PR TITLE
Patch: Fix UI bugs in follow adjustment form

### DIFF
--- a/app/views/dashboards/following_tags.html.erb
+++ b/app/views/dashboards/following_tags.html.erb
@@ -22,7 +22,7 @@
             <span class="crayons-indicator crayons-indicator--outlined crayons-indicator--accent ml-3">Default 1.0</span>
         </div>
 
-        <%= form_with url: bulk_update_follows_path, method: :patch, local: true, id: "follows_update_form" do |f| %>
+        <%= form_with url: bulk_update_follows_path, method: :patch, local: true, class: "sticky bg-base-10 pt-3 pb-1 z-elevate", html: { style: "top: 55px;margin-left:-1px"}, id: "follows_update_form" do |f| %>
           <button type="submit" class="crayons-btn crayons-btn--m mb-3" name="commit">Update Weights</button>
         <% end %>
         
@@ -42,7 +42,7 @@
                   <% end %>
                 </h3>
 
-                <p class="grid-cell__summary truncate-at-3 mb-4 fs-s">
+                <p class="grid-cell__summary truncate-at-2 mb-4 fs-m h-50">
                   <%= strip_tags(tag.short_summary) %>
                 </p>
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

PR https://github.com/forem/forem/pull/11454 introduced useful new functionality, but some of the styling is messed up. This PR introduces some better UX and fixes to styling (ultimately better than what they were before that PR too, IMO, so improvements all around)

### Current:

#### See inconsistent text field height.

<img width="1011" alt="Screen Shot 2021-01-05 at 2 39 44 PM" src="https://user-images.githubusercontent.com/3102842/103691247-dd69ff00-4f63-11eb-9c27-51f6467b52c6.png">

### Fix
#### Consistency of heights of everything.

<img width="678" alt="Screen Shot 2021-01-05 at 2 40 19 PM" src="https://user-images.githubusercontent.com/3102842/103691303-f2df2900-4f63-11eb-9949-2ea71e6d8936.png">

This PR also makes the submit button sticky, which I think helps make the whole flow more intuitive.

<img width="579" alt="Screen Shot 2021-01-05 at 2 41 08 PM" src="https://user-images.githubusercontent.com/3102842/103691374-0f7b6100-4f64-11eb-9f11-c8487bc0249a.png">

## Related Tickets & Documents

https://github.com/forem/forem/pull/11454

### UI accessibility concerns?

I think we're all good here.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

