### PR TITLE
Adds ratio param to Cover Image native bridge image picker

### DIFF
--- a/app/javascript/article-form/components/ArticleCoverImage.jsx
+++ b/app/javascript/article-form/components/ArticleCoverImage.jsx
@@ -59,6 +59,7 @@ export class ArticleCoverImage extends Component {
     e.preventDefault();
     window.webkit.messageHandlers.imageUpload.postMessage({
       id: 'native-cover-image-upload-message',
+      ratio: `${100.0 / 42.0}`,
     });
   };
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The native bridge interface now supports a `ratio` param on top of the DOM element id and this PR adds the ratio restriction to cover images. This way we're making sure users will always crop perfectly to fit the cover images aspect ratio.

This `ratio` param is optional and the normal image upload in the Editor doesn't use it. This allows users to upload image without the final crop step.

## Related Tickets & Documents

- https://github.com/forem/ForemWebView-ios/issues/21
- https://github.com/forem/ForemWebView-ios/pull/22

## QA Instructions, Screenshots, Recordings

This recording shows both image upload steps. The cover image has a final step that forces the user to select a final crop on the images but the image upload doesn't (allowing for any aspect ratio)

https://share.getcloudapp.com/RBu9A4A6

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: We have tests to ensure the native bridge calls are being handled in Preact but this new features live in `forem/ForemWebView-ios`
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [ ] No documentation needed
- [x] Will be doing a docs overhaul in `forem/ForemWebView-ios` to make sure the public interfaces are well documented (outside the scope of this PR)

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![perfect fit](https://media.giphy.com/media/cPkjQVmA4wFJPhDLKH/giphy.gif)
