### PR TITLE
[Travis] Use directories cache for Bundle and Yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 cache:
   bundler: true
-  npm: true
   directories:
+    - node_modules
     - $HOME/.nvm
     - ~/.cache # cache folder with Cypress binary
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache:
-  bundler: true
   directories:
+    - vendor/bundle
     - node_modules
     - $HOME/.nvm
     - ~/.cache # cache folder with Cypress binary


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] CI

## Description
Essentially reverting 3764cd6. For some reason, this works again but caches are still not showing up on Travis's dashboard. This should be a UI issue as the cache is working as expected.

## Related Tickets & Documents
n/a
## QA Instructions, Screenshots, Recordings
How to verify that it is actually working? There are two dependencies command to look for

`bin/ci-bundle` and `yarn install --frozen-lockfile`. 

Each of these should not take more than 5 seconds.


This is a tiny image but it shows that it took only 1.8 second to run yarn install.
![image](https://user-images.githubusercontent.com/15793250/103701930-891b4b00-4f74-11eb-9cdd-543341b8528f.png)
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a