### PR TITLE
Add libv8 library for MacOS 11.0 Big Sur

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,6 +430,7 @@ GEM
       http (>= 2.0, < 5.0)
     libv8 (8.4.255.0)
     libv8 (8.4.255.0-x86_64-darwin-19)
+    libv8 (8.4.255.0-x86_64-darwin-20)
     liquid (4.0.3)
     listen (3.4.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -833,6 +834,7 @@ GEM
 PLATFORMS
   ruby
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   active_record_union (~> 1.3)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

After setting up Forem on Big Sur, a Darwin-20 version of the `libv8` gem was added to the `Gemfile.lock` file. Following @rhymes prior art in https://github.com/forem/forem/pull/12031, I'm thinking we should commit this change.

(I'm curious why this is happening now though: perhaps libv8 binary gems? Are we going to have to add this for ever type of environment libv8 runs in?!)

## Related Tickets & Documents

https://github.com/forem/forem/pull/12031

## Added tests?

- [ ] Yes
- [x] No, and this is why: not needed - gemfile.lock addition
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Tim Cook thank you](https://media.giphy.com/media/TLm3ig25UPL7roCPLC/giphy.gif)
