### PR TITLE
Feature:Add ability to add a Tag Resource Admin through Admin

### DIFF
--- a/app/lib/constants/role.rb
+++ b/app/lib/constants/role.rb
@@ -19,6 +19,7 @@ module Constants
                      "Resource Admin: Broadcast",
                      "Resource Admin: HtmlVariant",
                      "Resource Admin: DisplayAd",
-                     "Resource Admin: ListingCategory"].freeze
+                     "Resource Admin: ListingCategory",
+                     "Resource Admin: Tag"].freeze
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
I have needed to add a Resource Tag admin twice now and both times I had to do it through a console since its not an option in admin. This changes that :) 

## QA Instructions, Screenshots, Recordings
1. Go to `/admin/users`
2. Click on any user and select "Manage User"
3. Add the "Resource Admin: Tag" option and they should be able to work with tags in admin.

## Added tests?
- [x] No, this method and endpoint is test, we are merely adding an additional option


![alt_text](https://media1.tenor.com/images/655f2ff0e7acff83530cb89e67618548/tenor.gif?itemid=12461713)
