### PR TITLE
Remove looking for work columns

### DIFF
--- a/app/javascript/onboarding/components/__tests__/ProfileForm.test.jsx
+++ b/app/javascript/onboarding/components/__tests__/ProfileForm.test.jsx
@@ -43,10 +43,10 @@ describe('ProfileForm', () => {
         profile_fields: [
           {
             id: 36,
-            attribute_name: 'looking_for_work',
+            attribute_name: 'education',
             description: '',
-            input_type: 'check_box',
-            label: 'Looking for work?',
+            input_type: 'text_field',
+            label: 'Education',
             placeholder_text: '',
           },
         ],
@@ -119,7 +119,7 @@ describe('ProfileForm', () => {
   it('should render the correct group headings', async () => {
     const { findByText } = renderProfileForm();
 
-    const heading1 = await findByText(/Looking for work?/i);
+    const heading1 = await findByText('Education');
     const heading2 = await findByText('Name');
 
     expect(heading1).toBeInTheDocument();
@@ -129,7 +129,7 @@ describe('ProfileForm', () => {
   it('should render the correct fields', async () => {
     const { findByLabelText } = renderProfileForm();
 
-    const field1 = await findByLabelText(/Looking for work?/i);
+    const field1 = await findByLabelText(/Education/i);
     const field2 = await findByLabelText(/Name/i);
     const field3 = await findByLabelText(/Website URL/i);
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -15,7 +15,6 @@ class Profile < ApplicationRecord
     brand_color1: :bg_color_hex,
     brand_color2: :text_color_hex,
     display_email_on_profile: :email_public,
-    display_looking_for_work_on_profile: :looking_for_work_publicly,
     education: :education,
     git_lab_url: :gitlab_url,
     linked_in_url: :linkedin_url,

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -41,8 +41,6 @@ class UserPolicy < ApplicationPolicy
     instagram_url
     linkedin_url
     location
-    looking_for_work
-    looking_for_work_publicly
     mastodon_url
     medium_url
     mobile_comment_notifications

--- a/app/services/profile_fields/add_work_fields.rb
+++ b/app/services/profile_fields/add_work_fields.rb
@@ -7,8 +7,6 @@ module ProfileFields
       field "Employer name", :text_field, placeholder: "Acme Inc.", display_area: "header"
       field "Employer URL", :text_field, placeholder: "https://dev.com", display_area: "settings_only"
       field "Employment title", :text_field, placeholder: "Junior Frontend Engineer", display_area: "header"
-      field "Looking for work", :check_box, display_area: "settings_only"
-      field 'Display "looking for work" on profile', :check_box, display_area: "settings_only"
       field "Recruiters can contact me about job opportunities", :check_box, display_area: "settings_only"
     end
   end

--- a/app/views/articles/_user_metadata.html.erb
+++ b/app/views/articles/_user_metadata.html.erb
@@ -71,16 +71,6 @@
           </div>
         </li>
       <% end %>
-      <% if @user.looking_for_work_publicly == true && @user.looking_for_work == true %>
-        <li>
-          <div class="key">
-            Work status
-          </div>
-          <div class="value">
-            I'm looking for work!
-          </div>
-        </li>
-      <% end %>
       <% if @user.education.present? %>
         <li>
           <div class="key">

--- a/app/views/pages/_privacy_text.html.erb
+++ b/app/views/pages/_privacy_text.html.erb
@@ -33,7 +33,7 @@
   We do host first-party advertising on <%= community_name %>. We do not run any code from advertisers and all ad images are hosted on managed <%= community_name %> servers. For more details, see our section on Advertising Details.
   <br>
   <br>
-  We may use User Personal Information with your permission, so we can perform services you have authorized. For example, if you indicate you are looking for work, we may contact you with opportunities.
+  We may use User Personal Information with your permission, so we can perform services you have authorized.
   <br>
   <br>
   We may share User Personal Information with a limited number of third party vendors who process it on our behalf to provide or improve our service, and who have agreed to privacy restrictions similar to our own Privacy Statement. Our third party vendors are listed below.

--- a/app/views/users/_metadata.html.erb
+++ b/app/views/users/_metadata.html.erb
@@ -13,35 +13,27 @@
       <% end %>
       <%# As we migrate to more generalized profiles, we don't want to break DEV %>
       <% if SiteConfig.dev_to? %>
-        <% if @user.employment_title.present? || (@user.looking_for_work_publicly == true && @user.looking_for_work == true) %>
-          <% if @user.employment_title.present? %>
-            <div class="crayons-definition">
-              <strong class="crayons-definition__title">Work</strong>
-              <p class="crayons-definition__value">
-                <%= @user.employment_title %>
-                <% if @user.employer_name.present? %>
-                  <span class="opacity-50"> at </span>
-                  <% if @user.employer_url.present? %>
-                    <a href="<%= @user.employer_url %>" class="crayons-link crayons-link--brand" target="_blank" rel="noopener"><%= @user.employer_name %></a>
-                  <% else %>
-                    <%= @user.employer_name %>
-                  <% end %>
+        <% if @user.employment_title.present? %>
+          <div class="crayons-definition">
+            <strong class="crayons-definition__title">Work</strong>
+            <p class="crayons-definition__value">
+              <%= @user.employment_title %>
+              <% if @user.employer_name.present? %>
+                <span class="opacity-50"> at </span>
+                <% if @user.employer_url.present? %>
+                  <a href="<%= @user.employer_url %>" class="crayons-link crayons-link--brand" target="_blank" rel="noopener"><%= @user.employer_name %></a>
+                <% else %>
+                  <%= @user.employer_name %>
                 <% end %>
-              </p>
-            </div>
-          <% end %>
-          <% if @user.looking_for_work_publicly == true && @user.looking_for_work == true %>
-            <div class="crayons-definition">
-              <strong class="crayons-definition__title">Work status</strong>
-              <p class="crayons-definition__value">I'm looking for work!</p>
-            </div>
-          <% end %>
+              <% end %>
+            </p>
+          </div>
         <% end %>
       <% end %>
     </div>
   <% end %>
 <% else %>
-  <% if @user.employment_title.present? || (@user.looking_for_work_publicly == true && @user.looking_for_work == true) || @user.education.present? %>
+  <% if @user.employment_title.present? || @user.education.present? %>
     <div class="profile-header__bottom fs-base">
       <% if @user.education.present? %>
         <div class="crayons-definition">
@@ -64,13 +56,6 @@
               <% end %>
             <% end %>
           </p>
-        </div>
-      <% end %>
-
-      <% if @user.looking_for_work_publicly == true && @user.looking_for_work == true %>
-        <div class="crayons-definition">
-          <strong class="crayons-definition__title">Work status</strong>
-          <p class="crayons-definition__value">I'm looking for work!</p>
         </div>
       <% end %>
     </div>

--- a/db/migrate/20210108031718_remove_looking_for_work_from_users.rb
+++ b/db/migrate/20210108031718_remove_looking_for_work_from_users.rb
@@ -1,0 +1,8 @@
+class RemoveLookingForWorkFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      remove_column :users, :looking_for_work
+      remove_column :users, :looking_for_work_publicly
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_183127) do
+ActiveRecord::Schema.define(version: 2021_01_08_031718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
+  enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+  enable_extension "unaccent"
 
   create_table "ahoy_events", force: :cascade do |t|
     t.string "name"
@@ -836,6 +838,16 @@ ActiveRecord::Schema.define(version: 2021_01_05_183127) do
     t.index ["slug"], name: "index_pages_on_slug", unique: true
   end
 
+  create_table "pg_search_documents", force: :cascade do |t|
+    t.text "content"
+    t.datetime "created_at", precision: 6, null: false
+    t.bigint "searchable_id"
+    t.string "searchable_type"
+    t.datetime "updated_at", precision: 6, null: false
+    t.index "to_tsvector('simple'::regconfig, COALESCE(content, ''::text))", name: "index_pg_search_documents_on_content", using: :gin
+    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id"
+  end
+
   create_table "podcast_episode_appearances", force: :cascade do |t|
     t.boolean "approved", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
@@ -1283,8 +1295,6 @@ ActiveRecord::Schema.define(version: 2021_01_05_183127) do
     t.string "linkedin_url"
     t.string "location"
     t.datetime "locked_at"
-    t.boolean "looking_for_work", default: false
-    t.boolean "looking_for_work_publicly", default: false
     t.string "mastodon_url"
     t.string "medium_url"
     t.boolean "mobile_comment_notifications", default: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,10 +14,8 @@ ActiveRecord::Schema.define(version: 2021_01_08_031718) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
-  enable_extension "pg_trgm"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
-  enable_extension "unaccent"
 
   create_table "ahoy_events", force: :cascade do |t|
     t.string "name"
@@ -836,16 +834,6 @@ ActiveRecord::Schema.define(version: 2021_01_08_031718) do
     t.string "title"
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_pages_on_slug", unique: true
-  end
-
-  create_table "pg_search_documents", force: :cascade do |t|
-    t.text "content"
-    t.datetime "created_at", precision: 6, null: false
-    t.bigint "searchable_id"
-    t.string "searchable_type"
-    t.datetime "updated_at", precision: 6, null: false
-    t.index "to_tsvector('simple'::regconfig, COALESCE(content, ''::text))", name: "index_pg_search_documents_on_content", using: :gin
-    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable_type_and_searchable_id"
   end
 
   create_table "podcast_episode_appearances", force: :cascade do |t|

--- a/lib/data/dev_profile_fields.csv
+++ b/lib/data/dev_profile_fields.csv
@@ -17,12 +17,10 @@ Education,text_field,,,Work,header,false
 Employer name,text_field,Acme Inc.,,Work,header,false
 Employer URL,text_field,https://dev.com,,Work,header,false
 Employment title,text_field,Junior Frontend Engineer,,Work,header,false
-Looking for work,check_box,,,Work,settings_only,false
-"Display ""looking for work"" on profile",check_box,,,Work,settings_only,false
 Recruiters can contact me about job opportunities,check_box,,,Work,settings_only,false
 Skills/Languages,text_area,,What tools and languages are you most experienced with? Are you specialized or more of a generalist?,Coding,left_sidebar,false
 Currently learning,text_area,,"What are you learning right now? What are the new tools and languages you're picking up right now?",Coding,left_sidebar,false
 Currently hacking on,text_area,,What projects are currently occupying most of your time?,Coding,left_sidebar,false
 Available for,text_area,,"What kinds of collaborations or discussions are you available for? What's a good reason to say Hey! to you these days?",Coding,left_sidebar,false
 Brand color 1,color_field,#000000,"Used for backgrounds, borders etc.",Branding,settings_only,false
-Brand color 2,color_field,#000000,Used for texts (usually put on Brand color 1).,Branding,settings_only,false
+Brand color 2,color_field,#000000,Used for texts (usually put on Brand color 2).,Branding,settings_only,false

--- a/lib/data/dev_profile_fields.csv
+++ b/lib/data/dev_profile_fields.csv
@@ -23,4 +23,4 @@ Currently learning,text_area,,"What are you learning right now? What are the new
 Currently hacking on,text_area,,What projects are currently occupying most of your time?,Coding,left_sidebar,false
 Available for,text_area,,"What kinds of collaborations or discussions are you available for? What's a good reason to say Hey! to you these days?",Coding,left_sidebar,false
 Brand color 1,color_field,#000000,"Used for backgrounds, borders etc.",Branding,settings_only,false
-Brand color 2,color_field,#000000,Used for texts (usually put on Brand color 2).,Branding,settings_only,false
+Brand color 2,color_field,#000000,Used for texts (usually put on Brand color 1).,Branding,settings_only,false

--- a/lib/data_update_scripts/20210108033107_remove_looking_for_work_profile_fields.rb
+++ b/lib/data_update_scripts/20210108033107_remove_looking_for_work_profile_fields.rb
@@ -1,0 +1,10 @@
+module DataUpdateScripts
+  class RemoveLookingForWorkProfileFields
+    def run
+      # destroy_by is idempotent by default: if no record can be found an empty
+      # array will be returned.
+      ProfileField.destroy_by(attribute_name: "looking_for_work")
+      ProfileField.destroy_by(attribute_name: "display_looking_for_work_on_profile")
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/create_profile_fields_spec.rb
+++ b/spec/lib/data_update_scripts/create_profile_fields_spec.rb
@@ -15,7 +15,7 @@ describe DataUpdateScripts::CreateProfileFields do
     it "creates all profile fields and groups" do
       expect do
         described_class.new.run
-      end.to change { profile_field_and_group_count }.from([0, 0]).to([28, 5])
+      end.to change { profile_field_and_group_count }.from([0, 0]).to([26, 5])
     end
   end
 
@@ -29,7 +29,7 @@ describe DataUpdateScripts::CreateProfileFields do
       expect do
         described_class.new.run
       end.not_to change { profile_field_and_group_count }
-      expect(profile_field_and_group_count).to eq [28, 5]
+      expect(profile_field_and_group_count).to eq [26, 5]
     end
   end
 end

--- a/spec/services/profiles/update_spec.rb
+++ b/spec/services/profiles/update_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Profiles::Update, type: :service do
   end
 
   let(:profile) do
-    create(:profile, data: { looking_for_work: true, removed: "Bla" })
+    create(:profile, data: { education: "maybe", removed: "Bla" })
   end
   let(:user) { profile.user }
 
   it "correctly typecasts new attributes", :aggregate_failures do
-    described_class.call(user, profile: { location: 123, looking_for_work: "false" })
+    described_class.call(user, profile: { location: 123, education: "false" })
     expect(user.location).to eq "123"
-    expect(profile.looking_for_work).to be false
+    expect(profile.education).to eq "false"
   end
 
   it "removes old attributes from the profile" do
@@ -43,7 +43,7 @@ RSpec.describe Profiles::Update, type: :service do
 
   it "updates the profile_updated_at column" do
     expect do
-      described_class.call(user, profile: { looking_for_work: "false" })
+      described_class.call(user, profile: { education: "false" })
     end.to change { user.reload.profile_updated_at }
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR removes the columns `looking_for_work` and `looking_for_work_publicly` from the `users` table. It also removes code using these columns and has a data update script for removing the associated profile fields that were meant to replace them. The columns where previously due to profile generalization work, so we can just go ahead and remove them.

Question: we have a somewhat related column for "Recruiters can contact me about job opportunities", should we remove this too as part of this PR? /cc @vaidehijoshi

## Related Tickets & Documents

https://github.com/forem/internalEngineering/issues/366

## QA Instructions, Screenshots, Recordings

Nothing specific, the specs should cover this. You can go to `http://localhost:3000/settings` and verify that the checkbox in the "Work" section is gone after the data update script removed the profile field.

### UI accessibility concerns?

None

## Added tests?

- [X] Yes, updated existing tests
- 
## Added to documentation?

- [X] No documentation needed
