### PR TITLE
Show comment posting errors

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -260,11 +260,16 @@ function handleCommentSubmit(event) {
           activateRunkitTags();
         })
       } else {
+        form.classList.remove('submitting');
+        var responseStatus = response.status;
         response.json().then(function parseError(errorReponse) {
-          form.classList.remove('submitting');
-          showRateLimitModal('made a comment', 'making another comment')
-          return false;
+          if (responseStatus === 429) {
+            showRateLimitModal('made a comment', 'making another comment')
+          } else {
+            alert(errorReponse.error)
+          }
         });
+        return false;
       }
       return false;
     });

--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -266,7 +266,7 @@ function handleCommentSubmit(event) {
           if (responseStatus === 429) {
             showRateLimitModal('made a comment', 'making another comment')
           } else {
-            alert(errorReponse.error)
+            showUserAlertModal('Error posting comment', 'Your comment could not be posted due to an error: ' + errorReponse.error, 'OK')
           }
         });
         return false;

--- a/spec/system/comments/user_fills_out_comment_spec.rb
+++ b/spec/system/comments/user_fills_out_comment_spec.rb
@@ -64,6 +64,24 @@ RSpec.describe "Creating Comment", type: :system, js: true do
     end
   end
 
+  context "when there is an error posting a comment" do
+    let(:unconfigured_twitter_comment) { "{% twitter 733111952256335874 %}" }
+
+    before do
+      stub_request(:post, "https://api.twitter.com/oauth2/token")
+        .to_return(status: 400, body: '{"errors":[{"code":215,"message":"Bad Authentication data."}]}', headers: {})
+    end
+
+    it "displays a error modal" do
+      visit article.path.to_s
+      wait_for_javascript
+
+      fill_in "text-area", with: unconfigured_twitter_comment
+      click_button("Submit")
+      expect(page).to have_text("Error posting comment")
+    end
+  end
+
   context "with Runkit tags" do
     before do
       visit article.path.to_s


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As outlined in Issue https://github.com/forem/forem/issues/11912: when a use encounters an error with their comment posting, the 'rate limit' modal is displayed instead of an error message. Previously NOTHING was displayed: this PR at least displays the content of the error message.

Long term better error messaging would be desirable, but at least for now this will let users know they aren't actually hitting a rate limit.

## Related Tickets & Documents

resolves https://github.com/forem/forem/issues/11912
https://github.com/forem/forem/pull/11102

## QA Instructions, Screenshots, Recordings

1. Attempt to post a comment that contains an error. An easy way to do this is by posting the exactly same comment twice, or using a Twitter liquidtag on a Forem instance that doesn't not have Twitter API keys set.

<img width="898" alt="The_Waste_Land_Beatae_tenetur_-_DEV_local__Community_🌱" src="https://user-images.githubusercontent.com/37842/104047714-b734a100-51a7-11eb-941a-58e38348a5a5.png">

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/TqiwHbFBaZ4ti/giphy.gif)
