### PR TITLE
Use an updated version of adding trusted for admins

### DIFF
--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -69,7 +69,7 @@ module Moderator
       when "Trusted"
         remove_negative_roles
         user.remove_role :pro
-        add_trusted_role
+        TagModerators::AddTrustedRole.call(user)
       when "Admin"
         check_super_admin
         remove_negative_roles
@@ -84,7 +84,7 @@ module Moderator
         user.add_role(:single_resource_admin, role.split("Resource Admin: ").last.safe_constantize)
       when "Pro"
         remove_negative_roles
-        add_trusted_role
+        TagModerators::AddTrustedRole.call(user)
         user.add_role :pro
       end
       create_note(role, note)
@@ -110,15 +110,6 @@ module Moderator
       user.add_role :warned
       user.remove_role :banned
       remove_privileges
-    end
-
-    def add_trusted_role
-      return if user.has_role?(:trusted)
-
-      user.add_role :trusted
-      user.update(email_community_mod_newsletter: true)
-      NotifyMailer.with(user: user).trusted_role_email.deliver_now
-      MailchimpBot.new(user).manage_community_moderator_list
     end
 
     def remove_negative_roles


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
This updates the admin trusted adding to use `TagModerators::AddTrustedRole` instead of a custom method within the class. Overall this is cleaner and reuses code, and more importantly is safer (can't add banned users).

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings
1. Try to add trusted to a user
2. See that it works

### UI accessibility concerns?
Nope

## Added tests?
- [x] No, and this is why: already tested

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No