### PR TITLE
Bug Fix:Fix development.rb to Correctly Detect Rails command

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -128,7 +128,7 @@ Rails.application.configure do
     Bullet.add_whitelist(type: :n_plus_one_query, class_name: "User", association: :profile)
 
     # Check if there are any data update scripts to run during startup
-    if %w[c console runner s server].include?(ENV["COMMAND"]) && DataUpdateScript.scripts_to_run?
+    if %w[Console Server].any? { |const| Rails.const_defined?(const) } && DataUpdateScript.scripts_to_run?
       message = "Data update scripts need to be run before you can start the application. " \
         "Please run 'rails data_updates:run'"
       raise message

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -128,7 +128,7 @@ Rails.application.configure do
     Bullet.add_whitelist(type: :n_plus_one_query, class_name: "User", association: :profile)
 
     # Check if there are any data update scripts to run during startup
-    if %w[Console Server].any? { |const| Rails.const_defined?(const) } && DataUpdateScript.scripts_to_run?
+    if %w[Console Server DBConsole].any? { |const| Rails.const_defined?(const) } && DataUpdateScript.scripts_to_run?
       message = "Data update scripts need to be run before you can start the application. " \
         "Please run 'rails data_updates:run'"
       raise message


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
ENV["COMMAND"] no longer seems to be present when a rails command is run. I am not sure when this changed but I have updated our code to use a different method to detect a console or server start in order to prevent it from succeeding if there are data update scripts that need running. 

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-48564710

## QA Instructions, Screenshots, Recordings
1. Open a console locally
2. run `DataUpdateScript.last.destroy`
3. close the console
4. Try to reopen the console or start a rails server. Both should fail.
5. run `bundle exec bin/setup`
6. You should be able to open a console and start a server now.

## Added tests?
- [x] No, minor update for local env


![alt_text](https://media0.giphy.com/media/l1J9uLBPjqCVIM2GI/giphy.gif)
