### PR TITLE
Bug Fix:Use permitted_origins Instead of Deprecated origin_whitelist

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
       Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
       Sidekiq::Web.set :sessions, Rails.application.config.session_options
       Sidekiq::Web.class_eval do
-        use Rack::Protection, origin_whitelist: [URL.url] # resolve Rack Protection HttpOrigin
+        use Rack::Protection, permitted_origins: [URL.url] # resolve Rack Protection HttpOrigin
       end
       mount Sidekiq::Web => "/sidekiq"
       mount FieldTest::Engine, at: "abtests"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I noticed that we recently lost our ability to run POST/PUT/DELETE requests in Sidekiq. When I dug into it I found the following error. The error traces back to a [deprecation message that is triggered](https://github.com/sinatra/sinatra/blob/master/rack-protection/lib/rack/protection/http_origin.rb#L37) bc we were using. `origin_whitelist` instead of the updated `permitted_origins`. This updates to use the new method in hope that it will fix this issue bc not triggering that warning code.
```
ArgumentError: wrong number of arguments (given 1, expected 2)
 set_cookie_domain.rb  13 call(...)
[PROJECT_ROOT]/app/middlewares/set_cookie_domain.rb:13:in `call'
11       env["rack.session.options"][:domain] = ".#{SiteConfig.app_domain}"
12     end
13     @app.call(env)
14   end
15 end
Full Backtrace
 base.rb  58 warn(...)
[GEM_ROOT]/gems/rack-protection-2.1.0/lib/rack/protection/base.rb:58:in `warn'
 http_origin.rb  37 accepts?(...)
[GEM_ROOT]/gems/rack-protection-2.1.0/lib/rack/protection/http_origin.rb:37:in `accepts?'
```

## Related Tickets & Documents
Fixes: https://app.honeybadger.io/fault/66984/1f42a38e121a218bc2c7020e1dc56762
https://github.com/orgs/forem/projects/6#card-51995670

## QA Instructions, Screenshots, Recordings
Need to test in production since we don't have the HTTP origin restrictions in development mode. 

## Added tests?
- [x] No, this cannot be replicated in testing so there are no tests for it

![alt_text](https://media.tenor.com/images/961044341e3bf6d800670e0514f3ce0d/tenor.gif)
