### PR TITLE
Standardize bot meta tags

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -83,8 +83,8 @@
         @article.processed_html.exclude?("<code>")) ||
       @article.featured_number.to_i < 1500000000 ||
       @article.score < -1 %>
-      <meta name="googlebot" content="noindex">
-      <meta name="googlebot" content="nofollow">
+      <meta name="robots" content="noindex">
+      <meta name="robots" content="nofollow">
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/users/_meta.html.erb
+++ b/app/views/users/_meta.html.erb
@@ -20,6 +20,6 @@
 <% end %>
 
 <% if @user.banned %>
-  <meta name="googlebot" content="noindex">
-  <meta name="googlebot" content="nofollow">
+  <meta name="robots" content="noindex">
+  <meta name="robots" content="nofollow">
 <% end %>

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe "UserProfiles", type: :request do
     it "renders noindex meta if banned" do
       user.add_role(:banned)
       get "/#{user.username}"
-      expect(response.body).to include("<meta name=\"googlebot\" content=\"noindex\">")
+      expect(response.body).to include("<meta name=\"robots\" content=\"noindex\">")
     end
 
     it "does not render noindex meta if not banned" do
       get "/#{user.username}"
-      expect(response.body).not_to include("<meta name=\"googlebot\" content=\"noindex\">")
+      expect(response.body).not_to include("<meta name=\"robots\" content=\"noindex\">")
     end
 
     it "renders rss feed link if any stories" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

While doing some research for an RFC earlier today, I noticed that we are a bit inconsistent in our meta tag usage and use both `robots` and `googlebot`. This PR standardizes on the more generic `robots` as I don't think we ever want to restrict `noindex` and `nofollow` specifically to Google only.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added tests?

- [X] Yes, updated existing ones

## Added to documentation?

- [X] No documentation needed
