### PR TITLE
Use SiteConfig twitter keys before env

### DIFF
--- a/app/services/twitter_client/client.rb
+++ b/app/services/twitter_client/client.rb
@@ -57,8 +57,8 @@ module TwitterClient
 
       def target
         Twitter::REST::Client.new(
-          consumer_key: ApplicationConfig["TWITTER_KEY"],
-          consumer_secret: ApplicationConfig["TWITTER_SECRET"],
+          consumer_key: SiteConfig.twitter_key.presence || ApplicationConfig["TWITTER_KEY"],
+          consumer_secret: SiteConfig.twitter_secret.presence || ApplicationConfig["TWITTER_SECRET"],
           user_agent: "TwitterRubyGem/#{Twitter::Version} (#{URL.url})",
           timeouts: {
             connect: 5,

--- a/spec/services/twitter_client/client_spec.rb
+++ b/spec/services/twitter_client/client_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe TwitterClient::Client, type: :service, vcr: true do
       end
     end
 
+    it "works properly when SiteConfig is set" do
+      VCR.use_cassette("twitter_client_status") do
+        allow(SiteConfig).to receive(:twitter_key).and_return("test")
+        tweet = described_class.status(tweet_id)
+        expect(tweet.text).to be_present
+      end
+    end
+
     it "raises NotFound if the status does not exist" do
       VCR.use_cassette("twitter_client_status_not_found") do
         expect do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Currently we use the `SiteConfig` version of the Twitter keys _only_ for authentication, but still ENV vars for fetching tweets.

I think there are some further adjustments we can make to the Forem Cloud setup such that we actually could provide apps with our own fallback keys in most cases, but we should always use theirs first.

<img width="718" alt="Screen Shot 2021-01-11 at 10 18 37 AM" src="https://user-images.githubusercontent.com/3102842/104200203-61096d00-53f6-11eb-90fd-84a240cc8056.png">

## Related Tickets & Documents
https://github.com/forem/forem/issues/10836

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## Added tests?

- [x] Yes - Only very basic regression test.
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed
