### PR TITLE
Feeds::Import: add index to users.feed_fetched_at

### DIFF
--- a/db/migrate/20210111151630_add_index_to_users_feed_fetched_at.rb
+++ b/db/migrate/20210111151630_add_index_to_users_feed_fetched_at.rb
@@ -1,0 +1,7 @@
+class AddIndexToUsersFeedFetchedAt < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :users, :feed_fetched_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_08_031718) do
+ActiveRecord::Schema.define(version: 2021_01_11_151630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1338,6 +1338,7 @@ ActiveRecord::Schema.define(version: 2021_01_08_031718) do
     t.index ["created_at"], name: "index_users_on_created_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["facebook_username"], name: "index_users_on_facebook_username"
+    t.index ["feed_fetched_at"], name: "index_users_on_feed_fetched_at"
     t.index ["feed_url"], name: "index_users_on_feed_url", where: "((COALESCE(feed_url, ''::character varying))::text <> ''::text)"
     t.index ["github_username"], name: "index_users_on_github_username", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

`Feeds::Import` at each run selects users based on `feed_fetched_at` - since #12126 was deployed. We forgot to add an index on that field.

## Related Tickets & Documents

#12126

## QA Instructions, Screenshots, Recordings

Nothing, trust the wind

## Added tests?

- [ ] Yes
- [x] No, and this is why: although it's technically possible to test for index presence, we don't really do it in RSpec
- [ ] I need help with writing tests

