### PR TITLE
Adds cloudinary rounded corners param

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -62,13 +62,13 @@ module ApplicationHelper
     content_for ? title(title_text) : title_text
   end
 
-  def optimized_image_url(url, width: 500, quality: 80, fetch_format: "auto", random_fallback: true)
+  def optimized_image_url(url, width: 500, quality: 80, fetch_format: "auto", random_fallback: true, radius: nil)
     fallback_image = asset_path("#{rand(1..40)}.png") if random_fallback
 
     return unless (image_url = url.presence || fallback_image)
 
     normalized_url = Addressable::URI.parse(image_url).normalize.to_s
-    Images::Optimizer.call(normalized_url, width: width, quality: quality, fetch_format: fetch_format)
+    Images::Optimizer.call(normalized_url, width: width, quality: quality, fetch_format: fetch_format, radius: radius)
   end
 
   def optimized_image_tag(image_url, optimizer_options: {}, image_options: {})

--- a/app/views/service_worker/manifest.json.erb
+++ b/app/views/service_worker/manifest.json.erb
@@ -8,17 +8,17 @@
   "theme_color": "#000000",
   "homepage_url": "<%= app_url %>",
   "icons": [{
-    "src": "<%= optimized_image_url(SiteConfig.logo_png, width: 192, fetch_format: "png") %>",
+    "src": "<%= optimized_image_url(SiteConfig.logo_png, width: 192, fetch_format: "png", radius: 40) %>",
     "sizes": "192x192",
     "type": "image/png",
     "purpose": "any maskable"
   }, {
-    "src": "<%= optimized_image_url(SiteConfig.logo_png, width: 128, fetch_format: "png") %>",
+    "src": "<%= optimized_image_url(SiteConfig.logo_png, width: 128, fetch_format: "png", radius: 40) %>",
     "sizes": "128x128",
     "type": "image/png",
     "purpose": "any maskable"
   }, {
-    "src": "<%= optimized_image_url(SiteConfig.logo_png, width: 512, fetch_format: "png") %>",
+    "src": "<%= optimized_image_url(SiteConfig.logo_png, width: 512, fetch_format: "png", radius: 40) %>",
     "sizes": "512x512",
     "type": "image/png",
     "purpose": "any maskable"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

As requested a while ago, using rounded corners in `manifest.json` would refine the looks of the PWA installed locally.

## Related Tickets & Documents

Closes #1999

## QA Instructions, Screenshots, Recordings

Install PWA locally and check that image is using rounded corners. You can also manually check the `/manifest.json` rendered and see that it includes the `r_40` param.

```json
{
  "name": "fdoxyz Community",
  "short_name": "fdoxyz.ngrok.io",
  "description": "fdoxyz description",
  "start_url": "/",
  "display": "standalone",
  "background_color": "#000000",
  "theme_color": "#000000",
  "homepage_url": "https://fdoxyz.ngrok.io",
  "icons": [{
    "src": "https://res.cloudinary.com/fdoxyz/image/fetch/s--C1OIsSIy--/c_limit,f_png,fl_progressive,q_80,r_40,w_192/https://fdoxyz.ngrok.io/assets/icon.png",
    "sizes": "192x192",
    "type": "image/png",
    "purpose": "any maskable"
  }, {
    "src": "https://res.cloudinary.com/fdoxyz/image/fetch/s--PGKinQBu--/c_limit,f_png,fl_progressive,q_80,r_40,w_128/https://fdoxyz.ngrok.io/assets/icon.png",
    "sizes": "128x128",
    "type": "image/png",
    "purpose": "any maskable"
  }, {
    "src": "https://res.cloudinary.com/fdoxyz/image/fetch/s--wQrkkYro--/c_limit,f_png,fl_progressive,q_80,r_40,w_512/https://fdoxyz.ngrok.io/assets/icon.png",
    "sizes": "512x512",
    "type": "image/png",
    "purpose": "any maskable"
  }]
}
```

__Side by side comparison of current DEV chrome app vs this patch:__

<img width="1398" alt="Screen Shot 2021-01-11 at 12 16 54" src="https://user-images.githubusercontent.com/6045239/104221768-ff9dca00-5406-11eb-99d6-9063e17eb8ac.png">

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: This patch only adds a param sent into the cloudinary helper
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![round the corner](https://media.giphy.com/media/xT1R9Uc7WOcLXGyCD6/giphy.gif)