### PR TITLE
Encode emails properly before sending to /confirm-email

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -29,7 +29,7 @@ class RegistrationsController < Devise::RegistrationsController
       yield resource if block_given?
       if resource.persisted?
         update_first_user_permissions(resource)
-        redirect_to "/confirm-email?email=#{resource.email}"
+        redirect_to "/confirm-email?email=#{CGI.escape(resource.email)}"
       else
         render action: "by_email"
       end

--- a/cypress/integration/loginFlows/initialAdminLogin.spec.js
+++ b/cypress/integration/loginFlows/initialAdminLogin.spec.js
@@ -31,7 +31,7 @@ describe('Initial admin signup', () => {
         .type(admin.username);
       cy.get('@registrationForm')
         .findByLabelText(/^Email$/i)
-        .type(encodeURI(admin.email));
+        .type(encodeURIComponent(admin.email));
       cy.get('@registrationForm')
         .findByLabelText('Password')
         .type(admin.password);

--- a/cypress/integration/loginFlows/initialAdminLogin.spec.js
+++ b/cypress/integration/loginFlows/initialAdminLogin.spec.js
@@ -31,7 +31,7 @@ describe('Initial admin signup', () => {
         .type(admin.username);
       cy.get('@registrationForm')
         .findByLabelText(/^Email$/i)
-        .type(admin.email);
+        .type(encodeURI(admin.email));
       cy.get('@registrationForm')
         .findByLabelText('Password')
         .type(admin.password);

--- a/cypress/integration/loginFlows/initialAdminLogin.spec.js
+++ b/cypress/integration/loginFlows/initialAdminLogin.spec.js
@@ -51,13 +51,15 @@ describe('Initial admin signup', () => {
       // The initial administrator user was create and is redirected to the confirm email screen.
       cy.url().should(
         'eq',
-        Cypress.config().baseUrl + '/confirm-email?email=' + admin.email,
+        Cypress.config().baseUrl +
+          '/confirm-email?email=' +
+          encodeURIComponent(admin.email),
       );
 
       cy.findByTestId('resend-confirmation-form').as('confirmationForm');
       cy.get('@confirmationForm')
         .findByLabelText(/^Confirmation email address$/i)
-        .should('have.value', admin.email);
+        .should('have.value', encodeURIComponent(admin.email));
       cy.get('@confirmationForm').findByText(
         /^Resend confirmation instructions$/i,
       );

--- a/cypress/integration/loginFlows/initialAdminLogin.spec.js
+++ b/cypress/integration/loginFlows/initialAdminLogin.spec.js
@@ -31,7 +31,7 @@ describe('Initial admin signup', () => {
         .type(admin.username);
       cy.get('@registrationForm')
         .findByLabelText(/^Email$/i)
-        .type(encodeURIComponent(admin.email));
+        .type(admin.email);
       cy.get('@registrationForm')
         .findByLabelText('Password')
         .type(admin.password);
@@ -59,7 +59,7 @@ describe('Initial admin signup', () => {
       cy.findByTestId('resend-confirmation-form').as('confirmationForm');
       cy.get('@confirmationForm')
         .findByLabelText(/^Confirmation email address$/i)
-        .should('have.value', encodeURIComponent(admin.email));
+        .should('have.value', admin.email);
       cy.get('@confirmationForm').findByText(
         /^Resend confirmation instructions$/i,
       );

--- a/spec/system/authentication/user_logs_in_with_email_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_email_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe "Authenticating with Email" do
 
         expect(page).to have_current_path("/confirm-email", ignore_query: true)
       end
+
+      it "displays the properly decoded email" do
+        decoded_email = user.email.sub("@", "+something@")
+        user.email = decoded_email
+        sign_up_user
+
+        expect(page).to have_text(decoded_email)
+      end
     end
 
     context "when trying to register with an already existing email" do

--- a/spec/system/authentication/user_logs_in_with_email_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_email_spec.rb
@@ -13,22 +13,22 @@ RSpec.describe "Authenticating with Email" do
     let(:user) { build(:user, saw_onboarding: false) }
 
     context "when using valid credentials" do
-      it "creates a new user", js: true do
-        expect do
-          visit sign_up_path(state: "new-user")
-          click_link(sign_up_link, match: :first)
-
-          fill_in_user(user)
-          click_button("Sign up", match: :first)
-        end.to change(User, :count).by(1)
-      end
-
-      it "logs in and redirects to email confirmation" do
+      def sign_up_user
         visit sign_up_path(state: "new-user")
         click_link(sign_up_link, match: :first)
 
         fill_in_user(user)
         click_button("Sign up", match: :first)
+      end
+
+      it "creates a new user", js: true do
+        expect do
+          sign_up_user
+        end.to change(User, :count).by(1)
+      end
+
+      it "logs in and redirects to email confirmation" do
+        sign_up_user
 
         expect(page).to have_current_path("/confirm-email", ignore_query: true)
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Before, some emails were not encoded properly, `andy+hi@forem.com`. This PR ensures that the email is always encoded before redirecting, so that symbols like `+` are not scrubbed accidentally.

## Related Tickets & Documents
Closes https://github.com/forem/internalEngineering/issues/105

## QA Instructions, Screenshots, Recordings
1. Visit localhost:3000/confirm-email?email=some+email@test.com
2. Check that it properly displays on the page and form

### UI accessibility concerns?
Nope!

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Nope