### PR TITLE
Bug Fix:Update Admin Route in View to go to Edit page

### DIFF
--- a/app/views/articles/tags/_sidebar.html.erb
+++ b/app/views/articles/tags/_sidebar.html.erb
@@ -69,7 +69,7 @@
                id="tag-admin-button"
                data-tag="<%= @tag_model.name %>"
                class="crayons-btn crayons-btn--outlined mod-action-button fs-s"
-               href="/admin/tags/<%= @tag_model.id %>"
+               href="/admin/tags/<%= @tag_model.id %>/edit"
                style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>"
                data-no-instant>
               Admin


### PR DESCRIPTION

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Quick little route fix for @pkfrank 

## Related Tickets & Documents
Fixes: https://github.com/forem/forem/issues/12212

## QA Instructions, Screenshots, Recordings
1. Go to a tag page and click on the Admin button and you should be redirected to the proper edit page in admin

## Added tests?
- [x] No, given this bug was very minor I see little value in writing a full-fledged feature test for it.

![alt_text](https://media1.giphy.com/media/l0HlEMf3CdWiETeGk/200.gif)
