### PR TITLE
Enable new rules and run Rubocop autocorrect

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,10 @@ Layout/ClassStructure:
   StyleGuide: '#consistent-classes'
   Enabled: true
 
+Lint/DeprecatedConstants:
+  Description: 'Checks for deprecated constants.'
+  Enabled: true
+
 Layout/DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'
   StyleGuide: '#consistent-multi-line-chains'
@@ -124,6 +128,10 @@ Layout/MultilineMethodCallIndentation:
     that span more than one line.
   Enabled: true
   EnforcedStyle: indented
+
+Lint/RedundantDirGlobSort:
+  Description: 'Checks for redundant `sort` method to `Dir.glob` and `Dir[]`.'
+  Enabled: true
 
 Layout/SpaceAroundMethodCallOperator:
   Description: 'Checks method call operators to not have spaces around them.'
@@ -404,11 +412,10 @@ Style/Encoding:
   Description: 'Use UTF-8 as the source file encoding.'
   Enabled: false
 
-Style/HashExcept:
-  Description: >-
-                 Checks for usages of `Hash#reject`, `Hash#select`, and `Hash#filter` methods
-                 that can be replaced with `Hash#except` method.
-  Enabled: true
+Style/EndlessMethod:
+  Description: 'Avoid the use of multi-lined endless method definitions.'
+  StyleGuide: '#endless-methods'
+  Enabled: pending
 
 Style/ExponentialNotation:
   Description: 'When using exponential notation, favor a mantissa between 1 (inclusive) and 10 (exclusive).'
@@ -444,6 +451,12 @@ Style/HashAsLastArrayItem:
 Style/HashEachMethods:
   Description: 'Use Hash#each_key and Hash#each_value.'
   StyleGuide: '#hash-each'
+  Enabled: true
+
+Style/HashExcept:
+  Description: >-
+                 Checks for usages of `Hash#reject`, `Hash#select`, and `Hash#filter` methods
+                 that can be replaced with `Hash#except` method.
   Enabled: true
 
 Style/HashLikeCase:

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Comments", type: :request do
         expect(response.body).not_to include('<meta name="googlebot" content="noindex">')
       end
 
-      it "displays noindex if comment has score of less than 0" do
+      it "displays noindex if commentable has score of less than 0" do
         comment.commentable.update_column(:score, -5)
         get comment.path
         expect(response.body).to include('<meta name="googlebot" content="noindex">')

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
     let(:tagged_article) { create(:article, tags: tag) }
 
     it "returns published articles" do
-
       result = feed.published_articles_by_tag
       expect(result).to include article
       expect(result).not_to include unpublished_article


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Rubocop 1.8 added a bunch of new rules, this enables them https://github.com/rubocop-hq/rubocop/releases/tag/v1.8.0

Most of them are for Ruby 3.0, I reckon they are going to help with the transition in the future.

## Related Tickets & Documents

https://github.com/rubocop-hq/rubocop/releases/tag/v1.8.0
