### PR TITLE
[Travis] Create after_deploy Honeycomb script

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -27,3 +27,4 @@ app/javascript/Snackbar/__stories__/
 app/javascript/utilities/__tests__/
 docs/
 spec/
+scripts/after_deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,8 @@ script:
 after_script:
   - ./cc-test-reporter format-coverage -t simplecov -o ./coverage/codeclimate.$KNAPSACK_PRO_CI_NODE_INDEX.json ./coverage/spec/.resultset.json
   - ./cc-test-reporter sum-coverage --output - --parts $COVERAGE_REPORTS_TOTAL coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
+after_deploy:
+  - bash scripts/after_deploy.sh
 notifications:
   slack:
     if: branch = master
@@ -110,6 +112,7 @@ jobs:
       if: type != pull_request
       script: skip
       after_script: skip
+      after_deploy: skip
       deploy:
         provider: heroku
         api_key: '$HEROKU_AUTH_TOKEN'

--- a/scripts/after_deploy.sh
+++ b/scripts/after_deploy.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-COMMIT="$(git rev-parse HEAD)"
-COMMIT="$(echo $COMMIT | cut -c1-7)"
+COMMIT="$(git rev-parse HEAD | cut -c1-7)"
 
 curl "https://api.honeycomb.io/1/markers/${HONEYCOMB_DATASET}" -X POST  \
     -H "X-Honeycomb-Team: ${HONEYCOMB_API_KEY}"  \

--- a/scripts/after_deploy.sh
+++ b/scripts/after_deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+COMMIT="$(git rev-parse HEAD)"
+COMMIT="$(echo $COMMIT | cut -c1-7)"
+
+curl "https://api.honeycomb.io/1/markers/${HONEYCOMB_DATASET}" -X POST  \
+    -H "X-Honeycomb-Team: ${HONEYCOMB_API_KEY}"  \
+    -d '{"type":"deploy", "message":"'${COMMIT}'"}'


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
This will add a marker to our Honeycomb board whenever the app is deployed to Heroku. It provides additional context used for debugging and analytics.

## Related Tickets & Documents
[Honeycomb's documentation](https://docs.honeycomb.io/api/markers/#create-a-marker)

Resolves https://github.com/orgs/forem/projects/6#card-52224759

## QA Instructions, Screenshots, Recordings
This is a curl command. I've tested it thoroughly locall.y If it doesn't work, it wouldn't cause any problem and I'll address it immediately.

here's what the feature looks like. It's the dotted line.
![image](https://user-images.githubusercontent.com/15793250/104345536-76e96180-54cc-11eb-8dc4-d1de06f610cb.png))


## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a