### PR TITLE
Only show user count for large userbases

### DIFF
--- a/app/views/shared/_auth_widget.html.erb
+++ b/app/views/shared/_auth_widget.html.erb
@@ -1,6 +1,6 @@
 <div class="crayons-card crayons-card--secondary p-4">
   <h2 class="fs-l fw-bold mb-2">
-    <a href="<%= about_path %>"><%= community_name %></a> is a community of <%= number_with_delimiter User.registered.estimated_count %> amazing <%= community_members_label %>
+    <%= render "shared/authentication_title" %>
   </h2>
   <p class="color-base-70 mb-4">
     <% if SiteConfig.tagline.present? %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds the previous PR #11021 to the shared auth widget.

## Related Tickets & Documents

#11021 & #11914

## QA Instructions, Screenshots, Recordings

1. Ensure you are logged out.
2. Refresh the home feed and view the auth widget displayed above the navigation links on the left sidebar. It shouldn't have the user count in there anymore. The count is only displayed when the DB threshold is met from LARGE_USERBASE_THRESHOLD as per the other auth widgets.

## Added tests?

- [ ] Yes
- [x] No, as they are used not the original #11021 and this is just a cleanup.
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

no

## [optional] What gif best describes this PR or how it makes you feel?

![counting members](https://media.giphy.com/media/l41YtZOb9EUABnuqA/giphy.gif)
