### PR TITLE
Add sorting feature to /admin/tags

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -8,16 +8,9 @@ module Admin
     end
 
     def index
-      tags = case params[:state]
-             when "supported"
-               Tag.where(supported: true).order(taggings_count: :desc)
-             when "unsupported"
-               Tag.where(supported: false).order(taggings_count: :desc)
-             else
-               Tag.order(taggings_count: :desc)
-             end
-      @q = tags.ransack(params[:q])
-      @tags = @q.result.page(params[:page]).per(50)
+      params[:q] = { supported_not_null: "true" } if params[:q].blank?
+      @q = Tag.ransack(params[:q])
+      @tags = @q.result.order(taggings_count: :desc).page(params[:page]).per(50)
     end
 
     def new

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -8,15 +8,16 @@ module Admin
     end
 
     def index
-      @tags = case params[:state]
-              when "supported"
-                Tag.where(supported: true).order(taggings_count: :desc).page(params[:page]).per(50)
-              when "unsupported"
-                Tag.where(supported: false).order(taggings_count: :desc).page(params[:page]).per(50)
-              else
-                Tag.order(taggings_count: :desc).page(params[:page]).per(50)
-              end
-      @tags = @tags.where("tags.name ILIKE :search", search: "%#{params[:search]}%") if params[:search].present?
+      tags = case params[:state]
+             when "supported"
+               Tag.where(supported: true).order(taggings_count: :desc)
+             when "unsupported"
+               Tag.where(supported: false).order(taggings_count: :desc)
+             else
+               Tag.order(taggings_count: :desc)
+             end
+      @q = tags.ransack(params[:q])
+      @tags = @q.result.page(params[:page]).per(50)
     end
 
     def new

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -2,15 +2,15 @@ module Admin
   class TagsController < Admin::ApplicationController
     layout "admin"
 
+    before_action :set_default_options, only: %i[index]
     before_action :badges_for_options, only: %i[new create edit update]
     after_action only: [:update] do
       Audit::Logger.log(:moderator, current_user, params.dup)
     end
 
     def index
-      params[:q] = { supported_not_null: "true" } if params[:q].blank?
       @q = Tag.ransack(params[:q])
-      @tags = @q.result.order(taggings_count: :desc).page(params[:page]).per(50)
+      @tags = @q.result.page(params[:page]).per(50)
     end
 
     def new
@@ -46,6 +46,11 @@ module Admin
     end
 
     private
+
+    def set_default_options
+      params[:q] = { supported_not_null: "true" } if params[:q].blank?
+      params[:q][:s] = "taggings_count desc" if params[:q][:s].blank?
+    end
 
     def badges_for_options
       @badges_for_options = Badge.pluck(:title, :id)

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -33,11 +33,11 @@
 <table class="crayons-table" width="100%">
   <thead>
     <tr>
-      <th scope="col">Tag</th>
-      <th scope="col">ID</th>
-      <th scope="col">Alias For</th>
-      <th scope="col">Taggings Count</th>
-      <th scope="col">Category</th>
+      <th scope="col"><%= sort_link(@q, :name) %></th>
+      <th scope="col"><%= sort_link(@q, :id) %></th>
+      <th scope="col"><%= sort_link(@q, :alias_for) %></th>
+      <th scope="col"><%= sort_link(@q, :taggings_count) %></th>
+      <th scope="col"><%= sort_link(@q, :category) %></th>
       <th scope="col">Is Moderated?</th>
     </tr>
   </thead>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,20 +1,24 @@
 <div class="flex items-center mb-6">
   <div class="crayons-tabs">
     <div class="nav-item">
-      <a href="/admin/tags" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params[:state].blank? %>">All</a>
+      <a href="/admin/tags?q[supported_not_null]=true" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params.dig(:q, :supported_not_null) %>">All</a>
     </div>
     <div class="nav-item">
-      <a href="/admin/tags?state=supported" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params[:state] == "supported" %>">Supported</a>
+      <a href="/admin/tags?q[supported_eq]=true" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params.dig(:q, :supported_eq) == "true" %>">Supported</a>
     </div>
     <div class="nav-item">
-      <a href="/admin/tags?state=unsupported" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params[:state] == "unsupported" %>">Unsupported</a>
+      <a href="/admin/tags?q[supported_eq]=false" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params.dig(:q, :supported_eq) == "false" %>">Unsupported</a>
     </div>
   </div>
 
   <div class="m-auto">
     <%= search_form_for(@q, url: admin_tags_path, class: "inline-flex") do |f| %>
       <%= f.search_field(:name_cont, aria: { label: "Search" }, class: "crayons-textfield") %>
-      <%= f.hidden_field(:state, params[:state]) if params[:state].present? %>
+      <% if params.dig(:q, :supported_eq) %>
+        <%= f.hidden_field(:supported_eq) %>
+      <% else %>
+        <%= f.hidden_field(:supported_not_null) %>
+      <% end %>
       <%= f.submit "Search", class: "crayons-btn ml-2" %>
     <% end %>
   </div>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -12,12 +12,10 @@
   </div>
 
   <div class="m-auto">
-    <%= form_tag(admin_tags_path, method: "get", class: "inline-flex") do %>
-      <%= text_field_tag(:search, params[:search], aria: { label: "Search" }, class: "crayons-textfield") %>
-      <% if params[:state].present? %>
-        <%= hidden_field_tag(:state, params[:state]) %>
-      <% end %>
-      <%= submit_tag("Search", class: "crayons-btn ml-2") %>
+    <%= search_form_for(@q, url: admin_tags_path, class: "inline-flex") do |f| %>
+      <%= f.search_field(:name_cont, aria: { label: "Search" }, class: "crayons-textfield") %>
+      <%= f.hidden_field(:state, params[:state]) if params[:state].present? %>
+      <%= f.submit "Search", class: "crayons-btn ml-2" %>
     <% end %>
   </div>
 

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -33,11 +33,11 @@
 <table class="crayons-table" width="100%">
   <thead>
     <tr>
-      <th scope="col"><%= sort_link(@q, :name) %></th>
-      <th scope="col"><%= sort_link(@q, :id) %></th>
-      <th scope="col"><%= sort_link(@q, :alias_for) %></th>
-      <th scope="col"><%= sort_link(@q, :taggings_count) %></th>
-      <th scope="col"><%= sort_link(@q, :category) %></th>
+      <th scope="col"><%= sort_link(@q, :name, {}, { aria: { label: "Sort by Name" } }) %></th>
+      <th scope="col"><%= sort_link(@q, :id, {}, { aria: { label: "Sort by ID" } }) %></th>
+      <th scope="col"><%= sort_link(@q, :alias_for, {}, { aria: { label: "Sort by Alias For" } }) %></th>
+      <th scope="col"><%= sort_link(@q, :taggings_count, {}, { aria: { label: "Sort by Taggings Count" } }) %></th>
+      <th scope="col"><%= sort_link(@q, :category, {}, { aria: { label: "Sort by Category" } }) %></th>
       <th scope="col">Is Moderated?</th>
     </tr>
   </thead>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,13 +1,13 @@
 <div class="flex items-center mb-6">
   <div class="crayons-tabs">
     <div class="nav-item">
-      <a href="/admin/tags?q[supported_not_null]=true" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params.dig(:q, :supported_not_null) %>">All</a>
+      <a href="/admin/tags?q[supported_not_null]=true" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params.dig(:q, :supported_not_null) %>" aria-label="All Tags">All</a>
     </div>
     <div class="nav-item">
-      <a href="/admin/tags?q[supported_eq]=true" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params.dig(:q, :supported_eq) == "true" %>">Supported</a>
+      <a href="/admin/tags?q[supported_eq]=true" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params.dig(:q, :supported_eq) == "true" %>" aria-label="Supported Tags">Supported</a>
     </div>
     <div class="nav-item">
-      <a href="/admin/tags?q[supported_eq]=false" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params.dig(:q, :supported_eq) == "false" %>">Unsupported</a>
+      <a href="/admin/tags?q[supported_eq]=false" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params.dig(:q, :supported_eq) == "false" %>" aria-label="Unsupported Tags">Unsupported</a>
     </div>
   </div>
 
@@ -44,7 +44,7 @@
   <tbody class="crayons-card">
     <% @tags.each do |tag| %>
       <tr>
-        <td><%= link_to tag.name, edit_admin_tag_path(tag.id) %></td>
+        <td><%= link_to tag.name, edit_admin_tag_path(tag.id), aria: { label: "#{tag.name} tag" } %></td>
         <td><%= tag.id %></td>
         <td><%= tag.alias_for %></td>
         <td><%= tag.taggings_count %></td>

--- a/spec/system/admin/admin_views_tags_spec.rb
+++ b/spec/system/admin/admin_views_tags_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Admin updates a tag", type: :system do
+  let(:super_admin) { create(:user, :super_admin) }
+  let!(:tag1) { create(:tag, name: "alpha", supported: true, taggings_count: 1) }
+  let!(:tag2) { create(:tag, name: "betical", supported: false, taggings_count: 2) }
+
+  context "when viewing the default page" do
+    before do
+      sign_in super_admin
+      visit admin_tags_path
+    end
+
+    it "defaults to viewing all tags" do
+      tag_table_body = find(".crayons-card")
+      expect(tag_table_body.all("tr>td>a").count).to eq 2
+    end
+
+    it "defaults to sorting by taggings count, descending" do
+      tag_links = find(".crayons-card").all("tr>td>a")
+      expect(tag_links[0].text).to include tag2.name
+      expect(tag_links[1].text).to include tag1.name
+    end
+
+    it "can sort by other columns, like tag name" do
+      find_link(text: "Name").click
+      tag_links = find(".crayons-card").all("tr>td>a")
+      expect(tag_links[0].text).to include tag1.name
+      expect(tag_links[1].text).to include tag2.name
+    end
+  end
+
+  context "when viewing supported tags" do
+    it "shows only supported tags" do
+      sign_in super_admin
+      visit "#{admin_tags_path}?q[supported_eq]=true"
+      expect(page.body).to include tag1.name
+      expect(page.body).not_to include tag2.name
+    end
+  end
+
+  context "when viewing unsupported tags" do
+    it "shows only unsupported tags" do
+      sign_in super_admin
+      visit "#{admin_tags_path}?q[supported_eq]=false"
+      expect(page.body).to include tag2.name
+      expect(page.body).not_to include tag1.name
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
This adds sorting options to `/admin/tags`, and also uses Ransack for all search / sorting related functions. And... that's pretty much it.

## Related Tickets & Documents
Closes https://github.com/forem/internalEngineering/issues/225

## QA Instructions, Screenshots, Recordings
1. Visit `localhost:3000/admin/tags` as an admin
2. Click on the headers, name, ID, alias for, and test that the sorting works
3. Click on Supported or Unsupported and see if sorting works there
4. Complete a search with the search function and try to sort your results

Screenshot of sorting arrows (Ransack default):
![Screen Shot 2021-01-12 at 4 42 05 PM](https://user-images.githubusercontent.com/17884966/104377909-2803f200-54f5-11eb-9742-37bcd184aac3.png)

### UI accessibility concerns?
The sort links should have aria labels for them. Also added some other aria labels for links. Not sure if I needed to add `#{tag.name} tag` to the tag links, but it seemed to make more sense to me?

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?

![A tiger mascot reminds you to stop and sort your recycling.](https://media.giphy.com/media/KETFJXwXzMOeGFUvPT/giphy.gif)
