### PR TITLE
Log onboarding_checkbox_update Params

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -163,6 +163,10 @@ class UsersController < ApplicationController
   end
 
   def onboarding_checkbox_update
+    # TODO: mstruve will remove once debugging is done
+    Rails.logger.error("onboarding_checkbox_update_params:#{params}")
+    Rails.logger.error("onboarding_checkbox_update_user_params:#{params[:user]}")
+
     if params[:user]
       permitted_params = %i[
         checked_code_of_conduct checked_terms_and_conditions email_newsletter email_digest_periodic


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Debugging logs

## Description
We have a bug where we are seeing params get sent to the server during the onboarding flow but then when the server processes them they seems to "disappear". This logging is an effort to try and get us more clarity into what is happening. When I looked into this I found that there are 2 different traces for onboarding_checkbox_update when email_digest is present in the params which seems weird. https://ui.honeycomb.io/thepracticaldev/datasets/rails/result/2qwrFBqJnXC?tab=raw

Trace 1: This does NOT have any sql update, it  loads the user checks a couple things, enqueues a cache bust and indexing job but that is it https://ui.honeycomb.io/thepracticaldev/datasets/rails/result/2qwrFBqJnXC/trace/FpFCLEBCoeE

Trace 2: This DOES update the user with the params. Then does all the redis things. Basically Trace 1 skips over the UPDATE sql command.
https://ui.honeycomb.io/thepracticaldev/datasets/rails/result/2qwrFBqJnXC/trace/kc4xA4RLWrR

Trace 1 makes me believe that this if params line is returning false. The params look the exact same between the two requests but something is causing them to be handled differently

UPDATE: Seeing the same thing in Datadog but no params are present to try and dig into why params[:user] might be nil.
