### PR TITLE
Update I18n default

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

When bundling the app I noticed the following output:

> HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
> But that may break your application.
> 
> If you are upgrading your Rails application from an older version of Rails:
> 
> Please check your Rails app for 'config.i18n.fallbacks = true'.
> If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
> 'config.i18n.fallbacks = [I18n.default_locale]'.
> If not, fallbacks will be broken in your app by I18n 1.1.x.
> 
> If you are starting a NEW Rails application, you can ignore this notice.

We apparently hadn't updated this setting yet, so this PR takes care of that.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added tests?

- [X] No, and this is why: nothing specific to test here

## Added to documentation?

- [X] No documentation needed
