### PR TITLE
Dependabot: disable language/ecosystem labels attached to PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,12 +14,14 @@ updates:
       # see <https://github.com/forem/forem/issues/12068>
       - dependency-name: "binding_of_caller"
         versions: [">= 1.0"]
+    labels: []
 
   # Set update schedule for Yarn/NPM
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
+    labels: []
 
   # Set update schedule for GitHub Actions
   # https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/keeping-your-actions-up-to-date-with-dependabot


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Dependabot [automatically creates](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#labels) labels based on the language or ecosystem of the dependency its going to update, which in our case means `javascript` and `ruby` 99% of the time. 

We don't want those.

## Added tests?

- [ ] Yes
- [x] No, and this is why: this only affects the Dependabot bot
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

Delete the actual [javascript](https://github.com/forem/forem/labels/javascript) and [ruby](https://github.com/forem/forem/labels/ruby) labels from the repo