### PR TITLE
Workaround for Apple auth problems (still in beta)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -531,7 +531,10 @@ class User < ApplicationRecord
   end
 
   def authenticated_with_all_providers?
-    identities_enabled.pluck(:provider).map(&:to_sym) == Authentication::Providers.enabled
+    # ga_providers refers to Generally Available (not in beta)
+    ga_providers = Authentication::Providers.enabled.reject { |sym| sym == :apple }
+    enabled_providers = identities.pluck(:provider).map(&:to_sym)
+    (ga_providers - enabled_providers).empty?
   end
 
   def rate_limiter

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -92,7 +92,10 @@ module Broadcasts
       end
 
       def authenticated_with_all_providers?
-        identities.count == Authentication::Providers.enabled.size
+        # ga_providers refers to Generally Available (not in beta)
+        ga_providers = Authentication::Providers.enabled.reject { |sym| sym == :apple }
+        enabled_providers = identities.pluck(:provider).map(&:to_sym)
+        (ga_providers - enabled_providers).empty?
       end
 
       def user_is_following_tags?

--- a/app/views/users/_additional_authentication.html.erb
+++ b/app/views/users/_additional_authentication.html.erb
@@ -1,7 +1,13 @@
 <% unless @user.authenticated_with_all_providers? %>
   <div class="crayons-card crayons-card--content-rows block">
     <% authentication_enabled_providers.each do |provider| %>
-      <% next if provider.provider_name == :apple && !Flipper.enabled?(:apple_auth) %>
+      <!--
+        TODO: [@forem/oss] Only until we refactor our cookie configurations
+        we'll be able to connect existing accounts with SIWA. This should be
+        done when Apple Auth Provider is no longer in 'Beta':
+        https://github.com/forem/forem/pull/12114
+      -->
+      <% next if provider.provider_name == :apple %>
       <% unless @user.authenticated_through?(provider.provider_name) %>
         <%= form_with url: provider.sign_in_path(state: "profile"), class: "flex w-100", local: true do |f| %>
           <%= f.button type: :submit, class: "crayons-btn crayons-btn--icon-left crayons-btn--brand-#{provider.provider_name} m-1" do %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -19,7 +19,7 @@ APPLE_OMNIAUTH_SETUP = lambda do |env|
   env["omniauth.strategy"].options[:client_id] = SiteConfig.apple_client_id
   env["omniauth.strategy"].options[:scope] = "email name"
   env["omniauth.strategy"].options[:key_id] = SiteConfig.apple_key_id
-  env["omniauth.strategy"].options[:pem] = SiteConfig.apple_pem
+  env["omniauth.strategy"].options[:pem] = SiteConfig.apple_pem.to_s.gsub("\\n", "\n")
   env["omniauth.strategy"].options[:provider_ignores_state] = true
   env["omniauth.strategy"].options[:team_id] = SiteConfig.apple_team_id
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -913,7 +913,7 @@ RSpec.describe User, type: :model do
   end
 
   describe "#authenticated_with_all_providers?" do
-    let(:provider) { Authentication::Providers.available.first }
+    let(:provider) { (Authentication::Providers.available - [:apple]).first }
 
     it "returns false if the user has no related identity" do
       expect(user.authenticated_with_all_providers?).to be(false)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

#11934 added SIWA (Sign in with Apple) in beta mode (feature flag). We found a problem that made it impossible to connect existing accounts with SIWA ([more info here](https://forem.team/fdoxyz/samesite-cookies-and-siwa-39if)).

#12114 is currently blocked due to that problem so we are going to wait until we can sort that out before taking SIWA out of beta.

This PR adds a workaround to avoid showing the option to connect existing accounts with SIWA in order to enable it for DEV, until we are able to finish #12114 

## Related Tickets & Documents

#11934

#12114 

## QA Instructions, Screenshots, Recordings

Apple auth workflow remains unchanged (available in https://community.benhalpern.com) but now the button to connect an existing account shouldn't be visible in `/settings`. In order to check this you can try out these steps:

1. Enable Twitter/GitHub/Facebook auth
2. Enable Apple auth (you can add gibberish to the keys that's not a problem)
3. While unauthenticated you should see the OAuth providers (including Apple although it won't work for you locally)
4. Authenticate with `admin@forem.local` and go to `/settings`
5. You should be able to see the "Connect with X" for the non-beta Auth Providers and SIWA should not be visible here
6. If you authenticate with all OAuth providers then no option should be visible here

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: The existing tests around authentication providers remain unchanged (only fixed one that fails until we take Apple auth out from beta)
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![not yet](https://media.giphy.com/media/3o6MbsNXyeLcAgKysw/giphy.gif)
