### PR TITLE
Log User Save Error Messages When it Fails

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -164,7 +164,6 @@ class UsersController < ApplicationController
 
   def onboarding_checkbox_update
     # TODO: mstruve will remove once debugging is done
-    Rails.logger.error("onboarding_checkbox_update_params:#{params}")
     Rails.logger.error("onboarding_checkbox_update_user_params:#{params[:user]}")
 
     if params[:user]
@@ -176,7 +175,15 @@ class UsersController < ApplicationController
 
     current_user.saw_onboarding = true
     authorize User
-    render_update_response(current_user.save)
+
+    # TODO: mstruve will remove once debugging is done
+    result = current_user.save
+    unless result
+      errors = current_user.errors.full_messages.join(", ")
+      Rails.logger.error("onboarding_checkbox_update_errors:#{errors}")
+    end
+
+    render_update_response(result)
   end
 
   def join_org


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Debugging

## Description
This is a follow up to #12252 after discovering the following:

If `email_digest_periodic` and `email_newsletter` are both false I have found that those traces do not have update commands. Rails is smart enough to figure out that if nothing on the model is being updated then it doesnt hit the database with an update command.
```
# UPDATE
[14] pry(main)> u.assign_attributes(email_digest_periodic: false)
=> nil
[15] pry(main)> u.save
   (0.3ms)  BEGIN
  BanishedUser Exists? (0.3ms)  SELECT 1 AS one FROM "banished_users" WHERE "banished_users"."username" = $1 LIMIT $2  [["username", "mstruve"], ["LIMIT", 1]]
  User Update (0.6ms)  UPDATE "users" SET "email_digest_periodic" = $1, "updated_at" = $2 WHERE "users"."id" = $3  [["email_digest_periodic", false], ["updated_at", "2021-01-13 21:26:35.351201"], ["id", 13]]
   (0.7ms)  COMMIT
=> true

# NOT UPDATING ANYTHING
[16] pry(main)> u.assign_attributes(email_digest_periodic: false)
=> nil
[17] pry(main)> u.save
   (0.3ms)  BEGIN
  BanishedUser Exists? (0.4ms)  SELECT 1 AS one FROM "banished_users" WHERE "banished_users"."username" = $1 LIMIT $2  [["username", "mstruve"], ["LIMIT", 1]]
   (0.4ms)  COMMIT
=> true
```

That still leaves us with those times when we send `email_digest_periodic`  or `email_newsletter`  true. In the majority of those cases, I see the SQL Update in Honeycomb. BUT I found one where that was not the case bc the update was rolled back. I do not know why we could not save the user but the goal of this is to find out. 

## Related Issue
https://github.com/forem/forem/issues/12138