### PR TITLE
Update Gemfile.lock for Bundler 2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,6 +431,7 @@ GEM
     libv8 (8.4.255.0)
     libv8 (8.4.255.0-x86_64-darwin-19)
     libv8 (8.4.255.0-x86_64-darwin-20)
+    libv8 (8.4.255.0-x86_64-linux)
     liquid (4.0.3)
     listen (3.4.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -471,6 +472,8 @@ GEM
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     nokogiri (1.11.1-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.1-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -835,6 +838,7 @@ PLATFORMS
   ruby
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   active_record_union (~> 1.3)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

After upgrading to Bundler 2.2 locally, I had problems bundling on Linux. This is caused by older bundler versions not recording platform-specific information in the lockfile, but trying to resolve it at installation time instead.  I explicitly added support for `x86_64-linux` with `bundle lock --add-platform x86_64-linux` and can now bundle again. 

See [this issue](https://github.com/rubyjs/libv8/issues/310) for context, specifically [this comment](https://github.com/rubyjs/libv8/issues/310#issuecomment-744372178) outlining the problem and [this comment](https://github.com/rubyjs/libv8/issues/310#issuecomment-744461218) with the solution.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Install Bundler 2.2 on Linux and verify that you can successfully run `bundle install`, especially `bundle install --local`.

### UI accessibility concerns?

n/a

## Added tests?

- [X] No, and this is why: no code changes

## Added to documentation?

- [x] No documentation needed
