### PR TITLE
Fix creator flow in /admin/config when :apple_auth feature flag is enabled

### DIFF
--- a/app/views/admin/configs/_apple_auth_provider_settings.html.erb
+++ b/app/views/admin/configs/_apple_auth_provider_settings.html.erb
@@ -5,7 +5,7 @@ requires a custom partial
 -->
 <fieldset class="config-authentication-form">
   <div
-    class="crayons-notice crayons-notice--warning auth-warning <%= provider_keys_configured?(provider.provider_name) ? "hidden" : "" %>">
+    class="crayons-notice crayons-notice--warning auth-warning <%= authentication_enabled_providers.include?(provider.provider_name) ? "hidden" : "" %>">
       <strong>Note:</strong> This authentication provider will <strong>not</strong> be enabled if the key or secret are missing. Please make sure that you enter your key and secret correctly.
   </div>
   <div class="crayons-field">

--- a/spec/system/authentication/creator_config_edit_spec.rb
+++ b/spec/system/authentication/creator_config_edit_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Creator config edit", type: :system, js: true do
+  let(:admin) { create(:user, :super_admin) }
+
+  # Apple auth is in Beta so we need to enable the Feature Flag to test it
+  before { Flipper.enable(:apple_auth) }
+
+  context "when a creator browses /admin/config" do
+    before do
+      sign_in admin
+      allow(SiteConfig).to receive(:invite_only_mode).and_return(false)
+    end
+
+    it "presents all available OAuth providers" do
+      visit "/admin/config"
+
+      within("div[data-target='#authenticationBodyContainer']") do
+        click_on("Show info", match: :first)
+      end
+
+      Authentication::Providers.available.each do |provider|
+        element = find(".config-authentication__item--label", text: /#{provider}/i)
+        expect(element).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Our test suite had coverage for OAuth providers user-facing flow, but because of a recent refactor the `/admin/config` flow broke when the `:apple_auth` feature flag is enabled (pretty specific and difficult for to detect manual QA).

This PR fixes the bug and introduces a very simple spec where we check for the available providers in `/admin/config`

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

In `master` if you enable the feature flag `Flipper.enable(:apple_auth)` and visit `/admin/config` you'll run into a broken page. With this PR the error shouldn't appear and the page should continue to work as expected.

### UI accessibility concerns?

None

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![flags](https://media.giphy.com/media/ieUrjrroOkIhSWTekm/giphy.gif)
