### PR TITLE
Fix accidental publishing of draft articles

### DIFF
--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -251,11 +251,12 @@ export default class ArticleForm extends Component {
 
   handleArticleError = (response, publishFailed = false) => {
     window.scrollTo(0, 0);
+    const { published } = this.state;
     this.setState({
       errors: response,
       submitting: false,
       // Even if it's an update that failed, published will still be set to true
-      published: !publishFailed,
+      published: published && !publishFailed,
     });
   };
 

--- a/spec/system/articles/user_fixes_a_draft_spec.rb
+++ b/spec/system/articles/user_fixes_a_draft_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+# Regression test for https://github.com/forem/forem/issues/12131
+RSpec.describe "", type: :system do
+  let(:correct_liquid_tag) do
+    "{% codepen https://codepen.io/user/pen/abcdefg default-tab=result %}"
+  end
+  let(:incorrect_liquid_tag) do
+    '{% codepen https://codepen.io/user/pen/abcdefg default-tab="result" %}'
+  end
+
+  it "let's the user fix a broken draft without publishing", js: true, aggregate_failures: true do
+    # Create a new blog post and add content that validates correctly
+    sign_in create(:user)
+    visit new_path
+    fill_in "article-form-title", with: "Regression spec"
+    fill_in "article_body_markdown", with: correct_liquid_tag
+
+    # Save the draft
+    click_button "Save draft"
+    expect(page).to have_content("Unpublished post")
+
+    # Edit the blog post with content that doesn't pass validations
+    click_link("Click to edit")
+    fill_in "article_body_markdown", with: incorrect_liquid_tag
+
+    # Try to save the draft, there should still be both "Publish" and "Save Draft" buttons
+    click_button "Save draft"
+    expect(page).to have_content("Whoops, something went wrong")
+    expect(page).to have_selector(:link_or_button, "Publish")
+    expect(page).to have_selector(:link_or_button, "Save ")
+
+    # Fix the error
+    fill_in "article_body_markdown", with: correct_liquid_tag
+    click_button "Save draft"
+    expect(page).to have_content("Unpublished post")
+  end
+end

--- a/spec/system/articles/user_fixes_a_draft_spec.rb
+++ b/spec/system/articles/user_fixes_a_draft_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe "", type: :system do
 
   it "let's the user fix a broken draft without publishing", js: true, aggregate_failures: true do
     # Create a new blog post and add content that validates correctly
-    sign_in create(:user)
+    sign_in create(:user, editor_version: "v2")
     visit new_path
     fill_in "article-form-title", with: "Regression spec"
     fill_in "article_body_markdown", with: correct_liquid_tag
 
     # Save the draft
     click_button "Save draft"
-    expect(page).to have_content("Unpublished post")
+    expect(page).to have_content("Unpublished Post")
 
     # Edit the blog post with content that doesn't pass validations
     click_link("Click to edit")
@@ -33,6 +33,6 @@ RSpec.describe "", type: :system do
     # Fix the error
     fill_in "article_body_markdown", with: correct_liquid_tag
     click_button "Save draft"
-    expect(page).to have_content("Unpublished post")
+    expect(page).to have_content("Unpublished Post")
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

#12131 described a workflow that led to the accidental publishing of a draft post after fixing validation errors. This PR fixes that.

## Related Tickets & Documents

#12131 

## QA Instructions, Screenshots, Recordings

Follow the steps as outlined in the original issue and ensure that you still have the option to save a draft at the last step, not only "Save changes".

- Create a new blog post
- Add something that is validated, for example: `{% codepen https://codepen.io/DonKarlssonSan/pen/dyMaRJN default-tab=result %}`
- "Save draft"
- Edit the blog post
- Change the content to something that is not valid, for example: `{% codepen https://codepen.io/DonKarlssonSan/pen/dyMaRJN default-tab="result" %}`
- Click "Save draft"
- An error message is displayed: "Whoops, something went wrong: base: Invalid Options"
- Fix the error (remove the "" around result)
-  There should be both "Publish" and "Save Draft" buttons

### UI accessibility concerns?

None

## Added tests?

- [X] No, and this is why: verifying this approach first, then figuring out how to write a regression test for this in JS.

## Added to documentation?

- [X] No documentation needed
