### PR TITLE
Storybook dropdown should be accessible 11724

### DIFF
--- a/app/javascript/.storybook/preview.js
+++ b/app/javascript/.storybook/preview.js
@@ -67,6 +67,7 @@ const themeSwitcherDecorator = (storyFn) => {
 };
 
 addDecorator(themeSwitcherDecorator);
+addDecorator((Story) => <Story />);
 
 addParameters({
   options: {

--- a/app/javascript/crayons/Dropdown/__stories__/Dropdown.stories.jsx
+++ b/app/javascript/crayons/Dropdown/__stories__/Dropdown.stories.jsx
@@ -1,4 +1,5 @@
 import { h } from 'preact';
+import { useState, useRef, useEffect } from 'preact/hooks';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import './dropdown-css-helper.scss';
 import notes from './dropdowns.md';
@@ -10,33 +11,137 @@ export default {
   parameters: { notes },
 };
 
-export const Default = () => (
-  <div className="dropdown-trigger-container">
-    <a href="/" className="crayons-btn dropdown-trigger">
-      Hover to trigger dropdown
-    </a>
-    <Dropdown className={text('className', 'mb-2')}>
-      Hey, I&apos;m a dropdown content! Lorem ipsum dolor sit amet, consectetur
-      adipisicing elit. Sequi ea voluptates quaerat eos consequuntur temporibus.
-    </Dropdown>
-  </div>
-);
+export const Default = () => {
+  const activatorRef = useRef(null);
+  const dropdownInteractiveItemRef = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleActivatorClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleKeyUp = (event) => {
+    if (event.key === 'Escape' && isOpen) {
+      setIsOpen(false);
+    }
+  };
+
+  const handleClickOutside = (event) => {
+    if (
+      dropdownInteractiveItemRef.current?.contains(event.target) ||
+      activatorRef.current?.contains(event.target)
+    ) {
+      return;
+    }
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      dropdownInteractiveItemRef.current.focus();
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+      activatorRef.current.focus();
+    }
+  }, [isOpen]);
+
+  return (
+    // keyUp listener allows dropdown to be closed by keyboard, and is not interactive iteself
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div className="dropdown-trigger-container" onKeyUp={handleKeyUp}>
+      <button
+        className="crayons-btn dropdown-trigger"
+        aria-haspopup="true"
+        aria-controls="dropdown-content"
+        ref={activatorRef}
+        onClick={handleActivatorClick}
+      >
+        Click to trigger dropdown
+      </button>
+      <Dropdown
+        className={`${text('className', 'mb-2')} ${isOpen ? 'active' : ''}`}
+        id="dropdown-content"
+      >
+        <p>
+          Hey, I&apos;m a dropdown content! Lorem ipsum dolor sit amet,
+          consectetur adipisicing elit.
+        </p>
+        <a href="/" ref={dropdownInteractiveItemRef}>
+          Sequi ea voluptates
+        </a>
+      </Dropdown>
+    </div>
+  );
+};
 
 Default.story = {
   name: 'default',
 };
 
-export const AdditonalCssClasses = () => (
-  <div className="dropdown-trigger-container">
-    <a href="/" className="crayons-btn dropdown-trigger">
-      Hover to trigger dropdown
-    </a>
-    <Dropdown className={text('className', 'p-6')}>
-      Hey, I&apos;m a dropdown content! Lorem ipsum dolor sit amet, consectetur
-      adipisicing elit. Sequi ea voluptates quaerat eos consequuntur temporibus.
-    </Dropdown>
-  </div>
-);
+export const AdditonalCssClasses = () => {
+  const activatorRef = useRef(null);
+  const dropdownInteractiveItemRef = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleActivatorClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleKeyUp = (event) => {
+    if (event.key === 'Escape' && isOpen) {
+      setIsOpen(false);
+    }
+  };
+
+  const handleClickOutside = (event) => {
+    if (
+      dropdownInteractiveItemRef.current?.contains(event.target) ||
+      activatorRef.current?.contains(event.target)
+    ) {
+      return;
+    }
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      dropdownInteractiveItemRef.current.focus();
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+      activatorRef.current.focus();
+    }
+  }, [isOpen]);
+
+  return (
+    // keyUp listener allows dropdown to be closed by keyboard, and is not interactive iteself
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div className="dropdown-trigger-container" onKeyUp={handleKeyUp}>
+      <button
+        className="crayons-btn dropdown-trigger"
+        aria-haspopup="true"
+        aria-controls="dropdown-content"
+        ref={activatorRef}
+        onClick={handleActivatorClick}
+      >
+        Click to trigger dropdown
+      </button>
+      <Dropdown
+        className={`${text('className', 'p-6')} ${isOpen ? 'active' : ''}`}
+        id="dropdown-content"
+      >
+        <p>
+          Hey, I&apos;m a dropdown content! Lorem ipsum dolor sit amet,
+          consectetur adipisicing elit.
+        </p>
+        <a href="/" ref={dropdownInteractiveItemRef}>
+          Sequi ea voluptates
+        </a>
+      </Dropdown>
+    </div>
+  );
+};
 
 AdditonalCssClasses.story = {
   name: 'additional CSS classes',

--- a/app/javascript/crayons/Dropdown/__stories__/Dropdown.stories.jsx
+++ b/app/javascript/crayons/Dropdown/__stories__/Dropdown.stories.jsx
@@ -11,7 +11,7 @@ export default {
   parameters: { notes },
 };
 
-export const Default = () => {
+const DropdownWithActivator = ({ additionalDropdownClasses }) => {
   const activatorRef = useRef(null);
   const dropdownInteractiveItemRef = useRef(null);
   const [isOpen, setIsOpen] = useState(false);
@@ -53,6 +53,7 @@ export const Default = () => {
       <button
         className="crayons-btn dropdown-trigger"
         aria-haspopup="true"
+        aria-expanded={isOpen}
         aria-controls="dropdown-content"
         ref={activatorRef}
         onClick={handleActivatorClick}
@@ -60,7 +61,7 @@ export const Default = () => {
         Click to trigger dropdown
       </button>
       <Dropdown
-        className={`${text('className', 'mb-2')} ${isOpen ? 'active' : ''}`}
+        className={`${additionalDropdownClasses} ${isOpen ? 'active' : ''}`}
         id="dropdown-content"
       >
         <p>
@@ -74,74 +75,20 @@ export const Default = () => {
     </div>
   );
 };
+
+export const Default = () => (
+  <DropdownWithActivator
+    additionalDropdownClasses={text('className', 'mb-2')}
+  />
+);
 
 Default.story = {
   name: 'default',
 };
 
-export const AdditonalCssClasses = () => {
-  const activatorRef = useRef(null);
-  const dropdownInteractiveItemRef = useRef(null);
-  const [isOpen, setIsOpen] = useState(false);
-
-  const handleActivatorClick = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const handleKeyUp = (event) => {
-    if (event.key === 'Escape' && isOpen) {
-      setIsOpen(false);
-    }
-  };
-
-  const handleClickOutside = (event) => {
-    if (
-      dropdownInteractiveItemRef.current?.contains(event.target) ||
-      activatorRef.current?.contains(event.target)
-    ) {
-      return;
-    }
-    setIsOpen(false);
-  };
-
-  useEffect(() => {
-    if (isOpen) {
-      dropdownInteractiveItemRef.current.focus();
-      document.addEventListener('mousedown', handleClickOutside);
-    } else {
-      document.removeEventListener('mousedown', handleClickOutside);
-      activatorRef.current.focus();
-    }
-  }, [isOpen]);
-
-  return (
-    // keyUp listener allows dropdown to be closed by keyboard, and is not interactive iteself
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-    <div className="dropdown-trigger-container" onKeyUp={handleKeyUp}>
-      <button
-        className="crayons-btn dropdown-trigger"
-        aria-haspopup="true"
-        aria-controls="dropdown-content"
-        ref={activatorRef}
-        onClick={handleActivatorClick}
-      >
-        Click to trigger dropdown
-      </button>
-      <Dropdown
-        className={`${text('className', 'p-6')} ${isOpen ? 'active' : ''}`}
-        id="dropdown-content"
-      >
-        <p>
-          Hey, I&apos;m a dropdown content! Lorem ipsum dolor sit amet,
-          consectetur adipisicing elit.
-        </p>
-        <a href="/" ref={dropdownInteractiveItemRef}>
-          Sequi ea voluptates
-        </a>
-      </Dropdown>
-    </div>
-  );
-};
+export const AdditonalCssClasses = () => (
+  <DropdownWithActivator additionalDropdownClasses={text('className', 'p-6')} />
+);
 
 AdditonalCssClasses.story = {
   name: 'additional CSS classes',

--- a/app/javascript/crayons/Dropdown/__stories__/dropdown-css-helper.scss
+++ b/app/javascript/crayons/Dropdown/__stories__/dropdown-css-helper.scss
@@ -4,4 +4,12 @@
   .dropdown-trigger + .active {
     display: block;
   }
+
+  a:focus {
+    outline: -webkit-focus-ring-color auto 1px;
+  }
+
+  a:focus:not(:focus-visible) {
+    outline: none;
+  }
 }

--- a/app/javascript/crayons/Dropdown/__stories__/dropdown-css-helper.scss
+++ b/app/javascript/crayons/Dropdown/__stories__/dropdown-css-helper.scss
@@ -1,7 +1,7 @@
 .dropdown-trigger-container {
   position: relative;
 
-  .dropdown-trigger:hover + div {
+  .dropdown-trigger + .active {
     display: block;
   }
 }

--- a/app/javascript/crayons/Dropdown/__stories__/dropdown.html.stories.jsx
+++ b/app/javascript/crayons/Dropdown/__stories__/dropdown.html.stories.jsx
@@ -1,4 +1,5 @@
 import { h } from 'preact';
+import { useState, useRef, useEffect } from 'preact/hooks';
 import '../../storybook-utilities/designSystem.scss';
 import notes from './dropdowns.md';
 
@@ -7,32 +8,81 @@ export default {
   parameters: { notes },
 };
 
-export const Default = () => (
-  <div className="dropdown-trigger-container">
-    <a href="/" className="crayons-btn dropdown-trigger">
-      Hover to trigger dropdown
-    </a>
-    <div className="crayons-dropdown">
-      Hey, I&apos;m a dropdown content! Lorem ipsum dolor sit amet, consectetur
-      adipisicing elit. Sequi ea voluptates quaerat eos consequuntur temporibus.
+const DropdownWithActivator = ({ additionalDropdownClasses = '' }) => {
+  const activatorRef = useRef(null);
+  const dropdownInteractiveItemRef = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleActivatorClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleKeyUp = (event) => {
+    if (event.key === 'Escape' && isOpen) {
+      setIsOpen(false);
+    }
+  };
+
+  const handleClickOutside = (event) => {
+    if (
+      dropdownInteractiveItemRef.current?.contains(event.target) ||
+      activatorRef.current?.contains(event.target)
+    ) {
+      return;
+    }
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      dropdownInteractiveItemRef.current.focus();
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+      activatorRef.current.focus();
+    }
+  }, [isOpen]);
+
+  return (
+    // keyUp listener allows dropdown to be closed by keyboard, and is not interactive iteself
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div className="dropdown-trigger-container" onKeyUp={handleKeyUp}>
+      <button
+        className="crayons-btn dropdown-trigger"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        aria-controls="dropdown-content"
+        ref={activatorRef}
+        onClick={handleActivatorClick}
+      >
+        Click to trigger dropdown
+      </button>
+      <div
+        className={`crayons-dropdown ${additionalDropdownClasses} ${
+          isOpen ? 'active' : ''
+        }`}
+        id="dropdown-content"
+      >
+        <p>
+          Hey, I&apos;m a dropdown content! Lorem ipsum dolor sit amet,
+          consectetur adipisicing elit.
+        </p>
+        <a href="/" ref={dropdownInteractiveItemRef}>
+          Sequi ea voluptates
+        </a>
+      </div>
     </div>
-  </div>
-);
+  );
+};
+
+export const Default = () => <DropdownWithActivator />;
 
 Default.story = {
   name: 'default',
 };
 
 export const AdditonalCssClasses = () => (
-  <div className="dropdown-trigger-container">
-    <a href="/" className="crayons-btn dropdown-trigger">
-      Hover to trigger dropdown
-    </a>
-    <div className="crayons-dropdown p-6">
-      Hey, I&apos;m a dropdown content! Lorem ipsum dolor sit amet, consectetur
-      adipisicing elit. Sequi ea voluptates quaerat eos consequuntur temporibus.
-    </div>
-  </div>
+  <DropdownWithActivator additionalDropdownClasses="p-6" />
 );
 
 AdditonalCssClasses.story = {

--- a/app/javascript/crayons/Dropdown/__stories__/dropdowns.md
+++ b/app/javascript/crayons/Dropdown/__stories__/dropdowns.md
@@ -19,6 +19,6 @@ consider using an `aria-live` region to ensure the new content is announced to
 screen-reader users when the dropdown appears.
 
 A user should be able to open and close the dropdown by keyboard (e.g. using
-Enter and Escape), and appropriate `aria` (e.g. `aria-haspopup`) should be used
+Enter and Escape), and appropriate `aria` attributes (e.g. `aria-haspopup`) should be used
 to indicate the relationship between the activator button and the dropdown
 content.

--- a/app/javascript/crayons/Dropdown/__stories__/dropdowns.md
+++ b/app/javascript/crayons/Dropdown/__stories__/dropdowns.md
@@ -9,3 +9,16 @@ dependent on width:
 - < 250px: 16px 251 - 320px: 24px
 
 FYI: Dropdowns use “Box” component as background, with Level 3 elevation.
+
+### Dropdown accessibility
+
+When a dropdown of options is opened, focus should be sent to the first
+interactive item inside the dropdown content. When the dropdown is closed, focus
+should return to the activator button. If there are no interactive items,
+consider using an `aria-live` region to ensure the new content is announced to
+screen-reader users when the dropdown appears.
+
+A user should be able to open and close the dropdown by keyboard (e.g. using
+Enter and Escape), and appropriate `aria` (e.g. `aria-haspopup`) should be used
+to indicate the relationship between the activator button and the dropdown
+content.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

This PR updates the Dropdown Storybook stories so that they are keyboard accessible. The dropdowns can now be opened  and closed by keyboard (Enter / Esc), and can also be closed by clicking outside of the dropdown.

Notes have been added to the stories to give context on accessibility implications when using the dropdown component.

This PR ensures that our Storybook documents accessible usage of the Dropdown component, however wider work is needed to ensure all dropdowns used throughout the app are consistently handling keyboard events and focus in a way optimised for accessibility. This will need to be a generalised approach that accounts for both Preact and non-Preact usage. A new issue has been created for this here: #12297 

## Related Tickets & Documents

Closes #11724 - Storybook dropdown should be accessible

## QA Instructions, Screenshots, Recordings

- Open Storybook and navigate to Dropdowns
- In each of the Dropdown stories, you should be able to:
-- Focus the activator button by pressing the Tab key
-- When pressing enter on the focused button, the dropdown content should appear, and focus should be sent to the link inside the content
-- When the dropdown is open, pressing Escape should close it
-- When the dropdown is open, clicking outside of the dropdown content should close it
-- Clicking the button with the mouse should toggle the dropdown content open/closed
-- When using a screen reader (I have tested this on Safari with VoiceOver), the expanded/collapsed state of the dropdown should be announced when the activator button is focused

### UI accessibility concerns?

See above QA instructions. 

Please also note I've disabled a jsx-a11y warning regarding the `keyUp` handler on the wrapping `div` in both `Dropdown.stories.jsx` and `dropdown.html.stories.jsx`.  The event handler has been added to the containing (non-interactive) `div` to ensure Escape key presses are captured to collapse the dropdown content. As the containing `div` isn't expected to be interactive, the linter warning is in this case a false positive. A comment has been added to the code to this effect too.

## Added tests?

- [ ] Yes
- [X] No, and this is why: the underlying Dropdown component has not been changed, the code changes only impact the Storybook documentation
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [ ] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![a stoat pops its head up and down](https://media4.giphy.com/media/l41Yq0LrP3i7GOpqw/giphy.gif?cid=ecf05e47vrfwn40qh3nwnzcoc1ahkxt9l24oy9v42w75rl4v&rid=giphy.gif)
