### PR TITLE
secure Identity#email in case of missing auth_data_dump hash (#11936)

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -39,10 +39,9 @@ class Identity < ApplicationRecord
   end
 
   def email
-    if auth_data_dump&.info&.email
-      auth_data_dump.info.email
-    else
-      "No email found. Please relink your #{provider} account to avoid errors."
-    end
+    auth_data_dump = nil
+    return auth_data_dump.info.email if auth_data_dump&.info&.email
+
+    "No email found. Please relink your #{provider} account to avoid errors."
   end
 end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -39,7 +39,6 @@ class Identity < ApplicationRecord
   end
 
   def email
-    auth_data_dump = nil
     return auth_data_dump.info.email if auth_data_dump&.info&.email
 
     "No email found. Please relink your #{provider} account to avoid errors."

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -39,6 +39,10 @@ class Identity < ApplicationRecord
   end
 
   def email
-    auth_data_dump.info.email
+    if auth_data_dump&.info&.email
+      auth_data_dump.info.email
+    else
+      "No email found. Please relink your #{provider} account to avoid errors."
+    end
   end
 end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -42,8 +42,6 @@ class Identity < ApplicationRecord
   end
 
   def email
-    return auth_data_dump.info.email if auth_data_dump&.info&.email
-
-    format(NO_EMAIL_MSG, provider: provider)
+    auth_data_dump&.info&.email || format(NO_EMAIL_MSG, provider: provider)
   end
 end

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,4 +1,7 @@
 class Identity < ApplicationRecord
+  NO_EMAIL_MSG = "No email found. Please relink your %<provider>s " \
+                 "account to avoid errors.".freeze
+
   belongs_to :user
 
   scope :enabled, -> { where(provider: Authentication::Providers.enabled) }
@@ -41,6 +44,6 @@ class Identity < ApplicationRecord
   def email
     return auth_data_dump.info.email if auth_data_dump&.info&.email
 
-    "No email found. Please relink your #{provider} account to avoid errors."
+    format(NO_EMAIL_MSG, provider: provider)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Rare occurence of missing auth_data_dump from the oauth provider caused email method to return NoMethodError. 
Fix uses safe navigation operator to ensure presence of auth_data_dump:info:email to retrieve email, prints "no email found, please relink.." string when no email found.

## Related Tickets & Documents
#11936 
## QA Instructions, Screenshots, Recordings

Tested locally overwriting auth_data_dump = nil, what replicated the reported issue.
No email found string successfuly fills in the #{provider}.

### UI accessibility concerns?
N/A
## Added tests?

- [ ] Yes
- [X] No, and this is why: existing identity_spec.rb catches happy path. I did not add a test for "no email found" string return. If needed please let me know.
- [ ] I need help with writing tests
![image](https://user-images.githubusercontent.com/19828138/104925013-8837df80-599e-11eb-8cb8-f1a31f51b8ab.png)


## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed