### PR TITLE
Don't try to unsub users when destroying if Mailchimp is not enabled

### DIFF
--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -227,10 +227,6 @@ class SiteConfig < RailsSettings::Base
   end
   singleton_class.__send__(:alias_method, :apple_secret, :apple_key)
 
-  def self.mailchimp_newsletter_enabled?
-    mailchimp_api_key.present? && mailchimp_newsletter_id.present?
-  end
-
   # To get default values
   def self.get_default(field)
     get_field(field)[:default]

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -227,6 +227,10 @@ class SiteConfig < RailsSettings::Base
   end
   singleton_class.__send__(:alias_method, :apple_secret, :apple_key)
 
+  def self.mailchimp_newsletter_enabled?
+    mailchimp_api_key.present? && mailchimp_newsletter_id.present?
+  end
+
   # To get default values
   def self.get_default(field)
     get_field(field)[:default]

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -229,6 +229,6 @@ class SiteConfig < RailsSettings::Base
 
   # To get default values
   def self.get_default(field)
-    get_field(field).dig(:default)
+    get_field(field)[:default]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -259,7 +259,7 @@ class User < ApplicationRecord
   before_validation :set_username
   before_validation :strip_payment_pointer
   before_create :set_default_language
-  before_destroy :unsubscribe_from_newsletters, prepend: true
+  before_destroy :unsubscribe_from_newsletters, prepend: true, if: -> { SiteConfig.mailchimp_newsletter_enabled? }
   before_destroy :destroy_follows, prepend: true
 
   # NOTE: @citizen428 Temporary while migrating to generalized profiles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -259,7 +259,7 @@ class User < ApplicationRecord
   before_validation :set_username
   before_validation :strip_payment_pointer
   before_create :set_default_language
-  before_destroy :unsubscribe_from_newsletters, prepend: true, if: -> { SiteConfig.mailchimp_newsletter_enabled? }
+  before_destroy :unsubscribe_from_newsletters, prepend: true
   before_destroy :destroy_follows, prepend: true
 
   # NOTE: @citizen428 Temporary while migrating to generalized profiles
@@ -497,7 +497,7 @@ class User < ApplicationRecord
   end
 
   def unsubscribe_from_newsletters
-    return if email.blank?
+    return if email.blank? || (SiteConfig.mailchimp_api_key.blank? && SiteConfig.mailchimp_newsletter_id.blank?)
 
     Mailchimp::Bot.new(self).unsubscribe_all_newsletters
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -497,7 +497,8 @@ class User < ApplicationRecord
   end
 
   def unsubscribe_from_newsletters
-    return if email.blank? || (SiteConfig.mailchimp_api_key.blank? && SiteConfig.mailchimp_newsletter_id.blank?)
+    return if email.blank?
+    return if SiteConfig.mailchimp_api_key.blank? && SiteConfig.mailchimp_newsletter_id.blank?
 
     Mailchimp::Bot.new(self).unsubscribe_all_newsletters
   end

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -133,7 +133,7 @@ module Mailchimp
     end
 
     def unsub_community_mod
-      return unless SiteConfig.mailchimp_community_moderators_ids.present? && user.trusted
+      return unless SiteConfig.mailchimp_community_moderators_id.present? && user.trusted
 
       gibbon.lists(SiteConfig.mailchimp_community_moderators_id).members(target_md5_email).update(
         body: {

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -65,7 +65,7 @@ module Mailchimp
     end
 
     def manage_community_moderator_list
-      return false unless user.has_role?(:trusted) || SiteConfig.mailchimp_community_moderators_id.blank?
+      return false unless SiteConfig.mailchimp_community_moderators_id.blank? || user.has_role?(:trusted)
 
       success = false
       status = user.email_community_mod_newsletter ? "subscribed" : "unsubscribed"
@@ -91,7 +91,7 @@ module Mailchimp
     end
 
     def manage_tag_moderator_list
-      return false unless user.tag_moderator? || SiteConfig.mailchimp_tag_moderators_id.blank?
+      return false unless SiteConfig.mailchimp_tag_moderators_id.blank? || user.tag_moderator?
 
       success = false
 

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -125,7 +125,7 @@ module Mailchimp
     def unsub_sustaining_member
       return unless user.tag_moderator?
 
-      gibbon.lists(SiteConfig.mailchimp_tag_moderators_id).members(target_md5_email).update(
+      gibbon.lists(SiteConfig.mailchimp_sustaining_members_id).members(target_md5_email).update(
         body: {
           status: "unsubscribed"
         },
@@ -145,7 +145,7 @@ module Mailchimp
     def unsub_tag_mod
       return unless a_sustaining_member?
 
-      gibbon.lists(SiteConfig.mailchimp_sustaining_members_id).members(target_md5_email).update(
+      gibbon.lists(SiteConfig.mailchimp_tag_moderators_id).members(target_md5_email).update(
         body: {
           status: "unsubscribed"
         },

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -65,7 +65,7 @@ module Mailchimp
     end
 
     def manage_community_moderator_list
-      return false unless user.has_role?(:trusted)
+      return false unless user.has_role?(:trusted) || SiteConfig.mailchimp_community_moderators_id.blank?
 
       success = false
       status = user.email_community_mod_newsletter ? "subscribed" : "unsubscribed"
@@ -91,7 +91,7 @@ module Mailchimp
     end
 
     def manage_tag_moderator_list
-      return false unless user.tag_moderator?
+      return false unless user.tag_moderator? || SiteConfig.mailchimp_tag_moderators_id.blank?
 
       success = false
 
@@ -123,7 +123,7 @@ module Mailchimp
     end
 
     def unsub_sustaining_member
-      return unless user.tag_moderator?
+      return unless SiteConfig.mailchimp_sustaining_members_id && a_sustaining_member?
 
       gibbon.lists(SiteConfig.mailchimp_sustaining_members_id).members(target_md5_email).update(
         body: {
@@ -133,7 +133,7 @@ module Mailchimp
     end
 
     def unsub_community_mod
-      return unless user.has_role?(:trusted)
+      return unless SiteConfig.mailchimp_community_moderators_ids.present? && user.trusted
 
       gibbon.lists(SiteConfig.mailchimp_community_moderators_id).members(target_md5_email).update(
         body: {
@@ -143,7 +143,7 @@ module Mailchimp
     end
 
     def unsub_tag_mod
-      return unless a_sustaining_member?
+      return unless SiteConfig.mailchimp_tag_moderators_id.present? && user.tag_moderator?
 
       gibbon.lists(SiteConfig.mailchimp_tag_moderators_id).members(target_md5_email).update(
         body: {

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -65,7 +65,7 @@ module Mailchimp
     end
 
     def manage_community_moderator_list
-      return false unless SiteConfig.mailchimp_community_moderators_id.blank? || user.has_role?(:trusted)
+      return false unless SiteConfig.mailchimp_community_moderators_id.present? && user.has_role?(:trusted)
 
       success = false
       status = user.email_community_mod_newsletter ? "subscribed" : "unsubscribed"
@@ -91,7 +91,7 @@ module Mailchimp
     end
 
     def manage_tag_moderator_list
-      return false unless SiteConfig.mailchimp_tag_moderators_id.blank? || user.tag_moderator?
+      return false unless SiteConfig.mailchimp_tag_moderators_id.present? && user.tag_moderator?
 
       success = false
 
@@ -123,7 +123,7 @@ module Mailchimp
     end
 
     def unsub_sustaining_member
-      return unless SiteConfig.mailchimp_sustaining_members_id && a_sustaining_member?
+      return unless SiteConfig.mailchimp_sustaining_members_id.present? && a_sustaining_member?
 
       gibbon.lists(SiteConfig.mailchimp_sustaining_members_id).members(target_md5_email).update(
         body: {

--- a/spec/services/mailchimp/bot_spec.rb
+++ b/spec/services/mailchimp/bot_spec.rb
@@ -92,6 +92,10 @@ RSpec.describe Mailchimp::Bot, type: :service do
   end
 
   describe "manage community moderator list" do
+    before { SiteConfig.mailchimp_community_moderators_id = "something" }
+
+    after { SiteConfig.mailchimp_community_moderators_id = nil }
+
     it "returns false if user isn't a community moderator" do
       expect(described_class.new(user).manage_community_moderator_list).to be(false)
     end
@@ -99,6 +103,7 @@ RSpec.describe Mailchimp::Bot, type: :service do
     it "sends proper information" do
       user.update(email_community_mod_newsletter: true)
       user.add_role :trusted
+      SiteConfig.mailchimp_community_moderators_id = "something"
       described_class.new(user).manage_community_moderator_list
       expect(my_gibbon_client).to have_received(:upsert)
         .with(hash_including(
@@ -110,8 +115,12 @@ RSpec.describe Mailchimp::Bot, type: :service do
   end
 
   describe "manage tag moderator list" do
+    before { SiteConfig.mailchimp_tag_moderators_id = "something" }
+
+    after { SiteConfig.mailchimp_tag_moderators_id = nil }
+
     it "returns false if user isn't a tag moderator" do
-      expect(described_class.new(user).manage_community_moderator_list).to be(false)
+      expect(described_class.new(user).manage_tag_moderator_list).to be(false)
     end
 
     it "sends proper information" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
This fixes a bug where when destroying a user, we try to unsubscribe them from newsletters that don't exist. This previously had a runtime error with the Mailchimp API where a blank/invalid Mailchimp API key was given when trying to destroy a user.

For the most part, new Forem communities do not have Mailchimp set up. This PR adjusts for that typical situation.

## Related Tickets & Documents
Closes https://github.com/forem/internalCommunity/issues/2

## QA Instructions, Screenshots, Recordings
1. Start `rails console --sandbox`
2. Set `SiteConfig.mailchimp_api_key = ""`
3. Attempt to destroy a user: `User.first.destroy`
4. See that it destroys the user successfully

### UI accessibility concerns?
No UI changes

## Added tests?
- [x] No, and this is why: the default test environment already has no Mailchimp API key and skips over this situation. But maybe that means we _should_ write a test for this, since it's still untested?

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
No