### PR TITLE
Fix autoloading deprecation

### DIFF
--- a/config/initializers/audit_events.rb
+++ b/config/initializers/audit_events.rb
@@ -6,4 +6,6 @@
 # Example:
 # Audit::Subscribe.listen :internal, :quest_user
 
-Audit::Subscribe.listen(:moderator, :internal) unless Rails.env.test?
+Rails.application.reloader.to_prepare do
+  Audit::Subscribe.listen(:moderator, :internal) unless Rails.env.test?
+end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -48,14 +48,16 @@ def forem_cloud_config
   end
 end
 
-if Rails.env.production? && ENV["FILE_STORAGE_LOCATION"] != "file"
-  if ENV["FOREM_CONTEXT"] == "forem_cloud"
-    forem_cloud_config
-  elsif ApplicationConfig["AWS_ID"].present?
-    standard_production_config
+Rails.application.reloader.to_prepare do
+  if Rails.env.production? && ENV["FILE_STORAGE_LOCATION"] != "file"
+    if ENV["FOREM_CONTEXT"] == "forem_cloud"
+      forem_cloud_config
+    elsif ApplicationConfig["AWS_ID"].present?
+      standard_production_config
+    else
+      local_storage_config
+    end
   else
     local_storage_config
   end
-else
-  local_storage_config
 end

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -12,37 +12,36 @@ COMPONENT_FINGERPRINTS = {
   "internal" => "internal"
 }.freeze
 
-# https://docs.honeybadger.io/lib/ruby/gem-reference/configuration.html
-Honeybadger.configure do |config|
-  config.env = "#{ApplicationConfig['APP_DOMAIN']}-#{Rails.env}"
-  config.api_key = ApplicationConfig["HONEYBADGER_API_KEY"]
-  config.revision = ApplicationConfig["RELEASE_FOOTPRINT"]
+Rails.application.reloader.to_prepare do
+  # https://docs.honeybadger.io/lib/ruby/gem-reference/configuration.html
+  Honeybadger.configure do |config|
+    config.env = "#{ApplicationConfig['APP_DOMAIN']}-#{Rails.env}"
+    config.api_key = ApplicationConfig["HONEYBADGER_API_KEY"]
+    config.revision = ApplicationConfig["RELEASE_FOOTPRINT"]
 
-  # Prevent Ruby from exiting until all queued notices have been delivered to Honeybadger.
-  # When set to true(default), it can lead to a large number of errors causing a process to get stuck.
-  # To prevent this we set it to false ensuring that a process can exit quickly regardless of errors.
-  # Logging allows us to fill in gaps if we need to when errors get discarded.
-  config.send_data_at_exit = false
+    # Prevent Ruby from exiting until all queued notices have been delivered to Honeybadger.
+    # When set to true(default), it can lead to a large number of errors causing a process to get stuck.
+    # To prevent this we set it to false ensuring that a process can exit quickly regardless of errors.
+    # Logging allows us to fill in gaps if we need to when errors get discarded.
+    config.send_data_at_exit = false
 
-  config.exceptions.ignore += [
-    Pundit::NotAuthorizedError,
-    ActiveRecord::RecordNotFound,
-    ActiveRecord::QueryCanceled,
-    RateLimitChecker::LimitReached,
-  ]
-  config.request.filter_keys += %w[authorization]
-  config.sidekiq.attempt_threshold = 10
-  config.breadcrumbs.enabled = true
+    config.exceptions.ignore +=
+      config.request.filter_keys += %w[authorization]
+    config.sidekiq.attempt_threshold = 10
+    config.breadcrumbs.enabled = true
 
-  config.before_notify do |notice|
-    notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("feeds_import")
-                           notice.error_message
-                         elsif (msg_key = MESSAGE_FINGERPRINTS.keys.detect do |k, _v|
-                                  notice.error_message&.include?(k)
-                                end)
-                           MESSAGE_FINGERPRINTS[msg_key]
-                         elsif (cmp_key = COMPONENT_FINGERPRINTS.keys.detect { |k, _v| notice.component&.include?(k) })
-                           COMPONENT_FINGERPRINTS[cmp_key]
-                         end
+    config.before_notify do |notice|
+      notice.fingerprint = if notice.error_message&.include?("SIGTERM") && notice.component&.include?("feeds_import")
+                             notice.error_message
+                           elsif (msg_key = MESSAGE_FINGERPRINTS.keys.detect do |k, _v|
+                                    notice.error_message&.include?(k)
+                                  end)
+                             MESSAGE_FINGERPRINTS[msg_key]
+                           elsif (cmp_key = COMPONENT_FINGERPRINTS.keys.detect do |k, _v|
+                                    notice.component&.include?(k)
+                                  end)
+                             COMPONENT_FINGERPRINTS[cmp_key]
+                           end
+    end
   end
 end

--- a/config/initializers/reverse_markdown.rb
+++ b/config/initializers/reverse_markdown.rb
@@ -1,3 +1,5 @@
-Dir.glob(Rails.root.join("app/lib/reverse_markdown/converters/*.rb")).sort.each do |filename|
-  require_dependency filename
+Rails.application.reloader.to_prepare do
+  Dir.glob(Rails.root.join("app/lib/reverse_markdown/converters/*.rb")).sort.each do |filename|
+    require_dependency filename
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In #8766 we enabled Rails 6 new autoloader - Zeitwerk - but there were a bunch of deprecation that were left behind. 

## Related Tickets & Documents

- #8766
- https://discuss.rubyonrails.org/t/initialization-autoloaded-the-constants-x-y-and-z-isnt-enough-information/74719/11
- https://discuss.rubyonrails.org/t/initialization-autoloaded-the-constants-x-y-and-z-isnt-enough-information/74719/12
- https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots

## QA Instructions, Screenshots, Recordings

1. on `master`, load the console with `bundle exec rails c`, see this blob of text:

```text
DEPRECATION WARNING: Initialization autoloaded the constants Audit, Audit::Helper, Audit::Subscribe, Images, Images::Optimizer, RateLimitChecker, ReverseMarkdown::Converters::CustomPre, and ReverseMarkdown::Converters::CustomText.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload RateLimitChecker, for example,
the expected changes won't be reflected in that stale Class object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <main> at /forem/config/environment.rb:5)
```

2. do the same thing on this branch and you'll see the deprecation is gone


## Added tests?

- [ ] Yes
- [x] No, and this is why: Rails builtin feature that autoload constants on boot, nothing to test
- [ ] I need help with writing tests
