### PR TITLE
Fix deprecation warnings

### DIFF
--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -4,9 +4,9 @@ module Images
       return img_src if img_src.blank? || img_src.starts_with?("/")
 
       if imgproxy_enabled?
-        imgproxy(img_src, kwargs)
+        imgproxy(img_src, **kwargs)
       else
-        cloudinary(img_src, kwargs)
+        cloudinary(img_src, **kwargs)
       end
     end
 

--- a/app/services/slack/messengers/article_published.rb
+++ b/app/services/slack/messengers/article_published.rb
@@ -10,8 +10,8 @@ module Slack
         @article = article
       end
 
-      def self.call(*args)
-        new(*args).call
+      def self.call(**args)
+        new(**args).call
       end
 
       def call


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix some deprecation warnings in _Images::Optimizer_ and _Slack::Messengers::ArticlePublished_. See the commit messages for the deprecation warnings which were addressed.

## Related Tickets & Documents

References #11282 (There are more deprecation warnings, so it's not closing the issue)

## Added tests?

- [ ] Yes
- [x] No, and this is why: Running `RUBYOPT="-W:deprecated" bundle exec rspec` doesn't display those deprecation warnings anymore
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed
