### PR TITLE
Remove OSS team from CODEOWNERS file and add backend team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /app/workers/                                       @forem/sre
 /config/                                            @forem/sre
 /db/                                                @forem/sre @forem/backend
-/docs/                                              @forem/oss    @jacobherrington
+/docs/                                              @jacobherrington
 /lib/data_update_scripts/                           @forem/sre
 /lib/sidekiq/                                       @forem/sre
 /spec/rails_helper.rb                               @forem/sre @forem/backend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,20 +9,20 @@
 /app/services/search/                               @forem/sre
 /app/workers/                                       @forem/sre
 /config/                                            @forem/sre
-/db/                                                @forem/sre
+/db/                                                @forem/sre @forem/backend
 /docs/                                              @forem/oss    @jacobherrington
 /lib/data_update_scripts/                           @forem/sre
 /lib/sidekiq/                                       @forem/sre
-/spec/rails_helper.rb                               @forem/sre
+/spec/rails_helper.rb                               @forem/sre @forem/backend
 /spec/support/                                      @forem/sre
 .buildkite/                                         @forem/systems @forem/sre
 .travis.yml                                         @forem/sre
 Containerfile                                       @forem/systems
 docker-compose.yml                                  @forem/systems
 Dockerfile                                          @forem/systems
-Gemfile                                             @forem/sre    @forem/oss
-Gemfile.lock                                        @forem/sre    @forem/oss
-package.json                                        @forem/oss    @forem/frontend
+Gemfile                                             @forem/sre @forem/backend
+Gemfile.lock                                        @forem/sre @forem/backend
+package.json                                        @forem/frontend
 podman-compose.yml                                  @forem/systems
 scripts/                                            @forem/systems
-yarn.lock                                           @forem/oss    @forem/frontend
+yarn.lock                                           @forem/frontend


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Documentation Update

## Description
Since we no longer have a dedicated OSS team and will be working off of our rotation I am removing the OSS team from Github. This means we will no longer use it via CODEOWNERS so I have removed it and replaced it in a couple of places with the Backend team. 

I thought about trying to update the team every week with the new people on the rotation but that seemed like it would be too much manual work and that I would eventually start missing or forget so I decided to remove it instead. Let me know if anyone else has thoughts or suggestions regarding this! 

![alt_text](https://media3.giphy.com/media/lKXEBR8m1jWso/200.gif)
