### PR TITLE
Cache only the static badge achievement data for notifications

### DIFF
--- a/app/views/notifications/_badgeachievement.html.erb
+++ b/app/views/notifications/_badgeachievement.html.erb
@@ -1,6 +1,5 @@
 <% json_data = notification.json_data %>
 <div class="crayons-card notification notification--promoted grid gap-4">
-  <% cache "activity-badge-reward-#{json_data['badge_achievement']['badge_id']}" do %>
     <header class="mb-2 m:mb-4">
       <h3 class="fw-normal fs-l s:fs-xl m:fs-2xl">
       You received the <strong class="fw-bold"><%= sanitize(json_data["badge_achievement"]["badge"]["title"]) %></strong> badge
@@ -10,7 +9,6 @@
 
     <div class="crayons-card crayons-card--secondary p-4 w-100 grid gap-2">
       <img class="w-100 max-w-50 l:max-w-25 h-auto inline-block mx-auto" src="<%= optimized_image_url(json_data["badge_achievement"]["badge"]["badge_image_url"], width: 250) %>" alt="<%= json_data["badge_achievement"]["badge"]["title"] %>">
-  <% end %>
       <p class="color-base-70"><em><%= json_data["badge_achievement"]["rewarding_context_message"].html_safe %></em></p>
     </div>
 

--- a/app/views/notifications/_badgeachievement.html.erb
+++ b/app/views/notifications/_badgeachievement.html.erb
@@ -7,10 +7,10 @@
       </h3>
       <p class="fs-l"><%= json_data["badge_achievement"]["badge"]["description"] %></p>
     </header>
-  <% end %>
 
     <div class="crayons-card crayons-card--secondary p-4 w-100 grid gap-2">
       <img class="w-100 max-w-50 l:max-w-25 h-auto inline-block mx-auto" src="<%= optimized_image_url(json_data["badge_achievement"]["badge"]["badge_image_url"], width: 250) %>" alt="<%= json_data["badge_achievement"]["badge"]["title"] %>">
+  <% end %>
       <p class="color-base-70"><em><%= json_data["badge_achievement"]["rewarding_context_message"].html_safe %></em></p>
     </div>
 

--- a/app/views/notifications/_badgeachievement.html.erb
+++ b/app/views/notifications/_badgeachievement.html.erb
@@ -7,12 +7,12 @@
       </h3>
       <p class="fs-l"><%= json_data["badge_achievement"]["badge"]["description"] %></p>
     </header>
+  <% end %>
 
     <div class="crayons-card crayons-card--secondary p-4 w-100 grid gap-2">
       <img class="w-100 max-w-50 l:max-w-25 h-auto inline-block mx-auto" src="<%= optimized_image_url(json_data["badge_achievement"]["badge"]["badge_image_url"], width: 250) %>" alt="<%= json_data["badge_achievement"]["badge"]["title"] %>">
       <p class="color-base-70"><em><%= json_data["badge_achievement"]["rewarding_context_message"].html_safe %></em></p>
     </div>
-  <% end %>
 
   <p><a href="<%= json_data["user"]["path"] %>" class="crayons-btn w-100 m:w-50">Visit your profile</a></p>
   <p class="max-w-75 mx-auto">You also get <a href="/credits" class="crayons-link crayons-link--brand fw-bold">5 new credits</a> to use for <a href="/listings">community listings</a> if you have anything you'd like to promote. 🎉</p>

--- a/lib/data_update_scripts/20210121161149_clear_badge_achievement_notification_cache.rb
+++ b/lib/data_update_scripts/20210121161149_clear_badge_achievement_notification_cache.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class ClearBadgeAchievementNotificationCache
+    def run
+      Badge.ids.each do |badge_id|
+        Rails.cache.delete("activity-badge-reward-#{badge_id}")
+      end
+    end
+  end
+end

--- a/lib/data_update_scripts/20210121161149_clear_badge_achievement_notification_cache.rb
+++ b/lib/data_update_scripts/20210121161149_clear_badge_achievement_notification_cache.rb
@@ -1,9 +1,0 @@
-module DataUpdateScripts
-  class ClearBadgeAchievementNotificationCache
-    def run
-      Badge.ids.each do |badge_id|
-        Rails.cache.delete("activity-badge-reward-#{badge_id}")
-      end
-    end
-  end
-end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We had a bug where we cached the custom rewarding message for the notification a user receives when they are awarded a new badge. This fixes it by removing the cache altogether, since it wasn't really preventing any N+1 calls.

## Related Tickets & Documents
Closes #11957 and closes #11646

## QA Instructions, Screenshots, Recordings
1. Paste this into `rails console`:
```
# feel free to replace User.last with yourself
ba = BadgeAchievement.create!(badge_id: 1, rewarding_context_markdown_message: "test", user: User.last)
Notifications::NewBadgeAchievement::Send.call(ba)
```
2. Visit `localhost:3000/notifications`, you can add `?username=User.last.username` if you ended up using the last user instead of yourself. You'll need to be a `super_admin`.

### UI accessibility concerns?
Nope

## Added tests?
- [x] No, and this is why: don't think I can test the cache

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Nope, the data update script should take care of things.

## [optional] What gif best describes this PR or how it makes you feel?

![Marvel's Loki says, "Possibly," with a little wicked smile.](https://media.giphy.com/media/YWF5f4DTOoJ0c/giphy.gif)
