### PR TITLE
Log Relevant Data from Self-Deletion Flow to Honeycomb

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -109,11 +109,12 @@ class UsersController < ApplicationController
     if destroy_token.blank?
       flash[:settings_notice] = "Your token has expired, please request a new one. Tokens only last for 12 hours after account deletion is initiated."
       redirect_to user_settings_path("account")
-    else
-      raise ActionController::RoutingError, "Not Found" unless destroy_token == params[:token]
-
+    elsif destroy_token != params[:token]
+      Honeycomb.add_field("user_id", @user.id)
       Honeycomb.add_field("destroy_token", destroy_token)
       Honeycomb.add_field("token", params[:token])
+
+      raise ActionController::RoutingError, "Not Found"
     end
     # rubocop:enable Layout/LineLength
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -111,6 +111,9 @@ class UsersController < ApplicationController
       redirect_to user_settings_path("account")
     else
       raise ActionController::RoutingError, "Not Found" unless destroy_token == params[:token]
+
+      Honeycomb.add_field("destroy_token", destroy_token)
+      Honeycomb.add_field("token", params[:token])
     end
     # rubocop:enable Layout/LineLength
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -110,7 +110,6 @@ class UsersController < ApplicationController
       flash[:settings_notice] = "Your token has expired, please request a new one. Tokens only last for 12 hours after account deletion is initiated."
       redirect_to user_settings_path("account")
     elsif destroy_token != params[:token]
-      Honeycomb.add_field("user_id", @user.id)
       Honeycomb.add_field("destroy_token", destroy_token)
       Honeycomb.add_field("token", params[:token])
 

--- a/spec/system/user/user_self_destroy_spec.rb
+++ b/spec/system/user/user_self_destroy_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe "User destroys their profile", type: :system, js: true do
     expect do
       get user_confirm_destroy_path(token: mismatch_token)
     end.to raise_error(ActionController::RoutingError)
-    expect(Honeycomb).to have_received(:add_field).with("user_id", user.id)
     expect(Honeycomb).to have_received(:add_field).with("destroy_token", token)
     expect(Honeycomb).to have_received(:add_field).with("token", mismatch_token)
   end

--- a/spec/system/user/user_self_destroy_spec.rb
+++ b/spec/system/user/user_self_destroy_spec.rb
@@ -3,9 +3,11 @@ require "rails_helper"
 RSpec.describe "User destroys their profile", type: :system, js: true do
   let(:user) { create(:user) }
   let(:token) { SecureRandom.hex(10) }
+  let(:mismatch_token) { SecureRandom.hex(10) }
 
   before do
     sign_in user
+    allow(Honeycomb).to receive(:add_field)
   end
 
   it "requests self-destroy" do
@@ -33,8 +35,11 @@ RSpec.describe "User destroys their profile", type: :system, js: true do
     click_button "Delete Account"
     allow(Rails.cache).to receive(:read).and_return(token)
     expect do
-      get user_confirm_destroy_path(token: SecureRandom.hex(10))
+      get user_confirm_destroy_path(token: mismatch_token)
     end.to raise_error(ActionController::RoutingError)
+    expect(Honeycomb).to have_received(:add_field).with("user_id", user.id)
+    expect(Honeycomb).to have_received(:add_field).with("destroy_token", token)
+    expect(Honeycomb).to have_received(:add_field).with("token", mismatch_token)
   end
 
   it "destroys an account" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds error logging to Honeycomb to `UsersController#confirm_destroy`. In the event that there is a token mismatch between the `destroy_token` and `params[:token]`, the user's ID, `destroy_token`, and `params[:token]` will be logged to Honeycomb for debugging purposes. Additionally, this PR refactors `#confirm_destroy` ever so slightly to make the conditional a little bit more readable and adds tests around Honeycomb error logging to the existing `user_self_destroy_spec.rb`.

## Related Tickets & Documents
Relates to PR #12266

## QA Instructions, Screenshots, Recordings
Please make sure that all checks pass and that Travis builds green! ♻️ 

### UI accessibility concerns?
N/A

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?
**🐝 🍯**

![Honey comb with bees](https://media.giphy.com/media/Q8IU7LvVQ3SaQ77Zy1/giphy.gif)
