### PR TITLE
Remove Extra href from Admin Articles Index

### DIFF
--- a/app/views/admin/articles/index.html.erb
+++ b/app/views/admin/articles/index.html.erb
@@ -50,7 +50,7 @@
       </li>
       <li class="nav-item">
         <a
-          href="href="<%= admin_articles_path(state: "satellite-not-buffered") %>""
+          href="<%= admin_articles_path(state: "satellite-not-buffered") %>"
           class="nav-link <%= "active" if params[:state] == "satellite-not-buffered" %>">Satellite</a>
       </li>
     </ul>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Minor clean up ✂️  

## Description
I came across an extra `href=""` in `admin/articles/index.html.erb` while working. This PR removes the superfluous `href=""` from the view.

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings
**BEFORE**:
- Navigate to `/admin/articles` and click on the "Satellite" tab:
![Screen Shot 2021-01-21 at 11 52 13 AM](https://user-images.githubusercontent.com/32834804/105398633-d0921000-5bdf-11eb-9552-6e07fc802394.png)

- Observe the `ActiveRecord::RecordNotFound at /admin/href=` error displayed in your browser:
![Screen Shot 2021-01-21 at 11 52 04 AM](https://user-images.githubusercontent.com/32834804/105398595-c4a64e00-5bdf-11eb-8f50-846d47a7a96d.png)

**AFTER**:
- Navigate to `/admin/articles` and click on the "Satellite" tab:
![Screen Shot 2021-01-21 at 11 52 13 AM](https://user-images.githubusercontent.com/32834804/105398633-d0921000-5bdf-11eb-9552-6e07fc802394.png)

- Observe that you no longer run into this error and are instead, shown the "Satellite" page:
![Screen Shot 2021-01-21 at 11 52 38 AM](https://user-images.githubusercontent.com/32834804/105398564-be17d680-5bdf-11eb-8529-d919959aff32.png)

### UI accessibility concerns?
N/A

## Added tests?

- [ ] Yes
- [x] No, and this is why: this PR just removes an extra `href=""`
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Michael Scott: "Clean up on aisle five"](https://media.giphy.com/media/OTszKBXzfG5e8/giphy.gif)
