### PR TITLE
Move mini_racer and sassc-rails out of production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ gem "jsonapi-serializer", "~> 2.1" # Serializer for Ruby objects
 gem "kaminari", "~> 1.2" # A Scope & Engine based, clean, powerful, customizable and sophisticated paginator
 gem "katex", "~> 0.6.1" # This rubygem enables you to render TeX math to HTML using KaTeX. It uses ExecJS under the hood
 gem "liquid", "~> 5.0" # A secure, non-evaling end user template engine with aesthetic markup
-gem "mini_racer", "~> 0.3.1" # Minimal embedded v8
 gem "nokogiri", "~> 1.11" # HTML, XML, SAX, and Reader parser
 gem "octokit", "~> 4.20" # Simple wrapper for the GitHub API
 gem "oj", "~> 3.11" # JSON parser and object serializer
@@ -95,7 +94,6 @@ gem "rolify", "~> 5.3" # Very simple Roles library
 gem "rouge", "~> 3.26" # A pure-ruby code highlighter
 gem "rubyzip", "~> 2.3" # Rubyzip is a ruby library for reading and writing zip files
 gem "s3_direct_upload", "~> 0.1" # Direct Upload to Amazon S3
-gem "sassc-rails", "~> 2.1.2" # Integrate SassC-Ruby into Rails
 gem "sidekiq", "~> 6.1.2" # Sidekiq is used to process background jobs with the help of Redis
 gem "sidekiq-cron", "~> 1.1" # Allows execution of scheduled cron jobs as specific times
 gem "sidekiq-unique-jobs", "~> 7.0.0" # Ensures that Sidekiq jobs are unique when enqueued
@@ -147,12 +145,14 @@ group :development, :test do
   gem "dotenv-rails", "~> 2.7.6" # For loading ENV variables locally
   gem "faker", "~> 2.15" # A library for generating fake data such as names, addresses, and phone numbers
   gem "knapsack_pro", "~> 2.11.0" # Help parallelize Ruby spec builds
+  gem "mini_racer", "~> 0.3.1" # Minimal embedded v8
   gem "pry-byebug", "~> 3.8" # Combine 'pry' with 'byebug'. Adds 'step', 'next', 'finish', 'continue' and 'break' commands to control execution
   gem "rspec-rails", "~> 4.0" # rspec-rails is a testing framework for Rails 3+
   gem "rubocop", "~> 1.8", require: false # Automatic Ruby code style checking tool
   gem "rubocop-performance", "~> 1.9", require: false # A collection of RuboCop cops to check for performance optimizations in Ruby code
   gem "rubocop-rails", "~> 2.9", require: false # Automatic Rails code style checking tool
   gem "rubocop-rspec", "~> 2.1", require: false # Code style checking for RSpec files
+  gem "sassc-rails", "~> 2.1.2" # Integrate SassC-Ruby into Rails
   gem "spring", "~> 2.1" # Preloads your application so things like console, rake and tests run faster
   gem "spring-commands-rspec", "~> 1.0" # rspec command for spring
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization, but only on production

## Description
These two gems were originally added in https://github.com/forem/forem/pull/7458 with the intention of speeding up system spec. What we just noticed now is that `mini_racer` comes with large dependencies that are about ~200 MB total.

If there's an area I expect this to slow down is overall compilation during deployment. I don't think there should be any performance impact elsewhere.

## Related Tickets & Documents
Resolves https://github.com/forem/forem/pull/12378

## QA Instructions, Screenshots, Recordings
n/a

## Added tests?
- [x] No, and this is why: not needed

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Keep an eye on production!
