### PR TITLE
Fix flash of unstyled content

### DIFF
--- a/app/views/layouts/_asset_reconciliation.html.erb
+++ b/app/views/layouts/_asset_reconciliation.html.erb
@@ -20,30 +20,29 @@
   var pageCrayons = document.querySelector("meta[name='proper-stylesheet-crayons']");
   var pageViews = document.querySelector("meta[name='proper-stylesheet-views']");
   var pageMinimal = document.querySelector("meta[name='proper-stylesheet-minimal']");
-
   if (headCacheCheck && headCrayons && // If these elements exist, we can proceed.
     parseInt(pageCacheCheck.content) > parseInt(headCacheCheck.content) && // If page cached-at is larger than head cached-at
     (pageCrayons.content != headCrayons.href || // If the head-cached values do not match page-cached, we replace
       pageViews.content != headViews.href ||
       pageMinimal.content != headMinimal.href)
   ) {
-    var head = document.head;
+    var docBody = document.body;
     // Add new stylesheets if we deem we should.
     var link = document.createElement("link");
     link.type = "text/css";
     link.rel = "stylesheet";
     link.href = pageCrayons.content;
-    head.appendChild(link);
+    docBody.appendChild(link);
     var link = document.createElement("link");
     link.type = "text/css";
     link.rel = "stylesheet";
     link.href = pageViews.content;
-    head.appendChild(link);
+    docBody.appendChild(link);
     var link = document.createElement("link");
     link.type = "text/css";
     link.rel = "stylesheet";
     link.href = pageMinimal.content;
-    head.appendChild(link);
+    docBody.appendChild(link);
 
     // Take a breath and then remove the old ones.
     // If we call this immediately it could cause a flash of unstyled comments.

--- a/app/views/layouts/_styles.html.erb
+++ b/app/views/layouts/_styles.html.erb
@@ -1,9 +1,3 @@
-<%# We used to inline a good majority of our CSS %>
-<%# We are currently testing a simpler method of just using "traditional" render-blocking CSS  %>
-<%# The trade-off is the potential to render without blocking the page %>
-<%# But if we in-line everything we lose the ability to cache assets for repeat visitors %>
-<%# This is a production test to see how this might affect UX and/or SEO %>
-
 <%= stylesheet_link_tag "crayons", media: "all", id: "main-crayons-stylesheet" %>
 <%= stylesheet_link_tag "views", media: "all", id: "main-views-stylesheet" %>
 <%= stylesheet_link_tag "minimal", media: "all", id: "main-minimal-stylesheet" %>

--- a/app/views/layouts/_styles.html.erb
+++ b/app/views/layouts/_styles.html.erb
@@ -1,3 +1,3 @@
-<%= stylesheet_link_tag "crayons", media: "all", id: "main-crayons-stylesheet" %>
-<%= stylesheet_link_tag "views", media: "all", id: "main-views-stylesheet" %>
-<%= stylesheet_link_tag "minimal", media: "all", id: "main-minimal-stylesheet" %>
+<%= stylesheet_link_tag "crayons", media: "all", id: "#{qualifier}-crayons-stylesheet" %>
+<%= stylesheet_link_tag "views", media: "all", id: "#{qualifier}-views-stylesheet" %>
+<%= stylesheet_link_tag "minimal", media: "all", id: "#{qualifier}-minimal-stylesheet" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,9 @@
       </div>
     <% end %>
     <%= yield %>
-    <%= render "layouts/asset_reconciliation" %>
+    <% if user_signed_in? %>
+      <%= render "layouts/asset_reconciliation" %>
+    <% end %>
   </div>
 </div>
 <%= render "shell/bottom" %>

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -18,13 +18,6 @@
       <% end %>
       <meta name="environment" content="<%= Rails.env %>">
       <%= render "layouts/styles" %>
-      <style>
-        .home {
-          position: relative;
-          margin: auto;
-          max-width: 1250px;
-        }
-      </style>
       <% unless user_signed_in? %>
         <%= javascript_packs_with_chunks_tag "base", "Search", defer: true %>
       <% end %>
@@ -63,6 +56,7 @@
         data-deployed-at="<%= ForemInstance.deployed_at %>"
         data-latest-commit-id="<%= ForemInstance.latest_commit_id %>"
         data-ga-tracking="<%= SiteConfig.ga_tracking_id %>">
+        <%= render "layouts/styles" %>
         <div id="body-styles">
           <style>
             :root {

--- a/app/views/shell/_top.html.erb
+++ b/app/views/shell/_top.html.erb
@@ -17,7 +17,7 @@
         <meta name="monetization" content="<%= SiteConfig.payment_pointer %>">
       <% end %>
       <meta name="environment" content="<%= Rails.env %>">
-      <%= render "layouts/styles" %>
+      <%= render "layouts/styles", qualifier: "main" %>
       <% unless user_signed_in? %>
         <%= javascript_packs_with_chunks_tag "base", "Search", defer: true %>
       <% end %>
@@ -56,7 +56,8 @@
         data-deployed-at="<%= ForemInstance.deployed_at %>"
         data-latest-commit-id="<%= ForemInstance.latest_commit_id %>"
         data-ga-tracking="<%= SiteConfig.ga_tracking_id %>">
-        <%= render "layouts/styles" %>
+        <%# Repeat of stylesheets in <head> to fix rendering glitch: https://github.com/forem/forem/issues/12377 %>
+        <%= render "layouts/styles", qualifier: "secondary" %>
         <div id="body-styles">
           <style>
             :root {

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -12,6 +12,8 @@ end
 
 RSpec.describe "StoriesIndex", type: :request do
   describe "GET stories index" do
+    let(:user) { create(:user) }
+
     it "renders page with article list and proper attributes", :aggregate_failures do
       article = create(:article, featured: true)
       navigation_link = create(:navigation_link)

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -159,16 +159,22 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.body.scan(/(?=class="crayons-story__cover__image)/).count).to be > 1
     end
 
-    it "has necessary asset reconciliation code" do
-      # Ensure code elements are available for fixing assets if necessary.
-      # app/views/layouts/_asset_reconciliation.html.erb
-      # Basic regression test to ensure we don't accidentally remove something we should not.
-      get "/"
-      expect(response.body).to include('<meta name="head-cached-at"')
-      expect(response.body).to include('<meta name="page-cached-at"')
-      expect(response.body).to include('"main-crayons-stylesheet"')
-      expect(response.body).to include('"main-minimal-stylesheet"')
-      expect(response.body).to include("if (headCacheCheck && headCrayons &&")
+    context "when user signed in" do
+      before do
+        sign_in user
+      end
+
+      it "has necessary asset reconciliation code" do
+        # Ensure code elements are available for fixing assets if necessary.
+        # app/views/layouts/_asset_reconciliation.html.erb
+        # Basic regression test to ensure we don't accidentally remove something we should not.
+        get "/"
+        expect(response.body).to include('<meta name="head-cached-at"')
+        expect(response.body).to include('<meta name="page-cached-at"')
+        expect(response.body).to include('"main-crayons-stylesheet"')
+        expect(response.body).to include('"main-minimal-stylesheet"')
+        expect(response.body).to include("if (headCacheCheck && headCrayons &&")
+      end
     end
 
     context "with campaign hero" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There is an bug with the timing of how all the CSS is loaded from cold. There is evidence that Google is detecting this as a cumulative layout shift problem that needs to be adjusted, and anecdotally I have run into this occasionally myself.

More details in the linked issue, but here's the visual:

https://user-images.githubusercontent.com/3102842/105424035-8ecf8c80-5c14-11eb-9eaa-d5f8653ce43b.mov

I speculate that all the variables we use in CSS trips up the content rendering tree and we get a flash of the "user agent styling" mid-way through rendering the content. It only shows up for non-logged-in traffic, and I believe this is due to the fact that we run less blocking JS on non-logged-in traffic (a good thing). Signed in traffic incidentally gets other render-blocking resources to hide the content tree mishaps.

My solution is to include the stylesheet links in both the head and the body. The browser will know not to fetch them both from source, so it should not cause extra delays, but this seems to alter the paint timing such that users and SEO bots do not get tripped up with this glitch.

I modified the "asset reconciliation" functionality to ensure if we append additional stylesheets they will land after both stylesheets. I also modified the logic to only run this for _signed in traffic_. Ultimately this is not related to the fix, but it reduces the amount of moving pieces. "Asset reconciliation" is designed to help fix mismatches between cached shell and body content which is much more likely to occur for repeat signed-in traffic. We could revisit this another time.

This is definitely just a patch which can be supplemented by further investigation into refactoring of our CSS to get a better handle on things, but this hack doesn't add any great additional code complexity.

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/12377

## QA Instructions, Screenshots, Recordings

Details in the issue.

### UI accessibility concerns?

None that I am aware of.

## Added tests?

- [x] Yes - modified test.
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
