### PR TITLE
Optimize Admin::FeedbackMessagesController by adding proper indexes

### DIFF
--- a/db/migrate/20210125085442_add_indexes_to_ahoy_messages_feedback_message_id_and_feedback_messages_status.rb
+++ b/db/migrate/20210125085442_add_indexes_to_ahoy_messages_feedback_message_id_and_feedback_messages_status.rb
@@ -1,0 +1,8 @@
+class AddIndexesToAhoyMessagesFeedbackMessageIdAndFeedbackMessagesStatus < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :ahoy_messages, :feedback_message_id, algorithm: :concurrently
+    add_index :feedback_messages, :status, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_21_102114) do
+ActiveRecord::Schema.define(version: 2021_01_25_085442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 2021_01_21_102114) do
     t.string "utm_medium"
     t.string "utm_source"
     t.string "utm_term"
+    t.index ["feedback_message_id"], name: "index_ahoy_messages_on_feedback_message_id"
     t.index ["to"], name: "index_ahoy_messages_on_to"
     t.index ["token"], name: "index_ahoy_messages_on_token"
     t.index ["user_id", "mailer"], name: "index_ahoy_messages_on_user_id_and_mailer"
@@ -511,6 +512,7 @@ ActiveRecord::Schema.define(version: 2021_01_21_102114) do
     t.index ["affected_id"], name: "index_feedback_messages_on_affected_id"
     t.index ["offender_id"], name: "index_feedback_messages_on_offender_id"
     t.index ["reporter_id"], name: "index_feedback_messages_on_reporter_id"
+    t.index ["status"], name: "index_feedback_messages_on_status"
   end
 
   create_table "field_test_events", force: :cascade do |t|


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

DEV has 30+ million email messages, to display some of them to the admin, they
all are scanned to find those that belong to the requested feedback messages.
This results in SQL queries that can take up to 15 seconds.

By adding an index, we cut the SQL response time to milliseconds.

This is the query (found [via Datadog](https://app.datadoghq.com/apm/resource/practical_developer-postgres/postgres.query/95589555382369c8?end=1611565561961&env=production&index=apm-search&maxPercentile=100&paused=false&query=env%3Aproduction%20service%3Apractical_developer-postgres%20operation_name%3Apostgres.query%20resource_name%3A%22SELECT%20ahoy_messages%20.%20to%2C%20ahoy_messages%20.%20subject%2C%20ahoy_messages%20.%20content%2C%20ahoy_messages%20.%20utm_campaign%2C%20ahoy_messages%20.%20feedback_message_id%20FROM%20ahoy_messages%20WHERE%20ahoy_messages%20.%20feedback_message_id%20IN%20%28%20SELECT%20feedback_messages%20.%20id%20FROM%20feedback_messages%20WHERE%20feedback_messages%20.%20status%20%3D%20%3F%20ORDER%20BY%20feedback_messages%20.%20created_at%20DESC%20LIMIT%20%3F%20OFFSET%20%3F%20%29%22&start=1608973561961)):

```sql
SELECT ahoy_messages . to, ahoy_messages . subject, ahoy_messages . content, ahoy_messages . utm_campaign, ahoy_messages . feedback_message_id FROM ahoy_messages WHERE ahoy_messages . feedback_message_id IN ( SELECT feedback_messages . id FROM feedback_messages WHERE feedback_messages . status = ? ORDER BY feedback_messages . created_at DESC LIMIT ? OFFSET ? )
```

This is where we generate it:

https://github.com/forem/forem/blob/06a61914244060f8d217d9ec6a1b2fd324325b57/app/controllers/admin/feedback_messages_controller.rb#L14

https://github.com/forem/forem/blob/06a61914244060f8d217d9ec6a1b2fd324325b57/app/models/email_message.rb#L13-L16

This is the [current query plan](https://explain.depesz.com/s/EAmp):

![Screenshot_2021-01-25 EAmp current dp - email messages explain depesz com](https://user-images.githubusercontent.com/146201/105684677-92556300-5ef5-11eb-9c2a-8f2f03b15c6d.png)

it spends 80% of the time scanning a 30 million rows table.

This is [similar to the query plan](https://explain.depesz.com/s/LOrn) it's going to have in production:

![Screenshot_2021-01-25 LOrn explain depesz com](https://user-images.githubusercontent.com/146201/105685305-33dcb480-5ef6-11eb-8adb-d62044784e2c.png)

## QA Instructions, Screenshots, Recordings

QA here is a bit tricky, as you need to populate the `ahoy_messages` table with a lot of data. 
An alternative option, though it's not 1:1 on production is to disable sequential scan with `set enable_seqscan=false;` in your local PostgreSQL and run `EXPLAIN ANALYZE` on the query, before and after you run the migration.

## Added tests?

- [ ] Yes
- [x] No, and this is why: we don't have explicit tests for index presence, we might want them eventually
- [ ] I need help with writing tests
