### PR TITLE
Optimize column selection for articles belonging to "any" given tag

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -73,7 +73,7 @@ module Admin
     def articles_satellite
       Article.published.where(last_buffered: nil)
         .includes(:user, :buffer_updates)
-        .tagged_with(Tag.bufferized_tags, any: true)
+        .tagged_with(Tag.bufferized_tags, any: true).unscope(:select)
         .limited_columns_internal_select
         .order(hotness_score: :desc)
         .page(params[:page])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -304,7 +304,8 @@ class User < ApplicationRecord
   end
 
   def followed_articles
-    Article.tagged_with(cached_followed_tag_names, any: true)
+    Article
+      .tagged_with(cached_followed_tag_names, any: true).unscope(:select)
       .union(Article.where(user_id: cached_following_users_ids))
       .where(language: preferred_languages_array, published: true)
   end

--- a/app/services/article_api_index_service.rb
+++ b/app/services/article_api_index_service.rb
@@ -77,7 +77,7 @@ class ArticleApiIndexService
 
   def tagged_articles
     articles = Article.published.includes(:user, :organization)
-    articles = articles.tagged_with(tags, any: true) if tags
+    articles = articles.tagged_with(tags, any: true).unscope(:select) if tags
     articles = articles.tagged_with(tags_exclude, exclude: true) if tags_exclude
 
     articles

--- a/app/services/articles/get_user_stickies.rb
+++ b/app/services/articles/get_user_stickies.rb
@@ -6,8 +6,8 @@ module Articles
       author
         .articles
         .published
+        .tagged_with(article_tags, any: true).unscope(:select)
         .limited_column_select
-        .tagged_with(article_tags, any: true)
         .where.not(id: article.id)
         .order(published_at: :desc)
         .limit(3)

--- a/app/services/articles/suggest_stickies.rb
+++ b/app/services/articles/suggest_stickies.rb
@@ -25,7 +25,7 @@ module Articles
 
       Article
         .published
-        .tagged_with(article_tags, any: true)
+        .tagged_with(article_tags, any: true).unscope(:select)
         .limited_column_select
         .where("public_reactions_count > ? OR comments_count > ?", reaction_count_num, comment_count_num)
         .where.not(id: article.id)
@@ -40,7 +40,7 @@ module Articles
 
       Article
         .published
-        .tagged_with(SUGGESTION_TAGS, any: true)
+        .tagged_with(SUGGESTION_TAGS, any: true).unscope(:select)
         .limited_column_select
         .where("comments_count > ?", comment_count_num)
         .where.not(id: article.id)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

When `acts-as-taggable-on`'s `.tagged_with()` is used with `any: true`,
the gem will use `SELECT *` regardless of any previous (or following) requests
of selecting a limited amount of columns.

Given that the `articles` table has [73 columns](https://dev.to/admin/blazer/queries/314-number-of-columns-in-all-tables)
that will amount to wasted RAM memory for columns we don't need.

By "unscoping" any previous `select()` we can optimize used memory.

Before:

```ruby
[24] pry(main)> Article.tagged_with([:ruby], any: true).select(:id, :name).to_sql
=> "SELECT \"articles\".*, \"articles\".\"id\", \"name\" FROM \"articles\" WHERE EXISTS (SELECT * FROM \"taggings\" WHERE \"taggings\".\"taggable_id\" = \"articles\".\"id\" AND \"taggings\".\"taggable_type\" = 'Article' AND \"taggings\".\"tag_id\" IN (SELECT \"tags\".\"id\" FROM \"tags\" WHERE (\"tags\".\"name\" LIKE 'ruby' ESCAPE '!')))"
```

Note, how the SQL query is `articles.*, articles.column_a`

After:

```ruby
[25] pry(main)> Article.tagged_with([:ruby], any: true).unscope(:select).select(:id, :name).to_sql
=> "SELECT \"articles\".\"id\", \"name\" FROM \"articles\" WHERE EXISTS (SELECT * FROM \"taggings\" WHERE \"taggings\".\"taggable_id\" = \"articles\".\"id\" AND \"taggings\".\"taggable_type\" = 'Article' AND \"taggings\".\"tag_id\" IN (SELECT \"tags\".\"id\" FROM \"tags\" WHERE (\"tags\".\"name\" LIKE 'ruby' ESCAPE '!')))"
```

`articles.*` is gone :-)

## Related Tickets & Documents

- https://github.com/mbleigh/acts-as-taggable-on/issues/936
- https://github.com/mbleigh/acts-as-taggable-on/blob/47da5036dea61cb971bfaf72de5fa93c85255307/lib/acts_as_taggable_on/taggable/tagged_with_query/any_tags_query.rb#L2-L8

## Added tests?

- [ ] Yes
- [x] No, and this is why: being this an optimization, we actually need to make sure all existing tests pass 
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed
