### PR TITLE
updates article form to have warning modal

### DIFF
--- a/app/assets/stylesheets/components/modals.scss
+++ b/app/assets/stylesheets/components/modals.scss
@@ -88,6 +88,16 @@
       padding: var(--modal-body-padding);
       max-height: 100%;
       overflow-y: auto;
+
+      .crayons-btn-group {
+        padding-top: var(--modal-body-padding);
+        .crayons-btn {
+          border-radius: var(--radius);
+        }
+        :first-child {
+          margin-right: var(--su-2);
+        }
+      }
     }
   }
 

--- a/app/assets/stylesheets/components/modals.scss
+++ b/app/assets/stylesheets/components/modals.scss
@@ -88,16 +88,6 @@
       padding: var(--modal-body-padding);
       max-height: 100%;
       overflow-y: auto;
-
-      .crayons-btn-group {
-        padding-top: var(--modal-body-padding);
-        .crayons-btn {
-          border-radius: var(--radius);
-        }
-        :first-child {
-          margin-right: var(--su-2);
-        }
-      }
     }
   }
 

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -370,11 +370,7 @@ export default class ArticleForm extends Component {
               <Button className="mr-2" variant="danger" url="/" tagName="a">
                 Yes, leave the page
               </Button>
-              <Button
-                aria-label="Cancel"
-                variant="secondary"
-                onClick={this.toggleModal}
-              >
+              <Button variant="secondary" onClick={this.toggleModal}>
                 No, keep editing
               </Button>
             </div>

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -366,8 +366,8 @@ export default class ArticleForm extends Component {
               You've made changes to your post. Do you want to navigate to leave
               this page?
             </p>
-            <div className="pt-4 flex gap-2">
-              <Button variant="danger" url="/" tagName="a">
+            <div className="pt-4">
+              <Button className="mr-2" variant="danger" url="/" tagName="a">
                 Yes, leave the page
               </Button>
               <Button

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -5,7 +5,7 @@ import postscribe from 'postscribe';
 import { KeyboardShortcuts } from '../shared/components/useKeyboardShortcuts';
 import { submitArticle, previewArticle } from './actions';
 import { EditorActions, Form, Header, Help, Preview } from './components';
-import { Button, ButtonGroup, Modal } from '@crayons';
+import { Button, Modal } from '@crayons';
 
 /* global activateRunkitTags */
 
@@ -276,10 +276,6 @@ export default class ArticleForm extends Component {
     });
   };
 
-  navigateHome = () => {
-    window.location.href = '/';
-  };
-
   switchHelpContext = ({ target }) => {
     this.setState({
       ...this.setCommonProps({
@@ -356,24 +352,26 @@ export default class ArticleForm extends Component {
           version={version}
         />
         {this.state.showModal && (
-          <Modal title="You have unsaved changes" onClose={this.toggleModal}>
-            <div>
-              <p>
-                You've made changes to your post. Do you want to navigate to
-                leave this page?
-              </p>
-              <ButtonGroup className="crayons-article-form__modal__button-group">
-                <Button variant="danger" onClick={this.navigateHome}>
-                  Yes, go back
-                </Button>
-                <Button
-                  aria-label="Cancel"
-                  variant="secondary"
-                  onClick={this.toggleModal}
-                >
-                  No, keep editing
-                </Button>
-              </ButtonGroup>
+          <Modal
+            size="s"
+            title="You have unsaved changes"
+            onClose={this.toggleModal}
+          >
+            <p>
+              You've made changes to your post. Do you want to navigate to leave
+              this page?
+            </p>
+            <div className="pt-4 flex gap-2">
+              <Button variant="danger" url="/" tagName="a">
+                Yes, go back
+              </Button>
+              <Button
+                aria-label="Cancel"
+                variant="secondary"
+                onClick={this.toggleModal}
+              >
+                No, keep editing
+              </Button>
             </div>
           </Modal>
         )}

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -4,10 +4,10 @@ import linkState from 'linkstate';
 import postscribe from 'postscribe';
 import { KeyboardShortcuts } from '../shared/components/useKeyboardShortcuts';
 import { submitArticle, previewArticle } from './actions';
+import { EditorActions, Form, Header, Help, Preview } from './components';
+import { Button, ButtonGroup, Modal } from '@crayons';
 
 /* global activateRunkitTags */
-
-import { EditorActions, Form, Header, Help, Preview } from './components';
 
 /*
   Although the state fields: id, description, canonicalUrl, series, allSeries and
@@ -246,6 +246,7 @@ export default class ArticleForm extends Component {
       edited: false,
       helpFor: null,
       helpPosition: 0,
+      showModal: false,
     });
   };
 
@@ -267,6 +268,16 @@ export default class ArticleForm extends Component {
     this.setState({
       edited: true,
     });
+  };
+
+  toggleModal = () => {
+    this.setState({
+      showModal: !this.state.showModal,
+    });
+  };
+
+  navigateHome = () => {
+    window.location.href = '/';
   };
 
   switchHelpContext = ({ target }) => {
@@ -312,6 +323,7 @@ export default class ArticleForm extends Component {
           organizationId={organizationId}
           onToggle={this.handleOrgIdChange}
           siteLogo={siteLogo}
+          displayModal={this.toggleModal}
         />
 
         {previewShowing ? (
@@ -343,6 +355,28 @@ export default class ArticleForm extends Component {
           helpPosition={helpPosition}
           version={version}
         />
+        {this.state.showModal && (
+          <Modal title="You have unsaved changes" onClose={this.toggleModal}>
+            <div>
+              <p>
+                You've made changes to your post. Do you want to navigate to
+                leave this page?
+              </p>
+              <ButtonGroup className="crayons-article-form__modal__button-group">
+                <Button variant="danger" onClick={this.navigateHome}>
+                  Yes, go back
+                </Button>
+                <Button
+                  aria-label="Cancel"
+                  variant="secondary"
+                  onClick={this.toggleModal}
+                >
+                  No, keep editing
+                </Button>
+              </ButtonGroup>
+            </div>
+          </Modal>
+        )}
 
         <EditorActions
           published={published}

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -271,9 +271,14 @@ export default class ArticleForm extends Component {
   };
 
   toggleModal = () => {
-    this.setState({
-      showModal: !this.state.showModal,
-    });
+    if (this.state.edited) {
+      this.setState({
+        showModal: !this.state.showModal,
+      });
+    } else {
+      // If the user has not edited the body we send them home
+      window.location.href = '/';
+    }
   };
 
   switchHelpContext = ({ target }) => {
@@ -363,7 +368,7 @@ export default class ArticleForm extends Component {
             </p>
             <div className="pt-4 flex gap-2">
               <Button variant="danger" url="/" tagName="a">
-                Yes, go back
+                Yes, leave the page
               </Button>
               <Button
                 aria-label="Cancel"

--- a/app/javascript/article-form/components/Close.jsx
+++ b/app/javascript/article-form/components/Close.jsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { Button } from '@crayons';
 
-export const Close = () => {
+export const Close = ({ displayModal }) => {
   const Icon = () => (
     <svg
       width="24"
@@ -22,9 +22,8 @@ export const Close = () => {
       <Button
         variant="ghost"
         contentType="icon"
-        url="/"
-        tagName="a"
         icon={Icon}
+        onClick={() => displayModal()}
       />
     </div>
   );

--- a/app/javascript/article-form/components/Close.jsx
+++ b/app/javascript/article-form/components/Close.jsx
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { Button } from '@crayons';
 
-export const Close = ({ displayModal }) => {
+export const Close = ({ displayModal = () => {} }) => {
   const Icon = () => (
     <svg
       width="24"

--- a/app/javascript/article-form/components/Header.jsx
+++ b/app/javascript/article-form/components/Header.jsx
@@ -11,6 +11,7 @@ export const Header = ({
   organizationId,
   onToggle,
   siteLogo,
+  displayModal,
 }) => {
   return (
     <div className="crayons-article-form__header">
@@ -25,12 +26,13 @@ export const Header = ({
         onToggle={onToggle}
       />
       <Tabs onPreview={onPreview} previewShowing={previewShowing} />
-      <Close />
+      <Close displayModal={displayModal} />
     </div>
   );
 };
 
 Header.propTypes = {
+  displayModal: PropTypes.func.isRequired,
   onPreview: PropTypes.func.isRequired,
   previewShowing: PropTypes.bool.isRequired,
   organizations: PropTypes.string.isRequired,

--- a/app/javascript/article-form/components/__tests__/Close.test.jsx
+++ b/app/javascript/article-form/components/__tests__/Close.test.jsx
@@ -15,6 +15,6 @@ describe('<Close />', () => {
     const { getByTitle } = render(<Close />);
     const icon = getByTitle(/Close the editor/i);
 
-    expect(icon.closest('a').getAttribute('href')).toEqual('/');
+    expect(icon).toBeDefined();
   });
 });

--- a/app/javascript/crayons/Modal/Modal.jsx
+++ b/app/javascript/crayons/Modal/Modal.jsx
@@ -54,7 +54,7 @@ export const Modal = ({
         aria-label="modal"
         className="crayons-modal__box"
       >
-        {title.length > 0 && title && (
+        {title && title.length > 0 && (
           <div className="crayons-modal__box__header">
             <h2>{title}</h2>
             <Button

--- a/app/javascript/crayons/Modal/Modal.jsx
+++ b/app/javascript/crayons/Modal/Modal.jsx
@@ -54,7 +54,7 @@ export const Modal = ({
         aria-label="modal"
         className="crayons-modal__box"
       >
-        {title && title.length > 0 && (
+        {title && (
           <div className="crayons-modal__box__header">
             <h2>{title}</h2>
             <Button


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR closes #11753, by warning a user before they leave the edit post page. Without this modal it can be a jarring experience to the user to click the x navigate away from the page.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
You can go to `/new` and test it out
<img width="1002" alt="Screen Shot 2021-01-25 at 4 19 53 PM" src="https://user-images.githubusercontent.com/15366319/105768069-d82c1e80-5f29-11eb-841f-6098146183c4.png">
![modal](https://user-images.githubusercontent.com/15366319/105768095-e1b58680-5f29-11eb-8049-56c935acd894.gif)


_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

### UI accessibility concerns?
Currently the `x` on the modal doesn't escape with keyboard navigation but it looks like that will be fixed by #12428

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [x] Yes: modified a test
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] What gif best describes this PR or how it makes you feel?

![Bachelorette winner saying it's 'really nerve wracking'](https://media.giphy.com/media/QQ3FSZoVbmixeQpTR1/giphy.gif)
