### PR TITLE
Explicitly adds the unique jobs middleware

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -42,11 +42,24 @@ Sidekiq.configure_server do |config|
 
   config.server_middleware do |chain|
     chain.add Sidekiq::HoneycombMiddleware
+    chain.add SidekiqUniqueJobs::Middleware::Client
   end
+
+  config.server_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Server
+  end
+
+  SidekiqUniqueJobs::Server.configure(config)
 
   # This allows us to define custom logic to handle when a worker has exhausted all
   # of it's retries. For more details: https://github.com/mperham/sidekiq/wiki/Error-Handling#death-notification
   config.death_handlers << lambda do |job, _ex|
     Sidekiq::WorkerRetriesExhaustedReporter.report_final_failure(job)
+  end
+end
+
+Sidekiq.configure_client do |config|
+  config.client_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Client
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When in OSS Rotation we merged the `sidekiq-unique-jobs` [bump to 7.x](https://github.com/forem/forem/pull/12361) version but we missed [this note](https://github.com/mhenrixon/sidekiq-unique-jobs#add-the-middleware) that mentions we need to manually add the middleware in order for it to work properly (it wasn't this way before).

I realized the locks weren't being enforeced while working on [this spike PR](https://github.com/forem/forem/pull/12419)

## Related Tickets & Documents

#12361

## QA Instructions, Screenshots, Recordings

Add this dummy worker:

```ruby
class UniqueJobsWorker
  include Sidekiq::Worker

  sidekiq_options queue: :low_priority,
                  retry: 10,
                  lock: :until_executed,
                  on_conflict: :replace

  def perform
    puts "SiteConfig.app_domain: #{SiteConfig.app_domain}"
  end
end
```

Boot the app locally with `bin/startup` and in a separate console run this:

```ruby
3.times { UniqueJobsWorker.perform_in(3.seconds.from_now) }

# or in order to see the logs in the console run the following one liner:

UniqueJobsWorker.perform_in(3.seconds.from_now); UniqueJobsWorker.perform_in(3.seconds.from_now); UniqueJobsWorker.perform_in(3.seconds.from_now);
```

Due to the locks in place **the job should only run once**

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [x] I need help with writing tests

I tried adding tests to cover this situation but I haven't been able to make them work properly. If anyone has ideas on how to do this I'd be open to adding tests to add coverage to this situation. 

This is something that I tried (but didn't work):

```ruby
require "rails_helper"

class UniqueWorker
  include Sidekiq::Worker

  sidekiq_options queue: :low_priority,
                  retry: 10,
                  lock: :until_executed,
                  on_conflict: :replace

  def perform
    puts "SiteConfig.app_domain: #{SiteConfig.app_domain}"
  end
end

RSpec.describe UniqueWorker, type: :woker do
  describe "sidekiq-unique-jobs locks" do
    it "replaces previous jobs in the queue based on its lock + strategy" do
      allow(SiteConfig).to receive(:app_domain).and_return('STUB')

      UniqueWorker.perform_in(3.seconds.from_now)
      UniqueWorker.perform_in(3.seconds.from_now)

      sidekiq_perform_enqueued_jobs

      expect(SiteConfig).to have_received(:app_domain).once
    end
  end
end
```

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![did i do that](https://media.giphy.com/media/BxWTWalKTUAdq/giphy.gif)
