### PR TITLE
Fix Typo: should be "min" not "max"

### DIFF
--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -666,7 +666,7 @@
                   <%= f.number_field :periodic_email_digest_min,
                                      class: "crayons-textfield",
                                      value: SiteConfig.periodic_email_digest_min,
-                                     placeholder: Constants::SiteConfig::DETAILS[:periodic_email_digest_max][:placeholder] %>
+                                     placeholder: Constants::SiteConfig::DETAILS[:periodic_email_digest_min][:placeholder] %>
                 </div>
 
                 <%= render "form_submission", f: f %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Description for `periodic_email_digest_min` field is currently
`periodic_email_digest_max`, but it should be `periodic_email_digest_min`

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings

You can view the description fix at admin/config -> email digest frequency tab.

### UI accessibility concerns?

n/a

## Added tests?

- [ ] Yes
- [x] No, and this is why: Just a description typo
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a

