### PR TITLE
Add flash message for email confirmation

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,13 @@
+class ConfirmationsController < Devise::ConfirmationsController
+  FLASH_MESSAGE = "Email sent! Please contact support at %<email>s if you are "\
+    "having trouble receiving your confirmation instructions.".freeze
+
+  def create
+    self.resource = resource_class.send_confirmation_instructions(resource_params)
+    resource.errors.clear # Don't leak user information, like paranoid mode.
+
+    message = format(FLASH_MESSAGE, email: SiteConfig.email_addresses[:members])
+    flash.now[:global_notice] = message
+    render :new
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,12 +11,13 @@ Rails.application.routes.draw do
     omniauth_callbacks: "omniauth_callbacks",
     registrations: "registrations",
     invitations: "invitations",
-    passwords: "passwords"
+    passwords: "passwords",
+    confirmations: "confirmations"
   }
 
   devise_scope :user do
     get "/enter", to: "registrations#new", as: :sign_up
-    get "/confirm-email", to: "devise/confirmations#new"
+    get "/confirm-email", to: "confirmations#new"
     delete "/sign_out", to: "devise/sessions#destroy"
   end
 

--- a/spec/system/authentication/user_request_confirmation_spec.rb
+++ b/spec/system/authentication/user_request_confirmation_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe "/confirm-email", type: :system do
+  it "stays on the same page and displays a flash message", :aggregate_failures do
+    visit confirm_email_path
+    fill_in "user_email", with: "test@example.com"
+    click_button "Save draft"
+
+    expect(page).to have_current_path("/users/confirmation")
+    expected_message = format(ConfirmationsController::FLASH_MESSAGE,
+                              email: SiteConfig.email_addresses[:members])
+    expect(page).to have_content(expected_message)
+  end
+end

--- a/spec/system/authentication/user_request_confirmation_spec.rb
+++ b/spec/system/authentication/user_request_confirmation_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "/confirm-email", type: :system do
   it "stays on the same page and displays a flash message", :aggregate_failures do
     visit confirm_email_path
     fill_in "user_email", with: "test@example.com"
-    click_button "Save draft"
+    click_button "Resend confirmation instructions"
 
-    expect(page).to have_current_path("/users/confirmation")
+    expect(page).to have_current_path(user_confirmation_path)
     expected_message = format(ConfirmationsController::FLASH_MESSAGE,
                               email: SiteConfig.email_addresses[:members])
     expect(page).to have_content(expected_message)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor (UX)

## Description

This PR adds clearer messaging on the `/confirm-email` page via the global flash.

## Related Tickets & Documents

Closes https://github.com/forem/security/issues/333

## QA Instructions, Screenshots, Recordings

1. Go to `/confirm-email`
2. Enter an email address and submit the form
3. Ensure you are on `/users/confirmation` (we render and don't redirect) and see the following flash message.

![devise-confirmations](https://user-images.githubusercontent.com/47985/105969824-418f6700-60bb-11eb-8daf-ef9a4b66ec56.png)

### UI accessibility concerns?

n/a

## Added tests?

- [X] Yes

## Added to documentation?

- [X] No documentation needed
