### PR TITLE
Add nodejs to the production container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -55,7 +55,7 @@ USER root
 
 RUN dnf install --setopt install_weak_deps=false -y bash curl ImageMagick \
                 iproute jemalloc less libcurl \
-                postgresql tzdata \
+                postgresql tzdata nodejs \
                 && dnf -y clean all \
                 && rm -rf /var/cache/yum
 


### PR DESCRIPTION
Since we have removed mini_racer from the Gemfile we need to have a js runtime inside the container

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
