### PR TITLE
Remove extra asterisks in contributing guide

### DIFF
--- a/docs/contributing/forem.md
+++ b/docs/contributing/forem.md
@@ -23,9 +23,7 @@ All [issues](https://github.com/forem/forem/issues) labeled
 [ready for dev](https://github.com/forem/forem/issues?q=is%3Aissue+is%3Aopen+label%3A%22ready+for+dev%22)
 and
 [bug](https://github.com/forem/forem/issues?q=is%3Aissue+is%3Aopen+label%3A%22type%3A+bug%22+label%3Abug)
-are up for grabs.
-
-\*\*Please note that issues with the
+are up for grabs. Please note that issues with the
 [Forem team](https://github.com/forem/forem/labels/Forem%20team) label are
 internal tasks that will be completed by a Forem
 [core team member](https://github.com/forem/forem/#core-team).


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

https://github.com/forem/forem/pull/12472 made some _content_ fixes to the contributing guide, but some extra asterisks got added by mistake 🙈 

This PR removes those, since they seem out of place and will cause grammar nerds like me to not be able to sleep at night 🙃 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Before this change:_
<img width="883" alt="Screen Shot 2021-01-28 at 9 06 31 PM" src="https://user-images.githubusercontent.com/6921610/106234304-71b73280-61ad-11eb-9ead-cd0cc43521d2.png">

_After this change:_
<img width="862" alt="Screen Shot 2021-01-28 at 9 11 37 PM" src="https://user-images.githubusercontent.com/6921610/106234308-74b22300-61ad-11eb-9084-9b712e4c0692.png">

### UI accessibility concerns?

Nope :) 

## Added tests?

- [ ] Yes
- [x] No, and this is why: _just a docs change!_
- [ ] I need help with writing tests

## Added to documentation?

- [x] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [ ] No documentation needed

## What gif best describes this PR or how it makes you feel?
![panda is sad it made a typo](https://media3.giphy.com/media/14aUO0Mf7dWDXW/giphy.gif?cid=5a38a5a2pyrzthuo8x9zd8b2sdw0jto7rc4qidgel033yy6m&rid=giphy.gif)
