### PR TITLE
Update /contact page with links to filing bug reports + forem.dev

### DIFF
--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -36,8 +36,10 @@
       Report a vulnerability: <a href="https://dev.to/security">dev.to/security</a> 🐛
     </p>
     <p>
-      Please make a GitHub issue for feature requests:
-      <a href="https://github.com/forem/forem">forem/forem</a>.
+      To report a bug, please create <a href="https://github.com/forem/forem/issues/new/choose">a bug report</a> in our open source repository.
+    </p>
+    <p>
+      To request a feature, please visit <a href="https://forem.dev">forem.dev</a> and write a post!
     </p>
   </div>
 </div>

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe "Pages", type: :request do
     it "has proper headline" do
       get "/contact"
       expect(response.body).to include("Contact")
+      expect(response.body).to include("@#{SiteConfig.social_media_handles['twitter']}")
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

- [x] Updates the copy on the default `/contact` page to explain how to file bug reports.
- [x] Also adds a note to prompt users to check out [forem.dev](http://forem.dev/) to file feature requests (seemed like a good opportunity to potentially drive traffic to that forem, which we are consciously trying to utilize more 😸)

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/12371 🎉 

## QA Instructions, Screenshots, Recordings

Run the app locally, and head to `/contact`. The page should now explicitly describe how to file a bug report, and should link you to forem.dev for feature requests:
<img width="1007" alt="Screen Shot 2021-01-28 at 9 23 56 PM" src="https://user-images.githubusercontent.com/6921610/106235606-dbd0d700-61af-11eb-9b16-93842c4ee7fc.png">

### UI accessibility concerns?

This adds text within semantic HTML...so hopefully not 😛 

## Added tests?

- [x] Yes (the page was already tested, I actually just improved the pre-existing test 🙃)
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed