### PR TITLE
Don't redirect to /serviceworker.js on sign in.

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,7 +5,8 @@ class RegistrationsController < Devise::RegistrationsController
     if user_signed_in?
       redirect_to root_path(signin: "true")
     else
-      if URI(request.referer || "").host == URI(request.base_url).host
+      referer_path = URI(request.referer || "").path
+      if URI(request.referer || "").host == URI(request.base_url).host && referer_path != "/serviceworker.js"
         store_location_for(:user, request.referer)
       end
       super


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
On sign in, do not redirect if referer was /serviceworker.js

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

I was able to regularly reproduce this issue like so: When as a signed out user, clicking on an email link notifying me about a new follower, I was redirected to the sign in page. Upon signing in, I was redirected to /serviceworker.js path. This should no longer take you to /serviceworker.js.

### UI accessibility concerns?
n/a

## Added tests?

- [ ] Yes
- [x] No, and this is why: tiny?
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a