### PR TITLE
Fix tag alias problems

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -2,6 +2,12 @@ module Admin
   class TagsController < Admin::ApplicationController
     layout "admin"
 
+    ALLOWED_PARAMS = %i[
+      id supported rules_markdown short_summary pretty_name bg_color_hex
+      text_color_hex user_id alias_for badge_id requires_approval
+      category social_preview_template wiki_body_markdown submission_template
+    ].freeze
+
     before_action :set_default_options, only: %i[index]
     before_action :badges_for_options, only: %i[new create edit update]
     after_action only: [:update] do
@@ -38,6 +44,7 @@ module Admin
     def update
       @tag = Tag.find(params[:id])
       if @tag.update(tag_params)
+        ::Tags::AliasRetagWorker.perform_async(@tag.id) if tag_alias_updated?
         flash[:success] = "#{@tag.name} tag successfully updated!"
       else
         flash[:error] = "The tag update failed: #{@tag.errors_as_sentence}"
@@ -57,12 +64,11 @@ module Admin
     end
 
     def tag_params
-      allowed_params = %i[
-        id supported rules_markdown short_summary pretty_name bg_color_hex
-        text_color_hex user_id alias_for badge_id requires_approval
-        category social_preview_template wiki_body_markdown submission_template
-      ]
-      params.require(:tag).permit(allowed_params)
+      params.require(:tag).permit(ALLOWED_PARAMS)
+    end
+
+    def tag_alias_updated?
+      tag_params[:alias_for].present?
     end
   end
 end

--- a/app/workers/tags/alias_retag_worker.rb
+++ b/app/workers/tags/alias_retag_worker.rb
@@ -1,0 +1,18 @@
+module Tags
+  class AliasRetagWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :low_priority, retry: 5
+
+    def perform(tag_id)
+      tag = Tag.find_by(id: tag_id)
+      return unless tag
+
+      tag.taggings.each do |tagging|
+        taggable = tagging.taggable
+        new_tag_list = ActsAsTaggableOn::TagParser.new(taggable.tag_list).parse
+        taggable.update(tag_list: new_tag_list)
+      end
+    end
+  end
+end

--- a/app/workers/tags/alias_retag_worker.rb
+++ b/app/workers/tags/alias_retag_worker.rb
@@ -8,7 +8,7 @@ module Tags
       tag = Tag.find_by(id: tag_id)
       return unless tag
 
-      tag.taggings.each do |tagging|
+      tag.taggings.find_each do |tagging|
         taggable = tagging.taggable
         new_tag_list = ActsAsTaggableOn::TagParser.new(taggable.tag_list).parse
         taggable.update(tag_list: new_tag_list)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Currently, when we make a tag an alias for another tag, the existing articles won't get updated, so they don't show up on the preferred tag's tag page. To [quote @michael-tharrington](https://github.com/forem/forem/issues/3675#issuecomment-724950813):

> When `#a` becomes an alias for `#b` the following happens:
> - `dev.to/t/a` redirects to `dev.to/t/b`
> - any future posts that are posted with the tag `#a` are transformed upon posting to use the tag `#b` instead (this is done with a search and replace behind the scenes) 
> 
> What we're missing is:
> - any previous posts that have been tagged `#a` should also transform their tag to `#b`... right now, they just keep the old tag and thus remain hidden.  

This PR adds the missing piece, i.e. updating tags for existing articles.

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/3675

## QA Instructions, Screenshots, Recordings

1. Create two tags for test purposes, e.g. "original" and "alias"
2. Create a new article and tag it with "alias"
3. Go to `/admin/tags/` and click on "alias"
4. On the edit page, make it an alias for "original":
    ![image](https://user-images.githubusercontent.com/47985/106242936-0fa50e80-623b-11eb-901a-4dfd194c0844.png)
5. Visit the article, it should now be tagged with "original" and the "alias" tag should be gone.

### UI accessibility concerns?

No UI changes.

## Added tests?

- [X] Yes

## Added to documentation?

- [X] No documentation needed
