### PR TITLE
Ignore feed_admin_publish_permission column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
     youtube_url
   ].freeze
 
-  self.ignored_columns = PROFILE_COLUMNS
+  self.ignored_columns = PROFILE_COLUMNS + %w[feed_admin_publish_permission]
 
   # NOTE: @citizen428 This is temporary code during profile migration and will
   # be removed.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

We use the `feed_admin_publish_permission` attribute in admin views to decide whether or not something can be published to the RSS feed, but there no longer seems to be a way for users to change this setting.

Note: we currently have 406 users (out of ~550k) who have this attribute set to `false`. 

## Related Tickets & Documents

First step of https://github.com/forem/forem/issues/12356

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

No UI changes

## Added tests?

- [X] No, and this is why: they aren't necessary here

## Added to documentation?

- [X] No documentation needed
