### PR TITLE
Verify link is available and wait for JS before testing

### DIFF
--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -142,8 +142,6 @@ RSpec.describe "Views an article", type: :system do
   describe "when an article is not published" do
     let(:article) { create(:article, user: article_user, published: false) }
     let(:article_path) { article.path + query_params }
-    let(:href) { "#{article.path}/edit" }
-    let(:link_text) { "Click to edit" }
 
     context "with the article password, and the logged-in user is authorized to update the article" do
       let(:query_params) { "?preview=#{article.password}" }

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -149,7 +149,8 @@ RSpec.describe "Views an article", type: :system do
 
       it "shows the article edit link", js: true do
         visit article_path
-        expect(page.body).to include('display: inline-block;">Click to edit</a>')
+        edit_link = find("a#author-click-to-edit")
+        expect(edit_link.matches_style?(display: "inline-block")).to be true
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a flakey spec where the "Click to Edit" link on an author's article does not appear yet until the JS has completed. Hopefully using `find` will allow Capybara to finish waiting for the Javascript to run.

## QA Instructions, Screenshots, Recordings
1. Hope that CI passes

### UI accessibility concerns?
No

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed