### PR TITLE
Bug Fix:Bust Bottom Shell Content on Admin Config Update

### DIFF
--- a/app/views/shell/_bottom.html.erb
+++ b/app/views/shell/_bottom.html.erb
@@ -1,6 +1,6 @@
 <!-- Start Bottom Shell -->
 <% unless internal_navigation? %>
-  <% cache("footer-and-signup-modal--#{user_signed_in?}--#{ForemInstance.deployed_at}", expires_in: 24.hours) do %>
+  <% cache("footer-and-signup-modal-#{user_signed_in?}-#{ForemInstance.deployed_at&.rfc3339}-#{SiteConfig.admin_action_taken_at&.rfc3339}", expires_in: 24.hours) do %>
     <%= render "layouts/footer" %>
     <%= render "layouts/signup_modal" unless user_signed_in? %>
   <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Update the footer cache whenever the admin configs are updated. Given we bust this cache every 24 hours and on every deploy, I dont think busting it for an admin config change will impact its use much since that happens far less often than deploys and likely is done less than every 24 hours. I want to also note that on a successful config change we bust our edge cache for the footer, naturally, we should ensure that our Redis cache is also busted. 

## Related Tickets & Documents
Fixes: https://github.com/forem/forem/issues/12473

## QA Instructions, Screenshots, Recordings
1. Have caching enabled
2. Update the community name and verify it updates in the footer

## Added tests?
- [x] No, testing a view cache like this is tricky so I decided manual testing was sufficient


![alt_text](https://media2.giphy.com/media/xT5LMzWVNsfgu6srOU/giphy.gif)
