### PR TITLE
Bug Fix:ForemInstance.deployed_at is a String, not a datetime

### DIFF
--- a/app/views/shell/_bottom.html.erb
+++ b/app/views/shell/_bottom.html.erb
@@ -1,6 +1,6 @@
 <!-- Start Bottom Shell -->
 <% unless internal_navigation? %>
-  <% cache("footer-and-signup-modal-#{user_signed_in?}-#{ForemInstance.deployed_at&.rfc3339}-#{SiteConfig.admin_action_taken_at&.rfc3339}", expires_in: 24.hours) do %>
+  <% cache("footer-and-signup-modal-#{user_signed_in?}-#{ForemInstance.deployed_at}-#{SiteConfig.admin_action_taken_at&.rfc3339}", expires_in: 24.hours) do %>
     <%= render "layouts/footer" %>
     <%= render "layouts/signup_modal" unless user_signed_in? %>
   <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We use `rfc3339` to convert dates into a nice readable string with no space. Turns out `ForemInstance.deployed_at` is a string and not a DateTime 🤦‍♀️ 
