### PR TITLE
Optimization: Set ForemInstance.deployed_at Locally to Better Mirror Production

### DIFF
--- a/app/models/forem_instance.rb
+++ b/app/models/forem_instance.rb
@@ -1,6 +1,8 @@
 class ForemInstance
   def self.deployed_at
-    @deployed_at ||= ApplicationConfig["RELEASE_FOOTPRINT"].presence || ENV["HEROKU_RELEASE_CREATED_AT"].presence
+    @deployed_at ||= ApplicationConfig["RELEASE_FOOTPRINT"].presence ||
+      ENV["HEROKU_RELEASE_CREATED_AT"].presence ||
+      Time.current.to_s
   end
 
   def self.latest_commit_id

--- a/spec/models/forem_instance_spec.rb
+++ b/spec/models/forem_instance_spec.rb
@@ -2,7 +2,10 @@ require "rails_helper"
 
 RSpec.describe ForemInstance, type: :model do
   describe "deployed_at" do
-    before { allow(ENV).to receive(:[]) }
+    before do
+      allow(ENV).to receive(:[])
+      described_class.instance_variable_set(:@deployed_at, nil)
+    end
 
     after do
       described_class.instance_variable_set(:@deployed_at, nil)
@@ -17,6 +20,14 @@ RSpec.describe ForemInstance, type: :model do
       allow(ApplicationConfig).to receive(:[]).with("RELEASE_FOOTPRINT").and_return("")
       allow(ENV).to receive(:[]).with("HEROKU_RELEASE_CREATED_AT").and_return("A deploy date set on Heroku")
       expect(described_class.deployed_at).to eq(ENV["HEROKU_RELEASE_CREATED_AT"])
+    end
+
+    it "sets to current time if HEROKU_RELEASE_CREATED_AT and RELEASE_FOOTPRINT are not present" do
+      Timecop.freeze do
+        allow(ApplicationConfig).to receive(:[]).with("RELEASE_FOOTPRINT").and_return("")
+        allow(ENV).to receive(:[]).with("HEROKU_RELEASE_CREATED_AT").and_return("")
+        expect(described_class.deployed_at).to eq(Time.current.to_s)
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
Locally `ForemInstance.deployed_at` is nil. This makes it hard to test certain changes because in production `ForemInstance.deployed_at` is a string and therefore behaves differently. This recent difference led to an outage because I had handled the nil case but not the case where it was a string. With this update, `ForemInstance.deployed_at` will be set to the current time as a string locally which will allow us to better catch errors like the one that caused our recent outage. Here is the same error occurring locally. 

<img width="710" alt="Screen Shot 2021-01-31 at 4 56 00 PM" src="https://user-images.githubusercontent.com/1813380/106399335-a0b3eb00-63dd-11eb-8700-28d5f8cd4505.png">

## Added tests?
- [x] yes


![never again gif](https://media.tenor.com/images/a12c2e91113b02c16b020cbb70529241/tenor.gif)
