### PR TITLE
Add Message to the postgres.db_table_size dataset on Datadog

### DIFF
--- a/app/workers/metrics/record_data_counts_worker.rb
+++ b/app/workers/metrics/record_data_counts_worker.rb
@@ -4,7 +4,7 @@ module Metrics
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform
-      models = [User, Article, Organization, Comment, Podcast, PodcastEpisode, Listing, PageView, Notification]
+      models = [User, Article, Organization, Comment, Podcast, PodcastEpisode, Listing, PageView, Notification, Message]
       models.each do |model|
         db_count = begin
           model.count


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We want to track the size of the `Message` table across the fleet


## Added tests?

- [ ] Yes
- [x] No, and this is why: not needed, the test is already in place
- [ ] I need help with writing tests
