### PR TITLE
Optimization:Throttle Tag Index Endpoints

### DIFF
--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -30,8 +30,8 @@ module Rack
       track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
     end
 
-    throttle("message_throttle", limit: 2, period: 1) do |request|
-      if request.path.starts_with?("/messages") && request.post?
+    throttle("message_tag_throttle", limit: 2, period: 1) do |request|
+      if message_or_tag_request(request)
         track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
       end
     end
@@ -41,6 +41,11 @@ module Rack
 
       Honeycomb.add_field("fastly_client_ip", ip_address)
       ip_address.to_s
+    end
+
+    def self.message_or_tag_request(request)
+      (request.path.starts_with?("/messages") && request.post?) ||
+        request.path.include?("/t/")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Over the past couple of months we have repeatedly gotten latency alerts from our app when someone decides to comb through all of our tag endpoints. The Tag index is notoriously slow which is why when someone tries to hit is 5+ times in a second we end up with latency alerts. This uses the same throttling we apply to messages(via chat) to the `/t/:tag` endpoint. Unless someone reload the page incredibly fast, they should not hit this throttle. The only thing that should hit this throttle would be a bot or script.

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-53073578

## Added tests?
- [x] I tried

![going to stop you right there gif](https://media.tenor.com/images/df8e7c9395b3c64bfde03b2d1aff6c94/tenor.gif)
