### PR TITLE
Provide default authentication providers in seed.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,7 @@ puts "Seeding with multiplication factor: #{SEEDS_MULTIPLIER}\n\n"
 
 SiteConfig.public = true
 SiteConfig.waiting_on_first_user = false
+SiteConfig.authentication_providers = Authentication::Providers.available
 
 ##############################################################################
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
I'm trying to reduce the additional step of creating an account in the Rails console every time I reset my db. I think this is a sensible change and would save everyone's time.

## Related Tickets & Documents
n/a
## QA Instructions, Screenshots, Recordings
0. Pull down this branch
1. `bin/rails db:reset`
2. `bin/setup`
3. Start up the rails server and try to log in. You should see Facebook, Github, and Twitter listed there.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a