### PR TITLE
Don't allow invites to users who are already registered

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -11,6 +11,13 @@ module Admin
     def create
       email = params.dig(:user, :email)
       name = params.dig(:user, :name)
+
+      if User.exists?(["lower(email) = ? AND registered = ?", email, true])
+        flash[:error] = "Invitation was not sent. There is already a registered user with the email: #{email}"
+        redirect_to admin_invitations_path
+        return
+      end
+
       username = "#{name.downcase.tr(' ', '_').gsub(/[^0-9a-z ]/i, '')}_#{rand(1000)}"
       User.invite!(email: email,
                    name: name,

--- a/spec/requests/admin/invitations_spec.rb
+++ b/spec/requests/admin/invitations_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "/admin/invitations", type: :request do
         post "/admin/invitations",
              params: { user: { email: admin.email, name: "Roger #{rand(1000)}" } }
       end.not_to change { User.all.count }
+      expect(admin.reload.registered).to be true
       expect(flash[:error].present?).to be true
     end
   end

--- a/spec/requests/admin/invitations_spec.rb
+++ b/spec/requests/admin/invitations_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe "/admin/invitations", type: :request do
            params: { user: { email: "hey#{rand(1000)}@email.co", name: "Roger #{rand(1000)}" } }
       expect(User.last.registered).to be false
     end
+
+    it "does not create an invitation if a user with that email exists" do
+      post "/admin/invitations",
+           params: { user: { email: admin.email, name: "Roger #{rand(1000)}" } }
+      expect(flash[:error].present?).to be true
+    end
   end
 
   describe "DELETE /admin/invitations" do

--- a/spec/requests/admin/invitations_spec.rb
+++ b/spec/requests/admin/invitations_spec.rb
@@ -31,8 +31,10 @@ RSpec.describe "/admin/invitations", type: :request do
     end
 
     it "does not create an invitation if a user with that email exists" do
-      post "/admin/invitations",
-           params: { user: { email: admin.email, name: "Roger #{rand(1000)}" } }
+      expect do
+        post "/admin/invitations",
+             params: { user: { email: admin.email, name: "Roger #{rand(1000)}" } }
+      end.not_to change { User.all.count }
       expect(flash[:error].present?).to be true
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where a registered user can be accidentally flipped back to `registered: false` if they are invited again, which then leads to their profile and comments not being viewable directly (under the show page).

## Related Tickets & Documents
Resolves https://github.com/forem/internalCommunity/issues/8

## QA Instructions, Screenshots, Recordings
1. Visit `localhost:3000/admin/invites/new`
2. Try to send an invite to an existing registered user's email

### UI accessibility concerns?
Nope

## Added tests?
- [x] Yes

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
Nope