### PR TITLE
Remove old code for feedback messages email to the reporter

### DIFF
--- a/app/helpers/feedback_messages_helper.rb
+++ b/app/helpers/feedback_messages_helper.rb
@@ -15,20 +15,6 @@ module FeedbackMessagesHelper
     { subject: "#{SiteConfig.community_name} Code of Conduct Violation", body: body }.freeze
   end
 
-  def reporter_email_details
-    body = <<~HEREDOC
-      Hi there,
-
-      Thank you for flagging content that may be in violation of the #{SiteConfig.community_name} Code of Conduct and/or our Terms of Use. We are looking into your report and will take appropriate action.
-
-      We appreciate your help as we work to foster a positive and inclusive environment for all!
-
-      #{SiteConfig.community_name} Team
-    HEREDOC
-
-    { subject: "#{SiteConfig.community_name} Report", body: body }.freeze
-  end
-
   def affected_email_details
     body = <<~HEREDOC
       Hi there,

--- a/app/views/admin/feedback_messages/_feedback_message.html.erb
+++ b/app/views/admin/feedback_messages/_feedback_message.html.erb
@@ -43,7 +43,7 @@
               <a href="<%= feedback_message.offender.path %>">@<%= feedback_message.offender.username %></a>
             </h5>
           <% else %>
-          <h5 class="fw-bold">
+            <h5 class="fw-bold">
               Reported URL (new tab):
             </h5>
             <h5>
@@ -74,12 +74,12 @@
           </p>
           <% else %>
             <h5 class="fw-bold">
-            Message from Offender:
-          </h5>
-          <div class="reported__message">
-                 <%= raw(feedback_message.message) %>
-          </div>
-            <% end %>
+              Message from Offender:
+            </h5>
+            <div class="reported__message">
+              <%= raw(feedback_message.message) %>
+            </div>
+          <% end %>
         </div>
       </div>
       <hr>
@@ -108,25 +108,14 @@
           <h4 class="fw-bold">Email Form:</h4>
           <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="nav-item">
-              <a class="nav-link active" href="#reporter-<%= feedback_message.id %>" aria-controls="reporter-<%= feedback_message.id %>" role="tab" data-toggle="tab">Reporter</a>
-            </li>
-            <li role="presentation" class="nav-item">
-              <a class="nav-link" href="#offender-<%= feedback_message.id %>" aria-controls="offender-<%= feedback_message.id %>" role="tab" data-toggle="tab">Offender</a>
+              <a class="nav-link active" href="#offender-<%= feedback_message.id %>" aria-controls="offender-<%= feedback_message.id %>" role="tab" data-toggle="tab">Offender</a>
             </li>
             <li role="presentation" class="nav-item">
               <a class="nav-link" href="#affected-<%= feedback_message.id %>" aria-controls="affected-<%= feedback_message.id %>" role="tab" data-toggle="tab">Affected</a>
             </li>
           </ul>
           <div class="tab-content my-3">
-            <div role="tabcard" class="tab-pane fade active show" data-id="<%= feedback_message.id %>" data-userType="reporter" id="reporter-<%= feedback_message.id %>">
-              <h5 class="fw-bold">Send To:</h5>
-              <%= email_field_tag :reporter_email_to, feedback_message.reporter&.email, class: "form-control my-1", id: "reporter__emailto__#{feedback_message.id}", required: true %>
-              <h5 class="fw-bold">Subject:</h5>
-              <%= text_field_tag :reporter_email_subject, reporter_email_details[:subject], class: "form-control my-1", id: "reporter__subject__#{feedback_message.id}" %>
-              <h5 class="fw-bold">Body:</h5>
-              <%= text_area_tag :reporter_email_body, reporter_email_details[:body], class: "form-control my-1", style: "height: 300px;", id: "reporter__body__#{feedback_message.id}" %>
-            </div>
-            <div role="tabcard" class="tab-pane fade" data-id="<%= feedback_message.id %>" data-userType="offender" id="offender-<%= feedback_message.id %>">
+            <div role="tabcard" class="tab-pane fade active show" data-id="<%= feedback_message.id %>" data-userType="offender" id="offender-<%= feedback_message.id %>">
               <h5 class="fw-bold">Send To:</h5>
               <%= email_field_tag :offender_email_to, feedback_message.offender&.email, class: "form-control my-1", id: "offender__emailto__#{feedback_message.id}", required: true %>
               <h5 class="fw-bold">Subject:</h5>

--- a/spec/helpers/feedback_messages_helper_spec.rb
+++ b/spec/helpers/feedback_messages_helper_spec.rb
@@ -10,15 +10,6 @@ RSpec.describe FeedbackMessagesHelper, type: :helper do
     end
   end
 
-  describe "#reporter_email_details" do
-    it "have proper subject and body" do
-      expect(helper.reporter_email_details).to include(
-        subject: "#{SiteConfig.community_name} Report",
-        body: a_string_starting_with("Hi"),
-      )
-    end
-  end
-
   describe "#affected_email_details" do
     it "have proper subject and body" do
       expect(helper.affected_email_details).to include(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Removed the code related to sending an email to the reporter about their feedback message.
The rfc talks about deleting `send_email` as well, but as I see we still need `send_email` and `feedback_message_resolution_email` along with the js function `sendEmail` to send emails to the offender and affected users.

## Related Tickets & Documents
https://github.com/forem/rfcs/pull/9

### UI accessibility concerns?
Before:
![изображение](https://user-images.githubusercontent.com/30115/106868778-4322e580-66e0-11eb-9843-b1f459851145.png)


After:
![изображение](https://user-images.githubusercontent.com/30115/106868679-1ec70900-66e0-11eb-8897-81b910ae1f9c.png)

