### PR TITLE
fix typo in nav links form

### DIFF
--- a/app/views/admin/navigation_links/_form.html.erb
+++ b/app/views/admin/navigation_links/_form.html.erb
@@ -16,7 +16,7 @@
 <div class="form-group">
   <%= form.label :position %>
   <%= form.number_field :position, class: "form-control" %>
-  <div class="alert alert-info">Detemines the order placement of the links in the sidebar</div>
+  <div class="alert alert-info">Determines the order placement of the links in the sidebar</div>
 </div>
 <div class="form-group">
   <%= form.check_box :display_only_when_signed_in %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Quick fix for a small typo in the Navigation links modal I noticed while reviewing a PR in a similar area

## Related Tickets & Documents

N/A 

## QA Instructions, Screenshots, Recordings

In the admin area
- Go to Navigation Links
- Add or edit a navigation link
- "detemines" is changed to "determines"

### UI accessibility concerns?

N/A

## Added tests?

- [ ] Yes
- [X] No, and this is why:  small typo fix, doesn't affect any existing tests
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [X] No documentation needed


