### PR TITLE
Delete all notifications instead of destroying

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -27,7 +27,7 @@ class Organization < ApplicationRecord
   has_many :credits, dependent: :restrict_with_error
   has_many :display_ads, dependent: :destroy
   has_many :listings, dependent: :destroy
-  has_many :notifications, dependent: :destroy
+  has_many :notifications, dependent: :delete_all
   has_many :organization_memberships, dependent: :delete_all
   has_many :profile_pins, as: :profile, inverse_of: :profile, dependent: :destroy
   has_many :sponsorships, dependent: :destroy

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Organization, type: :model do
       it { is_expected.to have_many(:credits).dependent(:restrict_with_error) }
       it { is_expected.to have_many(:display_ads).dependent(:destroy) }
       it { is_expected.to have_many(:listings).dependent(:destroy) }
-      it { is_expected.to have_many(:notifications).dependent(:destroy) }
+      it { is_expected.to have_many(:notifications).dependent(:delete_all) }
       it { is_expected.to have_many(:organization_memberships).dependent(:delete_all) }
       it { is_expected.to have_many(:profile_pins).dependent(:destroy) }
       it { is_expected.to have_many(:sponsorships).dependent(:destroy) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This updates deleting an organization's notifications with `:destroy` to `:delete_all`. Hopefully speeds things up.

Since the notifications table has no callbacks I think it's fine to change it to `delete_all`.

## Related Issues
#12575

## [optional] What gif best describes this PR or how it makes you feel?

![A person frowns with disgust, then considers the thought, then changes their mind and says, "No." Then reconsiders one last time and says, "Well..."](https://media.giphy.com/media/fXJyMfUdqVCMPAnPJM/giphy.gif)