### PR TITLE
Optimize StoriesController's tagged article count

### DIFF
--- a/spec/initializers/rack/attack_spec.rb
+++ b/spec/initializers/rack/attack_spec.rb
@@ -132,7 +132,7 @@ describe Rack::Attack, type: :request, throttle: true do
 
     # rubocop:disable RSpec/AnyInstance, RSpec/ExampleLength
     it "throttles viewing tags" do
-      allow_any_instance_of(StoriesController).to receive(:cached_tagged_count).and_return(0)
+      allow_any_instance_of(StoriesController).to receive(:tagged_count).and_return(0)
       allow_any_instance_of(StoriesController).to receive(:stories_by_timeframe).and_return(Article.none)
       allow_any_instance_of(Articles::Feeds::LargeForemExperimental).to receive(
         :published_articles_by_tag,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Reduce the time it takes to get published articles counts on tag page from >900ms to ~200ms by leveraging indexes

shoutout to @mstruve and @rhymes for their benchmarking tips!

## Related Tickets & Documents
continuation to https://github.com/forem/forem/pull/12574

## QA Instructions, Screenshots, Recordings
Navigate to any `/t/[tag]` page, you should see the articles count listed on lower left side without issue

## Added tests?
- [x] No, and this is why: existing specs is suffice.

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
