### PR TITLE
Optimize published_articles_by_tag fetch speed

### DIFF
--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -28,11 +28,10 @@ module Articles
       end
 
       def published_articles_by_tag
-        articles = Article.published.limited_column_select
+        articles = @tag.present? ? Tag.find_by(name: @tag).articles : Article
+        articles.published.limited_column_select
           .includes(top_comments: :user)
           .page(@page).per(@number_of_articles)
-        articles = articles.cached_tagged_with(@tag) if @tag.present? # More efficient than tagged_with
-        articles
       end
 
       # Timeframe values from Timeframe::DATETIMES

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
   describe "#published_articles_by_tag" do
     let(:unpublished_article) { create(:article, published: false) }
     let(:tag) { "foo" }
-    let(:tagged_article) { create(:article, tags: tag) }
+    let!(:tagged_article) { create(:article, tags: tag) }
 
     it "returns published articles" do
       result = feed.published_articles_by_tag


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Reduce tagged article fetch time from ~1000 ms to ~250 ms.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
Continuation of https://github.com/forem/forem/pull/12581 and https://github.com/forem/forem/pull/12574
## Added tests?
- [x] no, because existing test is surface

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a