### PR TITLE
Fix bug when trying to preview a blank draft article

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -104,8 +104,7 @@ class ArticlesController < ApplicationController
             title: parsed["title"],
             tags: (Article.new.tag_list.add(parsed["tags"], parser: ActsAsTaggableOn::TagParser) if parsed["tags"]),
             cover_image: (ApplicationController.helpers.cloud_cover_url(parsed["cover_image"]) if parsed["cover_image"])
-          },
-                 status: :ok
+          }, status: :ok
         end
       end
     end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -104,7 +104,8 @@ class ArticlesController < ApplicationController
             title: parsed["title"],
             tags: (Article.new.tag_list.add(parsed["tags"], parser: ActsAsTaggableOn::TagParser) if parsed["tags"]),
             cover_image: (ApplicationController.helpers.cloud_cover_url(parsed["cover_image"]) if parsed["cover_image"])
-          }
+          },
+                 status: :ok
         end
       end
     end

--- a/app/javascript/article-form/actions.js
+++ b/app/javascript/article-form/actions.js
@@ -13,7 +13,13 @@ export function previewArticle(payload, successCb, failureCb) {
     }),
     credentials: 'same-origin',
   })
-    .then((response) => response.json())
+    .then((response) => {
+      if (response.status !== 200) {
+        throw response;
+      }
+
+      return response.json();
+    })
     .then(successCb)
     .catch(failureCb);
 }

--- a/app/javascript/article-form/actions.js
+++ b/app/javascript/article-form/actions.js
@@ -13,12 +13,14 @@ export function previewArticle(payload, successCb, failureCb) {
     }),
     credentials: 'same-origin',
   })
-    .then((response) => {
+    .then(async (response) => {
+      const payload = await response.json();
+
       if (response.status !== 200) {
-        throw response;
+        throw payload;
       }
 
-      return response.json();
+      return payload;
     })
     .then(successCb)
     .catch(failureCb);

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -160,18 +160,11 @@ export class ArticleForm extends Component {
   };
 
   showPreview = (response) => {
-    if (response.processed_html) {
-      this.setState({
-        ...this.setCommonProps({ previewShowing: true }),
-        previewResponse: response,
-        errors: null,
-      });
-    } else {
-      this.setState({
-        errors: response,
-        submitting: false,
-      });
-    }
+    this.setState({
+      ...this.setCommonProps({ previewShowing: true }),
+      previewResponse: response,
+      errors: null,
+    });
   };
 
   handleOrgIdChange = (e) => {
@@ -180,9 +173,10 @@ export class ArticleForm extends Component {
   };
 
   failedPreview = (response) => {
-    // TODO: console.log should not be part of production code. Remove it!
-    // eslint-disable-next-line no-console
-    console.log(response);
+    this.setState({
+      errors: response,
+      submitting: false,
+    });
   };
 
   handleConfigChange = (e) => {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a bug where an error was thrown if you try to preview an empty draft article.

Here, we are passing in the entire `showPreview` function in as a _succcess_ callback:
https://github.com/forem/forem/blob/c6c1950b9e421cf9f3086b6a761ce1f74e797d7a/app/javascript/article-form/articleForm.jsx#L158

And in the success callback, we're trying to handle an error. We should split these apart.

The JS shouldn't throw an error due to empty HTML so we need to update the conditional of `if (response.processed_html)`.

I noticed there's a TODO under the failure callback and all we're doing is logging right now. I moved the error logic to that callback, but that doesn't seem to work quite right yet. Moving that logic would allow us to rely on the `status` code from the server to determine success instead of `processed_html` being blank or not.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/12572

## Added tests?
- [x] I need help with writing tests

## Added to documentation?
- [x] No documentation needed
