### PR TITLE
Remove feed_admin_publish_permission from ignored_columns

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
     youtube_url
   ].freeze
 
-  self.ignored_columns = PROFILE_COLUMNS + %w[feed_admin_publish_permission]
+  self.ignored_columns = PROFILE_COLUMNS
 
   # NOTE: @citizen428 This is temporary code during profile migration and will
   # be removed.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Cleanup

## Description

We already removed the `feed_admin_publish_permission` and related code, but removing the column from `ignored_columns` slipped through the cracks.

## Related Tickets & Documents

#12356

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added tests?

- [X] No, and this is why: nothing to test here

## Added to documentation?

- [X] No documentation needed
