### PR TITLE
Fix incorrect datetime format

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -30,7 +30,7 @@
       data-params="<%= params.merge(sort_by: "hotness_score", sort_direction: "desc").to_json(only: %i[tag username q sort_by sort_direction]) %>" data-which="<%= @list_of %>"
       data-tag=""
       data-feed="<%= params[:timeframe] || "base-feed" %>"
-      data-articles-since="<%= Timeframe.datetime(params[:timeframe]) %>">
+      data-articles-since="<%= Timeframe.datetime_iso8601(params[:timeframe]) %>">
 
     <%= render "articles/sidebar" %>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix


## Description
This has been an ongoing error message since November 2020. It was because the time was not in the proper format.

## Related Tickets & Documents
Resolves https://app.honeybadger.io/fault/66984/7ea884586993901ab72615451d8200f6
## QA Instructions, Screenshots, Recordings
0. Pull down this branch and start up the rails server
1. Navigate to `/top/week`. You should not need any XHR issue in your browser console nor should you see any Elasticserach 400 errors in your server log.

## Added tests?
- [x] No, and this is why: I'm not quote sure how to test this since it didn't evoke any error

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
