### PR TITLE
fix dropdown-menu not closing when click outside or click on a item on mobile

### DIFF
--- a/app/javascript/topNavigation/utilities.js
+++ b/app/javascript/topNavigation/utilities.js
@@ -63,6 +63,17 @@ export function initializeTouchDevice(memberTopMenu, menuNavButton) {
         menuNavButton.addEventListener('click', (_event) => {
           toggleHeaderMenu(memberTopMenu, menuNavButton);
         });
+
+        document.addEventListener('click', (_event) => {
+          // if clicking outside of the menu or on a menu item, close it
+          if (document.activeElement.id !== 'member-menu-button') {
+            blurHeaderMenu(
+              memberTopMenu,
+              menuNavButton,
+              document.getElementById('first-nav-link'),
+            );
+          }
+        });
       } else {
         crayonsHeaderMenuClassList.add('desktop');
         menuNavButton.addEventListener('click', (_event) => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
On the dev.to (mobile or application) when we click on menu its dont close if we click outisde(like on desktop one) or on a menu link.

## Related Tickets & Documents

Closes  #12466

## QA Instructions, Screenshots, Recordings

- Pull down this branch and start up the rails server
- Login and open the dropdown menu on mobile view (maybe need a refresh after resize the window).

## Added tests?

- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_

## Added to documentation?

- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
no
## [optional] What gif best describes this PR or how it makes you feel?

![Awesome!](https://i.giphy.com/media/5hmJjbIVi8vMHWw3rv/giphy.webp)
