### PR TITLE
Update PR template with communicating changes section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,6 +49,20 @@ accessibility is impacted and tested. For more info, check out the
       have not been included_
 - [ ] I need help with writing tests
 
+## Does this change need to be communicated?
+
+_Please take a moment to consider if your PR will directly impact Forem users
+(members or creators), the Forem development process, or our support and/or
+marketing teams. You may want to include this in a Changelog post, write a
+[forem.dev](http://forem.dev) post, update documentation, or share this change
+internally._
+
+- [ ] Yes, this change will be communicated: _please replace this line with
+      details on how you will communicate your change_
+- [ ] No, and this is why not: _please replace this line with details on why
+      this change doesn't need to be communicated_
+- [ ] I'm not sure how best to communicate this change and need help
+
 ## Added to documentation?
 
 - [ ] [Developer Docs](https://docs.forem.com) and/or

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,27 +49,23 @@ accessibility is impacted and tested. For more info, check out the
       have not been included_
 - [ ] I need help with writing tests
 
-## Does this change need to be communicated?
+## How will this change be communicated?
 
-_Please take a moment to consider if your PR will directly impact Forem users
-(members or creators), the Forem development process, or our support and/or
-marketing teams. You may want to include this in a Changelog post, write a
-[forem.dev](http://forem.dev) post, update documentation, or share this change
-internally._
+_Please take a moment to consider if your PR will directly impact Forem members
+or creators, the development process, or any of our internal teams. You may want
+to include this in a Changelog post, write a [forem.dev](http://forem.dev) post,
+update documentation, or share this change internally._
 
-- [ ] Yes, this change will be communicated: _please replace this line with
-      details on how you will communicate your change_
-- [ ] No, and this is why not: _please replace this line with details on why
-      this change doesn't need to be communicated_
+- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
+      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or [Storybook](https://storybook.forem.com/) (for Crayons components)
+- [ ] I've updated the README or inline documentation
+- [ ] I will include this in the [Changelog](https://forem.dev/t/changelog) or
+      in a [forem.dev](http://forem.dev) post
+- [ ] I will share this internally with the appropriate team
+- [ ] This change does not need to be communicated, and this is why not: _please
+      replace this line with details on why this change doesn't need to be
+      shared_
 - [ ] I'm not sure how best to communicate this change and need help
-
-## Added to documentation?
-
-- [ ] [Developer Docs](https://docs.forem.com) and/or
-      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
-- [ ] [Storybook](https://storybook.forem.com/) (for Crayons components)
-- [ ] README
-- [ ] No documentation needed
 
 ## [optional] Are there any post deployment tasks we need to perform?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,23 +49,23 @@ accessibility is impacted and tested. For more info, check out the
       have not been included_
 - [ ] I need help with writing tests
 
-## How will this change be communicated?
+## [Forem core team only] How will this change be communicated?
 
-_Please take a moment to consider if your PR will directly impact Forem members
-or creators, the development process, or any of our internal teams. You may want
-to include this in a Changelog post, write a [forem.dev](http://forem.dev) post,
-update documentation, or share this change internally._
+_Will this PR introduce a change that impacts Forem members or creators, the
+development process, or any of our internal teams? If so, please note how you
+will share this change with the people who need to know about it._
 
 - [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
-      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or [Storybook](https://storybook.forem.com/) (for Crayons components)
-- [ ] I've updated the README or inline documentation
-- [ ] I will include this in the [Changelog](https://forem.dev/t/changelog) or
-      in a [forem.dev](http://forem.dev) post
-- [ ] I will share this internally with the appropriate team
+      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
+      [Storybook](https://storybook.forem.com/) (for Crayons components)
+- [ ] I've updated the README or added inline documentation
+- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
+      or in a [forem.dev](http://forem.dev) post
+- [ ] I will share this change internally with the appropriate team
+- [ ] I'm not sure how best to communicate this change and need help
 - [ ] This change does not need to be communicated, and this is why not: _please
       replace this line with details on why this change doesn't need to be
       shared_
-- [ ] I'm not sure how best to communicate this change and need help
 
 ## [optional] Are there any post deployment tasks we need to perform?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -61,7 +61,7 @@ will share this change with the people who need to know about it._
 - [ ] I've updated the README or added inline documentation
 - [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
       or in a [forem.dev](http://forem.dev) post
-- [ ] I will share this change internally with the appropriate team
+- [ ] I will share this change internally with the appropriate teams
 - [ ] I'm not sure how best to communicate this change and need help
 - [ ] This change does not need to be communicated, and this is why not: _please
       replace this line with details on why this change doesn't need to be


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

A recent [incident](https://forem.team/vaidehijoshi/communicating-support-tooling-changes-53pm) prompted me to open this PR, which updates our PR template with a `How will this change be communicated?` section, rolled up with our `Added to documentation?` section. Not only do I think it will help us in communicating things _internally_, but I think it will make us more self-aware as a team as to when + how we need to communicate changes to the broader community as well as our users (like [this recent example](https://github.com/forem/forem/pull/12502#pullrequestreview-582866986)).

## Related Tickets & Documents

https://forem.team/vaidehijoshi/communicating-support-tooling-changes-53pm

## QA Instructions, Screenshots, Recordings

None :)

### UI accessibility concerns?

None :)

## Added tests?

- [ ] Yes
- [x] No, and this is why: _just a PR template change!_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] README
- [x] No documentation needed
