### PR TITLE
Add guard clause to AliasRetagWorker

### DIFF
--- a/app/workers/tags/alias_retag_worker.rb
+++ b/app/workers/tags/alias_retag_worker.rb
@@ -10,6 +10,8 @@ module Tags
 
       tag.taggings.find_each do |tagging|
         taggable = tagging.taggable
+        next if taggable.nil?
+
         new_tag_list = ActsAsTaggableOn::TagParser.new(taggable.tag_list).parse
         taggable.update(tag_list: new_tag_list)
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
As I tried to manually run `AliasRetagWorker` on some of the older tags, things were falling because the `taggings` were nil. This warrants a database clean up but to smoothen the process, for now, this guard clause is necessary.

## Related Tickets & Documents
https://github.com/forem/forem/issues/3675
## QA Instructions, Screenshots, Recordings
n/a

## Added tests?
- [x] No, and this is why: existing spec is suffice.

## Added to documentation?
- [x] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a
