### PR TITLE
Ignore two Carrierwave CVEs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
       script:
         - yarn test --colors
         - bundle exec rails db:create db:schema:load assets:precompile
-        - bundle exec bundle-audit check --update --ignore CVE-2015-9284
+        - bundle exec bundle-audit check --update --ignore CVE-2015-9284 CVE-2021-21288 CVE-2021-21305
         - bin/test-console-check
         - yarn build-storybook
         - bundle exec rake data_updates:run # required for at least creating the first admin user in e2e tests.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Temporary "fix"

## Description

In https://github.com/forem/forem/pull/12607 we discovered that the upgrade from Carrierwave 2.1.0 to 2.1.1 is more involved than the minor version increase suggests. However, there are two new CVEs against Carrierwave ([CVE-2021-21288](https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-fwcm-636p-68r5) and [CVE-2021-21305](https://github.com/carrierwaveuploader/carrierwave/security/advisories/GHSA-cf3w-g86h-35x4)) that currently stop our builds from passing due to the `bundle audit` check.

As a **temporary workaround** this PR disables the check for these two specific CVEs to give us a bit more time to address the update issues. We should still try to do this in a timely manner, as the security issues are of medium and high criticality respectively.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added tests?

- [X] No, and this is why: nothing to test

## Added to documentation?

- [X] No documentation needed
