### PR TITLE
Adds a feature flag for Data Update Scripts

### DIFF
--- a/app/views/admin/admin_portals/index.html.erb
+++ b/app/views/admin/admin_portals/index.html.erb
@@ -22,19 +22,21 @@
     <% end %>
   </div>
 
-  <div class="grid gap-2 m:gap-4 l:gap-6 m:grid-cols-2 l:grid-cols-3 px-2 m:px-0">
-    <div>
-      <div class="mt-6 mb-2"> Tech Resources </div>
-      <% AdminHelper::TECH_MENU_ITEMS.each do |tech_menu_item| %>
-        <div class="tag-card crayons-card branded-4 p-4 m:p-6 m:pt-4 flex flex-col relative">
-          <h3 class="crayons-tag crayons-tag--l mb-2">
-            <a href="/admin/<%= tech_menu_item[:controller] %>" class="crayons-link">
-              <%= tech_menu_item[:name].to_s.titleize %>
-            </a>
-          </h3>
-        </div>
-      <% end %>
+  <% if FeatureFlag.enabled?(:data_update_scripts) %>
+    <div class="grid gap-2 m:gap-4 l:gap-6 m:grid-cols-2 l:grid-cols-3 px-2 m:px-0">
+      <div>
+        <div class="mt-6 mb-2"> Tech Resources </div>
+        <% AdminHelper::TECH_MENU_ITEMS.each do |tech_menu_item| %>
+          <div class="tag-card crayons-card branded-4 p-4 m:p-6 m:pt-4 flex flex-col relative">
+            <h3 class="crayons-tag crayons-tag--l mb-2">
+              <a href="/admin/<%= tech_menu_item[:controller] %>" class="crayons-link">
+                <%= tech_menu_item[:name].to_s.titleize %>
+              </a>
+            </h3>
+          </div>
+        <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 
 </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -59,8 +59,10 @@
       <div class="crayons-layout__left-sidebar">
         <nav class="hidden m:block">
           <%= render "admin/shared/navbar", menu_items: admin_menu_items %>
-          <p class="crayons-field__description mt-4 mb-3">Tech Resources</p>
-          <%= render "admin/shared/navbar", menu_items: AdminHelper::TECH_MENU_ITEMS %>
+          <% if FeatureFlag.enabled?(:data_update_scripts) %>
+            <p class="crayons-field__description mt-4 mb-3">Tech Resources</p>
+            <%= render "admin/shared/navbar", menu_items: AdminHelper::TECH_MENU_ITEMS %>
+          <% end %>
         </nav>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,9 +63,12 @@ Rails.application.routes.draw do
                                               destroy], path: "listings/categories"
 
       resources :comments, only: [:index]
-      resources :data_update_scripts, only: %i[index show] do
-        member do
-          post :force_run
+      # We do not expose the Data Update Scripts to all Forems by default.
+      constraints(->(_request) { FeatureFlag.enabled?(:data_update_scripts) }) do
+        resources :data_update_scripts, only: %i[index show] do
+          member do
+            post :force_run
+          end
         end
       end
       resources :events, only: %i[index create update new edit]

--- a/spec/requests/admin/admin_portals_spec.rb
+++ b/spec/requests/admin/admin_portals_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 RSpec.describe "/admin", type: :request do
   let(:super_admin) { create(:user, :super_admin) }
 
-  before { sign_in super_admin }
+  before do
+    sign_in super_admin
+    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(false)
+    allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(false)
+  end
 
   describe "profile admin feature flag" do
     it "shows the option when the feature flag is enabled" do
@@ -40,4 +44,25 @@ RSpec.describe "/admin", type: :request do
       expect(response.body).to include(ENV["HEROKU_RELEASE_CREATED_AT"])
     end
   end
+
+  describe "data update scripts admin feature flag" do
+    it "shows the option when the feature flag is enabled" do
+      allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(true)
+
+      get admin_path
+
+      expect(response.body).to include("Tech Resources")
+      expect(response.body).to include("Data Update Scripts")
+    end
+
+    it "does not show the option when the feature flag is disabled" do
+      allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(false)
+
+      get admin_path
+
+      expect(response.body).not_to include("Tech Resources")
+      expect(response.body).not_to include("Data Update Scripts")
+    end
+  end
+
 end

--- a/spec/requests/admin/data_update_scripts_spec.rb
+++ b/spec/requests/admin/data_update_scripts_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe "/admin/data_update_scripts", type: :request do
   context "when the user is not an tech admin" do
     let(:user) { create(:user) }
 
-    before { sign_in user }
+    before do
+      sign_in user
+      allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(false)
+      allow(Flipper).to receive(:enabled?).with(:data_update_scripts).and_return(true)
+    end
 
     describe "GET /admin/data_update_scripts" do
       it "blocks the request" do
@@ -18,7 +22,11 @@ RSpec.describe "/admin/data_update_scripts", type: :request do
   context "when the user is a tech admin" do
     let(:user) { create(:user, :admin, :tech_admin) }
 
-    before { sign_in user }
+    before do
+      sign_in user
+      allow(Flipper).to receive(:enabled?).with(:profile_admin).and_return(false)
+      allow(Flipper).to receive(:enabled?).with(:data_update_scripts).and_return(true)
+    end
 
     describe "GET /admin/data_update_scripts" do
       it "allows the request" do

--- a/spec/requests/admin/sidebar_spec.rb
+++ b/spec/requests/admin/sidebar_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 RSpec.describe "admin sidebar", type: :request do
   let(:super_admin) { create(:user, :super_admin) }
 
-  before { sign_in super_admin }
+  before do
+    sign_in super_admin
+    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(false)
+    allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(false)
+  end
 
   describe "profile admin feature flag" do
     it "shows the option in the sidebar when the feature flag is enabled" do
@@ -20,6 +24,25 @@ RSpec.describe "admin sidebar", type: :request do
       get admin_articles_path
 
       expect(response.body).not_to include("Config: Profile Setup")
+    end
+  end
+
+  describe "data update script admin feature flag" do
+    it "shows the option in the sidebar when the feature flag is enabled" do
+      allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(true)
+
+      get admin_articles_path
+
+      expect(response.body).to include("Tech Resources")
+      expect(response.body).to include("Data Update Scripts")
+    end
+
+    it "does not show the option in the sidebar when the feature flag is disabled" do
+      allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(false)
+
+      get admin_articles_path
+
+      expect(response.body).not_to include("Data Update Scripts")
     end
   end
 end

--- a/spec/routing/data_update_scripts_admin_routes_spec.rb
+++ b/spec/routing/data_update_scripts_admin_routes_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Data Update Scripts admin routes", type: :routing do
+  it "renders the data update scripts admin route if the feature flag is enabled" do
+    allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(true)
+
+    expect(get: admin_data_update_scripts_path).to route_to(
+      controller: "admin/data_update_scripts",
+      action: "index",
+      locale: nil,
+    )
+  end
+
+  it "does not render the profile admin route if the feature flag is disabled" do
+    allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(false)
+
+    expect(get: admin_data_update_scripts_path).not_to route_to(
+      controller: "admin/data_update_scripts",
+      action: "index",
+      locale: nil,
+    )
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds a feature flag :data_update_scripts which removes the menu item from the admin index and sidebar and also disables the routes.

## Related Tickets & Documents
https://github.com/forem/internalEngineering/issues/276
A forem team post where this was discussed: https://forem.team/ridhwana/comment/2nc

## QA Instructions, Screenshots, Recordings

**Enabling and disabling the feature flag through the UI** 
- Go to http://localhost:3000/admin/feature_flags/
- Click on add feature
- Type in data_update_scripts
<img width="1677" alt="Screenshot 2021-02-10 at 11 01 48" src="https://user-images.githubusercontent.com/2786819/107497807-af4b9080-6b9b-11eb-934b-5e4b6c21b85b.png">
- Click on Fully Enable 
![Uploading Screenshot 2021-02-10 at 11.01.56.png…]()

Do the same to disable it.

**Enabling and disabling the feature flag through the Console** 
- Open the rails console `rails c`
- Run `Flipper.enable(:data_update_scripts)`

To disable it, run `Flipper.disable(:data_update_scripts)`

**Test the Admin index:**

- Ensure the feature flag is disabled.
- Go to /admin
- Ensure that you don't see the data update scripts link (it would usually be at the bottom under a heading called Tech Resources)

- Enable the feature flag using one of the techniques above
- Reload /admin, you should now see a "Data Update Scripts option under Tech resources:
<img width="1667" alt="Screenshot 2021-02-10 at 12 32 59" src="https://user-images.githubusercontent.com/2786819/107498194-1ec18000-6b9c-11eb-9c4b-bf62cbd7b126.png">

**Admin sidebar menu:**
- Ensure the feature flag is disabled.
- Go an admin page, e.g. /admin/articles
- Ensure that you don't see the data update scripts link (it would be right at the bottom under a section called tech resources)
- Enable the feature flag.
- Reload the page, you should now see a "Data Update Script" option, under tech Rrsources 
Articles
Routing constraint
Ensure the feature flag is disabled.
Go to /admin/profile_fields
You should be redirected to our root route.
Enable the feature flag in the Rails console:
Flipper.enable(:profile_admin)
Going to /admin/profile_fields should now render the profile admin page.

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added to documentation?

- [ ] [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [ ] [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] README
- [ ] No documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
