### PR TITLE
Fix infinite redirect loop for articles

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -86,14 +86,17 @@ class StoriesController < ApplicationController
 
   def handle_possible_redirect
     potential_username = params[:username].tr("@", "").downcase
+    if @article.organization
+      redirect_permanently_to(@article.path)
+      return
+    end
+
     @user = User.find_by("old_username = ? OR old_old_username = ?", potential_username, potential_username)
     if @user&.articles&.find_by(slug: params[:slug])
       redirect_permanently_to(URI.parse("/#{@user.username}/#{params[:slug]}").path)
       return
-    elsif (@organization = @article.organization)
-      redirect_permanently_to(URI.parse("/#{@organization.slug}/#{params[:slug]}").path)
-      return
     end
+
     not_found
   end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -85,12 +85,12 @@ class StoriesController < ApplicationController
   end
 
   def handle_possible_redirect
-    potential_username = params[:username].tr("@", "").downcase
     if @article.organization
       redirect_permanently_to(@article.path)
       return
     end
 
+    potential_username = params[:username].tr("@", "").downcase
     @user = User.find_by("old_username = ? OR old_old_username = ?", potential_username, potential_username)
     if @user&.articles&.find_by(slug: params[:slug])
       redirect_permanently_to(URI.parse("/#{@user.username}/#{params[:slug]}").path)

--- a/spec/requests/articles/org_redirect_spec.rb
+++ b/spec/requests/articles/org_redirect_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+# Regression spec for https://github.com/forem/forem/issues/12444
+RSpec.describe "", type: :request do
+  it "does not infinitely redirect", :aggregate_failures do
+    organization = create(:organization, username: "test")
+    organization.update(username: "not_test")
+    organization.update(username: "test")
+    article = create(:article, organization: organization)
+    user = article.user
+
+    get "/#{user.username}/#{article.slug}"
+
+    expect(response).to redirect_to(article.path)
+    follow_redirect!
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

The original issue described a redirect loop and suspected that this is related to the interaction of `username`, `old_username`, and `old_old_username`. However, my investigation led me down a different path and I provided a detailed explanation in [this comment](https://github.com/forem/forem/issues/12444#issuecomment-777197399). I'll only share the tl;dr here:

> 1. This only seems to happen to articles that belong to organizations but are accessed via the author's slug.
> 2. I'm not yet sure if the best possible fix is the one regarding `old_username` and `old_old_username` described in the original issue or if we want to update the logic in `StoriesController#show` instead.

By making the article part of an organization I was able to reproduce the redirect loop.

After digging a bit deeper into the code I'm now convinced that this isn't really related to the usernames (as soon as we redirect correctly the `if` condition in `StoriesController#show` should take care of this), so instead I just rearranged the logic in the `handle_possible_redirect` method as follows:

1. Check for the existence of an organization first.
2. If an organization exists, permanently redirect to the article's `path`. This path takes organizations into account, thanks to `Article#calculated_path` (which gets used in the `set_caches` `before_save` action).

This resolved the redirect loop for me.

## Related Tickets & Documents

https://github.com/forem/forem/issues/12444

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

### UI accessibility concerns?

n/a

## Added tests?


- [X] No, and this is why: still struggling with a spec that fails on `master` but is green on this branch.
