### PR TITLE
Fixing `gap` property for all occurrences of `flex` to work in Safari

### DIFF
--- a/app/assets/javascripts/utilities/showUserAlertModal.js
+++ b/app/assets/javascripts/utilities/showUserAlertModal.js
@@ -75,7 +75,7 @@ const getModalHtml = (
             </svg>
           </button>
       </div>
-      <div class="crayons-modal__box__body pt-0 flex gap-2">
+      <div class="crayons-modal__box__body pt-0 flex">
         <div class="w-75">
           <h2>
             ${title}

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -143,8 +143,7 @@ label {
 }
 
 .config-authentication-form {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: var(--su-4);
   padding-top: var(--su-6);
   padding-bottom: var(--su-2);

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -108,7 +108,8 @@ label {
 }
 
 .config-authentication__item {
-  display: flex;
+  display: grid;
+  grid-template-columns: 40px 1fr;
   gap: var(--su-2);
   padding-top: var(--su-3);
   padding-bottom: var(--su-3);

--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -333,6 +333,26 @@
   }
 }
 
+.crayons-btn-actions {
+  --btn-wrap-gap: var(--su-2);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  // line height to give us protection in cases of wrapping:
+  // btn line height + buttin vertical padding * 2 to get top and bottom + our gap value
+  line-height: calc(
+    var(--su-6) + (var(--vertical-padding) * 2) + var(--btn-wrap-gap)
+  );
+
+  .crayons-btn {
+    margin-right: var(--btn-wrap-gap);
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+
 // Grouped buttons
 .crayons-btn-group {
   display: flex;

--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -338,18 +338,13 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  // line height to give us protection in cases of wrapping:
-  // btn line height + buttin vertical padding * 2 to get top and bottom + our gap value
-  line-height: calc(
-    var(--su-6) + (var(--vertical-padding) * 2) + var(--btn-wrap-gap)
-  );
+  // add negative margin to correct for the bottom margin on the buttons
+  margin-bottom: calc(0rem - var(--btn-wrap-gap));
+  margin-left: calc(0rem - var(--btn-wrap-gap));
 
   .crayons-btn {
-    margin-right: var(--btn-wrap-gap);
-
-    &:last-child {
-      margin-right: 0;
-    }
+    margin-left: var(--btn-wrap-gap);
+    margin-bottom: var(--btn-wrap-gap);
   }
 }
 

--- a/app/assets/stylesheets/components/modals.scss
+++ b/app/assets/stylesheets/components/modals.scss
@@ -46,8 +46,8 @@
   }
 
   &__box {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-rows: auto 1fr;
     max-width: var(--modal-max-width);
     background: var(--card-bg);
     color: var(--card-color);

--- a/app/assets/stylesheets/components/modals.scss
+++ b/app/assets/stylesheets/components/modals.scss
@@ -83,11 +83,11 @@
     }
 
     &__body {
-      flex: 1 auto;
       font-size: var(--modal-body-font-size);
       padding: var(--modal-body-padding);
       max-height: 100%;
       overflow-y: auto;
+      grid-auto-rows: min-content;
     }
   }
 

--- a/app/assets/stylesheets/listings.scss
+++ b/app/assets/stylesheets/listings.scss
@@ -193,8 +193,6 @@
 
       .listing-row-actions {
         padding: var(--su-2) 0;
-        display: flex;
-        gap: var(--su-2);
 
         .pill {
           background: $bold-blue;

--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -58,7 +58,6 @@
 
   &__main {
     padding: var(--content-padding-y) var(--content-padding-x);
-    gap: var(--su-7);
   }
 
   &__body {

--- a/app/assets/stylesheets/views/signin.scss
+++ b/app/assets/stylesheets/views/signin.scss
@@ -25,7 +25,6 @@
   &__container {
     @media (min-width: $breakpoint-s) {
       display: flex;
-      grid-gap: var(--su-7);
       flex-direction: row;
       align-items: center;
     }
@@ -39,6 +38,7 @@
     @media (min-width: $breakpoint-s) {
       height: 80px;
       width: 80px;
+      margin-right: var(--su-7);
     }
   }
 

--- a/app/javascript/admin/adminModal.js
+++ b/app/javascript/admin/adminModal.js
@@ -37,9 +37,9 @@ export const adminModal = function ({
             </svg>
           </button>
         </header>
-        <div class="crayons-modal__box__body flex flex-col gap-4">
+        <div class="crayons-modal__box__body grid gap-4">
           ${body}
-          <div class="flex gap-2">
+          <div class="crayons-btn-actions">
             <button
               class="crayons-btn ${leftBtnClasses}"
               data-action="click->config#${leftBtnAction}"

--- a/app/javascript/listings/dashboard/rowElements/actionButtons.jsx
+++ b/app/javascript/listings/dashboard/rowElements/actionButtons.jsx
@@ -4,7 +4,7 @@ import { Button } from '@crayons';
 
 export const ActionButtons = ({ isDraft, editUrl, deleteConfirmUrl }) => {
   return (
-    <div className="listing-row-actions">
+    <div className="listing-row-actions crayons-btn-actions">
       {isDraft && (
         <Button tagName="a" url={editUrl}>
           View draft

--- a/app/views/admin/configs/_apple_auth_provider_settings.html.erb
+++ b/app/views/admin/configs/_apple_auth_provider_settings.html.erb
@@ -48,7 +48,7 @@ requires a custom partial
                      value: SiteConfig.apple_team_id,
                      placeholder: Constants::SiteConfig::DETAILS[:apple_team_id][:placeholder] %>
   </div>
-  <div class="flex gap-2">
+  <div class="crayons-btn-actions">
     <% if authentication_provider_enabled?(provider) %>
       <button
         class="crayons-btn crayons-btn--danger"

--- a/app/views/admin/configs/_auth_provider_settings.html.erb
+++ b/app/views/admin/configs/_auth_provider_settings.html.erb
@@ -19,7 +19,7 @@
                      value: SiteConfig.public_send("#{provider.provider_name}_secret"),
                      placeholder: Constants::SiteConfig::DETAILS[:"#{provider.provider_name}_secret"][:placeholder] %>
   </div>
-  <div class="flex gap-2">
+  <div class="crayons-btn-actions">
     <% if authentication_provider_enabled?(provider) %>
       <button
         class="crayons-btn crayons-btn--danger"

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -273,7 +273,7 @@
                                              placeholder: Constants::SiteConfig::DETAILS[:recaptcha_secret_key][:placeholder] %>
                           </div>
                         </div>
-                        <div>
+                        <divm class="crayons-btn-actions">
                           <% if SiteConfig.allow_email_password_registration %>
                             <button
                               class="crayons-btn crayons-btn--danger"
@@ -281,7 +281,7 @@
                               Disable
                             </button>
                              <button
-                              class="ml-2 crayons-btn crayons-btn--secondary"
+                              class="crayons-btn crayons-btn--secondary"
                               data-action="click->config#hideEmailAuthSettings">
                               Close
                             </button>

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -273,7 +273,7 @@
                                              placeholder: Constants::SiteConfig::DETAILS[:recaptcha_secret_key][:placeholder] %>
                           </div>
                         </div>
-                        <divm class="crayons-btn-actions">
+                        <div class="crayons-btn-actions">
                           <% if SiteConfig.allow_email_password_registration %>
                             <button
                               class="crayons-btn crayons-btn--danger"

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -255,7 +255,7 @@
                             <%= admin_config_description Constants::SiteConfig::DETAILS[:require_captcha_for_email_password_registration][:description] %>
                           </div>
                         </div>
-                        <div id="recaptchaContainer" class="ml-7 <%= SiteConfig.require_captcha_for_email_password_registration ? "flex flex-col gap-4" : "hidden" %>" aria-labelledby="recaptchaContainer">
+                        <div id="recaptchaContainer" class="ml-7 <%= SiteConfig.require_captcha_for_email_password_registration ? "grid gap-4" : "hidden" %>" aria-labelledby="recaptchaContainer">
                           <div class="crayons-field">
                             <%= admin_config_label :recaptcha_site_key, "Google reCAPTCHA site key" %>
                             <%= admin_config_description Constants::SiteConfig::DETAILS[:recaptcha_site_key][:description] %>

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -34,7 +34,7 @@
         aria-labelledby="getStartedHeader">
 
         <%= form_for(SiteConfig.new, url: admin_config_path) do |f| %>
-          <fieldset class="flex flex-column gap-4">
+          <fieldset class="grid gap-4">
 
           <% VerifySetupCompleted::MANDATORY_CONFIGS.each do |config_key| %>
             <%# we need to list the config as separate fields if the data structure is a Hash %>
@@ -124,7 +124,7 @@
                          expanded: false
                        } %>
             <div id="apiBodyContainer" class="card-body collapse hide" aria-labelledby="apiBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :health_check_token %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:health_check_token][:description] %>

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -273,7 +273,7 @@
                                              placeholder: Constants::SiteConfig::DETAILS[:recaptcha_secret_key][:placeholder] %>
                           </div>
                         </div>
-                        <div class="flex gap-2">
+                        <div>
                           <% if SiteConfig.allow_email_password_registration %>
                             <button
                               class="crayons-btn crayons-btn--danger"
@@ -281,7 +281,7 @@
                               Disable
                             </button>
                              <button
-                              class="crayons-btn crayons-btn--secondary"
+                              class="ml-2 crayons-btn crayons-btn--secondary"
                               data-action="click->config#hideEmailAuthSettings">
                               Close
                             </button>

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -373,7 +373,7 @@
                          expanded: false
                        } %>
             <div id="campaignBodyContainer" class="card-body collapse hide" aria-labelledby="campaignBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :campaign_hero_html_variant_name, "Campaign hero HTML variant name" %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:campaign_hero_html_variant_name][:description] %>
@@ -463,7 +463,7 @@
                          expanded: false
                        } %>
             <div id="contentBodyContainer" class="card-body collapse hide" aria-labelledby="contentBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :community_name %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:community_name][:description] %>
@@ -561,7 +561,7 @@
                        } %>
 
             <div id="creditsBodyContainer" class="card-body collapse hide" aria-labelledby="creditsBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <%= f.fields_for :credit_prices_in_cents do |price_field| %>
                   <div class="crayons-field">
                     <%= admin_config_label "Credit price in cents (S)" %>
@@ -611,7 +611,7 @@
                          expanded: false
                        } %>
             <div id="emailBodyContainer" class="card-body collapse hide" aria-labelledby="emailBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                   <div class="crayons-field">
                     <label for="site_config_email_addresses_default" class="crayons-field__label">
                       Default
@@ -650,7 +650,7 @@
                          expanded: false
                        } %>
             <div id="emailDigestBodyContainer" class="card-body collapse hide" aria-labelledby="emailDigestBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :periodic_email_digest_max %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:periodic_email_digest_max][:description] %>
@@ -685,7 +685,7 @@
                          expanded: false
                        } %>
             <div id="jobsBodyContainer" class="card-body collapse hide" aria-labelledby="jobsBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :jobs_url, "Jobs URL" %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:jobs_url][:description] %>
@@ -718,7 +718,7 @@
                          expanded: false
                        } %>
             <div id="gaBodyContainer" class="card-body collapse hide" aria-labelledby="gaBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :ga_tracking_id, "View ID" %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:ga_tracking_id][:description] %>
@@ -743,7 +743,7 @@
                          expanded: false
                        } %>
             <div id="imagesBodyContainer" class="card-body collapse hide" aria-labelledby="imagesBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :main_social_image %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:main_social_image][:description] %>
@@ -821,7 +821,7 @@
                          expanded: false
                        } %>
             <div id="mascotBodyContainer" class="card-body collapse hide" aria-labelledby="mascotBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :mascot_user_id, "Mascot user ID" %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:mascot_user_id][:description] %>
@@ -899,7 +899,7 @@
                          expanded: false
                        } %>
             <div id="metaKeywordsBodyContainer" class="card-body collapse hide" aria-labelledby="metaKeywordsBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <%= f.fields_for :meta_keywords do |meta_keywords_field| %>
                   <% SiteConfig.meta_keywords.each do |area, keywords| %>
                     <div class="crayons-field">
@@ -931,7 +931,7 @@
                          expanded: false
                        } %>
             <div id="monetizationBodyContainer" class="card-body collapse hide" aria-labelledby="monetizationBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :shop_url, "Shop URL" %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:shop_url][:description] %>
@@ -984,7 +984,7 @@
                          expanded: false
                        } %>
             <div id="newsletterBodyContainer" class="card-body collapse hide" aria-labelledby="newsletterBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :mailchimp_api_key, "Mailchimp API Key" %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:mailchimp_api_key][:description] %>
@@ -1041,7 +1041,7 @@
                          expanded: false
                        } %>
             <div id="onboardingBodyContainer" class="card-body collapse hide" aria-labelledby="onboardingBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :onboarding_background_image %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:onboarding_background_image][:description] %>
@@ -1091,7 +1091,7 @@
                          expanded: false
                        } %>
             <div id="rateLimitsBodyContainer" class="card-body collapse hide" aria-labelledby="rateLimitsBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <% configurable_rate_limits.each do |key, field_hash| %>
                   <div class="crayons-field">
                     <%= admin_config_label field_hash[:title] %>
@@ -1130,7 +1130,7 @@
                          expanded: false
                        } %>
             <div id="socialMediaBodyContainer" class="card-body collapse hide" aria-labelledby="socialMediaBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :twitter_hashtag %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:twitter_hashtag][:description] %>
@@ -1170,7 +1170,7 @@
                          expanded: false
                        } %>
             <div id="sponsorsContainer" class="card-body collapse hide" aria-labelledby="sponsorsContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :sponsor_headline %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:sponsor_headline][:description] %>
@@ -1196,7 +1196,7 @@
                          expanded: false
                        } %>
             <div id="tagsBodyContainer" class="card-body collapse hide" aria-labelledby="tagsBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-field">
                   <%= admin_config_label :sidebar_tags %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:sidebar_tags][:description] %>
@@ -1223,7 +1223,7 @@
                          expanded: false
                        } %>
             <div id="uxBodyContainer" class="card-body collapse hide" aria-labelledby="uxBodyContainer">
-              <fieldset class="flex flex-column gap-4">
+              <fieldset class="grid gap-4">
                 <div class="crayons-fieldx">
                   <%= admin_config_label :feed_style %>
                   <%= admin_config_description Constants::SiteConfig::DETAILS[:feed_style][:description] %>

--- a/app/views/articles/tag_index.html.erb
+++ b/app/views/articles/tag_index.html.erb
@@ -6,9 +6,9 @@
 <% cache("tag-stories-index-#{params}-#{flag}-#{@tag_model.updated_at}-#{user_signed_in?}", expires_in: expiry_minutes.minutes) do %>
   <div class="crayons-layout">
     <header class="tag-header crayons-card branded-4" style="border-top-color: <%= Color::CompareHex.new([@tag_model.bg_color_hex || "#0000000", @tag_model.text_color_hex || "#ffffff"]).brightness(0.88) %>">
-      <div class="flex gap-4">
+      <div class="flex">
         <% if @tag_model.badge_id && @tag_model.badge %>
-            <img src="<%= optimized_image_url(@tag_model.badge.badge_image_url, width: 64) %>" alt="" class="" style="transform: rotate(<%= -25 + (@tag_model.id.digits.first * 5) %>deg); width: 64px; height: 64px;" />
+            <img src="<%= optimized_image_url(@tag_model.badge.badge_image_url, width: 64) %>" alt="" class="mr-4" style="transform: rotate(<%= -25 + (@tag_model.id.digits.first * 5) %>deg); width: 64px; height: 64px;" />
         <% end %>
         <div class="flex flex-col w-100 justify-center">
           <div class="flex justify-between items-center">

--- a/app/views/users/_comments_section.html.erb
+++ b/app/views/users/_comments_section.html.erb
@@ -30,11 +30,11 @@
           <h4 class="fw-bold fs-base m-0 mb-1">
             <%= comment.commentable.title %>
           </h4>
-          <div class="inline-flex items-center fs-s gap-2">
+          <div class="flex items-center fs-s">
             <p class="color-base-80">
               <%= truncate(strip_tags(comment.processed_html), length: 64).html_safe %>
             <p>
-            <small class="color-base-60 fs-s comment-date whitespace-nowrap">
+            <small class="ml-2 color-base-60 fs-s comment-date whitespace-nowrap">
               <time datetime="<%= comment.decorate.published_timestamp %>"><%= comment.readable_publish_date %></time>
             </small>
           </div>

--- a/app/views/users/_extensions.html.erb
+++ b/app/views/users/_extensions.html.erb
@@ -35,9 +35,9 @@
 
 <div class="crayons-card crayons-card--content-rows">
   <header>
-    <h2 class="crayons-subtitle-1 flex gap-2 items-center">
+    <h2 class="crayons-subtitle-1 flex items-center">
       Web monetization
-      <span class="crayons-indicator crayons-indicator--accent">beta</span>
+      <span class="ml-2 crayons-indicator crayons-indicator--accent">beta</span>
     </h2>
     <p class="color-base-70">
       Receive micropayments for time spent reading your posts directy. <a href="https://dev.to/hacksultan/web-monetization-like-i-m-5-1418">Learn more</a>

--- a/app/views/users/_integrations.html.erb
+++ b/app/views/users/_integrations.html.erb
@@ -8,9 +8,9 @@
       <p style="font-size: 1.1em"><strong><a href="https://app.stackbit.com/dashboard">Go To Your Stackbit Dashboard</a></strong></p>
       <p style="font-size: 1.1em"><strong><a href="https://app.stackbit.com/create?ref=devto">Create New Stackbit Site</a></strong></p>
     <% else %>
-      <h3 class="crayons-subtitle-2 flex gap-2 items-center">
+      <h3 class="crayons-subtitle-2 flex items-center">
         Connect to Stackbit
-        <span class="crayons-indicator crayons-indicator--accent">beta</span>
+        <span class="ml-2 crayons-indicator crayons-indicator--accent">beta</span>
       </h3>
       <p class="mb-4">
         Automatically generate a self-hosted static blog feed from your <%= community_name %> posts.

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -59,9 +59,9 @@
 
   <div class="crayons-card crayons-card--content-rows">
     <header>
-      <h2 class="crayons-subtitle-1 flex items-center gap-2">
+      <h2 class="crayons-subtitle-1 flex items-center">
         Mobile notifications
-        <span class="crayons-indicator crayons-indicator--accent">beta</span>
+        <span class="ml-2 crayons-indicator crayons-indicator--accent">beta</span>
       </h2>
       <p class="color-base-70">
         Additional settings will be rolled out as new notification features are made available.

--- a/app/views/users/_response_templates.html.erb
+++ b/app/views/users/_response_templates.html.erb
@@ -32,7 +32,7 @@
     <% end %>
 
   <%= form_with model: @response_template do |f| %>
-    <section class="flex flex-col gap-3">
+    <section class="grid gap-3">
       <% if @response_template&.persisted? %>
         <% title = params[:previous_title] || @response_template.title %>
         <% content = params[:previous_content] || @response_template.content %>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<div class="gap-2 m:gap-4 hidden m:grid js-user-info">
+<div class="m:gap-4 hidden m:grid js-user-info">
   <% cache "user-profile-sidebar-additional-#{@user.id}-#{@user.github_repos_updated_at}-#{@user.badge_achievements_count}-#{@user.organization_info_updated_at}", expires_in: 2.days do %>
     <% if @user.organizations.present? %>
       <div class="crayons-card crayons-card--secondary">

--- a/app/views/users/confirm_destroy.html.erb
+++ b/app/views/users/confirm_destroy.html.erb
@@ -2,7 +2,7 @@
   <div class="crayons-card min-w-0 text-padding">
     <h2 class="crayons-title mb-4"> Destroy your account</h2>
     <div class="settings-form">
-        <%= form_tag user_full_delete_path, method: :delete, autocomplete: "off", id: "delete__account", class: "flex flex-col gap-4 mb-4" do %>
+        <%= form_tag user_full_delete_path, method: :delete, autocomplete: "off", id: "delete__account", class: "grid gap-4 mb-4" do %>
           Deleting your account will:
           <ul class="my-0 ml-6 list-disc">
             <li>delete your profile, along with your Twitter and/or GitHub associations.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Safari doesn't support the `gap` property on `flex` containers. This PR contains individual fixes for all of the occurrences of `display: flex` + `gap`

## Related Tickets & Documents

- closes #12452: `gap` doesn't work with `flex` on Safari 

## Detailed description of changes

There were three general fixes that applied to the majority of instances:

### Use `.grid` instead of `.flex.flex-column`

Several layouts used a combo of classes that basically resulted in this:

```css
.example {
  display: flex;
  flex-direction: column;
  gap: 1em;
}
```

With no other flex-related properties in place, this is identical in every way to the default behavior of `display: grid`:

```diff
.example {
- display: flex;
- flex-direction: column;
+ display: grid;
  gap: 1em;
}
```

This was applied in the following files: 

- app/views/admin/configs/show.html.erb
- app/views/users/_response_templates.html.erb
- app/views/users/confirm_destroy.html.erb
- app/assets/stylesheets/admin.scss (`.config-authentication__item`)

### Use child margin instead of flex gap

Many instances of flex+gap were headings with text and one indicator/tooltip, or a div containing exactly one `figure` and one `div`. This was fixed generally by removing the `gap-*` class from the heading and adding `mr-*` or `ml-*` to the indicator/tooltop/figure:

- app/views/articles/tag_index.html.erb
- app/views/users/_extensions.html.erb
- app/views/users/_integrations.html.erb
- app/views/users/_notifications.html.erb
- app/views/users/_comments_section.html.erb
- app/assets/stylesheets/views/signin.scss (`.authentication-feed__container`)

### Add class for crayons-btn-actions

This pattern occurs pretty often: a div containing only one or more buttons. I added a class to the buttons scss:

```scss
.crayons-btn-actions {
  --btn-wrap-gap: var(--su-2);
  display: flex;
  flex-wrap: wrap;
  align-items: center;
  // add negative margin to correct for the bottom margin on the buttons
  margin-bottom: calc(0rem - var(--btn-wrap-gap));
  margin-left: calc(0rem - var(--btn-wrap-gap));

  .crayons-btn {
    margin-left: var(--btn-wrap-gap);
    margin-bottom: var(--btn-wrap-gap);
  }
}
```

This mimics flex+gap, and is an easy class addition and easy swap out once flex gap is supported in target browsers. This was applied in the following files:

- app/assets/stylesheets/components/buttons.scss
- app/views/admin/configs/show.html.erb
- app/javascript/admin/adminModal.js
- app/views/admin/configs/_auth_provider_settings.html.erb
- app/views/admin/configs/_apple_auth_provider_settings.html.erb
- app/javascript/listings/dashboard/rowElements/actionButtons.jsx

### Misc

A couple random other spots were flex+gap was used:

- `gap-2` safely deleted since there’s only one element:
  app/assets/javascripts/utilities/showUserAlertModal.js
- remove unused class for clarity
  app/views/users/_sidebar.html.erb
- Use actual grid columns: this was a two-column fixed-width setup and so was ripe for actual `grid` layout.
  app/assets/stylesheets/admin.scss

## QA Instructions, Screenshots, Recordings

Nothing specific, other than going to the routes using the views listed above.

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: There are no visual regression tests, which would be the only appropriate tests here
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![YOLO](https://media0.giphy.com/media/FuvVKU8Jxq1CE/giphy.gif)
