### PR TITLE
Refactor:Change Image Article Upload Path to uploads/articles

### DIFF
--- a/app/uploaders/article_image_uploader.rb
+++ b/app/uploaders/article_image_uploader.rb
@@ -1,6 +1,6 @@
 class ArticleImageUploader < BaseUploader
   def store_dir
-    "i/"
+    "uploads/articles/"
   end
 
   def filename

--- a/spec/requests/image_uploads_spec.rb
+++ b/spec/requests/image_uploads_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "ImageUploads", type: :request do
         "image/jpeg",
       )
     end
+    let(:image_directory_regex) { "\/uploads\/articles\/.+\." }
 
     context "when not logged-in" do
       it "responds with 401" do
@@ -38,13 +39,13 @@ RSpec.describe "ImageUploads", type: :request do
         # this test is a little flimsy
         post "/image_uploads", headers: headers, params: { image: [image] }
         expect(response.parsed_body["links"].length).to eq(1)
-        expect(response.body).to match("\/i\/.+\.")
+        expect(response.body).to match(image_directory_regex)
       end
 
       it "supports for uploading a single image not in an array" do
         post "/image_uploads", headers: headers, params: { image: image }
         expect(response.parsed_body["links"].length).to eq(1)
-        expect(response.body).to match("\/i\/.+\.")
+        expect(response.body).to match(image_directory_regex)
       end
 
       it "supports upload of more than one image at a time" do
@@ -53,7 +54,7 @@ RSpec.describe "ImageUploads", type: :request do
         )
         post "/image_uploads", headers: headers, params: { image: [image, image2] }
 
-        expect(response.body).to match("\/i\/.+\.")
+        expect(response.body).to match(image_directory_regex)
         expect(response.parsed_body["links"].length).to eq(2)
       end
 

--- a/spec/uploaders/article_image_uploader_spec.rb
+++ b/spec/uploaders/article_image_uploader_spec.rb
@@ -26,7 +26,7 @@ describe ArticleImageUploader, type: :uploader do
   end
 
   it "stores files in the correct directory" do
-    expect(uploader.store_dir).to eq("i/")
+    expect(uploader.store_dir).to eq("uploads/articles/")
   end
 
   describe "filename" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Change the upload path for article images to `uploads/articles/` to match our other upload path convention. 

## Related Tickets & Documents
Closes https://github.com/forem/internalEngineering/issues/335

## QA Instructions, Screenshots, Recordings
Upload an image locally and see the new path used in your directory tree under the `/public` directory

## Added tests?
- [x] Yes


![no sweat gif](https://media3.giphy.com/media/SS7n4YOfeHSNBoUPNn/200.gif)
