### PR TITLE
Part 1: Shows Relevant #help Posts in Homepage Sidebar

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -132,13 +132,6 @@ class Article < ApplicationRecord
 
   scope :cached_tagged_by_approval_with, ->(tag) { cached_tagged_with(tag).where(approved: true) }
 
-  scope :active_help, lambda {
-    published
-      .cached_tagged_with("help")
-      .order(created_at: :desc)
-      .where("published_at > ? AND comments_count < ? AND score > ?", 12.hours.ago, 6, -4)
-  }
-
   scope :limited_column_select, lambda {
     select(:path, :title, :id, :published,
            :comments_count, :public_reactions_count, :cached_tag_list,
@@ -209,6 +202,23 @@ class Article < ApplicationRecord
     boosted_additional_articles Boolean, default: false
     boosted_dev_digest_email Boolean, default: false
     boosted_additional_tags String, default: ""
+  end
+
+  def self.active_help
+    stories = published
+      .cached_tagged_with("help")
+      .order(created_at: :desc)
+      .where("published_at > ? AND comments_count < ? AND score > ?", 12.hours.ago, 6, -4)
+    if stories.size.positive?
+      published
+        .cached_tagged_with("help")
+        .order(created_at: :desc)
+        .where("published_at > ? AND comments_count < ? AND score > ?", 12.hours.ago, 6, -4)
+    else
+      published
+        .cached_tagged_with("help")
+        .order(created_at: :desc)
+    end
   end
 
   def self.active_threads(tags = ["discuss"], time_ago = nil, number = 10)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -209,16 +209,11 @@ class Article < ApplicationRecord
       .cached_tagged_with("help")
       .order(created_at: :desc)
       .where("published_at > ? AND comments_count < ? AND score > ?", 12.hours.ago, 6, -4)
-    if stories.size.positive?
-      published
-        .cached_tagged_with("help")
-        .order(created_at: :desc)
-        .where("published_at > ? AND comments_count < ? AND score > ?", 12.hours.ago, 6, -4)
-    else
-      published
-        .cached_tagged_with("help")
-        .order(created_at: :desc)
-    end
+    return stories if stories.size.positive?
+
+    published
+      .cached_tagged_with("help")
+      .order(created_at: :desc)
   end
 
   def self.active_threads(tags = ["discuss"], time_ago = nil, number = 10)

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -682,30 +682,18 @@ RSpec.describe Article, type: :model do
   end
 
   describe ".active_help" do
-    let!(:filtered_article) do
-      create(:article, user: user, cached_tag_list: "help", published_at: 12.hours.ago, comments_count: 6, score: -4)
-    end
-    let!(:unfiltered_article) do
-      create(:article, user: user, cached_tag_list: "help", published_at: 12.hours.ago, score: -10)
-    end
-
     it "returns properly filtered articles under the 'help' tag" do
-      # articles = described_class.active_help
-      # article = filtered_article.active_help
-      # binding.pry
-      # expect(article.size).to eq(1)
-      # expect(articles).not_to be_empty
-      # expect(article).to include(filtered_article)
-
-      filtered_article = create(:article, user: user, cached_tag_list: "help", published_at: 12.hours.ago, comments_count: 6, score: -4)
+      filtered_article = create(:article, user: user, tags: "help",
+                                          published_at: 13.hours.ago, comments_count: 5, score: -3)
       articles = described_class.active_help
-      expect(articles.first).to eq(filtered_article)
+      expect(articles).to include(filtered_article)
     end
 
     it "returns any published articles tagged with 'help' when there are no articles that fit the criteria" do
-      article = described_class.active_help
-      # article = unfiltered_article.active_help
-      expect(article).to include(unfiltered_article)
+      unfiltered_article = create(:article, user: user, tags: "help",
+                                            published_at: 10.hours.ago, comments_count: 8, score: -5)
+      articles = described_class.active_help
+      expect(articles).to include(unfiltered_article)
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -681,6 +681,34 @@ RSpec.describe Article, type: :model do
     end
   end
 
+  describe ".active_help" do
+    let!(:filtered_article) do
+      create(:article, user: user, cached_tag_list: "help", published_at: 12.hours.ago, comments_count: 6, score: -4)
+    end
+    let!(:unfiltered_article) do
+      create(:article, user: user, cached_tag_list: "help", published_at: 12.hours.ago, score: -10)
+    end
+
+    it "returns properly filtered articles under the 'help' tag" do
+      # articles = described_class.active_help
+      # article = filtered_article.active_help
+      # binding.pry
+      # expect(article.size).to eq(1)
+      # expect(articles).not_to be_empty
+      # expect(article).to include(filtered_article)
+
+      filtered_article = create(:article, user: user, cached_tag_list: "help", published_at: 12.hours.ago, comments_count: 6, score: -4)
+      articles = described_class.active_help
+      expect(articles.first).to eq(filtered_article)
+    end
+
+    it "returns any published articles tagged with 'help' when there are no articles that fit the criteria" do
+      article = described_class.active_help
+      # article = unfiltered_article.active_help
+      expect(article).to include(unfiltered_article)
+    end
+  end
+
   describe ".seo_boostable" do
     let!(:top_article) do
       create(:article, organic_page_views_past_month_count: 20, score: 30, tags: "good, greatalicious", user: user)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The "Definition of Done" for this RFC is:
> This feature is deployed to all Forems, and we can assert that every size Forem, regardless of Forem size, can render articles on the sidebar. We should be able to see that every Forem (even if those that have few posts or old posts) can always display posts for a tag, regardless of an article's `published_at` date or `score`.

This PR is part one of a two-part solution to ensure that posts show beneath the tags in the homepage's righthand sidebar, regardless of the Forem's size and the article's `published_at` date, `score`, and `comment_count`. The first part of this two-part solution focuses specifically on the #help tag in the homepage's righthand sidebar. To accomplish this, I've updated the `active_help` scope the Article model. This scope is responsible for determining which posts to show under the #help tag found in the homepage's righthand sidebar. In addition to this, I've added a test for this work to `spec/models/article_spec.rb`.

## Related Tickets & Documents
Relates to [RFC 20](https://github.com/forem/rfcs/pull/20)

## QA Instructions, Screenshots, Recordings
- To QA this PR, please first ensure that you have admin-status and then navigate to `/admin/config` and scroll to the `/tags` section:
<img width="1037" alt="Screen Shot 2021-02-12 at 3 36 49 PM" src="https://user-images.githubusercontent.com/32834804/107829988-22920580-6d48-11eb-89c9-5a0c50cb3f3f.png">

- In order to have tags display in the sidebar and to test this PR, you need to first set some tags, like "help" (⚠️ in order to test this, you will need to set the "help" tag!):
<img width="981" alt="Screen Shot 2021-02-12 at 3 39 42 PM" src="https://user-images.githubusercontent.com/32834804/107830176-89afba00-6d48-11eb-8237-6075727a1ce7.png">

- After setting the tags, navigate to the homepage and observe that there are no articles beneath the "help" tag:
<img width="1329" alt="Screen Shot 2021-02-12 at 3 41 20 PM" src="https://user-images.githubusercontent.com/32834804/107830312-c380c080-6d48-11eb-8c5d-5b92deee8db8.png">

- In order to see articles displayed beneath the "help" tag, create a post that uses the "help" tag:
<img width="959" alt="Screen Shot 2021-02-12 at 3 44 14 PM" src="https://user-images.githubusercontent.com/32834804/107830499-2b370b80-6d49-11eb-905d-02cd131f288c.png">
<img width="923" alt="Screen Shot 2021-02-12 at 3 44 31 PM" src="https://user-images.githubusercontent.com/32834804/107830510-34c07380-6d49-11eb-8cda-fa899abae7f2.png">

- After creating an article with the "help" tag, navigate back to the homepage. Observe that your article tagged with "help" displays in the sidebar:
<img width="1328" alt="Screen Shot 2021-02-12 at 3 46 20 PM" src="https://user-images.githubusercontent.com/32834804/107830608-75b88800-6d49-11eb-91ba-d5ba34c5740b.png">

- To test that the article tagged with "help" displays in the sidebar as expected if it meets the `#active_help` requirements, first drop into the console and update the article to match `where(published_at: 12.hours.ago.., comments_count: ..5, score: -3..)`:
```
article = Article.last
article.update(comments_count: 5, published_at: 13.hours.ago, score: -3)
```

- After updating the article, navigate back to the homepage. Observe that your article shows in the sidebar as expected:
<img width="1351" alt="Screen Shot 2021-02-12 at 3 53 06 PM" src="https://user-images.githubusercontent.com/32834804/107831043-67b73700-6d4a-11eb-9f2e-b34189a49b4f.png">

- Try to break things! ⚒️ 

### UI accessibility concerns?
I don't believe so!

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I've updated the [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
👀  I've added documentation to the Admin Guide. The draft can be found [here](https://app.gitbook.com/@forem/s/forem-admin-guide/~/drafts/-MTIAVU4sD3GjFmS6HXB/admin/config/tags). Any and all feedback welcome!
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post-deployment tasks we need to perform?
This will need to be deployed to all Forems.

## [optional] What gif best describes this PR or how it makes you feel?

![Cat Rescuing Cat Stuck in Tree](https://media.giphy.com/media/hDHHqEyHT88mY/giphy.gif)
