### PR TITLE
Remove language columns

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -10,6 +10,8 @@ class Article < ApplicationRecord
   SEARCH_CLASS = Search::FeedContent
   DATA_SYNC_CLASS = DataSync::Elasticsearch::Article
 
+  self.ignored_columns = %w[language]
+
   acts_as_taggable_on :tags
   resourcify
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
     youtube_url
   ].freeze
 
-  self.ignored_columns = PROFILE_COLUMNS
+  self.ignored_columns = PROFILE_COLUMNS + %w[language_settings]
 
   # NOTE: @citizen428 This is temporary code during profile migration and will
   # be removed.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This  is one of the final clean up tasks related to #12356, adding `articles.language` and `users.language_settings` to `ignored_columns` so we can drop them from the DB.

## Related Tickets & Documents

 #12356

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added tests?

- [ ] No, and this is why: nothing to test here
