### PR TITLE
Redirect users to sign up path after they self-delete their account

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -122,7 +122,7 @@ class UsersController < ApplicationController
       Users::DeleteWorker.perform_async(@user.id)
       sign_out @user
       flash[:global_notice] = "Your account deletion is scheduled. You'll be notified when it's deleted."
-      redirect_to root_path
+      redirect_to new_user_registration_path
     else
       flash[:settings_notice] = "Please, provide an email to delete your account"
       redirect_to user_settings_path("account")

--- a/spec/requests/user/user_destroy_spec.rb
+++ b/spec/requests/user/user_destroy_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe "UserDestroy", type: :request do
         expect(controller.current_user).to eq nil
       end
 
-      it "redirects to root" do
+      it "redirects to sign up" do
         delete "/users/full_delete"
-        expect(response).to redirect_to "/"
+        expect(response).to redirect_to new_user_registration_path
         expect(flash[:global_notice]).to include("Your account deletion is scheduled")
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This PR redirects users to the sign-up page after they self-delete their account.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/6139

## QA Instructions, Screenshots, Recordings
Here is what it looks like once a user confirms their account deletion:
![Screen Shot 2021-02-15 at 1 48 23 PM](https://user-images.githubusercontent.com/15987080/107984308-a7be2a00-6f95-11eb-9c91-fc9cf1a56022.png)

To test...
1. Log in to an account.
2. Go to **Settings** --> **Account** and delete the account.
3. Follow the confirmation link sent via email (I usually just search `mime` in my console where the server is running and get the link directly from there).
4. Confirm the account deletion.
5. Confirm that you're redirected to the sign-up page with a flash notice 🎉 .

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: this is a bug fix that does not affect core behavior.

![lebron_james_pointing_gif](https://media.giphy.com/media/3og0IUaHP9M4c1Kire/giphy.gif)
