### PR TITLE
Drop language settings columns

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -10,8 +10,6 @@ class Article < ApplicationRecord
   SEARCH_CLASS = Search::FeedContent
   DATA_SYNC_CLASS = DataSync::Elasticsearch::Article
 
-  self.ignored_columns = %w[language]
-
   acts_as_taggable_on :tags
   resourcify
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
     youtube_url
   ].freeze
 
-  self.ignored_columns = PROFILE_COLUMNS + %w[language_settings]
+  self.ignored_columns = PROFILE_COLUMNS
 
   # NOTE: @citizen428 This is temporary code during profile migration and will
   # be removed.

--- a/db/migrate/20210216023520_drop_language_columns.rb
+++ b/db/migrate/20210216023520_drop_language_columns.rb
@@ -1,0 +1,8 @@
+class DropLanguageColumns < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      remove_column :articles, :language
+      remove_column :users, :language_settings
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_01_055410) do
+ActiveRecord::Schema.define(version: 2021_02_16_023520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -108,7 +108,6 @@ ActiveRecord::Schema.define(version: 2021_02_01_055410) do
     t.integer "featured_number"
     t.string "feed_source_url"
     t.integer "hotness_score", default: 0
-    t.string "language"
     t.datetime "last_buffered"
     t.datetime "last_comment_at", default: "2017-01-01 05:00:00"
     t.datetime "last_experience_level_rating_at"
@@ -1273,7 +1272,6 @@ ActiveRecord::Schema.define(version: 2021_02_01_055410) do
     t.integer "invitations_count", default: 0
     t.bigint "invited_by_id"
     t.string "invited_by_type"
-    t.jsonb "language_settings", default: {}, null: false
     t.datetime "last_article_at", default: "2017-01-01 05:00:00"
     t.datetime "last_comment_at", default: "2017-01-01 05:00:00"
     t.datetime "last_followed_at"
@@ -1349,7 +1347,6 @@ ActiveRecord::Schema.define(version: 2021_02_01_055410) do
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
-    t.index ["language_settings"], name: "index_users_on_language_settings", using: :gin
     t.index ["old_old_username"], name: "index_users_on_old_old_username"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["twitter_username"], name: "index_users_on_twitter_username", unique: true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR finally removes the remaining language settings columns from `articles` and `users`.

## Related Tickets & Documents

Closes #12356 

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added tests?

- [X] No, and this is why: nothing to test here
