### PR TITLE
Add data update script for backfilling usernames

### DIFF
--- a/lib/data_update_scripts/20210218041143_backfill_usernames.rb
+++ b/lib/data_update_scripts/20210218041143_backfill_usernames.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class BackfillUsernames
+    def run
+      User.where(username: nil).find_each do |user|
+        user.update(username: "user#{user.id}")
+      end
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/backfill_usernames_spec.rb
+++ b/spec/lib/data_update_scripts/backfill_usernames_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20210218041143_backfill_usernames.rb",
+)
+
+describe DataUpdateScripts::BackfillUsernames do
+  it " " do
+    user = create(:user)
+    user.update_column(:username, nil)
+    expect do
+      described_class.new.run
+    end.to change { user.reload.username }.from(nil).to("user#{user.id}")
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Data update

## Description

Before we can add a non-null constraint to the DB to ensure that usernames are present (we already have a validation), we need to fix the existing users that previously slipped through the cracks (45 in the case of DEV). This script assigns them a username of the form "user#{user.id}" for this purpose.

## Related Tickets & Documents

#2207

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added tests?

- [X] Yes