### PR TITLE
Prevent banned users from using API

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -36,10 +36,10 @@ module Api
       def authenticate!
         if doorkeeper_token
           @user = User.find(doorkeeper_token.resource_owner_id)
-          return error_unauthorized unless @user
+          return error_unauthorized unless @user && !@user.banned
         elsif request.headers["api-key"]
           @user = authenticate_with_api_key
-          return error_unauthorized unless @user
+          return error_unauthorized unless @user && !@user.banned
         elsif current_user
           @user = current_user
         else

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -34,18 +34,8 @@ module Api
       end
 
       def authenticate!
-        if doorkeeper_token
-          @user = User.find(doorkeeper_token.resource_owner_id)
-          return error_unauthorized unless @user && !@user.banned
-        elsif request.headers["api-key"]
-          @user = authenticate_with_api_key
-          return error_unauthorized unless @user && !@user.banned
-        elsif current_user
-          @user = current_user
-          return error_unauthorized if @user.banned
-        else
-          error_unauthorized
-        end
+        @user = authenticated_user
+        return error_unauthorized unless @user && !@user.banned
       end
 
       def authorize_super_admin
@@ -77,6 +67,16 @@ module Api
         # see <https://www.slideshare.net/NickMalcolm/timing-attacks-and-ruby-on-rails>
         secure_secret = ActiveSupport::SecurityUtils.secure_compare(api_secret.secret, api_key)
         return api_secret.user if secure_secret
+      end
+
+      def authenticated_user
+        if doorkeeper_token
+          User.find(doorkeeper_token.resource_owner_id)
+        elsif request.headers["api-key"]
+          authenticate_with_api_key
+        elsif current_user
+          current_user
+        end
       end
     end
   end

--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -42,6 +42,7 @@ module Api
           return error_unauthorized unless @user && !@user.banned
         elsif current_user
           @user = current_user
+          return error_unauthorized if @user.banned
         else
           error_unauthorized
         end

--- a/app/policies/api_secret_policy.rb
+++ b/app/policies/api_secret_policy.rb
@@ -1,6 +1,6 @@
 class ApiSecretPolicy < ApplicationPolicy
   def create?
-    true
+    !user_is_banned?
   end
 
   def destroy?

--- a/app/services/users/delete_activity.rb
+++ b/app/services/users/delete_activity.rb
@@ -9,6 +9,7 @@ module Users
       delete_profile_info(user)
       user.access_grants.delete_all
       user.access_tokens.delete_all
+      user.api_secrets.delete_all
       user.created_podcasts.update_all(creator_id: nil)
       user.blocker_blocks.delete_all
       user.blocked_blocks.delete_all

--- a/spec/policies/api_secret_policy_spec.rb
+++ b/spec/policies/api_secret_policy_spec.rb
@@ -28,4 +28,11 @@ RSpec.describe ApiSecretPolicy, type: :policy do
     it { is_expected.to forbid_actions %i[destroy] }
     it { is_expected.to permit_mass_assignment_of(valid_attributes) }
   end
+
+  context "when the user is banned" do
+    let(:user) { create(:user, :banned) }
+    let(:api_secret) { build_stubbed(:api_secret) }
+
+    it { is_expected.to forbid_actions %i[create] }
+  end
 end

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -551,6 +551,12 @@ RSpec.describe "Api::V0::Articles", type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
 
+      it "fails with a banned user" do
+        user.add_role(:banned)
+        post api_articles_path, headers: { "api-key" => api_secret.secret, "content-type" => "application/json" }
+        expect(response).to have_http_status(:unauthorized)
+      end
+
       it "fails with the wrong api key" do
         post api_articles_path, headers: { "api-key" => "foobar", "content-type" => "application/json" }
         expect(response).to have_http_status(:unauthorized)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This PR prevents banned users from using the API, as well prevents them from creating new API keys. It also deletes all API keys that a user has when they are deleted.

I didn't add any error handling here since we don't have a set policy on that response for banned users yet.

## Related Tickets & Documents
https://github.com/forem/internalCommunity/issues/24

## QA Instructions, Screenshots, Recordings
1. Make yourself banned `user.add_role :banned`
2. Go to /settings/account
3. Attempt to create a new API
4. Run into a 500 error


1. Visit /api/articles
2. See that you get the unauthorized response 401

### UI accessibility concerns?
Nope

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?

![A woman says, "Request's been denied."](https://media.giphy.com/media/1zlj55brLYCYmJqujn/giphy.gif)
