### PR TITLE
[15 mins fix] Title clipping on /new view for `prefers-reduced-motion: reduce` settings.

### DIFF
--- a/app/assets/stylesheets/base/reset.scss
+++ b/app/assets/stylesheets/base/reset.scss
@@ -154,10 +154,15 @@ sup {
 
 // Remove all animations and transitions for people that prefer not to see them
 @media (prefers-reduced-motion: reduce) {
-  * {
-    animation-duration: 0.01ms !important;
+  *,
+  ::before,
+  ::after {
+    animation-delay: -1ms !important;
+    animation-duration: 1ms !important;
     animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+    background-attachment: initial !important;
     scroll-behavior: auto !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
   }
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes clipping title field on `/new` view - caused by `prefers-reduced-motion: reduce` settings that we overwrite in our reset. Kudos to @benhalpern for finding the root cause of this bug since it's been open for several months and we couldn't find what exactly caused this behavior. 

## Related Tickets & Documents

- Closes #10114

## QA Instructions, Screenshots, Recordings

1. Go to your system preferences and find settings (in accessibility tab) related to reducing motion. check the checkbox.
2. Go to `/new` and play with the title field. It should no longer be clipped.

**Before:** 

![image](https://user-images.githubusercontent.com/5906351/91770366-ed2c9d80-eb95-11ea-8a58-b4f19f3700d7.jpg)

**After:**

![image](https://user-images.githubusercontent.com/108287/108415588-07cefd80-722e-11eb-914a-95c1f9ad8696.png)

## Added tests?

- [ ] Yes
- [x] No, and this is why: not needed
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_