### PR TITLE
Add new DUS for backfilling usernames

### DIFF
--- a/lib/data_update_scripts/20210218041143_backfill_usernames.rb
+++ b/lib/data_update_scripts/20210218041143_backfill_usernames.rb
@@ -1,9 +1,7 @@
 module DataUpdateScripts
   class BackfillUsernames
     def run
-      User.where(username: nil).find_each do |user|
-        user.update(username: "user#{user.id}")
-      end
+      # Superseded by BackfillUsernamesWithoutValidations
     end
   end
 end

--- a/lib/data_update_scripts/20210219031051_backfill_usernames_without_validations.rb
+++ b/lib/data_update_scripts/20210219031051_backfill_usernames_without_validations.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class BackfillUsernamesWithoutValidations
+    def run
+      User.where(username: nil).find_each do |user|
+        user.update_column(:username, "user#{user.id}")
+      end
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/backfill_usernames_without_validations_spec.rb
+++ b/spec/lib/data_update_scripts/backfill_usernames_without_validations_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 require Rails.root.join(
-  "lib/data_update_scripts/20210218041143_backfill_usernames.rb",
+  "lib/data_update_scripts/20210219031051_backfill_usernames_without_validations.rb",
 )
 
-describe DataUpdateScripts::BackfillUsernames do
-  it " " do
+describe DataUpdateScripts::BackfillUsernamesWithoutValidations do
+  it "backfills usernames" do
     user = create(:user)
     user.update_column(:username, nil)
     expect do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

The data update script in #12728 only updated 3 out of 45 users. This was due to the remaining 42 users being invalid for other reasons (duplicate emails or too long emails). To be able to move on with the original task of adding a non-null constraint I made a new script using `update_column` to avoid this problem and we have to deal with the email validation problems separately.

## Related Tickets & Documents

#2207 

## Added tests?

- [X] Yes
