### PR TITLE
Add check constraint for users.username

### DIFF
--- a/db/migrate/20210219043102_add_check_constraint_for_username.rb
+++ b/db/migrate/20210219043102_add_check_constraint_for_username.rb
@@ -1,0 +1,12 @@
+class AddCheckConstraintForUsername < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      execute(<<~SQL.squish)
+        ALTER TABLE "users"
+        ADD CONSTRAINT "users_username_null"
+        CHECK ("username" IS NOT NULL)
+        NOT VALID
+      SQL
+    end
+  end
+end

--- a/db/migrate/20210219043102_add_check_constraint_for_username.rb
+++ b/db/migrate/20210219043102_add_check_constraint_for_username.rb
@@ -3,7 +3,7 @@ class AddCheckConstraintForUsername < ActiveRecord::Migration[6.0]
     safety_assured do
       execute(<<~SQL.squish)
         ALTER TABLE "users"
-        ADD CONSTRAINT "users_username_null"
+        ADD CONSTRAINT "users_username_not_null"
         CHECK ("username" IS NOT NULL)
         NOT VALID
       SQL

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_16_023520) do
+ActiveRecord::Schema.define(version: 2021_02_19_043102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1275,7 +1275,7 @@ ActiveRecord::Schema.define(version: 2021_02_16_023520) do
     t.datetime "last_article_at", default: "2017-01-01 05:00:00"
     t.datetime "last_comment_at", default: "2017-01-01 05:00:00"
     t.datetime "last_followed_at"
-    t.datetime "last_moderation_notification", default: "2017-01-01 05:00:00"
+    t.datetime "last_moderation_notification", default: "2016-12-31 17:00:00"
     t.datetime "last_notification_activity"
     t.string "last_onboarding_page"
     t.datetime "last_reacted_at"
@@ -1355,9 +1355,9 @@ ActiveRecord::Schema.define(version: 2021_02_16_023520) do
 
   create_table "users_gdpr_delete_requests", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
-    t.string "email"
+    t.string "email", null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "user_id"
+    t.integer "user_id", null: false
     t.string "username"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1275,7 +1275,7 @@ ActiveRecord::Schema.define(version: 2021_02_19_043102) do
     t.datetime "last_article_at", default: "2017-01-01 05:00:00"
     t.datetime "last_comment_at", default: "2017-01-01 05:00:00"
     t.datetime "last_followed_at"
-    t.datetime "last_moderation_notification", default: "2016-12-31 17:00:00"
+    t.datetime "last_moderation_notification", default: "2017-01-01 05:00:00"
     t.datetime "last_notification_activity"
     t.string "last_onboarding_page"
     t.datetime "last_reacted_at"
@@ -1355,9 +1355,9 @@ ActiveRecord::Schema.define(version: 2021_02_19_043102) do
 
   create_table "users_gdpr_delete_requests", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
-    t.string "email", null: false
+    t.string "email"
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "user_id", null: false
+    t.integer "user_id"
     t.string "username"
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR adds a [check constraint](https://www.postgresql.org/docs/11/ddl-constraints.html#DDL-CONSTRAINTS-CHECK-CONSTRAINTS) for the `users.username` column.

Why a check constraint?

* Adding a `not-null` constraint to an existing table is not safe, as it acquires an `ACCESS EXCLUSIVE LOCK` blocking all writes on the table. The check constraint only needs a `SHARE UPDATE EXCLUSIVE` lock, which only blocks schema changes (`ALTER TABLE` commands).
* There's a [recommended way for doing this safely with `strong_migrations`](https://github.com/ankane/strong_migrations#setting-not-null-on-an-existing-column), but alas this is only supported in Postgres 12+. We have the following in `config/initializers/strong_migrations.rb` and are still running Postgres 10 on Travis:
    ```ruby
    StrongMigrations.target_postgresql_version = 11
    ```
    Due to this the recommended way does not work, the second migration is flagged as unsafe as described in [this issue](https://github.com/ankane/strong_migrations/issues/137).
* Check constraints are functionally equivalent to not-null constraints ([source](https://www.postgresql.org/docs/11/ddl-constraints.html)):
    > A not-null constraint is always written as a column constraint. A not-null constraint is functionally equivalent to creating a check `constraint CHECK (column_name IS NOT NULL)`, but in PostgreSQL creating an explicit not-null constraint is more efficient.

    This [blog post](https://medium.com/doctolib/adding-a-not-null-constraint-on-pg-faster-with-minimal-locking-38b2c00c4d1c) puts the mentioned overhead on writes at about 1%, something I think we can live with.

Downsides:

* Check constraints do not show up in `db/schema.rb` pre Rails 6.1.
* They need to be removed before removing the column (probably a moot point, we're unlikely to remove `username`).

I think, for the time being, this is a solution that works for us. Once we're using Postgres 12 everywhere, we can validate the check constraint, add a regular not-null constraint and drop the check constraint. If we're running Rails 6.1 at this point we can even use nice migration DSL methods for this purpose:

```ruby
class ValidateUsernameNotNull < ActiveRecord::Migration[6.1]
  def change
    validate_check_constraint :users, name: "users_username_null"

    change_column_null :users, :username, false
    remove_check_constraint :users, name: "users_username_null"
  end
end
```

## Related Tickets & Documents

Closes #2207

## QA Instructions, Screenshots, Recordings

* Run the migration locally
* Start a Postgres console, e.g. with `rails dbconsole`
* Verify that the check constraint was added (`\d users`, scroll down, look for this):
     ![image](https://user-images.githubusercontent.com/47985/108459864-165afa80-72aa-11eb-8d1d-e6eda1c57c1f.png)

## Added tests?

- [X] No, and this is why: just a migration
