### PR TITLE
Make sure skip link scroll accounts for sticky header

### DIFF
--- a/app/assets/stylesheets/base/main.scss
+++ b/app/assets/stylesheets/base/main.scss
@@ -44,6 +44,10 @@ body {
     padding-top: var(--header-height);
     min-height: calc(100vh - var(--header-height));
   }
+
+  #main-content {
+    scroll-margin-top: var(--header-height);
+  }
 }
 
 .wrapper {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we scroll to `#main-content` on the home page, the next focusable item (the Feed tab) is currently not visible due to the sticky header. As we roll out skip link functionality to other pages, we will see the same. This PR adds a `scroll-margin-top` to `#main-content` which corrects the current issue on the home feed, and sets us up for extending that skip link functionality to other pages too (which will have the same `main-content` ID).

## Related Tickets & Documents

Contributes towards #1153 

## QA Instructions, Screenshots, Recordings

Previous behaviour:

![gif showing feed tabs hidden after skip link activation](https://user-images.githubusercontent.com/20773163/108498299-94b49e00-72a4-11eb-8497-813352e1235a.gif)


New behaviour:

![gif showing the feed tabs are now visible on skip link activation](https://user-images.githubusercontent.com/20773163/108498140-5a4b0100-72a4-11eb-87fa-4e11beb3845f.gif)


### UI accessibility concerns?

This helps boost the accessibility of our skip link behaviour, as the next focusable item after skip link click is now visible.

## Added tests?

- [ ] Yes
- [X] No, and this is why: We can't (yet) trigger the skip link meaningfully in Cypress, and I think this should be included in that test when possible
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: This is a very minor UI change

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Merida from Brave shoots an arrow into the centre of a target](https://media.giphy.com/media/QFypAZbq5lz3i/giphy.gif)
