### PR TITLE
Optimization:Sync Smaller Subset of Github Repos Hourly

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -133,7 +133,7 @@ get_podcast_episodes:
   cron: "5 * * * *"
   class: "Podcasts::EnqueueGetEpisodesWorker"
 update_latest_github_repos:
-  description: "Fetches the latest info about stored GitHub repositories (runs daily at 16:30 UTC)"
-  cron: "30 16 * * *"
+  description: "Fetches the latest info about stored GitHub repositories (runs hourly, 45 min after the hour)"
+  cron: "45 * * * *"
   class: "GithubRepos::UpdateLatestWorker"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Recently the GithubRepoSyncWorker has been [triggering Datadog alarms to go off](https://app.datadoghq.com/monitors/15346499?live=1w) bc it syncs all of our Github repos at once each day. Rather than syncing everything at the same time, let's spread the load out and rolling update smaller batches at a time. 

After this is deployed I will manually go into DEV and update `updated_at` timestamps of GithubRepos to spread out the load. 

## Added tests?
- [x] No not needed bc we are only changing an external worker schedule

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams, SRE

![every hour gif](https://media1.tenor.com/images/d824dd7d8d8b038d94589b9dcfe6a2a2/tenor.gif?itemid=17700653)
