### PR TITLE
Implement an API for Organization statistics

### DIFF
--- a/spec/requests/api/v0/organizations_spec.rb
+++ b/spec/requests/api/v0/organizations_spec.rb
@@ -158,4 +158,100 @@ RSpec.describe "Api::V0::Organizations", type: :request do
       end
     end
   end
+
+  describe "GET /api/organizations/:username/status(/:status)" do
+    context "when request is unauthenticated" do
+      let(:user) { create(:user) }
+      let(:public_token) { create :doorkeeper_access_token, resource_owner: user, scopes: "public" }
+
+      it "return unauthorized" do
+        get api_organization_status_path
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "returns forbidden when requesting for all with only public scope" do
+        get api_organization_status_path(status: :all), params: { access_token: public_token.token }
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns forbidden status when requesting unpublished with public scope" do
+        get api_organization_status_path(status: :unpublished), params: { access_token: public_token.token }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when request is authenticated" do
+      let(:user) { create(:user) }
+      let(:access_token) { create :doorkeeper_access_token, resource_owner: user, scopes: "public read_articles" }
+      let(:org_user) { create(:user, :org_member) }
+      let(:organization) { org_user.organizations.first }
+      let!(:article) { create(:article, user: org_user, organization: organization) }
+
+      it "works with bearer authorization" do
+        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
+
+        get api_organization_status_path, headers: headers
+        expect(response.media_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns proper response specification" do
+        get api_organization_status_path, params: { access_token: access_token.token }
+        expect(response.media_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns success when requesting published articles with public token" do
+        public_token = create(:doorkeeper_access_token, resource_owner: user, scopes: "public")
+        get api_organization_status_path(status: :published), params: { access_token: public_token.token }
+        expect(response.media_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "return only orgs's articles including markdown" do
+        create(:article, organization: organization)
+
+        get api_organization_status_path, params: { access_token: access_token.token }
+        expect(response.parsed_body.length).to eq(1)
+        expect(response.parsed_body[0]["body_markdown"]).not_to be_nil
+      end
+
+      it "only includes published articles by default" do
+        create(:article, published: false, published_at: nil, organization: organization)
+        get api_organization_status_path, params: { access_token: access_token.token }
+        expect(response.parsed_body.length).to eq(0)
+      end
+
+      it "only includes published articles when asking for published articles" do
+        create(:article, published: false, published_at: nil, organization: organization)
+        get me_api_articles_path(status: :published), params: { access_token: access_token.token }
+        expect(response.parsed_body.length).to eq(0)
+      end
+
+      it "only includes unpublished articles when asking for unpublished articles" do
+        create(:article, published: false, published_at: nil, organization: organization)
+        get me_api_articles_path(status: :unpublished), params: { access_token: access_token.token }
+        expect(response.parsed_body.length).to eq(1)
+      end
+
+      it "orders unpublished articles by reverse order when asking for unpublished articles" do
+        older = create(:article, published: false, published_at: nil, organization: organization)
+        newer = nil
+        Timecop.travel(1.day.from_now) do
+          newer = create(:article, published: false, published_at: nil, organization: organization)
+        end
+        get me_api_articles_path(status: :unpublished), params: { access_token: access_token.token }
+        expected_order = response.parsed_body.map { |resp| resp["id"] }
+        expect(expected_order).to eq([newer.id, older.id])
+      end
+
+      it "puts unpublished articles at the top when asking for all articles" do
+        create(:article, organization: organization)
+        create(:article, published: false, published_at: nil,organization: organization)
+        get me_api_articles_path(status: :all), params: { access_token: access_token.token }
+        expected_order = response.parsed_body.map { |resp| resp["published"] }
+        expect(expected_order).to eq([false, true])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Implements an API endpoint to show article statistics for an organisation.

Borrows heavily from `/api/articles/me`. Should prevent organisations having to use webscrapers on their respective organisation dashboards to get statistics. 

## Related Tickets & Documents

https://github.com/forem/forem/issues/6222

## QA Instructions, Screenshots, Recordings

_DRAFT_

### UI accessibility concerns?

None

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

While in draft, waiting for CI

![maybe this will work?](https://media.giphy.com/media/yj5oYHjoIwv28/giphy.gif)
