### PR TITLE
Update credit purchase button on submit

### DIFF
--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -143,6 +143,12 @@
   </div>
 </div>
   <script>
+    var form = document.getElementById('new_credit');
+    form.onsubmit = function(event) {
+      var button = event.submitter;
+      button.disabled = true;
+      button.textContent = "Submitting...";
+    }
 
     var stripe = Stripe('<%= SiteConfig.stripe_publishable_key %>');
     var elements = stripe.elements();

--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -145,7 +145,7 @@
   <script>
     var form = document.getElementById('new_credit');
     form.onsubmit = function(event) {
-      var button = event.submitter;
+      var button = document.getElementById('add-credit-card-button');
       button.disabled = true;
       button.textContent = "Submitting...";
     }

--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -143,11 +143,15 @@
   </div>
 </div>
   <script>
-    var form = document.getElementById('new_credit');
-    form.onsubmit = function(event) {
+    function changeSubmitButton(opts) {
       var button = document.getElementById('add-credit-card-button');
-      button.disabled = true;
-      button.textContent = "Submitting...";
+      button.disabled = !opts.active;
+      button.textContent = opts.text;
+    }
+
+    var form = document.getElementById('new_credit');
+    form.onsubmit = function(_event) {
+      changeSubmitButton({ text: 'Submitting...', active: false })
     }
 
     var stripe = Stripe('<%= SiteConfig.stripe_publishable_key %>');
@@ -212,6 +216,7 @@
           stripe.createToken(card).then(function(result) {
             if (result.error) {
               // Inform the user if there was an error.
+              changeSubmitButton({ text: "Complete Purchase", active: true });
               var errorElement = document.getElementById('card-errors');
               errorElement.textContent = result.error.message;
             } else {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug fix

## Description

A user accidentally purchased credits multiple times, because the submit button didn't give any indication of the form submission, so they pressed it repeatedly. This PR addresses that by adding an `onsubmit` handler which deactivates the button and changes its text.

Note: at first I tried to reuse the existing `onsubmit` handler which gets added in the `createCardElement` function. However, this does not seem to get attached when we already have a stored credit card because `if (document.getElementById("card-element"))` will be false. A separate handler seemed easier. In the long run, we generally might want to reconsider how we handle JS in cases like this, having it embedded at the bottom of the views feels a bit off.

## Related Tickets & Documents

Closes #11588

## QA Instructions, Screenshots, Recordings

Here's an example purchase with one of [Stripe's test cards](https://stripe.com/docs/testing#cards):

![credit_purchase](https://user-images.githubusercontent.com/47985/108801189-9ee9db80-75c7-11eb-89b5-ef5917f3190d.gif)

### UI accessibility concerns?

I don't think so.

## Added tests?

- [X] No, and this is why:  not quite sure how I would go about testing this and also thinking that the change is maybe small enough to do without a test?