### PR TITLE
[15 Min. Fix] Update Default bg_color and text_color Hexes on Tag Edit Page

### DIFF
--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -54,12 +54,12 @@
     <div class="tag-form-field">
       <%= label_tag :bg_color_hex %>
       <br>
-      <%= color_field_tag "tag[bg_color_hex]", @tag.bg_color_hex, placeholder: "Click for color picker", class: "tag-form-text-field" %>
+      <%= color_field_tag "tag[bg_color_hex]", @tag.bg_color_hex.presence || "#000000", placeholder: "#000000", placeholder: "Click for color picker", class: "tag-form-text-field" %>
     </div>
     <div class="tag-form-field">
       <%= label_tag :text_color_hex %>
       <br>
-      <%= color_field_tag "tag[text_color_hex]", @tag.text_color_hex, placeholder: "Click for color picker", class: "tag-form-text-field" %>
+      <%= color_field_tag "tag[text_color_hex]", @tag.text_color_hex.presence || "#ffffff", placeholder: "#ffffff", placeholder: "Click for color picker", class: "tag-form-text-field" %>
     </div>
     <div class="tag-form-field">
       <%= label_tag :short_summary %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -54,12 +54,12 @@
     <div class="tag-form-field">
       <%= label_tag :bg_color_hex %>
       <br>
-      <%= color_field_tag "tag[bg_color_hex]", @tag.bg_color_hex.presence || "#000000", placeholder: "#000000", placeholder: "Click for color picker", class: "tag-form-text-field" %>
+      <%= color_field_tag "tag[bg_color_hex]", @tag.bg_color_hex.presence || "#000000", placeholder: "#000000", class: "tag-form-text-field" %>
     </div>
     <div class="tag-form-field">
       <%= label_tag :text_color_hex %>
       <br>
-      <%= color_field_tag "tag[text_color_hex]", @tag.text_color_hex.presence || "#ffffff", placeholder: "#ffffff", placeholder: "Click for color picker", class: "tag-form-text-field" %>
+      <%= color_field_tag "tag[text_color_hex]", @tag.text_color_hex.presence || "#ffffff", placeholder: "#ffffff", class: "tag-form-text-field" %>
     </div>
     <div class="tag-form-field">
       <%= label_tag :short_summary %>

--- a/spec/system/tags/user_updates_a_tag_spec.rb
+++ b/spec/system/tags/user_updates_a_tag_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "User updates a tag", type: :system do
+  let(:super_admin) { create(:user, :super_admin) }
+  let(:tag_moderator) { create(:user) }
+  let(:tag) { create(:tag) }
+
+  describe "UPDATE /t/:tag/edit as a super_admin" do
+    context "when no colors have been choosen for the tag" do
+      before do
+        sign_in super_admin
+        visit "/t/#{tag}/edit"
+      end
+
+      it "defaults to white text for the color picker" do
+        expect(page).to have_field("tag_text_color_hex", with: "#ffffff")
+      end
+
+      it "defaults to black and white upon update", :aggregate_failures do
+        click_button("SAVE CHANGES")
+        tag.reload
+        expect(tag.bg_color_hex).to eq("#000000")
+        expect(tag.text_color_hex).to eq("#ffffff")
+      end
+    end
+
+    context "when colors have already been choosen for the tag" do
+      before do
+        sign_in super_admin
+        visit "/t/#{tag}/edit"
+      end
+
+      it "remains the same color it was unless otherwise updated via the color picker", :aggregate_failures do
+        click_button("SAVE CHANGES")
+        expect(tag.bg_color_hex).to eq(tag.bg_color_hex)
+        expect(tag.text_color_hex).to eq(tag.text_color_hex)
+      end
+    end
+  end
+
+  describe "UPDATE /t/:tag/edit as a tag_moderator" do
+    context "when no colors have been choosen for the tag" do
+      before do
+        tag_moderator.add_role(:tag_moderator, tag)
+        sign_in tag_moderator
+        visit "/t/#{tag}/edit"
+      end
+
+      it "defaults to white text for the color picker" do
+        expect(page).to have_field("tag_text_color_hex", with: "#ffffff")
+      end
+
+      it "defaults to black and white upon update", :aggregate_failures do
+        click_button("SAVE CHANGES")
+        tag.reload
+        expect(tag.bg_color_hex).to eq("#000000")
+        expect(tag.text_color_hex).to eq("#ffffff")
+      end
+    end
+
+    context "when colors have already been choosen for the tag" do
+      before do
+        tag_moderator.add_role(:tag_moderator, tag)
+        sign_in tag_moderator
+        visit "/t/#{tag}/edit"
+      end
+
+      it "remains the same color it was unless otherwise updated via the color picker", :aggregate_failures do
+        click_button("SAVE CHANGES")
+        expect(tag.bg_color_hex).to eq(tag.bg_color_hex)
+        expect(tag.text_color_hex).to eq(tag.text_color_hex)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
**The issue**:
> As a tag admin, I don't want to accidentally set my tag to using #000000 as the color hex for both text and background.

**The solution**:
This PR adds default hex colors to the `color_field_tag` to the `edit.html.erb` form for `/t/tag/edit`. The default `bg_color_hex` has been set to black, `#000000`, and the default `text_color_hex` has been set to white, `#ffffff` if a tag doesn't already have a `text_color_hex` or `bg_color_hex` set. If, however, a tag already has a `bg_color_hex` or `text_color_hex` set, the colors will default to whatever colors the tag already has set.

Additionally, this PR adds a system spec that tests that users with the correct permissions (admins or tag moderators) are able to successfully update the tags as expected.

## Related Tickets & Documents
Closes issue #11522 

## QA Instructions, Screenshots, Recordings
To QA this PR, first ensure that you have an admin role or tag moderator role (for the particular tag you create), and then please do the following:
- Create a new post with a new tag (one that didn't exist prior to you creating it) and navigate to the tag's edit page. Observe that the hex colors default to black and white:
<img width="1176" alt="Screen Shot 2021-02-22 at 11 01 49 AM" src="https://user-images.githubusercontent.com/32834804/108749704-5fef5380-74fd-11eb-90d2-9de72e5c1555.png">

- Without updating anything, click "SAVE CHANGES" and observe that the tag updates to a readable default of black and white:

**(Before clicking "SAVE CHANGES")**
<img width="635" alt="Screen Shot 2021-02-22 at 11 02 21 AM" src="https://user-images.githubusercontent.com/32834804/108749768-71d0f680-74fd-11eb-9d6d-7d2ac017a44d.png">

**(After clicking "SAVE CHANGES")**
<img width="947" alt="Screen Shot 2021-02-22 at 11 03 01 AM" src="https://user-images.githubusercontent.com/32834804/108749842-8ad9a780-74fd-11eb-996e-89394bc8f059.png">
- Next, update one or both of the tag's hex colors and click "SAVE CHANGES". Observe that the tag updates as expected and now defaults to the tag's current hex colors (whatever colors you updated the tag to), rather than black and white:
<img width="718" alt="Screen Shot 2021-02-22 at 11 04 03 AM" src="https://user-images.githubusercontent.com/32834804/108749955-af358400-74fd-11eb-8804-30051df7d425.png">

- Try to break things! 🛠️ 

### UI accessibility concerns?
I don't believe that this should bring up any UI concerns.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [x] I'm not sure how best to communicate this change and need help
⚠️ Due to the nature of this bug, I'm not sure if this fix warrants any update other than communicating on the issue itself that the bug has been fixed.
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Bob Ross Painting](https://media.giphy.com/media/d31vTpVi1LAcDvdm/giphy.gif)
