### PR TITLE
Spike: Add ThrottledCall utility class

### DIFF
--- a/app/lib/throttled_call.rb
+++ b/app/lib/throttled_call.rb
@@ -1,0 +1,16 @@
+class ThrottledCall
+  KEY_TEMPLATE = "throttled_call.%<key>s".freeze
+
+  # Executes the provided block and then blocks its execution for the provided
+  # time interval
+  #
+  # @param key [String, Symbol] used for generating the Redis cache key
+  # @param throttle_for [ActiveSupport::Duration] blocking time interval
+  def self.call(key, throttle_for:)
+    namespaced_key = format(KEY_TEMPLATE, key: key)
+    Rails.cache.fetch(namespaced_key, expires_in: throttle_for) do
+      yield if block_given?
+      true
+    end
+  end
+end

--- a/app/lib/throttled_call.rb
+++ b/app/lib/throttled_call.rb
@@ -6,7 +6,7 @@ class ThrottledCall
   #
   # @param key [String, Symbol] used for generating the Redis cache key
   # @param throttle_for [ActiveSupport::Duration] blocking time interval
-  def self.call(key, throttle_for:)
+  def self.perform(key, throttle_for:)
     namespaced_key = format(KEY_TEMPLATE, key: key)
     Rails.cache.fetch(namespaced_key, expires_in: throttle_for) do
       yield if block_given?

--- a/spec/lib/throttled_call_spec.rb
+++ b/spec/lib/throttled_call_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+class TestService
+  def call(*); end
+end
+
+RSpec.describe ThrottledCall do
+  let(:redis_cache) { ActiveSupport::Cache.lookup_store(:redis_cache_store) }
+  let(:service) { TestService.new }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(redis_cache)
+    allow(service).to receive(:call)
+  end
+
+  after { Rails.cache.clear }
+
+  it "calls the block if the call is not currently throttled" do
+    described_class.call(:test, throttle_for: 1.minute) { service.call }
+
+    expect(service).to have_received(:call)
+  end
+
+  it "does not call the block if the call is currently throttled" do
+    described_class.call(:test, throttle_for: 1.minute) { service.call }
+    described_class.call(:test, throttle_for: 1.minute) { service.call }
+
+    expect(service).to have_received(:call).once
+  end
+end

--- a/spec/lib/throttled_call_spec.rb
+++ b/spec/lib/throttled_call_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe ThrottledCall do
   after { Rails.cache.clear }
 
   it "calls the block if the call is not currently throttled" do
-    described_class.call(:test, throttle_for: 1.minute) { service.call }
+    described_class.perform(:test, throttle_for: 1.minute) { service.call }
 
     expect(service).to have_received(:call)
   end
 
   it "does not call the block if the call is currently throttled" do
-    described_class.call(:test, throttle_for: 1.minute) { service.call }
-    described_class.call(:test, throttle_for: 1.minute) { service.call }
+    described_class.perform(:test, throttle_for: 1.minute) { service.call }
+    described_class.perform(:test, throttle_for: 1.minute) { service.call }
 
     expect(service).to have_received(:call).once
   end

--- a/spec/workers/reactions/update_relevant_scores_worker_spec.rb
+++ b/spec/workers/reactions/update_relevant_scores_worker_spec.rb
@@ -45,5 +45,10 @@ RSpec.describe Reactions::UpdateRelevantScoresWorker, type: :worker do
         worker.perform(Reaction.maximum(:id).to_i + 1)
       end.not_to raise_error
     end
+
+    it "uses a throttled call for syncing the reactions count" do
+      allow(ThrottledCall).to receive(:perform)
+        .with(:sync_reactions_count, instance_of(ActiveSupport::Duration))
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

Based on our discussions in #3649, this PR implements an MVP version of a `ThrottledCall` utility class, which will execute a block and then prevent its repeated execution for a specified time interval:

```ruby
# This will execute the block and sleep for 3 seconds
ThrottledCall.call(:example, throttle_for: 5.minutes) { sleep 3 }

# This immediately returns true and won't execute the block
ThrottledCall.call(:example, throttle_for: 5.minutes) { sleep 3 }
```

Given that this is a spike the utility class is basically just a very thin wrapper around `Rails.cache.fetch` which already handles all the important logic, TTL, etc. The wrapper just adds key namespacing (all keys are prefixed with `throttled_call.`) and normalizes the stored value to `true` instead of the block result. I also experimented with returning the TTL (`Rails.cache.redis.ttl(namespaced_key)`) but I didn't think this provided enough benefit to be worth the extra roundtrip.

## Related Tickets & Documents

#3649

## QA Instructions, Screenshots, Recordings

If you want to try this out in your local environment, you need to activate the Redis cache store:

```sh
rails dev:cache
```

### UI accessibility concerns?

n/a

## Added tests?

- [X] Yes
