### PR TITLE
Don't sub mailchimp if mailchimp is not enabled

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -468,7 +468,7 @@ class User < ApplicationRecord
   def subscribe_to_mailchimp_newsletter
     return unless registered && email.present?
     return if SiteConfig.mailchimp_api_key.blank? && SiteConfig.mailchimp_newsletter_id.blank?
-    return if saved_changes.key?(:unconfirmed_email)
+    return if saved_changes.key?(:unconfirmed_email) && saved_changes.key?(:confirmation_sent_at)
     return unless saved_changes.key?(:email) || saved_changes.key?(:email_newsletter)
 
     Users::SubscribeToMailchimpNewsletterWorker.perform_async(id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -466,10 +466,9 @@ class User < ApplicationRecord
   end
 
   def subscribe_to_mailchimp_newsletter
-    return unless registered
+    return unless registered && email.present?
     return if SiteConfig.mailchimp_api_key.blank? && SiteConfig.mailchimp_newsletter_id.blank?
-    return unless email.present? && email.include?("@")
-    return if saved_changes["unconfirmed_email"] && saved_changes["confirmation_sent_at"]
+    return if saved_changes.key?(:unconfirmed_email)
     return unless saved_changes.key?(:email) || saved_changes.key?(:email_newsletter)
 
     Users::SubscribeToMailchimpNewsletterWorker.perform_async(id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -467,6 +467,7 @@ class User < ApplicationRecord
 
   def subscribe_to_mailchimp_newsletter
     return unless registered
+    return if SiteConfig.mailchimp_api_key.blank? && SiteConfig.mailchimp_newsletter_id.blank?
     return unless email.present? && email.include?("@")
     return if saved_changes["unconfirmed_email"] && saved_changes["confirmation_sent_at"]
     return unless saved_changes.key?(:email) || saved_changes.key?(:email_newsletter)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -487,12 +487,6 @@ RSpec.describe User, type: :model do
         end
       end
 
-      it "does not enqueue with an invalid email" do
-        sidekiq_assert_no_enqueued_jobs(only: Users::SubscribeToMailchimpNewsletterWorker) do
-          user.update(email: "foobar")
-        end
-      end
-
       it "does not enqueue with an unconfirmed email" do
         sidekiq_assert_no_enqueued_jobs(only: Users::SubscribeToMailchimpNewsletterWorker) do
           user.update(unconfirmed_email: "bob@bob.com", confirmation_sent_at: Time.current)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -505,6 +505,13 @@ RSpec.describe User, type: :model do
         end
       end
 
+      it "does not enqueue if Mailchimp is not enabled" do
+        allow(SiteConfig).to receive(:mailchimp_api_key).and_return(nil)
+        sidekiq_assert_no_enqueued_jobs(only: Users::SubscribeToMailchimpNewsletterWorker) do
+          user.update(email: "something@real.com")
+        end
+      end
+
       it "does not enqueue when the email address or subscription status has not changed" do
         # The trait replaces the method with a dummy, but we need the actual method for this test.
         user = described_class.find(create(:user, :ignore_mailchimp_subscribe_callback).id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Don't attempt to subscribe a user to Mailchimp if it isn't enabled.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

1. Update a user's email in rails console
2. See that it doesn't create a background job in logs

### UI accessibility concerns?
Nope

## Added tests?

- [x] Yes


## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [x] This change does not need to be communicated, and this is why not: it's a minor bug fix

## [optional] Are there any post deployment tasks we need to perform?
No