### PR TITLE
Fix Markdown parsing of <code> tag

### DIFF
--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -130,7 +130,7 @@ module MarkdownProcessor
 
     def convert_code_tags_to_triple_backticks(content)
       # return content if there is not a <code> tag
-      return content unless (/^<code>$/).match?(content)
+      return content unless /^<code>$/.match?(content)
 
       # return content if there is a <pre> and <code> tag
       return content if /<code>/.match?(content) && /<pre>/.match?(content)

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -130,7 +130,7 @@ module MarkdownProcessor
 
     def convert_code_tags_to_triple_backticks(content)
       # return content if there is not a <code> tag
-      return content unless (content).match?(/^<code>$/)
+      return content unless (/^<code>$/).match?(content)
 
       # return content if there is a <pre> and <code> tag
       return content if /<code>/.match?(content) && /<pre>/.match?(content)

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -136,13 +136,12 @@ module MarkdownProcessor
       return content if /<code>/.match?(content) && /<pre>/.match(content)
 
       # check if <code> tag is on the same line
-      return content if /<code>(.*)<[\/\\]code>/.match?(content)
+      return content if %r{<code>(.*)</code>}.match?(content)
 
       # At this point, there should be <code> tags with no wrapping <pre> tag
       code_with_pre_tag = content.clone
-      code_with_pre_tag.gsub!('<code>',"```")
-      code_with_pre_tag.gsub!('</code>',"```")
-      return code_with_pre_tag
+      code_with_pre_tag.gsub!("<code>", "```")
+      code_with_pre_tag.gsub!("</code>", "```")
     end
 
     private

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -83,41 +83,41 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
   end
 
   it "converts code tag to triple backticks" do
-    content = "<code>\n this is some random code \n </code>"
-    code_span_object = described_class.new(content)
-    test = code_span_object.add_proper_code_tags(content)
+    content = "<code>\n this is some random code \n</code>"
+    code_block_object = described_class.new(content)
+    test = code_block_object.convert_code_tags_to_triple_backticks(content)
     expect(test).not_to include("<code>")
     expect(test).not_to include("</code>")
   end
 
   it "converts multiple code tags to triple backticks" do
-    content = "<code>\n this is some random code \n </code> \n\n <code> \n more random code \n </code>"
-    code_span_object = described_class.new(content)
-    test = code_span_object.add_proper_code_tags(content)
+    content = "<code>\n this is some random code \n</code>\n\n<code>\n more random code \n</code>"
+    code_block_object = described_class.new(content)
+    test = code_block_object.convert_code_tags_to_triple_backticks(content)
     expect(test).not_to include("<code>")
     expect(test).not_to include("</code>")
   end
 
   it "ignores code tag if pre tag is present" do
-    content = "<pre> \n <code>\n this is some random code \n </code> \n </pre>"
-    code_span_object = described_class.new(content)
-    test = code_span_object.add_proper_code_tags(content)
-    expect(test).to include("<pre> \n <code>")
-    expect(test).to include("</code> \n </pre>")
+    content = "<pre>\n<code>\n this is some random code \n</code>\n</pre>"
+    code_block_object = described_class.new(content)
+    test = code_block_object.convert_code_tags_to_triple_backticks(content)
+    expect(test).to include("<pre>\n<code>")
+    expect(test).to include("</code>\n</pre>")
   end
 
   it "ignores code tag if tags are inline" do
     content = "<code> this is some random code </code>"
-    code_span_object = described_class.new(content)
-    test = code_span_object.add_proper_code_tags(content)
+    code_block_object = described_class.new(content)
+    test = code_block_object.convert_code_tags_to_triple_backticks(content)
     expect(test).to include("<code>")
     expect(test).to include("</code>")
   end
 
   it "returns original content if code tag is not present" do
     content = "this is some random code"
-    code_span_object = described_class.new(content)
-    test = code_span_object.add_proper_code_tags(content)
+    code_block_object = described_class.new(content)
+    test = code_block_object.convert_code_tags_to_triple_backticks(content)
     expect(test).to be(content)
   end
 

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     test = code_block_object.convert_code_tags_to_triple_backticks(content)
     expect(test).not_to include("<code>")
     expect(test).not_to include("</code>")
+    expect(test).to include("```")
   end
 
   it "converts multiple code tags to triple backticks" do
@@ -96,6 +97,7 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     test = code_block_object.convert_code_tags_to_triple_backticks(content)
     expect(test).not_to include("<code>")
     expect(test).not_to include("</code>")
+    expect(test).to include("```")
   end
 
   it "ignores code tag if pre tag is present" do
@@ -104,6 +106,7 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     test = code_block_object.convert_code_tags_to_triple_backticks(content)
     expect(test).to include("<pre>\n<code>")
     expect(test).to include("</code>\n</pre>")
+    expect(test).not_to include("```")
   end
 
   it "ignores code tag if tags are inline" do
@@ -112,6 +115,7 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     test = code_block_object.convert_code_tags_to_triple_backticks(content)
     expect(test).to include("<code>")
     expect(test).to include("</code>")
+    expect(test).not_to include("```")
   end
 
   it "returns original content if code tag is not present" do

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -86,16 +86,16 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     content = "<code>\n this is some random code \n </code>"
     code_span_object = described_class.new(content)
     test = code_span_object.add_proper_code_tags(content)
-    expect(test).not_to include('<code>')
-    expect(test).not_to include('</code>')
+    expect(test).not_to include("<code>")
+    expect(test).not_to include("</code>")
   end
 
   it "converts multiple code tags to triple backticks" do
     content = "<code>\n this is some random code \n </code> \n\n <code> \n more random code \n </code>"
     code_span_object = described_class.new(content)
     test = code_span_object.add_proper_code_tags(content)
-    expect(test).not_to include('<code>')
-    expect(test).not_to include('</code>')
+    expect(test).not_to include("<code>")
+    expect(test).not_to include("</code>")
   end
 
   it "ignores code tag if pre tag is present" do

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -82,6 +82,45 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     expect(test).to eq("#{code_span}\n\n")
   end
 
+  it "converts code tag to triple backticks" do
+    content = "<code>\n this is some random code \n </code>"
+    code_span_object = described_class.new(content)
+    test = code_span_object.add_proper_code_tags(content)
+    expect(test).not_to include('<code>')
+    expect(test).not_to include('</code>')
+  end
+
+  it "converts multiple code tags to triple backticks" do
+    content = "<code>\n this is some random code \n </code> \n\n <code> \n more random code \n </code>"
+    code_span_object = described_class.new(content)
+    test = code_span_object.add_proper_code_tags(content)
+    expect(test).not_to include('<code>')
+    expect(test).not_to include('</code>')
+  end
+
+  it "ignores code tag if pre tag is present" do
+    content = "<pre> \n <code>\n this is some random code \n </code> \n </pre>"
+    code_span_object = described_class.new(content)
+    test = code_span_object.add_proper_code_tags(content)
+    expect(test).to include("<pre> \n <code>")
+    expect(test).to include("</code> \n </pre>")
+  end
+
+  it "ignores code tag if tags are inline" do
+    content = "<code> this is some random code </code>"
+    code_span_object = described_class.new(content)
+    test = code_span_object.add_proper_code_tags(content)
+    expect(test).to include("<code>")
+    expect(test).to include("</code>")
+  end
+
+  it "returns original content if code tag is not present" do
+    content = "this is some random code"
+    code_span_object = described_class.new(content)
+    test = code_span_object.add_proper_code_tags(content)
+    expect(test).to be(content)
+  end
+
   context "when rendering links markdown" do
     # the following specs are testing HTMLRouge
     it "renders properly if protocol http is included" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Since the redcarpet gem has issues with `<code>` tags when they are not inline or wrapped by a `<pre>` I decided to create a method that converts the `<code>` tags to triple backticks (```) before rendering it using the redcarpet gem. 

## Related Tickets & Documents
resolves [issue#12046](https://github.com/forem/forem/issues/12046)

## Screenshots

We enter the same post as in the issue: 
![Screenshot before rendering](https://user-images.githubusercontent.com/65631154/108940557-cca74280-7610-11eb-96d1-63b93619b6ea.png)

We get the appropriate code block rendered: 
![Screenshot after rendering](https://user-images.githubusercontent.com/65631154/108940605-e3e63000-7610-11eb-9f7f-a5e16f1d03c7.png)

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

