### PR TITLE
Refactor: Extract Role Removal Into a Service

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -44,24 +44,33 @@ module Admin
       role = params[:role].to_sym
       resource_type = params[:resource_type]
 
-      if role == :super_admin
-        flash[:danger] = "Super Admin roles cannot be removed."
-        redirect_to "/admin/users/#{params[:id]}/edit" and return
-      end
-
       @user = User.find(params[:user_id])
 
-      if @user.id == current_user.id
-        flash[:danger] = "Admins cannot remove roles from themselves."
-      elsif role == :single_resource_admin && !resource_type.safe_constantize.nil?
-        User.find(params[:user_id]).remove_role(role, resource_type.safe_constantize)
-        flash[:success] = "Role: #{role.to_s.humanize.titlecase} has been successfully removed from the user!"
-      elsif User.find(params[:user_id]).remove_role(role)
+      response = Users::RemoveRole.call(@user, role, resource_type)
+      if response.success?
         flash[:success] = "Role: #{role.to_s.humanize.titlecase} has been successfully removed from the user!"
       else
-        flash[:danger] = "There was an issue removing this role. Please try again."
+        flash[:danger] = response.error_mesage
       end
       redirect_to edit_admin_user_path(@user.id)
+      # if role == :super_admin # def super_admin? private method
+      #   flash[:danger] = "Super Admin roles cannot be removed."
+      #   redirect_to "/admin/users/#{params[:id]}/edit" and return # remove this redirect!
+      # end
+
+      # @user = User.find(params[:user_id])
+
+      # if @user.id == current_user.id
+      #   flash[:danger] = "Admins cannot remove roles from themselves."
+      # elsif role == :single_resource_admin && !resource_type.safe_constantize.nil?
+      # User.find(params[:user_id]).remove_role(role, resource_type.safe_constantize)
+      #   flash[:success] = "Role: #{role.to_s.humanize.titlecase} has been successfully removed from the user!"
+      # elsif User.find(params[:user_id]).remove_role(role) # remove_role(role, nil)
+      #   flash[:success] = "Role: #{role.to_s.humanize.titlecase} has been successfully removed from the user!"
+      # else
+      #   flash[:danger] = "There was an issue removing this role. Please try again."
+      # end
+      # redirect_to edit_admin_user_path(@user.id)
     end
 
     def user_status

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -53,7 +53,7 @@ module Admin
       if response.success
         flash[:success] = "Role: #{role.to_s.humanize.titlecase} has been successfully removed from the user!"
       else
-        flash[:danger] = response.error_mesage
+        flash[:danger] = response.error_message
       end
       redirect_to edit_admin_user_path(@user.id)
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -46,31 +46,16 @@ module Admin
 
       @user = User.find(params[:user_id])
 
-      response = Users::RemoveRole.call(@user, role, resource_type)
-      if response.success?
+      response = ::Users::RemoveRole.call(user: @user,
+                                          role: role,
+                                          resource_type: resource_type,
+                                          current_user: current_user)
+      if response.success
         flash[:success] = "Role: #{role.to_s.humanize.titlecase} has been successfully removed from the user!"
       else
         flash[:danger] = response.error_mesage
       end
       redirect_to edit_admin_user_path(@user.id)
-      # if role == :super_admin # def super_admin? private method
-      #   flash[:danger] = "Super Admin roles cannot be removed."
-      #   redirect_to "/admin/users/#{params[:id]}/edit" and return # remove this redirect!
-      # end
-
-      # @user = User.find(params[:user_id])
-
-      # if @user.id == current_user.id
-      #   flash[:danger] = "Admins cannot remove roles from themselves."
-      # elsif role == :single_resource_admin && !resource_type.safe_constantize.nil?
-      # User.find(params[:user_id]).remove_role(role, resource_type.safe_constantize)
-      #   flash[:success] = "Role: #{role.to_s.humanize.titlecase} has been successfully removed from the user!"
-      # elsif User.find(params[:user_id]).remove_role(role) # remove_role(role, nil)
-      #   flash[:success] = "Role: #{role.to_s.humanize.titlecase} has been successfully removed from the user!"
-      # else
-      #   flash[:danger] = "There was an issue removing this role. Please try again."
-      # end
-      # redirect_to edit_admin_user_path(@user.id)
     end
 
     def user_status

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -49,7 +49,7 @@ module Admin
       response = ::Users::RemoveRole.call(user: @user,
                                           role: role,
                                           resource_type: resource_type,
-                                          current_user: current_user)
+                                          admin: current_user)
       if response.success
         flash[:success] = "Role: #{role.to_s.humanize.titlecase} has been successfully removed from the user!"
       else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -292,4 +292,10 @@ module ApplicationHelper
   def admin_config_description(content)
     tag.p(content, class: "crayons-field__description") unless content.empty?
   end
+
+  def role_display_name(role)
+    return "suspended" if role.name == "banned"
+
+    role.name
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -294,8 +294,6 @@ module ApplicationHelper
   end
 
   def role_display_name(role)
-    return "suspended" if role.name == "banned"
-
-    role.name
+    role.name == "banned" ? "Suspended" : role.name.titlecase
   end
 end

--- a/app/services/users/remove_role.rb
+++ b/app/services/users/remove_role.rb
@@ -17,6 +17,14 @@ module Users
     def call
       return response if super_admin?(role)
       return response if current_user?(user)
+
+      if @user.remove_role(role, resource_type.safe_constantize)
+        response.success = true
+      elsif @user.remove_role(role)
+        response.success = true
+      else
+        response.error = "There was an issue removing this role. Please try again."
+      end
     end
 
     private

--- a/app/services/users/remove_role.rb
+++ b/app/services/users/remove_role.rb
@@ -1,0 +1,38 @@
+module Users
+  class RemoveRole
+    attr_reader :user, :role, :resource_type, :current_user, :response
+
+    Response = Struct.new(:success, :error_message, keyword_init: true)
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    def initialize(user, _role, _resource_type)
+      @user = user
+      @role = params[:role].to_sym
+      @resource_type = params[:resource_type]
+    end
+
+    def call
+      return response if super_admin?(role)
+      return response if current_user?(user)
+    end
+
+    private
+
+    def super_admin?(role)
+      return false if role != :super_admin
+
+      response.error_message = "Super Admin roles cannot be removed."
+      true
+    end
+
+    def current_user?(user)
+      return false if user.id != current_user.id
+
+      response.error_message = "Admins cannot remove roles from themselves."
+      true
+    end
+  end
+end

--- a/app/services/users/remove_role.rb
+++ b/app/services/users/remove_role.rb
@@ -22,9 +22,10 @@ module Users
         response.success = true
       elsif user.remove_role(role)
         response.success = true
-      else
-        response.error_message = "There was an issue removing this role. Please try again."
       end
+      response
+    rescue StandardError => e
+      response.error_message = "There was an issue removing this role. #{e.message}"
       response
     end
 

--- a/app/services/users/remove_role.rb
+++ b/app/services/users/remove_role.rb
@@ -1,18 +1,16 @@
 module Users
   class RemoveRole
-    attr_reader :user, :role, :resource_type, :current_user, :response
-
     Response = Struct.new(:success, :error_message, keyword_init: true)
 
     def self.call(*args)
       new(*args).call
     end
 
-    def initialize(user:, role:, resource_type:, current_user:)
+    def initialize(user:, role:, resource_type:, admin:)
       @user = user
       @role = role
       @resource_type = resource_type&.safe_constantize
-      @current_user = current_user
+      @admin = admin
       @response = Response.new(success: false)
     end
 
@@ -20,9 +18,9 @@ module Users
       return response if super_admin_role?(role)
       return response if user_is_current_user?(user)
 
-      if !resource_type.nil? && @user.remove_role(role, resource_type)
+      if resource_type && user.remove_role(role, resource_type)
         response.success = true
-      elsif @user.remove_role(role)
+      elsif user.remove_role(role)
         response.success = true
       else
         response.error_message = "There was an issue removing this role. Please try again."
@@ -32,6 +30,8 @@ module Users
 
     private
 
+    attr_reader :user, :role, :resource_type, :admin, :response
+
     def super_admin_role?(role)
       return false if role != :super_admin
 
@@ -40,7 +40,7 @@ module Users
     end
 
     def user_is_current_user?(user)
-      return false if user.id != current_user.id
+      return false if user.id != admin.id
 
       response.error_message = "Admins cannot remove roles from themselves."
       true

--- a/app/views/admin/users/_current_roles.html.erb
+++ b/app/views/admin/users/_current_roles.html.erb
@@ -4,9 +4,7 @@
   <div class="crayons-card__body">
     <ul>
       <% @user.roles.each do |role| %>
-        <% if role.name == "banned" %>
-          <li>Suspended</li>
-        <% elsif role.name == "super_admin" || @user.id == current_user.id %>
+        <% if role.name == "banned" || role.name == "super_admin" || @user.id == current_user.id %>
           <li><%= role.name.titlecase %> <em><%= role.resource_name.to_s %></em></li>
         <% else %>
           <li>

--- a/app/views/admin/users/_current_roles.html.erb
+++ b/app/views/admin/users/_current_roles.html.erb
@@ -5,7 +5,7 @@
     <ul>
       <% @user.roles.each do |role| %>
         <% if role.name == "banned" || role.name == "super_admin" || @user.id == current_user.id %>
-          <li><%= role.name.titlecase %> <em><%= role.resource_name.to_s %></em></li>
+          <li><%= role_display_name(role) %> <em><%= role.resource_name.to_s %></em></li>
         <% else %>
           <li>
             <%= role.name.titlecase %> <em><%= role.resource_name.to_s %></em> &nbsp;

--- a/app/views/admin/users/_current_roles.html.erb
+++ b/app/views/admin/users/_current_roles.html.erb
@@ -8,7 +8,7 @@
           <li><%= role_display_name(role) %> <em><%= role.resource_name.to_s %></em></li>
         <% else %>
           <li>
-            <%= role.name.titlecase %> <em><%= role.resource_name.to_s %></em> &nbsp;
+            <%= role_display_name(role) %> <em><%= role.resource_name.to_s %></em> &nbsp;
             <%= link_to "X", url_for(action: :destroy, user_id: @user.id, role: role.name.to_sym, resource_type: role.resource_type), method: :delete, data: { confirm: "Are you sure?" },
                                                                                                                                       class: "crayons-btn crayons-btn--danger crayons-btn--s lh-base fs-xs" %>
           </li>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -21,7 +21,7 @@
       <h2>
         User Status
         <% if @user.banned %>
-          <span class="badge badge-danger">🚨 Member is Banned 🚨</span>
+          <span class="badge badge-danger">🚨 Member is Suspended 🚨</span>
         <% elsif @user.warned %>
           <span class="badge badge-warning">Member is Warned</span>
         <% elsif @user.comment_banned %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -21,7 +21,7 @@
       <h2>
         User Status
         <% if @user.banned %>
-          <span class="badge badge-danger">🚨 Member is Suspended 🚨</span>
+          <span class="badge badge-danger">🚨 Member is Banned 🚨</span>
         <% elsif @user.warned %>
           <span class="badge badge-warning">Member is Warned</span>
         <% elsif @user.comment_banned %>

--- a/spec/services/users/remove_role_spec.rb
+++ b/spec/services/users/remove_role_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe Users::RemoveRole, type: :service do
+  let(:current_user) { create(:user, :admin) }
+
+  context "when user is a super_admin" do
+    it "does not remove super_admin roles and raises an error", :aggregate_failures do
+      super_admin = create(:user, :super_admin)
+      resource_type = nil
+      role = super_admin.roles.first.name.to_sym
+      args = { user: super_admin, role: role, resource_type: resource_type, current_user: current_user }
+      role_removal = described_class.call(args)
+
+      expect(role_removal.success).to be false
+      expect(role_removal.error_message).to eq "Super Admin roles cannot be removed."
+    end
+  end
+
+  context "when current_user" do
+    it "does not remove roles and raises an error", :aggregate_failures do
+      role = current_user.roles.first
+      resource_type = nil
+      args = { user: current_user, role: role, resource_type: resource_type, current_user: current_user }
+      role_removal = described_class.call(args)
+
+      expect(role_removal.success).to be false
+      expect(role_removal.error_message).to eq "Admins cannot remove roles from themselves."
+    end
+  end
+
+  it "removes roles from users", :aggregate_failures do
+    user = create(:user, :trusted)
+    role = user.roles.first
+    resource_type = nil
+    args = { user: user, role: role, resource_type: resource_type, current_user: current_user }
+    role_removal = described_class.call(args)
+
+    expect(role_removal.success).to be true
+    expect(role_removal.error_message).to be_nil
+    expect(user.roles.count).to eq 1
+  end
+
+  it "removes :single_resource_admin roles from users", :aggregate_failures do
+    user = create(:user, :single_resource_admin)
+    role = user.roles.first
+    resource_type = "Comment"
+    args = { user: user, role: role, resource_type: resource_type, current_user: current_user }
+    role_removal = described_class.call(args)
+
+    expect(role_removal.success).to be true
+    expect(role_removal.error_message).to be_nil
+    expect(user.roles.count).to eq 1
+  end
+
+  it "returns an error if there is an issue removing the role" do
+    user = create(:user)
+    allow(user).to receive(:remove_role).and_return(false)
+    args = { user: user, role: nil, resource_type: nil, current_user: current_user }
+    role_removal = described_class.call(args)
+
+    expect(role_removal.success).to be false
+    expect(role_removal.error_message).to eq "There was an issue removing this role. Please try again."
+  end
+end

--- a/spec/services/users/remove_role_spec.rb
+++ b/spec/services/users/remove_role_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Users::RemoveRole, type: :service do
   context "when user is a super_admin" do
     it "does not remove super_admin roles and raises an error", :aggregate_failures do
       super_admin = create(:user, :super_admin)
-      resource_type = nil
       role = super_admin.roles.first.name.to_sym
+      resource_type = nil
       args = { user: super_admin, role: role, resource_type: resource_type, current_user: current_user }
       role_removal = described_class.call(args)
 

--- a/spec/services/users/remove_role_spec.rb
+++ b/spec/services/users/remove_role_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Users::RemoveRole, type: :service do
       super_admin = create(:user, :super_admin)
       role = super_admin.roles.first.name.to_sym
       resource_type = nil
-      args = { user: super_admin, role: role, resource_type: resource_type, current_user: current_user }
+      args = { user: super_admin, role: role, resource_type: resource_type, admin: current_user }
       role_removal = described_class.call(args)
 
       expect(role_removal.success).to be false
@@ -20,7 +20,7 @@ RSpec.describe Users::RemoveRole, type: :service do
     it "does not remove roles and raises an error", :aggregate_failures do
       role = current_user.roles.first
       resource_type = nil
-      args = { user: current_user, role: role, resource_type: resource_type, current_user: current_user }
+      args = { user: current_user, role: role, resource_type: resource_type, admin: current_user }
       role_removal = described_class.call(args)
 
       expect(role_removal.success).to be false
@@ -32,7 +32,7 @@ RSpec.describe Users::RemoveRole, type: :service do
     user = create(:user, :trusted)
     role = user.roles.first
     resource_type = nil
-    args = { user: user, role: role, resource_type: resource_type, current_user: current_user }
+    args = { user: user, role: role, resource_type: resource_type, admin: current_user }
     role_removal = described_class.call(args)
 
     expect(role_removal.success).to be true
@@ -44,7 +44,7 @@ RSpec.describe Users::RemoveRole, type: :service do
     user = create(:user, :single_resource_admin)
     role = user.roles.first
     resource_type = "Comment"
-    args = { user: user, role: role, resource_type: resource_type, current_user: current_user }
+    args = { user: user, role: role, resource_type: resource_type, admin: current_user }
     role_removal = described_class.call(args)
 
     expect(role_removal.success).to be true
@@ -55,7 +55,7 @@ RSpec.describe Users::RemoveRole, type: :service do
   it "returns an error if there is an issue removing the role" do
     user = create(:user)
     allow(user).to receive(:remove_role).and_return(false)
-    args = { user: user, role: nil, resource_type: nil, current_user: current_user }
+    args = { user: user, role: nil, resource_type: nil, admin: current_user }
     role_removal = described_class.call(args)
 
     expect(role_removal.success).to be false

--- a/spec/services/users/remove_role_spec.rb
+++ b/spec/services/users/remove_role_spec.rb
@@ -54,11 +54,10 @@ RSpec.describe Users::RemoveRole, type: :service do
 
   it "returns an error if there is an issue removing the role" do
     user = create(:user)
-    allow(user).to receive(:remove_role).and_return(false)
+    allow(user).to receive(:remove_role).and_raise(StandardError)
     args = { user: user, role: nil, resource_type: nil, admin: current_user }
     role_removal = described_class.call(args)
 
     expect(role_removal.success).to be false
-    expect(role_removal.error_message).to eq "There was an issue removing this role. Please try again."
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR refactors the work done in PR #12582, which gave admins the ability to remove roles via the admin panel. Specifically, this PR refactors `Admin::UsersController#destroy` extracting the logic into a service, `remove_role.rb`. Additionally, this PR cleans up the `_current_roles.html.erb` view by extracting some of the logic from the view into a helper method, `role_display_name`, for better reusability throughout admin-based views. Finally, this PR adds a spec around role removal within the newly implemented `Users::RemoveRole` service.

## Related Tickets & Documents
Refactors PR #12582 

## QA Instructions, Screenshots, Recordings
1️⃣  **To QA the removal of a base role from a user, please first ensure that you are an admin, and then do the following:**
- Navigate to `/admin/users/:id/edit`:
<img width="1075" alt="Screen Shot 2021-02-11 at 3 06 56 PM" src="https://user-images.githubusercontent.com/32834804/107704629-d5942d80-6c7a-11eb-86c9-103c222cb9b9.png">

- Click the "X" button next to the role of your choice. You should be prompted to confirm the removal of the role:

<img width="710" alt="Screen Shot 2021-02-11 at 3 08 07 PM" src="https://user-images.githubusercontent.com/32834804/107704718-f492bf80-6c7a-11eb-90b2-a26bf8f69947.png">

- After confirming the role removal, you should then be redirected back to `admin/users/:id/edit` and shown a flash message stating that the removal has been successful:

<img width="1055" alt="Screen Shot 2021-02-11 at 3 08 41 PM" src="https://user-images.githubusercontent.com/32834804/107704760-083e2600-6c7b-11eb-9b2e-5e40ab2c5241.png">

2️⃣  **To QA the removal of a `super_admin` role from a user, please first ensure that you are an admin, and then do the following:**
- Navigate to `/admin/users/:id/edit`:
![Screen Shot 2021-02-04 at 3 52 10 PM](https://user-images.githubusercontent.com/32834804/106965528-f26fb480-6700-11eb-99ae-aa51fee32a52.png)
- Notice that there is no "X" button next to the `super_admin` role:
![Screen Shot 2021-02-04 at 3 52 27 PM](https://user-images.githubusercontent.com/32834804/106965559-fc91b300-6700-11eb-9bcd-a088534e117e.png)

3️⃣  **To QA the removal of a role from yourself, please first ensure that you are an admin, and then do the following:**
- Navigate to your `/admin/users/:id/edit` page:
![Screen Shot 2021-02-04 at 3 45 07 PM](https://user-images.githubusercontent.com/32834804/106964825-f949f780-66ff-11eb-807c-37fef8af8086.png)

- Notice that there is no "X" button next to your roles:
![Screen Shot 2021-02-04 at 3 46 01 PM](https://user-images.githubusercontent.com/32834804/106964894-167ec600-6700-11eb-83bd-0ddecc9cbbcd.png)

### UI accessibility concerns?
N/A

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: this change is merely the refactoring of a previously implemented feature and the previously implemented feature was already communicated with the appropriate people!

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

!["It's A Wrap" Film Animation](https://media.giphy.com/media/lrylNue4ExZM5GLoDQ/giphy.gif)
