### PR TITLE
Make Sendgrid optional

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -121,18 +121,28 @@ Rails.application.configure do
 
   protocol = ENV["APP_PROTOCOL"] || "http://"
 
-  config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.default_url_options = { host: protocol + ENV["APP_DOMAIN"].to_s }
-  ActionMailer::Base.smtp_settings = {
-    address: "smtp.sendgrid.net",
-    port: "587",
-    authentication: :plain,
-    user_name: "apikey",
-    password: ENV["SENDGRID_API_KEY"],
-    domain: ENV["APP_DOMAIN"],
-    enable_starttls_auto: true
-  }
+
+  if ENV["SENDGRID_API_KEY"].present?
+    config.action_mailer.delivery_method = :smtp
+    ActionMailer::Base.smtp_settings = {
+      address: "smtp.sendgrid.net",
+      port: "587",
+      authentication: :plain,
+      user_name: "apikey",
+      password: ENV["SENDGRID_API_KEY"],
+      domain: ENV["APP_DOMAIN"],
+      enable_starttls_auto: true
+    }
+  else
+    config.action_mailer.delivery_method = :sendmail
+    # Defaults to:
+    # # config.action_mailer.sendmail_settings = {
+    # #   location: '/usr/sbin/sendmail',
+    # #   arguments: '-i -t'
+    # # }
+  end
 
   if ENV["HEROKU_APP_URL"].present? && ENV["HEROKU_APP_URL"] != ENV["APP_DOMAIN"]
     config.middleware.use Rack::HostRedirect,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This allows Forems to start in production mode without the need for SendGrid. The `:sendmail` configuration added here is provided in [Rails documentation](https://guides.rubyonrails.org/action_mailer_basics.html#example-action-mailer-configuration). it's also the same config in Gitlab.

Does it actually work? Not without the binary on the webserver and additional configuration.  

## Related Tickets & Documents
https://github.com/orgs/forem/projects/6#card-54196146

## QA Instructions, Screenshots, Recordings
TBD

## Added tests?
- [x] No
 
## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?
n/a