### PR TITLE
Grammar fixes on /admin/config

### DIFF
--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -147,7 +147,7 @@
           </div>
         <% end %>
 
-        <%= form_for(SiteConfig.new, url: admin_config_path, html: { data: { action: "submit->config#configUpdatePrecheck", "config-target": "authSectionForm", "testid": "authSectionForm" } }) do |f| %>
+        <%= form_for(SiteConfig.new, url: admin_config_path, html: { data: { action: "submit->config#configUpdatePrecheck", "config-target": "authSectionForm", testid: "authSectionForm" } }) do |f| %>
           <div class="card mt-3">
             <%= render partial: "admin/shared/card_header",
                        locals: {
@@ -355,7 +355,7 @@
                 </section>
               </section>
               <div class="crayons-notice crayons-notice--info mb-4">
-                Changing authentication keys will not take affect until this forem instance is restarted.
+                Changing authentication keys will not take effect until this Forem instance is restarted.
               </div>
 
               <%= render "form_submission", f: f %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix (spelling and grammar mistakes count as bugs, right? 🐛)
- [ ] Optimization
- [ ] Documentation Update

## Description

Quick grammar update on the `/admin/config` page, and some capitalization. I was actually on that page to do something else but....this was _really_ bothering me so here we are.

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings

N/A

### UI accessibility concerns?

N/A

## Added tests?

- [ ] Yes
- [x] No, and this is why: _just a grammar fix, buddy!_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _just a grammar fix, buddy!_

## What gif best describes this PR or how it makes you feel?

![twitching eye](https://media2.giphy.com/media/lz9lPkqddgoec/giphy.gif?cid=5a38a5a26k76wp0xrmgi2gqfad24r00yabk9uznvwtfhm0fz&rid=giphy.gif)
