### PR TITLE
Fix subscribe to discussion button when user is not logged in 

### DIFF
--- a/app/javascript/CommentSubscription/CommentSubscription.jsx
+++ b/app/javascript/CommentSubscription/CommentSubscription.jsx
@@ -83,7 +83,7 @@ export class CommentSubscription extends Component {
       onSubscribe,
       onUnsubscribe,
       positionType = 'relative',
-      userStatus
+      isLoggedIn
     } = this.props;
 
     const CogIcon = () => (
@@ -110,7 +110,7 @@ export class CommentSubscription extends Component {
           <Button
             variant="outlined"
             onClick={(_event) => {
-              if (userStatus == "logged-in") {
+              if (isLoggedIn) {
                 if (subscribed) {
                   onUnsubscribe(COMMENT_SUBSCRIPTION_TYPE.NOT_SUBSCRIBED);
                   this.setState({
@@ -122,7 +122,6 @@ export class CommentSubscription extends Component {
 
                 this.setState({ subscribed: !subscribed });
               } else {
-                _event.preventDefault();
                 showLoginModal();
               }
             }}
@@ -244,4 +243,5 @@ CommentSubscription.propTypes = {
   subscriptionType: PropTypes.oneOf(
     Object.entries(COMMENT_SUBSCRIPTION_TYPE).map(([, value]) => value),
   ).isRequired,
+  isLoggedIn: PropTypes.bool.isRequired,
 };

--- a/app/javascript/CommentSubscription/CommentSubscription.jsx
+++ b/app/javascript/CommentSubscription/CommentSubscription.jsx
@@ -1,3 +1,5 @@
+/* global showLoginModal */
+
 import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 import {

--- a/app/javascript/CommentSubscription/CommentSubscription.jsx
+++ b/app/javascript/CommentSubscription/CommentSubscription.jsx
@@ -81,6 +81,7 @@ export class CommentSubscription extends Component {
       onSubscribe,
       onUnsubscribe,
       positionType = 'relative',
+      userStatus
     } = this.props;
 
     const CogIcon = () => (
@@ -107,16 +108,21 @@ export class CommentSubscription extends Component {
           <Button
             variant="outlined"
             onClick={(_event) => {
-              if (subscribed) {
-                onUnsubscribe(COMMENT_SUBSCRIPTION_TYPE.NOT_SUBSCRIBED);
-                this.setState({
-                  subscriptionType: COMMENT_SUBSCRIPTION_TYPE.ALL,
-                });
-              } else {
-                onSubscribe(subscriptionType);
-              }
+              if (userStatus == "logged-in") {
+                if (subscribed) {
+                  onUnsubscribe(COMMENT_SUBSCRIPTION_TYPE.NOT_SUBSCRIBED);
+                  this.setState({
+                    subscriptionType: COMMENT_SUBSCRIPTION_TYPE.ALL,
+                  });
+                } else {
+                  onSubscribe(subscriptionType);
+                }
 
-              this.setState({ subscribed: !subscribed });
+                this.setState({ subscribed: !subscribed });
+              } else {
+                _event.preventDefault();
+                showLoginModal();
+              }
             }}
           >
             {subscribed ? 'Unsubscribe' : 'Subscribe'}

--- a/app/javascript/CommentSubscription/__tests__/CommentSubscription.test.jsx
+++ b/app/javascript/CommentSubscription/__tests__/CommentSubscription.test.jsx
@@ -55,9 +55,9 @@ describe('<CommentSubscription />', () => {
     const onSubscribe = jest.fn();
     const { getByText } = render(
       <CommentSubscription
-      onSubscribe={onSubscribe}
-      userStatus="logged-in"
-       />,
+        onSubscribe={onSubscribe}
+        isLoggedIn={true}
+      />,
     );
 
     const button = getByText(/subscribe/i, { selector: 'button' });
@@ -72,7 +72,7 @@ describe('<CommentSubscription />', () => {
       <CommentSubscription
         subscriptionType={COMMENT_SUBSCRIPTION_TYPE.AUTHOR}
         onUnsubscribe={onUnsubscribe}
-        userStatus="logged-in"
+        isLoggedIn={true}
       />,
     );
 

--- a/app/javascript/CommentSubscription/__tests__/CommentSubscription.test.jsx
+++ b/app/javascript/CommentSubscription/__tests__/CommentSubscription.test.jsx
@@ -54,7 +54,10 @@ describe('<CommentSubscription />', () => {
   it('should subscribe when the subscribe button is pressed', () => {
     const onSubscribe = jest.fn();
     const { getByText } = render(
-      <CommentSubscription onSubscribe={onSubscribe} />,
+      <CommentSubscription
+      onSubscribe={onSubscribe}
+      userStatus="logged-in"
+       />,
     );
 
     const button = getByText(/subscribe/i, { selector: 'button' });
@@ -69,6 +72,7 @@ describe('<CommentSubscription />', () => {
       <CommentSubscription
         subscriptionType={COMMENT_SUBSCRIPTION_TYPE.AUTHOR}
         onUnsubscribe={onUnsubscribe}
+        userStatus="logged-in"
       />,
     );
 

--- a/app/javascript/packs/articlePage.jsx
+++ b/app/javascript/packs/articlePage.jsx
@@ -25,6 +25,7 @@ const userDataIntervalID = setInterval(async () => {
 
     clearInterval(userDataIntervalID);
     const root = document.getElementById('comment-subscription');
+    const isLoggedIn = (userStatus === "logged-in");
 
     try {
       const {
@@ -34,14 +35,13 @@ const userDataIntervalID = setInterval(async () => {
       } = await import('../CommentSubscription');
 
       const { articleId } = document.getElementById('article-body').dataset;
-      
+
       let subscriptionType = 'not_subscribed';
 
-      if (userStatus === 'logged-in' && user !== null) {
-        const commentSubscriptionStatus = await getCommentSubscriptionStatus(
+      if (isLoggedIn && user !== null) {
+        ({ config: subscriptionType } = await getCommentSubscriptionStatus(
           articleId,
-        );
-        subscriptionType = commentSubscriptionStatus.config;
+        ));
       }
 
       const subscriptionRequestHandler = async (type) => {
@@ -56,7 +56,7 @@ const userDataIntervalID = setInterval(async () => {
           positionType="static"
           onSubscribe={subscriptionRequestHandler}
           onUnsubscribe={subscriptionRequestHandler}
-          userStatus={userStatus}
+          isLoggedIn={isLoggedIn}
         />,
         root,
       );
@@ -64,5 +64,4 @@ const userDataIntervalID = setInterval(async () => {
       document.getElementById('comment-subscription').innerHTML =
         '<p className="color-accent-danger">Unable to load Comment Subscription component.<br />Try refreshing the page.</p>';
     }
-  // }
 });

--- a/app/javascript/packs/articlePage.jsx
+++ b/app/javascript/packs/articlePage.jsx
@@ -23,14 +23,6 @@ top.addSnackbarItem = addSnackbarItem;
 const userDataIntervalID = setInterval(async () => {
   const { user = null, userStatus } = document.body.dataset;
 
-  if (userStatus === 'logged-out') {
-    // User is not logged on so nothing dynamic to add to the page.
-    clearInterval(userDataIntervalID);
-    return;
-  }
-
-  if (userStatus === 'logged-in' && user !== null) {
-    // Load the comment subscription button for logged on users.
     clearInterval(userDataIntervalID);
     const root = document.getElementById('comment-subscription');
 
@@ -42,9 +34,16 @@ const userDataIntervalID = setInterval(async () => {
       } = await import('../CommentSubscription');
 
       const { articleId } = document.getElementById('article-body').dataset;
-      const { config: subscriptionType } = await getCommentSubscriptionStatus(
-        articleId,
-      );
+      
+      let subscriptionType = 'not_subscribed';
+
+      if (userStatus === 'logged-in' && user !== null) {
+        const commentSubscriptionStatus = await getCommentSubscriptionStatus(
+          articleId,
+        );
+        subscriptionType = commentSubscriptionStatus.config;
+      }
+
       const subscriptionRequestHandler = async (type) => {
         const message = await setCommentSubscriptionStatus(articleId, type);
 
@@ -57,6 +56,7 @@ const userDataIntervalID = setInterval(async () => {
           positionType="static"
           onSubscribe={subscriptionRequestHandler}
           onUnsubscribe={subscriptionRequestHandler}
+          userStatus={userStatus}
         />,
         root,
       );
@@ -64,5 +64,5 @@ const userDataIntervalID = setInterval(async () => {
       document.getElementById('comment-subscription').innerHTML =
         '<p className="color-accent-danger">Unable to load Comment Subscription component.<br />Try refreshing the page.</p>';
     }
-  }
+  // }
 });

--- a/cypress/integration/loggedOutFlows/showLoginModal.spec.js
+++ b/cypress/integration/loggedOutFlows/showLoginModal.spec.js
@@ -43,4 +43,19 @@ describe('Show log in modal', () => {
       },
     );
   });
+
+  it('should show login modal for comment subscription', () => {
+    cy.findAllByText('Test article').last().click();
+    cy.findByRole('button', { name: /Subscribe/ }).as('subscribe').click();
+
+    cy.findByTestId('modal-container').as('modal');
+    cy.get('@modal').findByText('Log in to continue').should('exist');
+    cy.get('@modal').findByLabelText('Log in').should('exist');
+    cy.get('@modal').findByLabelText('Create new account').should('exist');
+    cy.get('@modal').findByRole('button').first().should('have.focus');
+
+    cy.get('@modal').findByRole('button', { name: /Close/ }).click();
+    cy.get('@subscribe').should('have.focus');
+    cy.findByTestId('modal-container').should('not.exist');
+  });
 });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Removed logic that would not load the comment subscription button functionally if a user was not logged in. Added logic inside the onClick function of the subscribe button so that it shows the login modal when a user is not logged in. 

## Related Tickets & Documents

resolves [issue#12571](https://github.com/forem/forem/issues/12571)

## Recordings

When a user tries to subscribe to a discussion and is not logged in:

![Subcribe-logged-out](https://user-images.githubusercontent.com/65631154/109402846-62dfaf00-7916-11eb-9813-f50b650e2012.gif)

## Added tests?

- [ ] Yes
- [ ] No, and this is why:
- [x] I need help with writing tests: The only thing that needs to be tested is the login modal popping up when the subscribe button is clicked (not too sure how to do that with jest at the moment) 

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
