### PR TITLE
Optimization:Enforce Uniqueness for Follows::UpdatePointsWorker and RatingVotes::AssignRatingWorker

### DIFF
--- a/app/workers/follows/update_points_worker.rb
+++ b/app/workers/follows/update_points_worker.rb
@@ -1,7 +1,7 @@
 module Follows
   class UpdatePointsWorker
     include Sidekiq::Worker
-    sidekiq_options queue: :low_priority, retry: 10
+    sidekiq_options queue: :low_priority, retry: 10, lock: :until_executing
 
     def perform(article_id, user_id)
       article = Article.find_by(id: article_id)

--- a/app/workers/rating_votes/assign_rating_worker.rb
+++ b/app/workers/rating_votes/assign_rating_worker.rb
@@ -2,7 +2,7 @@ module RatingVotes
   class AssignRatingWorker
     include Sidekiq::Worker
 
-    sidekiq_options queue: :low_priority, retry: 10
+    sidekiq_options queue: :low_priority, retry: 10, lock: :until_executing
 
     def perform(article_id, group = "experience_level")
       article = Article.find_by(id: article_id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
I noticed when looking at our low_priority Sidekiq queue after getting an alert that we were enqueuing a lot of duplicate `RatingVotes::AssignRatingWorker` and `Follows::UpdatePointsWorker` jobs. This change puts a lock on those jobs based on arguments to prevent the same job from being enqueued twice. 

https://github.com/orgs/forem/projects/6#card-55934607

## QA Instructions, Screenshots, Recordings

Stop your Sidekiq workers
Try to enqueue multiple of the same job with the same args and see that only one of them is enqueued. 

## Added tests?
- [x] No these workers already have tests

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams


![one at a time gif](https://media1.giphy.com/media/10tVhjcavACiBi/giphy.gif)
