### PR TITLE
Bug Fix:Update updated_at Timestamp Every time We Run Repo Sync Worker

### DIFF
--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -28,6 +28,7 @@ module GithubRepos
           stargazers_count: fetched_repo.stargazers_count,
           info_hash: fetched_repo.to_hash,
         )
+        repo.touch(:updated_at)
         if repo.user&.github_repos_updated_at&.before?(TOUCH_USER_COOLDOWN.ago)
           repo.user.touch(:github_repos_updated_at)
         end

--- a/spec/workers/github_repos/repo_sync_worker_spec.rb
+++ b/spec/workers/github_repos/repo_sync_worker_spec.rb
@@ -30,7 +30,17 @@ RSpec.describe GithubRepos::RepoSyncWorker, type: :worker do
 
       Timecop.freeze(3.days.from_now) do
         worker.perform(repo.id)
-        expect(old_updated_at).not_to eq(GithubRepo.find(repo.id).updated_at)
+        expect(old_updated_at).not_to eq(repo.reload.updated_at)
+      end
+    end
+
+    it "updates repo updated_at even if data is unchanged" do
+      worker.perform(repo.id)
+      old_updated_at = repo.updated_at.to_date
+
+      Timecop.freeze(3.days.from_now) do
+        worker.perform(repo.id)
+        expect(old_updated_at).not_to eq(repo.reload.updated_at.to_date)
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I noticed that we were still processing a ton of Repos every time we synced them on the hour despite me "spreading out" the updated_at timestamps last week. This led me to discover that the majority of the time we run the worker no data is getting updated for the GithubRepo. Since Rails is smart it saves us a trip to the database and doesn't even bother updating the object. The problem with this is that we never update `updated_at` which leads to us trying to resync every GithubRepo every hour since none of them ever have their `updated_at` timestamps updated. This PR fixes that by manually updating `updated_at` every time a worker runs for a repo. 

## QA Instructions, Screenshots, Recordings

Run the job and see that updated_at always gets updated despite data remaining unchanged. 

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
Rerun my script to spread out the timestamps of the github repos again
```ruby
github_ids.in_groups_of(1500).each_with_index do |ids, index|
  puts index.hours.ago
  GithubRepo.where(id: ids).update_all(updated_at: index.hours.ago)
end;
```

![New Girl facepalm gif](https://media1.giphy.com/media/26ueYUlPAmUkTBAM8/200.gif)
