### PR TITLE
Remove superfluous title attribute from sidebar SVGs

### DIFF
--- a/app/views/layouts/_sidebar_nav_link.html.erb
+++ b/app/views/layouts/_sidebar_nav_link.html.erb
@@ -1,6 +1,6 @@
 <% if !link.display_only_when_signed_in || (link.display_only_when_signed_in && user_signed_in?) %>
   <a href="<%= link.url %>" class="sidebar-navigation-link crayons-link crayons-link--block">
-    <span class="crayons-icon crayons-icon--default" title="Listings">
+    <span class="crayons-icon crayons-icon--default">
       <%= link.icon.html_safe %>
     </span>
     <%= link.name %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] ~Bug~ Accessibility Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As #12680 describes, 
> The SVGs [in the sidebar] are decorative in this case and don't need a title attribute.

This PR removes them :)

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/12680.

## QA Instructions, Screenshots, Recordings

Before this change:
![firefox developer tools with extra title attribute](https://user-images.githubusercontent.com/20773163/107793997-d0a0ae00-6d4e-11eb-8342-e78001667314.png)

After this change:
<img width="978" alt="Screen Shot 2021-03-01 at 5 38 37 PM" src="https://user-images.githubusercontent.com/6921610/109583759-462dad80-7ab5-11eb-8428-d6c1f4606b1e.png">


### UI accessibility concerns?

Yes, it's an _intentional_ UI accessibility change. It improves upon this current issue:
> The effect is that to assistive technology users, the links are announced "Listings Podcasts", "Listings Videos" etc.

## Added tests?

- [ ] Yes
- [x] No, and this is why: _As this just removes an unnecessary `title` attribute, I don't think we have or need tests for this bit_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _as this is a small a11y improvement, I don't think it warrants communication!_

## Are there any post deployment tasks we need to perform?
Nope!
