### PR TITLE
[15 minute fix] Remove disambiguatingDescription from user profile

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -389,7 +389,6 @@ class StoriesController < ApplicationController
       email: @user.email_public ? @user.email : nil,
       jobTitle: @user.employment_title.presence,
       description: @user.summary.presence || "404 bio not found",
-      disambiguatingDescription: user_disambiguating_description,
       worksFor: [user_works_for].compact,
       alumniOf: @user.education.presence
     }.reject { |_, v| v.blank? }
@@ -457,8 +456,8 @@ class StoriesController < ApplicationController
   end
 
   def user_works_for
-    # For further examples of the worksFor and disambiguatingDescription properties,
-    # please refer to this link: https://jsonld.com/person/
+    # For further examples of the worksFor properties, please refer to this
+    # link: https://jsonld.com/person/
     return unless @user.employer_name.presence || @user.employer_url.presence
 
     {
@@ -466,10 +465,6 @@ class StoriesController < ApplicationController
       name: @user.employer_name,
       url: @user.employer_url
     }.reject { |_, v| v.blank? }
-  end
-
-  def user_disambiguating_description
-    [@user.mostly_work_with, @user.currently_hacking_on, @user.currently_learning].compact
   end
 
   def user_same_as

--- a/spec/requests/user/user_show_spec.rb
+++ b/spec/requests/user/user_show_spec.rb
@@ -40,11 +40,6 @@ RSpec.describe "UserShow", type: :request do
         "email" => user.email,
         "jobTitle" => user.employment_title,
         "description" => user.summary,
-        "disambiguatingDescription" => [
-          user.mostly_work_with,
-          user.currently_hacking_on,
-          user.currently_learning,
-        ],
         "worksFor" => [
           {
             "@type" => "Organization",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR removes the `disambiguatingDescription` from the schema.org definition in `StoriesController` as it doesn't massively contribute to SEO but poses some problems with generalized profiles.

## Related Tickets & Documents

Closes #12818

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added tests?

- [X] No, and this is why: only removing untested code

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: Most people probably weren't even aware of this
