### PR TITLE
[15 Minute Fix]: Update email footer copy to account for email authentication

### DIFF
--- a/app/helpers/authentication_helper.rb
+++ b/app/helpers/authentication_helper.rb
@@ -23,6 +23,16 @@ module AuthenticationHelper
     Authentication::Providers.enabled_for_user(user)
   end
 
+  def signed_up_with(user = current_user)
+    providers = Authentication::Providers.enabled_for_user(user)
+
+    # If the user did not authenticate with any provider, they signed up with an email.
+    auth_method = providers.presence ? providers.map(&:official_name).to_sentence : "Email & Password"
+    verb = providers.size > 1 ? "any of those" : "that"
+
+    "Reminder: you used #{auth_method} to authenticate your account, so please use #{verb} to sign in if prompted."
+  end
+
   def available_providers_array
     Authentication::Providers.available.map(&:to_s)
   end

--- a/app/helpers/authentication_helper.rb
+++ b/app/helpers/authentication_helper.rb
@@ -27,7 +27,7 @@ module AuthenticationHelper
     providers = Authentication::Providers.enabled_for_user(user)
 
     # If the user did not authenticate with any provider, they signed up with an email.
-    auth_method = providers.presence ? providers.map(&:official_name).to_sentence : "Email & Password"
+    auth_method = providers.any? ? providers.map(&:official_name).to_sentence : "Email & Password"
     verb = providers.size > 1 ? "any of those" : "that"
 
     "Reminder: you used #{auth_method} to authenticate your account, so please use #{verb} to sign in if prompted."

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,30 +1,29 @@
 <html>
-<body style='font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;'>
-<table style="width:100%;max-width:700px;margin:auto;font-size:18px">
-  <tr>
-    <td style="padding:4%;">
-      <%= yield %>
-    </td>
-  </tr>
-  <% if @user %>
-    <tr>
-      <td style="padding:3% 12% 2% 4%;font-size:18px;line-height:22px;color:#7d7d7d">
-        <% providers = authentication_enabled_providers_for_user(@user).map(&:official_name) %>
-        Reminder: You used <b><%= providers.to_sentence %></b> to authenticate your account, so use <%= providers.size == 1 ? "that" : "any of those" %> to sign in if prompted.
+  <body style='font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif;'>
+    <table style="width:100%;max-width:700px;margin:auto;font-size:18px">
+      <tr>
+        <td style="padding:4%;">
+          <%= yield %>
+        </td>
+      </tr>
+      <% if @user %>
+        <tr>
+          <td style="padding:3% 12% 2% 4%;font-size:18px;line-height:22px;color:#7d7d7d">
+            <%= signed_up_with(@user) %>
 
-        <br /><br />
-        <div style="font-size:0.78em">
-          <% if @unsubscribe %>
-            <%= link_to "Unsubscribe", email_subscriptions_unsubscribe_url(ut: @unsubscribe), style: "color:#7d7d7d" %> |
-            <a href="<%= app_url(user_settings_path(:notifications)) %>" style="color:#7d7d7d">Adjust your email settings</a>
-          <% else %>
-            Don't want to get emails like this? Adjust your email settings at
-            <a href="<%= app_url(user_settings_path(:notifications)) %>"><%= app_url(user_settings_path(:notifications)) %></a>
-          <% end %>
-        </div>
-      </td>
-    </tr>
-  <% end %>
-</table>
-</body>
+            <br /><br />
+            <div style="font-size:0.78em">
+              <% if @unsubscribe %>
+                <%= link_to "Unsubscribe", email_subscriptions_unsubscribe_url(ut: @unsubscribe), style: "color:#7d7d7d" %> |
+                <a href="<%= app_url(user_settings_path(:notifications)) %>" style="color:#7d7d7d">Adjust your email settings</a>
+              <% else %>
+                Don't want to get emails like this? Adjust your email settings at
+                <a href="<%= app_url(user_settings_path(:notifications)) %>"><%= app_url(user_settings_path(:notifications)) %></a>
+              <% end %>
+            </div>
+          </td>
+        </tr>
+      <% end %>
+    </table>
+  </body>
 </html>

--- a/spec/helpers/authentication_helper_spec.rb
+++ b/spec/helpers/authentication_helper_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe AuthenticationHelper, type: :helper do
     end
   end
 
+  describe "#signed_up_with" do
+    it "returns an authentication reminder when a user auths with a provider" do
+      providers = Authentication::Providers.available.last(2)
+      allow(Authentication::Providers).to receive(:enabled).and_return(providers)
+      allow(user).to receive(:identities).and_return(user.identities.where(provider: providers))
+
+      expect(helper.signed_up_with(user)).to match(/GitHub and Twitter/)
+      expect(helper.signed_up_with(user)).to match(/use any of those/)
+    end
+
+    it "returns an authentication reminder when a user signs up with email" do
+      allow(Authentication::Providers).to receive(:enabled).and_return([])
+
+      expect(helper.signed_up_with(user)).to match(/Email & Password/)
+      expect(helper.signed_up_with(user)).to match(/use that/)
+    end
+  end
+
   describe "#available_providers_array" do
     it "returns array of available providers in lowercase" do
       provider = Authentication::Providers.available.first


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a a quick 15-minute fix I whipped up between meetings! 💪🏽

Our transactional emails render a copy reminder at the bottom of the layout to prompt users to remember how they logged into a Forem when they first signed up; unfortunately, that copy only account for third-party providers. So, if a user signed up with email, that copy reads weird:
> Reminder: You used to authenticate your account, so use any of those to sign in if prompted.

This PR take email authentication into account in that email by modifying the helper that the email body renders. While I was in the code, I took the liberty of refactoring some view logic into the pre-existing `AuthenticationHelper` helper, where other provider and auth-related logic lives 😃 

Now, when a user signs up with an email and password, they'll see this text:
> Reminder: you used Email & Password to authenticate your account, so please use that to sign in if prompted.

I also added tests for this logic since we do some fancy tense/grammar changing depending on how many providers who have authenticated with.

## Related Tickets & Documents

Fixes https://github.com/forem/forem/issues/12546.

## QA Instructions, Screenshots, Recordings

Send yourself any kind of email and make sure that the copy at the bottom of the page is both:
1) grammatically correct
2) reflects which provider you auth'ed with.

You can also gut-check my tests, too :) 

### UI accessibility concerns?

None, this is only a copy change.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _this is more of a bugfix than anything else_

## Are there any post deployment tasks we need to perform?
Nope!

## What gif best describes this PR or how it makes you feel?

![grammar beaver](https://media2.giphy.com/media/7JrwZgsIW2x1K/giphy.gif?cid=5a38a5a22lplazzgc031cal3dwru474fdsj7a2qkck93s3fy&rid=giphy.gif)
