### PR TITLE
Fix : background box of the button on profile via chat section issue: #12879

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -413,8 +413,8 @@
 .activechatchannel__activecontentexitbutton {
   font-size: 30px;
   position: absolute;
-  left: 4px;
-  top: 4px;
+  left: 80%;
+  top: -12px;
   z-index: 10;
   padding: 0px;
   height: 30px;

--- a/app/javascript/chat/content.jsx
+++ b/app/javascript/chat/content.jsx
@@ -14,6 +14,7 @@ const smartSvgIcon = (content, d) => (
     viewBox="0 0 24 24"
     width="24"
     height="24"
+    style={{ margin: '0 -12px' }}
   >
     <path data-content={content} fill="none" d="M0 0h24v24H0z" />
     <path data-content={content} d={d} />
@@ -74,7 +75,7 @@ export class Content extends Component {
           type="button"
           className="activechatchannel__activecontentexitbutton activechatchannel__activecontentexitbutton--fullscreen crayons-btn crayons-btn--secondary"
           data-content="fullscreen"
-          style={{ left: '39px' }}
+          style={{ left: '50%' }}
           title="fullscreen"
         >
           {' '}

--- a/app/javascript/chat/videoContent.jsx
+++ b/app/javascript/chat/videoContent.jsx
@@ -51,7 +51,7 @@ export function VideoContent(props) {
         aria-label={fullscreen ? 'Fullscreen' : 'Leave fullscreen'}
         className="activechatchannel__activecontentexitbutton activechatchannel__activecontentexitbutton--fullscreen crayons-btn crayons-btn--secondary"
         data-content="fullscreen"
-        style={{ left: '39px' }}
+        style={{ left: '75%' }}
       >
         {fullscreen
           ? smartSvgIcon(

--- a/app/javascript/chat/videoContent.jsx
+++ b/app/javascript/chat/videoContent.jsx
@@ -51,7 +51,7 @@ export function VideoContent(props) {
         aria-label={fullscreen ? 'Fullscreen' : 'Leave fullscreen'}
         className="activechatchannel__activecontentexitbutton activechatchannel__activecontentexitbutton--fullscreen crayons-btn crayons-btn--secondary"
         data-content="fullscreen"
-        style={{ left: '75%' }}
+        style={{ left: '50%' }}
       >
         {fullscreen
           ? smartSvgIcon(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It is related to the 
Issue : background box of the button on profile via chat section, closes #12879

## Related Tickets & Documents

#12879

## QA Instructions, Screenshots, Recordings

![Captdure](https://user-images.githubusercontent.com/67496096/109925462-ce939480-7ce7-11eb-9f36-ffdc4386a054.PNG)


### UI accessibility concerns?

The button is aligned to the right side and it is quite responsive too.
Now there is no overlapping over the profile picture.
Also, I made the SVG to be in the box.

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


