### PR TITLE
Remove mod button from top nav bar in mobile

### DIFF
--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -87,11 +87,7 @@ body.ten-x-hacker-theme {
   align-self: center;
 }
 
-.trusted-visible-block {
-  display: none !important;
-}
-
-body.trusted-status-true .trusted-visible-block {
+body.trusted-status-true {
   display: flex !important;
 }
 

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -87,7 +87,11 @@ body.ten-x-hacker-theme {
   align-self: center;
 }
 
-body.trusted-status-true {
+.trusted-visible-block {
+  display: none !important;
+}
+
+body.trusted-status-true .trusted-visible-block {
   display: flex !important;
 }
 

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -15,6 +15,7 @@
     <li class="px-1"><a href="<%= dashboard_path %>" class="crayons-link crayons-link--block">Dashboard</a></li>
     <li class="px-1"><a href="<%= new_path %>" class="crayons-link crayons-link--block">Write a Post</a></li>
     <li class="px-1"><a href="<%= readinglist_path %>" class="crayons-link crayons-link--block">Reading list</a></li>
+    <li class="px-1"><a href="<%= mod_path %>" class="crayons-link crayons-link--block" id="moderation-menu-link">Moderator Center</a></li>
     <li class="border-0 border-b-1 border-solid border-base-20 px-1 pb-1">
       <a href="<%= user_settings_path %>" class="crayons-link crayons-link--block" id="second-last-nav-link">Settings</a>
     </li>

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -13,9 +13,9 @@
       <a href="<%= admin_path %>" class="crayons-link crayons-link--block" data-no-instant>Admin</a>
     </li>
     <li class="px-1"><a href="<%= dashboard_path %>" class="crayons-link crayons-link--block">Dashboard</a></li>
+    <li class="px-1"><a href="<%= mod_path %>" class="crayons-link crayons-link--block trusted-visible-block">Moderator Center</a></li>
     <li class="px-1"><a href="<%= new_path %>" class="crayons-link crayons-link--block">Write a Post</a></li>
     <li class="px-1"><a href="<%= readinglist_path %>" class="crayons-link crayons-link--block">Reading list</a></li>
-    <li class="px-1"><a href="<%= mod_path %>" class="crayons-link crayons-link--block trusted-visible-block">Moderator Center</a></li>
     <li class="border-0 border-b-1 border-solid border-base-20 px-1 pb-1">
       <a href="<%= user_settings_path %>" class="crayons-link crayons-link--block" id="second-last-nav-link">Settings</a>
     </li>

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -15,7 +15,7 @@
     <li class="px-1"><a href="<%= dashboard_path %>" class="crayons-link crayons-link--block">Dashboard</a></li>
     <li class="px-1"><a href="<%= new_path %>" class="crayons-link crayons-link--block">Write a Post</a></li>
     <li class="px-1"><a href="<%= readinglist_path %>" class="crayons-link crayons-link--block">Reading list</a></li>
-    <li class="px-1 trusted-visible-block"><a href="<%= mod_path %>" class="crayons-link crayons-link--block">Moderator Center</a></li>
+    <li class="px-1"><a href="<%= mod_path %>" class="crayons-link crayons-link--block trusted-visible-block">Moderator Center</a></li>
     <li class="border-0 border-b-1 border-solid border-base-20 px-1 pb-1">
       <a href="<%= user_settings_path %>" class="crayons-link crayons-link--block" id="second-last-nav-link">Settings</a>
     </li>

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -15,7 +15,7 @@
     <li class="px-1"><a href="<%= dashboard_path %>" class="crayons-link crayons-link--block">Dashboard</a></li>
     <li class="px-1"><a href="<%= new_path %>" class="crayons-link crayons-link--block">Write a Post</a></li>
     <li class="px-1"><a href="<%= readinglist_path %>" class="crayons-link crayons-link--block">Reading list</a></li>
-    <li class="px-1"><a href="<%= mod_path %>" class="crayons-link crayons-link--block" id="moderation-menu-link">Moderator Center</a></li>
+    <li class="px-1 trusted-visible-block"><a href="<%= mod_path %>" class="crayons-link crayons-link--block">Moderator Center</a></li>
     <li class="border-0 border-b-1 border-solid border-base-20 px-1 pb-1">
       <a href="<%= user_settings_path %>" class="crayons-link crayons-link--block" id="second-last-nav-link">Settings</a>
     </li>

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -32,7 +32,7 @@
       <% if user_signed_in? %>
         <a href="<%= new_path %>" class="crayons-btn hidden mr-2 whitespace-nowrap m:block ml-auto">Write a post</a>
 
-        <a id="moderation-link" class="crayons-header__link hidden crayons-btn crayons-btn--ghost crayons-btn--icon-rounded m:flex" aria-label="Moderation" href="<%= mod_path %>">
+        <a id="moderation-link" class="crayons-header__link hidden crayons-btn crayons-btn--ghost crayons-btn--icon-rounded m:flex trusted-visible-block" aria-label="Moderation" href="<%= mod_path %>">
           <%= inline_svg_tag("mod.svg", aria: true, class: "crayons-icon", title: "Moderation") %>
         </a>
 

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -32,7 +32,7 @@
       <% if user_signed_in? %>
         <a href="<%= new_path %>" class="crayons-btn hidden mr-2 whitespace-nowrap m:block ml-auto">Write a post</a>
 
-        <a id="moderation-link" class="crayons-header__link crayons-btn crayons-btn--ghost crayons-btn--icon-rounded trusted-visible-block m:flex" aria-label="Moderation" href="<%= mod_path %>">
+        <a id="moderation-link" class="crayons-header__link hidden crayons-btn crayons-btn--ghost crayons-btn--icon-rounded m:flex" aria-label="Moderation" href="<%= mod_path %>">
           <%= inline_svg_tag("mod.svg", aria: true, class: "crayons-icon", title: "Moderation") %>
         </a>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Remove the mod button in the top nav bar, since it was causing a bug that pushed off the profile menu button in mobile.

## Related Tickets & Documents
Resolves https://github.com/forem/internalEngineering/issues/393

## QA Instructions, Screenshots, Recordings
![Screen Shot 2021-03-04 at 3 11 31 PM](https://user-images.githubusercontent.com/17884966/110024081-ed038b00-7cfb-11eb-8fe8-8a5163e6242a.png)

### UI accessibility concerns?
Should be okay! Just added a link with nothing special about it.

## Added tests?
- [x] No, and this is why: I could add an e2e test but I'd rather not slow down this bug fix. Maybe in a separate PR.

## [Forem core team only] How will this change be communicated?
- [ ] Other: I will share this change with moderators in the appropriate Connect channels

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?

![Three dudes go swoosh, and slide across the floor.](https://media.giphy.com/media/WNJAUbRAlDxrWltxim/giphy.gif)
