### PR TITLE
Disable serviceworkers in Safari part2

### DIFF
--- a/app/assets/javascripts/serviceworker-companion.js
+++ b/app/assets/javascripts/serviceworker-companion.js
@@ -1,19 +1,30 @@
 'use strict';
 
-if (
-  'serviceWorker' in navigator &&
-  !('safari' in window)
-) {
-  // Safari has issues with the service worker, so we'll just skip it on those browsers
-  navigator.serviceWorker
-    .register('/serviceworker.js', { scope: '/' })
-    .then(function swStart(registration) {
-      // registered!
-    })
-    .catch((error) => {
-      // eslint-disable-next-line no-console
-      console.log('ServiceWorker registration failed: ', error);
-    });
+if ('serviceWorker' in navigator) {
+  // Safari has issues with the service worker, so we'll just skip it on those browsers, and unregister it if it's loaded
+  if (
+    /Safari/i.test(navigator.userAgent) &&
+    /Apple Computer/.test(navigator.vendor)
+  ) {
+    //unregister serviceworker
+    navigator.serviceWorker
+      .getRegistration('/serviceworker.js')
+      .then(function (registration) {
+        if (registration) {
+          registration.unregister();
+        }
+      });
+  } else {
+    navigator.serviceWorker
+      .register('/serviceworker.js', { scope: '/' })
+      .then(function swStart(registration) {
+        // registered!
+      })
+      .catch((error) => {
+        // eslint-disable-next-line no-console
+        console.log('ServiceWorker registration failed: ', error);
+      });
+  }
 }
 
 window.addEventListener('beforeinstallprompt', (e) => {

--- a/app/assets/javascripts/serviceworker-companion.js
+++ b/app/assets/javascripts/serviceworker-companion.js
@@ -2,10 +2,7 @@
 
 if (
   'serviceWorker' in navigator &&
-  !(
-    /Safari/i.test(navigator.userAgent) &&
-    /Apple Computer/.test(navigator.vendor)
-  )
+  !('safari' in window)
 ) {
   // Safari has issues with the service worker, so we'll just skip it on those browsers
   navigator.serviceWorker

--- a/app/assets/javascripts/serviceworker-companion.js
+++ b/app/assets/javascripts/serviceworker-companion.js
@@ -1,6 +1,13 @@
 'use strict';
 
-if ('serviceWorker' in navigator) {
+if (
+  'serviceWorker' in navigator &&
+  !(
+    /Safari/i.test(navigator.userAgent) &&
+    /Apple Computer/.test(navigator.vendor)
+  )
+) {
+  // Safari has issues with the service worker, so we'll just skip it on those browsers
   navigator.serviceWorker
     .register('/serviceworker.js', { scope: '/' })
     .then(function swStart(registration) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A follow up/correction to PR https://github.com/forem/forem/pull/12907: at the last minute I changed how I was detecting Safari in `app/assets/javascripts/serviceworker-companion.js`. Unfortunately, the new detection method doesn't work on mobile Safari (it's used for web based pushed notification, which Safari on iOS doesn't support!). So, it's back to the old method of looking at the combination of `userAgent` and `vendor`.

A silver lining is that this gives us a chance to look for a registered service worker on Safari, and unregister it if we find it! I tested out this functionality on desktop Safari and mobile Safari, and it successfully unregisters any existing Forem service worker! 

## Related Tickets & Documents

https://github.com/forem/forem/pull/12907


## [optional] What gif best describes this PR or how it makes you feel?

https://user-images.githubusercontent.com/37842/110044341-95bae600-7d0e-11eb-9120-8b6f1ecf8c5f.mp4

