### PR TITLE
[15 minute fix] Remove outdated language from RSS import

### DIFF
--- a/app/views/users/_publishing_from_rss.html.erb
+++ b/app/views/users/_publishing_from_rss.html.erb
@@ -15,7 +15,7 @@
     <% end %>
     <p>
       Posts will land in your <a href="/dashboard">dashboard</a>
-      <strong>as drafts</strong>, and then you can publish from there (or give <%= community_name %> admins permission to do so).
+      <strong>as drafts</strong>, and then you can publish from there.
     </p>
     <p>Formatting will typically look good, but you may have to make manual fixes. In the case of Medium, you may have to manually fix embeds.</p>
     <p>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Copy chage
 
## Description

This PR removes some outdated language from the RSS settings page as requested by @michael-tharrington.

## Related Tickets & Documents

Closes #12900 

## QA Instructions, Screenshots, Recordings

![image](https://user-images.githubusercontent.com/47985/110064879-8c7a5980-7da0-11eb-92a0-012160f572fa.png)

### UI accessibility concerns?

n/a

## Added tests?

- [X] No, and this is why: only changed copy

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: minor copy change, the functionality already didn;t exist.
