### PR TITLE
Hide mod button in mobile

### DIFF
--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -93,6 +93,11 @@ body.ten-x-hacker-theme {
 
 body.trusted-status-true .trusted-visible-block {
   display: flex !important;
+  &.hidden {
+    @media screen and (max-width: $breakpoint-s) {
+      display: none !important;
+    }
+  }
 }
 
 .app-shell-loader {

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -93,11 +93,6 @@ body.ten-x-hacker-theme {
 
 body.trusted-status-true .trusted-visible-block {
   display: flex !important;
-  &.hidden {
-    @media screen and (max-width: $breakpoint-s) {
-      display: none !important;
-    }
-  }
 }
 
 .app-shell-loader {

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -32,9 +32,11 @@
       <% if user_signed_in? %>
         <a href="<%= new_path %>" class="crayons-btn hidden mr-2 whitespace-nowrap m:block ml-auto">Write a post</a>
 
-        <a id="moderation-link" class="crayons-header__link crayons-btn crayons-btn--ghost crayons-btn--icon-rounded m:flex trusted-visible-block hidden" aria-label="Moderation" href="<%= mod_path %>">
-          <%= inline_svg_tag("mod.svg", aria: true, class: "crayons-icon", title: "Moderation") %>
-        </a>
+        <span class="trusted-visible-block">
+          <a id="moderation-link" class="crayons-header__link crayons-btn crayons-btn--ghost crayons-btn--icon-rounded m:flex hidden" aria-label="Moderation" href="<%= mod_path %>">
+            <%= inline_svg_tag("mod.svg", aria: true, class: "crayons-icon", title: "Moderation") %>
+          </a>
+        </span>
 
         <a href="<%= connect_path %>" id="connect-link" class="crayons-header__link crayons-btn crayons-btn--ghost crayons-btn--icon-rounded" aria-label="Connect">
           <%= inline_svg_tag("connect.svg", aria: true, class: "crayons-icon", title: "Connect") %>

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -32,7 +32,7 @@
       <% if user_signed_in? %>
         <a href="<%= new_path %>" class="crayons-btn hidden mr-2 whitespace-nowrap m:block ml-auto">Write a post</a>
 
-        <a id="moderation-link" class="crayons-header__link hidden crayons-btn crayons-btn--ghost crayons-btn--icon-rounded m:flex trusted-visible-block" aria-label="Moderation" href="<%= mod_path %>">
+        <a id="moderation-link" class="crayons-header__link crayons-btn crayons-btn--ghost crayons-btn--icon-rounded m:flex trusted-visible-block hidden" aria-label="Moderation" href="<%= mod_path %>">
           <%= inline_svg_tag("mod.svg", aria: true, class: "crayons-icon", title: "Moderation") %>
         </a>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where the mod center button wasn't actually hidden in mobile. 😓 

## Related Tickets & Documents
https://github.com/forem/forem/pull/12906
https://github.com/forem/internalEngineering/issues/393

## QA Instructions, Screenshots, Recordings
1. Log in as a `trusted` user
2. See that the mod button icon displays in the top nav bar
3. Go into mobile view
4. See that the same mod button is hidden


1. Log in as a non-trusted user
2. See that mod button icon is not present

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?
- [x] I need help with writing tests (end to end test is best here)

## [Forem core team only] How will this change be communicated?
- [x] I request this change in the next [Changelog](https://forem.dev/t/changelog) post

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?

![Frodo says, "It's done."](https://media.giphy.com/media/3oKIPf3C7HqqYBVcCk/giphy-downsized.gif)