### PR TITLE
[15 Minute Fix]: Ensure crayons banners are accessible

### DIFF
--- a/app/views/chat_channel_memberships/index.html.erb
+++ b/app/views/chat_channel_memberships/index.html.erb
@@ -1,5 +1,5 @@
 <% if flash[:settings_notice] %>
-  <div class="crayons-banner" id="notice" style="padding: 35px 4px">
+  <div class="crayons-banner" id="notice" style="padding: 35px 4px" aria-live="polite">
     <%= flash[:settings_notice] %>
   </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
 <style>.app-shell-loader {display: none;}</style>
 <div id="page-content" class="wrapper <%= view_class %>" data-current-page="<%= current_page %>">
   <% if flash[:global_notice] %>
-    <div class="crayons-banner">
+    <div class="crayons-banner" aria-live="polite">
       <%= flash[:global_notice] %>
     </div>
   <% end %>

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 
 <% if flash[:error].present? %>
-  <div class="crayons-banner crayons-banner--error">
+  <div class="crayons-banner crayons-banner--error" role="alert">
     <%= flash[:error] %>
   </div>
 <% end %>

--- a/app/views/partnerships/_flashes.html.erb
+++ b/app/views/partnerships/_flashes.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% if flash[:error].present? %>
-  <div class="crayons-banner crayons-banner--error" style="margin-bottom: 25px;">
+  <div class="crayons-banner crayons-banner--error" style="margin-bottom: 25px;" role="alert">
     <%= flash[:error] %>
   </div>
 <% end %>

--- a/app/views/partnerships/_flashes.html.erb
+++ b/app/views/partnerships/_flashes.html.erb
@@ -1,5 +1,5 @@
 <% if flash[:notice] %>
-  <div class="crayons-banner crayons-banner--success" style="margin-bottom: 25px;">
+  <div class="crayons-banner crayons-banner--success" style="margin-bottom: 25px;" aria-live="polite">
     <%= flash[:notice] %>
   </div>
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -7,13 +7,13 @@
 <% end %>
 
 <% if flash[:error].present? %>
-  <div class="crayons-banner crayons-banner--error">
+  <div class="crayons-banner crayons-banner--error" role="alert">
     <%= flash[:error] %>
   </div>
 <% end %>
 
 <% if params[:state] == "previous-registration" %>
-  <div class="crayons-banner crayons-banner--error">
+  <div class="crayons-banner crayons-banner--error" role="alert">
     There is an existing account authorized with that social account. Contact
     <%= email_link %> if this is a mistake.
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,7 @@
 <% title "Settings" %>
 
 <% if flash[:settings_notice] %>
-  <div class="crayons-banner">
+  <div class="crayons-banner" aria-live="polite">
     <%= flash[:settings_notice] %>
   </div>
 <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents
Fixes https://github.com/forem/forem/issues/12758.

After reading the [accessibility docs around the alert role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role), I noticed that they suggest using `role="alert"` specifically when you are rendering an error message to the user. I went through and checked all the crayons banners that are rendering errors, and in those cases, I used `role="alert"` instead of `aria-live="polite"`.

## QA Instructions, Screenshots, Recordings
Before this change, we were getting a warning from axe about the crayons banner not being accessible. This was due to the fact that it didn't have a `role` attribute with the value of `"alert"` (the main landmark warning is actually incorrect).

Before this change, you'd see this when running axe locally:
<img width="1552" alt="Screen Shot 2021-03-05 at 3 54 55 PM" src="https://user-images.githubusercontent.com/6921610/110187620-cc0b6a80-7dcd-11eb-9c1f-0ed3519a3596.png">

After this change, the warning disappears:
<img width="1552" alt="Screen Shot 2021-03-05 at 3 55 18 PM" src="https://user-images.githubusercontent.com/6921610/110187622-ce6dc480-7dcd-11eb-9a33-6970099f8326.png">

### UI accessibility concerns?

_Please use axe to test this out and make sure you're not seeing errors with the banner. Also, for the banners with the `role="alert"` attribute, please enable Voice Over on those pages and make sure that the banner text is heard aloud._

## Added tests?

- [ ] Yes
- [x] No, and this is why: _This is adding an accessibility attribute, so there's nothing to test (we'd just be testing the browser's handling of the aria API 😛)_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _It's assumed that this would already work on any truly accessible site!_

## Are there any post deployment tasks we need to perform?
Nope!