### PR TITLE
Fix : background box of the button on profile via chat section issue 2nd PR: #12879 

### DIFF
--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -413,7 +413,7 @@
 .activechatchannel__activecontentexitbutton {
   font-size: 30px;
   position: absolute;
-  margin-left: 75%;
+  margin-left: 80%;
   margin-top: -4px;
   left: 4px;
   top: 4px;

--- a/app/assets/stylesheets/chat.scss
+++ b/app/assets/stylesheets/chat.scss
@@ -413,6 +413,8 @@
 .activechatchannel__activecontentexitbutton {
   font-size: 30px;
   position: absolute;
+  margin-left: 75%;
+  margin-top: -4px;
   left: 4px;
   top: 4px;
   z-index: 10;

--- a/app/javascript/chat/content.jsx
+++ b/app/javascript/chat/content.jsx
@@ -75,7 +75,7 @@ export class Content extends Component {
           type="button"
           className="activechatchannel__activecontentexitbutton activechatchannel__activecontentexitbutton--fullscreen crayons-btn crayons-btn--secondary"
           data-content="fullscreen"
-          style={{ left: "15px", marginLeft: "0px" }}
+          style={{ left: "-80px", marginLeft: "0px" }}
           title="fullscreen"
         >
           {' '}

--- a/app/javascript/chat/content.jsx
+++ b/app/javascript/chat/content.jsx
@@ -14,6 +14,7 @@ const smartSvgIcon = (content, d) => (
     viewBox="0 0 24 24"
     width="24"
     height="24"
+    style={{ marginLeft:'-12px', marginTop:'-4px' }}
   >
     <path data-content={content} fill="none" d="M0 0h24v24H0z" />
     <path data-content={content} d={d} />
@@ -74,7 +75,7 @@ export class Content extends Component {
           type="button"
           className="activechatchannel__activecontentexitbutton activechatchannel__activecontentexitbutton--fullscreen crayons-btn crayons-btn--secondary"
           data-content="fullscreen"
-          style={{ left: '39px' }}
+          style={{ left: "15px", marginLeft: "0px" }}
           title="fullscreen"
         >
           {' '}

--- a/app/javascript/chat/videoContent.jsx
+++ b/app/javascript/chat/videoContent.jsx
@@ -7,6 +7,7 @@ const smartSvgIcon = (content, d) => (
     viewBox="0 0 24 24"
     width="24"
     height="24"
+
   >
     <path data-content={content} fill="none" d="M0 0h24v24H0z" />
     <path data-content={content} d={d} />
@@ -51,7 +52,7 @@ export function VideoContent(props) {
         aria-label={fullscreen ? 'Fullscreen' : 'Leave fullscreen'}
         className="activechatchannel__activecontentexitbutton activechatchannel__activecontentexitbutton--fullscreen crayons-btn crayons-btn--secondary"
         data-content="fullscreen"
-        style={{ left: '39px' }}
+        style={{ left: '15px', marginLeft:'0px' }}
       >
         {fullscreen
           ? smartSvgIcon(

--- a/app/javascript/chat/videoContent.jsx
+++ b/app/javascript/chat/videoContent.jsx
@@ -52,7 +52,7 @@ export function VideoContent(props) {
         aria-label={fullscreen ? 'Fullscreen' : 'Leave fullscreen'}
         className="activechatchannel__activecontentexitbutton activechatchannel__activecontentexitbutton--fullscreen crayons-btn crayons-btn--secondary"
         data-content="fullscreen"
-        style={{ left: '15px', marginLeft:'0px' }}
+        style={{ left: '-80px', marginLeft:'0px' }}
       >
         {fullscreen
           ? smartSvgIcon(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It is the 2nd PR for the changes.

It is related to the 
Issue: background box of the button on a profile via chat section, 
issue:  #12879

## Related Tickets & Documents

#12879

## QA Instructions, Screenshots, Recordings

https://user-images.githubusercontent.com/67496096/110204804-14dd2500-7e9b-11eb-96cb-d3c5022f217a.mp4




### UI accessibility concerns?

The button is aligned to the right side and it is quite responsive too.
Now there is no overlapping over the profile picture.
Also, I made the SVG to be in the box.

