### PR TITLE
Limit mentions in comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,6 +12,7 @@ class Comment < ApplicationRecord
   COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze
   TITLE_DELETED = "[deleted]".freeze
   TITLE_HIDDEN = "[hidden by post author]".freeze
+  MAX_USER_MENTIONS = 6
 
   belongs_to :commentable, polymorphic: true, optional: true
   belongs_to :user
@@ -39,7 +40,7 @@ class Comment < ApplicationRecord
   after_save :bust_cache
 
   validate :published_article, if: :commentable
-  validate :mention_total
+  validate :user_mentions_in_markdown
   validates :body_markdown, presence: true, length: { in: BODY_MARKDOWN_SIZE_RANGE }
   validates :body_markdown, uniqueness: { scope: %i[user_id ancestry commentable_id commentable_type] }
   validates :commentable_id, presence: true, if: :commentable_type
@@ -304,13 +305,15 @@ class Comment < ApplicationRecord
     errors.add(:commentable_id, "is not valid.") if commentable_type == "Article" && !commentable.published
   end
 
-  def mention_total
+  def user_mentions_in_markdown
     # The "comment-mentioned-user" css is added by Html::Parser#user_link_if_exists
-    mentions_in_markdown = Nokogiri::HTML(processed_html).css(".comment-mentioned-user").map do |link|
+    mentions = Nokogiri::HTML(processed_html).css(".comment-mentioned-user").map do |link|
       link.text.delete("@").downcase
     end
 
-    errors.add(:base, "You cannot mention more than 6 users in a comment!") if mentions_in_markdown.size > 6
+    return unless mentions.size > MAX_USER_MENTIONS
+
+    errors.add(:base, "You cannot mention more than #{MAX_USER_MENTIONS} users in a comment!")
   end
 
   def record_field_test_event

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -39,6 +39,7 @@ class Comment < ApplicationRecord
   after_save :bust_cache
 
   validate :published_article, if: :commentable
+  validate :mention_total
   validates :body_markdown, presence: true, length: { in: BODY_MARKDOWN_SIZE_RANGE }
   validates :body_markdown, uniqueness: { scope: %i[user_id ancestry commentable_id commentable_type] }
   validates :commentable_id, presence: true, if: :commentable_type
@@ -301,6 +302,15 @@ class Comment < ApplicationRecord
 
   def published_article
     errors.add(:commentable_id, "is not valid.") if commentable_type == "Article" && !commentable.published
+  end
+
+  def mention_total
+    # The "comment-mentioned-user" css is added by Html::Parser#user_link_if_exists
+    mentions_in_markdown = Nokogiri::HTML(processed_html).css(".comment-mentioned-user").map do |link|
+      link.text.delete("@").downcase
+    end
+
+    errors.add(:base, "You cannot mention more than 6 users in a comment!") if mentions_in_markdown.size > 6
   end
 
   def record_field_test_event

--- a/app/services/mentions/create_all.rb
+++ b/app/services/mentions/create_all.rb
@@ -36,7 +36,7 @@ module Mentions
     end
 
     def extract_usernames_from_mentions_in_text
-      # Paired with the process that creates the "comment-mentioned-user"
+      # The "comment-mentioned-user" css is added by Html::Parser#user_link_if_exists
       doc = Nokogiri::HTML(notifiable.processed_html)
       doc.css(".comment-mentioned-user").map do |link|
         link.text.delete("@").downcase

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -84,6 +84,22 @@ RSpec.describe Comment, type: :model do
         expect(subject).not_to be_valid
       end
     end
+
+    describe "#mention_total" do
+      it "is valid with less than six mentions in markdown" do
+        subject.commentable_type = "Article"
+
+        subject.body_markdown = "hi @#{user.username}! " * 6
+        expect(subject).to be_valid
+      end
+
+      it "is invalid with more than six mentions in markdown" do
+        subject.commentable_type = "Article"
+
+        subject.body_markdown = "hi @#{user.username}! " * 7
+        expect(subject).not_to be_valid
+      end
+    end
     # rubocop:enable RSpec/NamedSubject
 
     describe "#after_commit" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

As described in https://github.com/forem/internalEngineering/issues/391, limiting mentions in comments is an important spam mitigation need.

This PR adds validations around mentioning users in a comment, and limits the number of mentions you can include in a comment to six. As the original issue describes, somewhere between 5-10 usernames seems fair in terms of how many mentions we allow; I specifically choose six because that is the same number of mentions [we plan to show](https://github.com/forem/rfcs/pull/16/files#diff-b1fe05dec5655c4a78f12ac288b96dfcb82cd5877e10a16064ef520210a9a064R48) in our upcoming @-mention autocomplete feature.

## Related Tickets & Documents

https://github.com/forem/internalEngineering/issues/391

## QA Instructions, Screenshots, Recordings

1. Make sure you are logged in as a user. Go to any article, and attempt to leave a comment with more than 6 usernames in the comment's body:
<img width="763" alt="Screen Shot 2021-03-07 at 4 27 51 PM" src="https://user-images.githubusercontent.com/6921610/110260893-e3c82780-7f62-11eb-8bf7-18e2a13e43ba.png">

2. When you click "submit" you should see an error describing the cap on mentions for comments:
<img width="975" alt="Screen Shot 2021-03-07 at 4 28 07 PM" src="https://user-images.githubusercontent.com/6921610/110260919-f93d5180-7f62-11eb-9389-4226f8b69d35.png">

3. Try leaving a comment again, but this time, make sure that you have under 6 usernames in the comment's body:
<img width="795" alt="Screen Shot 2021-03-07 at 4 28 27 PM" src="https://user-images.githubusercontent.com/6921610/110260935-08bc9a80-7f63-11eb-904f-98d1f36d3339.png">

4. This time, your comment should post successfully:
<img width="796" alt="Screen Shot 2021-03-07 at 4 28 35 PM" src="https://user-images.githubusercontent.com/6921610/110260947-1c680100-7f63-11eb-95a0-0688015fc8c1.png">

5. Finally, try to edit that same comment and add more usernames to the body:
<img width="981" alt="Screen Shot 2021-03-07 at 4 29 00 PM" src="https://user-images.githubusercontent.com/6921610/110260953-25f16900-7f63-11eb-8860-f1b1f597231e.png">

6. You should see a similar error when you try to edit a comment with more than 6 mentions:
<img width="978" alt="Screen Shot 2021-03-07 at 4 29 10 PM" src="https://user-images.githubusercontent.com/6921610/110260975-343f8500-7f63-11eb-9659-de76ea020b01.png">

Everything else about leaving comments should work as expected provided you have fewer than 6 usernames in the comment's body :) 

### UI accessibility concerns?

_None, as this is not changing the UI and is only adding validations on the backend.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## Are there any post deployment tasks we need to perform?

None :) 

