### PR TITLE
Add rate limit for new user comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -56,7 +56,7 @@ class CommentsController < ApplicationController
   # POST /comments
   # POST /comments.json
   def create
-    rate_limit!(:comment_creation)
+    rate_limit!(rate_limit_to_use)
 
     @comment = Comment.new(permitted_attributes(Comment))
     @comment.user_id = current_user.id
@@ -282,5 +282,13 @@ class CommentsController < ApplicationController
   def redirect_to_comment_path
     flash[:error] = "Something went wrong; Comment NOT deleted."
     redirect_to "#{@comment.path}/mod"
+  end
+
+  def rate_limit_to_use
+    if current_user.created_at.before?(3.days.ago.beginning_of_day)
+      :comment_creation
+    else
+      :comment_antispam_creation
+    end
   end
 end

--- a/app/helpers/rate_limit_checker_helper.rb
+++ b/app/helpers/rate_limit_checker_helper.rb
@@ -12,6 +12,12 @@ module RateLimitCheckerHelper
       title: "Limit number of posts created by a new member",
       description: "How many posts can a 3-day-old member create within any 5 minute period?"
     },
+    rate_limit_published_comment_antispam_creation: {
+      min: 0,
+      placeholder: 1,
+      title: "Limit number of comments created by a new member",
+      description: "How many comments can a 3-day-old member create within any 5 minute period?"
+    },
     rate_limit_article_update: {
       min: 1,
       placeholder: 30,

--- a/app/helpers/rate_limit_checker_helper.rb
+++ b/app/helpers/rate_limit_checker_helper.rb
@@ -10,13 +10,7 @@ module RateLimitCheckerHelper
       min: 0,
       placeholder: 1,
       title: "Limit number of posts created by a new member",
-      description: "How many posts can a 3-day-old member create within any 5 minute period?"
-    },
-    rate_limit_published_comment_antispam_creation: {
-      min: 0,
-      placeholder: 1,
-      title: "Limit number of comments created by a new member",
-      description: "How many comments can a 3-day-old member create within any 5 minute period?"
+      description: "How many posts can a new member (3 days or less) create within any 5 minute period?"
     },
     rate_limit_article_update: {
       min: 1,
@@ -59,6 +53,12 @@ module RateLimitCheckerHelper
       placeholder: 9,
       title: "Limit number of comments created",
       description: "How many comments can someone create within any 30 second period?"
+    },
+    rate_limit_comment_antispam_creation: {
+      min: 0,
+      placeholder: 1,
+      title: "Limit number of comments created by a new member",
+      description: "How many comments can a new member (3 days or less) create within any 5 minute period?"
     },
     rate_limit_listing_creation: {
       min: 1,

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -170,6 +170,7 @@ class SiteConfig < RailsSettings::Base
   # Rate limits and spam prevention
   field :rate_limit_follow_count_daily, type: :integer, default: 500
   field :rate_limit_comment_creation, type: :integer, default: 9
+  field :rate_limit_comment_antispam_creation, type: :integer, default: 1
   field :rate_limit_listing_creation, type: :integer, default: 1
   field :rate_limit_published_article_creation, type: :integer, default: 9
   field :rate_limit_published_article_antispam_creation, type: :integer, default: 1
@@ -182,7 +183,6 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_feedback_message_creation, type: :integer, default: 5
   field :rate_limit_user_update, type: :integer, default: 15
   field :rate_limit_user_subscription_creation, type: :integer, default: 3
-  field :rate_limit_published_comment_antispam_creation, type: :integer, default: 1
 
   field :spam_trigger_terms, type: :array, default: []
 

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -182,6 +182,7 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_feedback_message_creation, type: :integer, default: 5
   field :rate_limit_user_update, type: :integer, default: 15
   field :rate_limit_user_subscription_creation, type: :integer, default: 3
+  field :rate_limit_published_comment_antispam_creation, type: :integer, default: 1
 
   field :spam_trigger_terms, type: :array, default: []
 

--- a/app/services/rate_limit_checker.rb
+++ b/app/services/rate_limit_checker.rb
@@ -10,6 +10,7 @@ class RateLimitChecker
     organization_creation: { retry_after: 300 },
     published_article_creation: { retry_after: 30 },
     published_article_antispam_creation: { retry_after: 300 },
+    published_comment_antispam_creation: { retry_after: 300 },
     reaction_creation: { retry_after: 30 },
     send_email_confirmation: { retry_after: 120 },
     user_subscription_creation: { retry_after: 30 },
@@ -95,6 +96,14 @@ class RateLimitChecker
     # TODO: Vaidehi Joshi - We should make this time frame configurable.
     user.articles.published.where("created_at > ?", 5.minutes.ago).size >
       SiteConfig.rate_limit_published_article_antispam_creation
+  end
+
+  def check_published_comment_antispam_creation_limit
+    return true if user.created_at.before?(3.days.ago)
+
+    # TODO: We should make this time frame configurable.
+    user.comments.published.where(created_at: 5.minutes.ago...).size >
+      SiteConfig.rate_limit_published_comment_antispam_creation
   end
 
   def check_follow_account_limit

--- a/app/services/rate_limit_checker.rb
+++ b/app/services/rate_limit_checker.rb
@@ -10,11 +10,11 @@ class RateLimitChecker
     organization_creation: { retry_after: 300 },
     published_article_creation: { retry_after: 30 },
     published_article_antispam_creation: { retry_after: 300 },
-    published_comment_antispam_creation: { retry_after: 300 },
     reaction_creation: { retry_after: 30 },
     send_email_confirmation: { retry_after: 120 },
     user_subscription_creation: { retry_after: 30 },
-    user_update: { retry_after: 30 }
+    user_update: { retry_after: 30 },
+    comment_antispam_creation: { retry_after: 300 }
   }.with_indifferent_access.freeze
 
   def initialize(user = nil)
@@ -98,12 +98,10 @@ class RateLimitChecker
       SiteConfig.rate_limit_published_article_antispam_creation
   end
 
-  def check_published_comment_antispam_creation_limit
-    return true if user.created_at.before?(3.days.ago)
-
+  def check_comment_antispam_creation_limit
     # TODO: We should make this time frame configurable.
-    user.comments.published.where(created_at: 5.minutes.ago...).size >
-      SiteConfig.rate_limit_published_comment_antispam_creation
+    user.comments.where(created_at: 5.minutes.ago...).size >
+      SiteConfig.rate_limit_comment_antispam_creation
   end
 
   def check_follow_account_limit

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe "CommentsCreate", type: :request do
     end
 
     it "returns 429 Too Many Requests when a user reaches their rate limit" do
+      # avoid hitting new user rate limit check
+      allow(user).to receive(:created_at).and_return(1.week.ago)
       allow(rate_limit_checker).to receive(:limit_by_action)
         .with(:comment_creation)
         .and_return(true)

--- a/spec/requests/comments_create_spec.rb
+++ b/spec/requests/comments_create_spec.rb
@@ -33,15 +33,30 @@ RSpec.describe "CommentsCreate", type: :request do
     expect(NotificationSubscription.last.notifiable).to eq(Comment.last)
   end
 
-  it "returns 429 Too Many Requests when a user reaches their rate limit" do
-    allow(RateLimitChecker).to receive(:new).and_return(rate_limit_checker)
-    allow(rate_limit_checker).to receive(:limit_by_action)
-      .with(:comment_creation)
-      .and_return(true)
+  context "when users hit their rate limits" do
+    before do
+      allow(RateLimitChecker).to receive(:new).and_return(rate_limit_checker)
+    end
 
-    post comments_path, params: comment_params
+    it "returns 429 Too Many Requests when a user reaches their rate limit" do
+      allow(rate_limit_checker).to receive(:limit_by_action)
+        .with(:comment_creation)
+        .and_return(true)
 
-    expect(response).to have_http_status(:too_many_requests)
+      post comments_path, params: comment_params
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "returns 429 Too Many Requests when a new user reaches their rate limit" do
+      allow(rate_limit_checker).to receive(:limit_by_action)
+        .with(:comment_antispam_creation)
+        .and_return(true)
+
+      post comments_path, params: comment_params
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
   end
 
   context "when user is posting on an author that blocks user" do

--- a/spec/services/rate_limit_checker_spec.rb
+++ b/spec/services/rate_limit_checker_spec.rb
@@ -26,10 +26,11 @@ RSpec.describe RateLimitChecker, type: :service do
       expect { limiter.limit_by_action(action) }.to raise_error("Invalid Cache Key: no unique component present")
     end
 
-    # We check published_article_creation + :published_article_antispam_creation
-    # limit against database, rather than our cache.
-    described_class::ACTION_LIMITERS.except(:published_article_creation,
-                                            :published_article_antispam_creation).each do |action, _options|
+    # We check the excepted limits against the database, rather than our cache.
+    described_class::ACTION_LIMITERS
+      .except(:published_article_creation,
+              :published_article_antispam_creation,
+              :comment_antispam_creation).each do |action, _options|
       it "returns true if #{action} limit has been reached" do
         allow(Rails.cache).to receive(:read).with(
           cache_key(action), raw: true

--- a/spec/system/comments/user_fills_out_comment_spec.rb
+++ b/spec/system/comments/user_fills_out_comment_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe "Creating Comment", type: :system, js: true do
     let(:rate_limit_checker) { RateLimitChecker.new(user) }
 
     before do
+      # avoid hitting new user rate limit check
+      allow(user).to receive(:created_at).and_return(1.week.ago)
       allow(RateLimitChecker).to receive(:new).and_return(rate_limit_checker)
       allow(rate_limit_checker).to receive(:limit_by_action)
         .with(:comment_creation)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

This PR adds a new rate limit for comments created by new users (account age of 3 days or less). 

## Related Tickets & Documents

https://github.com/forem/rfcs/pull/85

## QA Instructions, Screenshots, Recordings

### Screenshot

Placed this option right below comment creation, where it seems to make the most sense:

![2021-03-09 11_36_54-Configs and 6 more pages - Personal - Microsoft​ Edge Beta](https://user-images.githubusercontent.com/47985/110419464-f6aa3b80-80cb-11eb-9782-3ba91703ed7a.png)

### QA instructions

1. Make a new user or update the created_at attribute of an existing one (`user.touch(:created_at)`)
2. Create a comment
3. Create another comment, you should see an error:
    ![image](https://user-images.githubusercontent.com/47985/110426393-9a99e400-80d8-11eb-824c-19e8e67b9429.png)

### UI accessibility concerns?

n/a

## Added tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] I've updated the [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)