### PR TITLE
[Search 2.0] Add Search::Postgres::Tag behind a feature flag

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -50,9 +50,13 @@ class SearchController < ApplicationController
   ].freeze
 
   def tags
-    tag_docs = Search::Tag.search_documents("name:#{params[:name]}* AND supported:true")
+    result = if FeatureFlag.enabled?(:search_2_tags)
+               Search::Postgres::Tag.search_documents(params[:name])
+             else
+               Search::Tag.search_documents("name:#{params[:name]}* AND supported:true")
+             end
 
-    render json: { result: tag_docs }
+    render json: { result: result }
   rescue Search::Errors::Transport::BadRequest
     render json: { result: [] }
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,6 +10,11 @@ class Tag < ActsAsTaggableOn::Tag
   include Purgeable
   include Searchable
 
+  include PgSearch::Model
+  pg_search_scope :search_by_name,
+                  against: :name,
+                  using: { tsearch: { prefix: true } }
+
   ALLOWED_CATEGORIES = %w[uncategorized language library tool site_mechanic location subcommunity].freeze
   HEX_COLOR_REGEXP = /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/.freeze
 

--- a/app/services/search/postgres/tag.rb
+++ b/app/services/search/postgres/tag.rb
@@ -7,7 +7,7 @@ module Search
         ::Tag
           .search_by_name(term)
           .where(supported: true)
-          .order(hotness_score: :desc)
+          .reorder(hotness_score: :desc)
           .select(*ATTRIBUTES)
           .as_json
       end

--- a/app/services/search/postgres/tag.rb
+++ b/app/services/search/postgres/tag.rb
@@ -1,0 +1,16 @@
+module Search
+  module Postgres
+    class Tag
+      ATTRIBUTES = %i[id name hotness_score rules_html supported short_summary].freeze
+
+      def self.search_documents(term)
+        ::Tag
+          .search_by_name(term)
+          .where(supported: true)
+          .order(hotness_score: :desc)
+          .select(*ATTRIBUTES)
+          .as_json
+      end
+    end
+  end
+end

--- a/db/migrate/20210310154630_add_index_to_tags_supported.rb
+++ b/db/migrate/20210310154630_add_index_to_tags_supported.rb
@@ -1,0 +1,7 @@
+class AddIndexToTagsSupported < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :tags, :supported, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_04_195203) do
+ActiveRecord::Schema.define(version: 2021_03_10_154630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1142,6 +1142,7 @@ ActiveRecord::Schema.define(version: 2021_03_04_195203) do
     t.text "wiki_body_markdown"
     t.index ["name"], name: "index_tags_on_name", unique: true
     t.index ["social_preview_template"], name: "index_tags_on_social_preview_template"
+    t.index ["supported"], name: "index_tags_on_supported"
   end
 
   create_table "tweets", force: :cascade do |t|

--- a/spec/services/search/postgres/tag_spec.rb
+++ b/spec/services/search/postgres/tag_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Search::Postgres::Tag, type: :service do
+  describe "::search_documents" do
+    it "does not find non supported tags" do
+      tag = create(:tag, supported: false)
+
+      expect(described_class.search_documents(tag.name)).to be_empty
+    end
+
+    it "returns data in the expected format" do
+      tag = create(:tag, supported: true)
+
+      result = described_class.search_documents(tag.name)
+
+      expect(result.first.keys).to match_array(
+        %w[id name hotness_score rules_html supported short_summary],
+      )
+    end
+
+    it "finds a tag by its name" do
+      tag = create(:tag, supported: true)
+
+      expect(described_class.search_documents(tag.name)).to be_present
+    end
+
+    it "finds a tag by a partial name" do
+      tag = create(:tag, supported: true)
+
+      expect(described_class.search_documents(tag.name.first(1))).to be_present
+    end
+
+    it "finds multiple tags whose names have common parts", :aggregate_failures do
+      java = create(:tag, name: "java")
+      javascript = create(:tag, name: "javascript")
+      ruby = create(:tag, name: "ruby")
+
+      result = described_class.search_documents("jav")
+      tags = result.map { |r| r["name"] }
+
+      expect(tags).to include(java.name)
+      expect(tags).to include(javascript.name)
+      expect(tags).not_to include(ruby.name)
+    end
+
+    it "order tags by decreasing hotness score" do
+      java = create(:tag, name: "java", hotness_score: 10)
+      javascript = create(:tag, name: "javascript", hotness_score: 20)
+
+      result = described_class.search_documents("jav")
+      tags = result.map { |r| r["name"] }
+
+      expect(tags).to match_array([javascript.name, java.name])
+    end
+  end
+end

--- a/spec/services/search/postgres/tag_spec.rb
+++ b/spec/services/search/postgres/tag_spec.rb
@@ -44,13 +44,21 @@ RSpec.describe Search::Postgres::Tag, type: :service do
     end
 
     it "order tags by decreasing hotness score" do
-      java = create(:tag, name: "java", hotness_score: 10)
-      javascript = create(:tag, name: "javascript", hotness_score: 20)
+      tag1 = create(:tag, name: "javascript1")
+      tag2 = create(:tag, name: "javascript2")
+
+      # see Tag#calculate_hotness_score
+      create(:article, score: 50, tags: [], tag_list: tag1.name)
+      create(:article, score: 100, tags: [], tag_list: tag2.name)
+
+      # to re-calculate the score
+      tag1.save!
+      tag2.save!
 
       result = described_class.search_documents("jav")
       tags = result.map { |r| r["name"] }
 
-      expect(tags).to eq([javascript.name, java.name])
+      expect(tags).to eq([tag2.name, tag1.name])
     end
   end
 end

--- a/spec/services/search/postgres/tag_spec.rb
+++ b/spec/services/search/postgres/tag_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Search::Postgres::Tag, type: :service do
       result = described_class.search_documents("jav")
       tags = result.map { |r| r["name"] }
 
-      expect(tags).to match_array([javascript.name, java.name])
+      expect(tags).to eq([javascript.name, java.name])
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds "searching for tags" behind a feature flag, using the new PostgreSQL FTS added in #12905

A few considerations:

- Our current `/search/tags` endpoint, if it's not given a `name` parameter, [returns an arbitrary list of tags](https://dev.to/search/tags) as ES can both be used as a search engine but also to enumerate indexed documents. Given that nowhere in the frontend we use this latter capability, I decided not to implement it
- If a `name` parameter is not given on the URL, nothing happens and an empty result set is returned. I didn't change it to a 404 to avoid breaking the UI
- Thanks to @Ridhwana I decided to skip the recommended activation of feature flags by way of data update script as we don't want to have admins of other Forems to accidentally enable it until we've tested it thoroughly ourselves

## Related Tickets & Documents

RFC 0153: https://github.com/forem/rfcs/pull/153

Where we use this functionality in the frontend:

https://github.com/forem/forem/blob/4b902b01c039550b86d79298415808193e7f7ffc/app/javascript/shared/components/tags.jsx#L318-L319

## QA Instructions, Screenshots, Recordings

1. Open the website locally, go to http://localhost:3000/new or http://localhost:3000/listings/new and look for tags
2. Load the console, activate the flag with `FeatureFlag.enable(:search_2_tags)`
3. Repeat step 1

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

We'll test it on selected Forems in production and monitor the performance in production
