### PR TITLE
[15 min fix] Adopt session cookie configuration for remember me cookie

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -211,7 +211,7 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  config.rememberable_options = { secure: ApplicationConfig["FORCE_SSL_IN_RAILS"] == "true", same_site: :lax }
 
   # ==> Configuration for :validatable
   # Range for password length.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

After enabling secure session cookies everywhere I noticed how our `remember_user_token` has a slightly different configuration than the [session cookie's](https://github.com/forem/forem/blob/4b902b01c039550b86d79298415808193e7f7ffc/config/initializers/session_store.rb#L21-L22). As I believe those two go hand in hand, I transferred part of the configuration to the "remember me" cookie (`HttpOnly` is always enabled, so no change there).

This will only affect new users or new logins as, unlike Rails, Devise doesn't "upgrade" properties on the existing `remember_me_token`

## QA Instructions, Screenshots, Recordings

1. Start ngrok with `ngrok http 3000`
2. Take note of the https URL
3. set this URL in `.env` in `APP_DOMAIN` and `APP_PROTOCOL` and set `FORCE_SSL_IN_RAILS` to `false`
4. start the app and open the URL in the browser
5. Load the console, change password to your user with `user.reset_password(PASSWORD, PASSWORD)` and login with email and password
6. make sure your `remember_me_token` cookie is set to `Secure: false` and `SameSite: Lax`
7. change `FORCE_SSL_IN_RAILS` in the `.env` file, restart the app
8. make sure you're still logged in, you'll now see that the session cookie has been upgraded to `Secure: true` but the remember me cookie hasn't (this is because Devise doesn't seem to upgrade cookies like Rails does)
9. log out, log in again and you'll see that the `remember_me_token` is not `Secure: true`

## Added tests?

- [ ] Yes
- [x] No, and this is why: gem configuration not applicable in unit test mode, can only be QAed
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
