### PR TITLE
Fix ddtrace warnings at app start

### DIFF
--- a/app/lib/forem_stats_drivers/datadog_driver.rb
+++ b/app/lib/forem_stats_drivers/datadog_driver.rb
@@ -20,7 +20,6 @@ module ForemStatsDrivers
         c.use :excon, split_by_domain: true
         c.use :httpclient, split_by_domain: false
         c.use :httprb, split_by_domain: true
-        c.use :aws
         c.use :rest_client
         c.use :concurrent_ruby
       end

--- a/app/lib/forem_stats_drivers/datadog_driver.rb
+++ b/app/lib/forem_stats_drivers/datadog_driver.rb
@@ -1,3 +1,5 @@
+require 'httpclient'
+
 module ForemStatsDrivers
   class DatadogDriver
     include ActsAsForemStatsDriver

--- a/app/lib/forem_stats_drivers/datadog_driver.rb
+++ b/app/lib/forem_stats_drivers/datadog_driver.rb
@@ -18,7 +18,7 @@ module ForemStatsDrivers
         c.use :http, split_by_domain: false
         c.use :faraday, split_by_domain: true
         c.use :excon, split_by_domain: true
-        c.use :httpclient, split_by_domain: true
+        c.use :httpclient, split_by_domain: false
         c.use :httprb, split_by_domain: true
         c.use :aws
         c.use :rest_client

--- a/app/lib/forem_stats_drivers/datadog_driver.rb
+++ b/app/lib/forem_stats_drivers/datadog_driver.rb
@@ -1,4 +1,4 @@
-require 'httpclient'
+require "httpclient"
 
 module ForemStatsDrivers
   class DatadogDriver


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `ddtrace` gem is tossing out warnings when the app boots:

```
➜  forem git:(master) ✗ rails runner 'puts Datadog::VERSION::STRING'
W, [2021-03-08T15:59:47.137969 #53934]  WARN -- ddtrace: [ddtrace] Unable to patch Datadog::Contrib::Httpclient::Integration (Available?: true, Loaded? false, Compatible? true, Patchable? false)
W, [2021-03-08T15:59:47.138045 #53934]  WARN -- ddtrace: [ddtrace] Unable to patch Datadog::Contrib::Aws::Integration (Available?: false, Loaded? false, Compatible? false, Patchable? false)
0.46.0
```

This PR fixes those warnings:

- Fixed the `httpclient` warning by loading the gem before the instrumentation
  - Seems to be loaded lazily in the `pusher` gem, so it's not being loaded at app boot
  - This PR also disables `split_by_domain` to be more cautious about the service explosion in Datadog we saw with #12908 
- Fixed the `aws` warning by deleting the AWS integration
  - Turns out we aren't using the AWS SDK directly — we use it via Fog, which uses `excon` (which we're already instrumenting)

Result:

```
➜  forem git:(fix-ddtrace-warnings-at-app-start) ✗ rails runner 'puts Datadog::VERSION::STRING'
0.46.0
```


## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [ ] Yes
- [x] No, and this is why: the offending code would have already run before a test could catch it
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

hug the systems team

## [optional] What gif best describes this PR or how it makes you feel?

![oops i did it again](https://media2.giphy.com/media/loFkgbqCLQjSQFC4ja/200.gif)
