### PR TITLE
Part 2: Shows Relevant Posts in Homepage Sidebar

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -56,4 +56,8 @@ module ArticlesHelper
   def utc_iso_timestamp(timestamp)
     timestamp&.utc&.iso8601
   end
+
+  def active_threads(**options)
+    Articles::ActiveThreadsQuery.call(options)
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -210,22 +210,6 @@ class Article < ApplicationRecord
     boosted_additional_tags String, default: ""
   end
 
-  def self.active_threads(tags = ["discuss"], time_ago = nil, number = 10)
-    stories = published.limit(number)
-    stories = if time_ago == "latest"
-                stories.order(published_at: :desc).where(score: -4..).presence || stories.order(published_at: :desc)
-              elsif time_ago
-                stories.order(comments_count: :desc).where(published_at: time_ago.., score: -4..).presence ||
-                  stories.order(comments_count: :desc)
-              else
-                stories.order(last_comment_at: :desc)
-                  .where(published_at: (tags.present? ? 5 : 2).days.ago.., score: -4..).presence ||
-                  stories.order(last_comment_at: :desc)
-              end
-    stories = tags.size == 1 ? stories.cached_tagged_with(tags.first) : stories.tagged_with(tags)
-    stories.pluck(:path, :title, :comments_count, :created_at)
-  end
-
   def self.seo_boostable(tag = nil, time_ago = 18.days.ago)
     # Time ago sometimes returns this phrase instead of a date
     time_ago = 5.days.ago if time_ago == "latest"

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -213,13 +213,15 @@ class Article < ApplicationRecord
   def self.active_threads(tags = ["discuss"], time_ago = nil, number = 10)
     stories = published.limit(number)
     stories = if time_ago == "latest"
-                stories.order(published_at: :desc).where("score > ?", -5)
+                stories.order(published_at: :desc).where("score > ?", -5).presence || stories.order(published_at: :desc)
               elsif time_ago
                 stories.order(comments_count: :desc)
-                  .where("published_at > ? AND score > ?", time_ago, -5)
+                  .where("published_at > ? AND score > ?", time_ago, -5).presence ||
+                  stories.order(comments_count: :desc)
               else
                 stories.order(last_comment_at: :desc)
-                  .where("published_at > ? AND score > ?", (tags.present? ? 5 : 2).days.ago, -5)
+                  .where("published_at > ? AND score > ?", (tags.present? ? 5 : 2).days.ago, -5).presence ||
+                  stories.order(last_comment_at: :desc)
               end
     stories = tags.size == 1 ? stories.cached_tagged_with(tags.first) : stories.tagged_with(tags)
     stories.pluck(:path, :title, :comments_count, :created_at)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -215,8 +215,7 @@ class Article < ApplicationRecord
     stories = if time_ago == "latest"
                 stories.order(published_at: :desc).where(score: -4..).presence || stories.order(published_at: :desc)
               elsif time_ago
-                stories.order(comments_count: :desc)
-                  .where(published_at: time_ago.., score: -4..).presence ||
+                stories.order(comments_count: :desc).where(published_at: time_ago.., score: -4..).presence ||
                   stories.order(comments_count: :desc)
               else
                 stories.order(last_comment_at: :desc)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -213,14 +213,14 @@ class Article < ApplicationRecord
   def self.active_threads(tags = ["discuss"], time_ago = nil, number = 10)
     stories = published.limit(number)
     stories = if time_ago == "latest"
-                stories.order(published_at: :desc).where("score > ?", -5).presence || stories.order(published_at: :desc)
+                stories.order(published_at: :desc).where(score: -4..).presence || stories.order(published_at: :desc)
               elsif time_ago
                 stories.order(comments_count: :desc)
-                  .where("published_at > ? AND score > ?", time_ago, -5).presence ||
+                  .where(published_at: time_ago.., score: -4..).presence ||
                   stories.order(comments_count: :desc)
               else
                 stories.order(last_comment_at: :desc)
-                  .where("published_at > ? AND score > ?", (tags.present? ? 5 : 2).days.ago, -5).presence ||
+                  .where(published_at: (tags.present? ? 5 : 2).days.ago.., score: -4..).presence ||
                   stories.order(last_comment_at: :desc)
               end
     stories = tags.size == 1 ? stories.cached_tagged_with(tags.first) : stories.tagged_with(tags)

--- a/app/queries/articles/active_threads_query.rb
+++ b/app/queries/articles/active_threads_query.rb
@@ -3,16 +3,16 @@ module Articles
     DEFAULT_OPTIONS = {
       tags: ["discuss"],
       time_ago: nil,
-      number: 10
+      count: 10
     }.with_indifferent_access.freeze
 
     MINIMUM_SCORE = -4
 
     def self.call(relation: Article.published, options: {})
       options = DEFAULT_OPTIONS.merge(options)
-      tags, time_ago, number = options.values_at(:tags, :time_ago, :number)
+      tags, time_ago, count = options.values_at(:tags, :time_ago, :count)
 
-      relation.limit(number)
+      relation.limit(count)
       relation = if time_ago == "latest"
                    relation.order(published_at: :desc).where(score: MINIMUM_SCORE..).presence ||
                      relation.order(published_at: :desc)

--- a/app/queries/articles/active_threads_query.rb
+++ b/app/queries/articles/active_threads_query.rb
@@ -1,0 +1,32 @@
+module Articles
+  class ActiveThreadsQuery
+    DEFAULT_OPTIONS = {
+      tags: ["discuss"],
+      time_ago: nil,
+      number: 10
+    }.with_indifferent_access.freeze
+
+    MINIMUM_SCORE = -4
+
+    def self.call(relation: Article.published, options: {})
+      options = DEFAULT_OPTIONS.merge(options)
+      tags, time_ago, number = options.values_at(:tags, :time_ago, :number)
+
+      relation.limit(number)
+      relation = if time_ago == "latest"
+                   relation.order(published_at: :desc).where(score: MINIMUM_SCORE..).presence ||
+                     relation.order(published_at: :desc)
+                 elsif time_ago
+                   relation.order(comments_count: :desc)
+                     .where(published_at: time_ago.., score: MINIMUM_SCORE..).presence ||
+                     relation.order(comments_count: :desc)
+                 else
+                   relation.order(last_comment_at: :desc)
+                     .where(published_at: (tags.present? ? 5 : 2).days.ago.., score: MINIMUM_SCORE..).presence ||
+                     relation.order(last_comment_at: :desc)
+                 end
+      relation = tags.size == 1 ? relation.cached_tagged_with(tags.first) : relation.tagged_with(tags)
+      relation.pluck(:path, :title, :comments_count, :created_at)
+    end
+  end
+end

--- a/app/queries/articles/active_threads_query.rb
+++ b/app/queries/articles/active_threads_query.rb
@@ -21,7 +21,7 @@ module Articles
                      .where(published_at: time_ago.., score: MINIMUM_SCORE..).presence ||
                      relation.order(comments_count: :desc)
                  else
-                   relation.order(last_comment_at: :desc)
+                   relation.order("last_comment_at DESC NULLS LAST")
                      .where(published_at: (tags.present? ? 5 : 2).days.ago.., score: MINIMUM_SCORE..).presence ||
                      relation.order(last_comment_at: :desc)
                  end

--- a/app/views/articles/tags/_sidebar_additional.html.erb
+++ b/app/views/articles/tags/_sidebar_additional.html.erb
@@ -2,7 +2,7 @@
   <div id="sidebar-wrapper-right" class="sidebar-wrapper sidebar-wrapper-right">
     <div class="sidebar-bg" id="sidebar-bg-right"></div>
     <div class="side-bar sidebar-additional showing" id="sidebar-additional">
-      <% active_threads = Articles::ActiveThreadsQuery.call(options: { tags: [@tag, "discuss"], time_ago: Timeframe.datetime(params[:timeframe]) }) %>
+      <% active_threads = active_threads(options: { tags: [@tag, "discuss"], time_ago: Timeframe.datetime(params[:timeframe]) }) %>
       <% if active_threads.present? %>
         <div class="widget">
           <header>

--- a/app/views/articles/tags/_sidebar_additional.html.erb
+++ b/app/views/articles/tags/_sidebar_additional.html.erb
@@ -2,7 +2,7 @@
   <div id="sidebar-wrapper-right" class="sidebar-wrapper sidebar-wrapper-right">
     <div class="sidebar-bg" id="sidebar-bg-right"></div>
     <div class="side-bar sidebar-additional showing" id="sidebar-additional">
-      <% active_threads = Articles::ActiveThreadsQuery.call(relation: Article.published, options: { tags: [@tag, "discuss"], time_ago: Timeframe.datetime(params[:timeframe]) }) %>
+      <% active_threads = Articles::ActiveThreadsQuery.call(options: { tags: [@tag, "discuss"], time_ago: Timeframe.datetime(params[:timeframe]) }) %>
       <% if active_threads.present? %>
         <div class="widget">
           <header>

--- a/app/views/articles/tags/_sidebar_additional.html.erb
+++ b/app/views/articles/tags/_sidebar_additional.html.erb
@@ -2,7 +2,7 @@
   <div id="sidebar-wrapper-right" class="sidebar-wrapper sidebar-wrapper-right">
     <div class="sidebar-bg" id="sidebar-bg-right"></div>
     <div class="side-bar sidebar-additional showing" id="sidebar-additional">
-      <% active_threads = Article.active_threads([@tag, "discuss"], Timeframe.datetime(params[:timeframe])) %>
+      <% active_threads = Articles::ActiveThreadsQuery.call(relation: Article.published, options: { tags: [@tag, "discuss"], time_ago: Timeframe.datetime(params[:timeframe]) }) %>
       <% if active_threads.present? %>
         <div class="widget">
           <header>

--- a/app/views/sidebars/_homepage_content.html.erb
+++ b/app/views/sidebars/_homepage_content.html.erb
@@ -42,7 +42,7 @@
               <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
             <% end %>
           <% else %>
-            <% Articles::ActiveThreadsQuery.call(relation: Article.published, options: { tags: [tag], time_ago: Timeframe.datetime(params[:timeframe]), number: 5 }).each do |plucked_article| %>
+            <% Articles::ActiveThreadsQuery.call(options: { tags: [tag], time_ago: Timeframe.datetime(params[:timeframe]), count: 5 }).each do |plucked_article| %>
               <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
             <% end %>
           <% end %>

--- a/app/views/sidebars/_homepage_content.html.erb
+++ b/app/views/sidebars/_homepage_content.html.erb
@@ -42,7 +42,7 @@
               <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
             <% end %>
           <% else %>
-            <% Article.active_threads([tag], Timeframe.datetime(params[:timeframe]), 5).each do |plucked_article| %>
+            <% Articles::ActiveThreadsQuery.call(relation: Article.published, options: { tags: [tag], time_ago: Timeframe.datetime(params[:timeframe]), number: 5 }).each do |plucked_article| %>
               <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
             <% end %>
           <% end %>

--- a/app/views/sidebars/_homepage_content.html.erb
+++ b/app/views/sidebars/_homepage_content.html.erb
@@ -42,7 +42,7 @@
               <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
             <% end %>
           <% else %>
-            <% Articles::ActiveThreadsQuery.call(options: { tags: [tag], time_ago: Timeframe.datetime(params[:timeframe]), count: 5 }).each do |plucked_article| %>
+            <% active_threads(options: { tags: [tag], time_ago: Timeframe.datetime(params[:timeframe]), count: 5 }).each do |plucked_article| %>
               <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
             <% end %>
           <% end %>

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -697,38 +697,6 @@ RSpec.describe Article, type: :model do
     end
   end
 
-  describe ".active_threads" do
-    let!(:filtered_article) do
-      create(:article, user: user, score: -2, tags: "discuss, watercooler")
-    end
-
-    context "when the articles fall within the constraints" do
-      it "returns the latest published article within the score constraints" do
-        articles = described_class.active_threads("discuss", "latest", 10)
-        expect(articles.first[0]).to eq(filtered_article.path)
-      end
-
-      it "returns the published article within the time_ago and score constraints" do
-        articles = described_class.active_threads("discuss", 1.hour.ago, 10)
-        expect(articles.first[0]).to eq(filtered_article.path)
-      end
-
-      it "returns the published article within the published_at and score constraints" do
-        articles = described_class.active_threads("discuss", 6.days.ago, 10)
-        expect(articles.first[0]).to eq(filtered_article.path)
-      end
-    end
-
-    context "when the articles do not fall within the constraints" do
-      it "returns the published article with the corresponding tag even if it does not fall within the constraints" do
-        article.update_columns(score: -25, cached_tag_list: "discuss")
-        articles = described_class.active_threads("discuss", nil, 10)
-        expect(articles.first[0]).to eq(filtered_article.path)
-        article.update_columns(score: 0, cached_tag_list: "javascript, html, css")
-      end
-    end
-  end
-
   describe ".seo_boostable" do
     let!(:top_article) do
       create(:article, organic_page_views_past_month_count: 20, score: 30, tags: "good, greatalicious", user: user)

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -697,6 +697,48 @@ RSpec.describe Article, type: :model do
     end
   end
 
+  describe ".active_threads" do
+    it "returns the latest published article in descending order" do
+      filtered_article = create(:article, user: user, published: true, score: -3)
+      articles = described_class.active_threads
+      expect(articles).to include(filtered_article)
+    end
+
+    it "returns published articles in descending order if there are no articles that match the criteria" do
+      unfiltered_article = create(:article, user: user, published: true, score: -10)
+      articles = described_class.active_threads
+      expect(articles).to include(unfiltered_article)
+    end
+
+    it "returns the published article filtered by time_ago and comment_count in descending order" do
+      filtered_article = create(:article, user: user,
+                                          published_at: 5.hours.ago, score: -3)
+      articles = described_class.active_threads
+      expect(articles).to include(filtered_article)
+    end
+
+    it "returns published articles filtered by comment_count if there are no aritcles that match the criteria" do
+      unfiltered_article = create(:article, user: user,
+                                            published_at: 10.hours.ago, score: -10)
+      articles = described_class.active_threads
+      expect(articles).to include(unfiltered_article)
+    end
+
+    it "returns the published article filtered by comment_count in descending order" do
+      filtered_article = create(:article, user: user, tags: "discuss",
+                                          published_at: 6.days.ago, score: -3)
+      articles = described_class.active_threads
+      expect(articles).to include(filtered_article)
+    end
+
+    it "returns published articles filtered by desc comment_count if there are no aritcles that match the criteria" do
+      unfiltered_article = create(:article, user: user,
+                                            published_at: 1.day.ago, score: -10)
+      articles = described_class.active_threads
+      expect(articles).to include(unfiltered_article)
+    end
+  end
+
   describe ".seo_boostable" do
     let!(:top_article) do
       create(:article, organic_page_views_past_month_count: 20, score: 30, tags: "good, greatalicious", user: user)

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -699,46 +699,28 @@ RSpec.describe Article, type: :model do
 
   describe ".active_threads" do
     let!(:filtered_article) do
-      create(:article, user: user, score: -3, tags: "discuss, watercooler")
+      create(:article, user: user, score: -2, tags: "discuss, watercooler")
     end
 
-    let!(:unfiltered_article) do
-      create(:article, user: user, score: -10, tags: "discuss, watercooler")
-    end
-
-    it "returns the latest published article in descending order" do
+    it "returns the latest published article within the score constraints" do
       articles = described_class.active_threads("discuss", "latest", 1)
       expect(articles.first[0]).to eq(filtered_article.path)
     end
 
-    it "returns published articles in descending order if there are no articles that match the criteria" do
-      # unfiltered_article = create(:article, user: user, published: true, score: -10)
+    it "returns the published article within the time_ago and score constraints" do
       articles = described_class.active_threads("discuss", 1.hour.ago, 1)
-      expect(articles.flatten).to include(unfiltered_article.path)
-    end
-
-    it "returns the published article filtered by time_ago and comment_count in descending order" do
-      articles = described_class.active_threads("discuss", nil, 1)
       expect(articles.first[0]).to eq(filtered_article.path)
     end
 
-    it "returns published articles filtered by comment_count if there are no aritcles that match the criteria" do
-      # unfiltered_article = create(:article, user: user,
-      #                                       published_at: 10.hours.ago, score: -10)
-      articles = described_class.active_threads("discuss", nil, 1)
-      expect(articles.flatten).to include(unfiltered_article.path)
-    end
-
-    it "returns the published article filtered by comment_count in descending order" do
+    it "returns the published article within the published_at and score constraints" do
       articles = described_class.active_threads("discuss", 6.days.ago, 1)
       expect(articles.first[0]).to eq(filtered_article.path)
     end
 
-    it "returns published articles filtered by desc comment_count if there are no aritcles that match the criteria" do
-      # unfiltered_article = create(:article, user: user,
-      #                                       published_at: 1.day.ago, score: -10)
-      articles = described_class.active_threads("discuss", 1.day.ago, 1)
-      expect(articles.first[0]).to include(unfiltered_article.path)
+    it "returns the published article with the corresponding tag even if it does not fall within the constraints" do
+      unfiltered_article = create(:article, user: user, published: true, score: -25, tags: "discuss, watercooler")
+      articles = described_class.active_threads("discuss", "latest", 1)
+      expect(articles.first[0]).to eq(unfiltered_article.path)
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -698,44 +698,47 @@ RSpec.describe Article, type: :model do
   end
 
   describe ".active_threads" do
+    let!(:filtered_article) do
+      create(:article, user: user, score: -3, tags: "discuss, watercooler")
+    end
+
+    let!(:unfiltered_article) do
+      create(:article, user: user, score: -10, tags: "discuss, watercooler")
+    end
+
     it "returns the latest published article in descending order" do
-      filtered_article = create(:article, user: user, published: true, score: -3)
-      articles = described_class.active_threads
-      expect(articles).to include(filtered_article)
+      articles = described_class.active_threads("discuss", "latest", 1)
+      expect(articles.first[0]).to eq(filtered_article.path)
     end
 
     it "returns published articles in descending order if there are no articles that match the criteria" do
-      unfiltered_article = create(:article, user: user, published: true, score: -10)
-      articles = described_class.active_threads
-      expect(articles).to include(unfiltered_article)
+      # unfiltered_article = create(:article, user: user, published: true, score: -10)
+      articles = described_class.active_threads("discuss", 1.hour.ago, 1)
+      expect(articles.flatten).to include(unfiltered_article.path)
     end
 
     it "returns the published article filtered by time_ago and comment_count in descending order" do
-      filtered_article = create(:article, user: user,
-                                          published_at: 5.hours.ago, score: -3)
-      articles = described_class.active_threads
-      expect(articles).to include(filtered_article)
+      articles = described_class.active_threads("discuss", nil, 1)
+      expect(articles.first[0]).to eq(filtered_article.path)
     end
 
     it "returns published articles filtered by comment_count if there are no aritcles that match the criteria" do
-      unfiltered_article = create(:article, user: user,
-                                            published_at: 10.hours.ago, score: -10)
-      articles = described_class.active_threads
-      expect(articles).to include(unfiltered_article)
+      # unfiltered_article = create(:article, user: user,
+      #                                       published_at: 10.hours.ago, score: -10)
+      articles = described_class.active_threads("discuss", nil, 1)
+      expect(articles.flatten).to include(unfiltered_article.path)
     end
 
     it "returns the published article filtered by comment_count in descending order" do
-      filtered_article = create(:article, user: user, tags: "discuss",
-                                          published_at: 6.days.ago, score: -3)
-      articles = described_class.active_threads
-      expect(articles).to include(filtered_article)
+      articles = described_class.active_threads("discuss", 6.days.ago, 1)
+      expect(articles.first[0]).to eq(filtered_article.path)
     end
 
     it "returns published articles filtered by desc comment_count if there are no aritcles that match the criteria" do
-      unfiltered_article = create(:article, user: user,
-                                            published_at: 1.day.ago, score: -10)
-      articles = described_class.active_threads
-      expect(articles).to include(unfiltered_article)
+      # unfiltered_article = create(:article, user: user,
+      #                                       published_at: 1.day.ago, score: -10)
+      articles = described_class.active_threads("discuss", 1.day.ago, 1)
+      expect(articles.first[0]).to include(unfiltered_article.path)
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -724,7 +724,7 @@ RSpec.describe Article, type: :model do
         article.update_columns(score: -25, cached_tag_list: "discuss")
         articles = described_class.active_threads("discuss", nil, 10)
         expect(articles.first[0]).to eq(filtered_article.path)
-        article.update_columns(score: -2, cached_tag_list: "")
+        article.update_columns(score: 0, cached_tag_list: "javascript, html, css")
       end
     end
   end

--- a/spec/queries/articles/active_threads_query_spec.rb
+++ b/spec/queries/articles/active_threads_query_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
       it "returns article with no ac" do
         article = create(:article, last_comment_at: Time.zone.now, tags: "discuss",
                                    score: described_class::MINIMUM_SCORE)
-        create(:article, last_comment_at: 2.days.ago, tags: "discuss", score: described_class::MINIMUM_SCORE)
+        create(:article, last_comment_at: nil, tags: "discuss", score: described_class::MINIMUM_SCORE)
 
         result = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
         expect(result.length).to eq(2)

--- a/spec/queries/articles/active_threads_query_spec.rb
+++ b/spec/queries/articles/active_threads_query_spec.rb
@@ -1,37 +1,107 @@
 require "rails_helper"
 
 RSpec.describe Articles::ActiveThreadsQuery, type: :query do
-  let(:user) { create(:user) }
-  let!(:filtered_article) do
-    create(:article, user: user, score: -2, tags: "discuss, watercooler")
+  # let(:user) { create(:user) }
+  let!(:completely_unrelated_article) do
+    create(:article, score: described_class::MINIMUM_SCORE - 1, tags: "watercooler")
   end
-  let!(:unfiltered_article) do
-    create(:article, user: user, score: -25, tags: "discuss")
-  end
+  # let!(:unfiltered_article) do
+  #   create(:article, user: user, score: -25, tags: "discuss")
+  # end
+  #
 
-  describe ".call" do
-    context "when the articles fall within the constraints" do
-      it "returns the latest published article falls within the score constraints" do
-        articles = described_class.call(options: { tags: "discuss", time_ago: "latest", count: 10 })
-        expect(articles.flatten).to include(filtered_article.path)
+  describe "::call" do
+    context "when time_ago is latest" do
+      it "returns latest article with good score" do
+        article = create(:article, tags: "discuss", score: described_class::MINIMUM_SCORE + 1)
+        create(:article, published_at: 2.days.ago, tags: "discuss", score: described_class::MINIMUM_SCORE + 1)
+
+        result = described_class.call(options: { tags: "discuss", time_ago: "latest", count: 10 })
+        expect(result.length).to eq(2)
+        expect(result.first.first).to eq(article.path)
       end
 
-      it "returns the published article falls within the time_ago and score constraints" do
-        articles = described_class.call(options: { tags: "discuss", time_ago: 1.hour.ago, count: 10 })
-        expect(articles.flatten).to include(filtered_article.path)
-      end
+      it "returns any article if no good article is found" do
+        article = create(:article, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
 
-      it "returns the published article falls within the published_at and score constraints" do
-        articles = described_class.call(options: { tags: "discuss", time_ago: 6.days.ago, count: 10 })
-        expect(articles.flatten).to include(filtered_article.path)
+        result = described_class.call(options: { tags: "discuss", time_ago: "latest", count: 10 })
+        expect(result.length).to eq(1)
+        expect(result.first.first).to eq(article.path)
       end
     end
 
-    context "when the published article does not fall within the constraints" do
-      it "returns the published article with the corresponding tag" do
-        articles = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
-        expect(articles.flatten).to include(unfiltered_article.path)
+    context "when given a precise time" do
+      it "returns article ordered_by comment ocunt based on time" do
+        time = 2.days.ago
+        article = create(:article, comments_count: 20, published_at: time, tags: "discuss",
+                                   score: described_class::MINIMUM_SCORE)
+        create(:article, comments_count: 10, tags: "discuss", score: described_class::MINIMUM_SCORE)
+        create(:article, published_at: time - 2.days,  comments_count: 30, tags: "discuss",
+                         score: described_class::MINIMUM_SCORE)
+
+        result = described_class.call(options: { tags: "discuss", time_ago: time, count: 10 })
+        expect(result.length).to eq(2)
+        expect(result.first.first).to eq(article.path)
+      end
+
+      it "returns anything when couldn't find quality article" do
+        time = 2.days.ago
+        article = create(:article, comments_count: 20, published_at: time - 5.days, tags: "discuss",
+                                   score: described_class::MINIMUM_SCORE)
+        create(:article, comments_count: 10, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
+
+        result = described_class.call(options: { tags: "discuss", time_ago: time, count: 10 })
+        expect(result.length).to eq(2)
+        expect(result.first.first).to eq(article.path)
+      end
+    end
+
+    context "when time_ago is not given" do
+      it "returns article with no ac" do
+        article = create(:article, last_comment_at: Time.zone.now, tags: "discuss",
+                                   score: described_class::MINIMUM_SCORE)
+        create(:article, last_comment_at: 2.days.ago, tags: "discuss", score: described_class::MINIMUM_SCORE)
+
+        result = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
+        expect(result.length).to eq(2)
+        expect(result.first.first).to eq(article.path)
+      end
+
+      it "returns any article if " do
+        article = create(:article, last_comment_at: Time.zone.now, tags: "discuss",
+                                   score: described_class::MINIMUM_SCORE - 10)
+        create(:article, last_comment_at: 2.days.ago, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
+
+        result = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
+        expect(result.length).to eq(2)
+        expect(result.first.first).to eq(article.path)
       end
     end
   end
+
+  # describe ".call" do
+  #   context "when the articles fall within the constraints" do
+  #     it "returns the latest published article falls within the score constraints" do
+  #       articles = described_class.call(options: { tags: "discuss", time_ago: "latest", count: 10 })
+  #       expect(articles.flatten).to include(filtered_article.path)
+  #     end
+  #
+  #     it "returns the published article falls within the time_ago and score constraints" do
+  #       articles = described_class.call(options: { tags: "discuss", time_ago: 1.hour.ago, count: 10 })
+  #       expect(articles.flatten).to include(filtered_article.path)
+  #     end
+  #
+  #     it "returns the published article falls within the published_at and score constraints" do
+  #       articles = described_class.call(options: { tags: "discuss", time_ago: 6.days.ago, count: 10 })
+  #       expect(articles.flatten).to include(filtered_article.path)
+  #     end
+  #   end
+  #
+  #   context "when the published article does not fall within the constraints" do
+  #     it "returns the published article with the corresponding tag" do
+  #       articles = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
+  #       expect(articles.flatten).to include(unfiltered_article.path)
+  #     end
+  #   end
+  # end
 end

--- a/spec/queries/articles/active_threads_query_spec.rb
+++ b/spec/queries/articles/active_threads_query_spec.rb
@@ -12,24 +12,24 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
   describe ".call" do
     context "when the articles fall within the constraints" do
       it "returns the latest published article falls within the score constraints" do
-        articles = described_class.call(options: { tags: "discuss", time_ago: "latest", number: 10 })
+        articles = described_class.call(options: { tags: "discuss", time_ago: "latest", count: 10 })
         expect(articles.flatten).to include(filtered_article.path)
       end
 
       it "returns the published article falls within the time_ago and score constraints" do
-        articles = described_class.call(options: { tags: "discuss", time_ago: 1.hour.ago, number: 10 })
+        articles = described_class.call(options: { tags: "discuss", time_ago: 1.hour.ago, count: 10 })
         expect(articles.flatten).to include(filtered_article.path)
       end
 
       it "returns the published article falls within the published_at and score constraints" do
-        articles = described_class.call(options: { tags: "discuss", time_ago: 6.days.ago, number: 10 })
+        articles = described_class.call(options: { tags: "discuss", time_ago: 6.days.ago, count: 10 })
         expect(articles.flatten).to include(filtered_article.path)
       end
     end
 
     context "when the published article does not fall within the constraints" do
       it "returns the published article with the corresponding tag" do
-        articles = described_class.call(options: { tags: "discuss", time_ago: nil, number: 10 })
+        articles = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
         expect(articles.flatten).to include(unfiltered_article.path)
       end
     end

--- a/spec/queries/articles/active_threads_query_spec.rb
+++ b/spec/queries/articles/active_threads_query_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Articles::ActiveThreadsQuery, type: :query do
+  let(:user) { create(:user) }
+  let!(:filtered_article) do
+    create(:article, user: user, score: -2, tags: "discuss, watercooler")
+  end
+  let!(:unfiltered_article) do
+    create(:article, user: user, score: -25, tags: "discuss")
+  end
+
+  describe ".call" do
+    context "when the articles fall within the constraints" do
+      it "returns the latest published article falls within the score constraints" do
+        articles = described_class.call(options: { tags: "discuss", time_ago: "latest", number: 10 })
+        expect(articles.flatten).to include(filtered_article.path)
+      end
+
+      it "returns the published article falls within the time_ago and score constraints" do
+        articles = described_class.call(options: { tags: "discuss", time_ago: 1.hour.ago, number: 10 })
+        expect(articles.flatten).to include(filtered_article.path)
+      end
+
+      it "returns the published article falls within the published_at and score constraints" do
+        articles = described_class.call(options: { tags: "discuss", time_ago: 6.days.ago, number: 10 })
+        expect(articles.flatten).to include(filtered_article.path)
+      end
+    end
+
+    context "when the published article does not fall within the constraints" do
+      it "returns the published article with the corresponding tag" do
+        articles = described_class.call(options: { tags: "discuss", time_ago: nil, number: 10 })
+        expect(articles.flatten).to include(unfiltered_article.path)
+      end
+    end
+  end
+end

--- a/spec/queries/articles/active_threads_query_spec.rb
+++ b/spec/queries/articles/active_threads_query_spec.rb
@@ -1,18 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Articles::ActiveThreadsQuery, type: :query do
-  # let(:user) { create(:user) }
-  let!(:completely_unrelated_article) do
+  before do
     create(:article, score: described_class::MINIMUM_SCORE - 1, tags: "watercooler")
   end
-  # let!(:unfiltered_article) do
-  #   create(:article, user: user, score: -25, tags: "discuss")
-  # end
-  #
 
   describe "::call" do
     context "when time_ago is latest" do
-      it "returns latest article with good score" do
+      it "returns the latest article with a good score", :aggregate_failures do
         article = create(:article, tags: "discuss", score: described_class::MINIMUM_SCORE + 1)
         create(:article, published_at: 2.days.ago, tags: "discuss", score: described_class::MINIMUM_SCORE + 1)
 
@@ -21,7 +16,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
         expect(result.first.first).to eq(article.path)
       end
 
-      it "returns any article if no good article is found" do
+      it "returns any article if no higher-quality article is found", :aggregate_failures do
         article = create(:article, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
 
         result = described_class.call(options: { tags: "discuss", time_ago: "latest", count: 10 })
@@ -31,7 +26,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
     end
 
     context "when given a precise time" do
-      it "returns article ordered_by comment ocunt based on time" do
+      it "returns article ordered_by comment_count based on time", :aggregate_failures do
         time = 2.days.ago
         article = create(:article, comments_count: 20, published_at: time, tags: "discuss",
                                    score: described_class::MINIMUM_SCORE)
@@ -44,7 +39,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
         expect(result.first.first).to eq(article.path)
       end
 
-      it "returns anything when couldn't find quality article" do
+      it "returns any article when no higher-quality article could be found", :aggregate_failures do
         time = 2.days.ago
         article = create(:article, comments_count: 20, published_at: time - 5.days, tags: "discuss",
                                    score: described_class::MINIMUM_SCORE)
@@ -57,7 +52,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
     end
 
     context "when time_ago is not given" do
-      it "returns article with no ac" do
+      it "returns articles ordered by last_comment_at, not based on time", :aggregate_failures do
         article = create(:article, last_comment_at: Time.zone.now, tags: "discuss",
                                    score: described_class::MINIMUM_SCORE)
         create(:article, last_comment_at: nil, tags: "discuss", score: described_class::MINIMUM_SCORE)
@@ -67,7 +62,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
         expect(result.first.first).to eq(article.path)
       end
 
-      it "returns any article if " do
+      it "returns any article, with nil articles last, if no higher-quality articles exist", :aggregate_failures do
         article = create(:article, last_comment_at: Time.zone.now, tags: "discuss",
                                    score: described_class::MINIMUM_SCORE - 10)
         create(:article, last_comment_at: 2.days.ago, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
@@ -78,30 +73,4 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
       end
     end
   end
-
-  # describe ".call" do
-  #   context "when the articles fall within the constraints" do
-  #     it "returns the latest published article falls within the score constraints" do
-  #       articles = described_class.call(options: { tags: "discuss", time_ago: "latest", count: 10 })
-  #       expect(articles.flatten).to include(filtered_article.path)
-  #     end
-  #
-  #     it "returns the published article falls within the time_ago and score constraints" do
-  #       articles = described_class.call(options: { tags: "discuss", time_ago: 1.hour.ago, count: 10 })
-  #       expect(articles.flatten).to include(filtered_article.path)
-  #     end
-  #
-  #     it "returns the published article falls within the published_at and score constraints" do
-  #       articles = described_class.call(options: { tags: "discuss", time_ago: 6.days.ago, count: 10 })
-  #       expect(articles.flatten).to include(filtered_article.path)
-  #     end
-  #   end
-  #
-  #   context "when the published article does not fall within the constraints" do
-  #     it "returns the published article with the corresponding tag" do
-  #       articles = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
-  #       expect(articles.flatten).to include(unfiltered_article.path)
-  #     end
-  #   end
-  # end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The "Definition of Done" for this RFC is:

> This feature is deployed to all Forems, and we can assert that every size Forem, regardless of Forem size, can render articles on the sidebar. We should be able to see that every Forem (even if those that have few posts or old posts) can always display posts for a tag, regardless of an article's `published_at` date or `score`.

This PR is part two of a two-part solution to ensure that posts show beneath the tags in the homepage's righthand sidebar, regardless of the Forem's size and the article's `published_at` date and `score`. The second part of this two-part solution focuses specifically on all active tags (including the `#discuss` tag) other than the `#help` tag, in the homepage's righthand sidebar. To accomplish this, I've removed the `active_threads` class method from the `Article` model and replaced it with `Articles::ActiveThreadsQuery` to follow the query object pattern. This is responsible for determining which posts to show under the active tags found in the homepage's righthand sidebar. In addition to this, I've replaced all `.active_threads` calls with `Articles::ActiveThreadsQuery.call(options: {...})` in the necessary views. Finally, I've added a test for this work to `spec/queries/articles/active_threads_query_spec.rb` and removed the tests from `spec/models/article_spec.rb`.

## Related Tickets & Documents
Relates to and closes [RFC 20](https://github.com/forem/rfcs/pull/20)

## QA Instructions, Screenshots, Recordings
**To QA this PR, please first ensure that you have admin-status and then navigate to `/admin/config` and scroll to the `/tags` section**:
<img width="1037" alt="107829988-22920580-6d48-11eb-89c9-5a0c50cb3f3f" src="https://user-images.githubusercontent.com/32834804/110387534-f7d15f00-801e-11eb-8a7a-e4edd87025a6.png">

- In order to have tags display in the sidebar and to test this PR, you need to first set some tags, like "discuss" and "watercooler" (⚠️ in order to test this, you will need to set the "discuss" tag!):
<img width="974" alt="Screen Shot 2021-03-08 at 3 02 33 PM" src="https://user-images.githubusercontent.com/32834804/110387750-526abb00-801f-11eb-8f61-05842a19a928.png">

- After setting the tags, navigate to the homepage and observe that there are no articles beneath the "watercooler" tag and that there are some posts beneath the "discuss" tag (these posts meet the criteria within `Articles::ActiveThreadsQuery`):
<img width="1128" alt="Screen Shot 2021-03-08 at 3 12 51 PM" src="https://user-images.githubusercontent.com/32834804/110388734-c5286600-8020-11eb-9e16-c1725b4a1e0f.png">

- In order to see articles (other than the ones created when you `seed` your database!) displayed beneath the "discuss" and "watercooler" tags, create a post that uses both tags:
<img width="892" alt="Screen Shot 2021-03-08 at 3 22 54 PM" src="https://user-images.githubusercontent.com/32834804/110389723-2997f500-8022-11eb-8897-612bfa7e11df.png">
<img width="910" alt="Screen Shot 2021-03-08 at 3 16 18 PM" src="https://user-images.githubusercontent.com/32834804/110389084-3d8f2700-8021-11eb-957b-7c90c42577c8.png">

- After creating articles with the "discuss" and "watercooler" tags and ensuring that they are lower-quality and do not fall within the constraints of `Articles::ActiveThreadsQuery`, navigate back to the homepage. Observe that your articles tagged with "discuss" and "watercooler" display in the sidebar:
![Screen Shot 2021-03-18 at 12 00 37 PM](https://user-images.githubusercontent.com/32834804/111674380-8ee9a400-87e1-11eb-90e1-1d232674b43f.png)
![Screen Shot 2021-03-18 at 12 01 24 PM](https://user-images.githubusercontent.com/32834804/111674485-ac1e7280-87e1-11eb-8c22-972333dd8031.png)

- Try to break things! ⚒️

### UI accessibility concerns?
None!

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
✅ I updated the Admin Guide in the first part of this two-part work!
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post-deployment tasks we need to perform?
This will need to be deployed to all Forems.

## [optional] What gif best describes this PR or how it makes you feel?

![New Post Gif](https://media.giphy.com/media/f61UuIFFm3MLMkds5b/giphy.gif)
