### PR TITLE
Revert "Adopt session cookie configuration for remember me cookie"

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -211,7 +211,7 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  config.rememberable_options = { secure: ApplicationConfig["FORCE_SSL_IN_RAILS"] == "true", same_site: :lax }
+  # config.rememberable_options = {}
 
   # ==> Configuration for :validatable
   # Range for password length.


### PR DESCRIPTION
This reverts commit cc2b76f7e43f33e15f5cdf84d8d8665188a0c607.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

At 16:00 UTC hours on Wednesday March 10th we've started noticing an uptick on login failures, while we're trying to understand what cause it, we decided to revert this related change

Reverts #12938 