### PR TITLE
Bump MAX_USER_MENTION_LIVE_AT in comment model

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,9 +12,9 @@ class Comment < ApplicationRecord
   COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze
   TITLE_DELETED = "[deleted]".freeze
   TITLE_HIDDEN = "[hidden by post author]".freeze
-  MAX_USER_MENTIONS = 7 # Explicitly set to 7 to accomodate DEV Top Seven Posts
-  # The date that we began limiting the nubmer of user mentions in a comment.
-  MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 3, 11).freeze
+  MAX_USER_MENTIONS = 7 # Explicitly set to 7 to accommodate DEV Top 7 Posts
+  # The date that we began limiting the number of user mentions in a comment.
+  MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 3, 12).freeze
 
   belongs_to :commentable, polymorphic: true, optional: true
   belongs_to :user


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

As I describe in https://github.com/forem/forem/pull/12923#issuecomment-796313142 we deployed the "limit mentions in comments" functionality yesterday to DEV. After confirming that it works as expected, I realized that the Forem fleet would not be deployed until the next day (today, Thursday March 11th), and that the date I set for the `MAX_USER_MENTION_LIVE_AT` would be in the past, but that there will likely be comments that were created after the `MAX_USER_MENTION_LIVE_AT` and before we deploy the fleet.

It seemed to me like the safest option here is to bump this date and ensure that we deploy the Forem fleet before midnight UTC today. I am coordinating with @Zhao-Andy to make sure that the fleet isn't deployed until this change is a part of it.

## Related Tickets & Documents

A follow up to https://github.com/forem/forem/pull/12923.

## QA Instructions, Screenshots, Recordings

You can follow the QA directions outlined [here](https://github.com/forem/forem/pull/12923#issuecomment-794471266), and we also have tests for this functionality :) 

### UI accessibility concerns?

_None!_

## Added tests?

- [ ] Yes
- [x] No, and this is why: _we already have test for this in `spec/models/comment_spec.rb`_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## Are there any post deployment tasks we need to perform?

This will need to be deployed to the Forem fleet shortly after this is merged (or anytime before midnight UTC)
