### PR TITLE
[Search 2.0] Add Search::Postgres::Username behind a feature flag

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -87,9 +87,13 @@ class SearchController < ApplicationController
   end
 
   def usernames
-    usernames = Search::User.search_usernames(params[:username])
+    result = if FeatureFlag.enabled?(:search_2_usernames)
+               Search::Postgres::Username.search_documents(params[:username])
+             else
+               Search::User.search_usernames(params[:username])
+             end
 
-    render json: { result: usernames }
+    render json: { result: result }
   rescue Search::Errors::Transport::BadRequest
     render json: { result: [] }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,11 @@ class User < ApplicationRecord
   include Searchable
   include Storext.model
 
+  include PgSearch::Model
+  pg_search_scope :search_by_username,
+                  against: :username,
+                  using: { tsearch: { prefix: true } }
+
   # @citizen428 Preparing to drop profile columns from the users table
   PROFILE_COLUMNS = %w[
     available_for

--- a/app/services/search/postgres/username.rb
+++ b/app/services/search/postgres/username.rb
@@ -1,0 +1,33 @@
+module Search
+  module Postgres
+    class Username
+      ATTRIBUTES = %i[
+        id
+        name
+        profile_image
+        username
+      ].freeze
+
+      def self.search_documents(term)
+        users = search_users(term)
+
+        # We need to re-map profile_image as the profile_image_90 method on the
+        # User model
+        users.map do |user|
+          {
+            id: user.id,
+            name: user.name,
+            profile_image_90: user.profile_image_90,
+            username: user.username
+          }
+        end.as_json
+      end
+
+      def self.search_users(term)
+        ::User
+          .search_by_username(term)
+          .select(*ATTRIBUTES)
+      end
+    end
+  end
+end

--- a/app/services/search/postgres/username.rb
+++ b/app/services/search/postgres/username.rb
@@ -22,6 +22,8 @@ module Search
           .search_by_username(term)
           .select(*ATTRIBUTES)
       end
+
+      private_class_method :search_users
     end
   end
 end

--- a/app/services/search/postgres/username.rb
+++ b/app/services/search/postgres/username.rb
@@ -11,16 +11,10 @@ module Search
       def self.search_documents(term)
         users = search_users(term)
 
-        # We need to re-map profile_image as the profile_image_90 method on the
-        # User model
         users.map do |user|
-          {
-            id: user.id,
-            name: user.name,
-            profile_image_90: user.profile_image_90,
-            username: user.username
-          }
-        end.as_json
+          user.as_json(only: %i[id name username])
+            .merge("profile_image_90" => user.profile_image_90)
+        end
       end
 
       def self.search_users(term)

--- a/app/services/search/postgres/username.rb
+++ b/app/services/search/postgres/username.rb
@@ -1,6 +1,8 @@
 module Search
   module Postgres
     class Username
+      MAX_RESULTS = 6
+
       ATTRIBUTES = %i[
         id
         name
@@ -20,6 +22,7 @@ module Search
       def self.search_users(term)
         ::User
           .search_by_username(term)
+          .limit(MAX_RESULTS)
           .select(*ATTRIBUTES)
       end
 

--- a/app/services/search/user.rb
+++ b/app/services/search/user.rb
@@ -29,7 +29,8 @@ module Search
               analyze_wildcard: true,
               allow_leading_wildcard: false
             }
-          }
+          },
+          size: Search::Postgres::Username::MAX_RESULTS # Limit the number of results we return to the frontend
         }
       end
 

--- a/db/migrate/20210312191925_add_username_tsvector_index_to_users.rb
+++ b/db/migrate/20210312191925_add_username_tsvector_index_to_users.rb
@@ -1,0 +1,24 @@
+class AddUsernameTsvectorIndexToUsers < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  INDEX = "to_tsvector('simple'::regconfig, COALESCE((username)::text, ''::text))"
+  private_constant :INDEX
+
+  def up
+    return if index_exists?(:users, INDEX, name: "index_usernames_as_tsvector")
+
+    add_index :users,
+              INDEX,
+              using: :gin,
+              algorithm: :concurrently,
+              name: "index_usernames_as_tsvector"
+  end
+
+  def down
+    return unless index_exists?(:users, INDEX, name: "index_usernames_as_tsvector")
+
+    remove_index :users,
+                 name: "index_usernames_as_tsvector",
+                 algorithm: :concurrently
+  end
+end

--- a/db/migrate/20210312191925_add_username_tsvector_index_to_users.rb
+++ b/db/migrate/20210312191925_add_username_tsvector_index_to_users.rb
@@ -5,20 +5,20 @@ class AddUsernameTsvectorIndexToUsers < ActiveRecord::Migration[6.0]
   private_constant :INDEX
 
   def up
-    return if index_exists?(:users, INDEX, name: "index_usernames_as_tsvector")
+    return if index_exists?(:users, INDEX, name: "index_users_on_username_as_tsvector")
 
     add_index :users,
               INDEX,
               using: :gin,
               algorithm: :concurrently,
-              name: "index_usernames_as_tsvector"
+              name: "index_users_on_username_as_tsvector"
   end
 
   def down
-    return unless index_exists?(:users, INDEX, name: "index_usernames_as_tsvector")
+    return unless index_exists?(:users, INDEX, name: "index_users_on_username_as_tsvector")
 
     remove_index :users,
-                 name: "index_usernames_as_tsvector",
+                 name: "index_users_on_username_as_tsvector",
                  algorithm: :concurrently
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_10_154630) do
+ActiveRecord::Schema.define(version: 2021_03_12_191925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1338,6 +1338,7 @@ ActiveRecord::Schema.define(version: 2021_03_10_154630) do
     t.boolean "welcome_notifications", default: true, null: false
     t.datetime "workshop_expiration"
     t.string "youtube_url"
+    t.index "to_tsvector('simple'::regconfig, COALESCE((username)::text, ''::text))", name: "index_usernames_as_tsvector", using: :gin
     t.index ["apple_username"], name: "index_users_on_apple_username"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_at"], name: "index_users_on_created_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1338,7 +1338,7 @@ ActiveRecord::Schema.define(version: 2021_03_12_191925) do
     t.boolean "welcome_notifications", default: true, null: false
     t.datetime "workshop_expiration"
     t.string "youtube_url"
-    t.index "to_tsvector('simple'::regconfig, COALESCE((username)::text, ''::text))", name: "index_usernames_as_tsvector", using: :gin
+    t.index "to_tsvector('simple'::regconfig, COALESCE((username)::text, ''::text))", name: "index_users_on_username_as_tsvector", using: :gin
     t.index ["apple_username"], name: "index_users_on_apple_username"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["created_at"], name: "index_users_on_created_at"

--- a/spec/services/search/postgres/username_spec.rb
+++ b/spec/services/search/postgres/username_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Search::Postgres::Username, type: :service do
+  it "defines necessary constants" do
+    expect(described_class::ATTRIBUTES).not_to be_nil
+    expect(described_class::MAX_RESULTS).not_to be_nil
+  end
+
   describe "::search_documents" do
     it "returns data in the expected format" do
       user = create(:user)
@@ -35,6 +40,19 @@ RSpec.describe Search::Postgres::Username, type: :service do
       expect(usernames).to include(alex.username)
       expect(usernames).to include(alexsmith.username)
       expect(usernames).not_to include(rhymes.username)
+    end
+
+    it "limits the number of results to the value of MAX_RESULTS" do
+      max_results = 1
+      stub_const("#{described_class}::MAX_RESULTS", max_results)
+
+      alex = create(:user, username: "alex")
+      alexsmith = create(:user, username: "alexsmith")
+
+      results = described_class.search_documents("alex")
+
+      expect(results.size).to eq(max_results)
+      expect([alex.username, alexsmith.username]).to include(results.first["username"])
     end
   end
 end

--- a/spec/services/search/postgres/username_spec.rb
+++ b/spec/services/search/postgres/username_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Search::Postgres::Username, type: :service do
+  describe "::search_documents" do
+    it "returns data in the expected format" do
+      user = create(:user)
+
+      result = described_class.search_documents(user.username)
+
+      expect(result.first.keys).to match_array(
+        %w[id name profile_image_90 username],
+      )
+    end
+
+    it "finds a user by their username" do
+      user = create(:user)
+
+      expect(described_class.search_documents(user.username)).to be_present
+    end
+
+    it "finds a user by a partial username" do
+      user = create(:user)
+
+      expect(described_class.search_documents(user.username.first(1))).to be_present
+    end
+
+    it "finds multiple users whose names have common parts", :aggregate_failures do
+      alex = create(:user, username: "alex")
+      alexsmith = create(:user, username: "alexsmith")
+      rhymes = create(:user, username: "rhymes")
+
+      result = described_class.search_documents("ale")
+      usernames = result.map { |r| r["username"] }
+
+      expect(usernames).to include(alex.username)
+      expect(usernames).to include(alexsmith.username)
+      expect(usernames).not_to include(rhymes.username)
+    end
+  end
+end

--- a/spec/services/search/user_spec.rb
+++ b/spec/services/search/user_spec.rb
@@ -86,5 +86,14 @@ RSpec.describe Search::User, type: :service do
     it "does not allow leading wildcards" do
       expect { described_class.search_usernames("*star") }.to raise_error(Search::Errors::Transport::BadRequest)
     end
+
+    it "limits the number of results to the value of MAX_RESULTS" do
+      max_results = 1
+      stub_const("Search::Postgres::Username::MAX_RESULTS", max_results)
+
+      usernames = described_class.search_usernames("star*")
+      expect(usernames.size).to eq(max_results)
+      expect([user1.username, user2.username]).to include(usernames.first["username"])
+    end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR adds "searching for usernames" behind a feature flag, using the new PostgreSQL FTS added in #12905. I don't believe the current search endpoint is being used yet. It is going to be used to support [mention-autocomplete](https://github.com/forem/rfcs/pull/16).

Here is the query plan when I ran this locally against 5,510 users.
```sql
                                                                  QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=2245.58..2245.86 rows=110 width=1277) (actual time=9.138..9.140 rows=19 loops=1)
   Sort Key: (ts_rank(to_tsvector('simple'::regconfig, COALESCE((users_1.username)::text, ''::text)), '''ale'':*'::tsquery, 0)) DESC, users.id
   Sort Method: quicksort  Memory: 35kB
   ->  Hash Join  (cost=1797.38..2241.85 rows=110 width=1277) (actual time=8.068..9.094 rows=19 loops=1)
         Hash Cond: (users.id = users_1.id)
         ->  Seq Scan on users  (cost=0.00..402.20 rows=5520 width=1273) (actual time=0.004..0.625 rows=5510 loops=1)
         ->  Hash  (cost=1796.00..1796.00 rows=110 width=23) (actual time=7.943..7.944 rows=19 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 10kB
               ->  Seq Scan on users users_1  (cost=0.00..1796.00 rows=110 width=23) (actual time=0.726..7.935 rows=19 loops=1)
                     Filter: (to_tsvector('simple'::regconfig, COALESCE((username)::text, ''::text)) @@ '''ale'':*'::tsquery)
                     Rows Removed by Filter: 5491
 Planning Time: 0.452 ms
 Execution Time: 9.254 ms
 ```

## Related Tickets & Documents
RFC 0153: https://github.com/forem/rfcs/pull/153
https://github.com/orgs/forem/projects/29#card-56724640
https://github.com/forem/rfcs/pull/16

## QA Instructions, Screenshots, Recordings
Fire up the console (`rails c`) and run:

```ruby
# Depending on the data in your local DB, you may want to adjust the username
# Here the username is "adm" - short for "admin"
Search::Postgres::Username.search_documents("adm")
```

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
We'll test it on selected Forems in production by turning on the feature flag.

![aol_instant_messenger_sign_in_screen](https://media.giphy.com/media/DOitPFO8XSUcU/giphy.gif)
