### PR TITLE
reenable article rescoring when moderators flag users 

### DIFF
--- a/app/services/moderator/sink_articles.rb
+++ b/app/services/moderator/sink_articles.rb
@@ -1,14 +1,7 @@
 module Moderator
   class SinkArticles
     def self.call(user_id)
-      # rubocop:disable Lint/UnreachableCode
-      # HOTFIX
-      # @mstruve: This worker is broken and needs to be fixed. It can inadvertantly
-      # bump up scores for a user's articles if they have a lot of good reactions
-      # this leads to clumps of articles from the same user in feeds
-      return
       Moderator::SinkArticlesWorker.perform_async(user_id)
-      # rubocop:enable Lint/UnreachableCode
     end
   end
 end

--- a/app/workers/moderator/sink_articles_worker.rb
+++ b/app/workers/moderator/sink_articles_worker.rb
@@ -9,9 +9,10 @@ module Moderator
       return unless user
 
       articles = Article.where(user: user)
-      reactions = Reaction.where(reactable: articles)
-      new_score = reactions.sum(:points) + Reaction.where(reactable: user).sum(:points)
-      articles.update_all(score: new_score)
+      reactions = Reaction.where(reactable: user)
+      articles.each do |article|
+        article.update(score: article.score + reactions.sum(&:points))
+      end
     rescue StandardError => e
       ForemStatsClient.count("moderators.sink", 1, tags: ["action:failed", "user_id:#{user.id}"])
       Honeybadger.notify(e)

--- a/app/workers/moderator/sink_articles_worker.rb
+++ b/app/workers/moderator/sink_articles_worker.rb
@@ -9,13 +9,20 @@ module Moderator
       return unless user
 
       articles = Article.where(user: user)
-      reactions = Reaction.where(reactable: user)
+      user_reactions_total =
+        reaction_score(Reaction.where(reactable: user))
       articles.each do |article|
-        article.update(score: article.score + reactions.sum(&:points))
+        article.update(score: reaction_score(article.reactions) + user_reactions_total)
       end
     rescue StandardError => e
       ForemStatsClient.count("moderators.sink", 1, tags: ["action:failed", "user_id:#{user.id}"])
       Honeybadger.notify(e)
+    end
+
+    private
+
+    def reaction_score(reactions)
+      reactions.sum(:points)
     end
   end
 end

--- a/app/workers/moderator/sink_articles_worker.rb
+++ b/app/workers/moderator/sink_articles_worker.rb
@@ -8,21 +8,10 @@ module Moderator
       user = User.find_by(id: user_id)
       return unless user
 
-      articles = Article.where(user: user)
-      user_reactions_total =
-        reaction_score(Reaction.where(reactable: user))
-      articles.each do |article|
-        article.update(score: reaction_score(article.reactions) + user_reactions_total)
-      end
+      Article.where(user: user).each(&:update_score)
     rescue StandardError => e
       ForemStatsClient.count("moderators.sink", 1, tags: ["action:failed", "user_id:#{user.id}"])
       Honeybadger.notify(e)
-    end
-
-    private
-
-    def reaction_score(reactions)
-      reactions.sum(:points)
     end
   end
 end

--- a/spec/services/moderator/sink_articles_spec.rb
+++ b/spec/services/moderator/sink_articles_spec.rb
@@ -7,16 +7,17 @@ RSpec.describe Moderator::SinkArticles, type: :service do
     create_list(:article, 3, user: user)
     user
   end
+  let(:scores) { -> { spam_user.articles.reload.pluck(:score) } }
   let(:vomit_reaction) { create(:reaction, reactable: spam_user, user: moderator, category: "vomit") }
 
-  xdescribe "#call" do
+  describe "#call" do
     it "lowers all of a user's articles' scores by 25 each if not confirmed" do
       vomit_reaction
       expect do
         sidekiq_perform_enqueued_jobs do
           described_class.call(spam_user.id)
         end
-      end.to change { spam_user.articles.sum(:score) }.from(0).to(-75)
+      end.to change(scores, :call).from([0, 0, 0]).to([-25, -25, -25])
     end
 
     it "lowers all of the user's articles' scores by 50 each if confirmed" do
@@ -25,7 +26,7 @@ RSpec.describe Moderator::SinkArticles, type: :service do
         sidekiq_perform_enqueued_jobs do
           described_class.call(spam_user.id)
         end
-      end.to change { spam_user.articles.sum(:score) }.from(0).to(-150)
+      end.to change(scores, :call).from([0, 0, 0]).to([-50, -50, -50])
     end
   end
 end

--- a/spec/services/moderator/sink_articles_spec.rb
+++ b/spec/services/moderator/sink_articles_spec.rb
@@ -28,5 +28,20 @@ RSpec.describe Moderator::SinkArticles, type: :service do
         end
       end.to change(scores, :call).from([0, 0, 0]).to([-50, -50, -50])
     end
+
+    context "when removing a user vomit reaction" do
+      before do
+        # pretend we had a confirmed vomit on the user
+        spam_user.articles.update(score: -50)
+      end
+
+      it "raises all of the user's articles but the moderation score" do
+        expect do
+          sidekiq_perform_enqueued_jobs do
+            described_class.call(spam_user.id)
+          end
+        end.to change(scores, :call).from([-50, -50, -50]).to([0, 0, 0])
+      end
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The user moderation is expected to rescore (downward) all articles for a user when a vomit reaction is added. Additionally the articles should rescore upward when user moderation reactions are removed. This was disabled last year because it caused some unexpected problems (one users articles were clogging the feed for everyone after everything they had written was given the same, very high, score). The underlying cause was the score calculation, which assigned the same total to all articles.

This PR changes the logic to process each articles score one by one when user moderation is being added or removed. Rather than setting all articles' scores to the sum of the reaction points for all articles, set the score equal to the sum of the reaction points of that one article plus the sum of the user reactions (from moderation). 

Initially I was going to just map a score adjustment (like score = score - 25)  against each of the articles, but realized that there were reasons this was the way it was initially. The main change now is breaking apart the article scoring to be per-article rather than a bulk update, which gains correctness (articles are correctly adjusted up or down) at the potential cost of many round trips to the database. I don't know _how_ frequently user moderation is happening to know if we need to worry about optimizing this as a special bulk query, this is already running in a background process when user vomit reactions are added or removed (which are moderator actions so not publicly available).

## Related Tickets & Documents

https://github.com/forem/forem/pull/9237
https://github.com/forem/forem/pull/6006
https://github.com/forem/forem/pull/6182

Fixes https://github.com/forem/forem/issues/12965

## QA Instructions, Screenshots, Recordings

- As a moderator
- add a vomit reaction to a user
![moderator-flag-user](https://user-images.githubusercontent.com/1237369/110996932-485bfb80-8342-11eb-92d7-9f6c8269d065.png)

- observe worker is started
![sidekiq-logs](https://user-images.githubusercontent.com/1237369/110997097-848f5c00-8342-11eb-83de-97067c0cee22.png)

- verify user's articles' scores have adjusted downward
![articles-scored](https://user-images.githubusercontent.com/1237369/110997159-9e30a380-8342-11eb-9e4b-db4db105f636.png)

- remove the vomit reaction from the user
UI was unclear, but resubmitting the "Flag user" form does trigger the destroy action,  Response from server: {"result":"destroy","category":"vomit"}

- verify worker is started
![sidekiq-logs](https://user-images.githubusercontent.com/1237369/110997105-878a4c80-8342-11eb-8d81-4ff15c024a44.png)

- verify the user's articles scores have adjusted upward (removing the negative feedback)
![score-reset](https://user-images.githubusercontent.com/1237369/110997257-c5877080-8342-11eb-97ee-0321fa6b8b5a.png)



### UI accessibility concerns?

None

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [x] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![moderators keeping abuse in check](https://user-images.githubusercontent.com/1237369/110995621-485afc00-8340-11eb-9607-88c3d3e1f351.gif)
