### PR TITLE
Make definition of new user configurable

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -285,10 +285,10 @@ class CommentsController < ApplicationController
   end
 
   def rate_limit_to_use
-    if current_user.created_at.before?(3.days.ago.beginning_of_day)
-      :comment_creation
-    else
+    if current_user.decorate.considered_new?
       :comment_antispam_creation
+    else
+      :comment_creation
     end
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -109,6 +109,8 @@ class UserDecorator < ApplicationDecorator
 
   def considered_new?
     min_days = SiteConfig.user_considered_new_days
-    created_at.after?(min_days.days.ago.beginning_of_day)
+    return false unless min_days.positive?
+
+    created_at.after?(min_days.days.ago)
   end
 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -106,4 +106,9 @@ class UserDecorator < ApplicationDecorator
   def stackbit_integration?
     access_tokens.any?
   end
+
+  def considered_new?
+    min_days = SiteConfig.user_considered_new_days
+    created_at.after?(min_days.days.ago.beginning_of_day)
+  end
 end

--- a/app/helpers/rate_limit_checker_helper.rb
+++ b/app/helpers/rate_limit_checker_helper.rb
@@ -1,4 +1,12 @@
 module RateLimitCheckerHelper
+  NEW_USER_MESSAGE = "How many %<thing>s can a new member (%<timeframe>s or less) " \
+    "create within any 5 minute period?".freeze
+
+  def self.new_user_message(thing)
+    timeframe = "day".pluralize(SiteConfig.user_considered_new_days)
+    format(NEW_USER_MESSAGE, thing: thing, timeframe: timeframe)
+  end
+
   CONFIGURABLE_RATES = {
     rate_limit_published_article_creation: {
       min: 0,
@@ -10,7 +18,7 @@ module RateLimitCheckerHelper
       min: 0,
       placeholder: 1,
       title: "Limit number of posts created by a new member",
-      description: "How many posts can a new member (3 days or less) create within any 5 minute period?"
+      description: new_user_message("posts")
     },
     rate_limit_article_update: {
       min: 1,
@@ -58,7 +66,7 @@ module RateLimitCheckerHelper
       min: 0,
       placeholder: 1,
       title: "Limit number of comments created by a new member",
-      description: "How many comments can a new member (3 days or less) create within any 5 minute period?"
+      description: new_user_message("comments")
     },
     rate_limit_listing_creation: {
       min: 1,

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -340,7 +340,7 @@ module Constants
         placeholder: ""
       },
       user_considered_new_days: {
-        description: "The number of days a user is considered new",
+        description: "The number of days a user is considered new. Use 0 to disable these checks.",
         placeholder: ::SiteConfig.user_considered_new_days
       },
       video_encoder_key: {

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -340,7 +340,7 @@ module Constants
         placeholder: ""
       },
       user_considered_new_days: {
-        description: "The number of days a user is considered new. Use 0 to disable these checks.",
+        description: "The number of days a user is considered new. The default is 3 days, but you can disable this entirely by inputting 0.",
         placeholder: ::SiteConfig.user_considered_new_days
       },
       video_encoder_key: {

--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -339,6 +339,10 @@ module Constants
         description: "The \"API secret key\" portion of consumer keys in the Twitter developer portal.",
         placeholder: ""
       },
+      user_considered_new_days: {
+        description: "The number of days a user is considered new",
+        placeholder: ::SiteConfig.user_considered_new_days
+      },
       video_encoder_key: {
         description: "Secret key used to allow AWS video encoding through the VideoStatesController",
         placeholder: ""

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -186,6 +186,8 @@ class SiteConfig < RailsSettings::Base
 
   field :spam_trigger_terms, type: :array, default: []
 
+  field :user_considered_new_days, type: :integer, default: 3
+
   # Social Media
   field :social_media_handles, type: :hash, default: {
     twitter: nil,

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -1,7 +1,7 @@
 module Articles
   class Creator
     def initialize(user, article_params, event_dispatcher = Webhook::DispatchEvent)
-      @user = user.decorate
+      @user = user
       @article_params = article_params
       @event_dispatcher = event_dispatcher
     end
@@ -31,7 +31,7 @@ module Articles
     attr_reader :user, :article_params, :event_dispatcher
 
     def rate_limit!
-      rate_limit_to_use = if user.considered_new?
+      rate_limit_to_use = if user.decorate.considered_new?
                             :published_article_antispam_creation
                           else
                             :published_article_creation

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -1,7 +1,7 @@
 module Articles
   class Creator
     def initialize(user, article_params, event_dispatcher = Webhook::DispatchEvent)
-      @user = user
+      @user = user.decorate
       @article_params = article_params
       @event_dispatcher = event_dispatcher
     end
@@ -31,7 +31,7 @@ module Articles
     attr_reader :user, :article_params, :event_dispatcher
 
     def rate_limit!
-      rate_limit_to_use = if user.created_at > 3.days.ago.beginning_of_day
+      rate_limit_to_use = if user.considered_new?
                             :published_article_antispam_creation
                           else
                             :published_article_creation

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -1092,6 +1092,15 @@
                        } %>
             <div id="rateLimitsBodyContainer" class="card-body collapse hide" aria-labelledby="rateLimitsBodyContainer">
               <fieldset class="grid gap-4">
+                <div class="crayons-field">
+                  <%= admin_config_label :user_considered_new_days %>
+                  <%= admin_config_description Constants::SiteConfig::DETAILS[:user_considered_new_days][:description] %>
+                  <%= f.number_field :user_considered_new_days,
+                                     class: "crayons-textfield",
+                                     value: SiteConfig.user_considered_new_days,
+                                     placeholder: Constants::SiteConfig::DETAILS[:user_considered_new_days][:placeholder] %>
+                </div>
+
                 <% configurable_rate_limits.each do |key, field_hash| %>
                   <div class="crayons-field">
                     <%= admin_config_label field_hash[:title] %>

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -228,4 +228,20 @@ RSpec.describe UserDecorator, type: :decorator do
       expect(user.decorate.stackbit_integration?).to be(true)
     end
   end
+
+  describe "#considered_new?" do
+    before do
+      allow(SiteConfig).to receive(:user_considered_new_days).and_return(3)
+    end
+
+    it "returns true for new users" do
+      user.created_at = 1.day.ago
+      expect(user.decorate.considered_new?).to be(true)
+    end
+
+    it "returns false for new users" do
+      user.created_at = 1.year.ago
+      expect(user.decorate.considered_new?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature

## Description

This PR makes the duration a user is considered new configurable via `SiteConfig`. We use this to limit the number of articles and comments a new user can create within a certain timeframe (currently hardcoded to 5 minutes).

## Related Tickets & Documents

https://github.com/forem/rfcs/pull/85

## QA Instructions, Screenshots, Recordings

![image](https://user-images.githubusercontent.com/47985/111252671-39c45b80-8644-11eb-8329-e6e93d1f5442.png)

### UI accessibility concerns?

n/a

## Added tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] I've updated the [Admin Guide](https://forem.gitbook.io/forem-admin-guide/)
- [X] I will share this change internally with the appropriate teams
