### PR TITLE
Add settings model generator

### DIFF
--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -14,3 +14,4 @@ end
 Rails.autoloaders.main.ignore(Rails.root.join("lib/data_update_scripts"))
 Rails.autoloaders.main.ignore(Rails.root.join("lib/generators/data_update"))
 Rails.autoloaders.main.ignore(Rails.root.join("lib/generators/service"))
+Rails.autoloaders.main.ignore(Rails.root.join("lib/generators/settings_model"))

--- a/lib/generators/settings_model/USAGE
+++ b/lib/generators/settings_model/USAGE
@@ -5,7 +5,7 @@ Examples:
     * Generating a settings model (you don't need to specify the Settings::
       namespace)
 
-        $ rails generate settings_model Notificiation
+        $ rails generate settings_model Notification
 
         # db/migrate/<timestamp>_create_settings.rb
         class CreateSettings < ActiveRecord::Migration[6.0]

--- a/lib/generators/settings_model/USAGE
+++ b/lib/generators/settings_model/USAGE
@@ -7,8 +7,8 @@ Examples:
 
         $ rails generate settings_model Notification
 
-        # db/migrate/<timestamp>_create_settings.rb
-        class CreateSettings < ActiveRecord::Migration[6.0]
+        # db/migrate/<timestamp>_create_settings_notifications.rb
+        class CreateSettingsNotifications < ActiveRecord::Migration[6.0]
           def self.up
             create_table :settings_notifications do |t|
               t.string :var, null: false
@@ -26,7 +26,7 @@ Examples:
         end
 
         # app/models/settings/notification.rb
-        module Settngs
+        module Settings
           class Notification < RailsSettings::Base
             self.table_name = :settings_notifications
 

--- a/lib/generators/settings_model/USAGE
+++ b/lib/generators/settings_model/USAGE
@@ -1,0 +1,42 @@
+Description:
+    Generates a settings model.
+
+Examples:
+    * Generating a settings model (you don't need to specify the Settings::
+      namespace)
+
+        $ rails generate settings_model Notificiation
+
+        # db/migrate/<timestamp>_create_settings.rb
+        class CreateSettings < ActiveRecord::Migration[6.0]
+          def self.up
+            create_table :settings_notifications do |t|
+              t.string :var, null: false
+              t.text :value, null: true
+
+              t.timestamps
+            end
+
+            add_index :settings_notifications, :var, unique: true
+          end
+
+          def self.down
+            drop_table :settings_notifications
+          end
+        end
+
+        # app/models/settings/notification.rb
+        module Settngs
+          class Notification < RailsSettings::Base
+            self.table_name = :settings_notifications
+
+            # The configuration is cached, change this if you want to force update
+            # the cache, or call Setting::Notification.clear_cache
+            cache_prefix { "v1" }
+
+            # Define your fields
+            # field :host, type: :string, default: "http://localhost:3000"
+            # field :default_locale, default: "en", type: :string
+          end
+        end
+

--- a/lib/generators/settings_model/settings_model_generator.rb
+++ b/lib/generators/settings_model/settings_model_generator.rb
@@ -28,7 +28,7 @@ class SettingsModelGenerator < Rails::Generators::NamedBase
   def create_migration_file
     migration_template(
       "migration.erb",
-      "db/migrate/create_settings.rb",
+      "db/migrate/create_#{table_name}.rb",
       migration_version: migration_version,
       table_name: table_name,
     )
@@ -54,6 +54,6 @@ class SettingsModelGenerator < Rails::Generators::NamedBase
   end
 
   def table_name
-    @table_name ||= ":settings_#{class_name.underscore.pluralize}"
+    @table_name ||= "settings_#{class_name.underscore.pluralize}"
   end
 end

--- a/lib/generators/settings_model/settings_model_generator.rb
+++ b/lib/generators/settings_model/settings_model_generator.rb
@@ -1,0 +1,59 @@
+# Based on https://github.com/huacnlee/rails-settings-cached/blob/main/lib/generators/settings/install_generator.rb
+
+require "rails/generators"
+require "rails/generators/migration"
+
+class SettingsModelGenerator < Rails::Generators::NamedBase
+  include Rails::Generators::Migration
+
+  argument :name, type: :string, default: "setting"
+
+  source_root File.expand_path("templates", __dir__)
+
+  @migrations = false
+
+  def self.next_migration_number(dirname) #:nodoc:
+    if ActiveRecord::Base.timestamped_migrations
+      if @migrations
+        (current_migration_number(dirname) + 1)
+      else
+        @migrations = true
+        Time.now.utc.strftime("%Y%m%d%H%M%S")
+      end
+    else
+      format "%.3d", current_migration_number(dirname) + 1
+    end
+  end
+
+  def create_migration_file
+    migration_template(
+      "migration.erb",
+      "db/migrate/create_settings.rb",
+      migration_version: migration_version,
+      table_name: table_name,
+    )
+  end
+
+  def create_model
+    template(
+      "model.erb",
+      File.join("app/models/settings", class_path, "#{file_name}.rb"),
+    )
+  end
+
+  def rails_version_major
+    Rails::VERSION::MAJOR
+  end
+
+  def rails_version_minor
+    Rails::VERSION::MINOR
+  end
+
+  def migration_version
+    "[#{rails_version_major}.#{rails_version_minor}]" if rails_version_major >= 5
+  end
+
+  def table_name
+    @table_name ||= ":settings_#{class_name.underscore.pluralize}"
+  end
+end

--- a/lib/generators/settings_model/settings_model_generator.rb
+++ b/lib/generators/settings_model/settings_model_generator.rb
@@ -21,7 +21,7 @@ class SettingsModelGenerator < Rails::Generators::NamedBase
         Time.now.utc.strftime("%Y%m%d%H%M%S")
       end
     else
-      format "%.3d", current_migration_number(dirname) + 1
+      format "%.3<number>d", number: current_migration_number(dirname) + 1
     end
   end
 

--- a/lib/generators/settings_model/templates/migration.erb
+++ b/lib/generators/settings_model/templates/migration.erb
@@ -1,16 +1,16 @@
-class CreateSettings < ActiveRecord::Migration<%= migration_version %>
+class Create<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_version %>
   def self.up
-    create_table <%= table_name %> do |t|
+    create_table :<%= table_name %> do |t|
       t.string :var, null: false
       t.text :value, null: true
 
       t.timestamps
     end
 
-    add_index <%= table_name %>, :var, unique: true
+    add_index :<%= table_name %>, :var, unique: true
   end
 
   def self.down
-    drop_table <%= table_name %>
+    drop_table :<%= table_name %>
   end
 end

--- a/lib/generators/settings_model/templates/migration.erb
+++ b/lib/generators/settings_model/templates/migration.erb
@@ -1,0 +1,16 @@
+class CreateSettings < ActiveRecord::Migration<%= migration_version %>
+  def self.up
+    create_table <%= table_name %> do |t|
+      t.string :var, null: false
+      t.text :value, null: true
+
+      t.timestamps
+    end
+
+    add_index <%= table_name %>, :var, unique: true
+  end
+
+  def self.down
+    drop_table <%= table_name %>
+  end
+end

--- a/lib/generators/settings_model/templates/model.erb
+++ b/lib/generators/settings_model/templates/model.erb
@@ -1,6 +1,6 @@
 module Settings
   class <%= class_name %> < RailsSettings::Base
-    self.table_name = <%= table_name %>
+    self.table_name = :<%= table_name %>
 
     # The configuration is cached, change this if you want to force update
     # the cache, or call Settings::<%= class_name %>.clear_cache

--- a/lib/generators/settings_model/templates/model.erb
+++ b/lib/generators/settings_model/templates/model.erb
@@ -1,0 +1,13 @@
+module Settings
+  class <%= class_name %> < RailsSettings::Base
+    self.table_name = <%= table_name %>
+
+    # The configuration is cached, change this if you want to force update
+    # the cache, or call Settings::<%= class_name %>.clear_cache
+    cache_prefix { "v1" }
+
+    # Define your fields
+    # field :host, type: :string, default: "http://localhost:3000"
+    # field :default_locale, default: "en", type: :string
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

This is step 1 in splitting `SiteConfig` into several smaller models in the `Settings::` namespace. This PR adds a generator for a migration and corresponding model, to make it easier to create new settings tables in the future:

```sh
$ rails generate settings_model --help
Usage:
  rails generate settings_model [NAME] [options]

Options:
  [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Generates a settings model.

Examples:
    * Generating a settings model (you don't need to specify the Settings::
      namespace)

        $ rails generate settings_model Notificiation

        # db/migrate/<timestamp>_create_settings.rb
        class CreateSettings < ActiveRecord::Migration[6.0]
          def self.up
            create_table :settings_notifications do |t|
              t.string :var, null: false
              t.text :value, null: true

              t.timestamps
            end

            add_index :settings_notifications, :var, unique: true
          end

          def self.down
            drop_table :settings_notifications
          end
        end

        # app/models/settings/notification.rb
        module Settngs
          class Notification < RailsSettings::Base
            self.table_name = :settings_notifications

            # The configuration is cached, change this if you want to force update
            # the cache, or call Settings::Notification.clear_cache
            cache_prefix { "v1" }

            # Define your fields
            # field :host, type: :string, default: "http://localhost:3000"
            # field :default_locale, default: "en", type: :string
          end
        end
```

## Related Tickets & Documents

https://github.com/forem/rfcs/pull/126

## QA Instructions, Screenshots, Recordings

1. Generate a new settings model
2. Run the migration
3. Confirm that the table and model match your expectations

### UI accessibility concerns?

n/a

## Added tests?

- [X] No, and this is why: we don't generally test our generators

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: internal developer tooling only
