### PR TITLE
When updating article scores, use new score for blackbox

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -375,8 +375,8 @@ class Article < ApplicationRecord
   end
 
   def update_score
-    new_score = reactions.sum(:points) + Reaction.where(reactable_id: user_id, reactable_type: "User").sum(:points)
-    update_columns(score: new_score,
+    self.score = reactions.sum(:points) + Reaction.where(reactable_id: user_id, reactable_type: "User").sum(:points)
+    update_columns(score: score,
                    comment_score: comments.sum(:score),
                    hotness_score: BlackBox.article_hotness_score(self),
                    spaminess_rating: BlackBox.calculate_spaminess(self))

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1008,4 +1008,13 @@ RSpec.describe Article, type: :model do
       expect(article.plain_html).not_to include("highlight__panel")
     end
   end
+
+  describe "#update_score" do
+    it "stably sets the correct blackbox values" do
+      create(:reaction, reactable: article, points: 1)
+
+      article.update_score
+      expect { article.update_score }.not_to change { article.reload.hotness_score }
+    end
+  end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we call update_score on Articles, we want to mutate the instance before calling the blackbox methods, since the calculations there use `article.score` as input. Saving `self.score=` before then ensures the newly calculated value is factored in to the hotness and spaminess ratings being persisted.

Fixes #13008

## Related Tickets & Documents



## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: Bugfix around behavior that was "eventually consistent", this only impacts the ratings on articles when they're rescored, subsequent rescorings would have corrected and stabilized on the right values.

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![old caclulator](https://user-images.githubusercontent.com/1237369/111351189-ea385c80-8650-11eb-9384-c4d5a89a5c7c.png)
