### PR TITLE
Only check cache or database once

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -396,7 +396,9 @@ class User < ApplicationRecord
   end
 
   def trusted
-    @trusted ||= Rails.cache.fetch("user-#{id}/has_trusted_role", expires_in: 200.hours) do
+    return @trusted if defined? @trusted
+
+    @trusted = Rails.cache.fetch("user-#{id}/has_trusted_role", expires_in: 200.hours) do
       has_role? :trusted
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -890,6 +890,18 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#trusted" do
+    it "memoizes the result from rolify" do
+      allow(Rails.cache)
+        .to receive(:fetch)
+        .with("user-#{user.id}/has_trusted_role", expires_in: 200.hours)
+        .and_return(false)
+        .once
+
+      2.times { user.trusted }
+    end
+  end
+
   describe "profiles" do
     it "automatically creates a profile for new users", :aggregate_failures do
       user = create(:user)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Since `@trusted` is a boolean true/false value, we can't use the
`@ivar || value` pattern, and want instead to check if the variable
has been defined.

Fixes #13006


## Related Tickets & Documents

https://github.com/forem/forem/issues/13006

## QA Instructions, Screenshots, Recordings

Verification with this fix in place that cache/db are only hit once for both trusted and un-trusted users (prior behavior shown in the issue reproduction notes, db queries were occuring each time u.trusted was called for a non-trusted user).

```
[1] pry(main)> u = User.second
[2] pry(main)> u.trusted
  Role Load (0.8ms)  SELECT "roles".* FROM "roles" INNER JOIN "users_roles" ON "roles"."id" = "users_roles"."role_id" WHERE "users_roles"."user_id" = $1 AND (((roles.name = 'trusted') AND (roles.resource_type IS NULL) AND (roles.resource_id IS NULL)))  [["user_id", 2]]
=> false
[3] pry(main)> u.trusted
=> false                
[4] pry(main)> u.trusted
=> false          

[5] pry(main)> u = User.first
[6] pry(main)> u.trusted
  Role Load (2.1ms)  SELECT "roles".* FROM "roles" INNER JOIN "users_roles" ON "roles"."id" = "users_roles"."role_id" WHERE "users_roles"."user_id" = $1 AND (((roles.name = 'trusted') AND (roles.resource_type IS NULL) AND (roles.resource_id IS NULL)))  [["user_id", 1]]
=> true
[7] pry(main)> u.trusted
=> true                 
[8] pry(main)> u.trusted
=> true        
```

### UI accessibility concerns?

None

## Added tests?

- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: Internal optimization

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![rememberme](https://user-images.githubusercontent.com/1237369/111354770-a8111a00-8654-11eb-8f3d-976528b9b208.gif)

