### PR TITLE
Re-Add Reporter Email Form to /admin/reports

### DIFF
--- a/app/helpers/feedback_messages_helper.rb
+++ b/app/helpers/feedback_messages_helper.rb
@@ -1,42 +1,45 @@
 module FeedbackMessagesHelper
+  OFFENDER_EMAIL_BODY = <<~HEREDOC.freeze
+    Hello,
+
+    It has been brought to our attention that you have violated the #{SiteConfig.community_name} Code of Conduct and/or Terms of Use.
+
+    If this behavior continues, we may need to suspend your #{SiteConfig.community_name} account.
+
+    If you think that there's been a mistake, please reply to this email and we will take another look.
+
+    #{SiteConfig.community_name} Team
+  HEREDOC
+
+  REPORTER_EMAIL_BODY = <<~HEREDOC.freeze
+    Hi there,
+    Thank you for flagging content that may be in violation of the #{SiteConfig.community_name} Code of Conduct and/or our Terms of Use. We are looking into your report and will take appropriate action.
+    We appreciate your help as we work to foster a positive and inclusive environment for all!
+    #{SiteConfig.community_name} Team
+  HEREDOC
+
+  AFFECTED_EMAIL_BODY = <<~HEREDOC.freeze
+    Hi there,
+
+    We noticed some comments (made by others) on your post that violate the #{SiteConfig.community_name} Code of Conduct and/or our Terms of Use. We have zero tolerance for such behavior and are taking appropriate action.
+
+    Thanks for being awesome, and please don't hesitate to email us with any questions! We welcome all feedback and ideas as we continue working to foster an open and inclusive community.
+
+    #{SiteConfig.community_name} Team
+  HEREDOC
+
   def offender_email_details
-    body = <<~HEREDOC
-      Hello,
-
-      It has been brought to our attention that you have violated the #{SiteConfig.community_name} Code of Conduct and/or Terms of Use.
-
-      If this behavior continues, we may need to suspend your #{SiteConfig.community_name} account.
-
-      If you think that there's been a mistake, please reply to this email and we will take another look.
-
-      #{SiteConfig.community_name} Team
-    HEREDOC
-
+    body = format(OFFENDER_EMAIL_BODY)
     { subject: "#{SiteConfig.community_name} Code of Conduct Violation", body: body }.freeze
   end
 
   def reporter_email_details
-    body = <<~HEREDOC
-      Hi there,
-      Thank you for flagging content that may be in violation of the #{SiteConfig.community_name} Code of Conduct and/or our Terms of Use. We are looking into your report and will take appropriate action.
-      We appreciate your help as we work to foster a positive and inclusive environment for all!
-      #{SiteConfig.community_name} Team
-    HEREDOC
-
+    body = format(REPORTER_EMAIL_BODY)
     { subject: "#{SiteConfig.community_name} Report", body: body }.freeze
   end
 
   def affected_email_details
-    body = <<~HEREDOC
-      Hi there,
-
-      We noticed some comments (made by others) on your post that violate the #{SiteConfig.community_name} Code of Conduct and/or our Terms of Use. We have zero tolerance for such behavior and are taking appropriate action.
-
-      Thanks for being awesome, and please don't hesitate to email us with any questions! We welcome all feedback and ideas as we continue working to foster an open and inclusive community.
-
-      #{SiteConfig.community_name} Team
-    HEREDOC
-
+    body = format(AFFECTED_EMAIL_BODY)
     { subject: "Courtesy Notice from #{SiteConfig.community_name}", body: body }.freeze
   end
 end

--- a/app/helpers/feedback_messages_helper.rb
+++ b/app/helpers/feedback_messages_helper.rb
@@ -15,6 +15,17 @@ module FeedbackMessagesHelper
     { subject: "#{SiteConfig.community_name} Code of Conduct Violation", body: body }.freeze
   end
 
+  def reporter_email_details
+    body = <<~HEREDOC
+      Hi there,
+      Thank you for flagging content that may be in violation of the #{SiteConfig.community_name} Code of Conduct and/or our Terms of Use. We are looking into your report and will take appropriate action.
+      We appreciate your help as we work to foster a positive and inclusive environment for all!
+      #{SiteConfig.community_name} Team
+    HEREDOC
+
+    { subject: "#{SiteConfig.community_name} Report", body: body }.freeze
+  end
+
   def affected_email_details
     body = <<~HEREDOC
       Hi there,

--- a/app/views/admin/feedback_messages/_feedback_message.html.erb
+++ b/app/views/admin/feedback_messages/_feedback_message.html.erb
@@ -108,14 +108,27 @@
           <h4 class="fw-bold">Email Form:</h4>
           <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="nav-item">
-              <a class="nav-link active" href="#offender-<%= feedback_message.id %>" aria-controls="offender-<%= feedback_message.id %>" role="tab" data-toggle="tab">Offender</a>
+              <a class="nav-link active" href="#reporter-<%= feedback_message.id %>" aria-controls="reporter-<%= feedback_message.id %>" role="tab" data-toggle="tab">Reporter</a>
+            </li>
+            <li role="presentation" class="nav-item">
+              <a class="nav-link" href="#offender-<%= feedback_message.id %>" aria-controls="offender-<%= feedback_message.id %>" role="tab" data-toggle="tab">Offender</a>
             </li>
             <li role="presentation" class="nav-item">
               <a class="nav-link" href="#affected-<%= feedback_message.id %>" aria-controls="affected-<%= feedback_message.id %>" role="tab" data-toggle="tab">Affected</a>
             </li>
           </ul>
           <div class="tab-content my-3">
-            <div role="tabcard" class="tab-pane fade active show" data-id="<%= feedback_message.id %>" data-userType="offender" id="offender-<%= feedback_message.id %>">
+            <div role="tabcard" class="tab-pane fade active show" data-id="<%= feedback_message.id %>" data-userType="reporter" id="reporter-<%= feedback_message.id %>">
+              <div class="crayons-notice crayons-notice--info">Please note that all users who report abuse receive an automatic confirmation email. You can send an additional, follow-up email to this user by using the form below.</div>
+              <br>
+              <h5 class="fw-bold">Send To:</h5>
+              <%= email_field_tag :reporter_email_to, feedback_message.reporter&.email, class: "form-control my-1", id: "reporter__emailto__#{feedback_message.id}", required: true %>
+              <h5 class="fw-bold">Subject:</h5>
+              <%= text_field_tag :reporter_email_subject, reporter_email_details[:subject], class: "form-control my-1", id: "reporter__subject__#{feedback_message.id}" %>
+              <h5 class="fw-bold">Body:</h5>
+              <%= text_area_tag :reporter_email_body, reporter_email_details[:body], class: "form-control my-1", style: "height: 300px;", id: "reporter__body__#{feedback_message.id}" %>
+            </div>
+            <div role="tabcard" class="tab-pane fade" data-id="<%= feedback_message.id %>" data-userType="offender" id="offender-<%= feedback_message.id %>">
               <h5 class="fw-bold">Send To:</h5>
               <%= email_field_tag :offender_email_to, feedback_message.offender&.email, class: "form-control my-1", id: "offender__emailto__#{feedback_message.id}", required: true %>
               <h5 class="fw-bold">Subject:</h5>

--- a/spec/helpers/feedback_messages_helper_spec.rb
+++ b/spec/helpers/feedback_messages_helper_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe FeedbackMessagesHelper, type: :helper do
   describe "#offender_email_details" do
-    it "have proper subject and body" do
+    it "has the proper subject and body" do
       expect(helper.offender_email_details).to include(
         subject: "#{SiteConfig.community_name} Code of Conduct Violation",
         body: a_string_starting_with("Hello"),
@@ -11,7 +11,7 @@ RSpec.describe FeedbackMessagesHelper, type: :helper do
   end
 
   describe "#reporter_email_details" do
-    it "have proper subject and body" do
+    it "has the proper subject and body" do
       expect(helper.reporter_email_details).to include(
         subject: "#{SiteConfig.community_name} Report",
         body: a_string_starting_with("Hi"),
@@ -20,7 +20,7 @@ RSpec.describe FeedbackMessagesHelper, type: :helper do
   end
 
   describe "#affected_email_details" do
-    it "have proper subject and body" do
+    it "has the proper subject and body" do
       expect(helper.affected_email_details).to include(
         subject: "Courtesy Notice from #{SiteConfig.community_name}",
         body: a_string_starting_with("Hi"),

--- a/spec/helpers/feedback_messages_helper_spec.rb
+++ b/spec/helpers/feedback_messages_helper_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe FeedbackMessagesHelper, type: :helper do
     end
   end
 
+  describe "#reporter_email_details" do
+    it "have proper subject and body" do
+      expect(helper.reporter_email_details).to include(
+        subject: "#{SiteConfig.community_name} Report",
+        body: a_string_starting_with("Hi"),
+      )
+    end
+  end
+
   describe "#affected_email_details" do
     it "have proper subject and body" do
       expect(helper.affected_email_details).to include(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR re-adds the ability to manually send emails to abuse reporters via `/admin/reports` and adds a new, informative banner to the Reporter Email form that informs Admins of the following: `"Please note that all users who report abuse receive an automatic confirmation email. You can send an additional, follow-up email to this user by using the form below."`. For additional context, here is what needs to be implemented for this work to be considered "done," as stated in the issue for this PR:

> We should bring back that functionality that was removed previously since Forem admins occasionally need to be able to send a manual email in addition to the automatic ones.
>
> Additionally, for full clarity and communication, it seems important to include a note on this page that tells the Forem Admin that the user already received a confirmation email (sent automatically).

## Related Tickets & Documents
This PR closes issue [395](https://github.com/forem/internalEngineering/issues/395) and relates to PR #12567 

## QA Instructions, Screenshots, Recordings
To QA this PR, please first ensure that you have an `admin`-based role, then do the following:
- Navigate to `/admin/reports` and observe that the "Reporter" email form has been added back, with a `crayons` info banner that informs Admins of the following: `"Please note that all users who report abuse receive an automatic confirmation email. You can send an additional, follow-up email to this user by using the form below."`:
![Screen Shot 2021-03-16 at 12 46 53 PM](https://user-images.githubusercontent.com/32834804/111363635-e5c27280-8655-11eb-8755-eafb8ab3ad72.png)
- While here, test that you are able to send a Reporter an email manually by clicking the "Send Email" button, observing a confirmation that the email was sent, and verifying that the email was sent by checking `/admin/reports`, your console, or your `development.log` for the email:

**_Local Confirmation_**:

![Screen Shot 2021-03-16 at 12 49 53 PM](https://user-images.githubusercontent.com/32834804/111363825-1c988880-8656-11eb-9fb0-a3abb22d4bca.png)
![Screen Shot 2021-03-16 at 4 18 36 PM](https://user-images.githubusercontent.com/32834804/111387516-722f5e00-8673-11eb-9a74-38401414ddab.png)

**_Email Confirmation in Development Log_**:
```
Date: Tue, 16 Mar 2021 12:49:37 -0600
From: DEV Community <yo@dev.to> (local)
To: ullrich+charles@ratke.org
Subject: DEV(local) Community Report

----==_mimepart_6050fdc14d4f4_344c42860712f0
Content-Type: text/plain;
 charset=UTF-8
Content-Transfer-Encoding: 7bit


Hi there,
Thank you for flagging content that may be in violation of the DEV(local) Community Code of Conduct and/or our Terms of Use. We are looking into your report and will take appropriate action.
We appreciate your help as we work to foster a positive and inclusive environment for all!
DEV(local) Community Team



----==_mimepart_6050fdc14d4f4_344c42860712f0
```

### UI accessibility concerns?
Not that I know of!

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
🔍   **_You can find the updated Admin Guide here_**: https://forem.gitbook.io/forem-admin-guide/admin/reports
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Reporter Dog Without a Comment](https://media.giphy.com/media/1iuHoo38f5o1n7vvbs/giphy.gif)
