### PR TITLE
Use faster serializers for Search::Postgres::Tag

### DIFF
--- a/app/services/search/postgres/tag.rb
+++ b/app/services/search/postgres/tag.rb
@@ -4,13 +4,14 @@ module Search
       ATTRIBUTES = %i[id name hotness_score rules_html supported short_summary].freeze
 
       def self.search_documents(term)
-        ::Tag
-          .search_by_name(term)
-          .where(supported: true)
-          .reorder(hotness_score: :desc)
-          .select(*ATTRIBUTES)
-          .as_json
+        results = ::Tag.search_by_name(term).where(supported: true).reorder(hotness_score: :desc).select(*ATTRIBUTES)
+        serialize(results)
       end
+
+      def self.serialize(results)
+        Search::TagSerializer.new(results, is_collection: true).serializable_hash[:data].pluck(:attributes)
+      end
+      private_class_method :serialize
     end
   end
 end

--- a/spec/services/search/postgres/tag_spec.rb
+++ b/spec/services/search/postgres/tag_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Search::Postgres::Tag, type: :service do
       result = described_class.search_documents(tag.name)
 
       expect(result.first.keys).to match_array(
-        %w[id name hotness_score rules_html supported short_summary],
+        %i[id name hotness_score rules_html supported short_summary],
       )
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Search::Postgres::Tag, type: :service do
       ruby = create(:tag, name: "ruby")
 
       result = described_class.search_documents("jav")
-      tags = result.map { |r| r["name"] }
+      tags = result.pluck(:name)
 
       expect(tags).to include(java.name)
       expect(tags).to include(javascript.name)
@@ -56,7 +56,7 @@ RSpec.describe Search::Postgres::Tag, type: :service do
       tag2.save!
 
       result = described_class.search_documents("jav")
-      tags = result.map { |r| r["name"] }
+      tags = result.pluck(:name)
 
       expect(tags).to eq([tag2.name, tag1.name])
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

While researching serializers I noticed the following: when I added `Search::Tag` I used `.as_json` but that uses the default JSON gem which is quite slower than [jsonapi-serializer](https://github.com/jsonapi-serializer/jsonapi-serializer) that we use for Elasticsearch indexing.

Benchmarking speaks for itself:

```ruby
require 'benchmark/ips'

# essentially the query we use to search for tags
data = Tag.search_by_name("l").where(supported: true).reorder(hotness_score: :desc).select(%i[id name hotness_score rules_html supported short_summary])

# see app/serializers/search/tag_serializer.rb, we use this to index tags to ES
module Search
  class TagSerializer < ApplicationSerializer
    attributes :id, :name, :hotness_score, :supported, :short_summary, :rules_html
  end
end

Benchmark.ips do |x|
  x.report("as_json") do
    data.as_json
  end

  x.report("jsonapi-serializer") do
    Search::TagSerializer.new(data).serializable_hash[:data].pluck(:attributes)
  end

  x.compare!
end
```

```text
Warming up --------------------------------------
             as_json   398.000  i/100ms
  jsonapi-serializer   894.000  i/100ms
Calculating -------------------------------------
             as_json      4.123k (± 8.1%) i/s -     20.696k in   5.055469s
  jsonapi-serializer      9.100k (± 7.2%) i/s -     45.594k in   5.041176s

Comparison:
  jsonapi-serializer:     9100.0 i/s
             as_json:     4122.8 i/s - 2.21x  (± 0.00) slower
```

in this tiny case the gem is more than 2 times faster than `.as_json`, in general `jsonapi-serializer` (formerly known as `fastjson_api`) seems to be [consistently faster](https://buttercms.com/blog/json-serialization-in-rails-a-complete-guide) (which is why we use it to ingest data in Elasticsearch and to create hashes from objects for Webhooks)

## Related Tickets & Documents

#12937 

## QA Instructions, Screenshots, Recordings

No need, tests will do.

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: we need the existing tests to pass
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
