### PR TITLE
Add rake task to collect admin overview metrics

### DIFF
--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -6,5 +6,7 @@ module Ahoy
 
     belongs_to :visit
     belongs_to :user, optional: true
+
+    scope :overview_link_clicks, -> { where(name: "Overview Link Clicked") }
   end
 end

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -1,0 +1,9 @@
+namespace :metrics do
+  desc "Collects metrics from Forem instances"
+  task overview: :environment do
+    links_by_target = Ahoy::Event.overview_link_clicks.group("properties -> 'target'").count
+    links_by_target.each do |k, v|
+      puts "#{k.delete_prefix(URL.url)}: #{v}"
+    end
+  end
+end

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -1,6 +1,7 @@
 namespace :metrics do
   desc "Collects metrics from Forem instances"
   task overview: :environment do
+    puts "Admin Overview Link Tracking for #{SiteConfig.app_domain}:"
     links_by_target = Ahoy::Event.overview_link_clicks.group("properties -> 'target'").count
     links_by_target.each do |k, v|
       puts "#{k.delete_prefix(URL.url)}: #{v}"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A quick rake task to grab Ahoy events tracking which links have been clicked in the admin overview.

Usage: `bundle exec rake metrics:overview`

## Related Tickets & Documents

Closes https://github.com/forem/internalEngineering/issues/400

## QA Instructions, Screenshots, Recordings

Example:

```
$ bundle exec rake metrics:overview
/admin/invitations: 1
/admin/welcome: 1
```

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [ ] Yes
- [x] No, and this is why: We probably don't need to be testing a temporary Rake task
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
