### PR TITLE
Ensure user data is unset if no user is logged in

### DIFF
--- a/app/assets/javascripts/initializers/initializeBodyData.js
+++ b/app/assets/javascripts/initializers/initializeBodyData.js
@@ -47,6 +47,10 @@ function fetchBaseData() {
             ga('set', 'userId', JSON.parse(json.user).id);
           }
         }, 400);
+      } else {
+        // Ensure user data is not exposed if no one is logged in
+        document.body.dataset.user = undefined;
+        browserStoreCache('remove');
       }
     }
   };

--- a/app/assets/javascripts/initializers/initializeBodyData.js
+++ b/app/assets/javascripts/initializers/initializeBodyData.js
@@ -49,7 +49,7 @@ function fetchBaseData() {
         }, 400);
       } else {
         // Ensure user data is not exposed if no one is logged in
-        document.body.dataset.user = undefined;
+        delete document.body.dataset.user;
         browserStoreCache('remove');
       }
     }

--- a/cypress/integration/loginFlows/userLogin.spec.js
+++ b/cypress/integration/loginFlows/userLogin.spec.js
@@ -32,5 +32,8 @@ describe('User Login', () => {
     // User should be redirected to onboarding
     const { baseUrl } = Cypress.config();
     cy.url().should('equal', `${baseUrl}?signin=true`);
+
+    // User data should exist on the document
+    cy.document().should('have.nested.property', 'body.dataset.user');
   });
 });

--- a/cypress/integration/loginFlows/userLogin.spec.js
+++ b/cypress/integration/loginFlows/userLogin.spec.js
@@ -32,8 +32,5 @@ describe('User Login', () => {
     // User should be redirected to onboarding
     const { baseUrl } = Cypress.config();
     cy.url().should('equal', `${baseUrl}?signin=true`);
-
-    // User data should exist on the document
-    cy.document().should('have.nested.property', 'body.dataset.user');
   });
 });

--- a/cypress/integration/loginFlows/userLogout.spec.js
+++ b/cypress/integration/loginFlows/userLogout.spec.js
@@ -1,4 +1,4 @@
-describe('User Login', () => {
+describe('User Logout', () => {
   beforeEach(() => {
     cy.testSetup();
 

--- a/cypress/integration/loginFlows/userLogout.spec.js
+++ b/cypress/integration/loginFlows/userLogout.spec.js
@@ -23,7 +23,10 @@ describe('User Logout', () => {
     const { baseUrl } = Cypress.config();
     cy.url().should('equal', `${baseUrl}`);
 
-    // User data should not exist on the document
-    cy.document().should('not.have.nested.property', 'body.dataset.user');
+    // User data should not exist on the document or in localStorage
+    cy.document().should((doc) => {
+      expect(doc.body.dataset).not.to.have.property('user');
+      expect(localStorage.getItem('current_user')).to.be.null;
+    });
   });
 });

--- a/cypress/integration/loginFlows/userLogout.spec.js
+++ b/cypress/integration/loginFlows/userLogout.spec.js
@@ -1,0 +1,29 @@
+describe('User Login', () => {
+  beforeEach(() => {
+    cy.testSetup();
+
+    cy.fixture('users/changePasswordUser.json').as('user');
+
+    cy.get('@user').then((user) => {
+      cy.loginUser(user).then(() => {
+        cy.visit('/');
+      });
+    });
+  });
+
+  it('should allow a user to logout', () => {
+    // Click on the sign out button
+    cy.findByText('Sign Out').click({ force: true });
+
+    // Sign out confirmation page is rendered
+    cy.url().should('contains', '/signout_confirm');
+    cy.findByText('Yes, sign out').click();
+
+    // User should be redirected to the homepage
+    const { baseUrl } = Cypress.config();
+    cy.url().should('equal', `${baseUrl}`);
+
+    // User data should not exist on the document
+    cy.document().should('not.have.nested.property', 'body.dataset.user');
+  });
+});


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Immediately after a user logs out, the user object is still present (with their data) on the document. That causes some of our JS code to act a little odd and probably isn't the most secure thing in the world.

There might be a better way to do this, but this is pretty predictable and solves the issue.

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/12679

## QA Instructions, Screenshots, Recordings

Re: #12679

https://user-images.githubusercontent.com/11466782/111477500-2cb77300-86fd-11eb-9d6e-fb04542ca1b4.mp4

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [ ] Yes
- [x] No, and this is why: I'm not sure if we want a regression test for this, but I can add one if we do.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: minor bug fix
