### PR TITLE
Use faster serializers for Search::Postgres::Username

### DIFF
--- a/app/serializers/search/username_serializer.rb
+++ b/app/serializers/search/username_serializer.rb
@@ -1,0 +1,8 @@
+module Search
+  class UsernameSerializer < ApplicationSerializer
+    attributes :id,
+               :name,
+               :profile_image_90,
+               :username
+  end
+end

--- a/app/services/search/postgres/username.rb
+++ b/app/services/search/postgres/username.rb
@@ -11,22 +11,18 @@ module Search
       ].freeze
 
       def self.search_documents(term)
-        users = search_users(term)
+        results = ::User.search_by_username(term).limit(MAX_RESULTS).select(*ATTRIBUTES)
 
-        users.map do |user|
-          user.as_json(only: %i[id name username])
-            .merge("profile_image_90" => user.profile_image_90)
-        end
+        serialize(results)
       end
 
-      def self.search_users(term)
-        ::User
-          .search_by_username(term)
-          .limit(MAX_RESULTS)
-          .select(*ATTRIBUTES)
+      def self.serialize(results)
+        Search::UsernameSerializer
+          .new(results, is_collection: true)
+          .serializable_hash[:data]
+          .pluck(:attributes)
       end
-
-      private_class_method :search_users
+      private_class_method :serialize
     end
   end
 end

--- a/spec/services/search/postgres/username_spec.rb
+++ b/spec/services/search/postgres/username_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Search::Postgres::Username, type: :service do
       result = described_class.search_documents(user.username)
 
       expect(result.first.keys).to match_array(
-        %w[id name profile_image_90 username],
+        %i[id name profile_image_90 username],
       )
     end
 
@@ -35,7 +35,7 @@ RSpec.describe Search::Postgres::Username, type: :service do
       rhymes = create(:user, username: "rhymes")
 
       result = described_class.search_documents("ale")
-      usernames = result.map { |r| r["username"] }
+      usernames = result.pluck(:username)
 
       expect(usernames).to include(alex.username)
       expect(usernames).to include(alexsmith.username)
@@ -52,7 +52,7 @@ RSpec.describe Search::Postgres::Username, type: :service do
       results = described_class.search_documents("alex")
 
       expect(results.size).to eq(max_results)
-      expect([alex.username, alexsmith.username]).to include(results.first["username"])
+      expect([alex.username, alexsmith.username]).to include(results.first[:username])
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Inspired by the findings of @rhymes in https://github.com/forem/forem/pull/13022, this PR updates `Search::Postgres::Username` to use a serializer over `.as_json`.

```ruby
require 'benchmark/ips'

data = User.search_by_username("a").limit(6).select(%i[id name profile_image username])

Benchmark.ips do |x|
  x.report("as_json") do
    data.as_json
  end
  
  x.report("jsonapi-serializer") do
    Search::UsernameSerializer.new(data, is_collection: true).serializable_hash[:data].pluck(:attributes)
  end
  
  x.compare!
end
```

```
Warming up --------------------------------------
             as_json   237.000  i/100ms
  jsonapi-serializer   828.000  i/100ms
Calculating -------------------------------------
             as_json      2.406k (± 4.7%) i/s -     12.087k in   5.035621s
  jsonapi-serializer      7.780k (± 4.2%) i/s -     38.916k in   5.010714s

Comparison:
  jsonapi-serializer:     7780.5 i/s
             as_json:     2405.6 i/s - 3.23x  (± 0.00) slower
```

This more than 3x faster 🎉 .

## Related Tickets & Documents
https://github.com/forem/forem/pull/12975

## QA Instructions, Screenshots, Recordings
N/A - specs will do!

### UI accessibility concerns?
N/A

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

![must_go_faster_jurassic_park_gif](https://media.giphy.com/media/7XsFGzfP6WmC4/giphy.gif)
