### PR TITLE
Get the correct episode by finding the given podcast's episodes

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -46,7 +46,7 @@ class StoriesController < ApplicationController
       handle_possible_redirect
     else
       @podcast = Podcast.available.find_by!(slug: params[:username])
-      @episode = PodcastEpisode.available.find_by!(slug: params[:slug])
+      @episode = @podcast.podcast_episodes.available.find_by!(slug: params[:slug])
       handle_podcast_show
     end
   end

--- a/spec/requests/podcasts/podcast_episodes_index_spec.rb
+++ b/spec/requests/podcasts/podcast_episodes_index_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "PodcastEpisodesSpec", type: :request do
+RSpec.describe "Podcast Episodes Index Spec", type: :request do
   describe "GET podcast episodes index" do
     it "renders page with proper sidebar" do
       get "/pod"

--- a/spec/requests/podcasts/podcast_episodes_show_spec.rb
+++ b/spec/requests/podcasts/podcast_episodes_show_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe "Podcast Episodes Show Spec", type: :request do
+  describe "GET podcast episodes show" do
+    it "renders the correct podcast episode" do
+      podcast = create(:podcast)
+      podcast_episode = create(:podcast_episode, podcast: podcast)
+      get "/#{podcast.slug}/#{podcast_episode.slug}"
+      expect(response.body).to include podcast_episode.title
+    end
+
+    it "does not render another podcast's episode if the wrong podcast slug is given" do
+      podcast = create(:podcast)
+      other_podcast = create(:podcast)
+      podcast_episode = create(:podcast_episode, podcast: podcast)
+      expect do
+        get "/#{other_podcast.slug}/#{podcast_episode.slug}"
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description

**TLDR: you can visit another podcast's episode even with the wrong `podcast.slug`. This fixes that.**

So this bug occurred because podcast A had an episode with the same exact `slug` as podcast B. Podcast B's episode was created before podcast A's episode, so in our controller we pulled that episode instead. This is therefore a two part bug, where we:
1. don't have a uniqueness value for `podcast_episodes.slug`
2. `find_by` a podcast episode to render only by its `slug`, and not including the given `podcast.slug`

Interestingly, this means that you can visit a podcast episode's page and play that episode even if you're looking at a different podcast. For example, the Hanselminutes episode has URL of `/hanselminutes/programmatic-problem-solving-with-nicole-archambault`. You can technically change `hanselminutes` to any other valid podcast, like `devdiscuss`: https://dev.to/devdiscuss/programmatic-problem-solving-with-nicole-archambault

I think we'll want to discuss whether or not we want to:
1. enforce `podcast_episodes.slug` uniqueness. This means we'll need to handle appropriately if a slug is the same, maybe by adding an ID code like we do with `comments.slug`:
```ruby
"hanselminutes/programmatic-problem-solving-with-nicole-archambault-#{podcast_episode.id.to_s(26)}"
```
2. allow `podcast_episodes.slug` to be non-unique, and therefore display the appropriate podcast episode by updating the `stories_controller#show` action.

I think #2 is far easier solution, and wouldn't have to run any checks on the slug when creating a podcast episode (which is a task that happens pretty often, especially if the Forem has a lot of podcasts).

## Related Tickets & Documents
Resolves https://github.com/forem/forem/issues/13028
https://github.com/forem/internalCommunity/issues/55

## QA Instructions, Screenshots, Recordings
1. Visit `/:podcast_slug/:podcast_episode_slug` and see that it renders the appropriate podcast episode
2. Visit `/:other_podcast_slug/:podcast_episode_slug` and see that 404s / raises `ApplicationNotFound` error

### UI accessibility concerns?
Nope

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: This is a basic bug fix that very few people have run into, and communication by closing the issues is enough IMO.

## [optional] Are there any post deployment tasks we need to perform?
Nope