### PR TITLE
Change PushNotifications::Send to use user_ids

### DIFF
--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -3,6 +3,7 @@ class DevicesController < ApplicationController
   # This replaces the Authenticated Users Pusher Beams solution.
   # See: https://github.com/forem/forem/pull/12419/files#r563906038
   before_action :authenticate_user!, only: [:create]
+  skip_before_action :verify_authenticity_token, only: [:destroy]
 
   rescue_from ActiveRecord::ActiveRecordError do |exc|
     render json: { error: exc.message, status: 422 }, status: :unprocessable_entity
@@ -18,7 +19,7 @@ class DevicesController < ApplicationController
   end
 
   def destroy
-    device = Device.find_by(id: params[:id])
+    device = Device.find_by(unauthenticated_params)
     unless device
       render json: { error: "Not Found", status: 404 }, status: :not_found
       return
@@ -37,6 +38,21 @@ class DevicesController < ApplicationController
   def device_params
     {
       user: current_user,
+      token: params[:token],
+      platform: params[:platform],
+      app_bundle: params[:app_bundle]
+    }
+  end
+
+  # Unauthenticated params are used for `destroy` because in the mobile apps
+  # we react to when a user "has logged out", meaning we no longer have the
+  # `current_user` to validate ownership of the Device. In this case we
+  # confirm the ownership if all the values from `unauthenticated_params`
+  # match a Device. This is guaranteed because the PN token is unique per app
+  # & device, i.e. only the real owner of the device is able to provide them.
+  def unauthenticated_params
+    {
+      user_id: params[:id],
       token: params[:token],
       platform: params[:platform],
       app_bundle: params[:app_bundle]

--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -34,7 +34,7 @@ module Notifications
           )
         end
 
-        targets = User.where(id: user_ids, mobile_comment_notifications: true).ids
+        targets = User.where(id: user_ids, mobile_comment_notifications: true).order(:id).ids
 
         # Pusher Beams uses named Pub/Sub channels instead of raw user_ids
         target_channels = targets.map { |id| "user-notifications-#{id}" }

--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -17,14 +17,14 @@ module Notifications
         return if comment.score.negative?
 
         user_ids = Set.new(comment_user_ids + subscribed_user_ids + top_level_user_ids + author_subscriber_user_ids)
+        user_ids = user_ids.delete(comment.user_id)
 
         json_data = {
           user: user_data(comment.user),
           comment: comment_data(comment)
         }
 
-        targets = []
-        user_ids.delete(comment.user_id).each do |user_id|
+        user_ids.each do |user_id|
           Notification.create(
             user_id: user_id,
             notifiable_id: comment.id,
@@ -32,12 +32,25 @@ module Notifications
             action: nil,
             json_data: json_data,
           )
-
-          targets << "user-notifications-#{user_id}" if User.find_by(id: user_id)&.mobile_comment_notifications
         end
 
-        # Sends the push notification to Pusher Beams channels. Batch is in place to respect Pusher 100 channel limit.
-        targets.each_slice(100) { |batch| send_push_notifications(batch) }
+        targets = User.where(id: user_ids, mobile_comment_notifications: true).ids
+
+        if FeatureFlag.enabled?(:mobile_notifications)
+          # Send PNs using Rpush
+          PushNotifications::Send.call(
+            user_ids: targets,
+            title: "@#{comment.user.username}",
+            body: "re: #{comment.parent_or_root_article.title.strip}",
+            payload: { url: URL.url("/notifications/comments") },
+          )
+        else
+          # Pusher Beams uses named Pub/Sub channels instead of raw user_ids
+          targets.map! { |user_id| "user-notifications-#{user_id}" }
+          # Sends the push notification to Pusher Beams channels.
+          # Batch is in place to respect Pusher 100 channel limit.
+          targets.each_slice(100) { |batch| send_push_notifications(batch) }
+        end
 
         return unless comment.commentable.organization_id
 

--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -34,7 +34,7 @@ module Notifications
           )
         end
 
-        targets = User.where(id: user_ids, mobile_comment_notifications: true).order(:id).ids
+        targets = User.where(id: user_ids, mobile_comment_notifications: true).ids
 
         # Pusher Beams uses named Pub/Sub channels instead of raw user_ids
         target_channels = targets.map { |id| "user-notifications-#{id}" }
@@ -44,11 +44,12 @@ module Notifications
 
         if FeatureFlag.enabled?(:mobile_notifications)
           # Send PNs using Rpush
+          url_path = Rails.application.routes.url_helpers.notifications_path(:comments)
           PushNotifications::Send.call(
             user_ids: targets,
             title: "@#{comment.user.username}",
-            body: "re: #{comment.parent_or_root_article.title.strip}",
-            payload: { url: URL.url("/notifications/comments") },
+            body: "Re: #{comment.parent_or_root_article.title.strip}",
+            payload: { url: URL.url(url_path) },
           )
         end
 

--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -17,7 +17,7 @@ module Notifications
         return if comment.score.negative?
 
         user_ids = Set.new(comment_user_ids + subscribed_user_ids + top_level_user_ids + author_subscriber_user_ids)
-        user_ids = user_ids.delete(comment.user_id)
+        user_ids.delete(comment.user_id)
 
         json_data = {
           user: user_data(comment.user),

--- a/app/services/push_notifications/send.rb
+++ b/app/services/push_notifications/send.rb
@@ -1,11 +1,11 @@
 module PushNotifications
   class Send
-    def self.call(user:, title:, body:, payload:)
-      new(user: user, title: title, body: body, payload: payload).call
+    def self.call(user_ids:, title:, body:, payload:)
+      new(user_ids: user_ids, title: title, body: body, payload: payload).call
     end
 
-    def initialize(user:, title:, body:, payload:)
-      @user = user
+    def initialize(user_ids:, title:, body:, payload:)
+      @user_ids = user_ids
       @title = title
       @body = body
       @payload = payload
@@ -14,7 +14,7 @@ module PushNotifications
     def call
       return unless FeatureFlag.enabled?(:mobile_notifications)
 
-      @user.devices.find_each do |device|
+      Device.where(user_id: @user_ids).find_each do |device|
         device.create_notification(@title, @body, @payload)
       end
 

--- a/spec/requests/devices_spec.rb
+++ b/spec/requests/devices_spec.rb
@@ -44,21 +44,15 @@ RSpec.describe "Devices", type: :request do
 
   describe "DELETE /users/devices/:id" do
     let(:device) { create(:device, user: user) }
-    let(:params) do
-      {
-        token: device.token,
-        platform: device.platform,
-        app_bundle: device.app_bundle
-      }
-    end
-    let(:incomplete_params) do
-      {
-        platform: device.platform,
-        app_bundle: device.app_bundle
-      }
-    end
 
     context "when device not found" do
+      let(:incomplete_params) do
+        {
+          platform: device.platform,
+          app_bundle: device.app_bundle
+        }
+      end
+
       it "returns an error" do
         delete "/users/devices/123"
         expect(response.status).to eq(404)
@@ -75,6 +69,14 @@ RSpec.describe "Devices", type: :request do
     end
 
     context "when device deleted" do
+      let(:params) do
+        {
+          token: device.token,
+          platform: device.platform,
+          app_bundle: device.app_bundle
+        }
+      end
+
       it "deletes the device" do
         delete "/users/devices/#{device.user.id}", params: params
         expect(user.devices.count).to eq(0)

--- a/spec/requests/devices_spec.rb
+++ b/spec/requests/devices_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe "Devices", type: :request do
 
   describe "DELETE /users/devices/:id" do
     let(:device) { create(:device, user: user) }
+    let(:params) do
+      {
+        token: device.token,
+        platform: device.platform,
+        app_bundle: device.app_bundle
+      }
+    end
+    let(:incomplete_params) do
+      {
+        platform: device.platform,
+        app_bundle: device.app_bundle
+      }
+    end
 
     context "when device not found" do
       it "returns an error" do
@@ -52,11 +65,18 @@ RSpec.describe "Devices", type: :request do
         expect(response.parsed_body["error"]).to eq("Not Found")
         expect(response.parsed_body["status"]).to eq(404)
       end
+
+      it "return an error if device id doesn't match params" do
+        delete "/users/devices/123", params: incomplete_params
+        expect(response.status).to eq(404)
+        expect(response.parsed_body["error"]).to eq("Not Found")
+        expect(response.parsed_body["status"]).to eq(404)
+      end
     end
 
     context "when device deleted" do
       it "deletes the device" do
-        delete "/users/devices/#{device.id}"
+        delete "/users/devices/#{device.user.id}", params: params
         expect(user.devices.count).to eq(0)
         expect(response.status).to eq(204)
         expect(Device.find_by(id: device.id)).to be_nil

--- a/spec/services/notifications/new_comment/send_spec.rb
+++ b/spec/services/notifications/new_comment/send_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Notifications::NewComment::Send, type: :service do
     comment_sent = child_comment
     described_class.call(comment_sent)
 
-    channels = ["user-notifications-#{user2.id}", "user-notifications-#{user.id}"]
+    channels = ["user-notifications-#{user.id}", "user-notifications-#{user2.id}"]
     payload = described_class.new(comment_sent).__send__(:push_notification_payload)
     expect(Pusher::PushNotifications).to have_received(:publish_to_interests).with(interests: channels,
                                                                                    payload: payload)

--- a/spec/services/notifications/new_comment/send_spec.rb
+++ b/spec/services/notifications/new_comment/send_spec.rb
@@ -108,9 +108,11 @@ RSpec.describe Notifications::NewComment::Send, type: :service do
     comment_sent = child_comment
     described_class.call(comment_sent)
 
-    channels = ["user-notifications-#{user.id}", "user-notifications-#{user2.id}"]
+    channels = ["user-notifications-#{user2.id}", "user-notifications-#{user.id}"]
     payload = described_class.new(comment_sent).__send__(:push_notification_payload)
-    expect(Pusher::PushNotifications).to have_received(:publish_to_interests).with(interests: channels,
-                                                                                   payload: payload)
+    expect(Pusher::PushNotifications).to have_received(:publish_to_interests) do |block|
+      expect(block[:interests]).to match_array(channels)
+      expect(block[:payload]).to eq(payload)
+    end
   end
 end

--- a/spec/services/push_notifications/send_spec.rb
+++ b/spec/services/push_notifications/send_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe PushNotifications::Send, type: :service do
     it "creates a notification and enqueues it" do
       expect { described_class.call(many_targets_params) }
         .to change { Rpush::Client::Redis::Notification.all.count }.by(2)
-        .and change(PushNotifications::DeliverWorker.jobs, :size).by(1)
+        .and change { PushNotifications::DeliverWorker.jobs.size }.by(1)
     end
 
     it "creates a single notification for each of the user's devices when they have multiple" do
@@ -85,7 +85,7 @@ RSpec.describe PushNotifications::Send, type: :service do
 
       expect { described_class.call(many_targets_params) }
         .to change { Rpush::Client::Redis::Notification.all.count }.by(3)
-        .and change(PushNotifications::DeliverWorker.jobs, :size).by(1)
+        .and change { PushNotifications::DeliverWorker.jobs.size }.by(1)
     end
   end
 end

--- a/spec/services/push_notifications/send_spec.rb
+++ b/spec/services/push_notifications/send_spec.rb
@@ -2,11 +2,20 @@ require "rails_helper"
 
 RSpec.describe PushNotifications::Send, type: :service do
   let(:user) { create(:user) }
+  let(:user2) { create(:user) }
   let(:params) do
     {
-      user: user,
+      user_ids: [user.id],
       title: "Alert",
       body: "some alert here",
+      payload: ""
+    }
+  end
+  let(:many_targets_params) do
+    {
+      user_ids: [user.id, user2.id],
+      title: "Alert 2",
+      body: "some other alert",
       payload: ""
     }
   end
@@ -33,7 +42,7 @@ RSpec.describe PushNotifications::Send, type: :service do
     end
   end
 
-  context "with devices for user" do
+  context "with devices for one user" do
     before do
       allow(FeatureFlag).to receive(:enabled?).with(:mobile_notifications).and_return(true)
       allow(ApplicationConfig).to receive(:[]).with("RPUSH_IOS_PEM").and_return("dGVzdGluZw==")
@@ -52,6 +61,30 @@ RSpec.describe PushNotifications::Send, type: :service do
 
       expect { described_class.call(params) }
         .to change { Rpush::Client::Redis::Notification.all.count }.by(2)
+        .and change(PushNotifications::DeliverWorker.jobs, :size).by(1)
+    end
+  end
+
+  context "with devices for multiple users" do
+    before do
+      allow(FeatureFlag).to receive(:enabled?).with(:mobile_notifications).and_return(true)
+      allow(ApplicationConfig).to receive(:[]).with("RPUSH_IOS_PEM").and_return("dGVzdGluZw==")
+      allow(ApplicationConfig).to receive(:[]).with("COMMUNITY_NAME").and_return("Forem")
+      create(:device, user: user)
+      create(:device, user: user2)
+    end
+
+    it "creates a notification and enqueues it" do
+      expect { described_class.call(many_targets_params) }
+        .to change { Rpush::Client::Redis::Notification.all.count }.by(2)
+        .and change(PushNotifications::DeliverWorker.jobs, :size).by(1)
+    end
+
+    it "creates a single notification for each of the user's devices when they have multiple" do
+      create(:device, user: user)
+
+      expect { described_class.call(many_targets_params) }
+        .to change { Rpush::Client::Redis::Notification.all.count }.by(3)
         .and change(PushNotifications::DeliverWorker.jobs, :size).by(1)
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The bulk of Push Notifications was implemented in #12419 and lives behind the `mobile_notifications` Feature Flag.

What's included in this PR:
- Add the support to use Rpush to send the Push Notifications for new comments (the same Push Notification we have with Pusher Beams) based on the Feature Flag.
   - It slightly changes the way the `PushNotifications::Send` service works. It used to receive a User model but this is actually unnecessary. There is no real need to instantiate the User model since we only used it to get associated Devices. An array of user_ids is the new solution.
- Changes the way we find Devices for `devices#destroy` because the Apps react to when a user has logged out and we no longer make authenticated calls

## Related Tickets & Documents

- #12419
- Related to https://github.com/forem/rfcs/pull/68

## QA Instructions, Screenshots, Recordings

This one is quite tricky to test. We want to test this using one of the production sites (most likely https://community.benhalpern.com) as soon as we ship this and also https://github.com/forem/forem-ios/pull/34 to TestFlight

Here's a video of the Devices being registered and unregistered (device screen mirrored in the left side of the screen):

https://user-images.githubusercontent.com/6045239/111554157-657e3900-874b-11eb-8e8f-0361ce943fcf.mov

And here is what it looks like when a notification is sent triggered by a comment in a Post:

<img width="1431" alt="Screen Shot 2021-03-17 at 18 07 33" src="https://user-images.githubusercontent.com/6045239/111554297-a7a77a80-874b-11eb-8d16-93b13d0d0e18.png">


### UI accessibility concerns?

None because it only changes backend related code.

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: It's part of a series of PRs that are part of RFC 68 and when the RFC is considered complete we will communicate so accordingly

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![mr krabs send them in](https://media.giphy.com/media/3o8cHvJOGEthS4DHKE/giphy.gif)
