### PR TITLE
Add skip link functionality to tags page

### DIFF
--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -59,4 +59,4 @@
       </div>
     <% end %>
   </div>
-</div>
+</main>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -19,7 +19,7 @@
   <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
 <% end %>
 
-<div class="crayons-layout crayons-layout--1-col">
+<main id="main-content" class="crayons-layout crayons-layout--1-col">
   <header class="px-2 m:px-0">
     <h1>Top tags</h1>
   </header>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [X] Feature

## Description

This adds the "Skip to content" functionality to the tags page, so that users navigating by keyboard can go directly to the main content without tabbing through menu elements etc.

NB: In the current implementation, the skip link is only the first focusable element **on a fresh page load** and not on internal navigation. At the moment, if you navigate from home to the tags page, the first focusable element will be after the header bar.

As part of #1153 we will want to change that, but I think it should be completed last, after the individual pages have the skip link functionality set up. Otherwise we'll be degrading the UX in the interim, with users having to tab through the whole header on each page.

## Related Tickets & Documents

#1153

## QA Instructions, Screenshots, Recordings

- Go to the `/tags` page
- Refresh the browser (fresh page load as per above note)
- Press the `Tab` key
- You should see the 'skip to content' link which you can activate with either `Enter` or clicking
- Press the `Tab` key again and you should see that your focus is now inside the first tag in the main content, and not in any of the header sections, sidebars etc.


https://user-images.githubusercontent.com/20773163/111637738-a29d0680-87f1-11eb-8416-15127f29f7fb.mp4


### UI accessibility concerns?

This is an accessibility boost for keyboard navigation.

## Added tests?

- [X] No, and this is why: Cypress doesn't support the `Tab` event (yet!), and this change didn't affect any existing tests


## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] This change does not need to be communicated, and this is why not: I think we should communicate the change once the skip link functionality has been rolled out to all the main pages as per #1153 

