### PR TITLE
Fix async useEffect warning

### DIFF
--- a/app/javascript/crayons/MentionAutocompleteTextArea/MentionAutocompleteTextArea.jsx
+++ b/app/javascript/crayons/MentionAutocompleteTextArea/MentionAutocompleteTextArea.jsx
@@ -96,7 +96,7 @@ export const MentionAutocompleteTextArea = ({
   const inputRef = useRef(null);
   const popoverRef = useRef(null);
 
-  useEffect(async () => {
+  useEffect(() => {
     if (searchTerm.length < MIN_SEARCH_CHARACTERS) {
       return;
     }
@@ -106,22 +106,23 @@ export const MentionAutocompleteTextArea = ({
       return;
     }
 
-    const { result: fetchedUsers } = await fetchSuggestions(searchTerm);
-    const resultLength = Math.min(fetchedUsers.length, MAX_RESULTS_DISPLAYED);
+    fetchSuggestions(searchTerm).then(({ result: fetchedUsers }) => {
+      const resultLength = Math.min(fetchedUsers.length, MAX_RESULTS_DISPLAYED);
 
-    const results = fetchedUsers.slice(0, resultLength);
+      const results = fetchedUsers.slice(0, resultLength);
 
-    setCachedSearches({
-      ...cachedSearches,
-      [searchTerm]: results,
+      setCachedSearches({
+        ...cachedSearches,
+        [searchTerm]: results,
+      });
+
+      setUsers(results);
+
+      // Let screen reader users know a list has populated
+      if (!ariaHelperText && fetchedUsers.length > 0) {
+        setAriaHelperText(`Mention user, ${fetchedUsers.length} results found`);
+      }
     });
-
-    setUsers(results);
-
-    // Let screen reader users know a list has populated
-    if (!ariaHelperText && fetchedUsers.length > 0) {
-      setAriaHelperText(`Mention user, ${fetchedUsers.length} results found`);
-    }
   }, [searchTerm, fetchSuggestions, cachedSearches, ariaHelperText]);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

Refactors an async/wait back to the `.then()` since a warning is showing up for using `await` inside a `useEffect`. I'm not sure how I missed this warning when I originally changed it from `then` to async/await 🙈 

The other option would be to declare an async function inside the `useEffect` e.g.

```
useEffect(() => {
  const myAsyncFunction = async () => {
    // Do the things with await
  }

 // Call the declared function
 myAsyncFunction()
})
```

Personally in this particular case I find the `then...` more readable, but happy to change to this style if it's preferred. 

## Related Tickets & Documents

introduced in #13044 

## QA Instructions, Screenshots, Recordings

No change to previous behaviour in #13044

### UI accessibility concerns?

N/A

## Added tests?

- [X] No, and this is why: refactor only


## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not:  This change affects a storybook component only at the moment


