### PR TITLE
15 min fix - update closing tag in podcast episodes

### DIFF
--- a/app/views/podcast_episodes/index.html.erb
+++ b/app/views/podcast_episodes/index.html.erb
@@ -28,7 +28,7 @@
     <div class="loading-articles" id="loading-articles">
       loading...
     </div>
-  </div>
+  </main>
   <%= render "podcast_episodes/sidebar_additional" %>
 </div>
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Bug Fix

## Description

As spotted by @r3cha - in a previous PR I changed a `div` to a `main` but it seems I didn't update the closing tag.

## Related Tickets & Documents

Introduced in #12769

## QA Instructions, Screenshots, Recordings

Podcasts page should look/operate same as before, with no visible change and no impact on the skip link functionality.

### UI accessibility concerns?

N/A

## Added tests?

- [X] No, and this is why: Nothing additional to test here

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [X] This change does not need to be communicated, and this is why not: No user-facing impact


## [optional] What gif best describes this PR or how it makes you feel?

![Moira Rose admits its her blunder](https://media1.giphy.com/media/1NS0NcsFenn1yuYoaP/giphy.gif?cid=ecf05e47gdddgyn0v6k3cvzinxa9jaafnsfirfdbkhmvfnix&rid=giphy.gif)
