### PR TITLE
Optimize `Article.published` scope to use an index

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -118,7 +118,7 @@ class Article < ApplicationRecord
   scope :published, -> {
     self
       .where(published: true)
-      .where(Arel.sql("published_at < now()"))
+      .where("published_at <= ?", Time.current)
   }
   scope :unpublished, -> { where(published: false) }
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -110,6 +110,11 @@ class Article < ApplicationRecord
   serialize :cached_user
   serialize :cached_organization
 
+  # [@jgaskins] We use an index on `published`, but since it's a boolean value
+  #   the Postgres query planner often skips it due to lack of diversity of the
+  #   data in the column. However, since `published_at` is a *very* diverse
+  #   column and can scope down the result set significantly, the query planner
+  #   can make heavy use of it.
   scope :published, -> {
     self
       .where(published: true)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -110,7 +110,11 @@ class Article < ApplicationRecord
   serialize :cached_user
   serialize :cached_organization
 
-  scope :published, -> { where(published: true) }
+  scope :published, -> {
+    self
+      .where(published: true)
+      .where(Arel.sql("published_at < now()"))
+  }
   scope :unpublished, -> { where(published: false) }
 
   scope :admin_published_with, lambda { |tag_name|

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     transient do
       title { generate :title }
       published { true }
-      published_at { Time.now }
+      published_at { Time.current }
       date { "01/01/2015" }
       tags { "javascript, html, css" }
       canonical_url { Faker::Internet.url }

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     transient do
       title { generate :title }
       published { true }
+      published_at { Time.now }
       date { "01/01/2015" }
       tags { "javascript, html, css" }
       canonical_url { Faker::Internet.url }

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,10 +2,11 @@ FactoryBot.define do
   sequence(:title) { |n| "#{Faker::Book.title}#{n}" }
 
   factory :article do
+    published_at { Time.current }
+
     transient do
       title { generate :title }
       published { true }
-      published_at { Time.current }
       date { "01/01/2015" }
       tags { "javascript, html, css" }
       canonical_url { Faker::Internet.url }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -437,7 +437,7 @@ RSpec.describe Article, type: :model do
 
   describe "#published_at" do
     it "does not have a published_at if not published" do
-      unpublished_article = build(:article, published: false)
+      unpublished_article = build(:article, published: false, published_at: nil)
       unpublished_article.validate # to make sure the front matter extraction happens
       expect(unpublished_article.published_at).to be_nil
     end

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
     end
 
     it "fails with an unpublished article" do
-      article.update_columns(published: false)
+      article.update_columns(published: false, published_at: nil)
       get api_article_path(article.id)
       expect(response).to have_http_status(:not_found)
     end
@@ -424,7 +424,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
     end
 
     it "fails with an unpublished article" do
-      article.update_columns(published: false)
+      article.update_columns(published: false, published_at: nil)
       get slug_api_articles_path(username: article.username, slug: article.slug)
       expect(response).to have_http_status(:not_found)
     end
@@ -867,7 +867,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
   describe "PUT /api/articles/:id" do
     let!(:api_secret)   { create(:api_secret) }
     let!(:user)         { api_secret.user }
-    let(:article)       { create(:article, user: user, published: false) }
+    let(:article)       { create(:article, user: user, published: false, published_at: nil) }
     let(:path)          { api_article_path(article.id) }
     let!(:organization) { create(:organization) }
 
@@ -1092,7 +1092,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         put_article(body_markdown: "Yo ho ho", published: true)
         expect(response).to have_http_status(:ok)
 
-        article.update_columns(published: false)
+        article.update_columns(published: false, published_at: nil)
         put_article(published: true)
         expect(response).to have_http_status(:ok)
 

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -1092,7 +1092,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         put_article(body_markdown: "Yo ho ho", published: true)
         expect(response).to have_http_status(:ok)
 
-        article.update_columns(published: false, published_at: nil)
+        article.update_columns(published: false)
         put_article(published: true)
         expect(response).to have_http_status(:ok)
 

--- a/spec/requests/articles/articles_update_spec.rb
+++ b/spec/requests/articles/articles_update_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "ArticlesUpdate", type: :request do
   end
 
   it "creates a notification job if published the first time" do
-    draft = create(:article, published: false, user_id: user.id)
+    draft = create(:article, published: false, published_at: nil, user_id: user.id)
     sidekiq_assert_enqueued_with(job: Notifications::NotifiableActionWorker) do
       put "/articles/#{draft.id}", params: {
         article: { published: true, body_markdown: "blah"  }

--- a/spec/services/articles/updater_spec.rb
+++ b/spec/services/articles/updater_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Articles::Updater, type: :service do
   let(:user) { create(:user) }
   let!(:article) { create(:article, user: user) }
   let(:attributes) { { body_markdown: "sample" } }
-  let(:draft) { create(:article, user: user, published: false) }
+  let(:draft) { create(:article, user: user, published: false, published_at: nil) }
 
   it "updates an article" do
     described_class.call(user, article, attributes)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The index on `articles.published` is not being invoked due to lack of diversity in the values in that column (it only has 2 possible values other than `NULL`).

The index on `articles.published_at` is extremely diverse (when it's not `NULL`) and will be invoked any time it can reduce the scope of a query by an order of magnitude or more.

On DEV, this does not change the row count for the scope in production:

```ruby
irb(main):001:0> Article.where(published: true).count == Article.where(published: true).where(Arel.sql("published_at < now()")).count
# => true
```

The query plan for the `Articles::Feeds::LargeForemExperimental` service invoked in the `Stories::FeedController#show` endpoint goes from this (measured in production):

    Planning Time: 0.271 ms
    Execution Time: 329.258 ms

to this:

    Planning Time: 0.330 ms
    Execution Time: 0.468 ms

This is a reduction in query time of **99.7%**.

## Added tests?

- [ ] Yes
- [x] No, and this is why: the desired end result is the same
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

@forem/sre

- [ ] Ensure the latencies on these endpoints got better:
  - [ ] [`Stories::FeedsController#show`](https://app.datadoghq.com/apm/resource/practical_developer/rack.request/7c2a32d9f2b6fc66?end=1616193026195&env=production&index=apm-search&paused=false&query=env%3Aproduction%20service%3Apractical_developer%20operation_name%3Arack.request%20resource_name%3A%22Stories%3A%3AFeedsController%23show%22&start=1616149826195)
  - [ ] [`StoriesController#show`](https://app.datadoghq.com/apm/resource/practical_developer/rack.request/f6879dddc8e2b5c4?end=1616193266317&env=production&index=apm-search&paused=false&query=env%3Aproduction%20service%3Apractical_developer%20operation_name%3Arack.request%20resource_name%3AStoriesController%23show&start=1616106866317&spanID=4346552392155336079)
  - [ ] [`StoriesController#index`](https://app.datadoghq.com/apm/resource/practical_developer/rack.request/29bdfb87f415d6a4?end=1616193332989&env=production&index=apm-search&paused=false&query=env%3Aproduction%20service%3Apractical_developer%20operation_name%3Arack.request%20resource_name%3AStoriesController%23index&start=1616106932989)
- [ ] Ensure the latencies on [this dashboard](https://app.datadoghq.com/dashboard/7w7-zg8-rnz?from_ts=1616160043802&live=true&tile_size=m&to_ts=1616174443802) don't get worse
  - If they get meaningfully worse (especially at the high end), this may need to be reverted

## [optional] What gif best describes this PR or how it makes you feel?

![Ludicrous speed](https://images.squarespace-cdn.com/content/v1/54ac05ebe4b0b365f77e14db/1525382987551-8BBONDY0X0G35XDX4FG7/ke17ZwdGBToddI8pDm48kDIn-TOaJZ_YZ8WW77X2puBZw-zPPgdn4jUwVcJE1ZvWEtT5uBSRWt4vQZAgTJucoTqqXjS3CfNDSuuf31e0tVG6WFl4Fnkb3hCxLccvwYe0A2OmNo2cc0iuLqoH7rPQCSb8BodarTVrzIWCp72ioWw/Spaceballs+Meme.png)
