### PR TITLE
Added credits_awarded to badges

### DIFF
--- a/db/migrate/20210312095649_add_credits_awarded_to_badges.rb
+++ b/db/migrate/20210312095649_add_credits_awarded_to_badges.rb
@@ -1,5 +1,5 @@
 class AddCreditsAwardedToBadges < ActiveRecord::Migration[6.0]
   def change
-    add_column :badges, :credits_awarded, :integer, default: 0
+    add_column :badges, :credits_awarded, :integer, default: 0, null: false
   end
 end

--- a/db/migrate/20210312095649_add_credits_awarded_to_badges.rb
+++ b/db/migrate/20210312095649_add_credits_awarded_to_badges.rb
@@ -1,0 +1,5 @@
+class AddCreditsAwardedToBadges < ActiveRecord::Migration[6.0]
+  def change
+    add_column :badges, :credits_awarded, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -197,6 +197,7 @@ ActiveRecord::Schema.define(version: 2021_03_12_191925) do
   create_table "badges", force: :cascade do |t|
     t.string "badge_image"
     t.datetime "created_at", null: false
+    t.integer "credits_awarded", default: 0
     t.string "description", null: false
     t.string "slug", null: false
     t.string "title", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -197,7 +197,7 @@ ActiveRecord::Schema.define(version: 2021_03_12_191925) do
   create_table "badges", force: :cascade do |t|
     t.string "badge_image"
     t.datetime "created_at", null: false
-    t.integer "credits_awarded", default: 0
+    t.integer "credits_awarded", default: 0, null: false
     t.string "description", null: false
     t.string "slug", null: false
     t.string "title", null: false

--- a/lib/data_update_scripts/20210322092753_fill_badges_credits_awarded.rb
+++ b/lib/data_update_scripts/20210322092753_fill_badges_credits_awarded.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class FillBadgesCreditsAwarded
+    def run
+      return unless SiteConfig.dev_to?
+
+      Badge.update_all("credits_awarded = 5")
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/fill_badges_credits_awarded_spec.rb
+++ b/spec/lib/data_update_scripts/fill_badges_credits_awarded_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20210322092753_fill_badges_credits_awarded.rb",
+)
+
+describe DataUpdateScripts::FillBadgesCreditsAwarded do
+  it "updates badges on dev.to" do
+    allow(SiteConfig).to receive(:dev_to?).and_return(true)
+    badge = create(:badge, credits_awarded: 0)
+    expect do
+      described_class.new.run
+    end.to change { badge.reload.credits_awarded }.from(0).to(5)
+  end
+
+  it "doesn't update badges on other forems" do
+    allow(SiteConfig).to receive(:dev_to?).and_return(false)
+    badge = create(:badge, credits_awarded: 0)
+    expect do
+      described_class.new.run
+    end.not_to change { badge.reload.credits_awarded }
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This pr is a preparation to configure credits tied to badges. 
My plan is to:
- add a field to the `badges` table (with this or)
- update the badges on DEV (but not other forems) to award 5 credits
- add the logic to award (or not award) the configured number of credits in the next pr. This way the badges created right after the logic is deployed will award the configured number of credits (5), not the default (0).

## Related Tickets & Documents
https://github.com/forem/rfcs/pull/69

### UI accessibility concerns?
No

## Added tests?
- [x] No, and this is why: no logic added yet

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
We need to update all the existing badges so that `credits_awarded` would be `5`.
```
Badge.update_all("credits_awarded = 5")
```
I didn't use a `DataUpdateScript` because we need this only on DEV, not on other forems.