### PR TITLE
Remove deprecated Sidekiq::Web commands

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,6 @@ Rails.application.routes.draw do
     require "sidekiq/cron/web"
 
     authenticated :user, ->(user) { user.tech_admin? } do
-      Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
-      Sidekiq::Web.set :sessions, Rails.application.config.session_options
       Sidekiq::Web.class_eval do
         use Rack::Protection, permitted_origins: [URL.url] # resolve Rack Protection HttpOrigin
       end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Sidekiq 6.2.0 [deprecated](https://github.com/mperham/sidekiq/blob/master/Changes.md#620) `Sidekiq::Web.session_secret =` and `Sidekiq::Web.sessions =`

```
WARNING: Sidekiq::Web.session_secret= is no longer relevant and will be removed in Sidekiq 7.0. /forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.0/lib/sidekiq/web.rb:75:in `set'
WARNING: Sidekiq::Web.sessions= is no longer relevant and will be removed in Sidekiq 7.0. /forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.0/lib/sidekiq/web.rb:75:in `set'
```

this was also discussed in https://github.com/forem/forem/pull/13056#pullrequestreview-616507628

Production https://dev.to/sidekiq is working correctly

## Related Tickets & Documents

#13056

## QA Instructions, Screenshots, Recordings

None, QA has already been done in production at https://dev.to/sidekiq

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: removing a deprecated line that's also a no-op now
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
