### PR TITLE
Add skip link to notifications page

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -40,30 +40,32 @@
 </script>
 
 <% if user_signed_in? %>
-  <header class="crayons-layout crayons-layout--limited-l crayons-layout--1-col p-4 flex items-center justify-between">
-    <h1 class="crayons-title">Notifications</h1>
-    <a href="<%= user_settings_path(tab: :notifications) %>" class="crayons-btn crayons-btn--ghost">Settings</a>
-  </header>
+  <main id="main-content">
+    <header class="crayons-layout crayons-layout--limited-l crayons-layout--1-col p-4 flex items-center justify-between">
+      <h1 class="crayons-title">Notifications</h1>
+      <a href="<%= user_settings_path(tab: :notifications) %>" class="crayons-btn crayons-btn--ghost">Settings</a>
+    </header>
 
-  <div class="crayons-layout crayons-layout--limited-l crayons-layout--2-cols pt-0" id="notifications-container">
-    <div class="crayons-layout__sidebar-left">
-      <%= render "notifications/nav_menu" %>
-    </div>
-    <main class="crayons-layout__content">
-      <div id="articles-list">
-        <%= render "notifications_list", params: params %>
+    <div class="crayons-layout crayons-layout--limited-l crayons-layout--2-cols pt-0" id="notifications-container">
+      <div class="crayons-layout__sidebar-left">
+        <%= render "notifications/nav_menu" %>
       </div>
+      <main class="crayons-layout__content">
+        <div id="articles-list">
+          <%= render "notifications_list", params: params %>
+        </div>
 
-      <%# new or less active users that don't have a page worth of notifications
-          won't be shown the "load more" button %>
-      <% if @notifications.size >= @initial_page_size %>
-        <button id="load-more-button" type="button" class="crayons-btn crayons-btn--secondary crayons-btn--l my-6 w-100">
-          Load More
-        </button>
-      <% end %>
-    </main>
-  </div>
-  <%= render "articles/fitvids" %>
+        <%# new or less active users that don't have a page worth of notifications
+            won't be shown the "load more" button %>
+        <% if @notifications.size >= @initial_page_size %>
+          <button id="load-more-button" type="button" class="crayons-btn crayons-btn--secondary crayons-btn--l my-6 w-100">
+            Load More
+          </button>
+        <% end %>
+      </main>
+    </div>
+    <%= render "articles/fitvids" %>
+  </main>
 <% else %>
   <%= render "devise/registrations/registration_form" %>
 <% end %>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [X] Feature

## Description

This small change allows for the skip link functionality to work on the Notifications page. Also by adding the `<main>` tag it enhances the accessibility of the page by using the appropriate landmark region.

NB: In the current implementation, the skip link is only the first focusable element on a fresh page load and not on internal navigation. At the moment, if you navigate from home to the notifications page, the first focusable element will be after the header bar.

As part of #1153 we will want to change that, but I think it should be completed last, after the individual pages have the skip link functionality set up. Otherwise we'll be degrading the UX in the interim, with users having to tab through the whole header on each page.

## Related Tickets & Documents

#1153

## QA Instructions, Screenshots, Recordings

- Go to the /notifications page
- Refresh the browser (fresh page load as per above note)
- Press the Tab key
- You should see the 'skip to content' link which you can activate with either Enter or clicking
- Press the Tab key again and you should see that your focus skips the header bar and goes straight to the first item in the main content

https://user-images.githubusercontent.com/20773163/112304598-930c3a80-8c95-11eb-8eaa-383051bd700a.mp4

### UI accessibility concerns?

This improves the keyboard accessibility of the page and also implements the appropriate `main` page landmark, giving more context to screen reader users.

## Added tests?

- [X] No, and this is why: Cypress doesn't support the Tab event (yet!), and this change didn't affect any existing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] This change does not need to be communicated, and this is why not: I think we should communicate the change once the skip link functionality has been rolled out to all the main pages as per #1153

