### PR TITLE
Add skip link functionality to code of conduct, terms and privacy pages

### DIFF
--- a/app/views/pages/code_of_conduct.html.erb
+++ b/app/views/pages/code_of_conduct.html.erb
@@ -14,9 +14,9 @@
   <meta name="twitter:title" content="<%= community_name %> Code of Conduct">
 <% end %>
 
-<div class="crayons-layout crayons-layout--limited-l">
+<main id="main-content" class="crayons-layout crayons-layout--limited-l">
   <div class="crayons-card text-styles text-padding">
     <h1 class="fs-3xl s:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight mb-4 mt-0">Code of Conduct</h1>
     <%= render "coc_text" %>
   </div>
-</div>
+</main>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -19,9 +19,9 @@
   <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
 <% end %>
 
-<div class="crayons-layout crayons-layout--limited-l">
+<main id="main-content" class="crayons-layout crayons-layout--limited-l">
   <div class="crayons-card text-styles text-padding">
     <h1 class="fs-3xl s:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight mb-4 mt-0">Privacy Policy</h1>
     <%= render "privacy_text" %>
   </div>
-</div>
+</main>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -19,9 +19,9 @@
   <meta name="twitter:image:src" content="<%= SiteConfig.main_social_image %>">
 <% end %>
 
-<div class="crayons-layout crayons-layout--limited-l">
+<main id="main-content" class="crayons-layout crayons-layout--limited-l">
   <div class="crayons-card text-styles text-padding">
     <h1 class="fs-3xl s:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight mb-4 mt-0">Web Site Terms and Conditions of Use</h1>
     <%= render "terms_text" %>
   </div>
-</div>
+</main>


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [X] Feature

## Description

This small change allows for the skip link functionality to work on the default pages for:

- Code of Conduct
- Privacy Policy
- Terms of Use

Also by adding the <main> tag it enhances the accessibility of these pages by using the appropriate landmark region.

NB: In the current implementation, the skip link is only the first focusable element on a fresh page load and not on internal navigation. At the moment, if you navigate from home to the given page, the first focusable element will be after the header bar.

As part of #1153 we will want to change that, but I think it should be completed last, after the individual pages have the skip link functionality set up. Otherwise we'll be degrading the UX in the interim, with users having to tab through the whole header on each page.

## Related Tickets & Documents

#1153

## QA Instructions, Screenshots, Recordings

For each of the above pages:

- Visit the page
- Refresh the browser (fresh page load as per above note)
- Press the Tab key
- You should see the 'skip to content' link which you can activate with either Enter or clicking
- Press the Tab key again and you should see that your focus skips the header bar and goes straight to the first item in the main content

Terms of Use:

https://user-images.githubusercontent.com/20773163/112306352-a02a2900-8c97-11eb-957b-692484e42f29.mp4

Privacy Policy:

https://user-images.githubusercontent.com/20773163/112306395-a9b39100-8c97-11eb-805f-c23f906df49a.mp4

Code of Conduct:

https://user-images.githubusercontent.com/20773163/112306414-b0420880-8c97-11eb-8f3a-2c8d0714cb80.mp4

### UI accessibility concerns?

This improves the keyboard accessibility of these pages and also implements the appropriate main page landmark, giving more context to screen reader users.

## Added tests?

- [X] No, and this is why: Cypress doesn't support the Tab event (yet!), and this change didn't affect any existing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] This change does not need to be communicated, and this is why not: I think we should communicate the change once the skip link functionality has been rolled out to all the main pages as per #1153


