### PR TITLE
Add a GIN index on `comments.ancestry`

### DIFF
--- a/db/migrate/20210325040245_add_trigram_index_to_comments_ancestry.rb
+++ b/db/migrate/20210325040245_add_trigram_index_to_comments_ancestry.rb
@@ -1,0 +1,14 @@
+class AddTrigramIndexToCommentsAncestry < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :comments, :ancestry,
+      # There is already a btree index on this column, so we need to specify a different name
+      name: 'index_comments_on_ancestry_trgm',
+      # Using trigram operations requires a GIN index
+      using: :gin,
+      # Indexing for LIKE operations requires trigram operations
+      opclass: :gin_trgm_ops,
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_24_031738) do
+ActiveRecord::Schema.define(version: 2021_03_25_040245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -387,6 +387,7 @@ ActiveRecord::Schema.define(version: 2021_03_24_031738) do
     t.bigint "user_id"
     t.index "digest(body_markdown, 'sha512'::text), user_id, ancestry, commentable_id, commentable_type", name: "index_comments_on_body_markdown_user_ancestry_commentable", unique: true
     t.index ["ancestry"], name: "index_comments_on_ancestry"
+    t.index ["ancestry"], name: "index_comments_on_ancestry_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type"
     t.index ["created_at"], name: "index_comments_on_created_at"
     t.index ["score"], name: "index_comments_on_score"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We have a btree index on this table but it is not invoked with a `LIKE` operation that uses `%` - only when using `LIKE` with an exact match.

This query is DEV's second-most intense query by total time spent with a p50 latency of ~130ms. This index brings it down to 5ms at p90.

I don't know if the existing btree index on this column is ever even used. I'll have to investigate that later.

## Added tests?

- [ ] Yes
- [x] No, and this is why: Simply optimizing, existing behavior should be the same
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] What gif best describes this PR or how it makes you feel?


![Gotta go fast](https://media4.giphy.com/media/yXVO50FJIJMSQ/giphy.gif)


