### PR TITLE
Handle duplicate associations properly when merging a user

### DIFF
--- a/app/services/moderator/merge_user.rb
+++ b/app/services/moderator/merge_user.rb
@@ -13,7 +13,7 @@ module Moderator
     end
 
     def merge
-      raise "You cannot merge the same two user id#s" if @delete_user.id == @keep_user.id
+      raise "You cannot merge the same two user ID#s" if @delete_user.id == @keep_user.id
 
       handle_identities
       merge_content

--- a/app/services/moderator/merge_user.rb
+++ b/app/services/moderator/merge_user.rb
@@ -31,10 +31,10 @@ module Moderator
     private
 
     def handle_identities
-      error_message = "The user being deleted already has two identities. " \
+      error_message = "The user being deleted already has two or more identities. " \
         "Are you sure this is the right user to be deleted? " \
         "If so, a super admin will need to do this from the console to be safe."
-      raise error_message if @delete_user.identities.count.positive?
+      raise error_message if @delete_user.identities.count >= 2
 
       return true if
         @keep_user.identities.count.positive? ||

--- a/app/services/moderator/merge_user.rb
+++ b/app/services/moderator/merge_user.rb
@@ -23,6 +23,7 @@ module Moderator
       merge_chat_channels
       merge_sponsorships
       merge_profile
+      merge_badge_achievements
       update_social
       Users::DeleteWorker.new.perform(@delete_user.id, true)
       @keep_user.touch(:profile_updated_at)

--- a/spec/services/moderator/merge_user_spec.rb
+++ b/spec/services/moderator/merge_user_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Moderator::MergeUser, type: :service do
   let!(:keep_user) { create(:user) }
   let!(:delete_user) { create(:user) }
+  let(:user) { create(:user) }
   let(:delete_user_id) { delete_user.id }
   let(:admin) { create(:user, :super_admin) }
 
@@ -37,14 +38,77 @@ RSpec.describe Moderator::MergeUser, type: :service do
       expect(comment.reload.elasticsearch_doc.dig("_source", "user", "id")).to eq(keep_user.id)
     end
 
-    it "updates badge_achievements_count" do
-      create_list(:badge_achievement, 2, user: delete_user)
+    it "merges duplicate badge achievements" do
+      badge = create(:badge)
+      delete_user_badge = create(:badge_achievement, badge: badge, user: delete_user)
+      create(:badge_achievement, badge: badge, user: keep_user)
 
       sidekiq_perform_enqueued_jobs do
         described_class.call(admin: admin, keep_user: keep_user, delete_user_id: delete_user.id)
       end
 
-      expect(keep_user.reload.badge_achievements_count).to eq(2)
+      expect(Badge.find_by(id: delete_user_badge.id)).to be_nil
+    end
+
+    it "merges duplicate reactions without errors" do
+      delete_user_rxn = create(:reaction, reactable: article, user: delete_user)
+      create(:reaction, reactable: article, user: keep_user)
+
+      sidekiq_perform_enqueued_jobs do
+        described_class.call(admin: admin, keep_user: keep_user, delete_user_id: delete_user.id)
+      end
+
+      expect(Reaction.find_by(id: delete_user_rxn.id)).to be_nil
+    end
+
+    it "properly handles updating the role of the chat channel memberships" do
+      channel = create(:chat_channel)
+      create(:chat_channel_membership, user: delete_user, status: "active", chat_channel: channel, role: "mod")
+      create(:chat_channel_membership, user: keep_user, status: "active", chat_channel: channel, role: "member")
+
+      sidekiq_perform_enqueued_jobs do
+        described_class.call(admin: admin, keep_user: keep_user, delete_user_id: delete_user.id)
+      end
+
+      expect(ChatChannelMembership.where(user_id: keep_user.id, role: "mod").count).to eq 1
+    end
+
+    it "merges two duplicate chat channel memberships" do
+      channel = create(:chat_channel)
+      deleted_membership = create(:chat_channel_membership, user: delete_user, status: "active",
+                                                            chat_channel: channel, role: "member")
+      create(:chat_channel_membership, user: keep_user, status: "active", chat_channel: channel, role: "member")
+
+      sidekiq_perform_enqueued_jobs do
+        described_class.call(admin: admin, keep_user: keep_user, delete_user_id: delete_user.id)
+      end
+
+      expect(ChatChannelMembership.find_by(id: deleted_membership.id)).to be_nil
+    end
+
+    it "merges duplicate followers without errors" do
+      delete_user_follower = create(:follow, follower: user, followable: delete_user)
+      create(:follow, follower: user, followable: keep_user)
+
+      sidekiq_perform_enqueued_jobs do
+        described_class.call(admin: admin, keep_user: keep_user, delete_user_id: delete_user.id)
+      end
+
+      expect(Follow.find_by(id: delete_user_follower.id)).to be_nil
+    end
+
+    it "merges duplicate followables without errors" do
+      delete_followable_user = create(:follow, follower: delete_user, followable: user)
+      create(:follow, follower: keep_user, followable: user)
+      tag = create(:tag)
+      delete_followable_tag = create(:follow, follower: delete_user, followable: tag)
+
+      sidekiq_perform_enqueued_jobs do
+        described_class.call(admin: admin, keep_user: keep_user, delete_user_id: delete_user.id)
+      end
+
+      expect(Follow.find_by(id: delete_followable_user.id)).to be_nil
+      expect(delete_followable_tag.reload.follower_id).to eq keep_user.id
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description

This is a rough solution at fixing a long standing issue where merging a user fails because the current merge process doesn't account for duplicate rows. The basic idea is:
1. it looks for the intersections of the associated rows between the two users
2. deletes the intersecting associations from the user-to-be-deleted
3. updates all the user-to-be-deleted's non-duplicate rows to the user-to-be-kept

This also fixes a smaller bug where we were throwing an error message when trying to merge two users each with one `identity`, which shouldn't be an issue.

## Related Tickets & Documents
https://github.com/forem/internalCommunity/issues/54

## QA Instructions, Screenshots, Recordings
For the smaller bug:
1. Find two users each with one `identity`
2. Merge them via `/admin/users/:id/edit` (must be a `super_admin`)
3. See that you don't get the identity error: "The user being deleted already has two identities..."


For duplicate rows, it's best to test this in console:
```ruby
keep = User.first
delete = User.second

keep.follow(User.fourth)
delete.follow(User.fourth)

rxn_attributes = keep.reactions.first.attributes
rxn_attributes["id"] = nil
rxn_attributes["user_id"] = delete.id
Reaction.create!(rxn_attributes)



### UI accessibility concerns?
None, backend change

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?

![A chimpanzee stands at a podium, chattering nervously.](https://media.giphy.com/media/3o7TKQTq2YwQpFjEY0/giphy.gif)
