### PR TITLE
Sanitize Rpush iOS PEM certificate

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -60,7 +60,8 @@ class Device < ApplicationRecord
   def recreate_ios_app!
     app = Rpush::Apns2::App.new
     app.name = app_bundle
-    app.certificate = Base64.decode64(ApplicationConfig["RPUSH_IOS_PEM"])
+    sanitized_pem = ApplicationConfig["RPUSH_IOS_PEM"].to_s.gsub("\\n", "\n")
+    app.certificate = Base64.decode64(sanitized_pem)
     app.environment = Rails.env.production? ? "production" : "development"
     app.password = ""
     app.bundle_id = app_bundle


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR sanitizes PEM certificates used for Rpush iOS notifications. The problem with these certificates is that whether we are adding them via the admin dashboard (future) or other ways (i.e. Heroku ENV variable dashboard) they might end up being modified because of the escape character in `\n` that turns into `\\n`. This in turn makes the certificate invalid when used to sign requests.

This sanitization is already in place for other (Apple related) PEM files that need to be read, like the Apple Authentication from a SiteConfig [here](https://github.com/forem/forem/blob/master/config/initializers/devise.rb#L22).

## Related Tickets & Documents

[RFC 68](https://github.com/forem/rfcs/pull/68)

## QA Instructions, Screenshots, Recordings

Jump into [BHC](https://community.benhalpern.com/) Heroku dashboard and check out the ENV variables. Specifically `RPUSH_IOS_PEM` will contain an extra `\` for each linebreak `\n`.

### UI accessibility concerns?

None

## Added tests?

- [x] No, and this is why: This is a sanitation of a configuration and not a user-facing feature/functionality. Tests around PN delivery exist.

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: RFC 68 is still in progress and when finished will be communicated accordingly

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![simpsons certificate not insane](https://media.giphy.com/media/3orieJZZd34v3zkXFS/giphy.gif)
