### PR TITLE
[Search 2.0] Listings

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -75,11 +75,19 @@ class SearchController < ApplicationController
   end
 
   def listings
-    cl_docs = Search::Listing.search_documents(
-      params: listing_params.to_h,
-    )
+    result =
+      if FeatureFlag.enabled?(:search_2_listings)
+        Search::Postgres::Listing.search_documents(
+          category: listing_params[:category],
+          page: listing_params[:page],
+          per_page: listing_params[:per_page],
+          term: listing_params[:listing_search],
+        )
+      else
+        Search::Listing.search_documents(params: listing_params.to_h)
+      end
 
-    render json: { result: cl_docs }
+    render json: { result: result }
   end
 
   def users

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -4,6 +4,7 @@ class Listing < ApplicationRecord
   self.table_name = "classified_listings"
 
   include Searchable
+  include PgSearch::Model
 
   SEARCH_SERIALIZER = Search::ListingSerializer
   SEARCH_CLASS = Search::Listing
@@ -31,6 +32,12 @@ class Listing < ApplicationRecord
   validates :location, length: { maximum: 32 }
   validate :restrict_markdown_input
   validate :validate_tags
+
+  # [@atsmith813] this is adapted from the `listing_search` property in
+  # `config/elasticsearch/mappings/listings.json`
+  pg_search_scope :search_listings,
+                  against: %i[body_markdown cached_tag_list location slug title],
+                  using: { tsearch: { prefix: true } }
 
   scope :published, -> { where(published: true) }
 

--- a/app/serializers/search/listing_result_serializer.rb
+++ b/app/serializers/search/listing_result_serializer.rb
@@ -16,12 +16,12 @@ module Search
                :title,
                :user_id
 
-    attribute :tags do |cl|
-      cl.cached_tag_list.to_s.split(", ")
+    attribute :tags do |listing|
+      listing.cached_tag_list.to_s.split(", ")
     end
 
-    attribute :author do |cl|
-      ListingAuthorSerializer.new(cl.author)
+    attribute :author do |listing|
+      ListingAuthorSerializer.new(listing.author)
         .serializable_hash
         .dig(:data, :attributes)
     end

--- a/app/serializers/search/listing_result_serializer.rb
+++ b/app/serializers/search/listing_result_serializer.rb
@@ -1,0 +1,29 @@
+module Search
+  # TODO: [@atsmith813] Rename this to just ListingSerializer once Elasticsearch
+  # is fully removed
+  class ListingResultSerializer < ApplicationSerializer
+    attributes :id,
+               :body_markdown,
+               :bumped_at,
+               :category,
+               :contact_via_connect,
+               :expires_at,
+               :originally_published_at,
+               :location,
+               :processed_html,
+               :published,
+               :slug,
+               :title,
+               :user_id
+
+    attribute :tags do |cl|
+      cl.cached_tag_list.to_s.split(", ")
+    end
+
+    attribute :author do |cl|
+      ListingAuthorSerializer.new(cl.author)
+        .serializable_hash
+        .dig(:data, :attributes)
+    end
+  end
+end

--- a/app/services/search/postgres/listing.rb
+++ b/app/services/search/postgres/listing.rb
@@ -28,9 +28,11 @@ module Search
         page = page.to_i + 1
         per_page = [(per_page || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min
 
-        relation = ::Listing.where(published: true)
+        relation = ::Listing
+          .includes(:user, :organization, :listing_category)
+          .where(published: true)
 
-        relation = filter_by_category(category, relation) if category.present?
+        relation = relation.where("classified_listing_categories.slug": category) if category.present?
 
         relation = relation.search_listings(term) if term.present?
 
@@ -47,12 +49,6 @@ module Search
           .pluck(:attributes)
       end
       private_class_method :serialize
-
-      def self.filter_by_category(category, relation)
-        listing_category = ListingCategory.find_by(slug: category)
-        relation.where(classified_listing_category_id: listing_category.id)
-      end
-      private_class_method :filter_by_category
     end
   end
 end

--- a/app/services/search/postgres/listing.rb
+++ b/app/services/search/postgres/listing.rb
@@ -1,0 +1,55 @@
+module Search
+  module Postgres
+    class Listing
+      ATTRIBUTES = %i[
+        id
+        body_markdown
+        bumped_at
+        cached_tag_list
+        classified_listing_category_id
+        contact_via_connect
+        expires_at
+        organization_id
+        originally_published_at
+        location
+        processed_html
+        published
+        slug
+        title
+        user_id
+      ].freeze
+
+      DEFAULT_PER_PAGE = 75
+      MAX_PER_PAGE = 150 # to avoid querying too many items, we set a maximum amount for a page
+
+      def self.search_documents(category: nil, page: 0, per_page: DEFAULT_PER_PAGE, term: nil)
+        # NOTE: [@rhymes/atsmith813] we should eventually update the frontend
+        # to start from page 1
+        page = page.to_i + 1
+        per_page = [(per_page || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min
+
+        relation = ::Listing.where(published: true)
+
+        if category.present?
+          listing_category = ListingCategory.find_by(slug: category)
+          relation = relation.where(classified_listing_category_id: listing_category.id)
+        end
+
+        relation = relation.search_listings(term) if term.present?
+
+        relation = relation.includes(:listing_category).select(*ATTRIBUTES).order(bumped_at: :desc)
+        results = relation.page(page).per(per_page)
+
+        serialize(results)
+      end
+
+      def self.serialize(results)
+        Search::ListingResultSerializer
+          .new(results, is_collection: true)
+          .serializable_hash[:data]
+          .pluck(:attributes)
+      end
+      private_class_method :serialize
+    end
+  end
+end

--- a/app/services/search/postgres/listing.rb
+++ b/app/services/search/postgres/listing.rb
@@ -37,6 +37,7 @@ module Search
         relation = relation.search_listings(term) if term.present?
 
         relation = relation.select(*ATTRIBUTES).order(bumped_at: :desc)
+
         results = relation.page(page).per(per_page)
 
         serialize(results)

--- a/app/services/search/postgres/listing.rb
+++ b/app/services/search/postgres/listing.rb
@@ -18,9 +18,13 @@ module Search
         title
         user_id
       ].freeze
+      private_constant :ATTRIBUTES
 
       DEFAULT_PER_PAGE = 75
+      private_constant :DEFAULT_PER_PAGE
+
       MAX_PER_PAGE = 150 # to avoid querying too many items, we set a maximum amount for a page
+      private_constant :MAX_PER_PAGE
 
       def self.search_documents(category: nil, page: 0, per_page: DEFAULT_PER_PAGE, term: nil)
         # NOTE: [@rhymes/atsmith813] we should eventually update the frontend

--- a/app/services/search/postgres/listing.rb
+++ b/app/services/search/postgres/listing.rb
@@ -37,7 +37,7 @@ module Search
 
         relation = relation.search_listings(term) if term.present?
 
-        relation = relation.includes(:listing_category).select(*ATTRIBUTES).order(bumped_at: :desc)
+        relation = relation.select(*ATTRIBUTES).order(bumped_at: :desc)
         results = relation.page(page).per(per_page)
 
         serialize(results)

--- a/app/services/search/postgres/listing.rb
+++ b/app/services/search/postgres/listing.rb
@@ -30,10 +30,7 @@ module Search
 
         relation = ::Listing.where(published: true)
 
-        if category.present?
-          listing_category = ListingCategory.find_by(slug: category)
-          relation = relation.where(classified_listing_category_id: listing_category.id)
-        end
+        relation = filter_by_category(category, relation) if category.present?
 
         relation = relation.search_listings(term) if term.present?
 
@@ -50,6 +47,12 @@ module Search
           .pluck(:attributes)
       end
       private_class_method :serialize
+
+      def self.filter_by_category(category, relation)
+        listing_category = ListingCategory.find_by(slug: category)
+        relation.where(classified_listing_category_id: listing_category.id)
+      end
+      private_class_method :filter_by_category
     end
   end
 end

--- a/db/migrate/20210326172406_add_published_index_to_listings.rb
+++ b/db/migrate/20210326172406_add_published_index_to_listings.rb
@@ -1,0 +1,15 @@
+class AddPublishedIndexToListings < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def up
+    unless index_exists?(:classified_listings, :published)
+      add_index :classified_listings, :published, algorithm: :concurrently
+    end
+  end
+
+  def down
+    if index_exists?(:classified_listings, :published)
+      remove_index :classified_listings, column: :published, algorithm: :concurrently
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -388,7 +388,6 @@ ActiveRecord::Schema.define(version: 2021_03_26_172406) do
     t.bigint "user_id"
     t.index "digest(body_markdown, 'sha512'::text), user_id, ancestry, commentable_id, commentable_type", name: "index_comments_on_body_markdown_user_ancestry_commentable", unique: true
     t.index ["ancestry"], name: "index_comments_on_ancestry"
-    t.index ["ancestry"], name: "index_comments_on_ancestry_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type"
     t.index ["created_at"], name: "index_comments_on_created_at"
     t.index ["score"], name: "index_comments_on_score"
@@ -432,12 +431,12 @@ ActiveRecord::Schema.define(version: 2021_03_26_172406) do
   end
 
   create_table "devices", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "token", null: false
+    t.string "platform", null: false
     t.string "app_bundle", null: false
     t.datetime "created_at", precision: 6, null: false
-    t.string "platform", null: false
-    t.string "token", null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id", null: false
     t.index ["user_id", "token", "platform", "app_bundle"], name: "index_devices_on_user_id_and_token_and_platform_and_app_bundle", unique: true
   end
 
@@ -829,7 +828,6 @@ ActiveRecord::Schema.define(version: 2021_03_26_172406) do
     t.datetime "created_at", null: false
     t.string "description"
     t.boolean "is_top_level_path", default: false
-    t.boolean "landing_page", default: false, null: false
     t.text "processed_html"
     t.string "slug"
     t.string "social_image"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -388,6 +388,7 @@ ActiveRecord::Schema.define(version: 2021_03_26_172406) do
     t.bigint "user_id"
     t.index "digest(body_markdown, 'sha512'::text), user_id, ancestry, commentable_id, commentable_type", name: "index_comments_on_body_markdown_user_ancestry_commentable", unique: true
     t.index ["ancestry"], name: "index_comments_on_ancestry"
+    t.index ["ancestry"], name: "index_comments_on_ancestry_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type"
     t.index ["created_at"], name: "index_comments_on_created_at"
     t.index ["score"], name: "index_comments_on_score"
@@ -828,6 +829,7 @@ ActiveRecord::Schema.define(version: 2021_03_26_172406) do
     t.datetime "created_at", null: false
     t.string "description"
     t.boolean "is_top_level_path", default: false
+    t.boolean "landing_page", default: false, null: false
     t.text "processed_html"
     t.string "slug"
     t.string "social_image"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_183834) do
+ActiveRecord::Schema.define(version: 2021_03_26_172406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -344,6 +344,7 @@ ActiveRecord::Schema.define(version: 2021_03_25_183834) do
     t.bigint "user_id"
     t.index ["classified_listing_category_id"], name: "index_classified_listings_on_classified_listing_category_id"
     t.index ["organization_id"], name: "index_classified_listings_on_organization_id"
+    t.index ["published"], name: "index_classified_listings_on_published"
     t.index ["user_id"], name: "index_classified_listings_on_user_id"
   end
 
@@ -431,12 +432,12 @@ ActiveRecord::Schema.define(version: 2021_03_25_183834) do
   end
 
   create_table "devices", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "token", null: false
-    t.string "platform", null: false
     t.string "app_bundle", null: false
     t.datetime "created_at", precision: 6, null: false
+    t.string "platform", null: false
+    t.string "token", null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
     t.index ["user_id", "token", "platform", "app_bundle"], name: "index_devices_on_user_id_and_token_and_platform_and_app_bundle", unique: true
   end
 

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -70,16 +70,47 @@ RSpec.describe "Search", type: :request, proper_status: true do
   end
 
   describe "GET /search/listings" do
-    let(:mock_documents) do
-      [{ "title" => "listing1" }]
+    before do
+      sign_in authorized_user
     end
 
-    it "returns json" do
-      allow(Search::Listing).to receive(:search_documents).and_return(
-        mock_documents,
-      )
-      get "/search/listings"
-      expect(response.parsed_body).to eq("result" => mock_documents)
+    context "when using Elasticsearch" do
+      let(:mock_documents) do
+        [{ "title" => "listing1" }]
+      end
+
+      it "returns json" do
+        allow(Search::Listing).to receive(:search_documents).and_return(
+          mock_documents,
+        )
+        get "/search/listings"
+        expect(response.parsed_body).to eq("result" => mock_documents)
+      end
+    end
+
+    context "when using PostgreSQL" do
+      before do
+        allow(FeatureFlag).to receive(:enabled?).with(:search_2_listings).and_return(true)
+      end
+
+      it "returns the correct keys" do
+        create(:listing)
+        get search_listings_path
+        expect(response.parsed_body["result"]).to be_present
+      end
+
+      it "supports the search params" do
+        listing = create(:listing)
+
+        get search_listings_path(
+          category: listing.category,
+          page: 0,
+          per_page: 1,
+          term: listing.title.downcase,
+        )
+
+        expect(response.parsed_body["result"].first).to include("title" => listing.title)
+      end
     end
   end
 

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -70,10 +70,6 @@ RSpec.describe "Search", type: :request, proper_status: true do
   end
 
   describe "GET /search/listings" do
-    before do
-      sign_in authorized_user
-    end
-
     context "when using Elasticsearch" do
       let(:mock_documents) do
         [{ "title" => "listing1" }]

--- a/spec/services/search/postgres/listing_spec.rb
+++ b/spec/services/search/postgres/listing_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Search::Postgres::Listing, type: :service do
       published_listing = create(:listing, title: "Published Listing", published: true)
       unpublished_listing = create(:listing, title: "Unpublished Listing", published: false)
       result = described_class.search_documents(term: "Listing")
-      titles = result.map { |r| r.pluck(:title) }
+      titles = result.pluck(:title)
 
       expect(titles).not_to include(unpublished_listing.title)
       expect(titles).to include(published_listing.title)
@@ -117,7 +117,9 @@ RSpec.describe Search::Postgres::Listing, type: :service do
         )
 
         result = described_class.search_documents(term: "Ruby on Rails", category: job_listing.category)
-        ids = result.ids
+        # rubocop:disable Rails/PluckId
+        ids = result.pluck(:id)
+        # rubocop:enable Rails/PluckId
 
         expect(ids).to include(job_listing.id)
         expect(ids).not_to include(listing.id)

--- a/spec/services/search/postgres/listing_spec.rb
+++ b/spec/services/search/postgres/listing_spec.rb
@@ -1,0 +1,144 @@
+require "rails_helper"
+
+RSpec.describe Search::Postgres::Listing, type: :service do
+  let(:listing) { create(:listing) }
+
+  it "defines necessary constants", :aggregate_failures do
+    constants = [
+      described_class::ATTRIBUTES,
+      described_class::DEFAULT_PER_PAGE,
+      described_class::MAX_PER_PAGE,
+    ]
+
+    constants.each do |constant|
+      expect(constant).not_to be_nil
+    end
+  end
+
+  describe "::search_documents" do
+    it "does not include a listing that is unpublished", :aggregate_failures do
+      published_listing = create(:listing, title: "Published Listing", published: true)
+      unpublished_listing = create(:listing, title: "Unpublished Listing", published: false)
+      result = described_class.search_documents(term: "Listing")
+      titles = result.map { |r| r.pluck(:title) }
+
+      expect(titles).not_to include(unpublished_listing.title)
+      expect(titles).to include(published_listing.title)
+    end
+
+    context "when describing the result format" do
+      let(:result) { described_class.search_documents(term: listing.title) }
+
+      it "returns the correct attributes for the result" do
+        expected_keys = %i[
+          id body_markdown bumped_at category contact_via_connect expires_at
+          originally_published_at location processed_html published slug title
+          user_id tags author
+        ]
+
+        expect(result.first.keys).to match_array(expected_keys)
+      end
+
+      it "returns the correct attributes for the author" do
+        expected_keys = %i[username name profile_image_90]
+        expect(result.first[:author].keys).to match_array(expected_keys)
+      end
+
+      it "returns tag as an Array" do
+        expect(result.first[:tags]).to be_an_instance_of(Array)
+      end
+    end
+
+    context "when searching for a term" do
+      it "matches against the listing's body_markdown", :aggregate_failures do
+        listing.update_columns(body_markdown: "A Sweet New Opportunity")
+        result = described_class.search_documents(term: "new")
+
+        expect(result.first[:body_markdown]).to eq listing.body_markdown
+
+        result = described_class.search_documents(term: "old")
+        expect(result).to be_empty
+      end
+
+      it "matches against the listing's cached_tag_list", :aggregate_failures do
+        listing.update_columns(cached_tag_list: "javascript, beginners, ruby")
+        result = described_class.search_documents(term: "beginner")
+
+        expect(result.first[:tags].join(", ")).to eq listing.cached_tag_list
+
+        result = described_class.search_documents(term: "newbie")
+        expect(result).to be_empty
+      end
+
+      it "matches against the listing's location", :aggregate_failures do
+        listing.update_columns(location: "Tampa")
+        result = described_class.search_documents(term: "tampa")
+
+        expect(result.first[:location]).to eq listing.location
+
+        result = described_class.search_documents(term: "milan")
+        expect(result).to be_empty
+      end
+
+      it "matches against the listing's slug", :aggregate_failures do
+        listing.update_columns(slug: "some-cool-slug")
+        result = described_class.search_documents(term: "cool")
+
+        expect(result.first[:slug]).to eq listing.slug
+
+        result = described_class.search_documents(term: "lame")
+        expect(result).to be_empty
+      end
+
+      it "matches against the listing's title", :aggregate_failures do
+        listing.update_columns(title: "Awesome New Listing")
+        result = described_class.search_documents(term: "new")
+
+        expect(result.first[:title]).to eq listing.title
+
+        result = described_class.search_documents(term: "old")
+        expect(result).to be_empty
+      end
+    end
+
+    context "when searching for a term and filtering by category" do
+      it "selects results with the requested category" do
+        job_listings_category = create(:listing_category, name: "Job Listings", slug: "jobs")
+
+        job_listing = create(:listing,
+                             title: "Looking for a Ruby on Rails Developer!",
+                             listing_category: job_listings_category)
+
+        education_category = create(:listing_category, name: "Education/Courses", slug: "education")
+
+        listing.update_columns(
+          title: "New Ruby on Rails for Beginners Course!",
+          classified_listing_category_id: education_category.id,
+        )
+
+        result = described_class.search_documents(term: "Ruby on Rails", category: job_listing.category)
+        ids = result.ids
+
+        expect(ids).to include(job_listing.id)
+        expect(ids).not_to include(listing.id)
+      end
+    end
+
+    context "when paginating" do
+      before { create_list(:listing, 2) }
+
+      it "returns no results when out of pagination bounds" do
+        result = described_class.search_documents(page: 99)
+        expect(result).to be_empty
+      end
+
+      it "returns paginated results", :aggregate_failures do
+        result = described_class.search_documents(page: 0, per_page: 1)
+        expect(result.length).to eq(1)
+
+        result = described_class.search_documents(page: 1, per_page: 1)
+        expect(result.length).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/services/search/postgres/listing_spec.rb
+++ b/spec/services/search/postgres/listing_spec.rb
@@ -3,18 +3,6 @@ require "rails_helper"
 RSpec.describe Search::Postgres::Listing, type: :service do
   let(:listing) { create(:listing) }
 
-  it "defines necessary constants", :aggregate_failures do
-    constants = [
-      described_class::ATTRIBUTES,
-      described_class::DEFAULT_PER_PAGE,
-      described_class::MAX_PER_PAGE,
-    ]
-
-    constants.each do |constant|
-      expect(constant).not_to be_nil
-    end
-  end
-
   describe "::search_documents" do
     it "does not include a listing that is unpublished", :aggregate_failures do
       published_listing = create(:listing, title: "Published Listing", published: true)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR adds "searching for listings" behind a feature flag, using the new PostgreSQL FTS added #12905.

## Related Tickets & Documents
RFC 0153: https://github.com/forem/rfcs/pull/153
https://github.com/orgs/forem/projects/29#card-57639102

## QA Instructions, Screenshots, Recordings
1. Load the console, activate the flag with `FeatureFlag.enable(:search_2_listings)`.
2. Go to http://localhost:3000/listings.
2. Click on categories in the left column to make sure listings still filter by category.
3. Search for listings and make sure the results match what you expect.

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
Monitor our monitors for performance compared to Elasticsearch.

![new_listing_gif](https://media.giphy.com/media/gffzKp9UfClUkvFlHg/giphy.gif)
