### PR TITLE
[15 Min Fix]: Fix incorrect scope used by metrics:overview rake task

### DIFF
--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -7,6 +7,6 @@ module Ahoy
     belongs_to :visit
     belongs_to :user, optional: true
 
-    scope :overview_link_clicks, -> { where(name: "Overview Link Clicked") }
+    scope :overview_link_clicks, -> { where(name: "Admin Overview Link Clicked") }
   end
 end

--- a/lib/tasks/metrics.rake
+++ b/lib/tasks/metrics.rake
@@ -3,6 +3,9 @@ namespace :metrics do
   task overview: :environment do
     puts "Admin Overview Link Tracking for #{SiteConfig.app_domain}:"
     links_by_target = Ahoy::Event.overview_link_clicks.group("properties -> 'target'").count
+
+    return unless links_by_target
+
     links_by_target.each do |k, v|
       puts "#{k.delete_prefix(URL.url)}: #{v}"
     end

--- a/spec/tasks/metrics_spec.rb
+++ b/spec/tasks/metrics_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Metrics Overview task", type: :task do
+  before do
+    Rake::Task.clear
+    PracticalDeveloper::Application.load_tasks
+  end
+
+  describe "#overview" do
+    let(:event_name) { "Admin Overview Link Clicked" }
+    let(:click_target) { "https://forem.gitbook.io/forem-admin-guide/quick-start-guide" }
+
+    it "returns the event count and target for admin overview events" do
+      create(:ahoy_event, name: event_name, properties: {
+               action: "click", target: click_target
+             })
+
+      expect { Rake::Task["metrics:overview"].invoke }.to output(
+        "Admin Overview Link Tracking for localhost:3000:\n#{click_target}: 1\n",
+      ).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We merged a rake task yesterday that was meant to help us in fetching metrics around admin overview link clicks for a given Forem instance (https://github.com/forem/forem/pull/13023).

This was deployed to the fleet today, but when I went to test it out, I noticed that it wasn't working properly on any Forem instance, but it _was_ returning records for me locally.

After checking some assumptions and doing some digging, I figured out that the issue was actually that the scope was incorrect -- we were searching by the wrong event name! The event name for an event when an admin clicks on an overview link is [`Admin Overview Link Clicked`](https://github.com/jacobherrington/dev.to/blob/d0a4775cb823ae65f4e6bb3c7f1ac0dde7975d5f/app/javascript/admin/controllers/ahoy_controller.js#L17):

```javascript
ahoy.track('Admin Overview Link Clicked', properties);
```

But the scope in the rake task is looking for [`Overview Link Clicked`](https://github.com/jacobherrington/dev.to/blob/5c75d866597d81fd7afc2613f90f60c85cd38328/app/models/ahoy/event.rb#L10):

```ruby
scope :overview_link_clicks, -> { where(name: "Overview Link Clicked")
```

...which doesn't map to any event, so of course nothing was ever getting returned 😉 

I also figured out that the reason it was "working" for me locally was actually because I somehow already had events with the `Overview Link Clicked` name. I also figured out _how_ this happened 🤦🏽‍♀️

In the _original_ PR, we had used the event name `Overview Link Clicked`, but during PR review it was changed. So I had those old records saved locally from the initial instance where I QAed this PR, but never picked up on that while QAing the PR a second time.

Anyways, I also added a test for this rake task because a spec would've caught this typo and will help us catch future ones :) 

_Moral of the story: maybe you should reset your database more often, or at least check that the records you think you are referencing are actually there, and not some old record from a previous time that you QAed something! 😅_

## Related Tickets & Documents

Historical PR referenced in my PR description: https://github.com/forem/forem/pull/12726
Follow up fix to the work originally done in this PR: https://github.com/forem/forem/pull/13023

## QA Instructions, Screenshots, Recordings

To QA:
1. Go into your rails console and first run `Ahoy::Event.destroy_all`
2. Run this rake task (`bundle exec rake metrics:overview`) and observe that there is no output of link clicks
2. Go to the `/admin/overview` page, and click on any link(s) in the checklist
3. Run this rake task and observe that there is output with your link clicks

### UI accessibility concerns?

None, it's just a rake task :) 

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
