### PR TITLE
15 min fix - improve reliability of autocomplete cypress test

### DIFF
--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -6,12 +6,13 @@
         <div id="comment-subscription">
           <div role="presentation" class="crayons-btn-group">
             <span class="crayons-btn crayons-btn--outlined">Subscribe</span>
-          </div>  
+          </div>
         </div>
       </header>
 
       <div
         id="comments-container"
+        data-testid="comments-container"
         data-commentable-id="<%= @article.id %>"
         data-commentable-type="Article"
         data-has-recent-comment-activity="<%= @article.has_recent_comment_activity? %>">

--- a/cypress/integration/articleFlows/commentOnArticle.spec.js
+++ b/cypress/integration/articleFlows/commentOnArticle.spec.js
@@ -257,11 +257,12 @@ describe('Comment on articles', () => {
 
     cy.findByRole('link', { name: /Reply/ });
 
-    // Wait for the comment to save
-    cy.findByText('Edit');
-
-    cy.findAllByLabelText('Toggle dropdown menu').last().click();
-    cy.findByText('Edit').click();
+    cy.findByTestId('comments-container').within(() => {
+      cy.findByLabelText('Toggle dropdown menu').click();
+      // Wait for the menu to be visible
+      cy.findByText('Edit').should('be.visible');
+      cy.findByText('Edit').click();
+    });
 
     cy.findByDisplayValue('first comment').should('exist');
   });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Optimization

## Description

After merging the autocomplete work in #13126 we had a couple of instance of a failed Cypress test in CI. After running the specs locally multiple times it seems that occasionally it was not targeting the correct "toggle dropdown menu" because there are multiple on the page.

A later accessibility enhancement will be to make sure controls have unique names on this page, but for now to fix the flakiness I've scoped this test better with a data-testid on the comments container. I think this is good practice anyway, as the comments container is the area currently under test.

## Related Tickets & Documents

#13126 

## QA Instructions, Screenshots, Recordings

N/A no change to app functionality

### UI accessibility concerns?

N/A no change to app functionality

## Added tests?

- [X] Yes - test updated


## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] This change does not need to be communicated, and this is why not: Test update only


