### PR TITLE
Instrument EmailDigestArticleCollector

### DIFF
--- a/app/services/instrumentation.rb
+++ b/app/services/instrumentation.rb
@@ -1,0 +1,7 @@
+module Instrumentation
+  def instrument(operation, tags: [], &block)
+    # TODO: (@jgaskins): Extract the knowledge of which tracing library
+    # we're using, like we did with ForemStatsDriver
+    Datadog.tracer.trace operation, tags: tags, &block
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Instrumentation

## Description

On DEV, since we skip this with sidekiq-cron and instead process them
inline using Heroku Scheduler (which is not instrumented), we miss out
on all instrumentation for this process and have no idea how long it
takes to process each user.

With this instrumentation in place, we can see how long it takes to
process each user and aggregate them to see how long it takes to process
all users.

This commit also adds an Instrumentation mixin that we can use to
instrument blocks easily:


```ruby
instrument "MyClass.my_method", tags: { article: article.id } do |span|
  # ...
end
```

## Related Tickets & Documents

https://github.com/forem/internalEngineering/issues/274 — Optimize EmailDigestWorker for DEV Article Queries

## QA Instructions, Screenshots, Recordings

With this deployed, Datadog should have spans for a resource called `EmailDigestArticleCollector#articles_to_send`. They may not be available in the `practical-developer` service and may need to be indexed manually.

## Added tests?

- [ ] Yes
- [x] No, and this is why: The only new functionality is instrumentation and I'm honestly not sure whether we should write tests for that. Totally open to discussion on it, though.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams (@forem/sre)
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

A couple days after this is deployed (the Rake task runs once per day and we'll want multiple runs), check Datadog for the span mentioned above. Index it explicitly if necessary.

## [optional] What gif best describes this PR or how it makes you feel?

![NEED INPUT](https://www.dsmtuners.com/attachments/input-gif.345622/)
