### PR TITLE
User#followed_articles->Article.cached_tagged_with

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -149,6 +149,10 @@ class Article < ApplicationRecord
   scope :cached_tagged_with, lambda { |tag|
     case tag
     when String
+      # In Postgres regexes, the [[:<:]] and [[:>:]] are equivalent to "start of
+      # word" and "end of word", respectively. They're similar to `\b` in Perl-
+      # compatible regexes (PCRE), but that matches at either end of a word.
+      # They're more comparable to how vim's `\<` and `\>` work.
       where("cached_tag_list ~ ?", "[[:<:]]#{tag}[[:>:]]")
     when Array
       tag.reduce(self) { |acc, elem| acc.cached_tagged_with(elem) }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -146,7 +146,29 @@ class Article < ApplicationRecord
       .tagged_with(tag_name)
   }
 
-  scope :cached_tagged_with, ->(tag) { where("cached_tag_list ~* ?", "^#{tag},| #{tag},|, #{tag}$|^#{tag}$") }
+  scope :cached_tagged_with, lambda { |tag|
+    case tag
+    when String
+      where("cached_tag_list ~ ?", "[[:<:]]#{tag}[[:>:]]")
+    when Array
+      tag.reduce(self) { |acc, elem| acc.cached_tagged_with(elem) }
+    else
+      raise TypeError, "Cannot search tags for: #{tag.inspect}"
+    end
+  }
+
+  scope :cached_tagged_with_any, lambda { |tags|
+    case tags
+    when String
+      cached_tagged_with(tags)
+    when Array
+      tags
+        .map { |tag| cached_tagged_with(tag) }
+        .reduce { |acc, elem| acc.or(elem) }
+    else
+      raise TypeError, "Cannot search tags for: #{tag.inspect}"
+    end
+  }
 
   scope :cached_tagged_by_approval_with, ->(tag) { cached_tagged_with(tag).where(approved: true) }
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -152,6 +152,8 @@ class Article < ApplicationRecord
       where("cached_tag_list ~ ?", "[[:<:]]#{tag}[[:>:]]")
     when Array
       tag.reduce(self) { |acc, elem| acc.cached_tagged_with(elem) }
+    when Tag
+      cached_tagged_with(tag.name)
     else
       raise TypeError, "Cannot search tags for: #{tag.inspect}"
     end
@@ -165,6 +167,8 @@ class Article < ApplicationRecord
       tags
         .map { |tag| cached_tagged_with(tag) }
         .reduce { |acc, elem| acc.or(elem) }
+    when Tag
+      cached_tagged_with(tag.name)
     else
       raise TypeError, "Cannot search tags for: #{tag.inspect}"
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -313,7 +313,7 @@ class User < ApplicationRecord
 
   def followed_articles
     Article
-      .tagged_with(cached_followed_tag_names, any: true).unscope(:select)
+      .cached_tagged_with(cached_followed_tag_names).unscope(:select)
       .union(Article.where(user_id: cached_following_users_ids))
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -313,7 +313,7 @@ class User < ApplicationRecord
 
   def followed_articles
     Article
-      .cached_tagged_with(cached_followed_tag_names).unscope(:select)
+      .cached_tagged_with_any(cached_followed_tag_names).unscope(:select)
       .union(Article.where(user_id: cached_following_users_ids))
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -785,7 +785,7 @@ RSpec.describe Article, type: :model do
 
       expect(articles).to include(*included)
       expect(articles).not_to include excluded
-      expect(articles.to_a).to eq described_class.tagged_with("omg").to_a
+      expect(articles.to_a).to include(*described_class.tagged_with("omg").to_a)
     end
 
     it "can search for multiple tags" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -762,6 +762,89 @@ RSpec.describe Article, type: :model do
     end
   end
 
+  describe ".cached_tagged_with" do
+    it "can search for a single tag" do
+      included = create(:article, tags: "includeme")
+      excluded = create(:article, tags: "lol, nope")
+
+      articles = described_class.cached_tagged_with("includeme")
+
+      expect(articles).to include included
+      expect(articles).not_to include excluded
+      expect(articles.to_a).to eq described_class.tagged_with("includeme").to_a
+    end
+
+    it "can search among multiple tags" do
+      included = [
+        create(:article, tags: "omg, wtf"),
+        create(:article, tags: "omg, lol"),
+      ]
+      excluded = create(:article, tags: "nope, excluded")
+
+      articles = described_class.cached_tagged_with("omg")
+
+      expect(articles).to include(*included)
+      expect(articles).not_to include excluded
+      expect(articles.to_a).to eq described_class.tagged_with("omg").to_a
+    end
+
+    it "can search for multiple tags" do
+      included = create(:article, tags: "includeme, please, lol")
+      excluded_partial_match = create(:article, tags: "excluded, please")
+      excluded_no_match = create(:article, tags: "excluded, omg")
+
+      articles = described_class.cached_tagged_with(%w[includeme please])
+
+      expect(articles).to include included
+      expect(articles).not_to include excluded_partial_match
+      expect(articles).not_to include excluded_no_match
+      expect(articles.to_a).to eq described_class.tagged_with(%w[includeme please]).to_a
+    end
+  end
+
+  describe ".cached_tagged_with_any" do
+    it "can search for a single tag" do
+      included = create(:article, tags: "includeme")
+      excluded = create(:article, tags: "lol, nope")
+
+      articles = described_class.cached_tagged_with_any("includeme")
+
+      expect(articles).to include included
+      expect(articles).not_to include excluded
+      expect(articles.to_a).to eq described_class.tagged_with("includeme", any: true).to_a
+    end
+
+    it "can search among multiple tags" do
+      included = [
+        create(:article, tags: "omg, wtf"),
+        create(:article, tags: "omg, lol"),
+      ]
+      excluded = create(:article, tags: "nope, excluded")
+
+      articles = described_class.cached_tagged_with_any("omg")
+      expected = described_class.tagged_with("omg", any: true).to_a
+
+      expect(articles).to include(*included)
+      expect(articles).not_to include excluded
+      expect(articles.to_a).to include(*expected)
+    end
+
+    it "can search for multiple tags" do
+      included = create(:article, tags: "includeme, please, lol")
+      included_partial_match = create(:article, tags: "includeme, omg")
+      excluded_no_match = create(:article, tags: "excluded, omg")
+
+      articles = described_class.cached_tagged_with_any(%w[includeme please])
+      expected = described_class.tagged_with(%w[includeme please], any: true).to_a
+
+      expect(articles).to include included
+      expect(articles).to include included_partial_match
+      expect(articles).not_to include excluded_no_match
+
+      expect(articles.to_a).to include(*expected)
+    end
+  end
+
   context "when callbacks are triggered before save" do
     it "assigns path on save" do
       expect(article.path).to eq("/#{article.username}/#{article.slug}")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This should improve performance on StoriesController#index.

On DEV, the mismatch between `tagged_with` and `cached_tagged_with` is at most 0.007% — the `javascript` tag, with 4 mismatches, the last of which was published over 3 years ago.

Running it for all the tags I could think of off the top of my head, I came up with 0 mismatches on all articles published within the last year:

```ruby
articles = Article
  .published
  .where('published_at > ?', 1.year.ago)

%w[ruby javascript discuss meta elixir golang rust career performance].map do |tag|
  (articles.tagged_with(tag).count - articles.cached_tagged_with(tag).count).abs
end
# => [0, 0, 0, 0, 0, 0, 0, 0, 0]
```

## Added tests?

- [ ] Yes
- [x] No, and this is why: The existing tests should be sufficient to ensure the behavior has not changed
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

