### PR TITLE
[15 Min Fix] Got rid of some E2E test flakiness

### DIFF
--- a/cypress/integration/articleFlows/commentOnArticle.spec.js
+++ b/cypress/integration/articleFlows/commentOnArticle.spec.js
@@ -208,27 +208,32 @@ describe('Comment on articles', () => {
         { fixture: 'search/usernames.json' },
       );
 
-      cy.findByLabelText(/^Add a comment to the discussion$/i).click();
       // Get a handle to the newly substituted textbox
-      cy.findByRole('textbox', {
-        name: /^Add a comment to the discussion$/i,
-      }).type('first comment');
+      cy.findByRole('main')
+        .as('main')
+        .findByRole('textbox', /^Add a comment to the discussion$/i)
+        .focus()
+        .type('first comment');
 
-      cy.findByRole('button', { name: /Submit/ }).click();
-      cy.findByRole('link', { name: /Reply/ }).click();
+      cy.get('@main')
+        .findByRole('button', { name: /Submit/ })
+        .click();
+      cy.get('@main').findByRole('link', { name: /Reply/ }).click();
 
-      cy.findByRole('textbox', {
-        name: /Reply to a comment.../,
-      }).as('replyCommentBox');
+      cy.get('@main')
+        .findByRole('textbox', {
+          name: /Reply to a comment.../,
+        })
+        .as('replyCommentBox');
 
-      cy.get('@replyCommentBox').click().type('Some text @s');
+      cy.get('@main').get('@replyCommentBox').click().type('Some text @s');
 
       // Verify the combobox has appeared
-      cy.findByRole('combobox', { name: /Reply to a comment/ }).as(
-        'autocompleteCommentBox',
-      );
+      cy.get('@main')
+        .findByRole('combobox', { name: /Reply to a comment/ })
+        .as('autocompleteCommentBox');
 
-      cy.get('@autocompleteCommentBox').type('earch');
+      cy.get('@main').get('@autocompleteCommentBox').type('earch');
       cy.findByText('@search_user_1').click();
 
       cy.get('@replyCommentBox').should(

--- a/cypress/integration/articleFlows/commentOnArticle.spec.js
+++ b/cypress/integration/articleFlows/commentOnArticle.spec.js
@@ -253,7 +253,7 @@ describe('Comment on articles', () => {
       cy.findByRole('link', { name: /Reply/ });
 
       cy.findByTestId('comments-container').within(() => {
-        cy.findByLabelText('Toggle dropdown menu').click();
+        cy.findByRole('button', { name: 'Toggle dropdown menu' }).click();
         // Wait for the menu to be visible
         cy.findByText('Edit').should('be.visible');
         cy.findByText('Edit').click();


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

For some reason on my local the comment E2E test `'should pre-populate a comment field when editing'` was always failing even though it was passing on CI. My only guess is it's a  CPU speed thing maybe. This improves the selector for finding the button to display the comment context menu.

This PR also addresses another flaky test, `'should reply to a comment with user mention autocomplete'`.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

N/A E2E Test improvement

### UI accessibility concerns?

N/A E2E Test improvement

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: N/A E2E Test improvement

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Thor screaming yes! when he sees the Incredible Hulk in Thor Ragnarok](https://media.giphy.com/media/3ohhweiVB36rAlqVCE/giphy.gif)
