### PR TITLE
Bug Fix:Remove Suggest a Tweet since we no longer have that feature

### DIFF
--- a/app/views/articles/manage.html.erb
+++ b/app/views/articles/manage.html.erb
@@ -11,7 +11,6 @@
         <h3 class="manage-page-success"><%= flash[:pins_success] %></h3>
       <% end %>
       <h2>Tools:</h2>
-      <p><strong>Suggest a Tweet:</strong> Help get your post in front of more <%= community_members_label %> by suggesting a tweet that <a href="https://twitter.com/<%= SiteConfig.social_media_handles["twitter"] %>">@<%= SiteConfig.social_media_handles["twitter"] %></a> editors can use.
       <p><strong>Experience Level of Post:</strong> Is your post written more for a beginner or an advanced audience?  Adjust this level as a <em>gentle</em> indicator which will help show the post to the people who will benefit the most.
       <h2>Tips:</h2>
       <ol>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We recently removed Buffer from the app and the ability to for users to suggest Tweets. This removes the Suggest a Tweet copy from the Manage page for a post to avoid any confusion. 

## QA Instructions, Screenshots, Recordings
Load the manage page for a post and see the copy removed. 
BEFORE:
![Screen Shot 2021-03-30 at 1 38 41 PM](https://user-images.githubusercontent.com/1813380/113036428-eaa91b00-9159-11eb-859f-3d44ec83a46f.png)
AFTER:
<img width="1295" alt="Screen Shot 2021-03-30 at 2 09 48 PM" src="https://user-images.githubusercontent.com/1813380/113036451-f399ec80-9159-11eb-9e56-4dc12434f1d9.png">


## Added tests?

- [x] No bc this is a minor copy removal, not worth testing

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams


![I will try to fix you gif](https://thumbs.gfycat.com/AlertThisArgentinehornedfrog-small.gif)
