### PR TITLE
Optimization:✂️  Remove Unused Twitter Counts from User ✂️ 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   resourcify
+  self.ignored_columns = %w[twitter_following_count twitter_followers_count]
 
   include CloudinaryHelper
   include Searchable

--- a/app/services/authentication/providers/twitter.rb
+++ b/app/services/authentication/providers/twitter.rb
@@ -13,8 +13,6 @@ module Authentication
           name: name,
           remote_profile_image_url: Users::SafeRemoteProfileImageUrl.call(remote_profile_image_url),
           twitter_created_at: raw_info.created_at,
-          twitter_followers_count: raw_info.followers_count.to_i,
-          twitter_following_count: raw_info.friends_count.to_i,
           twitter_username: info.nickname
         }
       end
@@ -22,8 +20,6 @@ module Authentication
       def existing_user_data
         {
           twitter_created_at: raw_info.created_at,
-          twitter_followers_count: raw_info.followers_count.to_i,
-          twitter_following_count: raw_info.friends_count.to_i,
           twitter_username: info.nickname
         }
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -588,7 +588,6 @@ RSpec.describe User, type: :model do
 
     it "persists extracts relevant identity data from new twitter user" do
       new_user = user_from_authorization_service(:twitter, nil, "navbar_basic")
-      expect(new_user.twitter_followers_count).to eq(100)
       expect(new_user.twitter_created_at).to be_kind_of(ActiveSupport::TimeWithZone)
     end
 

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -541,8 +541,6 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.name).to eq(raw_info.name)
         expect(user.remote_profile_image_url).to eq(info.image.to_s.gsub("_normal", ""))
         expect(user.twitter_created_at.to_i).to eq(Time.zone.parse(raw_info.created_at).to_i)
-        expect(user.twitter_followers_count).to eq(raw_info.followers_count.to_i)
-        expect(user.twitter_following_count).to eq(raw_info.friends_count.to_i)
         expect(user.twitter_username).to eq(info.nickname)
       end
 
@@ -639,8 +637,6 @@ RSpec.describe Authentication::Authenticator, type: :service do
         raw_info = auth_payload.extra.raw_info
 
         expect(user.twitter_created_at.to_i).to eq(Time.zone.parse(raw_info.created_at).to_i)
-        expect(user.twitter_followers_count).to eq(raw_info.followers_count.to_i)
-        expect(user.twitter_following_count).to eq(raw_info.friends_count.to_i)
       end
 
       it "sets remember_me for the existing user" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
When digging through some old issues I came across this one [focused on making a user counters table](https://github.com/forem/forem/issues/4939). When glancing over all the counters that are currently on user it occurred to me that I didn't think many of them were used so I started grep'ing the codebase and I was right. This PR removes `twitter_followers_count` and `twitter_following_count` from the codebase. A follow-up PR with a migration will be used to remove them from the database as well. 

I figured with all the profile generalization work going on it would be nice to slim down the users table to only the columns being used to avoid any confusion about what needs to be generalized and/or moved off of it.  

## Added tests?
- [x] No since this is removing unused code we are actually removing tests

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams


![chop chop gif](https://media0.giphy.com/media/3o7TKsrsj48rm30nyU/200.gif)
