### PR TITLE
Optimization:Remove Twitter Counts From User Table in db

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
   resourcify
-  self.ignored_columns = %w[twitter_following_count twitter_followers_count]
 
   include CloudinaryHelper
   include Searchable

--- a/db/migrate/20210331181505_remove_twitter_counts_from_user.rb
+++ b/db/migrate/20210331181505_remove_twitter_counts_from_user.rb
@@ -1,0 +1,8 @@
+class RemoveTwitterCountsFromUser < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured do
+      remove_column :users, :twitter_following_count, :integer
+      remove_column :users, :twitter_followers_count, :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_26_172406) do
+ActiveRecord::Schema.define(version: 2021_03_31_181505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1323,8 +1323,6 @@ ActiveRecord::Schema.define(version: 2021_03_26_172406) do
     t.string "text_color_hex"
     t.string "twitch_url"
     t.datetime "twitter_created_at"
-    t.integer "twitter_followers_count"
-    t.integer "twitter_following_count"
     t.string "twitter_username"
     t.string "unconfirmed_email"
     t.string "unlock_token"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Followup PR to #13196 that actually removes the columns from the database. Given our recent issues with db backups this will ideally need to go out when we are NOT running a Postgres backup. 

## Added Tests?
- [x] No bc this only involves removing a db column

![mickey goodbye gif](https://media1.giphy.com/media/fxe8v45NNXFd4jdaNI/giphy.gif?cid=ecf05e4728ieev1mmvtre8k5ekuw9a1ratmqc0vhldkv6lr5&rid=giphy.gif)
