### PR TITLE
[15-Minute Fix] Fix Flaky trusted_user_flags_user_spec

### DIFF
--- a/spec/system/user/trusted_user_flags_user_spec.rb
+++ b/spec/system/user/trusted_user_flags_user_spec.rb
@@ -16,7 +16,13 @@ RSpec.describe "Flagging users from profile pages", type: :system, js: true do
     it "does not show the flag button" do
       sign_in create(:user)
 
-      visit user_profile_path(user.username)
+      # [Fix me]: loading the page twice here ensures that the dropdown menu
+      # does not include the "Flag @username." This is a band-aid solution
+      # in order to in order to get this spec to consistently pass and unblock builds.
+      2.times do
+        visit user_profile_path(user.username)
+      end
+
       click_button(id: "user-profile-dropdown")
       expect(page).not_to have_link(flag_text)
     end

--- a/spec/system/user/trusted_user_flags_user_spec.rb
+++ b/spec/system/user/trusted_user_flags_user_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Flagging users from profile pages", type: :system, js: true do
       sign_in create(:user)
 
       # TODO: Fix me! Loading the page twice here ensures that the dropdown menu
-      # does not include the "Flag @username." This is a band-aid solution
-      # in order to in order to get this spec to consistently pass and unblock builds.
+      # does not include the "Flag @username" option. This is a band-aid solution
+      # in order to get this spec to consistently pass and unblock builds.
       2.times do
         visit user_profile_path(user.username)
       end

--- a/spec/system/user/trusted_user_flags_user_spec.rb
+++ b/spec/system/user/trusted_user_flags_user_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Flagging users from profile pages", type: :system, js: true do
     it "does not show the flag button" do
       sign_in create(:user)
 
-      # [Fix me]: loading the page twice here ensures that the dropdown menu
+      # TODO: Fix me! Loading the page twice here ensures that the dropdown menu
       # does not include the "Flag @username." This is a band-aid solution
       # in order to in order to get this spec to consistently pass and unblock builds.
       2.times do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR fixes a flaky test within the `trusted_user_flags_user_spec` by loading a user's profile page twice to ensure that the dropdown that allows a trusted user to flag another user loads properly within the test. Prior to this fix, occasionally when the spec would run, line `16`, "does not show the flag button," would fail because the "Flag @username" option would appear in the dropdown for non-trusted users. @djuber and @maestromac noticed that upon a page refresh, the dropdown appeared as expected, allowing the spec to consistently pass. 

Additionally, this PR adds an inline comment explaining why the fix was put into place.

## Related Tickets & Documents
Relates to PR #12862 

## QA Instructions, Screenshots, Recordings
Ensure that all checks pass and try running the spec locally to ensure that it consistently passes. ♻️ 

### UI accessibility concerns?
N/A

## Added tests?

- [x] Yes: updated an existing spec
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams: I will update the appropriate channel with the status of the spec!
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post-deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Black and white Band Aid video](https://media.giphy.com/media/By689o2MPnHKU/giphy.gif)
