### PR TITLE
[15 Min Fix]: Extract a post's followers out of service and onto Article model

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -435,7 +435,7 @@ class Article < ApplicationRecord
     doc.to_html
   end
 
-  def authors_followers
+  def followers
     # This will return an array, but the items will NOT be ActiveRecord objects.
     # The followers may also occasionally be nil because orphaned follows can possibly exist in the database.
     followers = user.followers_scoped.where(subscription_status: "all_articles").map(&:follower)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -435,6 +435,19 @@ class Article < ApplicationRecord
     doc.to_html
   end
 
+  def authors_followers
+    # This will return an array, but the items will NOT be ActiveRecord objects.
+    # The followers may also occasionally be nil because orphaned follows can possibly exist in the database.
+    followers = user.followers_scoped.where(subscription_status: "all_articles").map(&:follower)
+
+    if organization_id
+      org_followers = organization.followers_scoped.where(subscription_status: "all_articles")
+      followers += org_followers.map(&:follower)
+    end
+
+    followers.uniq.compact
+  end
+
   private
 
   def search_score

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -25,7 +25,7 @@ module Notifications
         json_data[:organization] = organization_data(notifiable.organization) if notifiable.organization_id
 
         notifications_attributes = []
-        notifiable.followers.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
+        notifiable.followers.sort_by(&:updated_at).last(10_000).reverse_each do |follower|
           now = Time.current
           notifications_attributes.push(
             user_id: follower.id,

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -25,7 +25,7 @@ module Notifications
         json_data[:organization] = organization_data(notifiable.organization) if notifiable.organization_id
 
         notifications_attributes = []
-        notifiable.authors_followers.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
+        notifiable.followers.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
           now = Time.current
           notifications_attributes.push(
             user_id: follower.id,

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -16,6 +16,8 @@ module Notifications
       end
 
       def call
+        return unless notifiable.is_a?(Article)
+
         json_data = {
           user: user_data(notifiable.user),
           article: article_data(notifiable)
@@ -23,9 +25,7 @@ module Notifications
         json_data[:organization] = organization_data(notifiable.organization) if notifiable.organization_id
 
         notifications_attributes = []
-        # followers is an array and not an activerecord object
-        # followers can occasionally be nil because orphaned follows can possibly exist in the db (for now)
-        followers.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
+        notifiable.authors_followers.sort_by(&:updated_at).reverse[0..10_000].each do |follower|
           now = Time.current
           notifications_attributes.push(
             user_id: follower.id,
@@ -52,17 +52,6 @@ module Notifications
       private
 
       attr_reader :notifiable, :action
-
-      def followers
-        followers = notifiable.user.followers_scoped.where(subscription_status: "all_articles").map(&:follower)
-
-        if notifiable.organization_id
-          org_followers = notifiable.organization.followers_scoped.where(subscription_status: "all_articles")
-          followers += org_followers.map(&:follower)
-        end
-
-        followers.uniq.compact
-      end
 
       def choose_upsert_index(action)
         return :index_notifications_on_user_notifiable_and_action_not_null if action.present?

--- a/app/workers/notifications/notifiable_action_worker.rb
+++ b/app/workers/notifications/notifiable_action_worker.rb
@@ -4,7 +4,7 @@ module Notifications
 
     sidekiq_options queue: :low_priority, retry: 10
     def perform(notifiable_id, notifiable_type, action)
-      # checking type, but leaving space for notifyable types
+      # checking type, but leaving space for notifiable types
       return unless notifiable_type == "Article"
 
       notifiable = notifiable_type.constantize.find_by(id: notifiable_id)

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1118,13 +1118,13 @@ RSpec.describe Article, type: :model do
     end
   end
 
-  describe "#authors_followers" do
-    it "returns article_ID" do
+  describe "#followers" do
+    it "returns an array of users who follow the article's author" do
       following_user = create(:user)
       following_user.follow(user)
 
-      expect(article.authors_followers.length).to eq(1)
-      expect(article.authors_followers.first.username).to eq(following_user.username)
+      expect(article.followers.length).to eq(1)
+      expect(article.followers.first.username).to eq(following_user.username)
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1118,6 +1118,16 @@ RSpec.describe Article, type: :model do
     end
   end
 
+  describe "#authors_followers" do
+    it "returns article_ID" do
+      following_user = create(:user)
+      following_user.follow(user)
+
+      expect(article.authors_followers.length).to eq(1)
+      expect(article.authors_followers.first.username).to eq(following_user.username)
+    end
+  end
+
   describe "#update_score" do
     it "stably sets the correct blackbox values" do
       create(:reaction, reactable: article, points: 1)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

While working on https://github.com/forem/rfcs/pull/22, I found myself looking at the `Notifications::NotifiableAction::Send` service and noticed that we had some logic in that service for finding the followers of an article. While working on my RFC, I found myself duplicating this logic elsewhere, and realized that it was odd for this logic to be so tightly coupled to a service, when really, the article itself should be able to tell you which users follow it/the article's author!

This PR moves the `followers` method out of the service and onto the `Article` model such that you can ask any article for its followers without being constrained to being in this service:

```ruby
[9] pry(main)> a = Article.last
  Article Load (1.1ms)  SELECT "articles".* FROM "articles" ORDER BY "articles"."id" DESC LIMIT $1  [["LIMIT", 1]]
=> #<Article:0x00007fd5e09414a8 ...>
[10] pry(main)> a.followers
=> [#<User id: 12, ...]
[11] pry(main)> a.followers.count
=> 1
```

We also didn't have any tests for this method, and given that we rely on it to make sure we're sending notifications to the right users, seems like we should! So, I went ahead and added one. 😉 

## Related Tickets & Documents

A small, encapsulated PR in service of https://github.com/forem/rfcs/pull/22.

## QA Instructions, Screenshots, Recordings

Tests should all pass, including the new one I added. Since this PR just moves a method from a service into a model, the only thing to QA here is to make sure that the notification that you _should_ receive when a user you follow publishes an article does, in fact, still send as expected 😉 

### UI accessibility concerns?

_None._

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: _A small refactor that shouldn't really impact anyone_

## Are there any post deployment tasks we need to perform?
None!

