### PR TITLE
[15 min fix] improve accessible names of dashboard post actions

### DIFF
--- a/app/views/dashboards/_dashboard_article_row.html.erb
+++ b/app/views/dashboards/_dashboard_article_row.html.erb
@@ -85,15 +85,15 @@
         <% end %>
       <% end %>
     <% elsif article.published %>
-      <a href="<%= article.path %>/manage" class="crayons-btn crayons-btn--ghost crayons-btn--s">Manage</a>
+      <a href="<%= article.path %>/manage" class="crayons-btn crayons-btn--ghost crayons-btn--s" aria-label="Manage post: <%= article.title %>">Manage</a>
     <% elsif @user == article.user %>
       <a href="<%= article.path %>/delete_confirm" data-no-instant class="crayons-btn crayons-btn--ghost-danger crayons-btn--s">Delete</a>
     <% end %>
-    <a href="<%= article.path %>/edit" class="crayons-btn crayons-btn--ghost crayons-btn--s">Edit</a>
+    <a href="<%= article.path %>/edit" class="crayons-btn crayons-btn--ghost crayons-btn--s" aria-label="Edit post: <%= article.title %>">Edit</a>
 
     <div class="js-ellipsis-menu relative inline-block">
       <button class="crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon js-ellipsis-menu-trigger">
-        <%= inline_svg_tag("overflow-horizontal.svg", aria: true, class: "crayons-icon", title: "More...") %>
+        <%= inline_svg_tag("overflow-horizontal.svg", aria: true, class: "crayons-icon", title: "More options for post: #{article.title}") %>
       </button>
 
       <div class="crayons-dropdown top-100 right-0 align-left js-ellipsis-menu-dropdown p-1">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On the main dashboard, the post action links (Edit, Manage, More...) all have the same accessible names, making it hard for screen reader users to go straight to the link they want.

This PR adds aria-labels for the links which give the additional context of the post title, making it easier to skip straight to the relevant link.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

- Log in as a user with multiple posts
- Go the dashboard
- Using a screen reader, check the accessible name of the 'Manage' and 'Edit' links, as well as the overflow menu button

**Before the change:**

(notice many instances of Manage/Edit/More)

<img width="1569" alt="VoiceOver rotor showing multiple links with the same text" src="https://user-images.githubusercontent.com/20773163/113417549-89808200-93bb-11eb-9360-8107e1e7f4f1.png">

**After the change:**

<img width="1308" alt="VoiceOver rotor showing the links now have the post title included" src="https://user-images.githubusercontent.com/20773163/113417558-8dac9f80-93bb-11eb-9b80-4736a44b4523.png">


### UI accessibility concerns?

This improves the accessibility of the dashboard

## Added tests?

- [ ] Yes
- [X] No, and this is why: Minor change, no existing tests affected. Later when we add Cypress tests for major user flows, these accessible selectors will be tested
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [X] This change does not need to be communicated, and this is why not: minor change


