### PR TITLE
[15 min fix] Link settings profile fields with their labels

### DIFF
--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -21,22 +21,22 @@
     <h2>User</h2>
 
     <div class="crayons-field">
-      <%= f.label :name, class: "crayons-field__label" %>
+      <%= f.label :name, for: "user[name]", class: "crayons-field__label" %>
       <%= f.text_field "user[name]", maxlength: 30, class: "crayons-textfield", placeholder: "John Doe", value: @user.name %>
     </div>
 
     <div class="crayons-field">
-      <%= f.label :email, class: "crayons-field__label" %>
+      <%= f.label :email, for: "user[email]", class: "crayons-field__label" %>
       <%= f.text_field "user[email]", class: "crayons-textfield", placeholder: "john.doe@example.com", value: @user.email %>
     </div>
 
     <div class="crayons-field">
-      <%= f.label :username, class: "crayons-field__label" %>
+      <%= f.label :username, for: "user[username]", class: "crayons-field__label" %>
       <%= f.text_field "user[username]", maxlength: 30, class: "crayons-textfield", placeholder: "johndoe", value: @user.username %>
     </div>
 
     <div class="crayons-field">
-      <%= f.label :profile_image, class: "crayons-field__label" %>
+      <%= f.label :profile_image, for: "user[profile_image]", class: "crayons-field__label" %>
 
       <div class="flex items-center">
         <% if @user.profile_image_url.present? %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In Settings > Profile, the top user fields weren't associated with their inputs. This meant that screen reader users missed out on the vital information on what each field is for.

This PR adds a small piece of code to properly link those labels with their inputs.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

- As a logged in user, go to Settings
- Using a screen reader, check that the fields Name/Email/Username/Profile image are all announced with their labels
- You can also use the dev tools accessibility inspector to check this information

Before the change:

(note that no label accompanies the placeholder detail or current input values for the fields mentioned) 

<img width="1041" alt="screenshot showing the VoiceOver rotor, which details the above form controls as edit texts with placeholders but not labels" src="https://user-images.githubusercontent.com/20773163/113420826-ed0dae00-93c1-11eb-9a75-20e0e3cefbfc.png">

After the change:

(labels now included)

<img width="1183" alt="Screenshot of the rotor again, but this time the labels are included in the listing" src="https://user-images.githubusercontent.com/20773163/113420895-0ca4d680-93c2-11eb-9669-859d4e212328.png">


### UI accessibility concerns?

This fixes an accessibility bug for screen reader users.

## Added tests?

- [ ] Yes
- [X] No, and this is why: this is a minor change affecting no existing tests. When we add Cypress tests for the main user flows, these accessible names will be used and tested then
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: As this is a minor change fixing a (so far) unreported bug, I don't think this needs to be specially communicated


