### PR TITLE
[15 min fix] ✂️✂️✂️ Remove preact-textarea-autosize library ✂️✂️✂️

### DIFF
--- a/app/javascript/article-form/components/Title.jsx
+++ b/app/javascript/article-form/components/Title.jsx
@@ -1,23 +1,32 @@
 import { h } from 'preact';
+import { useRef, useLayoutEffect } from 'preact/hooks';
 import PropTypes from 'prop-types';
-// We use this magic Textarea component for title field because it's automatically
-// resizable. Even though it looks like a classic input, if you enter long title
-// it would wrap the text to the next line automatically resizing itself. It helps keep
-// the entire layout the way it is without having unnecessary scrolling and white spaces.
-// Keep in mind this is what happens only here - in preact component.
+// We use this hook for the title field to automatically grow the height of the textarea.
+// It helps keep the entire layout the way it is without having unnecessary scrolling and white spaces.
+// Keep in mind this is what happens only here - in the Preact component.
 // I'm mentioning this because the entire "Write a post" view is a preact component
 // BUT it is also a classic .html.erb view which is being loaded BEFORE this component
 // to give a feeling of blazing fast page load. And we do NOT use this magic autoresizing
 // functionality on .html.erb view because there's no point of it.
-import Textarea from 'preact-textarea-autosize';
+import { useTextAreaAutoResize } from '@utilities/textAreaUtils';
 
 export const Title = ({ onChange, defaultValue, switchHelpContext }) => {
+  const textAreaRef = useRef(null);
+  const { setTextArea } = useTextAreaAutoResize();
+
+  useLayoutEffect(() => {
+    if (textAreaRef.current) {
+      setTextArea(textAreaRef.current);
+    }
+  }, [setTextArea]);
+
   return (
     <div
       data-testid="article-form__title"
       className="crayons-article-form__title"
     >
-      <Textarea
+      <textarea
+        ref={textAreaRef}
         className="crayons-textfield crayons-textfield--ghost fs-3xl m:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight"
         type="text"
         id="article-form-title"

--- a/app/javascript/chat/compose.jsx
+++ b/app/javascript/chat/compose.jsx
@@ -1,7 +1,13 @@
 import { h } from 'preact';
-import { useState, useEffect, useMemo } from 'preact/hooks';
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  useLayoutEffect,
+} from 'preact/hooks';
 import PropTypes from 'prop-types';
-import Textarea from 'preact-textarea-autosize';
+import { useTextAreaAutoResize } from '@utilities/textAreaUtils';
 
 export const Compose = ({
   handleKeyDown,
@@ -18,6 +24,15 @@ export const Compose = ({
   activeChannelName,
 }) => {
   const [value, setValue] = useState('');
+  const textAreaRef = useRef(null);
+
+  const { setTextArea } = useTextAreaAutoResize();
+
+  useLayoutEffect(() => {
+    if (textAreaRef.current) {
+      setTextArea(textAreaRef.current);
+    }
+  }, [setTextArea]);
 
   useEffect(() => {
     if (!markdownEdited && startEditing) {
@@ -56,7 +71,8 @@ export const Compose = ({
           startEditing ? 'composer-container__edit' : 'messagecomposer'
         }
       >
-        <Textarea
+        <textarea
+          ref={textAreaRef}
           className={
             startEditing
               ? 'crayons-textfield composer-textarea__edit'

--- a/package.json
+++ b/package.json
@@ -172,7 +172,6 @@
     "postcss-smart-import": "^0.7.6",
     "postscribe": "^2.0.8",
     "preact": "^10.5.13",
-    "preact-textarea-autosize": "^4.0.7",
     "prop-types": "^15.7.2",
     "pusher-js": "^7.0.3",
     "rails-erb-loader": "^5.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15372,11 +15372,6 @@ postscribe@^2.0.8:
   dependencies:
     prescribe ">=1.1.2"
 
-preact-textarea-autosize@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/preact-textarea-autosize/-/preact-textarea-autosize-4.0.7.tgz#aa654ce1a0ed57027dca21e4710a78cb6f007457"
-  integrity sha1-qmVM4aDtVwJ9yiHkcQp4y28AdFc=
-
 preact@^10.5.13:
   version "10.5.13"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.13.tgz#85f6c9197ecd736ce8e3bec044d08fd1330fa019"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we implemented the mention autocomplete component, we created a custom Preact hook that we can use to auto-resize textareas. This removes the need for the `preact-textarea-autosize` 3rd party library.

This PR replaces the two remaining usages of that library (post title, chat compose) and removes the library from our dependencies.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

**In the post editor:**
- Start drafting a new post
- In the title input, start typing a really long title. Make sure it goes over multiple lines, and check that the text area expands to show everything you've entered

https://user-images.githubusercontent.com/20773163/113425200-5d6bfd80-93c9-11eb-8511-3e88acdfb337.mp4


**In the chat composer:**
- Go to any chat
- Start writing a message, make sure it goes over multiple lines, and check that the text area expands to show everything you've entered


https://user-images.githubusercontent.com/20773163/113425214-61981b00-93c9-11eb-8d5a-1cf557ef0500.mp4


### UI accessibility concerns?

N/A - UI only

## Added tests?

- [ ] Yes
- [X] No, and this is why: This is a UI only change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: No change to current functionality

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![cartoon cat holding scissors](https://i.giphy.com/media/XeeUDlRgrsSA8kUsvI/giphy.webp)
