### PR TITLE
[15-min-fix] Improve invalid FeedbackMessage error msg

### DIFF
--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -33,7 +33,8 @@ class FeedbackMessagesController < ApplicationController
       end
     else
       @previous_message = feedback_message_params[:message]
-      flash[:notice] = "Make sure the forms are filled 🤖"
+      flash[:notice] =
+        "Make sure the forms are filled 🤖. Other possible errors: #{@feedback_message.errors_as_sentence}"
 
       respond_to do |format|
         format.html { render "pages/report_abuse" }

--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -1,6 +1,8 @@
 class FeedbackMessagesController < ApplicationController
   # No authorization required for entirely public controller
   skip_before_action :verify_authenticity_token
+  FLASH_MESSAGE = "Make sure the forms are filled. 🤖 Other possible errors: "\
+    "%<errors>s".freeze
 
   def create
     flash.clear
@@ -33,8 +35,7 @@ class FeedbackMessagesController < ApplicationController
       end
     else
       @previous_message = feedback_message_params[:message]
-      flash[:notice] =
-        "Make sure the forms are filled 🤖. Other possible errors: #{@feedback_message.errors_as_sentence}"
+      flash[:notice] = format(FLASH_MESSAGE, errors: @feedback_message.errors_as_sentence.presence || "N/A")
 
       respond_to do |format|
         format.html { render "pages/report_abuse" }

--- a/app/models/feedback_message.rb
+++ b/app/models/feedback_message.rb
@@ -8,18 +8,24 @@ class FeedbackMessage < ApplicationRecord
   has_one :email_message, dependent: :nullify
   has_many :notes, as: :noteable, inverse_of: :noteable, dependent: :destroy
 
+  REPORTER_UNIQUENESS_SCOPE = %i[reported_url feedback_type].freeze
+  REPORTER_UNIQUENESS_MSG = "(you) previously reported this URL.".freeze
+  CATEGORIES = ["spam", "other", "rude or vulgar", "harassment", "bug", "listings"].freeze
+  STATUSES = %w[Open Invalid Resolved].freeze
+
   validates :feedback_type, :message, presence: true
   validates :reported_url, :category, presence: { if: :abuse_report? }, length: { maximum: 250 }
   validates :message, length: { maximum: 2500 }
   validates :category,
             inclusion: {
-              in: ["spam", "other", "rude or vulgar", "harassment", "bug", "listings"]
+              in: CATEGORIES
             }
   validates :status,
             inclusion: {
-              in: %w[Open Invalid Resolved]
+              in: STATUSES
             }
-  validates :reporter_id, uniqueness: { scope: %i[reported_url feedback_type] }, if: :abuse_report? && :reporter_id
+  validates :reporter_id, uniqueness: { scope: REPORTER_UNIQUENESS_SCOPE, message: REPORTER_UNIQUENESS_MSG },
+                          if: :abuse_report? && :reporter_id
 
   def abuse_report?
     feedback_type == "abuse-reports"

--- a/spec/models/feedback_message_spec.rb
+++ b/spec/models/feedback_message_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe FeedbackMessage, type: :model do
 
       it do
         expect(feedback_message).to validate_inclusion_of(:category)
-          .in_array(["spam", "other", "rude or vulgar", "harassment", "bug"])
+          .in_array(described_class::CATEGORIES)
       end
 
       it do
         expect(feedback_message).to validate_inclusion_of(:status)
-          .in_array(%w[Open Invalid Resolved])
+          .in_array(described_class::STATUSES)
       end
     end
 
@@ -35,7 +35,13 @@ RSpec.describe FeedbackMessage, type: :model do
       subject(:feedback_message) { abuse_report }
 
       it { is_expected.to validate_presence_of(:reported_url) }
-      it { is_expected.to validate_uniqueness_of(:reporter_id).scoped_to(%i[reported_url feedback_type]) }
+
+      it do
+        expect(feedback_message).to validate_uniqueness_of(:reporter_id)
+          .scoped_to(described_class::REPORTER_UNIQUENESS_SCOPE)
+          .with_message(described_class::REPORTER_UNIQUENESS_MSG)
+      end
+
       it { is_expected.to validate_length_of(:reported_url).is_at_most(250) }
       it { is_expected.to validate_presence_of(:category) }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Refactor

## Description
Add some better messaging for when abuse reports fail a validation. Also converts some objects to constants.

## QA Instructions, Screenshots, Recordings
1. Make an abuse report via localhost:3000/report-abuse
2. Make the same exact report
3. Confirm that the validation error makes sense

### UI accessibility concerns?
Nope

## Added tests?
- [x] Yes, just updated them

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: just a very small improvement

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![Homer Simpson rolls up in a car with Lisa Simpson watching and says, "Hey Lisa, check out my new computer."](https://media.giphy.com/media/l2JebxCNrQ5l0PZcs/giphy-downsized.gif)
