### PR TITLE
Limit mentions in posts

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -30,6 +30,10 @@ class Article < ApplicationRecord
   counter_culture :user
   counter_culture :organization
 
+  MAX_USER_MENTIONS = 7 # Explicitly set to 7 to accommodate DEV Top 7 Posts
+  # The date that we began limiting the number of user mentions in an article.
+  MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 4, 6).freeze
+
   has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :nullify
   has_many :html_variant_successes, dependent: :nullify
   has_many :html_variant_trials, dependent: :nullify
@@ -80,6 +84,7 @@ class Article < ApplicationRecord
   validate :validate_collection_permission
   validate :validate_tag
   validate :validate_video
+  validate :user_mentions_in_markdown
   validate :validate_co_authors, unless: -> { co_author_ids.blank? }
   validate :validate_co_authors_must_not_be_the_same, unless: -> { co_author_ids.blank? }
   validate :validate_co_authors_exist, unless: -> { co_author_ids.blank? }
@@ -627,6 +632,16 @@ class Article < ApplicationRecord
     return unless canonical_url.to_s.match?(/[[:space:]]/)
 
     errors.add(:canonical_url, "must not have spaces")
+  end
+
+  def user_mentions_in_markdown
+    return if created_at.present? && created_at.before?(MAX_USER_MENTION_LIVE_AT)
+
+    # The "comment-mentioned-user" css is added by Html::Parser#user_link_if_exists
+    mentions_count = Nokogiri::HTML(processed_html).css(".comment-mentioned-user").size
+    return if mentions_count <= MAX_USER_MENTIONS
+
+    errors.add(:base, "You cannot mention more than #{MAX_USER_MENTIONS} users in a post!")
   end
 
   def create_slug

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -32,7 +32,7 @@ class Article < ApplicationRecord
 
   MAX_USER_MENTIONS = 7 # Explicitly set to 7 to accommodate DEV Top 7 Posts
   # The date that we began limiting the number of user mentions in an article.
-  MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 4, 6).freeze
+  MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 4, 7).freeze
 
   has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :nullify
   has_many :html_variant_successes, dependent: :nullify

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -30,6 +30,8 @@ class Article < ApplicationRecord
   counter_culture :user
   counter_culture :organization
 
+  # TODO: Vaidehi Joshi - Extract this into a constant or SiteConfig variable
+  # after https://github.com/forem/rfcs/pull/22 has been completed?
   MAX_USER_MENTIONS = 7 # Explicitly set to 7 to accommodate DEV Top 7 Posts
   # The date that we began limiting the number of user mentions in an article.
   MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 4, 7).freeze

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,6 +12,9 @@ class Comment < ApplicationRecord
   COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze
   TITLE_DELETED = "[deleted]".freeze
   TITLE_HIDDEN = "[hidden by post author]".freeze
+
+  # TODO: Vaidehi Joshi - Extract this into a constant or SiteConfig variable
+  # after https://github.com/forem/rfcs/pull/22 has been completed?
   MAX_USER_MENTIONS = 7 # Explicitly set to 7 to accommodate DEV Top 7 Posts
   # The date that we began limiting the number of user mentions in a comment.
   MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 3, 12).freeze

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1091,6 +1091,33 @@ RSpec.describe Article, type: :model do
     end
   end
 
+  describe "#user_mentions_in_markdown" do
+    before do
+      stub_const("Article::MAX_USER_MENTIONS", 7)
+      stub_const("Article::MAX_USER_MENTION_LIVE_AT", 1.day.ago) # Set live_at date to a time in the past
+    end
+
+    it "is valid with any number of mentions if created before MAX_USER_MENTION_LIVE_AT date" do
+      # Explicitly set created_at date to a time before MAX_USER_MENTION_LIVE_AT
+      article = create(:article, created_at: 3.days.ago)
+
+      article.body_markdown = "hi @#{user.username}! " * (Article::MAX_USER_MENTIONS + 1)
+      expect(article).to be_valid
+    end
+
+    it "is valid with seven or fewer mentions if created after MAX_USER_MENTION_LIVE_AT date" do
+      article.body_markdown = "hi @#{user.username}! " * Article::MAX_USER_MENTIONS
+      expect(article).to be_valid
+    end
+
+    it "is invalid with more than seven mentions if created after MAX_USER_MENTION_LIVE_AT date" do
+      article.body_markdown = "hi @#{user.username}! " * (Article::MAX_USER_MENTIONS + 1)
+      expect(article).not_to be_valid
+      expect(article.errors[:base])
+        .to include("You cannot mention more than #{Article::MAX_USER_MENTIONS} users in a post!")
+    end
+  end
+
   describe "#update_score" do
     it "stably sets the correct blackbox values" do
       create(:reaction, reactable: article, points: 1)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -96,24 +96,24 @@ RSpec.describe Comment, type: :model do
         subject.created_at = 3.days.ago
         subject.commentable_type = "Article"
 
-        subject.body_markdown = "hi @#{user.username}! " * 8
+        subject.body_markdown = "hi @#{user.username}! " * (Comment::MAX_USER_MENTIONS + 1)
         expect(subject).to be_valid
       end
 
       it "is valid with seven or fewer mentions if created after MAX_USER_MENTION_LIVE_AT date" do
         subject.commentable_type = "Article"
 
-        subject.body_markdown = "hi @#{user.username}! " * 7
+        subject.body_markdown = "hi @#{user.username}! " * Comment::MAX_USER_MENTIONS
         expect(subject).to be_valid
       end
 
       it "is invalid with more than seven mentions if created after MAX_USER_MENTION_LIVE_AT date" do
         subject.commentable_type = "Article"
 
-        subject.body_markdown = "hi @#{user.username}! " * 8
+        subject.body_markdown = "hi @#{user.username}! " * (Comment::MAX_USER_MENTIONS + 1)
         expect(subject).not_to be_valid
         expect(subject.errors[:base])
-          .to include("You cannot mention more than 7 users in a comment!")
+          .to include("You cannot mention more than #{Comment::MAX_USER_MENTIONS} users in a comment!")
       end
     end
     # rubocop:enable RSpec/NamedSubject

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Comment, type: :model do
       end
     end
 
-    describe "#mention_total" do
+    describe "#user_mentions_in_markdown" do
       before do
         stub_const("Comment::MAX_USER_MENTIONS", 7)
         stub_const("Comment::MAX_USER_MENTION_LIVE_AT", 1.day.ago) # Set live_at date to a time in the past


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

As a part of [RFC #22](https://github.com/forem/rfcs/pull/22), we need to limit how many @-user mentions can be included in a single post. We [already do this for comments](https://github.com/forem/forem/pull/12923), and we should mirror the same functionality in posts -- for both consistency and anti-spam mitigation reasons.

I decided to make this a separate PR before opening up PRs for actual _notification functionality_ that will be ✨ _coming soon to a theatre near you!_ 🍿 🎥  This should make it easier to test and should take care of any potential spam issues _well before_ we roll out the "notification when mentioned in a post" functionality 😎 

The [design/implementation](https://github.com/forem/rfcs/blob/main/text/0022-expand-at-mention-to-posts.md#designimplementation) section of the related RFC mentions this: 
> There needs to be a cap/limit on how many people can be @-mentioned in a post in order to prevent spam. I would propose a limit of 10.

I initially set off to make the limit of @-mentioned users in a post as 10...but the more that I thought about it, and the more I looked at [what we do with comments](https://github.com/forem/forem/pull/12923), it seemed kind of weird to me to treat posts and comments differently for no real reason. So, you'll notice that this PR sets the max limit of mentions in a post to `7`, just like comments; we can always change this later or now if folks want, but I just went with my gut on this one!

## Related Tickets & Documents

A small, encapsulated piece of functionality in service of https://github.com/forem/rfcs/pull/22.
Similar to what we did in https://github.com/forem/forem/pull/12923.

## QA Instructions, Screenshots, Recordings

To QA this PR, make sure you are logged in as a user. 

1. Go to the article editor, and create a new post with _more than `7` @-mentions in the markdown

<img width="908" alt="Screen Shot 2021-04-05 at 2 05 46 PM" src="https://user-images.githubusercontent.com/6921610/113630280-6ef91380-961c-11eb-8330-adc79ac66aa9.png">

2. You should be able to preview the post, but when you try to save it, you shouldn't be able to. You should see a relevant error message explaining why:
<img width="911" alt="Screen Shot 2021-04-05 at 2 06 01 PM" src="https://user-images.githubusercontent.com/6921610/113630292-74565e00-961c-11eb-86c8-d033dadc845f.png">

3. Now, try to publish a post with a valid number of @-mentions (`7` or less):
<img width="913" alt="Screen Shot 2021-04-05 at 2 06 27 PM" src="https://user-images.githubusercontent.com/6921610/113630326-82a47a00-961c-11eb-9f2f-544b6b925862.png">

4. You should be able to save and preview it without any problems!
<img width="904" alt="Screen Shot 2021-04-05 at 2 06 41 PM" src="https://user-images.githubusercontent.com/6921610/113630436-af589180-961c-11eb-8786-47e66c86bc20.png">

5. Be sure to test this with **both** versions of the editor. The same "cap" of @-mentions should apply, regardless of the editor version:
<img width="913" alt="Screen Shot 2021-04-05 at 2 07 31 PM" src="https://user-images.githubusercontent.com/6921610/113630460-bbdcea00-961c-11eb-837e-08c63f788f5c.png">
<img width="904" alt="Screen Shot 2021-04-05 at 2 07 42 PM" src="https://user-images.githubusercontent.com/6921610/113630478-c4cdbb80-961c-11eb-9a9f-f272f7d5c1e9.png">
<img width="904" alt="Screen Shot 2021-04-05 at 2 07 51 PM" src="https://user-images.githubusercontent.com/6921610/113630486-c7301580-961c-11eb-93f8-20decd5ebc57.png">




### UI accessibility concerns?

_None!_

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams


## Are there any post deployment tasks we need to perform?

Not really -- the only thing to note here is that `MAX_USER_MENTION_LIVE_AT` should be set to a time that we all think is acceptable, as that is when this will go "live" for new posts. All _previous_ posts (posts created before the `MAX_USER_MENTION_LIVE_AT` date) will be unaffected.
