### PR TITLE
Update bundler from 2.1 to 2.2 in Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,7 @@ RUN curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo 
     dnf -y clean all && \
     rm -rf /var/cache/yum
 
-ENV BUNDLER_VERSION=2.1.4 BUNDLE_SILENCE_ROOT_WARNING=true BUNDLE_SILENCE_DEPRECATIONS=true
+ENV BUNDLER_VERSION=2.2.15 BUNDLE_SILENCE_ROOT_WARNING=true BUNDLE_SILENCE_DEPRECATIONS=true
 RUN gem install -N bundler:"${BUNDLER_VERSION}"
 
 ENV APP_USER=forem APP_UID=1000 APP_GID=1000 APP_HOME=/opt/apps/forem \
@@ -125,4 +125,3 @@ RUN bundle config --local build.sassc --disable-march-tune-native && \
 ENTRYPOINT ["./scripts/entrypoint.sh"]
 
 CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-p", "3000"]
-


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We started seeing buildkite failures building after the rails 6.1
upgrade

While the bundler version probably isn't important by itself,
changing the containerfile invalidates any cached layers used to speed
up the build - and one of them seems to have been problematic.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Failing docker builds look like this `docker build .` or `scripts/build_containers.sh`:

```
 ---> 23d72a0cafec
Step 15/50 : COPY . "${APP_HOME}"
 ---> 4108ac33077a
Step 16/50 : RUN mkdir -p "${APP_HOME}"/public/{assets,images,packs,podcasts,uploads}
 ---> Running in fe2de9207713
Removing intermediate container fe2de9207713
 ---> 823173213b7a
Step 17/50 : RUN RAILS_ENV=production NODE_ENV=production bundle exec rake assets:precompile
 ---> Running in 03539cd3c3d0
bundler: failed to load command: rake (/opt/apps/forem/vendor/bundle/ruby/2.7.0/bin/rake)
Gem::Exception: can't find executable rake for gem rake. rake is not currently included in the bundle, perhaps you meant to add it to your Gemfile?
  /usr/share/gems/gems/bundler-2.1.4/lib/bundler/rubygems_integration.rb:374:in `block in replace_bin_path'
  /usr/share/gems/gems/bundler-2.1.4/lib/bundler/rubygems_integration.rb:402:in `block in replace_bin_path'
  /opt/apps/forem/vendor/bundle/ruby/2.7.0/bin/rake:23:in `<top (required)>'
The command '/bin/sh -c RAILS_ENV=production NODE_ENV=production bundle exec rake assets:pr
```

Building container on this branch should succeed.

```
Bundle complete! 150 Gemfile dependencies, 340 gems now installed.
Bundled gems are installed into `./vendor/bundle`
Removing intermediate container d6f7b686f67d
 ---> f10c9c2beafd
Step 49/50 : ENTRYPOINT ["./scripts/entrypoint.sh"]
 ---> Running in 4bae57645318
Removing intermediate container 4bae57645318
 ---> c1772badff98
Step 50/50 : CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-p", "3000"]
 ---> Running in 46f9d2b97e0e
Removing intermediate container 46f9d2b97e0e
 ---> e081557ea9a5
Successfully built e081557ea9a5
```


### UI accessibility concerns?

None


## Added tests?

- [ ] Yes
- [x] No, and this is why: Build pipeline change - no runtime changes
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: only changes the build process - if you have a successfully built container there's nothing new.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
![containers](https://user-images.githubusercontent.com/1237369/113634157-e4bca980-9633-11eb-8671-0644033841f3.jpg)
