### PR TITLE
Change frame limit to match imgproxy

### DIFF
--- a/app/uploaders/base_uploader.rb
+++ b/app/uploaders/base_uploader.rb
@@ -2,7 +2,7 @@ class BaseUploader < CarrierWave::Uploader::Base
   include CarrierWave::BombShelter # limits size to 4096x4096
   include CarrierWave::MiniMagick # adds processing operations
 
-  FRAME_MAX = 1000
+  FRAME_MAX = 500
   FRAME_STRIP_MAX = 150
 
   process :validate_frame_count


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR reduces the maximum number of frames for animate GIFs from 1000 to 500 to match the value we use in imgproxy.

## Related Tickets & Documents

Closes https://github.com/forem/internalEngineering/issues/396

## QA Instructions, Screenshots, Recordings

* Try to upload a gif with more than 500 frames, it should not work.

### UI accessibility concerns?

None

## Added tests?

- [X] No, and this is why: covered by existing tests

## [Forem core team only] How will this change be communicated?

- [X] I'm not sure how best to communicate this change and need help
