### PR TITLE
[15 min fix] Allow resize hook to contrain max-height as well as min

### DIFF
--- a/app/javascript/article-form/components/Title.jsx
+++ b/app/javascript/article-form/components/Title.jsx
@@ -12,13 +12,14 @@ import { useTextAreaAutoResize } from '@utilities/textAreaUtils';
 
 export const Title = ({ onChange, defaultValue, switchHelpContext }) => {
   const textAreaRef = useRef(null);
-  const { setTextArea } = useTextAreaAutoResize();
+  const { setTextArea, setConstrainToContentHeight } = useTextAreaAutoResize();
 
   useLayoutEffect(() => {
     if (textAreaRef.current) {
+      setConstrainToContentHeight(true);
       setTextArea(textAreaRef.current);
     }
-  }, [setTextArea]);
+  }, [setTextArea, setConstrainToContentHeight]);
 
   return (
     <div

--- a/app/javascript/utilities/textAreaUtils.js
+++ b/app/javascript/utilities/textAreaUtils.js
@@ -118,6 +118,7 @@ const getIndexOfCurrentWordAutocompleteSymbol = (content, selectionIndex) => {
 /**
  * This hook can be used to keep the height of a textarea in step with the current content height, avoiding a scrolling textarea.
  * An optional array of additional elements can be set. If provided, all additional elements will receive the same height.
+ * Optionally, it can be specified to also constrain the max-height to the content height. Otherwise the max-height will continue to be managed only by the textarea's CSS
  *
  * @example
  *
@@ -127,6 +128,9 @@ const getIndexOfCurrentWordAutocompleteSymbol = (content, selectionIndex) => {
  */
 export const useTextAreaAutoResize = () => {
   const [textArea, setTextArea] = useState(null);
+  const [constrainToContentHeight, setConstrainToContentHeight] = useState(
+    false,
+  );
   const [additionalElements, setAdditionalElements] = useState([]);
 
   useEffect(() => {
@@ -137,9 +141,13 @@ export const useTextAreaAutoResize = () => {
     const resizeTextArea = () => {
       const { height } = calculateTextAreaHeight(textArea);
       const newHeight = `${height}px`;
-      textArea.style['min-height'] = newHeight;
-      additionalElements.forEach((element) => {
+
+      [textArea, ...additionalElements].forEach((element) => {
         element.style['min-height'] = newHeight;
+        if (constrainToContentHeight) {
+          // Don't allow the textarea to grow to a size larger than the content
+          element.style['max-height'] = newHeight;
+        }
       });
     };
 
@@ -149,7 +157,7 @@ export const useTextAreaAutoResize = () => {
     textArea.addEventListener('input', resizeTextArea);
 
     return () => textArea.removeEventListener('input', resizeTextArea);
-  }, [textArea, additionalElements]);
+  }, [textArea, additionalElements, constrainToContentHeight]);
 
-  return { setTextArea, setAdditionalElements };
+  return { setTextArea, setAdditionalElements, setConstrainToContentHeight };
 };


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When I removed the preact-textarea-autosize library I missed a small issue with the article editor title, where it was displaying with two lines of height by default, instead of one. This was because the new Preact hook only sets the `min-height` of the field, adjusting it to the content height.

This PR adds an optional setting in the Preact hook to also constrain the max-height. This defaults to `false` as in nearly all situations, the default `textarea` height is what we would want (the `Title` is an odd case, as it looks like a single line input, but is actually a textarea)

## Related Tickets & Documents

Closes #13268

## QA Instructions, Screenshots, Recordings

- Run the app and visit the `/new` page
- Check that when empty, the title has only one line's worth of height
- Check that as you type a very long title, it expands to fit the content
- Check that if you delete any of that title, it resizes to fit the content


https://user-images.githubusercontent.com/20773163/113687542-57736680-96c0-11eb-9845-52babfcfb76e.mp4


### UI accessibility concerns?

N/A - purely UI

## Added tests?

- [ ] Yes
- [X] No, and this is why: purely a styling issue
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: we picked up this bug quickly, and it's a minor fix


