### PR TITLE
[15 Min Fix]: Prevent NoMethodError when Html variant is not present

### DIFF
--- a/app/views/pages/badge.html.erb
+++ b/app/views/pages/badge.html.erb
@@ -7,7 +7,7 @@
   <title><%= community_name %> ❤️</title>
 </head>
 <body>
-<%= @html_variant.html.html_safe %>
+<%= @html_variant.html.html_safe if @html_variant.present? %>
 <div id="html-variant-element" data-variant-id="<%= @html_variant.id %>"></div>
 <script defer>
   setTimeout(function () {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed some errors come through on the therelicans.com/badge page:
`NoMethodError: undefined method 'html' for nil:NilClass`

I am not entirely sure _why_ `html_variant` would be `nil` at this point, but we should account for it.

## Related Tickets & Documents

Fixes https://app.honeybadger.io/projects/72638/faults/78731893.

## QA Instructions, Screenshots, Recordings

_Tests should pass!_

### UI accessibility concerns?

_None_

## Added tests?

- [ ] Yes
- [x] No, and this is why: _This is a presence check, and IMO doesn't need a test and probably should've been accounted for from the get go! 😅_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: _Doesn't need to be shared as it doesn't affect workflow!_

## Are there any post deployment tasks we need to perform?
Nope, I will be sure to resolve the error once it has been deployed to the fleet, though!