### PR TITLE
Ensure we have current user information before deciding how to handle the "flag user" button

### DIFF
--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -1,6 +1,5 @@
 /* global userData */
-/* eslint-disable no-alert */
-/* eslint-disable import/order */
+/* eslint-disable no-alert, import/order */
 import { request } from '@utilities/http';
 import { getUserDataAndCsrfToken } from '../chat/util';
 

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -1,7 +1,7 @@
 /* global userData */
 /* eslint-disable no-alert */
-import { request } from '@utilities/http';
 import { getUserDataAndCsrfToken } from '../chat/util';
+import { request } from '@utilities/http';
 
 /**
  * Adds a flag button visible only to trusted users on profile pages.
@@ -38,7 +38,13 @@ function addFlagUserBehavior(flagButton, userId, userName) {
             flagButton.innerHTML = `Flag ${userName}`;
           }
         })
-        .catch((e) => window.alert(`Something went wrong: ${e}`));
+        .catch((e) => {
+          const message = isUserFlagged
+            ? 'Unable to unflag user'
+            : 'Unable to flag user';
+          Honeybadger.notify(message, userData.profileUserID);
+          window.alert(`Something went wrong: ${e}`);
+        });
     }
   }
 

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -39,10 +39,11 @@ function addFlagUserBehavior(flagButton, userId, userName) {
           }
         })
         .catch((e) => {
-          const message = isUserFlagged
-            ? 'Unable to unflag user'
-            : 'Unable to flag user';
-          Honeybadger.notify(message, userData.profileUserID);
+          Honeybadger.notify(
+            isUserFlagged ? 'Unable to unflag user' : 'Unable to flag user',
+            userData.profileUserID,
+          );
+          // do we want to alert here, or _only_ log to honeybadger?
           window.alert(`Something went wrong: ${e}`);
         });
     }

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -45,7 +45,6 @@ function addFlagUserBehavior(flagButton) {
             isUserFlagged ? 'Unable to unflag user' : 'Unable to flag user',
             userData.profileUserID,
           );
-          // do we want to alert here, or _only_ log to honeybadger?
           window.alert(`Something went wrong: ${e}`);
         });
     }

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -7,6 +7,47 @@ import { getUserDataAndCsrfToken } from '../chat/util';
  * @function initFlag
  * @returns {(void|undefined)} This function has no useable return value.
  */
+
+function addFlagUserBehavior(flagButton, userId, userName) {
+  let isUserFlagged = flagButton.dataset.isUserFlagged === 'true';
+
+  function flag() {
+    const confirmFlag = window.confirm(
+      isUserFlagged
+        ? 'Are you sure you want to unflag this person? This will make all of their posts visible again.'
+        : 'Are you sure you want to flag this person? This will make all of their posts less visible.',
+    );
+
+    if (confirmFlag) {
+      fetch('/reactions', {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': window.csrfToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          reactable_type: 'User',
+          category: 'vomit',
+          reactable_id: userId,
+        }),
+      })
+        .then((response) => response.json())
+        .then((response) => {
+          if (response.result === 'create') {
+            isUserFlagged = true;
+            flagButton.innerHTML = `Unflag ${userName}`;
+          } else {
+            isUserFlagged = false;
+            flagButton.innerHTML = `Flag ${userName}`;
+          }
+        })
+        .catch((e) => window.alert(`Something went wrong: ${e}`));
+    }
+  }
+
+  flagButton.addEventListener('click', flag);
+}
+
 export function initFlag() {
   const flagButton = document.getElementById(
     'user-profile-dropdownmenu-flag-button',
@@ -17,56 +58,20 @@ export function initFlag() {
     return;
   }
 
-  getUserDataAndCsrfToken().then(({ _current_user, _csrfToken }) => {
+  getUserDataAndCsrfToken().then(() => {
     const user = userData();
     if (!user) {
       flagButton.remove;
       return;
     }
 
-    const { profileUserId, profileUserName } = flagButton.dataset;
-    let isUserFlagged = flagButton.dataset.isUserFlagged === 'true';
     const trustedOrAdmin = user.trusted || user.admin;
+    const { profileUserId, profileUserName } = flagButton.dataset;
 
     if (!trustedOrAdmin || user.id === parseInt(profileUserId, 10)) {
       flagButton.remove();
     }
-
-    function flag() {
-      const confirmFlag = window.confirm(
-        isUserFlagged
-          ? 'Are you sure you want to unflag this person? This will make all of their posts visible again.'
-          : 'Are you sure you want to flag this person? This will make all of their posts less visible.',
-      );
-
-      if (confirmFlag) {
-        fetch('/reactions', {
-          method: 'POST',
-          headers: {
-            'X-CSRF-Token': window.csrfToken,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            reactable_type: 'User',
-            category: 'vomit',
-            reactable_id: profileUserId,
-          }),
-        })
-          .then((response) => response.json())
-          .then((response) => {
-            if (response.result === 'create') {
-              isUserFlagged = true;
-              flagButton.innerHTML = `Unflag ${profileUserName}`;
-            } else {
-              isUserFlagged = false;
-              flagButton.innerHTML = `Flag ${profileUserName}`;
-            }
-          })
-          .catch((e) => window.alert(`Something went wrong: ${e}`));
-      }
-    }
-
-    flagButton.addEventListener('click', flag);
+    addFlagUserBehavior(flagButton, profileUserId, profileUserName);
   });
 }
 /* eslint-enable no-alert */

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -1,5 +1,7 @@
 /* global userData */
 /* eslint-disable no-alert */
+import { getUserDataAndCsrfToken } from '../chat/util';
+
 /**
  * Adds a flag button visible only to trusted users on profile pages.
  * @function initFlag
@@ -15,53 +17,56 @@ export function initFlag() {
     return;
   }
 
-  const user = userData();
-  if (!user) {
-    return;
-  }
-
-  const { profileUserId, profileUserName } = flagButton.dataset;
-  let isUserFlagged = flagButton.dataset.isUserFlagged === 'true';
-  const trustedOrAdmin = user.trusted || user.admin;
-
-  if (!trustedOrAdmin || user.id === parseInt(profileUserId, 10)) {
-    flagButton.remove();
-  }
-
-  function flag() {
-    const confirmFlag = window.confirm(
-      isUserFlagged
-        ? 'Are you sure you want to unflag this person? This will make all of their posts visible again.'
-        : 'Are you sure you want to flag this person? This will make all of their posts less visible.',
-    );
-
-    if (confirmFlag) {
-      fetch('/reactions', {
-        method: 'POST',
-        headers: {
-          'X-CSRF-Token': window.csrfToken,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          reactable_type: 'User',
-          category: 'vomit',
-          reactable_id: profileUserId,
-        }),
-      })
-        .then((response) => response.json())
-        .then((response) => {
-          if (response.result === 'create') {
-            isUserFlagged = true;
-            flagButton.innerHTML = `Unflag ${profileUserName}`;
-          } else {
-            isUserFlagged = false;
-            flagButton.innerHTML = `Flag ${profileUserName}`;
-          }
-        })
-        .catch((e) => window.alert(`Something went wrong: ${e}`));
+  getUserDataAndCsrfToken().then(({ _current_user, _csrfToken }) => {
+    const user = userData();
+    if (!user) {
+      flagButton.remove;
+      return;
     }
-  }
 
-  flagButton.addEventListener('click', flag);
+    const { profileUserId, profileUserName } = flagButton.dataset;
+    let isUserFlagged = flagButton.dataset.isUserFlagged === 'true';
+    const trustedOrAdmin = user.trusted || user.admin;
+
+    if (!trustedOrAdmin || user.id === parseInt(profileUserId, 10)) {
+      flagButton.remove();
+    }
+
+    function flag() {
+      const confirmFlag = window.confirm(
+        isUserFlagged
+          ? 'Are you sure you want to unflag this person? This will make all of their posts visible again.'
+          : 'Are you sure you want to flag this person? This will make all of their posts less visible.',
+      );
+
+      if (confirmFlag) {
+        fetch('/reactions', {
+          method: 'POST',
+          headers: {
+            'X-CSRF-Token': window.csrfToken,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            reactable_type: 'User',
+            category: 'vomit',
+            reactable_id: profileUserId,
+          }),
+        })
+          .then((response) => response.json())
+          .then((response) => {
+            if (response.result === 'create') {
+              isUserFlagged = true;
+              flagButton.innerHTML = `Unflag ${profileUserName}`;
+            } else {
+              isUserFlagged = false;
+              flagButton.innerHTML = `Flag ${profileUserName}`;
+            }
+          })
+          .catch((e) => window.alert(`Something went wrong: ${e}`));
+      }
+    }
+
+    flagButton.addEventListener('click', flag);
+  });
 }
 /* eslint-enable no-alert */

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -1,7 +1,7 @@
 /* global userData */
 /* eslint-disable no-alert */
-import { getUserDataAndCsrfToken } from '../chat/util';
 import { request } from '@utilities/http';
+import { getUserDataAndCsrfToken } from '../chat/util';
 
 /**
  * Adds a flag button visible only to trusted users on profile pages.

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -37,7 +37,7 @@ function addFlagUserBehavior(flagButton) {
         .catch((e) => {
           Honeybadger.notify(
             isUserFlagged ? 'Unable to unflag user' : 'Unable to flag user',
-            userData.profileUserID,
+            profileUserId,
           );
           window.alert(`Something went wrong: ${e}`);
         });

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -9,7 +9,9 @@ import { request } from '@utilities/http';
  * @returns {(void|undefined)} This function has no useable return value.
  */
 
-function addFlagUserBehavior(flagButton, userId, userName) {
+function addFlagUserBehavior(flagButton) {
+  const { profileUserId, profileUserName } = flagButton.dataset;
+
   let isUserFlagged = flagButton.dataset.isUserFlagged === 'true';
 
   function flag() {
@@ -25,17 +27,17 @@ function addFlagUserBehavior(flagButton, userId, userName) {
         body: {
           reactable_type: 'User',
           category: 'vomit',
-          reactable_id: userId,
+          reactable_id: profileUserId,
         },
       })
         .then((response) => response.json())
         .then((response) => {
           if (response.result === 'create') {
             isUserFlagged = true;
-            flagButton.innerHTML = `Unflag ${userName}`;
+            flagButton.innerHTML = `Unflag ${profileUserName}`;
           } else {
             isUserFlagged = false;
-            flagButton.innerHTML = `Flag ${userName}`;
+            flagButton.innerHTML = `Flag ${profileUserName}`;
           }
         })
         .catch((e) => {
@@ -70,12 +72,12 @@ export function initFlag() {
     }
 
     const trustedOrAdmin = user.trusted || user.admin;
-    const { profileUserId, profileUserName } = flagButton.dataset;
+    const { profileUserId } = flagButton.dataset;
 
     if (!trustedOrAdmin || user.id === parseInt(profileUserId, 10)) {
       flagButton.remove();
     }
-    addFlagUserBehavior(flagButton, profileUserId, profileUserName);
+    addFlagUserBehavior(flagButton);
   });
 }
 /* eslint-enable no-alert */

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -66,7 +66,7 @@ export function initFlag() {
   getUserDataAndCsrfToken().then(() => {
     const user = userData();
     if (!user) {
-      flagButton.remove;
+      flagButton.remove();
       return;
     }
 

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -1,5 +1,6 @@
 /* global userData */
 /* eslint-disable no-alert */
+/* eslint-disable import/order */
 import { request } from '@utilities/http';
 import { getUserDataAndCsrfToken } from '../chat/util';
 

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -1,6 +1,7 @@
 /* global userData */
 /* eslint-disable no-alert */
 import { getUserDataAndCsrfToken } from '../chat/util';
+import { request } from '@utilities/http';
 
 /**
  * Adds a flag button visible only to trusted users on profile pages.
@@ -19,17 +20,13 @@ function addFlagUserBehavior(flagButton, userId, userName) {
     );
 
     if (confirmFlag) {
-      fetch('/reactions', {
+      request('/reactions', {
         method: 'POST',
-        headers: {
-          'X-CSRF-Token': window.csrfToken,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+        body: {
           reactable_type: 'User',
           category: 'vomit',
           reactable_id: userId,
-        }),
+        },
       })
         .then((response) => response.json())
         .then((response) => {

--- a/app/javascript/profileDropdown/flagButton.js
+++ b/app/javascript/profileDropdown/flagButton.js
@@ -3,12 +3,6 @@
 import { request } from '@utilities/http';
 import { getUserDataAndCsrfToken } from '../chat/util';
 
-/**
- * Adds a flag button visible only to trusted users on profile pages.
- * @function initFlag
- * @returns {(void|undefined)} This function has no useable return value.
- */
-
 function addFlagUserBehavior(flagButton) {
   const { profileUserId, profileUserName } = flagButton.dataset;
 
@@ -52,6 +46,12 @@ function addFlagUserBehavior(flagButton) {
 
   flagButton.addEventListener('click', flag);
 }
+
+/**
+ * Adds a flag button visible only to trusted users on profile pages.
+ * @function initFlag
+ * @returns {(void|undefined)} This function has no useable return value.
+ */
 
 export function initFlag() {
   const flagButton = document.getElementById(

--- a/spec/system/user/trusted_user_flags_user_spec.rb
+++ b/spec/system/user/trusted_user_flags_user_spec.rb
@@ -16,12 +16,7 @@ RSpec.describe "Flagging users from profile pages", type: :system, js: true do
     it "does not show the flag button" do
       sign_in create(:user)
 
-      # TODO: Fix me! Loading the page twice here ensures that the dropdown menu
-      # does not include the "Flag @username" option. This is a band-aid solution
-      # in order to get this spec to consistently pass and unblock builds.
-      2.times do
-        visit user_profile_path(user.username)
-      end
+      visit user_profile_path(user.username)
 
       click_button(id: "user-profile-dropdown")
       expect(page).not_to have_link(flag_text)

--- a/spec/system/user/trusted_user_flags_user_spec.rb
+++ b/spec/system/user/trusted_user_flags_user_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Flagging users from profile pages", type: :system, js: true do
   let(:user) { create :user }
+  let(:unflag_text) { "Unflag @#{user.username}" }
   let(:flag_text) { "Flag @#{user.username}" }
 
   context "when not logged in" do
@@ -38,7 +39,11 @@ RSpec.describe "Flagging users from profile pages", type: :system, js: true do
 
       visit user_profile_path(user.username)
       click_button(id: "user-profile-dropdown")
-      expect(page).to have_link(flag_text)
+
+      accept_confirm do
+        click_link(id: "user-profile-dropdownmenu-flag-button")
+      end
+      expect(page).to have_link(unflag_text)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We saw issues with flaky tests around the new flag user button (when a trusted user was logged in after no user was logged in, the spec would fail because LSO was empty). 

The initial work-around was to request the page twice (the first time sets the LSO user data, the second time can successfully use it). 

This change wraps the logic around setting the flag button visibility in a call to the chat utility `getUserDataAndCsrfToken` as suggested by Nick in https://github.com/forem/forem/issues/13228#issuecomment-812715671

There's a missing reorganization likely needed where the `getUserDataAndCsrfToken` function should be promoted from chat/ to a shared location (`utilities/`?). 

## Related Tickets & Documents

https://github.com/forem/forem/pull/13224 work-around added here (removed in this PR)
fixes https://github.com/forem/forem/issues/13228

## QA Instructions, Screenshots, Recordings

I ran the system test multiple times in random order trying to shake out any unexpected weirdness. ~The ruby tests do not make assertions about the flag button's behavior, only its presence or absence, and it's shown by default (so possible to accidentally pass even though this code is skipped).~ Added a test around clicking the link and seeing the label text change to "Unflag user" in the trusted user case. 

~An indication that this is not working correctly would be if the flag button is shown on the page but has no action associated (the `window.confirm` triggers aren't fired and nothing posts to reactions when it's pressed) - that might be easiest to check manually.~

### UI accessibility concerns?

I don't think so?

## Added tests?

- [x] Yes
- [ ] No, and this is why: Addressing existing tests
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: Fixes behavior to match the expected flow.

## [optional] Are there any post deployment tasks we need to perform?

No

## [optional] What gif best describes this PR or how it makes you feel?

![Promise](https://user-images.githubusercontent.com/1237369/113757702-8b5a8600-96d8-11eb-877e-958855770365.jpg)
