### PR TITLE
Re-add Darwin-20 to gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -841,6 +841,8 @@ GEM
     zonebie (0.6.1)
 
 PLATFORMS
+  arm64-darwin-20
+  x86_64-darwin-18 
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-linux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -842,6 +842,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Re-adds Darwin-20 (Mac OS 11.x Big Sur) to `Gemfile.lock`. I suspect it dropped out during the Rails 6.1 upgrade.

## Added tests?

- [ ] Yes
- [x] No, and this is why: config file change
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/3ogwFLL6ztqSgPVrzO/giphy.gif)
