### PR TITLE
[15-min-fix] Add email type as utm_campaign column

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,6 +1,10 @@
 class NotifyMailer < ApplicationMailer
-  has_history extra: -> { { feedback_message_id: params[:feedback_message_id] } },
-              only: :feedback_message_resolution_email
+  has_history extra: lambda {
+    {
+      feedback_message_id: params[:feedback_message_id],
+      utm_campaign: params[:email_type]
+    }
+  }, only: :feedback_message_resolution_email
 
   def new_reply_email
     @comment = params[:comment]

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -281,6 +281,14 @@ RSpec.describe NotifyMailer, type: :mailer do
 
       expect(user.email_messages.last.feedback_message_id).to eq(feedback_message.id)
     end
+
+    it "tracks the email_type as the UTM campaign" do
+      assert_emails 1 do
+        email.deliver_now
+      end
+
+      expect(user.email_messages.last.utm_campaign).to eq("Reporter")
+    end
   end
 
   describe "#feedback_response_email" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix

## Description
When we upgraded to the latest `ahoy_email` gem, we removed tracking. However, I forgot we had an edge case of tracking where we "track" what type of email reply we sent (reporter, offender, affected). This PR adds saving the email message column `utm_campaign` back in, and I don't think it will actually track anything.

## Related Tickets & Documents
#13294 

## QA Instructions, Screenshots, Recordings
1. go to /admin/reports
2. Click "Send Email"
3. Go in `rails console`
4. `EmailMessage.last.utm_campaign == "reporter"` should return `true`

### UI accessibility concerns?
Nope

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams (Community Success)

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?

![A magnet is brought over a haystack to pull the needle out.](https://media.giphy.com/media/7WNhbYMIcgYn7pCzHh/giphy.gif)
