### PR TITLE
[15-Minute Fix] Sidebar Tags Show Relevant Posts on Homepage

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -57,7 +57,7 @@ module ArticlesHelper
     timestamp&.utc&.iso8601
   end
 
-  def active_threads(**options)
-    Articles::ActiveThreadsQuery.call(**options)
+  def active_threads(...)
+    Articles::ActiveThreadsQuery.call(...)
   end
 end

--- a/app/queries/articles/active_threads_query.rb
+++ b/app/queries/articles/active_threads_query.rb
@@ -19,12 +19,14 @@ module Articles
                  elsif time_ago
                    relation = relation.where(published_at: time_ago.., score: MINIMUM_SCORE..).presence || relation
                    relation.order(comments_count: :desc)
+                 elsif tags.present?
+                   relation = tags.size == 1 ? relation.cached_tagged_with(tags.first) : relation.tagged_with(tags)
+                   relation = relation.where(published_at: 5.days.ago.., score: MINIMUM_SCORE..).presence || relation
+                   relation.order("last_comment_at DESC NULLS LAST")
                  else
-                   relation = relation.where(published_at: (tags.present? ? 5 : 2).days.ago..,
-                                             score: MINIMUM_SCORE..).presence || relation
+                   relation = relation.where(published_at: 2.days.ago.., score: MINIMUM_SCORE..).presence || relation
                    relation.order("last_comment_at DESC NULLS LAST")
                  end
-      relation = tags.size == 1 ? relation.cached_tagged_with(tags.first) : relation.tagged_with(tags)
       relation.pluck(:path, :title, :comments_count, :created_at)
     end
   end

--- a/app/queries/articles/active_threads_query.rb
+++ b/app/queries/articles/active_threads_query.rb
@@ -8,7 +8,7 @@ module Articles
 
     MINIMUM_SCORE = -4
 
-    def self.call(relation: Article.published, options: {})
+    def self.call(relation: Article.published, **options)
       options = DEFAULT_OPTIONS.merge(options)
       tags, time_ago, count = options.values_at(:tags, :time_ago, :count)
 
@@ -20,9 +20,6 @@ module Articles
                  elsif time_ago
                    relation = relation.where(published_at: time_ago.., score: MINIMUM_SCORE..).presence || relation
                    relation.order(comments_count: :desc)
-                 elsif tags.present?
-                   relation = relation.where(published_at: 5.days.ago.., score: MINIMUM_SCORE..).presence || relation
-                   relation.order("last_comment_at DESC NULLS LAST")
                  else
                    relation = relation.where(published_at: 2.days.ago.., score: MINIMUM_SCORE..).presence || relation
                    relation.order("last_comment_at DESC NULLS LAST")

--- a/app/queries/articles/active_threads_query.rb
+++ b/app/queries/articles/active_threads_query.rb
@@ -13,6 +13,7 @@ module Articles
       tags, time_ago, count = options.values_at(:tags, :time_ago, :count)
 
       relation = relation.limit(count)
+      relation = tags.size == 1 ? relation.cached_tagged_with(tags.first) : relation.tagged_with(tags)
       relation = if time_ago == "latest"
                    relation = relation.where(score: MINIMUM_SCORE..).presence || relation
                    relation.order(published_at: :desc)
@@ -20,7 +21,6 @@ module Articles
                    relation = relation.where(published_at: time_ago.., score: MINIMUM_SCORE..).presence || relation
                    relation.order(comments_count: :desc)
                  elsif tags.present?
-                   relation = tags.size == 1 ? relation.cached_tagged_with(tags.first) : relation.tagged_with(tags)
                    relation = relation.where(published_at: 5.days.ago.., score: MINIMUM_SCORE..).presence || relation
                    relation.order("last_comment_at DESC NULLS LAST")
                  else

--- a/app/queries/articles/active_threads_query.rb
+++ b/app/queries/articles/active_threads_query.rb
@@ -21,7 +21,7 @@ module Articles
                    relation = relation.where(published_at: time_ago.., score: MINIMUM_SCORE..).presence || relation
                    relation.order(comments_count: :desc)
                  else
-                   relation = relation.where(published_at: 2.days.ago.., score: MINIMUM_SCORE..).presence || relation
+                   relation = relation.where(published_at: 3.days.ago.., score: MINIMUM_SCORE..).presence || relation
                    relation.order("last_comment_at DESC NULLS LAST")
                  end
       relation.pluck(:path, :title, :comments_count, :created_at)

--- a/app/queries/articles/active_threads_query.rb
+++ b/app/queries/articles/active_threads_query.rb
@@ -8,7 +8,7 @@ module Articles
 
     MINIMUM_SCORE = -4
 
-    def self.call(relation: Article.published, **options)
+    def self.call(relation: Article.published, options: {})
       options = DEFAULT_OPTIONS.merge(options)
       tags, time_ago, count = options.values_at(:tags, :time_ago, :count)
 

--- a/app/views/articles/tags/_sidebar_additional.html.erb
+++ b/app/views/articles/tags/_sidebar_additional.html.erb
@@ -2,7 +2,7 @@
   <div id="sidebar-wrapper-right" class="sidebar-wrapper sidebar-wrapper-right">
     <div class="sidebar-bg" id="sidebar-bg-right"></div>
     <div class="side-bar sidebar-additional showing" id="sidebar-additional">
-      <% active_threads = active_threads(options: { tags: [@tag, "discuss"], time_ago: Timeframe.datetime(params[:timeframe]) }) %>
+      <% active_threads = active_threads(tags: [@tag, "discuss"], time_ago: Timeframe.datetime(params[:timeframe])) %>
       <% if active_threads.present? %>
         <div class="widget">
           <header>

--- a/app/views/articles/tags/_sidebar_additional.html.erb
+++ b/app/views/articles/tags/_sidebar_additional.html.erb
@@ -2,7 +2,7 @@
   <div id="sidebar-wrapper-right" class="sidebar-wrapper sidebar-wrapper-right">
     <div class="sidebar-bg" id="sidebar-bg-right"></div>
     <div class="side-bar sidebar-additional showing" id="sidebar-additional">
-      <% active_threads = active_threads(tags: [@tag, "discuss"], time_ago: Timeframe.datetime(params[:timeframe])) %>
+      <% active_threads = active_threads(options: { tags: [@tag, "discuss"], time_ago: Timeframe.datetime(params[:timeframe]) }) %>
       <% if active_threads.present? %>
         <div class="widget">
           <header>

--- a/app/views/sidebars/_homepage_content.html.erb
+++ b/app/views/sidebars/_homepage_content.html.erb
@@ -42,7 +42,7 @@
               <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
             <% end %>
           <% else %>
-            <% active_threads(options: { tags: [tag], time_ago: Timeframe.datetime(params[:timeframe]), count: 5 }).each do |plucked_article| %>
+            <% active_threads(tags: [tag], time_ago: Timeframe.datetime(params[:timeframe]), count: 5).each do |plucked_article| %>
               <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
             <% end %>
           <% end %>

--- a/spec/queries/articles/active_threads_query_spec.rb
+++ b/spec/queries/articles/active_threads_query_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Articles::ActiveThreadsQuery, type: :query do
+  before do
+    create(:article, score: described_class::MINIMUM_SCORE - 1, tags: "watercooler")
+  end
+
   describe "::call" do
     context "when time_ago is latest" do
       it "returns the latest article with a good score", :aggregate_failures do

--- a/spec/queries/articles/active_threads_query_spec.rb
+++ b/spec/queries/articles/active_threads_query_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
         create(:article, published_at: time - 2.days,  comments_count: 30, tags: "discuss",
                          score: described_class::MINIMUM_SCORE)
 
-        result = described_class.call(tags: "discuss", time_ago: time, count: 10)
+        result = described_class.call(options: { tags: "discuss", time_ago: time, count: 10 })
         expect(result.length).to eq(2)
         expect(result.first.first).to eq(article.path)
       end
@@ -45,7 +45,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
                                    score: described_class::MINIMUM_SCORE)
         create(:article, comments_count: 10, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
 
-        result = described_class.call(tags: "discuss", time_ago: time, count: 10)
+        result = described_class.call(options: { tags: "discuss", time_ago: time, count: 10 })
         expect(result.length).to eq(2)
         expect(result.first.first).to eq(article.path)
       end
@@ -57,7 +57,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
                                    score: described_class::MINIMUM_SCORE)
         create(:article, last_comment_at: nil, tags: "discuss", score: described_class::MINIMUM_SCORE)
 
-        result = described_class.call(tags: "discuss", time_ago: nil, count: 10)
+        result = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
         expect(result.length).to eq(2)
         expect(result.first.first).to eq(article.path)
       end
@@ -67,7 +67,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
                                    score: described_class::MINIMUM_SCORE - 10)
         create(:article, last_comment_at: 2.days.ago, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
 
-        result = described_class.call(tags: "discuss", time_ago: nil, count: 10)
+        result = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
         expect(result.length).to eq(2)
         expect(result.first.first).to eq(article.path)
       end

--- a/spec/queries/articles/active_threads_query_spec.rb
+++ b/spec/queries/articles/active_threads_query_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Articles::ActiveThreadsQuery, type: :query do
-  before do
-    create(:article, score: described_class::MINIMUM_SCORE - 1, tags: "watercooler")
-  end
-
   describe "::call" do
     context "when time_ago is latest" do
       it "returns the latest article with a good score", :aggregate_failures do

--- a/spec/queries/articles/active_threads_query_spec.rb
+++ b/spec/queries/articles/active_threads_query_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
         article = create(:article, tags: "discuss", score: described_class::MINIMUM_SCORE + 1)
         create(:article, published_at: 2.days.ago, tags: "discuss", score: described_class::MINIMUM_SCORE + 1)
 
-        result = described_class.call(options: { tags: "discuss", time_ago: "latest", count: 10 })
+        result = described_class.call(tags: "discuss", time_ago: "latest", count: 10)
         expect(result.length).to eq(2)
         expect(result.first.first).to eq(article.path)
       end
@@ -19,7 +19,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
       it "returns any article if no higher-quality article is found", :aggregate_failures do
         article = create(:article, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
 
-        result = described_class.call(options: { tags: "discuss", time_ago: "latest", count: 10 })
+        result = described_class.call(tags: "discuss", time_ago: "latest", count: 10)
         expect(result.length).to eq(1)
         expect(result.first.first).to eq(article.path)
       end
@@ -34,7 +34,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
         create(:article, published_at: time - 2.days,  comments_count: 30, tags: "discuss",
                          score: described_class::MINIMUM_SCORE)
 
-        result = described_class.call(options: { tags: "discuss", time_ago: time, count: 10 })
+        result = described_class.call(tags: "discuss", time_ago: time, count: 10)
         expect(result.length).to eq(2)
         expect(result.first.first).to eq(article.path)
       end
@@ -45,7 +45,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
                                    score: described_class::MINIMUM_SCORE)
         create(:article, comments_count: 10, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
 
-        result = described_class.call(options: { tags: "discuss", time_ago: time, count: 10 })
+        result = described_class.call(tags: "discuss", time_ago: time, count: 10)
         expect(result.length).to eq(2)
         expect(result.first.first).to eq(article.path)
       end
@@ -57,7 +57,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
                                    score: described_class::MINIMUM_SCORE)
         create(:article, last_comment_at: nil, tags: "discuss", score: described_class::MINIMUM_SCORE)
 
-        result = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
+        result = described_class.call(tags: "discuss", time_ago: nil, count: 10)
         expect(result.length).to eq(2)
         expect(result.first.first).to eq(article.path)
       end
@@ -67,7 +67,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
                                    score: described_class::MINIMUM_SCORE - 10)
         create(:article, last_comment_at: 2.days.ago, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
 
-        result = described_class.call(options: { tags: "discuss", time_ago: nil, count: 10 })
+        result = described_class.call(tags: "discuss", time_ago: nil, count: 10)
         expect(result.length).to eq(2)
         expect(result.first.first).to eq(article.path)
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR updates a change to the options hash within `Articles::ActiveThreadsQuery` and the related specs, which were causing a single tag's posts to populate the sidebar tags on the homepage. Additionally, this PR fixes a bug where posts would "magically" appear and disappear from beneath sidebar tags on the homepage by filtering by tag at the beginning of `#call` rather than at the end.

## Related Tickets & Documents
Relates to PR #12942 and PR #13256 

## QA Instructions, Screenshots, Recordings
**To QA this PR, please first ensure that you have admin-status and then navigate to `/admin/config` and scroll to the `/tags` section**. In order to have tags display in the sidebar and to test this PR, you need to first set some tags, like "discuss," "git," and "watercooler":
![Screen Shot 2021-04-08 at 2 18 33 PM](https://user-images.githubusercontent.com/32834804/114090960-4f105c80-9875-11eb-932c-7b8f64a8eeee.png)

- After setting the tags, navigate to the homepage and observe that there are no articles beneath the "watercooler" tag and that there are some posts beneath the "discuss" and "git" tags (these posts meet the criteria within `Articles::ActiveThreadsQuery`) and that the posts beneath each sidebar tag are populated using the correct tags:
![Screen Shot 2021-04-08 at 2 19 15 PM](https://user-images.githubusercontent.com/32834804/114091049-694a3a80-9875-11eb-8d3a-54e869856380.png)

- In order to see articles (other than the ones created when you `seed` your database!) displayed beneath the "discuss," "git," and "watercooler" tags, create a post that uses these tags:
![Screen Shot 2021-04-08 at 2 21 33 PM](https://user-images.githubusercontent.com/32834804/114091290-b9c19800-9875-11eb-8d4b-b82c8886d9ce.png)

- After creating articles with the tags, observe that your lower-quality article tagged with "watercooler" displays in the sidebar beneath "watercooler," but that your lower-quality article does not appear beneath "git" since there are already higher-quality articles that take precedence:
![Screen Shot 2021-04-08 at 2 24 55 PM](https://user-images.githubusercontent.com/32834804/114091681-32c0ef80-9876-11eb-9ac0-f67054e56879.png)

- Repeat these steps using higher-quality and lower-quality articles and different tags to ensure that the posts display as expected and always, try to break things! ⚒️ 
![Screen Shot 2021-04-08 at 2 36 14 PM](https://user-images.githubusercontent.com/32834804/114092987-c941e080-9877-11eb-8e1a-11ea470a2760.png)

### UI accessibility concerns?
N/A

## Added tests?

- [x] Yes: I've adjusted existing specs
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post-deployment tasks we need to perform?
This change will need to be deployed to the Forem Fleet! 🚀 

## [optional] What gif best describes this PR or how it makes you feel?

![Aaliyah, "Try Again"](https://media.giphy.com/media/3o6MbaH9LYlaVpHWBa/giphy.gif)