### PR TITLE
[15 Min Fix] Now the load more button only appears (if necessary) when the reading list is finished loading

### DIFF
--- a/app/javascript/readingList/readingList.jsx
+++ b/app/javascript/readingList/readingList.jsx
@@ -1,4 +1,4 @@
-import { h, Component } from 'preact';
+import { h, Component, Fragment } from 'preact';
 import PropTypes from 'prop-types';
 
 import {
@@ -251,24 +251,26 @@ export class ReadingList extends Component {
                 )}
                 <section className="crayons-layout__content crayons-card mb-4">
                   {items.length > 0 ? (
-                    <ItemList
-                      items={items}
-                      archiveButtonLabel={archiveButtonLabel}
-                      toggleArchiveStatus={this.toggleArchiveStatus}
-                    />
+                    <Fragment>
+                      <ItemList
+                        items={items}
+                        archiveButtonLabel={archiveButtonLabel}
+                        toggleArchiveStatus={this.toggleArchiveStatus}
+                      />
+                      {showLoadMoreButton && (
+                        <div className="flex justify-center my-2">
+                          <Button
+                            onClick={this.loadNextPage}
+                            variant="secondary"
+                            className="w-max"
+                          >
+                            Load more
+                          </Button>
+                        </div>
+                      )}
+                    </Fragment>
                   ) : loading ? null : (
                     this.renderEmptyItems()
-                  )}
-                  {showLoadMoreButton && (
-                    <div className="flex justify-center my-2">
-                      <Button
-                        onClick={this.loadNextPage}
-                        variant="secondary"
-                        className="w-max"
-                      >
-                        Load more
-                      </Button>
-                    </div>
                   )}
                 </section>
               </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A small UI blip I noticed while testing out the reading list on dev.to. The load more button remains (if it was present) when filtering in the reading list and only disappears after the new data is filtered. Now it is not visible when loading the reading list between filtering states.

## Related Tickets & Documents

#12755

## QA Instructions, Screenshots, Recordings

Same QA instructions as #12755.

### UI accessibility concerns?

N/A

## Added tests?

- [ ] Yes
- [x] No, and this is why: Already covered by E2E tests.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![A loading progress bar](https://media.giphy.com/media/cnzP4cmBsiOrccg20V/giphy.gif)
