### PR TITLE
Switch from combobox to plaintextArea on click outside

### DIFF
--- a/app/javascript/crayons/MentionAutocompleteTextArea/MentionAutocompleteTextArea.jsx
+++ b/app/javascript/crayons/MentionAutocompleteTextArea/MentionAutocompleteTextArea.jsx
@@ -180,6 +180,13 @@ export const MentionAutocompleteTextArea = forwardRef(
           setSearchTerm('');
           setAriaHelperText('');
           setUsers([]);
+
+          const { selectionStart } = comboboxRef.current;
+
+          // Switch back to the plain text area
+          comboboxRef.current.classList.add('hidden');
+          plainTextAreaRef.current.classList.remove('hidden');
+          setCursorPosition(selectionStart + 1);
         }
       };
 

--- a/app/javascript/crayons/MentionAutocompleteTextArea/MentionAutocompleteTextArea.jsx
+++ b/app/javascript/crayons/MentionAutocompleteTextArea/MentionAutocompleteTextArea.jsx
@@ -124,7 +124,12 @@ export const MentionAutocompleteTextArea = forwardRef(
 
     const { setTextArea, setAdditionalElements } = useTextAreaAutoResize();
 
-    const { onChange, id: inputId, ...autocompleteInputProps } = inputProps;
+    const {
+      onChange,
+      onBlur,
+      id: inputId,
+      ...autocompleteInputProps
+    } = inputProps;
 
     useLayoutEffect(() => {
       if (autoResize && comboboxRef.current && plainTextAreaRef.current) {
@@ -277,6 +282,12 @@ export const MentionAutocompleteTextArea = forwardRef(
       }
     };
 
+    const handleComboboxBlur = () => {
+      // User has left the textarea, exit combobox functionality without refocusing plainTextArea
+      comboboxRef.current.classList.add('hidden');
+      plainTextAreaRef.current.classList.remove('hidden');
+    };
+
     const handleSelect = (username) => {
       // Construct the new textArea content with selected username inserted
       const textWithSelection = `${textContent.substring(
@@ -346,6 +357,10 @@ export const MentionAutocompleteTextArea = forwardRef(
             onChange={(e) => {
               onChange?.(e);
               handleTextInputChange(e);
+            }}
+            onBlur={(e) => {
+              onBlur?.(e);
+              handleComboboxBlur();
             }}
           />
 

--- a/cypress/integration/articleFlows/commentOnArticle.spec.js
+++ b/cypress/integration/articleFlows/commentOnArticle.spec.js
@@ -202,6 +202,37 @@ describe('Comment on articles', () => {
       cy.findByText('@search_user_1').should('not.be.visible');
     });
 
+    it('should close the autocomplete suggestions and exit combobox on click outside', () => {
+      cy.intercept(
+        { method: 'GET', url: '/search/usernames' },
+        { fixture: 'search/usernames.json' },
+      );
+
+      cy.findByLabelText(/^Add a comment to the discussion$/i).click();
+
+      // Get a handle to the newly substituted textbox
+      cy.findByRole('textbox', {
+        name: /^Add a comment to the discussion$/i,
+      }).as('plainTextArea');
+
+      cy.get('@plainTextArea').type('Some text @s');
+
+      // Verify the combobox has appeared
+      cy.findByRole('combobox', { name: /Add a comment to the discussion/ }).as(
+        'autocompleteCommentBox',
+      );
+
+      cy.get('@autocompleteCommentBox').type('earch');
+      cy.findByText('@search_user_1').should('be.visible');
+
+      // Click away from the dropdown
+      cy.get('@autocompleteCommentBox').click({ position: 'right' });
+      cy.findByText('@search_user_1').should('not.exist');
+
+      // Check the combobox has exited and we are returned to the plainTextArea
+      cy.get('@plainTextArea').should('have.focus');
+    });
+
     // TODO: Flaky spec
     xit('should reply to a comment with user mention autocomplete', () => {
       cy.intercept(

--- a/cypress/integration/articleFlows/commentOnArticle.spec.js
+++ b/cypress/integration/articleFlows/commentOnArticle.spec.js
@@ -233,6 +233,32 @@ describe('Comment on articles', () => {
       cy.get('@plainTextArea').should('have.focus');
     });
 
+    it('should exit combobox when blurred and refocused', () => {
+      cy.intercept(
+        { method: 'GET', url: '/search/usernames' },
+        { fixture: 'search/usernames.json' },
+      );
+
+      cy.findByLabelText(/^Add a comment to the discussion$/i).click();
+
+      // Get a handle to the newly substituted textbox
+      cy.findByRole('textbox', {
+        name: /^Add a comment to the discussion$/i,
+      }).as('plainTextArea');
+
+      cy.get('@plainTextArea').type('Some text @s');
+
+      // Verify the combobox has appeared
+      cy.findByRole('combobox', {
+        name: /Add a comment to the discussion/,
+      }).as('combobox');
+
+      // Blur the currently active textarea, and check that the blur results in the plainTextArea being restored
+      cy.get('@combobox').blur();
+      cy.get('@combobox').should('not.be.visible');
+      cy.get('@plainTextArea').should('be.visible');
+    });
+
     // TODO: Flaky spec
     xit('should reply to a comment with user mention autocomplete', () => {
       cy.intercept(


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There is a small bug in the autocomplete work - if I start a user mention, and then click outside of the dropdown to dismiss the options, we successfully close the dropdown and user can continue typing. However, if you then try to use the up/down arrow keys you will find they don't work. 

This was because we were still in the Reach UI combobox which suppresses the up/down arrow key events.

The fix is to treat the 'click outside dismiss' the same as the other cases where we exit the 'search mode', and flip back to a vanilla text area. This PR handles two types of 'click outside':

- Click outside of the dropdown of options but **inside** the text area
- Click outside of the textarea

## Related Tickets & Documents

Addresses part of #13323 

## QA Instructions, Screenshots, Recordings

**Test click outside dropdown, but within textarea:**
- Create a new post
- Add some text and start a user mention by typing `@sometext`
- When the dropdown appears, click outside elsewhere in the text area
- The cursor should appear where you have clicked, and you should be able to continue typing
- Try using the up/down arrow keys and check they are moving the cursor as you would expect
- Test in comments as well as posts


https://user-images.githubusercontent.com/20773163/114153056-d95ccd00-9916-11eb-9e7c-20322e168506.mp4

**Test click outside of textarea:**
- Create a new post
- Add multiple lines of text
- Somewhere in the middle of your text content, start an `@mention`
- While the dropdown is still open, click outside of the text area to blur it
- Click back into the text area and verify that the arrow keys move you up in down in your text content
- Test in comments as well as posts


https://user-images.githubusercontent.com/20773163/114559697-e99ce100-9c63-11eb-810a-6ba94aa67ee0.mp4



### UI accessibility concerns?

This has minimal impact on accessibility, but does improve it slightly. Previously the text area would remain in 'combobox' mode which suggests to screen reader users they may type to search and view suggestions (which wasn't true in the case they had clicked away from an `@mention`. The component now correctly updates back to a plain textarea, better reflecting its usage.

## Added tests?

- [ ] Yes
- [X] No, and this is why: This is really hard to test in Cypress, as it relies heavily on exact clicks and knowing where the cursor position is. I don't think we would be able to test this reliably other than manually.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: So far this bug has only been reported internally and is a minor change


## [optional] What gif best describes this PR or how it makes you feel?

![Abed from Community saying cool cool cool](https://i.giphy.com/media/2HONNTJbRhzKE/giphy.webp)
