### PR TITLE
Fix mention autocomplete positioning after scroll 

### DIFF
--- a/app/javascript/utilities/textAreaUtils.js
+++ b/app/javascript/utilities/textAreaUtils.js
@@ -117,7 +117,7 @@ const getIndexOfCurrentWordAutocompleteSymbol = (content, selectionIndex) => {
 
 /**
  * This hook can be used to keep the height of a textarea in step with the current content height, avoiding a scrolling textarea.
- * An optional array of additional elements can be set. If provided, all additional elements will receive the same height.
+ * An optional array of additional elements can be set. If provided, all elements will be set to the greatest content height.
  * Optionally, it can be specified to also constrain the max-height to the content height. Otherwise the max-height will continue to be managed only by the textarea's CSS
  *
  * @example
@@ -139,7 +139,13 @@ export const useTextAreaAutoResize = () => {
     }
 
     const resizeTextArea = () => {
-      const { height } = calculateTextAreaHeight(textArea);
+      const allElements = [textArea, ...additionalElements];
+
+      const allContentHeights = allElements.map(
+        (element) => calculateTextAreaHeight(element).height,
+      );
+
+      const height = Math.max(...allContentHeights);
       const newHeight = `${height}px`;
 
       [textArea, ...additionalElements].forEach((element) => {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We noticed in long posts (long enough to start scrolling) that the mention autocomplete dropdown was being positioned way lower than it should have. 

After a bit of investigation it seems `useTextAreaAutoResize` was the source of the problems. Although we were manipulating both text area heights, the height we calculated was always that of the `plainTextArea`, and consistently the height of whichever textarea is currently hidden is significantly less than the one without the `hidden` class. 

TL;DR - we were accidentally measuring the position of the cursor against a textarea with a different height from the one presented in the UI.

The proposed fix is to keep all text areas passed to `useTextAreaAutoResize` in step with the _largest_  calculated content size. I think this makes sense from the POV of the hook's usability in other places - we want to keep all elements in step at the same size **and** we want that size to fully encompass any content.


## Related Tickets & Documents

#13323

## QA Instructions, Screenshots, Recordings

- Go to create a new post
- Check you can add text and user mentions when the content is not yet scrolling
- Paste or type a load of text in so that the area is scrolling
- Experiment with adding a mention at the top/middle/bottom and check the position of the dropdown

NB: I did notice it can look a bit strange if the user scrolls the form while the dropdown is open (dropdown stays in fixed position, but the text area moves behind it), but I feel like that's a separate issue (if it is an issue at all) 

- Check post comments too to make sure no behaviour has been compromised there.

I've tested this locally on desktop and android 11.0


https://user-images.githubusercontent.com/20773163/114197885-b3e9b680-994a-11eb-90e6-f6f5ecd6a6ee.mp4



### UI accessibility concerns?

N/A this only affects UI positioning, not the functionality of the component

## Added tests?

- [ ] Yes
- [X] No, and this is why: purely a UI positioning issue
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: So far this bug has only been raised in internally, and it constitutes a fairly small change
      

## [optional] What gif best describes this PR or how it makes you feel?

![cat playing whack a mole](https://i.giphy.com/media/MVUyVpyjakkRW/giphy.webp)
