### PR TITLE
[15-min-fix] Don't prevent reaction notifications from being sent

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -65,10 +65,8 @@ class Reaction < ApplicationRecord
   # - reaction is negative
   # - receiver is the same user as the one who reacted
   # - receive_notification is disabled
-  def skip_notification_for?(receiver)
-    points.negative? ||
-      (user_id == reactable.user_id) ||
-      (receiver.is_a?(User) && reactable.receive_notifications == false)
+  def skip_notification_for?(_receiver)
+    points.negative? || (user_id == reactable.user_id)
   end
 
   def vomit_on_user?

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -344,13 +344,13 @@ RSpec.describe Notification, type: :model do
         end.to change(user.notifications, :count).by(0)
       end
 
-      it "does not send a notification to the author of an article" do
+      it "does send a notification to the author of an article" do
         article.update(receive_notifications: false)
         reaction = create(:reaction, reactable: article, user: user2)
 
         expect do
           described_class.send_reaction_notification_without_delay(reaction, reaction.reactable.user)
-        end.to change(user.notifications, :count).by(0)
+        end.to change(user.notifications, :count).by(1)
       end
     end
 

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -124,11 +124,6 @@ RSpec.describe Reaction, type: :model do
         reaction.reactable.user_id = user_id
         expect(reaction.skip_notification_for?(user)).to be(true)
       end
-
-      it "is true when the receive_notifications is false" do
-        reaction.reactable.receive_notifications = false
-        expect(reaction.skip_notification_for?(receiver)).to be(true)
-      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We currently don't say anywhere that we prevent reaction notifications when unsubscribing from a post. This removes this feature under the hood since it's more a bug (mismatched behavior).

## Related Tickets & Documents


## QA Instructions, Screenshots, Recordings
1. In development, unsubscribe to a post
2. Leave a reaction on your post via a different account (sign in as `User.first.email` and `password`, or create a like reaction in console: `Reaction.create!(user_id: 1, reactable: User.find(your_id).articles.published.last, category: "like")`
3. See that you get a notification (make sure you have Sidekiq running)

### UI accessibility concerns?
Nope

## Added tests?

- [x] No, and this is why: some context: this was technically expected behavior when we/I first made the notification subscription feature, but we never really adjusted the language appropriately. Therefore, it's now unexpected behavior and I think we should write a test when we clarify expectations here from a product perspective.

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: it's a small bug fix

## [optional] Are there any post deployment tasks we need to perform?
No