### PR TITLE
Expand @-mention functionality to posts

### DIFF
--- a/app/decorators/mention_decorator.rb
+++ b/app/decorators/mention_decorator.rb
@@ -1,0 +1,10 @@
+class MentionDecorator < ApplicationDecorator
+  def formatted_mentionable_type
+    # Articles are colloquially referred to as "posts".
+    mentionable_type == "Article" ? "post" : mentionable_type.downcase
+  end
+
+  def mentioned_by_blocked_user?
+    mentionable_type == "User" && UserBlock.blocking?(mentionable_id, user_id)
+  end
+end

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -35,6 +35,14 @@ class NotifyMailer < ApplicationMailer
 
     @mentioner = User.find(@mention.mentionable.user_id)
     @mentionable = @mention.mentionable
+
+    # FIXME: document why we do this!
+    @mentionable_type = if @mention.mentionable_type == "Article"
+                          "post"
+                        else
+                          @mention.mentionable_type.downcase
+                        end
+
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_mention_notifications)
 
     mail(to: @user.email, subject: "#{@mentioner.name} just mentioned you!")

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -36,7 +36,7 @@ class NotifyMailer < ApplicationMailer
     @mentioner = User.find(@mention.mentionable.user_id)
     @mentionable = @mention.mentionable
 
-    # FIXME: document why we do this!
+    # Articles are colloquially referred to as "posts", so we need to do some conditional renaming here.
     @mentionable_type = if @mention.mentionable_type == "Article"
                           "post"
                         else

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -45,7 +45,7 @@ class NotifyMailer < ApplicationMailer
 
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_mention_notifications)
 
-    mail(to: @user.email, subject: "#{@mentioner.name} just mentioned you!")
+    mail(to: @user.email, subject: "#{@mentioner.name} just mentioned you in their #{@mentionable_type}")
   end
 
   def unread_notifications_email

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -35,13 +35,7 @@ class NotifyMailer < ApplicationMailer
 
     @mentioner = User.find(@mention.mentionable.user_id)
     @mentionable = @mention.mentionable
-
-    # Articles are colloquially referred to as "posts", so we need to do some conditional renaming here.
-    @mentionable_type = if @mention.mentionable_type == "Article"
-                          "post"
-                        else
-                          @mention.mentionable_type.downcase
-                        end
+    @mentionable_type = MentionDecorator.new(@mention).formatted_mentionable_type
 
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_mention_notifications)
 

--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -35,7 +35,7 @@ class NotifyMailer < ApplicationMailer
 
     @mentioner = User.find(@mention.mentionable.user_id)
     @mentionable = @mention.mentionable
-    @mentionable_type = MentionDecorator.new(@mention).formatted_mentionable_type
+    @mentionable_type = @mention.decorate.formatted_mentionable_type
 
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_mention_notifications)
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -31,6 +31,7 @@ class Article < ApplicationRecord
   # The date that we began limiting the number of user mentions in an article.
   MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 4, 7).freeze
 
+  has_many :mentions, as: :mentionable, inverse_of: :mentionable, dependent: :destroy
   has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :nullify
   has_many :html_variant_successes, dependent: :nullify
   has_many :html_variant_trials, dependent: :nullify

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -43,10 +43,10 @@ class Notification < ApplicationRecord
     def send_to_mentioned_users_and_followers(notifiable, _action = nil)
       return unless notifiable.is_a?(Article) && notifiable.published?
 
-      # Checks to see if there are any @-mentions in the post, and creates the associated Mention model inline.
-      # We need to create associated mentions _before_ creating any notifications, as we don't
-      # want users to receive a second notification for the post being published if they have already
-      # received an initial notification about being @-mentioned in the post.
+      # Mentions::CreateAll will check to see if there are any @-mentions in the post, and will create the associated
+      # mentions inline. We need to create associated mentions inline because they need to exist _before_ creating any
+      # other Article-related notifications. This ensures that users will not receive a second notification for the
+      # post being published if they have already received an initial notification about being @-mentioned in the post.
       Mentions::CreateAll.call(notifiable)
 
       # Kicks off a worker to send any notifications about the post being published, if necessary.

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -43,8 +43,7 @@ class Notification < ApplicationRecord
     def send_to_mentioned_users_and_followers(notifiable, _action = nil)
       return unless notifiable.is_a?(Article) && notifiable.published?
 
-      # Mentions::CreateAll will check to see if there are any @-mentions in the post, and will create the associated
-      # mentions inline. We need to create associated mentions inline because they need to exist _before_ creating any
+      # We need to create associated mentions inline because they need to exist _before_ creating any
       # other Article-related notifications. This ensures that users will not receive a second notification for the
       # post being published if they have already received an initial notification about being @-mentioned in the post.
       Mentions::CreateAll.call(notifiable)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -40,10 +40,6 @@ class Notification < ApplicationRecord
       Notifications::NewFollowerWorker.new.perform(follow_data, is_read)
     end
 
-    def send_to_followers(notifiable, action = nil)
-      Notifications::NotifiableActionWorker.perform_async(notifiable.id, notifiable.class.name, action)
-    end
-
     def send_to_mentioned_users_and_followers(notifiable, _action = nil)
       return unless notifiable.is_a?(Article) && notifiable.published?
 
@@ -55,6 +51,10 @@ class Notification < ApplicationRecord
 
       # Kicks off a worker to send any notifications about the post being published, if necessary.
       Notification.send_to_followers(notifiable, "Published")
+    end
+
+    def send_to_followers(notifiable, action = nil)
+      Notifications::NotifiableActionWorker.perform_async(notifiable.id, notifiable.class.name, action)
     end
 
     def send_new_comment_notifications_without_delay(comment)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -82,13 +82,13 @@ class Notification < ApplicationRecord
     end
 
     def send_mention_notification(mention)
-      return if mention.mentionable_type == "User" && UserBlock.blocking?(mention.mentionable_id, mention.user_id)
+      return if MentionDecorator.new(mention).mentioned_by_blocked_user?
 
       Notifications::MentionWorker.perform_async(mention.id)
     end
 
     def send_mention_notification_without_delay(mention)
-      return if mention.mentionable_type == "User" && UserBlock.blocking?(mention.mentionable_id, mention.user_id)
+      return if MentionDecorator.new(mention).mentioned_by_blocked_user?
 
       Notifications::NewMention::Send.call(mention) if mention
     end

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -16,10 +16,12 @@ module Articles
       article = save_article
 
       if article.persisted?
+        # Subscribe author to notifications for all comments on their article.
         NotificationSubscription.create(user: user, notifiable_id: article.id, notifiable_type: "Article",
                                         config: "all_comments")
-        Notification.send_to_followers(article, "Published") if article.published?
 
+        # Send notifications to any mentioned users, followed by any users who follow the article's author.
+        Notification.send_to_mentioned_users_and_followers(article, "Published") if article.published?
         dispatch_event(article)
       end
 

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -21,7 +21,7 @@ module Articles
                                         config: "all_comments")
 
         # Send notifications to any mentioned users, followed by any users who follow the article's author.
-        Notification.send_to_mentioned_users_and_followers(article, "Published") if article.published?
+        Notification.send_to_mentioned_users_and_followers(article) if article.published?
         dispatch_event(article)
       end
 

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -28,13 +28,22 @@ module Articles
         user.rate_limiter.track_limit_by_action(:article_update)
 
         # send notification only the first time an article is published
-        send_notification = article.published && article.saved_change_to_published_at.present?
-        Notification.send_to_followers(article, "Published") if send_notification
+        send_notification = was_published && article.saved_change_to_published_at.present?
+        if send_notification
+          # Send notifications to any mentioned users, followed by any users who follow the article's author.
+          Notification.send_to_mentioned_users_and_followers(article, "Published")
+        else
+          # FIXME: clean this up??
+          # Create and send mentions inline if article processed_html now contains mentions
+          Mentions::CreateAll.call(article)
+        end
 
         # remove related notifications if unpublished
         if article.saved_changes["published"] == [true, false]
+          # FIXME: make sure @-mention notifications are removed
           Notification.remove_all_by_action_without_delay(notifiable_ids: article.id, notifiable_type: "Article",
                                                           action: "Published")
+
           if article.comments.exists?
             Notification.remove_all(notifiable_ids: article.comments.ids,
                                     notifiable_type: "Comment")

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -33,8 +33,8 @@ module Articles
           # and then send notifications to any users who follow the article's author so as to avoid double mentions.
           Notification.send_to_mentioned_users_and_followers(article)
         elsif article.published
-          # If the article has already been published and is just being updated, then we only need to
-          # create mentions and send notifications to mentioned users inline.
+          # If the article has already been published and is only being updated, then we need to create
+          # mentions and send notifications to mentioned users inline via the Mentions::CreateAll service.
           Mentions::CreateAll.call(article)
         end
 

--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -271,7 +271,6 @@ module Html
     end
 
     def user_link_if_exists(mention)
-      # FIXME: should this just be .mentioned-user instead of .comment-mentioned-user ??
       username = mention.delete("@").downcase
       if User.find_by(username: username)
         <<~HTML

--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -271,6 +271,7 @@ module Html
     end
 
     def user_link_if_exists(mention)
+      # FIXME: should this just be .mentioned-user instead of .comment-mentioned-user ??
       username = mention.delete("@").downcase
       if User.find_by(username: username)
         <<~HTML

--- a/app/services/mentions/create_all.rb
+++ b/app/services/mentions/create_all.rb
@@ -1,4 +1,7 @@
 module Mentions
+  # This class creates mentions + associated notifications for Articles and Comments.
+  # This class will check to see if there are any @-mentions in the post, and will
+  # create the associated mentions inline if necessary.
   class CreateAll
     def initialize(notifiable)
       @notifiable = notifiable
@@ -9,7 +12,6 @@ module Mentions
     end
 
     def call
-      # Creates mentions + associated notifications for Articles and Comments.
       mentioned_users = users_mentioned_in_text_excluding_author
 
       delete_mentions_removed_from_notifiable_text(mentioned_users)
@@ -77,8 +79,12 @@ module Mentions
       # If notifiable is an Article, we need to create the notification for the mention immediately so
       # that the notification exists in the database before we attempt to create other Article-related notifications.
       # However, if notifiable is a Comment, we can create the notification for the mention in the background.
-      Notification.send_mention_notification_without_delay(mention) if notifiable.is_a?(Article)
-      Notification.send_mention_notification(mention) if notifiable.is_a?(Comment)
+      case notifiable
+      when Article
+        Notification.send_mention_notification_without_delay(mention)
+      when Comment
+        Notification.send_mention_notification(mention)
+      end
 
       mention
     end

--- a/app/services/mentions/create_all.rb
+++ b/app/services/mentions/create_all.rb
@@ -65,7 +65,9 @@ module Mentions
     end
 
     def create_mention_for(user)
-      return if user_has_comment_notifications?(user)
+      if notifiable.is_a?(Comment) && user_has_comment_notifications?(user)
+        return
+      end
 
       # The mentionable_type is the model that created the mention, the user is the user to be mentioned.
       mention = Mention.create(user_id: user.id, mentionable_id: @notifiable.id,

--- a/app/services/mentions/create_all.rb
+++ b/app/services/mentions/create_all.rb
@@ -48,7 +48,7 @@ module Mentions
     end
 
     def reject_notifiable_author(users)
-      users.reject { |user| authored_by?(user, @notifiable) }
+      users.reject { |user| authored_by?(user, notifiable) }
     end
 
     def authored_by?(user, notifiable)
@@ -56,22 +56,23 @@ module Mentions
     end
 
     def delete_mentions_removed_from_notifiable_text(users)
-      mentions = @notifiable.mentions.where.not(user_id: users).destroy_all
+      mentions = notifiable.mentions.where.not(user_id: users).destroy_all
       Notification.remove_all(notifiable_ids: mentions.map(&:id), notifiable_type: "Mention") if mentions.present?
     end
 
     def user_has_comment_notifications?(user)
-      user.notifications.exists?(notifiable_id: @notifiable.id, notifiable_type: "Comment")
+      user.notifications.exists?(notifiable_id: notifiable.id, notifiable_type: "Comment")
     end
 
     def create_mention_for(user)
+      # Do not create additional notifications for being mentioned in a comment.
       if notifiable.is_a?(Comment) && user_has_comment_notifications?(user)
         return
       end
 
       # The mentionable_type is the model that created the mention, the user is the user to be mentioned.
-      mention = Mention.create(user_id: user.id, mentionable_id: @notifiable.id,
-                               mentionable_type: @notifiable.class.name)
+      mention = Mention.create(user_id: user.id, mentionable_id: notifiable.id,
+                               mentionable_type: notifiable.class.name)
 
       # If notifiable is an Article, we need to create the notification for the mention immediately so
       # that the notification exists in the database before we attempt to create other Article-related notifications.

--- a/app/services/mentions/create_all.rb
+++ b/app/services/mentions/create_all.rb
@@ -71,9 +71,9 @@ module Mentions
       mention = Mention.create(user_id: user.id, mentionable_id: @notifiable.id,
                                mentionable_type: @notifiable.class.name)
 
-      # If notifiable is an Article, we need to create the mention and associated notification immediately so
-      # that we have it in the database before kicking off any workers that send other Article-related notifications.
-      # However, if notifiable is a Comment, we can create the mention notification inline.
+      # If notifiable is an Article, we need to create the notification for the mention immediately so
+      # that the notification exists in the database before we attempt to create other Article-related notifications.
+      # However, if notifiable is a Comment, we can create the notification for the mention in the background.
       Notification.send_mention_notification_without_delay(mention) if notifiable.is_a?(Article)
       Notification.send_mention_notification(mention) if notifiable.is_a?(Comment)
 

--- a/app/services/notifications/new_mention/send.rb
+++ b/app/services/notifications/new_mention/send.rb
@@ -3,6 +3,7 @@ module Notifications
     class Send
       delegate :user_data, to: Notifications
       delegate :comment_data, to: Notifications
+      delegate :article_data, to: Notifications
 
       def initialize(mention)
         @mention = mention
@@ -28,7 +29,14 @@ module Notifications
 
       def json_data
         data = { user: user_data(mention.mentionable.user) }
-        data[:comment] = comment_data(mention.mentionable) if mention.mentionable_type == "Comment"
+
+        case mention.mentionable_type
+        when "Comment"
+          data[:comment] = comment_data(mention.mentionable)
+        when "Article"
+          data[:article] = article_data(mention.mentionable)
+        end
+
         data
       end
     end

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -25,7 +25,16 @@ module Notifications
         json_data[:organization] = organization_data(notifiable.organization) if notifiable.organization_id
 
         notifications_attributes = []
-        notifiable.followers.sort_by(&:updated_at).last(10_000).reverse_each do |follower|
+
+        # If a user was mentioned in the article, they will have already received a mention.
+        # We exclude them from the article_followers array if they already have a mention
+        # for this article in order to avoid sending a user multiple notifications for one article.
+        article_followers = notifiable.followers.reject do |f|
+          users_with_mentions_on_article = notifiable.mentions&.pluck(:user_id)
+          users_with_mentions_on_article.include?(f.id)
+        end
+
+        article_followers.sort_by(&:updated_at).last(10_000).reverse_each do |follower|
           now = Time.current
           notifications_attributes.push(
             user_id: follower.id,

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -29,9 +29,9 @@ module Notifications
         # If a user was mentioned in the article, they will have already received a mention.
         # We explicitly need to exclude them from the article_followers array if they already
         # have a mention in order to avoid sending a user multiple notifications for one article.
+        user_ids_with_article_mentions = notifiable.mentions&.pluck(:user_id)
         article_followers = notifiable.followers.reject do |follower|
-          users_with_mentions_on_article = notifiable.mentions&.pluck(:user_id)
-          users_with_mentions_on_article.include?(follower.id)
+          user_ids_with_article_mentions.include?(follower.id)
         end
 
         article_followers.sort_by(&:updated_at).last(10_000).reverse_each do |follower|

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -27,11 +27,11 @@ module Notifications
         notifications_attributes = []
 
         # If a user was mentioned in the article, they will have already received a mention.
-        # We exclude them from the article_followers array if they already have a mention
-        # for this article in order to avoid sending a user multiple notifications for one article.
-        article_followers = notifiable.followers.reject do |f|
+        # We explicitly need to exclude them from the article_followers array if they already
+        # have a mention in order to avoid sending a user multiple notifications for one article.
+        article_followers = notifiable.followers.reject do |follower|
           users_with_mentions_on_article = notifiable.mentions&.pluck(:user_id)
-          users_with_mentions_on_article.include?(f.id)
+          users_with_mentions_on_article.include?(follower.id)
         end
 
         article_followers.sort_by(&:updated_at).last(10_000).reverse_each do |follower|

--- a/app/views/mailers/notify_mailer/new_mention_email.html.erb
+++ b/app/views/mailers/notify_mailer/new_mention_email.html.erb
@@ -1,26 +1,31 @@
 <head>
-    <style type="text/css">
-      img {
-        max-width:100%;
-        height:auto;
-        border:none
-      }
-    </style>
+  <style type="text/css">
+    img {
+      max-width:100%;
+      height:auto;
+      border:none
+    }
+  </style>
 </head>
 
 <h2 style="font-size:25px;">
-  <a href="<%= user_url(@mentioner) %>"><%= @mentioner.name %></a> just mentioned you in their <%= @mention.mentionable_type.downcase %>!
+  <a href="<%= user_url(@mentioner) %>"><%= @mentioner.name %></a> just mentioned you in their <%= @mentionable_type %>!
 </h2>
-<table>
-  <tr>
-    <td style='color:#c3c3c3;font-size:14px;padding-bottom:8px'>
 
-    </td>
-  </tr>
-  <tr>
-    <td style='padding:20px;padding-bottom:30px;border-radius:3px;font-size:19px;background:#f4f4f4'>
-      <%= @mentionable.processed_html.html_safe %>
-      <a style="background:#3c7dc1;color:white;padding:5px 14px;border-radius:3px;text-decoration:none;display:inline-block;margin-top:4px;" href='<%= app_url(@mention.mentionable.path) %>'>View on <%= community_name %></a>
-    </td>
-  </tr>
-</table>
+<% if @mentionable.is_a?(Comment) %>
+  <table>
+    <tr>
+      <td style='color:#c3c3c3;font-size:14px;padding-bottom:8px'>
+
+      </td>
+    </tr>
+    <tr>
+      <td style='padding:20px;padding-bottom:30px;border-radius:3px;font-size:19px;background:#f4f4f4'>
+        <%= @mentionable.processed_html.html_safe %>
+        <a style="background:#3c7dc1;color:white;padding:5px 14px;border-radius:3px;text-decoration:none;display:inline-block;margin-top:4px;" href='<%= app_url(@mention.mentionable.path) %>'>View on <%= community_name %></a>
+      </td>
+    </tr>
+  </table>
+<% else %>
+  <a style="background:#3c7dc1;color:white;padding:5px 14px;border-radius:3px;text-decoration:none;display:inline-block;margin-top:4px;" href='<%= app_url(@mention.mentionable.path) %>'>Read their post on <%= community_name %></a>
+<% end %>

--- a/app/views/mailers/notify_mailer/new_mention_email.html.erb
+++ b/app/views/mailers/notify_mailer/new_mention_email.html.erb
@@ -9,7 +9,7 @@
 </head>
 
 <h2 style="font-size:25px;">
-  <a href="<%= user_url(@mentioner) %>"><%= @mentioner.name %></a> just mentioned you in their <%= @mentionable_type %>!
+  <a href="<%= user_url(@mentioner) %>"><%= @mentioner.name %></a> just mentioned you in their <%= @mentionable_type %>
 </h2>
 
 <% if @mentionable.is_a?(Comment) %>

--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -21,40 +21,7 @@
         <p class="lh-tight"><small class="fs-s color-base-60"><%= time_ago_in_words json_data["article"]["published_at"] %> ago</small></p>
       </header>
 
-      <article class="notification__preview crayons-card">
-        <a href="<%= json_data["article"]["path"] %>" class="crayons-link block notification__preview__inner">
-          <h3 class="notification__preview__title"><%= h(json_data["article"]["title"]) %></h3>
-          <div class="-ml-1">
-            <% json_data["article"]["cached_tag_list_array"].each do |tag| %>
-              <span class="crayons-tag"><span class="crayons-tag__prefix">#</span><%= tag %></span>
-            <% end %>
-          </div>
-        </a>
-
-        <% cache "activity-published-article-reactions-#{@last_user_reaction}-#{json_data['article']['updated_at']}-#{json_data['article']['id']}" do %>
-          <footer class="comment-actions notification__actions">
-            <button
-              class="crayons-btn crayons-btn--ghost crayons-btn--icon-left crayons-btn--s reaction-like reaction-button <%= Reaction.cached_any_reactions_for?(notification.mocked_object("article"), current_user, "like") ? "reacted" : "" %>"
-              data-reactable-id="<%= json_data["article"]["id"] %>"
-              data-category="like"
-              data-reactable-type="Article">
-              <%= inline_svg_tag("small-heart.svg", aria: true, class: "crayons-icon reaction-icon not-reacted", title: "Favorite heart button") %>
-              <%= inline_svg_tag("small-heart-filled.svg", aria: true, class: "crayons-icon reaction-icon--like reaction-icon reacted", title: "Favorite heart button") %>
-              <span class="hidden m:inline-block">Like</span>
-            </button>
-
-            <button
-              class="ml-auto crayons-btn crayons-btn--ghost crayons-btn--icon-right crayons-btn--s reaction-readinglist reaction-button readinglist-button <%= Reaction.cached_any_reactions_for?(notification.mocked_object("article"), current_user, "readinglist") ? "reacted" : "" %>"
-              data-reactable-id="<%= json_data["article"]["id"] %>"
-              data-category="readinglist"
-              data-reactable-type="Article">
-              <span class="reaction-button-text hidden m:inline-block">Save</span>
-              <%= inline_svg_tag("small-save.svg", aria: true, class: "crayons-icon reaction-icon not-reacted", title: "Save button") %>
-              <%= inline_svg_tag("small-save-filled.svg", aria: true, class: "crayons-icon reaction-icon--readinglist reaction-icon reacted", title: "Save button") %>
-            </button>
-          </footer>
-        <% end %>
-      </article>
+      <%= render "notifications/shared/article_preview", json_data: json_data, notification: notification, context: "default" %>
     </div>
   <% end %>
 </div>

--- a/app/views/notifications/_mention.html.erb
+++ b/app/views/notifications/_mention.html.erb
@@ -19,40 +19,7 @@
         <p class="lh-tight"><small class="fs-s color-base-60"><%= time_ago_in_words json_data["article"]["published_at"] %> ago</small></p>
       </header>
 
-      <article class="notification__preview crayons-card">
-        <a href="<%= json_data["article"]["path"] %>" class="crayons-link block notification__preview__inner">
-          <h3 class="notification__preview__title"><%= h(json_data["article"]["title"]) %></h3>
-          <div class="-ml-1">
-            <% json_data["article"]["cached_tag_list_array"].each do |tag| %>
-              <span class="crayons-tag"><span class="crayons-tag__prefix">#</span><%= tag %></span>
-            <% end %>
-          </div>
-        </a>
-
-        <% cache "activity-published-article-reactions-#{@last_user_reaction}-#{json_data['article']['updated_at']}-#{json_data['article']['id']}" do %>
-          <footer class="comment-actions notification__actions">
-            <button
-              class="crayons-btn crayons-btn--ghost crayons-btn--icon-left crayons-btn--s reaction-like reaction-button <%= Reaction.cached_any_reactions_for?(notification.mocked_object("article"), current_user, "like") ? "reacted" : "" %>"
-              data-reactable-id="<%= json_data["article"]["id"] %>"
-              data-category="like"
-              data-reactable-type="Article">
-              <%= inline_svg_tag("small-heart.svg", aria: true, class: "crayons-icon reaction-icon not-reacted", title: "Favorite heart button") %>
-              <%= inline_svg_tag("small-heart-filled.svg", aria: true, class: "crayons-icon reaction-icon--like reaction-icon reacted", title: "Favorite heart button") %>
-              <span class="hidden m:inline-block">Like</span>
-            </button>
-
-            <button
-              class="ml-auto crayons-btn crayons-btn--ghost crayons-btn--icon-right crayons-btn--s reaction-readinglist reaction-button readinglist-button <%= Reaction.cached_any_reactions_for?(notification.mocked_object("article"), current_user, "readinglist") ? "reacted" : "" %>"
-              data-reactable-id="<%= json_data["article"]["id"] %>"
-              data-category="readinglist"
-              data-reactable-type="Article">
-              <span class="reaction-button-text hidden m:inline-block">Save</span>
-              <%= inline_svg_tag("small-save.svg", aria: true, class: "crayons-icon reaction-icon not-reacted", title: "Save button") %>
-              <%= inline_svg_tag("small-save-filled.svg", aria: true, class: "crayons-icon reaction-icon--readinglist reaction-icon reacted", title: "Save button") %>
-            </button>
-          </footer>
-        <% end %>
-      </article>
+      <%= render "notifications/shared/article_preview", json_data: json_data, notification: notification, context: "default" %>
     </div>
     <% elsif notification.json_data["comment"] %>
       <h2 class="fs-base fw-normal mb-4">

--- a/app/views/notifications/_mention.html.erb
+++ b/app/views/notifications/_mention.html.erb
@@ -5,9 +5,60 @@
   <% end %>
 
   <div class="notification__content">
-    <h2 class="fs-base fw-normal mb-4">
-      <a href="<%= json_data["user"]["path"] %>" class="crayons-link fw-bold"><%= json_data["user"]["name"] %></a> mentioned you in a comment
-    </h2>
-    <%= render "notifications/shared/comment_box", json_data: json_data, notification: notification, context: "default" %>
+    <% if notification.json_data["article"] %>
+      <header class="mb-4">
+        <h2 class="fs-base fw-normal">
+          <a href="<%= json_data["user"]["path"] %>" class="crayons-link fw-bold">
+            <%= json_data["user"]["name"] %>
+          </a>
+          mentioned you a post!
+          <% if json_data["organization"] %>
+            under <a href="<%= json_data["organization"]["path"] %>" class="crayons-link fw-bold"><%= json_data["organization"]["name"] %></a>
+          <% end %>
+        </h2>
+        <p class="lh-tight"><small class="fs-s color-base-60"><%= time_ago_in_words json_data["article"]["published_at"] %> ago</small></p>
+      </header>
+
+      <article class="notification__preview crayons-card">
+        <a href="<%= json_data["article"]["path"] %>" class="crayons-link block notification__preview__inner">
+          <h3 class="notification__preview__title"><%= h(json_data["article"]["title"]) %></h3>
+          <div class="-ml-1">
+            <% json_data["article"]["cached_tag_list_array"].each do |tag| %>
+              <span class="crayons-tag"><span class="crayons-tag__prefix">#</span><%= tag %></span>
+            <% end %>
+          </div>
+        </a>
+
+        <% cache "activity-published-article-reactions-#{@last_user_reaction}-#{json_data['article']['updated_at']}-#{json_data['article']['id']}" do %>
+          <footer class="comment-actions notification__actions">
+            <button
+              class="crayons-btn crayons-btn--ghost crayons-btn--icon-left crayons-btn--s reaction-like reaction-button <%= Reaction.cached_any_reactions_for?(notification.mocked_object("article"), current_user, "like") ? "reacted" : "" %>"
+              data-reactable-id="<%= json_data["article"]["id"] %>"
+              data-category="like"
+              data-reactable-type="Article">
+              <%= inline_svg_tag("small-heart.svg", aria: true, class: "crayons-icon reaction-icon not-reacted", title: "Favorite heart button") %>
+              <%= inline_svg_tag("small-heart-filled.svg", aria: true, class: "crayons-icon reaction-icon--like reaction-icon reacted", title: "Favorite heart button") %>
+              <span class="hidden m:inline-block">Like</span>
+            </button>
+
+            <button
+              class="ml-auto crayons-btn crayons-btn--ghost crayons-btn--icon-right crayons-btn--s reaction-readinglist reaction-button readinglist-button <%= Reaction.cached_any_reactions_for?(notification.mocked_object("article"), current_user, "readinglist") ? "reacted" : "" %>"
+              data-reactable-id="<%= json_data["article"]["id"] %>"
+              data-category="readinglist"
+              data-reactable-type="Article">
+              <span class="reaction-button-text hidden m:inline-block">Save</span>
+              <%= inline_svg_tag("small-save.svg", aria: true, class: "crayons-icon reaction-icon not-reacted", title: "Save button") %>
+              <%= inline_svg_tag("small-save-filled.svg", aria: true, class: "crayons-icon reaction-icon--readinglist reaction-icon reacted", title: "Save button") %>
+            </button>
+          </footer>
+        <% end %>
+      </article>
+    </div>
+    <% elsif notification.json_data["comment"] %>
+      <h2 class="fs-base fw-normal mb-4">
+        <a href="<%= json_data["user"]["path"] %>" class="crayons-link fw-bold"><%= json_data["user"]["name"] %></a> mentioned you in a comment
+      </h2>
+      <%= render "notifications/shared/comment_box", json_data: json_data, notification: notification, context: "default" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/notifications/_mention.html.erb
+++ b/app/views/notifications/_mention.html.erb
@@ -11,7 +11,7 @@
           <a href="<%= json_data["user"]["path"] %>" class="crayons-link fw-bold">
             <%= json_data["user"]["name"] %>
           </a>
-          mentioned you a post!
+          mentioned you in a post
           <% if json_data["organization"] %>
             under <a href="<%= json_data["organization"]["path"] %>" class="crayons-link fw-bold"><%= json_data["organization"]["name"] %></a>
           <% end %>

--- a/app/views/notifications/_mention.html.erb
+++ b/app/views/notifications/_mention.html.erb
@@ -20,7 +20,6 @@
       </header>
 
       <%= render "notifications/shared/article_preview", json_data: json_data, notification: notification, context: "default" %>
-    </div>
     <% elsif notification.json_data["comment"] %>
       <h2 class="fs-base fw-normal mb-4">
         <a href="<%= json_data["user"]["path"] %>" class="crayons-link fw-bold"><%= json_data["user"]["name"] %></a> mentioned you in a comment

--- a/app/views/notifications/shared/_article_preview.html.erb
+++ b/app/views/notifications/shared/_article_preview.html.erb
@@ -1,0 +1,34 @@
+<article class="notification__preview crayons-card">
+  <a href="<%= json_data["article"]["path"] %>" class="crayons-link block notification__preview__inner">
+    <h3 class="notification__preview__title"><%= h(json_data["article"]["title"]) %></h3>
+    <div class="-ml-1">
+      <% json_data["article"]["cached_tag_list_array"].each do |tag| %>
+        <span class="crayons-tag"><span class="crayons-tag__prefix">#</span><%= tag %></span>
+      <% end %>
+    </div>
+  </a>
+
+  <% cache "activity-published-article-reactions-#{@last_user_reaction}-#{json_data['article']['updated_at']}-#{json_data['article']['id']}" do %>
+    <footer class="comment-actions notification__actions">
+      <button
+        class="crayons-btn crayons-btn--ghost crayons-btn--icon-left crayons-btn--s reaction-like reaction-button <%= Reaction.cached_any_reactions_for?(notification.mocked_object("article"), current_user, "like") ? "reacted" : "" %>"
+        data-reactable-id="<%= json_data["article"]["id"] %>"
+        data-category="like"
+        data-reactable-type="Article">
+        <%= inline_svg_tag("small-heart.svg", aria: true, class: "crayons-icon reaction-icon not-reacted", title: "Favorite heart button") %>
+        <%= inline_svg_tag("small-heart-filled.svg", aria: true, class: "crayons-icon reaction-icon--like reaction-icon reacted", title: "Favorite heart button") %>
+        <span class="hidden m:inline-block">Like</span>
+      </button>
+
+      <button
+        class="ml-auto crayons-btn crayons-btn--ghost crayons-btn--icon-right crayons-btn--s reaction-readinglist reaction-button readinglist-button <%= Reaction.cached_any_reactions_for?(notification.mocked_object("article"), current_user, "readinglist") ? "reacted" : "" %>"
+        data-reactable-id="<%= json_data["article"]["id"] %>"
+        data-category="readinglist"
+        data-reactable-type="Article">
+        <span class="reaction-button-text hidden m:inline-block">Save</span>
+        <%= inline_svg_tag("small-save.svg", aria: true, class: "crayons-icon reaction-icon not-reacted", title: "Save button") %>
+        <%= inline_svg_tag("small-save-filled.svg", aria: true, class: "crayons-icon reaction-icon--readinglist reaction-icon reacted", title: "Save button") %>
+      </button>
+    </footer>
+  <% end %>
+</article>

--- a/app/workers/mentions/create_all_worker.rb
+++ b/app/workers/mentions/create_all_worker.rb
@@ -4,6 +4,7 @@ module Mentions
     sidekiq_options queue: :default, retry: 10
 
     def perform(notifiable_id, notifiable_type)
+      # This worker is currently only used to create mentions on comments.
       return if ["Comment"].none?(notifiable_type)
 
       notifiable = notifiable_type.constantize.find_by(id: notifiable_id)

--- a/app/workers/mentions/create_all_worker.rb
+++ b/app/workers/mentions/create_all_worker.rb
@@ -1,10 +1,10 @@
 module Mentions
+  # This worker is currently only used to create mentions on comments.
   class CreateAllWorker
     include Sidekiq::Worker
     sidekiq_options queue: :default, retry: 10
 
     def perform(notifiable_id, notifiable_type)
-      # This worker is currently only used to create mentions on comments.
       return if ["Comment"].none?(notifiable_type)
 
       notifiable = notifiable_type.constantize.find_by(id: notifiable_id)

--- a/spec/decorators/mention_decorator_spec.rb
+++ b/spec/decorators/mention_decorator_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe MentionDecorator, type: :decorator do
+  let(:user) { create(:user) }
+
+  describe "#formatted_mentionable_type" do
+    let(:article) { create(:article) }
+    let(:comment) { create(:comment, user_id: user.id, commentable: article) }
+
+    it "returns the correct mentionable type for mentions on articles" do
+      mention = create(:mention, mentionable: article, user: user).decorate
+      expect(mention.decorate.formatted_mentionable_type).to eq("post")
+    end
+
+    it "returns the correct mentionable type for mentions on comments" do
+      mention = create(:mention, mentionable: comment, user: user).decorate
+      expect(mention.decorate.formatted_mentionable_type).to eq("comment")
+    end
+  end
+
+  describe "#mentioned_by_blocked_user?" do
+    let(:blocked_user) { create(:user) }
+    let(:mention) { create(:mention, mentionable: user, user: blocked_user) }
+
+    it "returns true if mentioned user has blocked the mentioner" do
+      create(:user_block, blocker: user, blocked: blocked_user, config: "default")
+
+      expect(mention.decorate.mentioned_by_blocked_user?).to eq(true)
+    end
+
+    it "returns false if mentioned user has not blocked the mentioner" do
+      expect(mention.decorate.mentioned_by_blocked_user?).to eq(false)
+    end
+  end
+end

--- a/spec/decorators/mention_decorator_spec.rb
+++ b/spec/decorators/mention_decorator_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe MentionDecorator, type: :decorator do
     it "returns true if mentioned user has blocked the mentioner" do
       create(:user_block, blocker: user, blocked: blocked_user, config: "default")
 
-      expect(mention.decorate.mentioned_by_blocked_user?).to eq(true)
+      expect(mention.decorate.mentioned_by_blocked_user?).to be(true)
     end
 
     it "returns false if mentioned user has not blocked the mentioner" do
-      expect(mention.decorate.mentioned_by_blocked_user?).to eq(false)
+      expect(mention.decorate.mentioned_by_blocked_user?).to be(false)
     end
   end
 end

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe NotifyMailer, type: :mailer do
       let(:comment_mention) { create(:mention, user: user2, mentionable: comment) }
       let(:email) { described_class.with(mention: comment_mention).new_mention_email }
 
-      it "renders proper subject and receiver" do
+      it "renders proper subject and receiver", :aggregate_failures do
         expect(email.subject).to eq("#{comment.user.name} just mentioned you in their comment")
         expect(email.to).to eq([user2.email])
       end
 
-      it "renders proper sender" do
+      it "renders proper sender", :aggregate_failures  do
         expect(email.from).to eq([SiteConfig.email_addresses[:default]])
         expected_from = "#{SiteConfig.community_name} <#{SiteConfig.email_addresses[:default]}>"
         expect(email["from"].value).to eq(expected_from)
@@ -68,12 +68,12 @@ RSpec.describe NotifyMailer, type: :mailer do
       let(:article_mention) { create(:mention, user: user2, mentionable: article) }
       let(:email) { described_class.with(mention: article_mention).new_mention_email }
 
-      it "renders proper subject and receiver" do
+      it "renders proper subject and receiver", :aggregate_failures  do
         expect(email.subject).to eq("#{article.user.name} just mentioned you in their post")
         expect(email.to).to eq([user2.email])
       end
 
-      it "renders proper sender" do
+      it "renders proper sender", :aggregate_failures  do
         expect(email.from).to eq([SiteConfig.email_addresses[:default]])
         expected_from = "#{SiteConfig.community_name} <#{SiteConfig.email_addresses[:default]}>"
         expect(email["from"].value).to eq(expected_from)

--- a/spec/mailers/notify_mailer_spec.rb
+++ b/spec/mailers/notify_mailer_spec.rb
@@ -48,21 +48,36 @@ RSpec.describe NotifyMailer, type: :mailer do
   end
 
   describe "#new_mention_email" do
-    let(:mention) { create(:mention, user: user2, mentionable: comment) }
-    let(:email) { described_class.with(mention: mention).new_mention_email }
+    context "when mentioning in a comment" do
+      let(:comment_mention) { create(:mention, user: user2, mentionable: comment) }
+      let(:email) { described_class.with(mention: comment_mention).new_mention_email }
 
-    it "renders proper subject" do
-      expect(email.subject).to eq("#{comment.user.name} just mentioned you!")
+      it "renders proper subject and receiver" do
+        expect(email.subject).to eq("#{comment.user.name} just mentioned you in their comment")
+        expect(email.to).to eq([user2.email])
+      end
+
+      it "renders proper sender" do
+        expect(email.from).to eq([SiteConfig.email_addresses[:default]])
+        expected_from = "#{SiteConfig.community_name} <#{SiteConfig.email_addresses[:default]}>"
+        expect(email["from"].value).to eq(expected_from)
+      end
     end
 
-    it "renders proper sender" do
-      expect(email.from).to eq([SiteConfig.email_addresses[:default]])
-      expected_from = "#{SiteConfig.community_name} <#{SiteConfig.email_addresses[:default]}>"
-      expect(email["from"].value).to eq(expected_from)
-    end
+    context "when mentioning in an article" do
+      let(:article_mention) { create(:mention, user: user2, mentionable: article) }
+      let(:email) { described_class.with(mention: article_mention).new_mention_email }
 
-    it "renders proper receiver" do
-      expect(email.to).to eq([user2.email])
+      it "renders proper subject and receiver" do
+        expect(email.subject).to eq("#{article.user.name} just mentioned you in their post")
+        expect(email.to).to eq([user2.email])
+      end
+
+      it "renders proper sender" do
+        expect(email.from).to eq([SiteConfig.email_addresses[:default]])
+        expected_from = "#{SiteConfig.community_name} <#{SiteConfig.email_addresses[:default]}>"
+        expect(email["from"].value).to eq(expected_from)
+      end
     end
   end
 

--- a/spec/mailers/previews/notify_mailer_preview.rb
+++ b/spec/mailers/previews/notify_mailer_preview.rb
@@ -13,8 +13,13 @@ class NotifyMailerPreview < ActionMailer::Preview
     NotifyMailer.with(user: User.last).unread_notifications_email
   end
 
-  def new_mention_email
+  def new_comment_mention_email
     mention = Mention.find_or_create_by(user: User.find(1), mentionable: Comment.find(1))
+    NotifyMailer.with(mention: mention).new_mention_email
+  end
+
+  def new_article_mention_email
+    mention = Mention.find_or_create_by(user: User.find(1), mentionable: Article.find(1))
     NotifyMailer.with(mention: mention).new_mention_email
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to belong_to(:user) }
 
     it { is_expected.to have_many(:comments).dependent(:nullify) }
+    it { is_expected.to have_many(:mentions).dependent(:destroy) }
     it { is_expected.to have_many(:html_variant_successes).dependent(:nullify) }
     it { is_expected.to have_many(:html_variant_trials).dependent(:nullify) }
     it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe Notification, type: :model do
         user2.follow(user)
       end
 
-      it "sends a single notification to mentioned user" do
+      it "sends a single notification to mentioned user", :aggregate_failures do
         expect do
           sidekiq_perform_enqueued_jobs do
             described_class.send_to_mentioned_users_and_followers(article)
@@ -410,7 +410,7 @@ RSpec.describe Notification, type: :model do
         expect(user2.notifications.first.notifiable_type).to eq("Mention")
       end
 
-      it "sends a notification to the organization's followers (who were not mentioned)" do
+      it "sends a notification to the organization's followers (who were not mentioned)", :aggregate_failures do
         user3.follow(user)
 
         expect do
@@ -430,7 +430,7 @@ RSpec.describe Notification, type: :model do
         user2.follow(user)
       end
 
-      it "sends a single notification to mentioned user" do
+      it "sends a single notification to mentioned user", :aggregate_failures do
         expect do
           sidekiq_perform_enqueued_jobs do
             described_class.send_to_mentioned_users_and_followers(org_article)
@@ -439,7 +439,7 @@ RSpec.describe Notification, type: :model do
         expect(user2.notifications.first.notifiable_type).to eq("Mention")
       end
 
-      it "sends a notification to the organization's followers (who were not mentioned)" do
+      it "sends a notification to the organization's followers (who were not mentioned)", :aggregate_failures do
         user3.follow(organization)
 
         expect do

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -392,6 +392,66 @@ RSpec.describe Notification, type: :model do
     end
   end
 
+  describe "send_to_mentioned_users_and_followers" do
+    let!(:mention_markdown) { "Hello there, @#{user2.username}!" }
+
+    context "when the notifiable is an article from a user" do
+      before do
+        article.update!(body_markdown: mention_markdown)
+        user2.follow(user)
+      end
+
+      it "sends a single notification to mentioned user" do
+        expect do
+          sidekiq_perform_enqueued_jobs do
+            described_class.send_to_mentioned_users_and_followers(article)
+          end
+        end.to change(user2.notifications, :count).from(0).to(1)
+        expect(user2.notifications.first.notifiable_type).to eq("Mention")
+      end
+
+      it "sends a notification to the organization's followers (who were not mentioned)" do
+        user3.follow(user)
+
+        expect do
+          sidekiq_perform_enqueued_jobs do
+            described_class.send_to_mentioned_users_and_followers(article)
+          end
+        end.to change(user3.notifications, :count).from(0).to(1)
+        expect(user3.notifications.first.notifiable_type).to eq("Article")
+      end
+    end
+
+    context "when the notifiable is an article from an organization" do
+      let(:org_article) { create(:article, organization: organization, user: user) }
+
+      before do
+        org_article.update!(body_markdown: mention_markdown)
+        user2.follow(user)
+      end
+
+      it "sends a single notification to mentioned user" do
+        expect do
+          sidekiq_perform_enqueued_jobs do
+            described_class.send_to_mentioned_users_and_followers(org_article)
+          end
+        end.to change(user2.notifications, :count).from(0).to(1)
+        expect(user2.notifications.first.notifiable_type).to eq("Mention")
+      end
+
+      it "sends a notification to the organization's followers (who were not mentioned)" do
+        user3.follow(organization)
+
+        expect do
+          sidekiq_perform_enqueued_jobs do
+            described_class.send_to_mentioned_users_and_followers(org_article)
+          end
+        end.to change(user3.notifications, :count).from(0).to(1)
+        expect(user3.notifications.first.notifiable_type).to eq("Article")
+      end
+    end
+  end
+
   describe "#send_to_followers" do
     context "when the notifiable is an article from a user" do
       it "sends a notification to the author's followers" do

--- a/spec/services/articles/creator_spec.rb
+++ b/spec/services/articles/creator_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Articles::Creator, type: :service do
       end
     end
 
+    it "delegates to the Mentions::CreateAll service" do
+      valid_attributes[:published] = true
+      allow(Mentions::CreateAll).to receive(:call)
+      article = described_class.call(user, valid_attributes)
+      expect(Mentions::CreateAll).to have_received(:call).with(article)
+    end
+
     it "creates a notification subscription" do
       expect do
         described_class.call(user, valid_attributes)
@@ -74,6 +81,12 @@ RSpec.describe Articles::Creator, type: :service do
       sidekiq_assert_no_enqueued_jobs only: Notifications::NotifiableActionWorker do
         described_class.call(user, invalid_body_attributes)
       end
+    end
+
+    it "doesn't delegate to the Mentions::CreateAll service" do
+      allow(Mentions::CreateAll).to receive(:call)
+      article = described_class.call(user, invalid_body_attributes)
+      expect(Mentions::CreateAll).not_to have_received(:call).with(article)
     end
 
     it "doesn't create a notification subscription" do

--- a/spec/services/mentions/create_all_spec.rb
+++ b/spec/services/mentions/create_all_spec.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples "valid notifiable and no mentions" do
     expect(Mention.all.size).to eq(0)
   end
 
-  it "creates a mention if notifiable is updated to include mention" do
+  it "creates a mention if notifiable is updated to include mention", :aggregate_failures do
     set_markdown_and_save(notifiable, markdown)
     described_class.call(notifiable)
     expect(Mention.all.size).to eq(0)
@@ -25,7 +25,7 @@ RSpec.shared_examples "valid notifiable and has mentions" do
     expect(Mention.all.size).to eq(1)
   end
 
-  it "deletes mention if deleted from notifiable" do
+  it "deletes mention if deleted from notifiable", :aggregate_failures do
     set_markdown_and_save(notifiable, mention_markdown)
     described_class.call(notifiable)
     expect(Mention.all.size).to eq(1)
@@ -49,7 +49,7 @@ RSpec.shared_examples "valid notifiable and has mentions" do
     expect(Mention.all.size).to eq(2)
   end
 
-  it "deletes one of multiple mentions if one of multiple is deleted" do
+  it "deletes one of multiple mentions if one of multiple is deleted", :aggregate_failures do
     user3 = create(:user)
 
     set_markdown_and_save(notifiable, "Hello @#{user.username} @#{user3.username}, you are cool.")

--- a/spec/services/mentions/create_all_spec.rb
+++ b/spec/services/mentions/create_all_spec.rb
@@ -100,8 +100,7 @@ RSpec.describe Mentions::CreateAll, type: :service do
   let(:mention_markdown)   { "Hello @#{user.username}, you are cool." }
 
   def set_markdown_and_save(notifiable, markdown)
-    notifiable.body_markdown = markdown
-    notifiable.save
+    notifiable.update(body_markdown: markdown)
   end
 
   it_behaves_like "valid notifiable and no mentions" do

--- a/spec/services/mentions/create_all_spec.rb
+++ b/spec/services/mentions/create_all_spec.rb
@@ -1,88 +1,140 @@
 require "rails_helper"
 
-RSpec.describe Mentions::CreateAll, type: :service do
-  let(:user)        { create(:user) }
-  let(:user2)       { create(:user) }
-  let(:article)     { create(:article, user_id: user.id) }
-  let(:comment)     { create(:comment, user_id: user2.id, commentable: article) }
-  let(:comment2)    do
-    create(
-      :comment,
-      body_markdown: "Hello @#{user.username}, you are cool.",
-      user_id: user2.id,
-      commentable: article,
-    )
+RSpec.shared_examples "valid notifiable and no mentions" do
+  it "does not create mentions if a user is not mentioned" do
+    set_markdown_and_save(notifiable, markdown)
+    described_class.call(notifiable)
+    expect(Mention.all.size).to eq(0)
   end
 
-  it "creates mention if there is a user mentioned and if the user doenst own the comment" do
-    comment.body_markdown = "Hello @#{user.username}, you are cool."
-    comment.save
-    described_class.call(comment)
+  it "creates a mention if notifiable is updated to include mention" do
+    set_markdown_and_save(notifiable, markdown)
+    described_class.call(notifiable)
+    expect(Mention.all.size).to eq(0)
+
+    set_markdown_and_save(notifiable, mention_markdown)
+    described_class.call(notifiable)
+    expect(Mention.all.size).to eq(1)
+  end
+end
+
+RSpec.shared_examples "valid notifiable and has mentions" do
+  it "creates mention if there is a user mentioned and if the user doesn't own notifiable" do
+    set_markdown_and_save(notifiable, mention_markdown)
+    described_class.call(notifiable)
     expect(Mention.all.size).to eq(1)
   end
 
-  it "deletes mention if deleted from comment" do
-    comment.body_markdown = "Hello @#{user.username}, you are cool."
-    comment.save
-    described_class.call(comment)
+  it "deletes mention if deleted from notifiable" do
+    set_markdown_and_save(notifiable, mention_markdown)
+    described_class.call(notifiable)
     expect(Mention.all.size).to eq(1)
-    comment.body_markdown = "Hello, you are cool."
-    comment.save
-    described_class.call(comment)
+
+    set_markdown_and_save(notifiable, "Hello, you are cool.")
+    described_class.call(notifiable)
     expect(Mention.all.size).to eq(0)
   end
 
   it "creates one mention even if multiple mentions of same user" do
-    comment.body_markdown = "Hello @#{user.username} @#{user.username} @#{user.username}, you rock."
-    comment.save
-    described_class.call(comment)
+    set_markdown_and_save(notifiable, "Hello @#{user.username} @#{user.username} @#{user.username}, you rock.")
+    described_class.call(notifiable)
     expect(Mention.all.size).to eq(1)
   end
 
-  it "ignores mentions when embedded within a comment liquid tag" do
-    markdown = "Check out this comment: {% comment #{comment2.id_code_generated} %}"
-    comment_with_liquid_tag = create(:comment, user_id: user2.id, commentable: article, body_markdown: markdown)
-
-    comment_with_liquid_tag.save
-    described_class.call(comment_with_liquid_tag)
-    expect(Mention.all.size).to eq(0)
-  end
-
   it "creates multiple mentions for multiple users" do
-    user2 = create(:user)
-    comment.body_markdown = "Hello @#{user.username} @#{user2.username}, you are cool."
-    comment.save
-    described_class.call(comment)
+    user3 = create(:user)
+
+    set_markdown_and_save(notifiable, "Hello @#{user.username} @#{user3.username}, you are cool.")
+    described_class.call(notifiable)
     expect(Mention.all.size).to eq(2)
   end
 
   it "deletes one of multiple mentions if one of multiple is deleted" do
-    user2 = create(:user)
-    comment.body_markdown = "Hello @#{user.username} @#{user2.username}, you are cool."
-    comment.save
-    described_class.call(comment)
+    user3 = create(:user)
+
+    set_markdown_and_save(notifiable, "Hello @#{user.username} @#{user3.username}, you are cool.")
+    described_class.call(notifiable)
     expect(Mention.all.size).to eq(2)
-    comment.body_markdown = "Hello @#{user2.username}, you are cool."
-    comment.save
-    described_class.call(comment)
+
+    set_markdown_and_save(notifiable, "Hello @#{user3.username}, you are cool.")
+    described_class.call(notifiable)
     expect(Mention.all.size).to eq(1)
   end
 
-  it "creates a mention on creation of comment" do
-    described_class.call(comment2)
+  it "creates a mention on creation of notifiable" do
+    described_class.call(notifiable)
     expect(Mention.all.size).to eq(1)
-  end
-
-  it "does not create a mention without valid mentionable" do
-    comment2.update_column(:body_markdown, "")
-    described_class.call(comment2)
-    expect(Mention.all.size).to eq(0)
   end
 
   it "does not create a mention when the user mentions themselves" do
-    comment.body_markdown = "Me, Myself and I @#{user2.username}"
-    comment.save
-    described_class.call(comment)
+    set_markdown_and_save(notifiable, "Me, Myself and I @#{user2.username}")
+    described_class.call(notifiable)
     expect(Mention.all.size).to eq(0)
+  end
+end
+
+RSpec.shared_examples "valid notifiable with embedded mentions" do
+  it "does not create a mention" do
+    comment = create(:comment, user_id: user2.id, commentable: article, body_markdown: "Hi there, @#{user.username}")
+    liquid_tag_markdown = "Check out this comment: {% comment #{comment.id_code_generated} %}"
+
+    notifiable.update_column(:body_markdown, liquid_tag_markdown)
+    described_class.call(notifiable)
+    expect(Mention.all.size).to eq(0)
+  end
+end
+
+RSpec.shared_examples "invalid notifiable and has mentions" do
+  it "does not create a mention without valid mentionable" do
+    notifiable.update_column(:body_markdown, "")
+    described_class.call(notifiable)
+    expect(Mention.all.size).to eq(0)
+  end
+end
+
+RSpec.describe Mentions::CreateAll, type: :service do
+  let(:user)               { create(:user) }
+  let(:user2)              { create(:user) }
+  let(:article)            { create(:article, user_id: user.id) }
+  let(:markdown)           { "Hello, you are cool." }
+  let(:mention_markdown)   { "Hello @#{user.username}, you are cool." }
+
+  def set_markdown_and_save(notifiable, markdown)
+    notifiable.body_markdown = markdown
+    notifiable.save
+  end
+
+  it_behaves_like "valid notifiable and no mentions" do
+    let(:notifiable) { create(:comment, body_markdown: markdown, user_id: user2.id, commentable: article) }
+  end
+
+  it_behaves_like "valid notifiable and has mentions" do
+    let(:notifiable) { create(:comment, body_markdown: mention_markdown, user_id: user2.id, commentable: article) }
+  end
+
+  it_behaves_like "valid notifiable with embedded mentions" do
+    # Explicitly use markdown here without a mention to test that embedded mentions do not trigger a notification.
+    let(:notifiable) { create(:comment, body_markdown: markdown, user_id: user2.id, commentable: article) }
+  end
+
+  it_behaves_like "invalid notifiable and has mentions" do
+    let(:notifiable) { create(:comment, body_markdown: mention_markdown, user_id: user2.id, commentable: article) }
+  end
+
+  it_behaves_like "valid notifiable and no mentions" do
+    let(:notifiable) { create(:article, user_id: user2.id) }
+  end
+
+  it_behaves_like "valid notifiable and has mentions" do
+    let(:notifiable) { create(:article, user_id: user2.id) }
+    before { notifiable.update!(body_markdown: mention_markdown) }
+  end
+
+  it_behaves_like "valid notifiable with embedded mentions" do
+    let(:notifiable) { create(:article, user_id: user2.id) }
+  end
+
+  it_behaves_like "invalid notifiable and has mentions" do
+    let(:notifiable) { create(:article, user_id: user2.id) }
   end
 end

--- a/spec/services/notifications/new_mention/send_spec.rb
+++ b/spec/services/notifications/new_mention/send_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
-RSpec.describe Notifications::NewMention::Send, type: :service do
-  let(:user) { create(:user) }
-  let(:comment) { create(:comment, commentable: create(:article)) }
-  let(:mention) { create(:mention, mentionable: comment, user: user) }
+RSpec.shared_examples "mentionable" do
+  let(:mention) { create(:mention, mentionable: mentionable, user: user) }
 
   it "creates a mention notification" do
     expect do
@@ -13,13 +11,27 @@ RSpec.describe Notifications::NewMention::Send, type: :service do
 
   it "creates a correct mention notification" do
     notification = described_class.call(mention)
+    mentionable_type = mentionable.class.to_s.downcase
     expect(notification.user_id).to eq(user.id)
     expect(notification.notifiable).to eq(mention)
-    expect(notification.json_data["comment"]["path"]).to eq(comment.path)
+    expect(notification.json_data[mentionable_type]["path"]).to eq(mentionable.path)
   end
 
   it "sends from proper mentioner" do
     notification = described_class.call(mention)
-    expect(notification.json_data["user"]["id"]).to eq(comment.user_id)
+    expect(notification.json_data["user"]["id"]).to eq(mentionable.user_id)
+  end
+end
+
+RSpec.describe Notifications::NewMention::Send, type: :service do
+  let(:user) { create(:user) }
+  let!(:article) { create(:article) }
+
+  it_behaves_like "mentionable" do
+    let(:mentionable) { create(:comment, commentable: article) }
+  end
+
+  it_behaves_like "mentionable" do
+    let(:mentionable) { article }
   end
 end

--- a/spec/services/notifications/new_mention/send_spec.rb
+++ b/spec/services/notifications/new_mention/send_spec.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples "mentionable" do
     end.to change(Notification, :count).by(1)
   end
 
-  it "creates a correct mention notification" do
+  it "creates a correct mention notification", :aggregate_failures do
     notification = described_class.call(mention)
     mentionable_type = mentionable.class.to_s.downcase
     expect(notification.user_id).to eq(user.id)

--- a/spec/services/notifications/notifiable_action/send_spec.rb
+++ b/spec/services/notifications/notifiable_action/send_spec.rb
@@ -8,51 +8,71 @@ RSpec.describe Notifications::NotifiableAction::Send, type: :service do
   let(:user2) { create(:user) }
   let(:user3) { create(:user) }
 
-  before do
-    user2.follow(user)
-    user3.follow(organization)
-  end
+  context "when following a user or organization" do
+    before do
+      user2.follow(user)
+      user3.follow(organization)
+    end
 
-  it "creates notifications" do
-    expect do
+    it "creates notifications" do
+      expect do
+        described_class.call(article, "Published")
+      end.to change(Notification, :count).by(2)
+    end
+
+    it "creates a correct user notification" do
       described_class.call(article, "Published")
-    end.to change(Notification, :count).by(2)
+      notifications = Notification.where(user_id: user2.id, notifiable_id: article.id, notifiable_type: "Article")
+      expect(notifications.size).to eq(1)
+      notification = notifications.first
+      expect(notification.action).to eq("Published")
+      expect(notification.json_data["article"]["id"]).to eq(article.id)
+      expect(notification.json_data["user"]["id"]).to eq(user.id)
+      expect(notification.json_data["user"]["username"]).to eq(user.username)
+    end
+
+    it "creates a correct organization notification" do
+      described_class.call(article, "Published")
+      notifications = Notification.where(user_id: user3.id, notifiable_id: article.id, notifiable_type: "Article")
+      expect(notifications.size).to eq(1)
+      notification = notifications.first
+      expect(notification.action).to eq("Published")
+      expect(notification.json_data["article"]["id"]).to eq(article.id)
+      expect(notification.json_data["user"]["id"]).to eq(user.id)
+      expect(notification.json_data["organization"]["id"]).to eq(organization.id)
+      expect(notification.json_data["organization"]["name"]).to eq(organization.name)
+    end
+
+    it "does not create a notification if the follower has muted the user" do
+      user2.follows.first.update(subscription_status: "none")
+      user3.stop_following(organization)
+      described_class.call(article, "Published")
+      expect(Notification.count).to eq(0)
+    end
+
+    it "doesn't fail if the notification already exists" do
+      notification = create(:notification, user: user2, action: "Published", notifiable: article)
+      result = described_class.call(article, "Published")
+      ids = result.to_a.map { |r| r["id"] }
+      expect(ids).to include(notification.id)
+    end
   end
 
-  it "creates a correct user notification" do
-    described_class.call(article, "Published")
-    notifications = Notification.where(user_id: user2.id, notifiable_id: article.id, notifiable_type: "Article")
-    expect(notifications.size).to eq(1)
-    notification = notifications.first
-    expect(notification.action).to eq("Published")
-    expect(notification.json_data["article"]["id"]).to eq(article.id)
-    expect(notification.json_data["user"]["id"]).to eq(user.id)
-    expect(notification.json_data["user"]["username"]).to eq(user.username)
-  end
+  context "when following a user or organization and being mentioned in an article" do
+    it "does not create a notification when following a user" do
+      user2.follow(user)
+      create(:mention, mentionable: article, user: user2)
 
-  it "creates a correct organization notification" do
-    described_class.call(article, "Published")
-    notifications = Notification.where(user_id: user3.id, notifiable_id: article.id, notifiable_type: "Article")
-    expect(notifications.size).to eq(1)
-    notification = notifications.first
-    expect(notification.action).to eq("Published")
-    expect(notification.json_data["article"]["id"]).to eq(article.id)
-    expect(notification.json_data["user"]["id"]).to eq(user.id)
-    expect(notification.json_data["organization"]["id"]).to eq(organization.id)
-    expect(notification.json_data["organization"]["name"]).to eq(organization.name)
-  end
+      described_class.call(article, "Published")
+      expect(Notification.count).to eq(0)
+    end
 
-  it "does not create a notification if the follower has muted the user" do
-    user2.follows.first.update(subscription_status: "none")
-    user3.stop_following(organization)
-    described_class.call(article, "Published")
-    expect(Notification.count).to eq 0
-  end
+    it "does not create a notification when following an organization" do
+      user3.follow(organization)
+      create(:mention, mentionable: article, user: user3)
 
-  it "doesn't fail if the notification already exists" do
-    notification = create(:notification, user: user2, action: "Published", notifiable: article)
-    result = described_class.call(article, "Published")
-    ids = result.to_a.map { |r| r["id"] }
-    expect(ids).to include(notification.id)
+      described_class.call(article, "Published")
+      expect(Notification.count).to eq(0)
+    end
   end
 end

--- a/spec/services/notifications/notifiable_action/send_spec.rb
+++ b/spec/services/notifications/notifiable_action/send_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Notifications::NotifiableAction::Send, type: :service do
       end.to change(Notification, :count).by(2)
     end
 
-    it "creates a correct user notification" do
+    it "creates a correct user notification", :aggregate_failures do
       described_class.call(article, "Published")
       notifications = Notification.where(user_id: user2.id, notifiable_id: article.id, notifiable_type: "Article")
       expect(notifications.size).to eq(1)
@@ -31,7 +31,7 @@ RSpec.describe Notifications::NotifiableAction::Send, type: :service do
       expect(notification.json_data["user"]["username"]).to eq(user.username)
     end
 
-    it "creates a correct organization notification" do
+    it "creates a correct organization notification", :aggregate_failures do
       described_class.call(article, "Published")
       notifications = Notification.where(user_id: user3.id, notifiable_id: article.id, notifiable_type: "Article")
       expect(notifications.size).to eq(1)

--- a/spec/workers/mentions/send_email_notification_worker_spec.rb
+++ b/spec/workers/mentions/send_email_notification_worker_spec.rb
@@ -1,32 +1,42 @@
 require "rails_helper"
 
+RSpec.shared_examples "a valid mentionable" do
+  context "with a mention" do
+    it "calls on NotifyMailer" do
+      worker.perform(mention.id) do
+        expect(NotifyMailer).to have_received(:new_mention_email).with(mention)
+      end
+    end
+  end
+
+  context "without a mention" do
+    it "does not error" do
+      expect { worker.perform(nil) }.not_to raise_error
+    end
+
+    it "does not call NotifyMailer" do
+      worker.perform(nil) do
+        expect(NotifyMailer).not_to have_received(:new_mention_email)
+      end
+    end
+  end
+end
+
 RSpec.describe Mentions::SendEmailNotificationWorker, type: :worker do
   include_examples "#enqueues_on_correct_queue", "default", 1
 
   describe "#perform" do
-    let(:worker) { subject }
-    let(:user) { create(:user) }
-    let(:mention) { create(:mention, user_id: user.id, mentionable_id: comment.id, mentionable_type: "Comment") }
-    let(:comment) { create(:comment, user_id: user.id, commentable: create(:article)) }
+    let(:worker)  { subject }
+    let(:user)    { create(:user) }
+    let(:article) { create(:article) }
+    let(:comment) { create(:comment, user_id: user.id, commentable: article) }
 
-    context "with mention" do
-      it "calls on NotifyMailer" do
-        worker.perform(mention.id) do
-          expect(NotifyMailer).to have_received(:new_mention_email).with(mention)
-        end
-      end
+    it_behaves_like "a valid mentionable" do
+      let(:mention) { create(:mention, user_id: user.id, mentionable_id: comment.id, mentionable_type: "Comment") }
     end
 
-    context "without a mention" do
-      it "does not error" do
-        expect { worker.perform(nil) }.not_to raise_error
-      end
-
-      it "does not call NotifyMailer" do
-        worker.perform(nil) do
-          expect(NotifyMailer).not_to have_received(:new_mention_email)
-        end
-      end
+    it_behaves_like "a valid mentionable" do
+      let(:mention) { create(:mention, user_id: user.id, mentionable_id: article.id, mentionable_type: "Article") }
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description

This PR completes the final piece of functionality to _fully_ ship [RFC #22](https://github.com/forem/rfcs/pull/22)! 🥰 

Per the RFC's [design/definition of done](https://github.com/forem/rfcs/blob/main/text/0022-expand-at-mention-to-posts.md#designimplementation), this PR does the following:
- [x] Allows articles to have mentions
- [x] Sends users who are mentioned in an article a single notification
- [x] Ensures that the correct notification shows up on the mentioned user's `/notification` page
- [x] Ensures that a user only receives one notification per article (_if a user follows an author/organization but also happen to be @-mentioned in the article, they _only_ receive the @-mention notification, and no other article notifications_)
- [x] Updates relevant views and mailer templates
- [x] Adds a TON of specs

## Related Tickets & Documents

Completes https://github.com/forem/rfcs/pull/22! 🎉 

## QA Instructions, Screenshots, Recordings

**To QA this PR, open up two browser windows, each with two different users. In this case, I have User A (Admin user) and User B (my user, `vaidehijoshi`).**

### Part 1: Testing @-mentions while following a user
1. Start by having User B follow User A. In User A's account, create an article, and mention User B:
<img width="812" alt="Screen Shot 2021-05-10 at 11 07 32 AM" src="https://user-images.githubusercontent.com/6921610/117854421-5349e400-b23e-11eb-9763-eacb04ed1f5c.png">
2. Publish the article written by User A:
<img width="1138" alt="Screen Shot 2021-05-10 at 11 07 47 AM" src="https://user-images.githubusercontent.com/6921610/117854628-85f3dc80-b23e-11eb-9259-46dd12a9b9ee.png">
3. Go to User B's account, and check that you see a notification icon:
<img width="288" alt="Screen Shot 2021-05-10 at 11 14 36 AM" src="https://user-images.githubusercontent.com/6921610/117854644-89876380-b23e-11eb-8347-6e54a0a62bf4.png">
4. Click on the icon, which takes you to the `/notifications` tab. You should see a notification that tells you that you were mentioned. You SHOULD NOT have received a notification telling you that User A published the article (which you normally would get if you follow User A). Instead, you should _only_ have a notification telling you that you were mentioned in the new post they published:
<img width="757" alt="Screen Shot 2021-05-10 at 11 08 11 AM" src="https://user-images.githubusercontent.com/6921610/117854769-a91e8c00-b23e-11eb-92ae-b53acb545960.png">
5. Clicking on the notification itself should take you to the newly-published article, and you should see your username mentioned 👍🏽 
<img width="1074" alt="Screen Shot 2021-05-10 at 11 08 27 AM" src="https://user-images.githubusercontent.com/6921610/117854791-ad4aa980-b23e-11eb-8cae-98718c647027.png">

### Part 2: Testing normal article published notifications
1. Now, create a new article from User A's account. This time, DO NOT mention User B.
<img width="1123" alt="Screen Shot 2021-05-10 at 11 15 51 AM" src="https://user-images.githubusercontent.com/6921610/117855195-19c5a880-b23f-11eb-9d59-c5854296b848.png">
2. In User B's account, check that you see a notification icon:
<img width="288" alt="Screen Shot 2021-05-10 at 11 14 36 AM" src="https://user-images.githubusercontent.com/6921610/117855301-32ce5980-b23f-11eb-90cb-4a6e526123d5.png">
3. You should see a normal "article published" notification:
<img width="1030" alt="Screen Shot 2021-05-10 at 11 14 45 AM" src="https://user-images.githubusercontent.com/6921610/117855210-1cc09900-b23f-11eb-96a8-ff43299810cb.png">

### Part 3: Testing embedded mentions
1. Find a comment that mentions User B (any comment should do!). For example:
<img width="1266" alt="Screen Shot 2021-05-10 at 1 59 12 PM" src="https://user-images.githubusercontent.com/6921610/117855486-61e4cb00-b23f-11eb-9682-a12f7ca0bfb5.png">
2. Create a new post from User A's account, using the `{% comment [id] %}` liquid tag syntax:
<img width="814" alt="Screen Shot 2021-05-10 at 1 59 44 PM" src="https://user-images.githubusercontent.com/6921610/117855775-ab351a80-b23f-11eb-86af-a407a67ca6c4.png">
3. Go to User B's account; if User B is still following User A, there should be a new notification, but it should NOT be a notification about being @-mentioned. Instead, it should only be a normal "article published" notification, and nothing else. 
<img width="752" alt="Screen Shot 2021-05-10 at 2 00 02 PM" src="https://user-images.githubusercontent.com/6921610/117855788-aff9ce80-b23f-11eb-950a-2d207879f78e.png">
4. You can try the same test after making User B "unfollow" User A, at which point User B should receive NO notifications.

### Part 4: Other oddities
1. Try testing this functionality out with both editors; the functionality should be exactly the same:
<img width="1411" alt="Screen Shot 2021-05-10 at 11 26 40 AM" src="https://user-images.githubusercontent.com/6921610/117856064-0535e000-b240-11eb-844d-54c73aa36504.png">
<img width="1036" alt="Screen Shot 2021-05-10 at 12 59 35 PM" src="https://user-images.githubusercontent.com/6921610/117856052-023aef80-b240-11eb-834a-32f81ad8692f.png">
2. Test that a user doesn't get more than one notification, no matter how many times they are mentioned! ALso test that you can't @-mention more than 7 times:
<img width="1266" alt="Screen Shot 2021-05-10 at 11 24 05 AM" src="https://user-images.githubusercontent.com/6921610/117856155-1f6fbe00-b240-11eb-878e-9b475c6844a3.png">
3. Test that you can [preview the new `new_article_mention_email` mailer](http://localhost:3000/rails/mailers/notify_mailer) locally, and that the job to send the email is enqueued when a mention notification is sent locally.
<img width="967" alt="Screen Shot 2021-05-10 at 11 18 25 AM" src="https://user-images.githubusercontent.com/6921610/117856252-3ca48c80-b240-11eb-96e7-d6c202705a8c.png">
<img width="1423" alt="Screen Shot 2021-05-10 at 11 31 38 AM" src="https://user-images.githubusercontent.com/6921610/117856371-652c8680-b240-11eb-961d-5a3bfad47760.png">


### UI accessibility concerns?

_This is mostly backend work, and the frontend work is reusing HTML markup code that already exists so, hopefully not!_

## Added tests?

- [x] You bet I did 😉 

## [Forem core team only] How will this change be communicated?
- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams

## Are there any post deployment tasks we need to perform?

Nothing special, nope! Just want to be sure to QA thoroughly and try it out on DEV before rolling it out to the fleet.

## What gif best describes this PR or how it makes you feel?

![omg sloth](https://media2.giphy.com/media/lRpD28vbtrqq2zpaKS/giphy.gif?cid=790b7611d9cb3f7b2095ed55fa1b94ec0f7c925ce7b1dafd&rid=giphy.gif&ct=g)
