### PR TITLE
15 minute fix: Add default argument to JsonApiSortParam

### DIFF
--- a/app/controllers/api/v0/followers_controller.rb
+++ b/app/controllers/api/v0/followers_controller.rb
@@ -29,7 +29,6 @@ module Api
 
       def order_criteria
         parse_sort_param(
-          params[:sort],
           allowed_fields: [:created_at],
           default_sort: { created_at: :desc },
         )

--- a/app/controllers/concerns/json_api_sort_param.rb
+++ b/app/controllers/concerns/json_api_sort_param.rb
@@ -6,7 +6,7 @@ module JsonApiSortParam
   #   array determines the sort order of the resulting hash.
   # @param default_sort [{Symbol => Symbol}] The default sort order. Used when
   #   the param string is nil/empty or when parsing it results in an empty hash.
-  def parse_sort_param(param_string, allowed_fields:, default_sort:)
+  def parse_sort_param(param_string = params[:sort], allowed_fields:, default_sort:)
     fields = param_string.to_s.split(",")
     unfiltered_hash = fields_to_hash(fields)
     sort = sort_and_filter(unfiltered_hash, allowed_fields)

--- a/spec/controllers/concerns/json_api_sort_param_spec.rb
+++ b/spec/controllers/concerns/json_api_sort_param_spec.rb
@@ -1,7 +1,20 @@
 require "rails_helper"
 
 RSpec.describe JsonApiSortParam do
-  let!(:controller) { Class.new { include JsonApiSortParam }.new }
+  let!(:controller) do
+    Class.new(Api::V0::ApiController) { include JsonApiSortParam }.new
+  end
+
+  it "uses the `sort` param of the controller by default" do
+    params = ActionController::Parameters.new(sort: "created_at,-updated_at")
+    allow(controller).to receive(:params).and_return(params)
+
+    params = controller.parse_sort_param(
+      allowed_fields: %i[created_at updated_at],
+      default_sort: { created_at: :desc },
+    )
+    expect(params).to eq({ created_at: :asc, updated_at: :desc })
+  end
 
   it "returns a default sort order if there are no sorting params" do
     params = controller.parse_sort_param(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

I recently added the `JsonApiSortParam`  concern. However, the included `parse_sort_param` method always required the param string to be passed it explicitly. Given that is a controller concern we can assume that a `params` method will always be available in the including scope, so I'm using this as the default now.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Refactoring only, specs should still pass

### UI accessibility concerns?

n/a

## Added tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [ ] This change does not need to be communicated, and this is why not: refactoring, no user-facing changes
