### PR TITLE
[15 min fix] Remove extra key handler on reading list archive button

### DIFF
--- a/app/javascript/readingList/components/ItemListItemArchiveButton.jsx
+++ b/app/javascript/readingList/components/ItemListItemArchiveButton.jsx
@@ -9,26 +9,17 @@ import { h } from 'preact';
 import PropTypes from 'prop-types';
 import { Button } from '@crayons';
 
-export const ItemListItemArchiveButton = ({ text, onClick }) => {
-  const onKeyUp = (e) => {
-    if (e.key === 'Enter') {
-      onClick(e);
-    }
-  };
-
-  return (
-    <Button
-      onClick={onClick}
-      onKeyUp={onKeyUp}
-      aria-label="Archive item"
-      role="button"
-      variant="ghost"
-      size="s"
-    >
-      {text}
-    </Button>
-  );
-};
+export const ItemListItemArchiveButton = ({ text, onClick }) => (
+  <Button
+    onClick={onClick}
+    aria-label="Archive item"
+    role="button"
+    variant="ghost"
+    size="s"
+  >
+    {text}
+  </Button>
+);
 
 ItemListItemArchiveButton.propTypes = {
   text: PropTypes.string.isRequired,

--- a/app/javascript/readingList/components/__tests__/ItemListItemArchiveButton.test.jsx
+++ b/app/javascript/readingList/components/__tests__/ItemListItemArchiveButton.test.jsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { render, fireEvent } from '@testing-library/preact';
+import { render } from '@testing-library/preact';
 import { axe } from 'jest-axe';
 import { ItemListItemArchiveButton } from '../ItemListItemArchiveButton';
 
@@ -17,18 +17,5 @@ describe('<ItemListItemArchiveButton />', () => {
     );
 
     expect(queryByText(/archive/i)).toBeDefined();
-  });
-
-  it('triggers the onClick if the Enter key is pressed', () => {
-    const onClick = jest.fn();
-    const { getByRole } = render(
-      <ItemListItemArchiveButton text="archive" onClick={onClick} />,
-    );
-
-    fireEvent.keyUp(getByRole('button'), { key: 'Enter', code: 'Enter' });
-    expect(onClick).toHaveBeenCalledTimes(1);
-
-    fireEvent.keyUp(getByRole('button'), { key: 'Space', code: 'Space' });
-    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed if you archive/unarchive a reading list item using the keyboard, it very often removes two items, instead of just the one you chose. Taking a little look it was because we had an additional `keyUp` handler, which isn't needed because the normal button 'onClick' is fired when Enter is pressed on the keyboard.

Screen recording of the bug:


https://user-images.githubusercontent.com/20773163/114703041-b79b8580-9d1c-11eb-8696-5805ac2cc44e.mp4



## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

- Save some items to your reading list
- Go to the reading list page
- Using the keyboard, select one of the archive buttons
- Press enter and check only the selected post is archived
- Repeat the process from the Archive page


https://user-images.githubusercontent.com/20773163/114703198-e44f9d00-9d1c-11eb-8d68-20f54069cbc3.mp4



### UI accessibility concerns?

This fixes a bug affecting the keyboard accessibility of the reading list

## Added tests?

- [ ] Yes
- [X] No, and this is why: I actually removed some tests testing a `keyUp` event that isn't needed. A button's 'onClick' is the same regardless whether activated by keyboard or mouse
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![a little pup typing](https://i.giphy.com/media/mFwqFZx1HxfQ4hwkz9/giphy.webp)
