### PR TITLE
[15 min fix] Intercept listings search call in listings cypress test

### DIFF
--- a/cypress/fixtures/search/listings.json
+++ b/cypress/fixtures/search/listings.json
@@ -1,0 +1,18 @@
+{
+  "result": [
+    {
+      "id": 1,
+      "title": "Listing title",
+      "body_markdown": "Some listing content",
+      "category": "cfp",
+      "contact_via_connect": false,
+      "expires_at": "2051-05-14T00:00:00.000Z",
+      "bumped_at": "2021-01-14T00:00:00.000Z",
+      "originally_published_at": "2021-04-14T11:41:16.790Z",
+      "published": true,
+      "user_id": 1,
+      "processed_html": "listing content",
+      "slug": "listing-title"
+    }
+  ]
+}

--- a/cypress/integration/listingFlows/viewListing.spec.js
+++ b/cypress/integration/listingFlows/viewListing.spec.js
@@ -21,9 +21,14 @@ describe('View listing', () => {
   });
 
   it('opens a listing from the listings page', () => {
+    cy.intercept(
+      '/search/listings?category=&listing_search=&page=0&per_page=75&tag_boolean_mode=all',
+      { fixture: 'search/listings.json' },
+    );
+
     cy.visit('/listings');
 
-    cy.findByText('Listing title').as('listingTitle');
+    cy.findByRole('link', { name: 'Listing title' }).as('listingTitle');
     cy.get('@listingTitle').click();
 
     cy.findByTestId('listings-modal').as('listingsModal');


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

One of the listings Cypress tests sometimes fails when running locally, due the seeded listing being replaced with the results of the `/search/listings` call. This PR adds some static listing data to return in place of the failed search call, ensuring the test only fails if the behaviour under test fails.

Since the test in question is checking whether a modal opens/closes, we don't lose anything by using the mocked data.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

N/A - no user-facing changes

### UI accessibility concerns?

N/A - no user-facing changes
## Added tests?

- [X] Yes - updated test
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

