### PR TITLE
[Search 2.0] Comments on search page

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -120,7 +120,8 @@ class SearchController < ApplicationController
   end
 
   def feed_content
-    class_name = params[:class_name]&.inquiry
+    class_name = params[:class_name].to_s.inquiry
+
     result =
       if class_name.blank?
         # If we are in the main feed and not filtering by type return

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -120,7 +120,7 @@ class SearchController < ApplicationController
   end
 
   def feed_content
-    class_name = params[:class_name].to_s.inquiry
+    class_name = feed_params[:class_name].to_s.inquiry
 
     result =
       if class_name.blank?
@@ -129,9 +129,11 @@ class SearchController < ApplicationController
         feed_content_search.concat(user_search)
       elsif class_name.Comment? && FeatureFlag.enabled?(:search_2_comments)
         Search::Postgres::Comment.search_documents(
-          term: feed_params[:search_fields],
           page: feed_params[:page],
           per_page: feed_params[:per_page],
+          sort_by: feed_params[:sort_by],
+          sort_direction: feed_params[:sort_direction],
+          term: feed_params[:search_fields],
         )
       elsif class_name.User?
         # No need to check for articles or podcast episodes if we know we only want users

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,7 +10,7 @@ class Comment < ApplicationRecord
   SEARCH_CLASS = Search::FeedContent
 
   BODY_MARKDOWN_SIZE_RANGE = (1..25_000).freeze
-  COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze
+  COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze # Also used in self.force_eager_load_serialized_data
   TITLE_DELETED = "[deleted]".freeze
   TITLE_HIDDEN = "[hidden by post author]".freeze
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,22 +11,10 @@ class Comment < ApplicationRecord
 
   BODY_MARKDOWN_SIZE_RANGE = (1..25_000).freeze
 
-  # Updates to this constant also require updates to FORCED_EAGER_LOAD_QUERY
-  # and Search::Postgres::Comment::QUERY_FILTER
+  # Updates to this constant also requires updates to:
+  # - Search::Postgres::Comment::QUERY_FILTER
+  # - Search::Postgres::Comment::FORCED_EAGER_LOAD_QUERY
   COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze
-
-  FORCED_EAGER_LOAD_QUERY = <<-SQL.freeze
-    LEFT JOIN users
-      ON comments.user_id = users.id
-    LEFT JOIN articles
-      ON comments.commentable_id = articles.id
-      AND comments.commentable_type = 'Article'
-    LEFT JOIN podcast_episodes
-      ON comments.commentable_id = podcast_episodes.id
-      AND comments.commentable_type = 'PodcastEpisode'
-    LEFT JOIN podcasts
-      ON podcast_episodes.podcast_id = podcasts.id
-  SQL
 
   TITLE_DELETED = "[deleted]".freeze
   TITLE_HIDDEN = "[hidden by post author]".freeze

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -75,9 +75,21 @@ class Comment < ApplicationRecord
   # [@atsmith813] this is adapted from the `search_field` property in
   # `config/elasticsearch/mappings/feed_content.json` and
   # `app/serializers/search/comment_serializer.rb`
+  #
+  # highlighter settings are taken from
+  # Search::QueryBuildersFeedContent#add_highlight_fields
   pg_search_scope :search_comments,
                   against: %i[body_markdown],
-                  using: { tsearch: { prefix: true } }
+                  using: {
+                    tsearch: {
+                      prefix: true,
+                      highlight: {
+                        StartSel: "<mark>",
+                        StopSel: "</mark>",
+                        MaxFragments: 2
+                      }
+                    }
+                  }
 
   scope :eager_load_serialized_data, -> { includes(:user, :commentable) }
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,9 +11,6 @@ class Comment < ApplicationRecord
 
   BODY_MARKDOWN_SIZE_RANGE = (1..25_000).freeze
 
-  # Updates to this constant also requires updates to:
-  # - Search::Postgres::Comment::QUERY_FILTER
-  # - Search::Postgres::Comment::FORCED_EAGER_LOAD_QUERY
   COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze
 
   TITLE_DELETED = "[deleted]".freeze

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,8 +11,10 @@ class Comment < ApplicationRecord
 
   BODY_MARKDOWN_SIZE_RANGE = (1..25_000).freeze
 
-  # Also used in Search::Postgres::Comment
+  # Updates to this constant also require updates to FORCED_EAGER_LOAD_QUERY
+  # and Search::Postgres::Comment::QUERY_FILTER
   COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze
+
   FORCED_EAGER_LOAD_QUERY = <<-SQL.freeze
     LEFT JOIN users
       ON comments.user_id = users.id

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -99,10 +99,6 @@ class Comment < ApplicationRecord
     commentable.comments.includes(:user).arrange(order: "score DESC").to_a[0..limit - 1].to_h
   end
 
-  def self.forced_eager_load_serialized_data
-    joins(FORCED_EAGER_LOAD_QUERY)
-  end
-
   def search_id
     "comment_#{id}"
   end

--- a/app/serializers/search/comment_serializer.rb
+++ b/app/serializers/search/comment_serializer.rb
@@ -18,10 +18,17 @@ module Search
       comment.commentable&.title
     end
 
+    # NOTE: not using the `NestedUserSerializer` because we don't need the
+    # the `pro` flag on the frontend, and we also avoid hitting Redis to
+    # fetch the cached value
     attribute :user do |comment|
-      NestedUserSerializer.new(comment.user).serializable_hash.dig(
-        :data, :attributes
-      )
+      user = comment.user
+
+      {
+        name: user.name,
+        profile_image_90: user.profile_image_90,
+        username: user.username
+      }
     end
   end
 end

--- a/app/serializers/search/comment_serializer.rb
+++ b/app/serializers/search/comment_serializer.rb
@@ -18,17 +18,10 @@ module Search
       comment.commentable&.title
     end
 
-    # NOTE: not using the `NestedUserSerializer` because we don't need the
-    # the `pro` flag on the frontend, and we also avoid hitting Redis to
-    # fetch the cached value
     attribute :user do |comment|
-      user = comment.user
-
-      {
-        name: user.name,
-        profile_image_90: user.profile_image_90,
-        username: user.username
-      }
+      NestedUserSerializer.new(comment.user).serializable_hash.dig(
+        :data, :attributes
+      )
     end
   end
 end

--- a/app/serializers/search/postgres_comment_serializer.rb
+++ b/app/serializers/search/postgres_comment_serializer.rb
@@ -28,8 +28,7 @@ module Search
     attribute :readable_publish_date_string, &:readable_publish_date
     attribute :title, &:commentable_title
 
-    # NOTE: not using the `NestedUserSerializer` because we don't need the
-    # the `pro` flag on the frontend, and we also avoid hitting Redis to
+    # NOTE: not using the `NestedUserSerializer` to avoid hitting Redis to
     # fetch the cached value
     attribute :user do |comment, params|
       user = params[:users][comment.user_id]

--- a/app/serializers/search/postgres_comment_serializer.rb
+++ b/app/serializers/search/postgres_comment_serializer.rb
@@ -1,0 +1,50 @@
+module Search
+  # TODO[@atsmith813]: Rename this to CommentSerializer once Elasticsearch is removed
+  class PostgresCommentSerializer < ApplicationSerializer
+    attribute :id, &:search_id
+
+    attributes :path, :public_reactions_count
+
+    attribute :body_text, &:body_markdown
+
+    attribute :class_name do |comment|
+      comment.class.name
+    end
+
+    attribute :highlight do |comment|
+      {
+        body_text: [comment.pg_search_highlight]
+      }
+    rescue PgSearch::PgSearchHighlightNotSelected
+      # This is needed because in Search::Postgres::Comment we only call the
+      # search if a term is provided. This means if a user searches with a
+      # blank term, we skip the line that executes .with_pg_search_highlight.
+      # Skipping this AND trying to call .pg_search_highlight raises an error
+      # which we ignore here - basically filling in highlights if they're
+      # there.
+    end
+
+    attribute :hotness_score, &:score
+    attribute :published do |comment|
+      comment.commentable&.published
+    end
+    attribute :published_at, &:created_at
+    attribute :readable_publish_date_string, &:readable_publish_date
+    attribute :title do |comment|
+      comment.commentable&.title
+    end
+
+    # NOTE: not using the `NestedUserSerializer` because we don't need the
+    # the `pro` flag on the frontend, and we also avoid hitting Redis to
+    # fetch the cached value
+    attribute :user do |comment|
+      user = comment.user
+
+      {
+        name: user.name,
+        profile_image_90: user.profile_image_90,
+        username: user.username
+      }
+    end
+  end
+end

--- a/app/serializers/search/postgres_comment_serializer.rb
+++ b/app/serializers/search/postgres_comment_serializer.rb
@@ -7,11 +7,11 @@ module Search
 
     attribute :body_text, &:body_markdown
 
-    attribute :class_name do |_comment|
+    attribute :class_name do |_comment, _params|
       "Comment"
     end
 
-    attribute :highlight do |comment|
+    attribute :highlight do |comment, _params|
       {
         body_text: [comment.pg_search_highlight]
       }
@@ -25,26 +25,17 @@ module Search
     end
 
     attribute :hotness_score, &:score
-    attribute :published do |comment|
-      comment.commentable&.published
-    end
+    attribute :published, &:commentable_published
     attribute :published_at, &:created_at
     attribute :readable_publish_date_string, &:readable_publish_date
-    attribute :title do |comment|
-      comment.commentable&.title
-    end
+    attribute :title, &:commentable_title
 
     # NOTE: not using the `NestedUserSerializer` because we don't need the
     # the `pro` flag on the frontend, and we also avoid hitting Redis to
     # fetch the cached value
-    attribute :user do |comment|
-      user = comment.user
-
-      {
-        name: user.name,
-        profile_image_90: user.profile_image_90,
-        username: user.username
-      }
+    attribute :user do |comment, params|
+      user = params[:users][comment.user_id]
+      user.slice(:name, :profile_image_90, :username).symbolize_keys
     end
   end
 end

--- a/app/serializers/search/postgres_comment_serializer.rb
+++ b/app/serializers/search/postgres_comment_serializer.rb
@@ -3,7 +3,17 @@ module Search
   class PostgresCommentSerializer < ApplicationSerializer
     attribute :id, &:search_id
 
-    attributes :path, :public_reactions_count
+    attributes :path do |comment, params|
+      user = params[:users][comment.user_id]
+
+      if user
+        "/#{user.username}/comment/#{comment.id_code_generated}"
+      else
+        "/404.html"
+      end
+    end
+
+    attributes :public_reactions_count
 
     attribute :body_text, &:body_markdown
 

--- a/app/serializers/search/postgres_comment_serializer.rb
+++ b/app/serializers/search/postgres_comment_serializer.rb
@@ -7,8 +7,8 @@ module Search
 
     attribute :body_text, &:body_markdown
 
-    attribute :class_name do |comment|
-      comment.class.name
+    attribute :class_name do |_comment|
+      "Comment"
     end
 
     attribute :highlight do |comment|

--- a/app/serializers/search/postgres_comment_serializer.rb
+++ b/app/serializers/search/postgres_comment_serializer.rb
@@ -7,9 +7,7 @@ module Search
 
     attribute :body_text, &:body_markdown
 
-    attribute :class_name do |_comment, _params|
-      "Comment"
-    end
+    attribute :class_name, -> { "Comment" }
 
     attribute :highlight do |comment, _params|
       {
@@ -25,7 +23,7 @@ module Search
     end
 
     attribute :hotness_score, &:score
-    attribute :published, &:commentable_published
+    attribute :published, -> { true }
     attribute :published_at, &:created_at
     attribute :readable_publish_date_string, &:readable_publish_date
     attribute :title, &:commentable_title

--- a/app/services/search/postgres/comment.rb
+++ b/app/services/search/postgres/comment.rb
@@ -40,7 +40,7 @@ module Search
 
         relation = relation.search_comments(term) if term.present?
 
-        relation = relation.select(*ATTRIBUTES).order("comments.score desc")
+        relation = relation.select(*ATTRIBUTES).reorder("comments.score": :desc)
 
         results = relation.page(page).per(per_page)
 

--- a/app/services/search/postgres/comment.rb
+++ b/app/services/search/postgres/comment.rb
@@ -1,0 +1,59 @@
+module Search
+  module Postgres
+    class Comment
+      ATTRIBUTES = [
+        "comments.id AS id",
+        "comments.body_markdown",
+        "comments.commentable_id",
+        "comments.commentable_type",
+        "comments.created_at",
+        "comments.public_reactions_count",
+        "comments.score",
+        "comments.user_id AS comment_user_id",
+        "users.id AS user_id",
+        "users.name",
+        "users.profile_image",
+        "users.username",
+      ].freeze
+      private_constant :ATTRIBUTES
+
+      DEFAULT_PER_PAGE = 60
+      private_constant :DEFAULT_PER_PAGE
+
+      MAX_PER_PAGE = 120 # to avoid querying too many items, we set a maximum amount for a page
+      private_constant :MAX_PER_PAGE
+
+      def self.search_documents(page: 0, per_page: DEFAULT_PER_PAGE, term: nil)
+        # NOTE: [@rhymes/atsmith813] we should eventually update the frontend
+        # to start from page 1
+        page = page.to_i + 1
+        per_page = [(per_page || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min
+
+        relation = ::Comment
+          .force_eager_load_serialized_data
+          .where(
+            comments: {
+              deleted: false,
+              hidden_by_commentable_user: false
+            },
+          )
+
+        relation = relation.search_comments(term) if term.present?
+
+        relation = relation.select(*ATTRIBUTES).order("comments.score desc")
+
+        results = relation.page(page).per(per_page)
+
+        serialize(results)
+      end
+
+      def self.serialize(results)
+        Search::CommentSerializer
+          .new(results, is_collection: true)
+          .serializable_hash[:data]
+          .pluck(:attributes)
+      end
+      private_class_method :serialize
+    end
+  end
+end

--- a/app/services/search/postgres/comment.rb
+++ b/app/services/search/postgres/comment.rb
@@ -64,6 +64,13 @@ module Search
       )
         # NOTE: [@rhymes/atsmith813] we should eventually update the frontend
         # to start from page 1
+        sort_by ||= DEFAULT_SORT_BY
+        # The UI and serializer rename created_at (the actual DB column name) to
+        # published_at
+        sort_by = "comments.created_at" if sort_by == "published_at"
+
+        sort_direction ||= DEFAULT_SORT_DIRECTION
+
         page = page.to_i + 1
         per_page = [(per_page || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min
 
@@ -71,9 +78,6 @@ module Search
 
         relation = relation.search_comments(term).with_pg_search_highlight if term.present?
 
-        # The UI and serializer rename created_at (the actual DB column name) to
-        # published_at
-        sort_by = "comments.created_at" if sort_by == "published_at"
         relation = relation.select(*ATTRIBUTES).reorder("#{sort_by}": sort_direction)
 
         results = relation.page(page).per(per_page)

--- a/app/services/search/postgres/comment.rb
+++ b/app/services/search/postgres/comment.rb
@@ -73,7 +73,7 @@ module Search
         # (see https://github.com/forem/forem/pull/4744#discussion_r345698674
         # and https://github.com/rails/rails/issues/15185#issuecomment-351868335
         # for additional context)
-        user_ids = relation.pluck(:user_id)
+        user_ids = results.pluck(:user_id)
         users = find_users(user_ids)
 
         serialize(results, users)

--- a/app/services/search/postgres/comment.rb
+++ b/app/services/search/postgres/comment.rb
@@ -68,7 +68,7 @@ module Search
 
         relation = ::Comment.joins(FORCED_EAGER_LOAD_QUERY).where(QUERY_FILTER)
 
-        relation = relation.search_comments(term) if term.present?
+        relation = relation.search_comments(term).with_pg_search_highlight if term.present?
 
         relation = relation.select(*ATTRIBUTES).reorder("comments.score": :desc)
 
@@ -78,7 +78,7 @@ module Search
       end
 
       def self.serialize(results)
-        Search::CommentSerializer
+        Search::PostgresCommentSerializer
           .new(results, is_collection: true)
           .serializable_hash[:data]
           .pluck(:attributes)

--- a/app/services/search/postgres/comment.rb
+++ b/app/services/search/postgres/comment.rb
@@ -62,8 +62,6 @@ module Search
         sort_direction: DEFAULT_SORT_DIRECTION,
         term: nil
       )
-        # NOTE: [@rhymes/atsmith813] we should eventually update the frontend
-        # to start from page 1
         sort_by ||= DEFAULT_SORT_BY
         # The UI and serializer rename created_at (the actual DB column name) to
         # published_at
@@ -71,6 +69,8 @@ module Search
 
         sort_direction ||= DEFAULT_SORT_DIRECTION
 
+        # NOTE: [@rhymes/atsmith813] we should eventually update the frontend
+        # to start from page 1
         page = page.to_i + 1
         per_page = [(per_page || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min
 

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -166,61 +166,87 @@ RSpec.describe "Search", type: :request, proper_status: true do
   end
 
   describe "GET /search/feed_content" do
-    let(:mock_documents) { [{ "title" => "article1" }] }
+    context "when using Elasticsearch" do
+      let(:mock_documents) { [{ "title" => "article1" }] }
 
-    it "returns json" do
-      allow(Search::FeedContent).to receive(:search_documents).and_return(
-        mock_documents,
-      )
+      it "returns json" do
+        allow(Search::FeedContent).to receive(:search_documents).and_return(
+          mock_documents,
+        )
 
-      get "/search/feed_content"
-      expect(response.parsed_body["result"]).to eq(mock_documents)
+        get "/search/feed_content"
+        expect(response.parsed_body["result"]).to eq(mock_documents)
+      end
+
+      it "queries only the user index if class_name=User" do
+        allow(Search::FeedContent).to receive(:search_documents)
+        allow(Search::User).to receive(:search_documents).and_return(
+          mock_documents,
+        )
+
+        get "/search/feed_content?class_name=User"
+        expect(Search::User).to have_received(:search_documents)
+        expect(Search::FeedContent).not_to have_received(:search_documents)
+      end
+
+      it "queries for Articles, Podcast Episodes and Users if no class_name filter is present" do
+        allow(Search::FeedContent).to receive(:search_documents).and_return(
+          mock_documents,
+        )
+        allow(Search::User).to receive(:search_documents).and_return(
+          mock_documents,
+        )
+
+        get "/search/feed_content"
+        expect(Search::User).to have_received(:search_documents)
+        expect(Search::FeedContent).to have_received(:search_documents)
+      end
+
+      it "queries for only Articles and Podcast Episodes if class_name!=User" do
+        allow(Search::FeedContent).to receive(:search_documents).and_return(
+          mock_documents,
+        )
+        allow(Search::User).to receive(:search_documents)
+
+        get "/search/feed_content?class_name=Article"
+        expect(Search::User).not_to have_received(:search_documents)
+        expect(Search::FeedContent).to have_received(:search_documents)
+      end
+
+      it "queries for approved" do
+        allow(Search::FeedContent).to receive(:search_documents).and_return(
+          mock_documents,
+        )
+
+        get "/search/feed_content?class_name=Article&approved=true"
+        expect(Search::FeedContent).to have_received(:search_documents).with(
+          params: { "approved" => "true", "class_name" => "Article" },
+        )
+      end
     end
 
-    it "queries only the user index if class_name=User" do
-      allow(Search::FeedContent).to receive(:search_documents)
-      allow(Search::User).to receive(:search_documents).and_return(
-        mock_documents,
-      )
+    context "when using PostgreSQL" do
+      before do
+        allow(FeatureFlag).to receive(:enabled?).with(:search_2_comments).and_return(true)
+      end
 
-      get "/search/feed_content?class_name=User"
-      expect(Search::User).to have_received(:search_documents)
-      expect(Search::FeedContent).not_to have_received(:search_documents)
-    end
+      it "returns the correct keys for comments" do
+        create(:comment, body_markdown: "Ruby on Rails rocks!")
+        get search_feed_content_path(q: "rails", class_name: "Comment")
+        expect(response.parsed_body["result"]).to be_present
+      end
 
-    it "queries for Articles, Podcast Episodes and Users if no class_name filter is present" do
-      allow(Search::FeedContent).to receive(:search_documents).and_return(
-        mock_documents,
-      )
-      allow(Search::User).to receive(:search_documents).and_return(
-        mock_documents,
-      )
+      it "supports the search params for comments" do
+        comment = create(:comment, body_markdown: "Ruby on Rails rocks!")
+        get search_feed_content_path(
+          q: "rails",
+          class_name: "Comment",
+          page: 0,
+          per_page: 1,
+        )
 
-      get "/search/feed_content"
-      expect(Search::User).to have_received(:search_documents)
-      expect(Search::FeedContent).to have_received(:search_documents)
-    end
-
-    it "queries for only Articles and Podcast Episodes if class_name!=User" do
-      allow(Search::FeedContent).to receive(:search_documents).and_return(
-        mock_documents,
-      )
-      allow(Search::User).to receive(:search_documents)
-
-      get "/search/feed_content?class_name=Article"
-      expect(Search::User).not_to have_received(:search_documents)
-      expect(Search::FeedContent).to have_received(:search_documents)
-    end
-
-    it "queries for approved" do
-      allow(Search::FeedContent).to receive(:search_documents).and_return(
-        mock_documents,
-      )
-
-      get "/search/feed_content?class_name=Article&approved=true"
-      expect(Search::FeedContent).to have_received(:search_documents).with(
-        params: { "approved" => "true", "class_name" => "Article" },
-      )
+        expect(response.parsed_body["result"].first).to include("body_text" => comment.body_markdown)
+      end
     end
   end
 

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -232,14 +232,14 @@ RSpec.describe "Search", type: :request, proper_status: true do
 
       it "returns the correct keys for comments" do
         create(:comment, body_markdown: "Ruby on Rails rocks!")
-        get search_feed_content_path(q: "rails", class_name: "Comment")
+        get search_feed_content_path(search_fields: "rails", class_name: "Comment")
         expect(response.parsed_body["result"]).to be_present
       end
 
       it "supports the search params for comments" do
         comment = create(:comment, body_markdown: "Ruby on Rails rocks!")
         get search_feed_content_path(
-          q: "rails",
+          search_fields: "rails",
           class_name: "Comment",
           page: 0,
           per_page: 1,

--- a/spec/services/search/postgres/comment_spec.rb
+++ b/spec/services/search/postgres/comment_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe Search::Postgres::Comment, type: :service do
+  let(:comment) { create(:comment) }
+
+  describe "::search_documents" do
+    it "does not include comments from commentables that are unpublished", :aggregate_failures do
+      comment_text = "Ruby on Rails rocks!"
+      published_article = create(:article, title: "Published Article", published: true)
+      unpublished_article = create(:article, title: "Unpublished Article", published: true)
+      comment_on_published_article = create(:comment, body_markdown: comment_text, commentable: published_article)
+      comment_on_unpublished_article = create(:comment, body_markdown: comment_text, commentable: unpublished_article)
+      unpublished_article.update_columns(published: false)
+
+      result = described_class.search_documents(term: "rails")
+      # rubocop:disable Rails/PluckId
+      ids = result.pluck(:id)
+      # rubocop:enable Rails/PluckId
+
+      expect(ids).not_to include(comment_on_unpublished_article.search_id)
+      expect(ids).to include(comment_on_published_article.search_id)
+    end
+
+    context "when describing the result format" do
+      let(:result) { described_class.search_documents(term: comment.body_markdown) }
+
+      it "returns the correct attributes for the result" do
+        expected_keys = %i[
+          id path public_reactions_count body_text class_name hotness_score
+          published published_at readable_publish_date_string title user
+        ]
+
+        expect(result.first.keys).to match_array(expected_keys)
+      end
+
+      it "returns the correct attributes for the user" do
+        expected_keys = %i[username name profile_image_90]
+        expect(result.first[:user].keys).to match_array(expected_keys)
+      end
+
+      it "orders the results by score (hotness_score) in descending order" do
+        comment_text = "Ruby on Rails rocks!"
+        comment = create(:comment, body_markdown: comment_text, score: 0)
+        hotter_comment = create(:comment, body_markdown: comment_text, score: 99)
+
+        result = described_class.search_documents(term: "rails")
+        scores = result.pluck(:hotness_score)
+
+        expect(scores).to eq([hotter_comment.score, comment.score])
+      end
+    end
+
+    context "when searching for a term" do
+      it "matches against the comment's body_markdown (body_text)", :aggregate_failures do
+        comment.update_columns(body_markdown: "Ruby on Rails rocks!")
+        result = described_class.search_documents(term: "rails")
+
+        expect(result.first[:body_text]).to eq comment.body_markdown
+
+        result = described_class.search_documents(term: "javascript")
+        expect(result).to be_empty
+      end
+    end
+
+    context "when paginating" do
+      before { create_list(:comment, 2) }
+
+      it "returns no results when out of pagination bounds" do
+        result = described_class.search_documents(page: 99)
+        expect(result).to be_empty
+      end
+
+      it "returns paginated results", :aggregate_failures do
+        result = described_class.search_documents(page: 0, per_page: 1)
+        expect(result.length).to eq(1)
+
+        result = described_class.search_documents(page: 1, per_page: 1)
+        expect(result.length).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/services/search/postgres/comment_spec.rb
+++ b/spec/services/search/postgres/comment_spec.rb
@@ -21,29 +21,6 @@ RSpec.describe Search::Postgres::Comment, type: :service do
         expect(ids).not_to include(comment_on_unpublished_article.search_id)
         expect(ids).to include(comment_on_published_article.search_id)
       end
-
-      # We don't currently search against comments on podcast episodes
-      xit "does not include comments from PodcastEpisodes that are unpublished", :aggregate_failures do
-        comment_text = "Ruby on Rails rocks!"
-        published_podcast = create(:podcast, published: true)
-        unpublished_podcast = create(:podcast, published: true)
-        published_podcast_episode = create(:podcast_episode, podcast_id: published_podcast.id)
-        unpublished_podcast_episode = create(:podcast_episode, podcast_id: unpublished_podcast.id)
-        comment_on_published_article = create(:comment,
-                                              body_markdown: comment_text,
-                                              commentable: published_podcast_episode)
-        comment_on_unpublished_article = create(:comment,
-                                                body_markdown: comment_text,
-                                                commentable: unpublished_podcast_episode)
-        unpublished_podcast.update_columns(published: false)
-
-        # rubocop:disable Rails/PluckId
-        ids = described_class.search_documents(term: "rails").pluck(:id)
-        # rubocop:enable Rails/PluckId
-
-        expect(ids).not_to include(comment_on_unpublished_article.search_id)
-        expect(ids).to include(comment_on_published_article.search_id)
-      end
     end
 
     context "when describing the result format" do

--- a/spec/services/search/postgres/comment_spec.rb
+++ b/spec/services/search/postgres/comment_spec.rb
@@ -50,8 +50,9 @@ RSpec.describe Search::Postgres::Comment, type: :service do
 
       it "returns the correct attributes for the result" do
         expected_keys = %i[
-          id path public_reactions_count body_text class_name hotness_score
-          published published_at readable_publish_date_string title user
+          id path public_reactions_count body_text class_name highlight
+          hotness_score published published_at readable_publish_date_string
+          title user
         ]
 
         expect(result.first.keys).to match_array(expected_keys)
@@ -60,6 +61,13 @@ RSpec.describe Search::Postgres::Comment, type: :service do
       it "returns the correct attributes for the user" do
         expected_keys = %i[username name profile_image_90]
         expect(result.first[:user].keys).to match_array(expected_keys)
+      end
+
+      it "returns highlights" do
+        expected_keys = %i[body_text]
+        expect(result.first[:highlight].keys).to match_array(expected_keys)
+        highlights = result.first[:highlight][:body_text].first
+        expect(highlights).to include("<mark>", "</mark>")
       end
 
       it "orders the results by score (hotness_score) in descending order" do

--- a/spec/services/search/postgres/comment_spec.rb
+++ b/spec/services/search/postgres/comment_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Search::Postgres::Comment, type: :service do
         expect(ids).to include(comment_on_published_article.search_id)
       end
 
-      it "does not include comments from PodcastEpisodes that are unpublished", :aggregate_failures do
+      # We don't currently search against comments on podcast episodes
+      xit "does not include comments from PodcastEpisodes that are unpublished", :aggregate_failures do
         comment_text = "Ruby on Rails rocks!"
         published_podcast = create(:podcast, published: true)
         unpublished_podcast = create(:podcast, published: true)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR is beginning the process of porting over the search results page to PostgreSQL FTS from Elasticsearch. Our game plan is to convert each endpoint one by one. This means the controller is going to look quite gnarly during this transition period, please bear with us 😅 

This PR adds the comment search behind a feature flag. Once the feature flag is enabled, any search with the comments filter will use PostgreSQL instead of Elasticsearch.

_**Please note there are code and PR comments below explaining more.**_

## Related Tickets & Documents
RFC 0153: https://github.com/forem/rfcs/pull/153
https://github.com/orgs/forem/projects/29#card-58641161

## QA Instructions, Screenshots, Recordings
1. Log into an account (local admin or your own).
2. Leave a comment on an article.
3. Go to search (http://localhost:3000/search).
4. Type a search term in the search box at the top related to the comment you left in step 2. Then click the `Comments` filter on the left.
5. Verify your comment shows up in the search results.
6. Fire up a console and activate the feature flag (`FeatureFlag.enable(:search_2_comments)`).
7. Repeat steps 3 - 5 and make sure your comment is included in the results :tada:.

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
I'll coordinate with the systems team to activate the feature flag.


![dog_typing_on_computer](https://media.giphy.com/media/wpoLqr5FT1sY0/giphy.gif)
