### PR TITLE
When there is no db connection, answer false as though there were no table

### DIFF
--- a/app/lib/database.rb
+++ b/app/lib/database.rb
@@ -7,7 +7,7 @@ module Database
   # @param table [String] the name of the table to check for
   def self.table_exists?(table)
     ActiveRecord::Base.connection.table_exists?(table)
-  rescue ActiveRecord::NoDatabaseError
+  rescue ActiveRecord::NoDatabaseError, ActiveRecord::ConnectionNotEstablished
     false
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When building containers, when there is no postgresql instance, this
check to AR::Base.connection is raising an error. We'd like to be able
to continue running `rake assets:precompile` without needing a live db
to check the schema for a table.

Handle connection errors as though they were a table missing.


## Related Tickets & Documents

https://github.com/forem/forem/pull/13114

## QA Instructions, Screenshots, Recordings

Stop postgresql

Run `bundle exec rake assets:precompile`

Succeed.

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: There weren't any existing tests for this helper utility. Requires stubbing out the database (to simulate error conditions) and might not be very indicative of real conditions.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

No

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: Hotfix to get buildkite running again. 


## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

(insert picture of me spending more time on an  image search than I did on the commit).