### PR TITLE
[15 min fix] Fix following tags input a11y errors

### DIFF
--- a/app/assets/javascripts/initializers/initScrolling.js
+++ b/app/assets/javascripts/initializers/initScrolling.js
@@ -121,12 +121,18 @@ function buildTagsHTML(tag) {
     antifollow +
     '</h3>' +
     '<p class="grid-cell__summary truncate-at-3"></p>' +
-    '<input name="follows[][id]" id="follow_id" type="hidden" form="follows_update_form" value="' +
+    '<input name="follows[][id]" id="follow_id_' +
+    tag.name +
+    '" type="hidden" form="follows_update_form" value="' +
     tag.id +
     '">' +
     '<input step="any" class="crayons-textfield flex-1 fs-s" required="required" type="number" form="follows_update_form" value="' +
     tag.points +
-    '" name="follows[][explicit_points]" id="follow_points">' +
+    '" name="follows[][explicit_points]" id="follow_points_' +
+    tag.name +
+    '" aria-label="' +
+    tag.name +
+    ' tag weight">' +
     '</div>'
   );
 }

--- a/app/assets/javascripts/initializers/initScrolling.js
+++ b/app/assets/javascripts/initializers/initScrolling.js
@@ -103,38 +103,17 @@ function buildTagsHTML(tag) {
       '<span class="crayons-indicator crayons-indicator--critical crayons-indicator--outlined" title="This tag has negative follow weight">Anti-follow</span>';
   }
 
-  return (
-    '<div class="crayons-card p-4 m:p-6 flex flex-col single-article" id="follows-' +
-    tag.id +
-    '" style="border: 1px solid ' +
-    tag.color +
-    '; box-shadow: 3px 3px 0' +
-    tag.color +
-    '">' +
-    '<h3 class="s:mb-1 p-0 fw-medium">' +
-    '<a href="/t/' +
-    tag.name +
-    '" class="crayons-tag crayons-tag--l">' +
-    '<span class="crayons-tag__prefix">#</span>' +
-    tag.name +
-    '</a>' +
-    antifollow +
-    '</h3>' +
-    '<p class="grid-cell__summary truncate-at-3"></p>' +
-    '<input name="follows[][id]" id="follow_id_' +
-    tag.name +
-    '" type="hidden" form="follows_update_form" value="' +
-    tag.id +
-    '">' +
-    '<input step="any" class="crayons-textfield flex-1 fs-s" required="required" type="number" form="follows_update_form" value="' +
-    tag.points +
-    '" name="follows[][explicit_points]" id="follow_points_' +
-    tag.name +
-    '" aria-label="' +
-    tag.name +
-    ' tag weight">' +
-    '</div>'
-  );
+  return `<div class="crayons-card p-4 m:p-6 flex flex-col single-article" id="follows-${tag.id}" style="border: 1px solid ${tag.color}; box-shadow: 3px 3px 0 ${tag.color}">
+    <h3 class="s:mb-1 p-0 fw-medium">
+      <a href="/t/${tag.name}" class="crayons-tag crayons-tag--l">
+        <span class="crayons-tag__prefix">#</span>${tag.name}
+      </a>
+      ${antifollow}
+    </h3>
+    <p class="grid-cell__summary truncate-at-3"></p>
+    <input name="follows[][id]" id="follow_id_${tag.name}" type="hidden" form="follows_update_form" value="${tag.id}">
+    <input step="any" class="crayons-textfield flex-1 fs-s" required="required" type="number" form="follows_update_form" value="${tag.points}" name="follows[][explicit_points]" id="follow_points_${tag.name}" aria-label="${tag.name} tag weight">
+  </div>`;
 }
 
 function fetchNextFollowingPage(el) {

--- a/app/views/dashboards/following_tags.html.erb
+++ b/app/views/dashboards/following_tags.html.erb
@@ -43,7 +43,7 @@
                   </p>
 
                   <%= fields(follow) do |f| %>
-                    <%= f.hidden_field(:id, name: "follows[][id]", form: "follows_update_form") %>
+                    <%= f.hidden_field(:id, name: "follows[][id]", form: "follows_update_form", id: "follow_id_#{follow.followable}") %>
                     <%= f.number_field(:explicit_points, step: :any, required: true, class: "crayons-textfield flex-1 fs-s", name: "follows[][explicit_points]", form: "follows_update_form", "aria-label": "#{follow.followable} tag weight", id: "explicit_points_#{follow.followable}") %>
                   <% end %>
                 </div>

--- a/app/views/dashboards/following_tags.html.erb
+++ b/app/views/dashboards/following_tags.html.erb
@@ -18,7 +18,7 @@
         <% if @followed_tags.any? %>
           <%= javascript_packs_with_chunks_tag "dashboardTagsDisableUnchangedButtons", defer: true %>
 
-          <div class="crayons-notice p-4 px-6 mb-4 mx-2 m:mx-0"  aria-live="polite">
+          <div class="crayons-notice p-4 px-6 mb-4 mx-2 m:mx-0" aria-live="polite">
               Adjust tag weight to modify your home feed. Higher values mean more appearances for that tag.
               <span class="crayons-indicator crayons-indicator--outlined crayons-indicator--accent ml-3">Default 1.0</span>
           </div>
@@ -44,7 +44,7 @@
 
                   <%= fields(follow) do |f| %>
                     <%= f.hidden_field(:id, name: "follows[][id]", form: "follows_update_form") %>
-                    <%= f.number_field(:explicit_points, step: :any, required: true, class: "crayons-textfield flex-1 fs-s", name: "follows[][explicit_points]", form: "follows_update_form") %>
+                    <%= f.number_field(:explicit_points, step: :any, required: true, class: "crayons-textfield flex-1 fs-s", name: "follows[][explicit_points]", form: "follows_update_form", "aria-label": "#{follow.followable} tag weight", id: "explicit_points_#{follow.followable}") %>
                   <% end %>
                 </div>
               <% end %>

--- a/spec/system/dashboards/user_scrolls_down_dashboard_follows_spec.rb
+++ b/spec/system/dashboards/user_scrolls_down_dashboard_follows_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe "Infinite scroll on dashboard", type: :system, js: true do
     it "updates two tag point values" do
       last_divs = page.all('div[id^="follows"]').last(2)
 
-      within(last_divs[0]) { fill_in "explicit_points_tag14", with: 5.0 }
-      within(last_divs[1]) { fill_in "explicit_points_tag15", with: 10.0 }
+      within(last_divs[0]) { fill_in with: 5.0, class: "crayons-textfield" }
+      within(last_divs[1]) { fill_in with: 10.0, class: "crayons-textfield" }
 
       click_button "commit"
 
       first_divs = page.all('div[id^="follows"]').first(2)
-      within(first_divs[0]) { expect(page).to have_field("explicit_points_tag15", with: 10.0) }
-      within(first_divs[1]) { expect(page).to have_field("explicit_points_tag14", with: 5.0) }
+      within(first_divs[0]) { expect(page).to have_field(with: 10.0, class: "crayons-textfield") }
+      within(first_divs[1]) { expect(page).to have_field(with: 5.0, class: "crayons-textfield") }
     end
   end
 

--- a/spec/system/dashboards/user_scrolls_down_dashboard_follows_spec.rb
+++ b/spec/system/dashboards/user_scrolls_down_dashboard_follows_spec.rb
@@ -44,14 +44,15 @@ RSpec.describe "Infinite scroll on dashboard", type: :system, js: true do
 
     it "updates two tag point values" do
       last_divs = page.all('div[id^="follows"]').last(2)
-      within(last_divs[0]) { fill_in "follow_explicit_points", with: 5.0 }
-      within(last_divs[1]) { fill_in "follow_explicit_points", with: 10.0 }
+
+      within(last_divs[0]) { fill_in "explicit_points_tag14", with: 5.0 }
+      within(last_divs[1]) { fill_in "explicit_points_tag15", with: 10.0 }
 
       click_button "commit"
 
       first_divs = page.all('div[id^="follows"]').first(2)
-      within(first_divs[0]) { expect(page).to have_field("follow_explicit_points", with: 10.0) }
-      within(first_divs[1]) { expect(page).to have_field("follow_explicit_points", with: 5.0) }
+      within(first_divs[0]) { expect(page).to have_field("explicit_points_tag15", with: 10.0) }
+      within(first_divs[1]) { expect(page).to have_field("explicit_points_tag14", with: 5.0) }
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The Dashboard > Following Tags page had a few accessibility errors where inputs were not given a unique id or a label. This PR fixes both of those issues.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

- Go to the user dashboard
- Select the 'Following Tags' link
- Check with a screen reader that each of the inputs has a unique/logical name
- Check that you can adjust the weights, and save the form
- Check that when you refresh/revisit the page, the weights are populated with the new values

Axe output before the change:

![screenshot showing 9 axe errors](https://user-images.githubusercontent.com/20773163/115029385-d38a5d00-9ebd-11eb-9ad8-ccc4be1d3594.png)

Axe output after the change:

![screenshot showing 3 axe errors](https://user-images.githubusercontent.com/20773163/115029679-23692400-9ebe-11eb-9db8-89ae2628ac91.png)


Screenshot of VoiceOver rotor form controls (after the change):

![screenshot showing the list of inputs with their names](https://user-images.githubusercontent.com/20773163/115029603-0df3fa00-9ebe-11eb-9d0c-24c868a27489.png)


### UI accessibility concerns?

This improves the accessibility of this section of the dashboard, allowing screen reader users to know what each input is for 

## Added tests?

- [ ] Yes
- [X] No, and this is why: No existing tests were affected, and small tweaks like these would be better tested as part of a larger e2e critical flow test
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

