### PR TITLE
Rename table_exists? to table_available? to indicate behavior

### DIFF
--- a/app/lib/database.rb
+++ b/app/lib/database.rb
@@ -5,7 +5,7 @@ module Database
   # hasn't been established yet.
   #
   # @param table [String] the name of the table to check for
-  def self.table_exists?(table)
+  def self.table_available?(table)
     ActiveRecord::Base.connection.table_exists?(table)
   rescue ActiveRecord::NoDatabaseError, ActiveRecord::ConnectionNotEstablished
     false

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -50,7 +50,7 @@ class Profile < ApplicationRecord
   # Generates typed accessors for all currently defined profile fields.
   def self.refresh_attributes!
     return if ENV["ENV_AVAILABLE"] == "false"
-    return unless Database.table_exists?("profiles")
+    return unless Database.table_available?("profiles")
 
     ProfileField.find_each do |field|
       store_attribute :data, field.attribute_name.to_sym, field.type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
       # NOTE: [@ridhwana] All these conditional statements are temporary conditions.
       # We check that the database table exists to avoid the DB setup failing
       # because the code relies on the presence of a table.
-      if Database.table_exists?("flipper_features")
+      if Database.table_available?("flipper_features")
         # NOTE: [@ridhwana] admin_routes will require the rails app to be reloaded when the feature flag is toggled
         # You can find more details on why we had to implement it this way in this PR
         # https://github.com/forem/forem/pull/13114


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We added a check for ConnectionNotEstablished, which causes the check
to return false if there is no database available (the case in
buildkite for rake tasks like assets:precompile), this changed the
implementation from an existence check (I can connect to the database,
but the table is not present, the situation when we have created a db,
but not yet populated the schema) to an availability check (either the
db is live but the table is absent, or the db is absent, in either
case we know we can't read from the table yet).

Change table_exists? to table_available? to indicate the new
behavior and update the two call sites.


## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

None. Same as before - travis tests should not fail when db:setup is called, and buildkite should not fail when assets:precompile is run.

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: method rename only
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: This is a small refactor.

## [optional] Are there any post deployment tasks we need to perform?

none

## [optional] What gif best describes this PR or how it makes you feel?

![intentions](https://user-images.githubusercontent.com/1237369/115038558-44694f00-9e95-11eb-92bc-d8ede867423f.gif)
