### PR TITLE
[15min fix] Return Device ID upon registration

### DIFF
--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -1,8 +1,8 @@
 class DevicesController < ApplicationController
-  # Devices can only be created for authenticated users.
-  # This replaces the Authenticated Users Pusher Beams solution.
+  # Device's `belongs_to :user` association enforces that only authenticated
+  # users are able to register devices. This replaces the Authenticated Users
+  # Pusher Beams solution.
   # See: https://github.com/forem/forem/pull/12419/files#r563906038
-  before_action :authenticate_user!, only: [:create]
   skip_before_action :verify_authenticity_token, only: [:destroy]
 
   rescue_from ActiveRecord::ActiveRecordError do |exc|
@@ -12,7 +12,9 @@ class DevicesController < ApplicationController
   def create
     device = Device.find_or_create_by(device_params)
     if device.persisted?
-      head :ok
+      # Even if the device ID may be irrelevant for the consumer, this
+      # serves as confirmation that it was registered successfully.
+      render json: { id: device.id }
     else
       render json: { error: device.errors_as_sentence }, status: :bad_request
     end

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -14,7 +14,7 @@ class DevicesController < ApplicationController
     if device.persisted?
       # Even if the device ID may be irrelevant for the consumer, this
       # serves as confirmation that it was registered successfully.
-      render json: { id: device.id }
+      render json: { id: device.id }, status: :created
     else
       render json: { error: device.errors_as_sentence }, status: :bad_request
     end

--- a/spec/requests/devices_spec.rb
+++ b/spec/requests/devices_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Devices", type: :request do
           app_bundle: "hello"
         }
         expect(user.devices.count).to eq(1)
+        expect(response).to have_http_status(:created)
       end
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/master/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/master/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Makes for a better way to confirm whether or not a Device has been registered properly. CSRF failures return a 200 response  and the consumers are mistakenly taking this as the Device was properly registered, when in fact it wasn't.

## Related Tickets & Documents

https://github.com/forem/ForemWebView-ios/pull/30

## QA Instructions, Screenshots, Recordings

So tricky to manually QA that I'd advice against it. Here are a couple screenshots of the Network tab making the request to my ngrok URL:

<img width="865" alt="Screen Shot 2021-04-16 at 08 46 47" src="https://user-images.githubusercontent.com/6045239/115042140-6f04d900-9e90-11eb-9b2c-299f0be9e65f.png">

<img width="756" alt="Screen Shot 2021-04-16 at 08 47 11" src="https://user-images.githubusercontent.com/6045239/115042153-71ffc980-9e90-11eb-9eb9-953531da7594.png">


### UI accessibility concerns?

None - Backend change

## Added tests?

- [x] No, and this is why: Already covered by tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: Small bugfix on a feature that will launch soon (not yet impacting production traffic)

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![yes or no](https://media.giphy.com/media/YPthyWQsWBJqbOJuMF/giphy.gif)
