### PR TITLE
[Bug fix] Re-add Email digest frequency to admin config

### DIFF
--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -633,9 +633,35 @@
                   </div>
                 <% end %>
               <% end %>
+              <%= render "form_submission", f: f %>
+            </fieldset>
+          </div>
+          </div>
+        <% end %>
+
+        <%= form_for(SiteConfig.new, url: admin_config_path, html: { data: { testid: "emailDigestSectionForm" } }) do |f| %>
+          <div class="card mt-3">
+            <%= render partial: "admin/shared/card_header",
+                       locals: {
+                         header: "Email digest frequency",
+                         state: "collapse",
+                         target: "emailDigestBodyContainer",
+                         expanded: false
+                       } %>
+          <div id="emailDigestBodyContainer" class="card-body collapse hide" aria-labelledby="emailDigestBodyContainer">
+            <fieldset class="grid gap-4">
+              <div class="crayons-field">
+                <%= admin_config_label :periodic_email_digest %>
+                <%= admin_config_description Constants::SiteConfig::DETAILS[:periodic_email_digest][:description] %>
+                <%= f.number_field :periodic_email_digest,
+                                   class: "crayons-textfield",
+                                   value: SiteConfig.periodic_email_digest,
+                                   placeholder: Constants::SiteConfig::DETAILS[:periodic_email_digest][:placeholder] %>
+              </div>
 
               <%= render "form_submission", f: f %>
             </fieldset>
+          </div>
           </div>
         <% end %>
 

--- a/cypress/integration/adminFlows/config/emailDigestFrequencySection.js
+++ b/cypress/integration/adminFlows/config/emailDigestFrequencySection.js
@@ -1,0 +1,46 @@
+describe('Email digest frequency Section', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.fixture('users/adminUser.json').as('user');
+
+    cy.get('@user').then((user) => {
+      cy.loginUser(user);
+    });
+  });
+
+  describe('email digency frequency settings', () => {
+    it('cam change the frequency', () => {
+      cy.get('@user').then(({ username }) => {
+        cy.visit('/admin/config');
+        cy.findByTestId('emailDigestSectionForm').as('emailDigestSectionForm');
+
+        cy.get('@emailDigestSectionForm')
+          .findByText('Email digest frequency')
+          .click();
+
+        cy.get('@emailDigestSectionForm')
+          .get('#site_config_periodic_email_digest')
+          .clear()
+          .type('42');
+
+        cy.get('@emailDigestSectionForm')
+          .findByPlaceholderText('Confirmation text')
+          .type(
+            `My username is @${username} and this action is 100% safe and appropriate.`,
+          );
+
+        cy.get('@emailDigestSectionForm')
+          .findByText('Update Site Configuration')
+          .click();
+
+        cy.url().should('contains', '/admin/config');
+
+        cy.findByText('Site configuration was successfully updated.').should(
+          'be.visible',
+        );
+
+        cy.get('#site_config_periodic_email_digest').should('have.value', '42');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

In https://github.com/forem/forem/pull/13095 I accidentally removed the "Email digest frequency" section from `/admin/config`. The request spec did not flag this since the controller still worked as expected, so I added an e2e test in this PR too.

## Related Tickets & Documents

https://github.com/forem/rfcs/pull/126

## QA Instructions, Screenshots, Recordings

1. Go to `/admin/config/`
2. Ensure the "Email digest frequency" section is there right below "Emails"
    ![image](https://user-images.githubusercontent.com/47985/115174615-c0f96900-a0f3-11eb-98c0-b5009dc16c4d.png)
3. Make sure you can change the digest frequency as expected.
     ![image](https://user-images.githubusercontent.com/47985/115174635-cce52b00-a0f3-11eb-8e72-a1a623be4060.png)

### UI accessibility concerns?

n/a

## Added tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
