### PR TITLE
Add missing class back in for signed out featured post on feed

### DIFF
--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -5,7 +5,8 @@
   <% end %>
   <% if featured == true || (feed_style_preference == "rich" && story.main_image.present?) %>
     <a href="<%= story.path %>" title="<%= story.title %>" aria-label="article"
-      style="background-color: <%= story.main_image_background_hex_color %>; background-image: url(<%= cloud_cover_url(story.main_image) %>);" class="crayons-story__cover__image">
+      style="background-color: <%= story.main_image_background_hex_color %>; background-image: url(<%= cloud_cover_url(story.main_image) %>);"
+      class="crayons-story__cover crayons-story__cover__image">
       <span class="hidden"><%= story.title %></span>
     </a>
   <% end %>

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "StoriesIndex", type: :request do
 
       allow(SiteConfig).to receive(:feed_style).and_return("basic")
       get "/"
-      expect(response.body.scan(/(?=class="crayons-story__cover__image)/).count).to be 1
+      expect(response.body.scan(/(?=class="crayons-story__cover crayons-story__cover__image)/).count).to be 1
     end
 
     it "shows multiple cover images if rich feed style" do
@@ -158,7 +158,7 @@ RSpec.describe "StoriesIndex", type: :request do
 
       allow(SiteConfig).to receive(:feed_style).and_return("rich")
       get "/"
-      expect(response.body.scan(/(?=class="crayons-story__cover__image)/).count).to be > 1
+      expect(response.body.scan(/(?=class="crayons-story__cover crayons-story__cover__image)/).count).to be > 1
     end
 
     context "with campaign hero" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This adds a missing class back in that shows the featured article's main image in the signed out view.

## Related Tickets & Documents
https://github.com/forem/forem/pull/13350
Closes https://github.com/forem/forem/issues/13419

## QA Instructions, Screenshots, Recordings
1. Be signed out
2. Go to the home page
3. See that the cover image is visible

### UI accessibility concerns?
Nope

## Added tests?

- [ ] Yes
- [x] No, and this is why: hot fix, will add an E2E test after

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: hot fix

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![A wild character with a huge smile, captioned with "Put on ur Monday face"](https://media.giphy.com/media/O6EeEC6TC6sw/giphy.gif)