### PR TITLE
Add reading_time to articles api responses

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -16,7 +16,7 @@ module Api
         title description main_image published_at crossposted_at social_image
         cached_tag_list slug path canonical_url comments_count
         public_reactions_count created_at edited_at last_comment_at published
-        updated_at video_thumbnail_url
+        updated_at video_thumbnail_url reading_time
       ].freeze
 
       SHOW_ATTRIBUTES_FOR_SERIALIZATION = [

--- a/app/views/api/v0/articles/_article.json.jbuilder
+++ b/app/views/api/v0/articles/_article.json.jbuilder
@@ -13,7 +13,6 @@ json.extract!(
   :public_reactions_count,
   :collection_id,
   :published_timestamp,
-  :reading_time
 )
 
 json.positive_reactions_count article.public_reactions_count
@@ -25,3 +24,4 @@ json.edited_at       utc_iso_timestamp(article.edited_at)
 json.crossposted_at  utc_iso_timestamp(article.crossposted_at)
 json.published_at    utc_iso_timestamp(article.published_at)
 json.last_comment_at utc_iso_timestamp(article.last_comment_at)
+json.reading_time_minutes article.reading_time

--- a/app/views/api/v0/articles/_article.json.jbuilder
+++ b/app/views/api/v0/articles/_article.json.jbuilder
@@ -13,6 +13,7 @@ json.extract!(
   :public_reactions_count,
   :collection_id,
   :published_timestamp,
+  :reading_time
 )
 
 json.positive_reactions_count article.public_reactions_count

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -17,7 +17,7 @@ info:
     Dates and date times, unless otherwise specified, must be in
     the [RFC 3339](https://tools.ietf.org/html/rfc3339) format.
 
-  version: "0.9.5"
+  version: "0.9.6"
   termsOfService: https://dev.to/terms
   contact:
     name: DEV Team
@@ -526,6 +526,7 @@ components:
         - published_timestamp
         - body_markdown
         - user
+        - reading_time
       properties:
         type_of:
           type: string
@@ -581,6 +582,10 @@ components:
           type: string
         user:
           $ref: "#/components/schemas/SharedUser"
+        reading_time:
+          description: Reading time, in minutes
+          type: integer
+          format: int32
         organization:
           $ref: "#/components/schemas/SharedOrganization"
         flare_tag:
@@ -1250,6 +1255,7 @@ components:
           published_at: '2019-10-24T13:52:17Z'
           last_comment_at: '2019-10-25T08:12:43Z'
           published_timestamp: '2019-10-24T13:52:17Z'
+          reading_time: 15
           user:
             name: Ben Halpern
             username: ben
@@ -1294,6 +1300,7 @@ components:
         published_at: "2019-08-01T15:47:54Z"
         last_comment_at: "2019-08-06T16:48:10Z"
         published_timestamp: "2019-08-01T15:47:54Z"
+        reading_time: 15
         body_html: |+
           <p>Today's episode of Byte Sized is about Leonhard Euler and the creation of <a href="https://en.wikipedia.org/wiki/Graph_theory">Graph Theory</a>.</p>
 

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -186,6 +186,7 @@ components:
         - last_comment_at
         - published_timestamp
         - user
+        - reading_time
       properties:
         type_of:
           type: string
@@ -254,6 +255,10 @@ components:
           format: date-time
         user:
           $ref: "#/components/schemas/SharedUser"
+        reading_time:
+          description: Reading time, in minutes
+          type: integer
+          format: int32
         organization:
           $ref: "#/components/schemas/SharedOrganization"
         flare_tag:
@@ -287,6 +292,7 @@ components:
         - body_html
         - body_markdown
         - user
+        - reading_time
       properties:
         type_of:
           type: string
@@ -359,6 +365,10 @@ components:
           type: string
         user:
           $ref: "#/components/schemas/SharedUser"
+        reading_time:
+          description: Reading time, in minutes
+          type: integer
+          format: int32
         organization:
           $ref: "#/components/schemas/SharedOrganization"
         flare_tag:

--- a/docs/api_v0.yml
+++ b/docs/api_v0.yml
@@ -186,7 +186,7 @@ components:
         - last_comment_at
         - published_timestamp
         - user
-        - reading_time
+        - reading_time_minutes
       properties:
         type_of:
           type: string
@@ -255,7 +255,7 @@ components:
           format: date-time
         user:
           $ref: "#/components/schemas/SharedUser"
-        reading_time:
+        reading_time_minutes:
           description: Reading time, in minutes
           type: integer
           format: int32
@@ -292,7 +292,7 @@ components:
         - body_html
         - body_markdown
         - user
-        - reading_time
+        - reading_time_minutes
       properties:
         type_of:
           type: string
@@ -365,7 +365,7 @@ components:
           type: string
         user:
           $ref: "#/components/schemas/SharedUser"
-        reading_time:
+        reading_time_minutes:
           description: Reading time, in minutes
           type: integer
           format: int32
@@ -526,7 +526,7 @@ components:
         - published_timestamp
         - body_markdown
         - user
-        - reading_time
+        - reading_time_minutes
       properties:
         type_of:
           type: string
@@ -582,7 +582,7 @@ components:
           type: string
         user:
           $ref: "#/components/schemas/SharedUser"
-        reading_time:
+        reading_time_minutes:
           description: Reading time, in minutes
           type: integer
           format: int32
@@ -1255,7 +1255,7 @@ components:
           published_at: '2019-10-24T13:52:17Z'
           last_comment_at: '2019-10-25T08:12:43Z'
           published_timestamp: '2019-10-24T13:52:17Z'
-          reading_time: 15
+          reading_time_minutes: 15
           user:
             name: Ben Halpern
             username: ben
@@ -1300,7 +1300,7 @@ components:
         published_at: "2019-08-01T15:47:54Z"
         last_comment_at: "2019-08-06T16:48:10Z"
         published_timestamp: "2019-08-01T15:47:54Z"
-        reading_time: 15
+        reading_time_minutes: 15
         body_html: |+
           <p>Today's episode of Byte Sized is about Leonhard Euler and the creation of <a href="https://en.wikipedia.org/wiki/Graph_theory">Graph Theory</a>.</p>
 

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         type_of id title description cover_image readable_publish_date social_image
         tag_list tags slug path url canonical_url comments_count public_reactions_count positive_reactions_count
         collection_id created_at edited_at crossposted_at published_at last_comment_at
-        published_timestamp user organization flare_tag
+        published_timestamp user organization flare_tag reading_time
       ]
 
       expect(response.parsed_body.first.keys).to match_array index_keys
@@ -334,7 +334,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         type_of id title description cover_image readable_publish_date social_image
         tag_list tags slug path url canonical_url comments_count public_reactions_count positive_reactions_count
         collection_id created_at edited_at crossposted_at published_at last_comment_at
-        published_timestamp body_html body_markdown user organization flare_tag
+        published_timestamp body_html body_markdown user organization flare_tag reading_time
       ]
 
       expect(response.parsed_body.keys).to match_array show_keys

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         type_of id title description cover_image readable_publish_date social_image
         tag_list tags slug path url canonical_url comments_count public_reactions_count positive_reactions_count
         collection_id created_at edited_at crossposted_at published_at last_comment_at
-        published_timestamp user organization flare_tag reading_time
+        published_timestamp user organization flare_tag reading_time_minutes
       ]
 
       expect(response.parsed_body.first.keys).to match_array index_keys
@@ -334,7 +334,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
         type_of id title description cover_image readable_publish_date social_image
         tag_list tags slug path url canonical_url comments_count public_reactions_count positive_reactions_count
         collection_id created_at edited_at crossposted_at published_at last_comment_at
-        published_timestamp body_html body_markdown user organization flare_tag reading_time
+        published_timestamp body_html body_markdown user organization flare_tag reading_time_minutes
       ]
 
       expect(response.parsed_body.keys).to match_array show_keys


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we serialize articles for the api, we omit reading time. There are applications that could use this.


## Related Tickets & Documents

Fixes #13436

## QA Instructions, Screenshots, Recordings

Exercise the api - expect existing keys, _and_ reading_time, in the json response for the article.


### UI accessibility concerns?

None - api change only

## Added tests?

- [x] Yes (adapted existing tests about response keys to match changes).
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post 
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![tl;dr](https://user-images.githubusercontent.com/1237369/115261964-b5a93c00-a0f9-11eb-81de-d8427e8df465.png)

