### PR TITLE
Bust cache after commit, rather than after save

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -271,10 +271,10 @@ class User < ApplicationRecord
 
   # NOTE: @citizen428 Temporary while migrating to generalized profiles
   after_save { |user| user.profile&.save if user.profile&.changed? }
-  after_save :bust_cache
   after_save :subscribe_to_mailchimp_newsletter
 
   after_create_commit :send_welcome_notification
+  after_commit :bust_cache
   after_commit :index_to_elasticsearch, on: %i[create update]
   after_commit :sync_related_elasticsearch_docs, on: %i[create update]
   after_commit :remove_from_elasticsearch, on: [:destroy]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
There's a (tiny) race condition where if an enclosing transaction
has not yet been committed when a user is created, and a sidekiq
worker begins find(:id) and fails, that the job is enqueued, started,
and skipped.

This changes the after_save hook on User to after_commit, ensuring the
user's assigned id is visible to other processes.

## Related Tickets & Documents

#13293 (does not fix)

## QA Instructions, Screenshots, Recordings

Not sure how effectively we can test this outside of an environment where edge caching is live. 
- create, update, and destroy a user.
- edge cache should be busted in each case via an enqueued sidekiq job

Fitness for task check:
 since the original context was "a new user is created after a 404 was returned, but the 404 response is cached, and the user is not accessible to the api" the post deploy acceptance check would be something like:
- find `SELECT MAX(id) FROM users` 
- check https://dev.to/api/users/(id + 1) and receive a (fresh) 404 response
- wait a few minutes for a sign-up, such that user (id + 1) is created, and the cache busting has occurred 
- reload the api request and observe a 200 with the user json in it 

A 404 with x-cache: miss/hit headers would indicate this change was not effective.

### UI accessibility concerns?

None, backend only change.

## Added tests?

- [ ] Yes
- [x] No, and this is why: change in mechanism, not behavior
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: change in implementation, not behavior

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![stairs](https://user-images.githubusercontent.com/1237369/115438068-90d4c780-a1d2-11eb-9734-7cacc0a88fd4.jpeg)
