### PR TITLE
When busting user cache, also clear the api response

### DIFF
--- a/app/services/edge_cache/bust_user.rb
+++ b/app/services/edge_cache/bust_user.rb
@@ -4,7 +4,7 @@ module EdgeCache
       return unless user
 
       username = user.username
-
+      user_id = user.id
       paths = [
         "/#{username}",
         "/#{username}?i=i",
@@ -14,6 +14,7 @@ module EdgeCache
         "/live/#{username}",
         "/live/#{username}?i=i",
         "/feed/#{username}",
+        "/api/users/#{user_id}",
       ]
 
       cache_bust = EdgeCache::Bust.new

--- a/spec/services/edge_cache/bust_user_spec.rb
+++ b/spec/services/edge_cache/bust_user_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe EdgeCache::BustUser, type: :service do
       "/live/#{username}",
       "/live/#{username}?i=i",
       "/feed/#{username}",
+      "/api/users/#{user.id}",
     ]
   end
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we clear the cached responses about a user, also clear the api response. This mirrors what we do for [Articles](https://github.com/forem/forem/blob/main/app/services/edge_cache/bust_article.rb#L28) already

## Related Tickets & Documents

#13293 

## QA Instructions, Screenshots, Recordings


### UI accessibility concerns?

None

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: bugfix. Will comment in the related issue.

## [optional] Are there any post deployment tasks we need to perform?

I can test this post deploy to confirm it behaves 

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/1237369/115586122-e1f7c080-a291-11eb-9c4e-e1e6b0434e9f.png)

