### PR TITLE
Add tsvector index to comments.body_markdown

### DIFF
--- a/db/migrate/20210421190438_add_body_markdown_tsvector_index_to_comments.rb
+++ b/db/migrate/20210421190438_add_body_markdown_tsvector_index_to_comments.rb
@@ -1,4 +1,4 @@
-class AddBodyMarkdownTsvectorIndexToUsers < ActiveRecord::Migration[6.1]
+class AddBodyMarkdownTsvectorIndexToComments < ActiveRecord::Migration[6.1]
   disable_ddl_transaction!
 
   INDEX = "to_tsvector('simple'::regconfig, COALESCE((body_markdown)::text, ''::text))"

--- a/db/migrate/20210421190438_add_body_markdown_tsvector_index_to_users.rb
+++ b/db/migrate/20210421190438_add_body_markdown_tsvector_index_to_users.rb
@@ -1,0 +1,27 @@
+class AddBodyMarkdownTsvectorIndexToUsers < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  INDEX = "to_tsvector('simple'::regconfig, COALESCE((body_markdown)::text, ''::text))"
+  private_constant :INDEX
+
+  INDEX_NAME = "index_comments_on_body_markdown_as_tsvector"
+  private_constant :INDEX_NAME
+
+  def up
+    return if index_name_exists?(:comments, INDEX_NAME)
+
+    add_index :comments,
+              INDEX,
+              using: :gin,
+              name: INDEX_NAME,
+              algorithm: :concurrently
+  end
+
+  def down
+    return unless index_name_exists?(:comments, INDEX_NAME)
+
+    remove_index :comments,
+                 name: INDEX_NAME,
+                 algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_20_135208) do
+ActiveRecord::Schema.define(version: 2021_04_21_190438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -388,6 +388,7 @@ ActiveRecord::Schema.define(version: 2021_04_20_135208) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index "digest(body_markdown, 'sha512'::text), user_id, ancestry, commentable_id, commentable_type", name: "index_comments_on_body_markdown_user_ancestry_commentable", unique: true
+    t.index "to_tsvector('simple'::regconfig, COALESCE(body_markdown, ''::text))", name: "index_comments_on_body_markdown_as_tsvector", using: :gin
     t.index ["ancestry"], name: "index_comments_on_ancestry"
     t.index ["ancestry"], name: "index_comments_on_ancestry_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
This PR follows https://github.com/forem/forem/pull/13401 and adds a tsvector index on `comments.body_markdown` to help speed up comments search.

## Related Tickets & Documents
https://github.com/forem/forem/pull/13401
https://ui.honeycomb.io/thepracticaldev/datasets/rails/result/oQgEzyaXWqK/a/vtBoa2nkXx4/comments

## QA Instructions, Screenshots, Recordings
1. Run `rails db:migrate` and see the index is added.
2. Run `rails db:rollback STEP=1` and see the index is removed.

## Added tests?
- [x] No, and this is why: this is a DB migration - no tests required.

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
I'll sync with SRE to monitor the results of this change.

## [optional] What gif best describes this PR or how it makes you feel?

![faster_jurassic_park_gif](https://media.giphy.com/media/7XsFGzfP6WmC4/giphy.gif)
