### PR TITLE
Revert "re-enable skipped tests"

### DIFF
--- a/spec/system/comments/user_fills_out_comment_spec.rb
+++ b/spec/system/comments/user_fills_out_comment_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Creating Comment", type: :system, js: true do
+RSpec.xdescribe "Creating Comment", type: :system, js: true do
   include_context "with runkit_tag"
 
   let(:user) { create(:user) }


### PR DESCRIPTION
Reverts forem/forem#13456

Let's ignore that spec some more - it started to segfault within hours of merging this in to master (it's still a real problem, it didn't magically go away, it is slowing us down still to work around it).