### PR TITLE
[15 min fix] Removed title attributes from SVGs that are purely decorative

### DIFF
--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -47,8 +47,8 @@
         <div class="editor-image-upload">
           <input type="file" id="image-upload-main" name="file" accept="image/*" style="display:none">
           <button type="button" class="crayons-btn crayons-btn--s crayons-btn--icon-left crayons-btn--ghost-dimmed" onclick="handleImageUpload(event,'main')">
-            <%= inline_svg_tag("image.svg", aria: true, class: "crayons-icon", title: "Image") %>
-            <span class="hidden s:inline-block">Upload image</span>
+            <%= inline_svg_tag("image.svg", aria: true, class: "crayons-icon") %>
+            <span class="hidden s:inline-block" aria-hidden="false">Upload image</span>
           </button>
           <label class="image-upload-file-label" id="image-upload-file-label-main"></label>
           <input type="submit" id='image-upload-submit-main' value="Upload" style="display:none">
@@ -56,8 +56,8 @@
         </div>
 
         <button type="button" class="crayons-btn crayons-btn--s crayons-btn--icon-left crayons-btn--ghost-dimmed response-templates-button" title="Use a response template" data-has-listener="false" data-form-id="new_comment">
-          <%= inline_svg_tag("templates.svg", aria: true, class: "crayons-icon", title: "Templates") %>
-          <span class="hidden s:inline-block">Templates</span>
+          <%= inline_svg_tag("templates.svg", aria: true, class: "crayons-icon") %>
+          <span class="hidden s:inline-block" aria-hidden="false">Templates</span>
         </button>
 
         <a href="/p/editor_guide" class="crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon crayons-btn--s ml-auto" target="_blank" rel="noopener" title="Markdown Guide">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes a couple of accessibility issues where a decorative image ends up mislabeling buttons with redundant information.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

### Before

##### Small screen

![image](https://user-images.githubusercontent.com/833231/115864028-4e92cc80-a404-11eb-9fe3-43478aec4519.png)

![image](https://user-images.githubusercontent.com/833231/115864116-72561280-a404-11eb-998b-497d5e56a7a7.png)

##### Large screen

![image](https://user-images.githubusercontent.com/833231/115863921-273bff80-a404-11eb-89a6-0c5afc9fd714.png)

![image](https://user-images.githubusercontent.com/833231/115864168-83068880-a404-11eb-98e9-ca677cae5316.png)

#### After

##### Small screen

![image](https://user-images.githubusercontent.com/833231/115863749-e5ab5480-a403-11eb-8247-0c607359f228.png)

![image](https://user-images.githubusercontent.com/833231/115864614-193aae80-a405-11eb-8496-9c9195a00b9f.png)

##### Large Screen

![image](https://user-images.githubusercontent.com/833231/115863807-fa87e800-a403-11eb-8756-881c3983acda.png)

![image](https://user-images.githubusercontent.com/833231/115864652-2c4d7e80-a405-11eb-8edf-644cba9b2c4c.png)

1. Navigate to an article
2. Click on the Add to discussion textarea to write a new comment.

![image](https://user-images.githubusercontent.com/833231/115863417-67e74900-a403-11eb-8a43-364dc3e24bd1.png)

3. The comment toolbar appears.

![image](https://user-images.githubusercontent.com/833231/115863360-57cf6980-a403-11eb-9f2f-95414d551efc.png)

4. Use the browser tools to select the buttons and notice that there is no longer redundant information in the labels and in the case of the templates button, there is a more descriptive label for screen readers, "Use a response template"


### UI accessibility concerns?

Fixes a couple of accessibility issues where a decorative image ends up mislabeling buttons with redundant information.

## Added tests?

- [ ] Yes
- [x] No, and this is why: I'm waiting until we fix some flaky comment E2E tests. Once those are sorted, I will add this to those tests.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Bilbo Baggins from the Lord of the Rings saying goodbye then disappearing into thin air](https://media.giphy.com/media/l49FqlUguNsGDNCGk/giphy.gif)
