### PR TITLE
Remove unused attributes from markdown parser

### DIFF
--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -9,8 +9,8 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
     ]
 
     self.attributes = %w[
-      alt colspan data-conversation data-lang data-no-instant data-url em height href id loop
-      name ref rel rowspan size span src start strong title type value width controls
+      alt colspan data-conversation data-lang data-no-instant data-url href id loop
+      name ref rel rowspan span src start type value width controls
     ]
   end
 

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -40,7 +40,7 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
 
   def scrub_valid_attributes(node)
     node.attributes.each_value do |attribute|
-      attribute.value = attribute.value.gsub(LIQUID_TAG_SYNTAX_REGEX, "")
+      attribute.value = attribute.value.remove(LIQUID_TAG_SYNTAX_REGEX)
     end
   end
 

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -29,12 +29,18 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
       end
 
       scrub_css_attribute(node)
+    elsif valid_alt_attr?(node)
+      raise ArgumentError, "Invalid markdown detected!"
     else
       super
     end
   end
 
   private
+
+  def valid_alt_attr?(node)
+    node.attributes["alt"]&.value&.scan(/\{%|%\}/)&.any?
+  end
 
   def inside_codeblock?(node)
     node.attributes["class"]&.value&.include?("highlight") ||

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -1,4 +1,5 @@
 class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
+  LIQUID_TAG_SYNTAX_REGEX = /\{%|%\}/.freeze
   def initialize
     super
 
@@ -39,7 +40,7 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
 
   def scrub_valid_attributes(node)
     node.attributes.each_value do |attribute|
-      attribute.value = attribute.value.gsub(/\{%|%\}/, "")
+      attribute.value = attribute.value.gsub(LIQUID_TAG_SYNTAX_REGEX, "")
     end
   end
 

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -10,7 +10,7 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
 
     self.attributes = %w[
       alt colspan data-conversation data-lang data-no-instant data-url href id loop
-      name ref rel rowspan span src start title type value width controls
+      name ref rel rowspan span src start title type value controls
     ]
   end
 

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -3,14 +3,14 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
     super
 
     self.tags = %w[
-      a abbr add aside b blockquote br button center cite code col colgroup dd del dl dt em em figcaption
+      a abbr add b blockquote br button center code col colgroup dd del dl dt em figcaption
       h1 h2 h3 h4 h5 h6 hr i img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
       tbody td tfoot th thead time tr u ul video
     ]
 
     self.attributes = %w[
       alt colspan data-conversation data-lang data-no-instant data-url href id loop
-      name ref rel rowspan span src start type value width controls
+      name ref rel rowspan span src start title type value width controls
     ]
   end
 

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -4,8 +4,8 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
 
     self.tags = %w[
       a abbr add b blockquote br button center code col colgroup dd del dl dt em figcaption
-      h1 h2 h3 h4 h5 h6 hr i img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
-      tbody td tfoot th thead time tr u ul video
+      h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
+      tbody td tfoot th thead time tr ul video
     ]
 
     self.attributes = %w[

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -29,17 +29,18 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
       end
 
       scrub_css_attribute(node)
-    elsif valid_alt_attr?(node)
-      raise ArgumentError, "Invalid markdown detected!"
     else
+      scrub_valid_attributes(node)
       super
     end
   end
 
   private
 
-  def valid_alt_attr?(node)
-    node.attributes["alt"]&.value&.scan(/\{%|%\}/)&.any?
+  def scrub_valid_attributes(node)
+    node.attributes.each_value do |attribute|
+      attribute.value = attribute.value.gsub(/\{%|%\}/, "")
+    end
   end
 
   def inside_codeblock?(node)

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -3,7 +3,7 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
     super
 
     self.tags = %w[
-      a abbr add b blockquote br button code col colgroup dd del dl dt em figcaption
+      a abbr add b blockquote br button cite code col colgroup dd del dl dt em figcaption
       h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
       tbody td tfoot th thead time tr ul video
     ]

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -3,7 +3,7 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
     super
 
     self.tags = %w[
-      a abbr add b blockquote br button center code col colgroup dd del dl dt em figcaption
+      a abbr add b blockquote br button code col colgroup dd del dl dt em figcaption
       h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
       tbody td tfoot th thead time tr ul video
     ]

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -3,7 +3,7 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
     super
 
     self.tags = %w[
-      a abbr add b blockquote br button cite code col colgroup dd del dl dt em figcaption
+      a abbr add b blockquote br button center cite code col colgroup dd del dl dt em figcaption
       h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
       tbody td tfoot th thead time tr ul video
     ]

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -5,7 +5,7 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
     self.tags = %w[
       a abbr add b blockquote br button center cite code col colgroup dd del dl dt em figcaption
       h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
-      tbody td tfoot th thead time tr ul video
+      tbody td tfoot th thead time tr u ul video
     ]
 
     self.attributes = %w[

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -53,9 +53,9 @@ module MarkdownProcessor
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       allowed_tags = %w[strong abbr aside em p h1 h2 h3 h4 h5 h6 i u b code pre
                         br ul ol li small sup sub img a span hr blockquote kbd]
-      ActionController::Base.helpers.sanitize markdown.render(@content),
+      ActionController::Base.helpers.sanitize(markdown.render(@content),
                                               tags: allowed_tags,
-                                              attributes: ALLOWED_ATTRIBUTES
+                                              attributes: ALLOWED_ATTRIBUTES)
     end
 
     def evaluate_limited_markdown
@@ -64,9 +64,9 @@ module MarkdownProcessor
       renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       allowed_tags = %w[strong i u b em p br code]
-      ActionController::Base.helpers.sanitize markdown.render(@content),
+      ActionController::Base.helpers.sanitize(markdown.render(@content),
                                               tags: allowed_tags,
-                                              attributes: ALLOWED_ATTRIBUTES
+                                              attributes: ALLOWED_ATTRIBUTES)
     end
 
     def evaluate_inline_limited_markdown
@@ -75,9 +75,9 @@ module MarkdownProcessor
       renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       allowed_tags = %w[strong i u b em code]
-      ActionController::Base.helpers.sanitize markdown.render(@content),
+      ActionController::Base.helpers.sanitize(markdown.render(@content),
                                               tags: allowed_tags,
-                                              attributes: ALLOWED_ATTRIBUTES
+                                              attributes: ALLOWED_ATTRIBUTES)
     end
 
     def evaluate_listings_markdown
@@ -87,9 +87,9 @@ module MarkdownProcessor
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       allowed_tags = %w[strong abbr aside em p h4 h5 h6 i u b code pre
                         br ul ol li small sup sub a span hr blockquote kbd]
-      ActionController::Base.helpers.sanitize markdown.render(@content),
+      ActionController::Base.helpers.sanitize(markdown.render(@content),
                                               tags: allowed_tags,
-                                              attributes: ALLOWED_ATTRIBUTES
+                                              attributes: ALLOWED_ATTRIBUTES)
     end
 
     def tags_used

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -109,7 +109,7 @@ module MarkdownProcessor
     def catch_xss_attempts(markdown)
       return unless markdown.match?(Regexp.union(BAD_XSS_REGEX))
 
-      raise ArgumentError, "Invalid markdown detected"
+      raise ArgumentError, "Invalid markdown detected!"
     end
 
     def escape_liquid_tags_in_codeblock(content)

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -52,7 +52,7 @@ module MarkdownProcessor
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       allowed_tags = %w[strong abbr aside em p h1 h2 h3 h4 h5 h6 i u b code pre
                         br ul ol li small sup sub img a span hr blockquote kbd]
-      allowed_attributes = %w[href strong em ref rel src title alt]
+      allowed_attributes = %w[href ref rel src title alt]
       ActionController::Base.helpers.sanitize markdown.render(@content),
                                               tags: allowed_tags,
                                               attributes: allowed_attributes
@@ -64,7 +64,7 @@ module MarkdownProcessor
       renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       allowed_tags = %w[strong i u b em p br code]
-      allowed_attributes = %w[href strong em ref rel src title alt]
+      allowed_attributes = %w[href ref rel src title alt]
       ActionController::Base.helpers.sanitize markdown.render(@content),
                                               tags: allowed_tags,
                                               attributes: allowed_attributes

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -8,6 +8,7 @@ module MarkdownProcessor
     ].freeze
 
     WORDS_READ_PER_MINUTE = 275.0
+    ALLOWED_ATTRIBUTES = %w[href src alt].freeze
 
     def initialize(content, source: nil, user: nil)
       @content = content
@@ -52,10 +53,9 @@ module MarkdownProcessor
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       allowed_tags = %w[strong abbr aside em p h1 h2 h3 h4 h5 h6 i u b code pre
                         br ul ol li small sup sub img a span hr blockquote kbd]
-      allowed_attributes = %w[href ref rel src title alt]
       ActionController::Base.helpers.sanitize markdown.render(@content),
                                               tags: allowed_tags,
-                                              attributes: allowed_attributes
+                                              attributes: ALLOWED_ATTRIBUTES
     end
 
     def evaluate_limited_markdown
@@ -64,10 +64,9 @@ module MarkdownProcessor
       renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       allowed_tags = %w[strong i u b em p br code]
-      allowed_attributes = %w[href ref rel src title alt]
       ActionController::Base.helpers.sanitize markdown.render(@content),
                                               tags: allowed_tags,
-                                              attributes: allowed_attributes
+                                              attributes: ALLOWED_ATTRIBUTES
     end
 
     def evaluate_inline_limited_markdown
@@ -76,10 +75,9 @@ module MarkdownProcessor
       renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       allowed_tags = %w[strong i u b em code]
-      allowed_attributes = %w[href strong em ref rel src title alt]
       ActionController::Base.helpers.sanitize markdown.render(@content),
                                               tags: allowed_tags,
-                                              attributes: allowed_attributes
+                                              attributes: ALLOWED_ATTRIBUTES
     end
 
     def evaluate_listings_markdown
@@ -89,10 +87,9 @@ module MarkdownProcessor
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       allowed_tags = %w[strong abbr aside em p h4 h5 h6 i u b code pre
                         br ul ol li small sup sub a span hr blockquote kbd]
-      allowed_attributes = %w[href strong em ref rel src title alt]
       ActionController::Base.helpers.sanitize markdown.render(@content),
                                               tags: allowed_tags,
-                                              attributes: allowed_attributes
+                                              attributes: ALLOWED_ATTRIBUTES
     end
 
     def tags_used

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -125,6 +125,11 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     expect(test).to be(content)
   end
 
+  it "permits abbr tags" do
+    result = generate_and_parse_markdown("<abbr title=\"ol korrect\">OK</abbr>")
+    expect(result).to include("<abbr title=\"ol korrect\">OK</abbr>")
+  end
+
   context "when rendering links markdown" do
     # the following specs are testing HTMLRouge
     it "renders properly if protocol http is included" do
@@ -361,11 +366,6 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
       result = generate_and_parse_markdown("- [A](#a)\n  - [B](#b)\n- [C](#c)")
       expect(result).not_to include("<br>")
     end
-
-    it "permits abbr and aside tags" do
-      result = generate_and_parse_markdown("<aside><abbr title=\"ol korrect\">OK</abbr><aside>")
-      expect(result).to include("<aside><abbr title=\"ol korrect\">OK</abbr><aside>")
-    end
   end
 
   context "when word as snake case" do
@@ -399,10 +399,25 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     end
   end
 
-  context "when writing an alt attribute" do
-    it "prevents the alt attribute from having Liquid tags inside" do
+  context "when using a valid attribute" do
+    let(:example_text) { "{% liquid example %}" }
+
+    it "prevents the attribute from having Liquid tags inside" do
       text = '<img src="x" alt="{% 404/404#">%}'
-      expect { generate_and_parse_markdown(text) }.to raise_error ArgumentError
+      expect(generate_and_parse_markdown(text)).to exclude("{%")
+    end
+
+    it "does not scrub attributes in inline code" do
+      inline_code = "`#{example_text}`"
+      expect(generate_and_parse_markdown(inline_code)).to include(example_text)
+      double_fenced_code = "``#{example_text}``"
+      expect(generate_and_parse_markdown(double_fenced_code)).to include(example_text)
+    end
+
+    it "does not scrub attributes in codeblocks" do
+      codeblock = "```\n#{example_text}\n```"
+      expect(generate_and_parse_markdown(codeblock)).to include("{%")
+      expect(generate_and_parse_markdown(codeblock)).to include("%}")
     end
   end
 end

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -398,4 +398,11 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
       expect(generate_and_parse_markdown(code_block)).to include("highlight ada")
     end
   end
+
+  context "when writing an alt attribute" do
+    it "prevents the alt attribute from having Liquid tags inside" do
+      text = '<img src="x" alt="{% 404/404#">%}'
+      expect { generate_and_parse_markdown(text) }.to raise_error ArgumentError
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This removes some attributes that would never really be used, or shouldn't be because they would add confusion. It's not documented anywhere that these attributes could have been used, and therefore I think we should remove them.

Also adds a method to scrub the attributes that are used.

## Related Tickets & Documents
None

## QA Instructions, Screenshots, Recordings
1. Go to /new
2. Try to 

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
TODO

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
Nope