### PR TITLE
Add skip link to tag page

### DIFF
--- a/app/assets/javascripts/utilities/slideSidebar.js
+++ b/app/assets/javascripts/utilities/slideSidebar.js
@@ -2,23 +2,22 @@ function slideSidebar(side, direction) {
   if (!document.getElementById('sidebar-wrapper-' + side)) {
     return;
   }
+  const mainContent =
+    document.getElementById('main-content') ||
+    document.getElementById('articles-list');
   if (direction === 'intoView') {
-    document.getElementById('articles-list').classList.add('modal-open');
+    mainContent.classList.add('modal-open');
     document.body.classList.add('modal-open');
     document
       .getElementById('sidebar-wrapper-' + side)
       .classList.add('swiped-in');
-    document
-      .getElementById('articles-list')
-      .addEventListener('touchmove', preventDefaultAction, false);
+    mainContent.addEventListener('touchmove', preventDefaultAction, false);
   } else {
-    document.getElementById('articles-list').classList.remove('modal-open');
+    mainContent.classList.remove('modal-open');
     document.body.classList.remove('modal-open');
     document
       .getElementById('sidebar-wrapper-' + side)
       .classList.remove('swiped-in');
-    document
-      .getElementById('articles-list')
-      .removeEventListener('touchmove', preventDefaultAction, false);
+    mainContent.removeEventListener('touchmove', preventDefaultAction, false);
   }
 }

--- a/app/views/articles/tag_index.html.erb
+++ b/app/views/articles/tag_index.html.erb
@@ -43,7 +43,7 @@
       data-requires-approval="<%= @tag_model.requires_approval %>"
       data-articles-since="<%= Timeframe.datetime_iso8601(params[:timeframe]) %>">
     <%= render "articles/tags/sidebar" %>
-    <div class="articles-list" id="articles-list">
+    <main class="articles-list" id="main-content">
       <header class="flex items-center p-2 m:p-0 m:pb-2" id="on-page-nav-controls">
         <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--icon mr-2 inline-block m:hidden" id="on-page-nav-butt-left" aria-label="nav-button-left">
           <div class="crayons-icon nav-icon ">
@@ -96,7 +96,7 @@
       <div class="loading-articles" id="loading-articles">
         loading...
       </div>
-    </div>
+    </main>
     <%= render "articles/tags/sidebar_additional" %>
   </div>
 

--- a/app/views/stories/_stories_list_script.html.erb
+++ b/app/views/stories/_stories_list_script.html.erb
@@ -10,7 +10,7 @@
       el.classList.remove("active");
     });
 
-    document.getElementById('articles-list').addEventListener('click', function (event) {
+    document.getElementById('main-content').addEventListener('click', function (event) {
       var clickedEl = event.target;
       if (hasClass(clickedEl, "bm-initial") || hasClass(clickedEl, "bm-success")) {
         //do nothing

--- a/spec/system/articles/user_visits_articles_by_tag_spec.rb
+++ b/spec/system/articles/user_visits_articles_by_tag_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "User visits articles by tag", type: :system do
       end
 
       it "shows the correct articles" do
-        within("#articles-list") do
+        within("#main-content") do
           expect(page).to have_text(article.title)
           expect(page).to have_text(article3.title)
           expect(page).not_to have_text(article2.title)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds the skip link functionality to the tag page, allowing users to skip directly to the list of articles. Due to the way we transition between pages at the moment, the skip link is currently only the first focusable element on a fresh page load. 

As part of #1153 we will want to change that, but it can be done as a final step once the functionality is ready on all of our pages.

## Related Tickets & Documents

#1153

## QA Instructions, Screenshots, Recordings

- From the home page, select a tag you're following
- Refresh the page (fresh page load as per above)
- Press the Tab key
- You should see the skip link is focused
- Activate the link with either Enter or a click
- Press the Tab key again 
- The focus should be on the Feed/Week/Month links and not in the sidebars/navigation header

https://user-images.githubusercontent.com/20773163/115882726-f3cd9500-a444-11eb-86cd-de6b87587dff.mp4

NB: This change required a minor refactor to the 'slideSidebar' code, so we need to check the left/right sidebars are still opening and closing on the tags page on mobile as expected:

https://user-images.githubusercontent.com/20773163/115883585-dc42dc00-a445-11eb-9fd5-19922e0bafbe.mp4


### UI accessibility concerns?

This adds an essential accessibility feature for keyboard users

## Added tests?

- [ ] Yes
- [X] No, and this is why: Updated relevant affected tests
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: once #1153 is completed we can communicate the change as a whole

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Next!](https://i.giphy.com/media/l0HlJiVs2oAtVet0c/giphy.webp)
