### PR TITLE
Add skip link to search results page

### DIFF
--- a/app/views/articles/search.html.erb
+++ b/app/views/articles/search.html.erb
@@ -2,47 +2,50 @@
   <%= render "articles/search/meta" %>
 <% end %>
 <div id="query-wrapper"></div>
-<header class="crayons-layout crayons-layout--limited-l crayons-layout--1-col p-4">
-  <div class="block m:hidden" id="mobile-search-container">
-    <form accept-charset="UTF-8" method="get" action="/search">
-      <input class="crayons-textfield" type="text" name="q" placeholder="Search..." autocomplete="on" />
-    </form>
+
+<main id="main-content">
+  <div class="crayons-layout crayons-layout--limited-l crayons-layout--1-col p-4">
+    <div class="block m:hidden" id="mobile-search-container">
+      <form accept-charset="UTF-8" method="get" action="/search">
+        <input class="crayons-textfield" type="text" name="q" placeholder="Search..." autocomplete="on" />
+      </form>
+    </div>
+
+    <div class="block s:flex items-center space-between">
+      <h1 class="crayons-title">Search results</h1>
+
+      <nav id="sorting-option-tabs" class="crayons-tabs crayons-tabs--wrapped ml-auto">
+        <a href="javascript:;" class="crayons-tabs__item <%= "crayons-tabs__item--current" if @current_ordering == :relevance %>">Most Relevant</a>
+        <a href="javascript:;" class="crayons-tabs__item <%= "crayons-tabs__item--current" if @current_ordering == :newest %>" data-sort-by="published_at" data-sort-direction="desc">Newest</a>
+        <a href="javascript:;" class="crayons-tabs__item <%= "crayons-tabs__item--current" if @current_ordering == :oldest %>" data-sort-by="published_at" data-sort-direction="asc">Oldest</a>
+      </nav>
+    </div>
   </div>
 
-  <div class="block s:flex items-center space-between">
-    <h1 class="crayons-title">Search results</h1>
+  <div class="crayons-layout crayons-layout--limited-l crayons-layout--2-cols pt-0" id="index-container"
+      data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which="<%= @list_of %>"
+      data-tag=""
+      data-feed="<%= params[:timeframe] || "base-feed" %>"
+      data-articles-since="<%= Timeframe.datetime_iso8601(params[:timeframe]) %>">
 
-    <nav id="sorting-option-tabs" class="crayons-tabs crayons-tabs--wrapped ml-auto">
-      <a href="javascript:;" class="crayons-tabs__item <%= "crayons-tabs__item--current" if @current_ordering == :relevance %>">Most Relevant</a>
-      <a href="javascript:;" class="crayons-tabs__item <%= "crayons-tabs__item--current" if @current_ordering == :newest %>" data-sort-by="published_at" data-sort-direction="desc">Newest</a>
-      <a href="javascript:;" class="crayons-tabs__item <%= "crayons-tabs__item--current" if @current_ordering == :oldest %>" data-sort-by="published_at" data-sort-direction="asc">Oldest</a>
-    </nav>
-  </div>
-</header>
+    <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left">
+      <div class="sidebar-bg" id="sidebar-bg-left"></div>
+      <%= render "articles/search/nav_menu" %>
+    </div>
 
-<div class="crayons-layout crayons-layout--limited-l crayons-layout--2-cols pt-0" id="index-container"
-     data-params="<%= params.to_json(only: %i[tag username q]) %>" data-which="<%= @list_of %>"
-     data-tag=""
-     data-feed="<%= params[:timeframe] || "base-feed" %>"
-     data-articles-since="<%= Timeframe.datetime_iso8601(params[:timeframe]) %>">
-
-  <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left">
-    <div class="sidebar-bg" id="sidebar-bg-left"></div>
-    <%= render "articles/search/nav_menu" %>
-  </div>
-
-  <div class="articles-list crayons-layout__content" id="articles-list">
-    <div id="banner-section"></div>
-    <div class="substories" id="substories">
-      <div class="p-9 align-center crayons-card">
-        <br />
+    <div class="articles-list crayons-layout__content" id="articles-list">
+      <div id="banner-section"></div>
+      <div class="substories" id="substories">
+        <div class="p-9 align-center crayons-card">
+          <br />
+        </div>
+      </div>
+      <div class="loading-articles" id="loading-articles">
+        loading...
       </div>
     </div>
-    <div class="loading-articles" id="loading-articles">
-      loading...
-    </div>
   </div>
-</div>
+</main>
 <%= render "articles/search" %>
 
 <%= render "stories/stories_list_script" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds the skip link functionality to the search results page. It also fixes an error flagged in axe for two `header` elements being on the same page. Due to the way we transition between pages at the moment, the skip link is currently only the first focusable element on a fresh page load.

As part of #1153 we will want to change that, but it can be done as a final step once the functionality is ready on all of our pages.

## Related Tickets & Documents

#1153

## QA Instructions, Screenshots, Recordings

- From the home page, type a search term and submit
- Refresh the page (fresh page load as per above)
- Press the Tab key and check the skip link appears
- Click the skip link with either Enter or the mouse
- Press Tab again and check that the Most relevant/Newest/Oldest tabs are where the focus is, and not in the navigation header

https://user-images.githubusercontent.com/20773163/115885592-03021200-a448-11eb-9019-cf3eff9c0e4e.mp4


### UI accessibility concerns?

This adds an essential accessibility feature for keyboard users

## Added tests?

- [ ] Yes
- [X] No, and this is why: Cypress can't yet test the Tab event properly, so for now this has to be a manual check
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: this is part of the wider #1153 issue and we can communicate the changes as a whole once complete

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![next please](https://media1.giphy.com/media/xT5LMPj2vNcstqvivK/giphy.gif?cid=ecf05e47lqrhhxm7ulyhi01f03dygxpzaf4hikrckajnd0ez&rid=giphy.gif&ct=g)
