### PR TITLE
Add skip link to stats and analytics pages

### DIFF
--- a/app/views/articles/stats.html.erb
+++ b/app/views/articles/stats.html.erb
@@ -1,9 +1,11 @@
 <% title "Stats for Your Article" %>
 
-<div id="user-dashboard">
-  <h1 class="fs-4xl fw-medium align-center my-5">Stats for "<%= link_to @article.title, @article.current_state_path, id: "article", data: { "article-id" => @article.id, "organization-id" => @organization_id } %>"</h1>
+<main id="main-content">
+  <div id="user-dashboard">
+    <h1 class="fs-4xl fw-medium align-center my-5">Stats for "<%= link_to @article.title, @article.current_state_path, id: "article", data: { "article-id" => @article.id, "organization-id" => @organization_id } %>"</h1>
 
-  <%= render "shared/stats" %>
-</div>
+    <%= render "shared/stats" %>
+  </div>
+</main>
 
 <%= javascript_packs_with_chunks_tag "analyticsArticle", defer: true %>

--- a/app/views/dashboards/analytics.erb
+++ b/app/views/dashboards/analytics.erb
@@ -1,13 +1,15 @@
 <% title "Analytics" %>
 
-<div class="dashboard-container analytics-container crayons-layout" id="user-dashboard">
-  <div class="crayons-card p-3 mt-5">
-    <h1 class="fs-4xl fw-medium">Analytics Dashboard for <%= @user_or_org.name %></h1>
-    <p>Welcome to the Analytics Dashboard, the home of in-depth user metrics so that authors can make data-driven decisions about the  <%= SiteConfig.community_member_label %> ecosystem.</p>
-    <p>This dashboard highlights deep insights especially relevant to  <%= SiteConfig.community_member_label %> relations, authors, and serious bloggers.</p>
-  </div>
+<main id="main-content">
+  <div class="dashboard-container analytics-container crayons-layout" id="user-dashboard">
+    <div class="crayons-card p-3 mt-5">
+      <h1 class="fs-4xl fw-medium">Analytics Dashboard for <%= @user_or_org.name %></h1>
+      <p>Welcome to the Analytics Dashboard, the home of in-depth user metrics so that authors can make data-driven decisions about the  <%= SiteConfig.community_member_label %> ecosystem.</p>
+      <p>This dashboard highlights deep insights especially relevant to  <%= SiteConfig.community_member_label %> relations, authors, and serious bloggers.</p>
+    </div>
 
-  <%= render "shared/stats" %>
-</div>
+    <%= render "shared/stats" %>
+  </div>
+</main>
 
 <%= javascript_packs_with_chunks_tag "analyticsDashboard", defer: true %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds the skip link functionality to the analytics dashboard and the article stats pages, along with a 'main' landmark. Due to the way we transition between pages at the moment, the skip link is currently only the first focusable element on a fresh page load.

As part of #1153 we will want to change that, but it can be done as a final step once the functionality is ready on all of our pages.

## Related Tickets & Documents

#1153

## QA Instructions, Screenshots, Recordings

- Go to `/dashboard/analytics`
- If you navigated there by a link click, refresh the page (as per above note on fresh page loads)
- Press the Tab key and check the skip link appears
- Click the skip link with either the Enter key or the mouse
- Press Tab again and check the next focused element is the Week/Month/Infinity links
- Go to one of your user's published articles and click the 'Stats' button
- Refresh the page as per above note
- Tab and check the skip link again, same as above


https://user-images.githubusercontent.com/20773163/115887727-1f9f4980-a44a-11eb-82d1-3ceb3045411c.mp4


### UI accessibility concerns?

This adds an essential accessibility feature for keyboard users, as well as the required `main` landmark.

## Added tests?

- [ ] Yes
- [X] No, and this is why: Cypress can't yet test the Tab event properly, so for now this has to be a manual check
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: this is part of the wider #1153 issue and we can communicate the changes as a whole once complete

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![nearly there](https://i.giphy.com/media/LMny8mw5VnvyKln1Jt/giphy.webp)
