### PR TITLE
add skip link to settings page

### DIFF
--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,96 +1,98 @@
 <% title "Settings" %>
 
-<% if flash[:settings_notice] %>
-  <div class="crayons-banner" aria-live="polite">
-    <%= flash[:settings_notice] %>
-  </div>
-<% end %>
-
-<% if flash[:error].present? %>
-  <div class="crayons-banner crayons-banner--error" role="alert">
-    <%= flash[:error] %>
-  </div>
-<% end %>
-
-<% if params[:state] == "previous-registration" %>
-  <div class="crayons-banner crayons-banner--error" role="alert">
-    There is an existing account authorized with that social account. Contact
-    <%= email_link %> if this is a mistake.
-  </div>
-<% end %>
-
-<header class="crayons-layout crayons-layout--limited-l crayons-layout--1-col p-4">
-  <% if @tab == "organization" && @organizations.present? %>
-    <h1 class="crayons-title">Settings for
-      <select class="crayons-select lh-tight w-25 align-text-top w-max" onchange="window.location.href=this.value">
-        <% options = @organizations.pluck(:slug, :id).each do |arr| %>
-          <% arr[0] = "@#{arr[0]}" %>
-          <% arr[1] = "/settings/organization/#{arr[1]}" %>
-        <% end.to_h.merge("New Organization" => "/settings/organization/new") %>
-        <%= options_for_select(options, "/settings/organization/#{params[:org_id]}") %>
-        <%# For example: %>
-        <%# <option value="/settings/organization/1>@devteam</option> %>
-        <%# <option value="/settings/organization/new" selected>New Organization</option> %>
-      </select>
-    </h1>
-  <% else %>
-    <h1 class="crayons-title">
-      Settings for <a href="<%= user_url(@user) || "#" %>">@<%= @user.username.truncate(User::USERNAME_MAX_LENGTH) %></a>
-    </h1>
-  <% end %>
-</header>
-
-<main class="crayons-layout crayons-layout--2-cols crayons-layout--limited-l pt-0">
-  <div class="crayons-layout__left-sidebar">
-    <nav class="hidden m:block">
-      <% Constants::Settings::TAB_LIST.each do |possible_tab| %>
-        <a class="crayons-link crayons-link--block <% if @tab == possible_tab.downcase.tr(' ', '-') %>crayons-link--current<% end %>" href="/settings/<%= possible_tab.downcase.tr(" ", "-") %>">
-          <%= inline_svg_tag("twemoji/#{possible_tab.downcase.tr(' ', '-')}", aria: true, class: "crayons-icon crayons-icon--default", title: possible_tab) %>
-          <%= possible_tab %>
-        </a>
-      <% end %>
-    </nav>
-    <div class="m:hidden p-2 pt-0">
-      <select id="mobile-page-selector" class="crayons-select">
-        <% Constants::Settings::TAB_LIST.each do |possible_tab| %>
-          <option value="/settings/<%= possible_tab.downcase.tr(" ", "-") %>" <% if @tab == possible_tab.downcase.tr(' ', '-') %> selected <% end %>>
-            <%= possible_tab %>
-          </option>
-        <% end %>
-      </select>
+<main id="main-content">
+  <% if flash[:settings_notice] %>
+    <div class="crayons-banner" aria-live="polite">
+      <%= flash[:settings_notice] %>
     </div>
+  <% end %>
+
+  <% if flash[:error].present? %>
+    <div class="crayons-banner crayons-banner--error" role="alert">
+      <%= flash[:error] %>
+    </div>
+  <% end %>
+
+  <% if params[:state] == "previous-registration" %>
+    <div class="crayons-banner crayons-banner--error" role="alert">
+      There is an existing account authorized with that social account. Contact
+      <%= email_link %> if this is a mistake.
+    </div>
+  <% end %>
+
+  <div class="crayons-layout crayons-layout--limited-l crayons-layout--1-col p-4">
+    <% if @tab == "organization" && @organizations.present? %>
+      <h1 class="crayons-title">Settings for
+        <select class="crayons-select lh-tight w-25 align-text-top w-max" onchange="window.location.href=this.value">
+          <% options = @organizations.pluck(:slug, :id).each do |arr| %>
+            <% arr[0] = "@#{arr[0]}" %>
+            <% arr[1] = "/settings/organization/#{arr[1]}" %>
+          <% end.to_h.merge("New Organization" => "/settings/organization/new") %>
+          <%= options_for_select(options, "/settings/organization/#{params[:org_id]}") %>
+          <%# For example: %>
+          <%# <option value="/settings/organization/1>@devteam</option> %>
+          <%# <option value="/settings/organization/new" selected>New Organization</option> %>
+        </select>
+      </h1>
+    <% else %>
+      <h1 class="crayons-title">
+        Settings for <a href="<%= user_url(@user) || "#" %>">@<%= @user.username.truncate(User::USERNAME_MAX_LENGTH) %></a>
+      </h1>
+    <% end %>
   </div>
 
-  <div class="crayons-layout__content">
-    <% if current_user.email.blank? %>
-      <div class="crayons-notice crayons-notice--warning mb-6" aria-live="polite">
-        <h3 class="mb-2">Confirm your email to complete your profile.</h3>
-        <p>
-          While you're at it, go ahead and fill everything out.
-          <% if @user.twitter_username.blank? %>
-            Connect your twitter account as well to complete your identity.
-          <% elsif @user.github_username.blank? %>
-            Connect your github account as well to complete your identity.
+  <div class="crayons-layout crayons-layout--2-cols crayons-layout--limited-l pt-0">
+    <div class="crayons-layout__left-sidebar">
+      <nav class="hidden m:block">
+        <% Constants::Settings::TAB_LIST.each do |possible_tab| %>
+          <a class="crayons-link crayons-link--block <% if @tab == possible_tab.downcase.tr(' ', '-') %>crayons-link--current<% end %>" href="/settings/<%= possible_tab.downcase.tr(" ", "-") %>">
+            <%= inline_svg_tag("twemoji/#{possible_tab.downcase.tr(' ', '-')}", aria: true, class: "crayons-icon crayons-icon--default", title: possible_tab) %>
+            <%= possible_tab %>
+          </a>
+        <% end %>
+      </nav>
+      <div class="m:hidden p-2 pt-0">
+        <select id="mobile-page-selector" class="crayons-select">
+          <% Constants::Settings::TAB_LIST.each do |possible_tab| %>
+            <option value="/settings/<%= possible_tab.downcase.tr(" ", "-") %>" <% if @tab == possible_tab.downcase.tr(' ', '-') %> selected <% end %>>
+              <%= possible_tab %>
+            </option>
           <% end %>
-        </p>
+        </select>
       </div>
-    <% end %>
+    </div>
 
-    <% if @user.unconfirmed_email.present? %>
-      <div class="crayons-notice crayons-notice--warning mb-6" role="alert">
-        <h3 class="mb-2">Email verification.</h3>
-        <p>You have requested a change to <a href="mailto:<%= @user.unconfirmed_email %>"><%= @user.unconfirmed_email %></a>. Check your inbox for the verification link to finalize the change.</p>
-      </div>
-    <% end %>
+    <div class="crayons-layout__content">
+      <% if current_user.email.blank? %>
+        <div class="crayons-notice crayons-notice--warning mb-6" aria-live="polite">
+          <h3 class="mb-2">Confirm your email to complete your profile.</h3>
+          <p>
+            While you're at it, go ahead and fill everything out.
+            <% if @user.twitter_username.blank? %>
+              Connect your twitter account as well to complete your identity.
+            <% elsif @user.github_username.blank? %>
+              Connect your github account as well to complete your identity.
+            <% end %>
+          </p>
+        </div>
+      <% end %>
 
-    <% if @user.errors.any? %>
-      <%= render partial: "users/errors", locals: { errors: @user.errors, title_suffix: "prohibited your profile from being saved" } %>
-    <% end %>
+      <% if @user.unconfirmed_email.present? %>
+        <div class="crayons-notice crayons-notice--warning mb-6" role="alert">
+          <h3 class="mb-2">Email verification.</h3>
+          <p>You have requested a change to <a href="mailto:<%= @user.unconfirmed_email %>"><%= @user.unconfirmed_email %></a>. Check your inbox for the verification link to finalize the change.</p>
+        </div>
+      <% end %>
 
-    <% if @organization&.errors&.any? %>
-      <%= render partial: "users/errors", locals: { errors: @organization.errors, title_suffix: "prohibited your organization profile from being saved" } %>
-    <% end %>
+      <% if @user.errors.any? %>
+        <%= render partial: "users/errors", locals: { errors: @user.errors, title_suffix: "prohibited your profile from being saved" } %>
+      <% end %>
 
-    <%= render "users/#{@tab.tr('-', '_')}", tab: @tab %>
+      <% if @organization&.errors&.any? %>
+        <%= render partial: "users/errors", locals: { errors: @organization.errors, title_suffix: "prohibited your organization profile from being saved" } %>
+      <% end %>
+
+      <%= render "users/#{@tab.tr('-', '_')}", tab: @tab %>
+    </div>
   </div>
 </main>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds the skip link functionality to the settings page, and refactors to ensure all main content is wrapped in the `main`. Due to the way we transition between pages at the moment, the skip link is currently only the first focusable element on a fresh page load.

As part of #1153 we will want to change that, but it can be done as a final step once the functionality is ready on all of our pages.

## Related Tickets & Documents

#1153

## QA Instructions, Screenshots, Recordings

- Go to `/settings`
- If you got to that page by clicking a link, refresh the page (as per above note)
- Press the Tab key and check the skip link appears
- Click the link with either the mouse or by pressing Enter
- Press Tab again and check that the next focused item is your username (settings for `@username`) and not any item in the header

https://user-images.githubusercontent.com/20773163/115889820-32b31900-a44c-11eb-8114-8c94b145c6df.mp4


### UI accessibility concerns?

This adds an essential accessibility feature for keyboard users

## Added tests?

- [ ] Yes
- [X] No, and this is why: Cypress can't test the Tab event at the moment, so for now this has to be manual
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: This is part of a batch of changes and the overall feature will be communicated once #1153 is fully closed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![one more](https://i.giphy.com/media/McVdbhbPdTZEEDaT7P/giphy.webp)
