### PR TITLE
Performance improvements to comments search

### DIFF
--- a/app/services/search/postgres/comment.rb
+++ b/app/services/search/postgres/comment.rb
@@ -92,7 +92,7 @@ module Search
         # (see https://github.com/forem/forem/pull/4744#discussion_r345698674
         # and https://github.com/rails/rails/issues/15185#issuecomment-351868335
         # for additional context)
-        user_ids = results.pluck(:user_id)
+        user_ids = results.pluck("comments.user_id")
         users = find_users(user_ids)
 
         serialize(results, users)

--- a/app/services/search/postgres/comment.rb
+++ b/app/services/search/postgres/comment.rb
@@ -23,13 +23,6 @@ module Search
       ].freeze
       private_constant :USER_ATTRIBUTES
 
-      ARTICLE_COMMENTABLE_QUERY = <<-SQL.freeze
-        LEFT JOIN articles
-          ON comments.commentable_id = articles.id
-          AND comments.commentable_type = 'Article'
-      SQL
-      private_constant :ARTICLE_COMMENTABLE_QUERY
-
       DEFAULT_PER_PAGE = 60
       private_constant :DEFAULT_PER_PAGE
 
@@ -41,19 +34,6 @@ module Search
 
       MAX_PER_PAGE = 120 # to avoid querying too many items, we set a maximum amount for a page
       private_constant :MAX_PER_PAGE
-
-      # We filter comments for those that are:
-      # 1. On Articles
-      # 2. Not deleted
-      # 3. Not hidden by commentable user (i.e. an Article author didn't hide the comment)
-      # 4. Are attached to published articles
-      QUERY_FILTER = <<-SQL.freeze
-        comments.commentable_type = 'Article' AND
-        comments.deleted = false AND
-        comments.hidden_by_commentable_user = false AND
-        articles.published = true
-      SQL
-      private_constant :QUERY_FILTER
 
       def self.search_documents(
         page: 0,
@@ -74,7 +54,14 @@ module Search
         page = page.to_i + 1
         per_page = [(per_page || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min
 
-        relation = ::Comment.joins(ARTICLE_COMMENTABLE_QUERY).where(QUERY_FILTER)
+        relation = ::Comment
+          .where(
+            deleted: false,
+            hidden_by_commentable_user: false,
+            commentable_type: "Article",
+          )
+          .joins("join articles on articles.id = comments.commentable_id")
+          .where("articles.published": true)
 
         relation = relation.search_comments(term).with_pg_search_highlight if term.present?
 

--- a/db/migrate/20210423162805_remove_indexes_from_comments.rb
+++ b/db/migrate/20210423162805_remove_indexes_from_comments.rb
@@ -1,0 +1,15 @@
+class RemoveIndexesFromComments < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :comments, column: :commentable_type, algorithm: :concurrently if index_exists?(:comments, :commentable_type)
+    remove_index :comments, column: :deleted, algorithm: :concurrently if index_exists?(:comments, :deleted)
+    remove_index :comments, column: :hidden_by_commentable_user, algorithm: :concurrently if index_exists?(:comments, :hidden_by_commentable_user)
+  end
+
+  def down
+    add_index :comments, :commentable_type, algorithm: :concurrently unless index_exists?(:comments, :commentable_type)
+    add_index :comments, :deleted, algorithm: :concurrently unless index_exists?(:comments, :deleted)
+    add_index :comments, :hidden_by_commentable_user, algorithm: :concurrently unless index_exists?(:comments, :hidden_by_commentable_user)
+  end
+end

--- a/db/migrate/20210423162847_add_partial_indexes_from_comments.rb
+++ b/db/migrate/20210423162847_add_partial_indexes_from_comments.rb
@@ -1,0 +1,13 @@
+class AddPartialIndexesFromComments < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :comments, :deleted, where: "deleted = false", algorithm: :concurrently unless index_exists?(:comments, :deleted)
+    add_index :comments, :hidden_by_commentable_user,where: "hidden_by_commentable_user = false",  algorithm: :concurrently unless index_exists?(:comments, :hidden_by_commentable_user)
+  end
+
+  def down
+    remove_index :comments, column: :deleted, algorithm: :concurrently if index_exists?(:comments, :deleted)
+    remove_index :comments, column: :hidden_by_commentable_user, algorithm: :concurrently if index_exists?(:comments, :hidden_by_commentable_user)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_22_171642) do
+ActiveRecord::Schema.define(version: 2021_04_23_162805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -392,10 +392,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_171642) do
     t.index ["ancestry"], name: "index_comments_on_ancestry"
     t.index ["ancestry"], name: "index_comments_on_ancestry_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type"
-    t.index ["commentable_type"], name: "index_comments_on_commentable_type"
     t.index ["created_at"], name: "index_comments_on_created_at"
-    t.index ["deleted"], name: "index_comments_on_deleted"
-    t.index ["hidden_by_commentable_user"], name: "index_comments_on_hidden_by_commentable_user"
     t.index ["score"], name: "index_comments_on_score"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_23_162805) do
+ActiveRecord::Schema.define(version: 2021_04_23_162847) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -393,6 +393,8 @@ ActiveRecord::Schema.define(version: 2021_04_23_162805) do
     t.index ["ancestry"], name: "index_comments_on_ancestry_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type"
     t.index ["created_at"], name: "index_comments_on_created_at"
+    t.index ["deleted"], name: "index_comments_on_deleted", where: "(deleted = false)"
+    t.index ["hidden_by_commentable_user"], name: "index_comments_on_hidden_by_commentable_user", where: "(hidden_by_commentable_user = false)"
     t.index ["score"], name: "index_comments_on_score"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Following up on our attempts in https://github.com/forem/forem/pull/13476, we're still not getting the performance we need out of the search for comments. This PR adds partial indexes instead of the full indexes on `comments.deleted` and `comments.hidden_by_commentable_user`. It also explicitly specifies `comments.user_id`.

## Related Tickets & Documents
https://github.com/forem/forem/pull/13476

## QA Instructions, Screenshots, Recordings
1. Run `rails db:migrate` and see the indexes are added.
2. Run `rails db:rollback STEP=2` and see the indexes are removed.

## Added tests?
- [x] No, and this is why: this is a DB migration - no tests required.

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
I'll sync with SRE to monitor the results of this change.

![2_chainz_idk_gif](https://media.giphy.com/media/fLm7tLuPr3XNnrqFmU/giphy.gif)
