### PR TITLE
Preload users instead of querying separately when searching for comments

### DIFF
--- a/app/serializers/search/postgres_comment_serializer.rb
+++ b/app/serializers/search/postgres_comment_serializer.rb
@@ -3,8 +3,8 @@ module Search
   class PostgresCommentSerializer < ApplicationSerializer
     attribute :id, &:search_id
 
-    attributes :path do |comment, params|
-      user = params[:users][comment.user_id]
+    attributes :path do |comment|
+      user = comment.user
 
       if user
         "/#{user.username}/comment/#{comment.id_code_generated}"
@@ -19,7 +19,7 @@ module Search
 
     attribute :class_name, -> { "Comment" }
 
-    attribute :highlight do |comment, _params|
+    attribute :highlight do |comment|
       {
         body_text: [comment.pg_search_highlight]
       }
@@ -40,9 +40,8 @@ module Search
 
     # NOTE: not using the `NestedUserSerializer` to avoid hitting Redis to
     # fetch the cached value
-    attribute :user do |comment, params|
-      user = params[:users][comment.user_id]
-      user.slice(:name, :profile_image_90, :username).symbolize_keys
+    attribute :user do |comment|
+      comment.user.slice(:name, :profile_image_90, :username).symbolize_keys
     end
   end
 end

--- a/app/serializers/search/postgres_comment_serializer.rb
+++ b/app/serializers/search/postgres_comment_serializer.rb
@@ -41,7 +41,13 @@ module Search
     # NOTE: not using the `NestedUserSerializer` to avoid hitting Redis to
     # fetch the cached value
     attribute :user do |comment|
-      comment.user.slice(:name, :profile_image_90, :username).symbolize_keys
+      user = comment.user
+
+      if user
+        user.slice(:name, :profile_image_90, :username).symbolize_keys
+      else
+        {}
+      end
     end
   end
 end

--- a/app/services/search/postgres/comment.rb
+++ b/app/services/search/postgres/comment.rb
@@ -15,14 +15,6 @@ module Search
       ].freeze
       private_constant :ATTRIBUTES
 
-      USER_ATTRIBUTES = %i[
-        id
-        name
-        profile_image
-        username
-      ].freeze
-      private_constant :USER_ATTRIBUTES
-
       DEFAULT_PER_PAGE = 60
       private_constant :DEFAULT_PER_PAGE
 
@@ -55,6 +47,7 @@ module Search
         per_page = [(per_page || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min
 
         relation = ::Comment
+          .includes(:user)
           .where(
             deleted: false,
             hidden_by_commentable_user: false,
@@ -69,33 +62,12 @@ module Search
 
         results = relation.page(page).per(per_page)
 
-        # NOTE: [@rhymes/atsmith813] an earlier version used `.includes(:user)`
-        # to preload users, unfortunately it's not possible in Rails to specify
-        # which fields of the included relation's table to select ahead of time.
-        # The `users` table is massive (115 columns on March 2021) and thus we
-        # shouldn't load it all in memory just to select a few fields.
-        # For these reasons I decided to avoid preloading altogether and issue
-        # an additional SQL query to load User objects
-        # (see https://github.com/forem/forem/pull/4744#discussion_r345698674
-        # and https://github.com/rails/rails/issues/15185#issuecomment-351868335
-        # for additional context)
-        user_ids = results.pluck("comments.user_id")
-        users = find_users(user_ids)
-
-        serialize(results, users)
+        serialize(results)
       end
 
-      def self.find_users(user_ids)
-        ::User
-          .where(id: user_ids)
-          .select(*USER_ATTRIBUTES)
-          .index_by(&:id)
-      end
-      private_class_method :find_users
-
-      def self.serialize(results, users)
+      def self.serialize(results)
         Search::PostgresCommentSerializer
-          .new(results, params: { users: users }, is_collection: true)
+          .new(results, is_collection: true)
           .serializable_hash[:data]
           .pluck(:attributes)
       end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
The chase continues...somehow comments search, seemingly at random, throws a `500` because it can't find the user for the comment. This PR changes the logic to 1) preload users instead of querying for them separately and 2) add a conditional to the serializer to prevent an error and return an empty hash instead.

## Related Tickets & Documents
https://github.com/forem/forem/pull/13489

## QA Instructions, Screenshots, Recordings
Specs should cover us here, but you can pull this locally, enable the `search_2_comments` feature flag, and search for comments.

## Added tests?
- [x] No, and this is why: already have tests in place

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
I'll sync with SRE to monitor the results of this change.

![2_chainz_idk_gif](https://media.giphy.com/media/fLm7tLuPr3XNnrqFmU/giphy.gif)
