### PR TITLE
Fix scroll-padding on article anchor links

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -6,6 +6,10 @@
   height: 10px;
 }
 
+:root {
+  scroll-padding-top: var(--header-height);
+}
+
 body.default-header {
   .crayons-article .crayons-article__body [id] {
     scroll-margin-top: var(--header-height);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fix scroll-padding on article anchor links.

## Related Tickets & Documents
Closes https://github.com/forem/forem/issues/9749

## QA Instructions, Screenshots, Recordings
So there was a lingering issue with anchor links on dev.to: the Section `#anchor` links on articles would make the heading of said section hide behind the header. This PR aims to fix that.

**To test this:**
Load up the minimal default article database, and head to `http://localhost:3000/ricky_ms_franecki/the-mermaids-singing-ut-quasi-91k`

Edit the URL to add `#main-title` at the end (for a position reset). Then, edit it to `#modi` to scroll to that section in the article.

### Before:

![before](https://user-images.githubusercontent.com/43412083/116067729-11019e00-a6a7-11eb-8ea5-aac3db529abc.png)

### After:

![after](https://user-images.githubusercontent.com/43412083/116067739-14952500-a6a7-11eb-971a-b76688363014.png)

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [x] I need help with writing tests. (Can this be tested?)
