### PR TITLE
aria-hidden accessibility tweak

### DIFF
--- a/app/views/admin/shared/_nested_sidebar.html.erb
+++ b/app/views/admin/shared/_nested_sidebar.html.erb
@@ -6,7 +6,7 @@
            href="/admin/<%= group[:children][0][:controller] %>"
            aria-page="<%= "page" if deduced_controller(request) == group[:children][0][:controller] %>"
            data-action="click->sidebar#expandDropdown">
-          <%= inline_svg_tag(group[:svg], aria: true, class: "dropdown-icon crayons-icon") %>
+          <%= inline_svg_tag(group[:svg], aria_hidden: true, class: "dropdown-icon crayons-icon") %>
           <%= display_name(group_name) %>
         </a>
       <% end %>
@@ -19,7 +19,7 @@
         aria-expanded="<%= (deduced_scope(request) == group_name.to_s).to_s %>"
         aria-controls="<%= group_name %>"
         data-action="click->sidebar#expandDropdown">
-        <%= inline_svg_tag(group[:svg], aria: true, class: "dropdown-icon crayons-icon") %>
+        <%= inline_svg_tag(group[:svg], aria_hidden: true, class: "dropdown-icon crayons-icon") %>
         <%= display_name(group_name) %>
       </button>
       <ul id="<%= group_name %>"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The SVGs used in the side navigation are decorative, and should be hidden from assistive technology users. Currently they have the attribute role="img" which causes them to be surfaced to screen reader users as images with missing alternative text.

These SVGs should be updated to:
```
remove role="img"
add aria-hidden="true" to hide them fully from screen reader users
```
Changing aria:true to aria:hidden removes the role="img" and adds aria-hidden="true" instead.

## Related Tickets & Documents
https://github.com/forem/internalEngineering/issues/415

## QA Instructions, Screenshots, Recordings

<img width="1670" alt="Screenshot 2021-04-26 at 18 47 34" src="https://user-images.githubusercontent.com/2786819/116120558-f1c33a80-a6bf-11eb-982c-acf1e0162aa7.png">


### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added tests?

- [ ] Yes
- [x] No, accessibility tweaks
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/l3Sab72Atlyf8HY616/giphy.gif)
