### PR TITLE
Enable redis cache store in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,22 +14,21 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
+    DEFAULT_EXPIRATION = 1.hour.to_i.freeze
+    config.cache_store = :redis_cache_store, { url: ENV["REDIS_URL"], expires_in: DEFAULT_EXPIRATION }
+
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    DEFAULT_EXPIRATION = 1.hour.to_i.freeze
-    config.cache_store = :redis_cache_store, { url: ENV["REDIS_URL"], expires_in: DEFAULT_EXPIRATION }
-
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
 
   # Don't care if the mailer can't send.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,9 +14,8 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
-    DEFAULT_EXPIRATION = 1.hour.to_i.freeze
-    config.cache_store = :redis_cache_store, { url: ENV["REDIS_URL"], expires_in: DEFAULT_EXPIRATION }
-
+  DEFAULT_EXPIRATION = 1.hour.to_i.freeze
+  config.cache_store = :redis_cache_store, { url: ENV["REDIS_URL"], expires_in: DEFAULT_EXPIRATION }
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We disable caching in controller development by default (you can touch an option file to enable this). However, we also disable Rails.cache as a data store.

We expect Rails.cache to be a working inter-process communication channel between sidekiq workers after commit 9973b7361e8936ecd95c938746093524ad56ff63 (passing the podcast episode rss item as a cache key/pointer, rather than a large hash/immediate value, and fetching the hash from cache in the "child" worker to create podcast episode). 

Always enable the rails cache redis data store, but do still disable action controller caching (the intended behavior in develolpment).  

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

I initially ran into this in the context of Podcasts::GetEpisodesWorker not behaving as expected. 

- Delete `tmp/caching-dev.txt` if present. 
- Restart sidekiq to load env file changes, 
- Restart rails console. 

```ruby
Podcast.first.podcast_episodes.destroy_all
# this should during processing enqueue 10 create episode workers (whether redis cache is enabled or not) - we're doing this inline in the rails console:
Podcasts::GetEpisodesWorker.new.perform(podcast_id: Podcast.first.id, limit: 10, force: true)

# when cache keys were read successfully, we create the episodes
Podcast.first.podcast_episodes.count
# expect 10, not 0
```

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: Development env only change - tests exist around the cache keys for GetEpisode being set to the hash content, we use the more natural `from_item` object to object conversion in the test for CreateEpisode. 
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: It looks like apart from the conditional in the development env initalizer and a spring watch option, the caching-dev.txt file was undocumented.

## [optional] Are there any post deployment tasks we need to perform?

None. This is a development only change.

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/1237369/116151376-26c49280-a6aa-11eb-8b4c-a7c4ca2c266b.png)
