### PR TITLE
[Search 2.0] Articles

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -156,7 +156,11 @@ class Article < ApplicationRecord
   serialize :cached_user
   serialize :cached_organization
 
-  pg_search_scope :search_reading_list,
+  # TODO: [@rhymes] Rename the article column and the trigger name.
+  # What was initially meant just for the reading list (filtered using the `reactions` table),
+  # is also used for the article search page.
+  # The name of the `tsvector` column and its related trigger should be adapted.
+  pg_search_scope :search_articles,
                   against: :reading_list_document,
                   using: {
                     tsearch: {

--- a/app/services/search/postgres/article.rb
+++ b/app/services/search/postgres/article.rb
@@ -1,0 +1,45 @@
+module Search
+  module Postgres
+    class Article
+      DEFAULT_SORT_BY = "hotness_score DESC, comments_count DESC".freeze
+
+      def self.search_documents(
+        term: nil,
+        user_id: nil,
+        sort_by: nil,
+        sort_direction: nil,
+        page: nil,
+        per_page: nil
+      )
+        relation = Homepage::ArticlesQuery.call(user_id: user_id, page: page, per_page: per_page)
+
+        relation = relation.search_articles(term) if term.present?
+
+        tag_flares = Homepage::FetchTagFlares.call(relation)
+
+        relation = sort(relation, sort_by, sort_direction)
+
+        # including user and organization as the last step as they are not needed
+        # by the query that fetches tag flares, they are only needed by the serializer
+        relation = relation.includes(:user, :organization)
+
+        serialize(relation, tag_flares)
+      end
+
+      def self.sort(relation, sort_by, sort_direction)
+        return relation.reorder(sort_by => sort_direction) if sort_by&.to_sym == :published_at
+
+        relation.reorder(DEFAULT_SORT_BY)
+      end
+      private_class_method :sort
+
+      def self.serialize(articles, tag_flares)
+        Homepage::ArticleSerializer
+          .new(articles, params: { tag_flares: tag_flares }, is_collection: true)
+          .serializable_hash[:data]
+          .pluck(:attributes)
+      end
+      private_class_method :serialize
+    end
+  end
+end

--- a/app/services/search/postgres/reading_list.rb
+++ b/app/services/search/postgres/reading_list.rb
@@ -72,7 +72,9 @@ module Search
           .select(*REACTION_ATTRIBUTES)
           .to_sql
 
-        relation = Article.joins("INNER JOIN (#{reaction_query_sql}) reactions ON reactions.reactable_id = articles.id")
+        relation = ::Article.joins(
+          "INNER JOIN (#{reaction_query_sql}) reactions ON reactions.reactable_id = articles.id",
+        )
 
         relation = relation.search_articles(term) if term.present?
 

--- a/app/services/search/postgres/reading_list.rb
+++ b/app/services/search/postgres/reading_list.rb
@@ -74,7 +74,7 @@ module Search
 
         relation = Article.joins("INNER JOIN (#{reaction_query_sql}) reactions ON reactions.reactable_id = articles.id")
 
-        relation = relation.search_reading_list(term) if term.present?
+        relation = relation.search_articles(term) if term.present?
 
         # NOTE: [@rhymes] A previous version was implemented with:
         # `.tagged_with(tags, any: false).reselect(*ATTRIBUTES)`

--- a/spec/services/search/postgres/article_spec.rb
+++ b/spec/services/search/postgres/article_spec.rb
@@ -1,0 +1,152 @@
+require "rails_helper"
+
+# rubocop:disable Rails/PluckId
+# This spec uses `pluck` on an array of hashes, but Rubocop can't tell the difference.
+RSpec.describe Search::Postgres::Article, type: :service do
+  describe "::search_documents" do
+    it "returns an empty result if there are no articles" do
+      expect(described_class.search_documents).to be_empty
+    end
+
+    it "does not return unpublished articles" do
+      article = create(:article, published: false)
+
+      expect(described_class.search_documents.pluck(:id)).not_to include(article.id)
+    end
+
+    it "returns published articles" do
+      article = create(:article)
+
+      expect(described_class.search_documents.pluck(:id)).to include(article.id)
+    end
+
+    context "when describing the result format" do
+      it "does not include a highlight attribute" do
+        create(:article)
+
+        expect(described_class.search_documents.first.key?(:highlight)).to be(false)
+      end
+    end
+
+    context "when filtering by user_id" do
+      it "returns articles belonging to a specific user", :aggregate_failures do
+        user = create(:user)
+        articles = create_list(:article, 2, user: user)
+        article = create(:article)
+
+        results = described_class.search_documents(user_id: user.id).pluck(:id)
+        expect(results).not_to include(article.id)
+        expect(results).to match_array(articles.pluck(:id))
+      end
+    end
+
+    context "when searching for a term" do
+      let(:article) { create(:article) }
+
+      it "matches against the article's body_markdown", :aggregate_failures do
+        article.update_columns(body_markdown: "Life of the party")
+
+        result = described_class.search_documents(term: "part").first
+        expect(result[:path]).to eq(article.path)
+
+        results = described_class.search_documents(term: "fiesta")
+        expect(results).to be_empty
+      end
+
+      it "matches against the article's title", :aggregate_failures do
+        article.update_columns(title: "Life of the party")
+
+        result = described_class.search_documents(term: "part").first
+        expect(result[:path]).to eq(article.path)
+
+        results = described_class.search_documents(term: "fiesta")
+        expect(results).to be_empty
+      end
+
+      it "matches against the article's tags", :aggregate_failures do
+        article.update_columns(cached_tag_list: "javascript, beginners, ruby")
+
+        result = described_class.search_documents(term: "beginner").first
+        expect(result[:path]).to eq(article.path)
+
+        results = described_class.search_documents(term: "newbie")
+        expect(results).to be_empty
+      end
+
+      it "matches against the article's organization's name", :aggregate_failures do
+        article.organization = create(:organization, name: "ACME corp")
+        article.save!
+
+        result = described_class.search_documents(term: "ACME").first
+        expect(result[:path]).to eq(article.path)
+
+        results = described_class.search_documents(term: "ECMA")
+        expect(results).to be_empty
+      end
+
+      it "matches against the article's user's name", :aggregate_failures do
+        result = described_class.search_documents(term: article.user_name.first(3)).first
+        expect(result[:path]).to eq(article.path)
+
+        results = described_class.search_documents(term: "notaname")
+        expect(results).to be_empty
+      end
+
+      it "matches against the article's user's username", :aggregate_failures do
+        result = described_class.search_documents(term: article.user_username.first(3)).first
+        expect(result[:path]).to eq(article.path)
+
+        results = described_class.search_documents(term: "notausername")
+        expect(results).to be_empty
+      end
+    end
+
+    context "when sorting" do
+      it "sorts by 'hotness_score' and 'comments_count' in descending order by default" do
+        article1, article2, article3 = create_list(:article, 3)
+
+        article1.update_columns(hotness_score: 10, comments_count: 10)
+        article2.update_columns(hotness_score: 10, comments_count: 11)
+        article3.update_columns(hotness_score: 9, comments_count: 20)
+
+        results = described_class.search_documents
+        expect(results.pluck(:id)).to eq([article2.id, article1.id, article3.id])
+      end
+
+      it "supports sorting by published_at in ascending and descending order", :aggregate_failures do
+        article1 = create(:article)
+
+        article2 = nil
+        Timecop.travel(1.week.ago) do
+          article2 = create(:article)
+        end
+
+        results = described_class.search_documents(sort_by: :published_at, sort_direction: :asc)
+        expect(results.pluck(:id)).to eq([article2.id, article1.id])
+
+        results = described_class.search_documents(sort_by: :published_at, sort_direction: :desc)
+        expect(results.pluck(:id)).to eq([article1.id, article2.id])
+      end
+    end
+
+    context "when paginating" do
+      it "returns no items when out of pagination bounds" do
+        create(:article)
+
+        result = described_class.search_documents(page: 99)
+        expect(result).to be_empty
+      end
+
+      it "returns paginated items", :aggregate_failures do
+        create_list(:article, 2)
+
+        result = described_class.search_documents(page: 0, per_page: 1)
+        expect(result.length).to eq(1)
+
+        result = described_class.search_documents(page: 1, per_page: 1)
+        expect(result.length).to eq(1)
+      end
+    end
+  end
+end
+# rubocop:enable Rails/PluckId


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This implements the following:

- default view of https://dev.to/search/ replacing the combined "articles + users" with just articles
- search articles pages: https://dev.to/search?q=&filters=class_name:Article and https://dev.to/search?q=ruby&filters=class_name:Article
- search articles but only my articles: https://dev.to/search?q=ruby&filters=MY_POSTS 

Basically this PR is a combination of #13339 and #13052 (without joining `reactions` like in the reading list) :D

**FYI:** we can't use "highlighting" for mainly two reasons:

1. this search is done on the `tsvector` column, not on the actual text, so (I tried) it obviously highlights the context of the processed `tsvector` column, making highlighting useless
2. switching back to searching all the columns plus higlighting times out in production and takes 1 second with 10k articles locally, so nope :D 

I perused [PostgreSQL FTS's ts_headline's documentation](https://www.postgresql.org/docs/11/textsearch-controls.html#TEXTSEARCH-HEADLINE) (the function used to highlight) and I believe there's no alternative right now, also:

>  ts_headline uses the original document, not a tsvector summary, so it can be slow and should be used with care.

:D

## QA Instructions, Screenshots, Recordings

1. Enable both feature flags: `:search_2_homepage` and `:search_2_articles`
2. Navigate homepage, profile page, organization page and make sure everything is okay
3. Go to homepage, search for something in the search bar
4. Sort results, click on "My posts only", remove the search term and check everything is correct

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

I'm going to do the same as with the homepage (second) rollout: enable it on my user, test it on DEV and then enable it for the larger user base