### PR TITLE
fix flaky Homepage::ArticleQuery spec

### DIFF
--- a/spec/queries/homepage/articles_query_spec.rb
+++ b/spec/queries/homepage/articles_query_spec.rb
@@ -177,8 +177,8 @@ RSpec.describe Homepage::ArticlesQuery, type: :query do
         article1.update_columns(comments_count: 1)
         article2.update_columns(comments_count: 2)
 
-        result = described_class.call(sort_by: :comments_count, sort_direction: :desc).ids
-        expect(result).not_to eq([article2.id, article1.id])
+        expect(Article).not_to receive(:order) # rubocop:disable RSpec/MessageSpies
+        described_class.call(sort_by: :comments_count, sort_direction: :desc).ids
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix flaky search ordering test case.

We can't rely on the database returning published articles in ID
order, since there are indexes on published_at and on published which
could very well be in any order (btree), and no explicit `ORDER BY id
ASC` was in the query.

I checked the query that's run in the test against blazer, and confirmed that under
real conditions the results are pretty far from ordered:

```
SELECT articles.id FROM articles WHERE (published_at <= '2021-04-27') AND articles.published = true LIMIT 10 OFFSET 0;
----
 id
166916
637099
132444
431420
501939
141182
565391
515964
146231
677241
```

Change the expectation to assert Article does not receive :order, and
remove the expectation that the ids are returned in the order created.



## Related Tickets & Documents

https://travis-ci.com/github/forem/forem/jobs/501453690#L1061-L1072 was a deploy that failed because of this (expected not [769, 768], got [769, 768]). 

## QA Instructions, Screenshots, Recordings

Test only change

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: edited test only
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: bugfix for flaky test (I will probably write something about the pattern of expecting a sorted response from the db without an explicit ORDER since it's a common source of flaky tests)
 
## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/1237369/116280645-84121f80-a74e-11eb-911d-9d0802f855ca.png)
