### PR TITLE
Optimize `Articles::Suggest` query

### DIFF
--- a/app/services/articles/suggest.rb
+++ b/app/services/articles/suggest.rb
@@ -46,7 +46,9 @@ module Articles
     end
 
     def suggestions_by_tag(max: MAX_DEFAULT)
-      Article.published.tagged_with(cached_tag_list_array, any: true)
+      Article
+        .published
+        .cached_tagged_with_any(cached_tag_list_array)
         .where.not(user_id: article.user_id)
         .where(tag_suggestion_query)
         .order(hotness_score: :desc)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Turns out #13541 was optimizing the wrong query. I overlooked the `organic_page_views_past_month` in the `WHERE` clause. This is the only query I could find in the app that uses this attribute.

## Related Tickets & Documents

#13541 

## Added tests?

- [ ] Yes
- [x] No, and this is why: there is no change to expected behavior
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

Check out [perf on Datadog](https://app.datadoghq.com/apm/resource/practical_developer-postgres/postgres.query/45a1af3b42e95283?end=1619546029290&env=production&index=apm-search&paused=false&query=env%3Aproduction%20service%3Apractical_developer-postgres%20operation_name%3Apostgres.query%20resource_name%3A%22SELECT%20articles%20.%20%2A%20FROM%20articles%20WHERE%20articles%20.%20published%20%3D%20%3F%20AND%20%28%20published_at%20%3C%3D%20%3F%20%29%20AND%20EXISTS%20%28%20SELECT%20%2A%20FROM%20taggings%20WHERE%20taggings%20.%20taggable_id%20%3D%20%3F%20.%20id%20AND%20taggings%20.%20taggable_type%20%3D%20%3F%20AND%20taggings%20.%20tag_id%20IN%20%28%20SELECT%20tags%20.%20id%20FROM%20tags%20WHERE%20%28%20tags%20.%20name%20LIKE%20%3F%20ESCAPE%20%3F%20OR%20tags%20.%20name%20LIKE%20%3F%20ESCAPE%20%3F%20OR%20tags%20.%20name%20LIKE%20%3F%20ESCAPE%20%3F%20OR%20tags%20.%20name%20LIKE%20%3F%20ESCAPE%20%3F%20%29%20%29%20%29%20AND%20articles%20.%20user_id%20%21%3D%20%3F%20AND%20%28%20organic_page_views_past_month_count%20%3E%20%3F%20%29%20ORDER%20BY%20articles%20.%20hotness_score%20DESC%20LIMIT%20%3F%20OFFSET%20%3F%22&start=1619545129290)

## [optional] What gif best describes this PR or how it makes you feel?

![Second verse, same as the first](https://user-images.githubusercontent.com/108205/116289228-4fa75f00-a760-11eb-9d3c-384af1039e91.png)