### PR TITLE
[Search 2.0] Fix podcast values

### DIFF
--- a/app/serializers/search/postgres_podcast_episode_serializer.rb
+++ b/app/serializers/search/postgres_podcast_episode_serializer.rb
@@ -1,6 +1,10 @@
 module Search
   # TODO[@atsmith813]: Rename this to PodcastEpisodeSerializer once Elasticsearch is removed
   class PostgresPodcastEpisodeSerializer < ApplicationSerializer
+    def self.podcast_image_url(podcast_episode)
+      Images::Profile.call(podcast_episode.podcast.profile_image_url, length: 90)
+    end
+
     attribute :id, &:search_id
 
     attributes :body_text, :comments_count, :path, :published_at, :quote,
@@ -11,16 +15,14 @@ module Search
     attribute :hotness_score, -> { 0 }
 
     attribute :main_image do |podcast_episode|
-      Images::Profile.call(podcast_episode.podcast.profile_image_url, length: 90)
+      podcast_image_url(podcast_episode)
     end
 
     attribute :podcast do |podcast_episode|
-      podcast = podcast_episode.podcast
-
       {
-        slug: podcast.slug,
-        image_url: podcast.image_url,
-        title: podcast.title
+        slug: podcast_episode.podcast_slug,
+        image_url: podcast_image_url(podcast_episode),
+        title: podcast_episode.title
       }
     end
 

--- a/app/services/search/postgres/podcast_episode.rb
+++ b/app/services/search/postgres/podcast_episode.rb
@@ -14,6 +14,7 @@ module Search
         "podcast_episodes.published_at",
         "podcast_episodes.quote",
         "podcast_episodes.reactions_count",
+        "podcast_episodes.slug",
         "podcast_episodes.subtitle",
         "podcast_episodes.summary",
         "podcast_episodes.title",

--- a/app/services/search/postgres/podcast_episode.rb
+++ b/app/services/search/postgres/podcast_episode.rb
@@ -6,7 +6,6 @@ module Search
         "podcasts.image",
         "podcasts.published",
         "podcasts.slug",
-        "podcasts.title",
         "podcast_episodes.body",
         "podcast_episodes.comments_count",
         "podcast_episodes.id",

--- a/spec/services/search/postgres/podcast_episode_spec.rb
+++ b/spec/services/search/postgres/podcast_episode_spec.rb
@@ -80,7 +80,15 @@ RSpec.describe Search::Postgres::PodcastEpisode, type: :service do
 
       it "returns the correct attributes for the podcast" do
         expected_keys = %i[slug image_url title]
-        expect(result.first[:podcast].keys).to match_array(expected_keys)
+        podcast = result.first[:podcast]
+        expect(podcast.keys).to match_array(expected_keys)
+
+        expect(podcast[:slug]).to eq(podcast_episode.podcast_slug)
+
+        image_url = Images::Profile.call(podcast_episode.podcast.profile_image_url, length: 90)
+        expect(podcast[:image_url]).to eq(image_url)
+
+        expect(podcast[:title]).to eq(podcast_episode.title)
       end
 
       it "orders the results by published_at in descending order" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
In https://github.com/forem/forem/pull/13475 we returned data under the `podcast` key to mimic Elasticsearch. We didn't realize that the values are actually from `PodcastEpisode` and not `Podcast`, despite the name :sweat_smile:.

**Side note**
It feels a little weird we show the same text (`PodcastEpisode.title`) twice...I wonder if the top was originally supposed to be `Podcast.title` and the bottom text was supposed to be `PodcastEpisode.title`. Either way, updating the frontend is out of the scope of this PR and the Search 2.0 RFC. I added [a note to our cleanup list](https://github.com/orgs/forem/projects/29#card-59639576) to revisit this later after Elasticsearch is gone. In other words, this PR _should_ bring it up to par with our _current_ setup.
![Screen Shot 2021-04-27 at 4 33 24 PM](https://user-images.githubusercontent.com/15987080/116309383-af106980-a776-11eb-85b1-8e0684ecb266.png)

## Related Tickets & Documents
https://github.com/forem/forem/pull/13475

## QA Instructions, Screenshots, Recordings
1. Make sure you have `PodcastEpisodes` and `Podcasts` locally.
2. Enable the feature flag in a console - `FeatureFlag.enable(:search_2_podcast_episodes)`.
3. Fire up the server and search for some podcasts (i.e. `python`).
4. Make sure the UI returns the title of the `PodcastEpisode` and _not_ the `Podcast` itself.
5. Make sure clicking the image takes you to the `podcast` page.
6. Make sure clicking the title takes you to the `podcast_episode` page.

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
I'll re-sync with SRE to re-enable the feature flag.

![are_we_there_yet_gif](https://media.giphy.com/media/CciRoAXgphSZWZwvL4/giphy.gif)
