### PR TITLE
Do not create mentions when embedded within a comment liquid tag

### DIFF
--- a/app/services/mentions/create_all.rb
+++ b/app/services/mentions/create_all.rb
@@ -38,9 +38,13 @@ module Mentions
     def extract_usernames_from_mentions_in_text
       # The "mentioned-user" css is added by Html::Parser#user_link_if_exists
       doc = Nokogiri::HTML(notifiable.processed_html)
-      doc.css(".mentioned-user").map do |link|
-        link.text.delete("@").downcase
+
+      # Remove any mentions that are embedded within a comment liquid tag
+      non_liquid_tag_mentions = doc.css(".mentioned-user").reject do |tag|
+        tag.ancestors(".liquid-comment").any?
       end
+
+      non_liquid_tag_mentions.map { |link| link.text.delete("@").downcase }
     end
 
     def reject_notifiable_author(users)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Ensures that any @-mentions that are _embedded content_ within a comment liquid tag are ignored when deciding which users to send mention notifications to.

## Related Tickets & Documents

Fixes https://github.com/forem/forem/issues/13348.

## QA Instructions, Screenshots, Recordings

_You'll want two different user accounts open (using an incognito tab or separate browser to test this):_

1. Create a comment that has a mention within it with one user account. Use that comment to create _another_ comment that uses the `{% comment [comment_id] %}` syntax embedded within it. Any @-mentions _within the embedded comment_ should not turn into mentions, nor should the user be notified about them. For example, a comment like this **should not** trigger a notification for `@vaidehijoshi`, since the mention is embedded as a liquid tag:
<img width="750" alt="Screen Shot 2021-04-27 at 3 37 09 PM" src="https://user-images.githubusercontent.com/6921610/116321601-36f27580-a76f-11eb-812e-b2971c5a3ed3.png">

2. Create a comment that has a mention within it with one user account. Use that comment to create _another_ comment that uses the `{% comment [comment_id] %}` syntax embedded within it. This time, **add an additional @-mention** outside of the embedded liquid tag content. Any @-mentions _within the embedded comment_ should not turn into mentions, but the @-mention outside of the liquid tag _should trigger a notification_ for that user. For example, a comment like this **should** trigger a notification for `@vaidehijoshi`, since there is an @-mention _outside of_ the embedded liquid tag:
<img width="752" alt="Screen Shot 2021-04-27 at 3 36 57 PM" src="https://user-images.githubusercontent.com/6921610/116321607-3a85fc80-a76f-11eb-87db-70da94468bf1.png">

### UI accessibility concerns?

_This is a backend change, so nope!_

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: _It's kind of expected behavior, and the fact that we didn't have this is a bug on our end_
