### PR TITLE
Add auto-remove .o native extension rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - main
 language: ruby
 cache:
   directories:
@@ -69,8 +72,29 @@ notifications:
 
 jobs:
   include:
+    - stage: Test
+      name: "Node 0"
+      env: KNAPSACK_PRO_CI_NODE_INDEX=0
+    - stage: Test
+      name: "Node 1"
+      env: KNAPSACK_PRO_CI_NODE_INDEX=1
+    - stage: Test
+      name: "Node 2"
+      env: KNAPSACK_PRO_CI_NODE_INDEX=2
+    - stage: Test
+      name: "Front-end tests, Storybook, bundle audit, console check, e2e"
+      script:
+        - yarn lint:frontend
+        - yarn test --colors
+        - bundle exec rails db:create db:schema:load assets:precompile
+        - bundle exec bundle-audit check --update
+        - bin/test-console-check
+        - yarn build-storybook
+        - bin/e2e-ci
+
     - stage: Deploy
-      name: Deploy BenHalpern
+      name: Deploy DEV
+      if: type != pull_request
       install: skip
       script: skip
       after_script: skip
@@ -78,4 +102,17 @@ jobs:
         provider: heroku
         api_key: '$HEROKU_AUTH_TOKEN'
         app:
-          mac/misc/remove-native-c-from-heroku-slug: benhalpern-community
+          main: practicaldev
+      after_deploy:
+        - bash scripts/after_deploy.sh
+    - stage: Deploy
+      name: Deploy BenHalpern
+      if: type != pull_request
+      install: skip
+      script: skip
+      after_script: skip
+      deploy:
+        provider: heroku
+        api_key: '$HEROKU_AUTH_TOKEN'
+        app:
+          main: benhalpern-community

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-branches:
-  only:
-    - main
 language: ruby
 cache:
   directories:
@@ -72,42 +69,8 @@ notifications:
 
 jobs:
   include:
-    - stage: Test
-      name: "Node 0"
-      env: KNAPSACK_PRO_CI_NODE_INDEX=0
-    - stage: Test
-      name: "Node 1"
-      env: KNAPSACK_PRO_CI_NODE_INDEX=1
-    - stage: Test
-      name: "Node 2"
-      env: KNAPSACK_PRO_CI_NODE_INDEX=2
-    - stage: Test
-      name: "Front-end tests, Storybook, bundle audit, console check, e2e"
-      script:
-        - yarn lint:frontend
-        - yarn test --colors
-        - bundle exec rails db:create db:schema:load assets:precompile
-        - bundle exec bundle-audit check --update
-        - bin/test-console-check
-        - yarn build-storybook
-        - bin/e2e-ci
-
-    - stage: Deploy
-      name: Deploy DEV
-      if: type != pull_request
-      install: skip
-      script: skip
-      after_script: skip
-      deploy:
-        provider: heroku
-        api_key: '$HEROKU_AUTH_TOKEN'
-        app:
-          main: practicaldev
-      after_deploy:
-        - bash scripts/after_deploy.sh
     - stage: Deploy
       name: Deploy BenHalpern
-      if: type != pull_request
       install: skip
       script: skip
       after_script: skip
@@ -115,4 +78,4 @@ jobs:
         provider: heroku
         api_key: '$HEROKU_AUTH_TOKEN'
         app:
-          main: benhalpern-community
+          mac/misc/remove-native-c-from-heroku-slug: benhalpern-community

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,11 +1,12 @@
-# Adapted from https://github.com/heroku/heroku-buildpack-ruby/issues/792
 namespace :assets do
+  # Adapted from https://github.com/heroku/heroku-buildpack-ruby/issues/792
   desc "Remove 'node_modules' folder"
   task rm_node_modules: :environment do
     Rails.logger.info "Removing node_modules folder"
     FileUtils.remove_dir("node_modules", true)
   end
 
+  # Adapted from https://github.com/sass/sassc-ruby/issues/200
   desc "Removes extra .o files from native extension builds"
   task clean_gem_artifacts: :environment do
     Bundler.bundle_path.glob("**/ext/**/*.o").each(&:delete)

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -5,10 +5,16 @@ namespace :assets do
     Rails.logger.info "Removing node_modules folder"
     FileUtils.remove_dir("node_modules", true)
   end
+
+  desc "Removes extra .o files from native extension builds"
+  task clean_gem_artifacts: :environment do
+    Bundler.bundle_path.glob("**/ext/**/*.o").each(&:delete)
+  end
 end
 
 unless ENV["WEBPACKER_PRECOMPILE"] == "false"
   Rake::Task["assets:clean"].enhance do
     Rake::Task["assets:rm_node_modules"].invoke
+    Rake::Task["assets:clean_gem_artifacts"].invoke
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Our Heroku Slug size is currently 348.2 MiB of 500 MiB. It's good but could better.  One of our gem `sassc-ruby` currently includes 160MB of binary that we don't need. This PR removes it during the Heroku asset cleanup step.

Update: This changes drop our slug size to 278.3M

## Related Tickets & Documents
follow up to https://github.com/forem/forem/pull/12372
## QA Instructions, Screenshots, Recordings
n/a

### UI accessibility concerns?
n/a

## Added tests?
- [x] No, and this is why: this touches CD side

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post-deployment tasks we need to perform?
I will closely monitor staging first
