### PR TITLE
[Search 2.0] Change podcast_episode query

### DIFF
--- a/app/services/search/postgres/podcast_episode.rb
+++ b/app/services/search/postgres/podcast_episode.rb
@@ -1,24 +1,20 @@
 module Search
   module Postgres
     class PodcastEpisode
-      ATTRIBUTES = [
-        "podcasts.id",
-        "podcasts.image",
-        "podcasts.published",
-        "podcasts.slug",
-        "podcast_episodes.body",
-        "podcast_episodes.comments_count",
-        "podcast_episodes.id",
-        "podcast_episodes.podcast_id",
-        "podcast_episodes.processed_html",
-        "podcast_episodes.published_at",
-        "podcast_episodes.quote",
-        "podcast_episodes.reactions_count",
-        "podcast_episodes.slug",
-        "podcast_episodes.subtitle",
-        "podcast_episodes.summary",
-        "podcast_episodes.title",
-        "podcast_episodes.website_url",
+      ATTRIBUTES = %w[
+        body
+        comments_count
+        id
+        podcast_id
+        processed_html
+        published_at
+        quote
+        reactions_count
+        slug
+        subtitle
+        summary
+        title
+        website_url
       ].freeze
       private_constant :ATTRIBUTES
 

--- a/db/migrate/20210428190634_add_tsvector_index_on_searchable_columnns_to_podcast_episodes.rb
+++ b/db/migrate/20210428190634_add_tsvector_index_on_searchable_columnns_to_podcast_episodes.rb
@@ -1,0 +1,74 @@
+class AddTsvectorIndexOnSearchableColumnnsToPodcastEpisodes < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    query = <<-SQL
+      ((((
+        to_tsvector('simple'::regconfig, COALESCE(body, ''::text)) ||
+        to_tsvector('simple'::regconfig, COALESCE((subtitle)::text, ''::text))) ||
+        to_tsvector('simple'::regconfig, COALESCE((title)::text, ''::text
+      )))))
+    SQL
+
+    unless index_name_exists?(:podcast_episodes, :index_podcast_episodes_on_search_fields_as_tsvector)
+      add_index :podcast_episodes,
+                query,
+                using: :gin,
+                name: :index_podcast_episodes_on_search_fields_as_tsvector,
+                algorithm: :concurrently
+    end
+    
+    # Removing unused existing indexes
+    if index_name_exists?(:podcast_episodes, :index_podcast_episodes_on_body_as_tsvector)
+      remove_index :podcast_episodes,
+                   name: :index_podcast_episodes_on_body_as_tsvector,
+                   algorithm: :concurrently
+    end
+
+    if index_name_exists?(:podcast_episodes, :index_podcast_episodes_on_subtitle_as_tsvector)
+      remove_index :podcast_episodes,
+                   name: :index_podcast_episodes_on_subtitle_as_tsvector,
+                   algorithm: :concurrently
+    end
+
+    if index_name_exists?(:podcast_episodes, :index_podcast_episodes_on_title_as_tsvector)
+      remove_index :podcast_episodes,
+                   name: :index_podcast_episodes_on_title_as_tsvector,
+                   algorithm: :concurrently
+    end
+
+  end
+
+  def down
+    if index_name_exists?(:podcast_episodes, :index_podcast_episodes_on_search_fields_as_tsvector)
+      remove_index :podcast_episodes,
+                   name: :index_podcast_episodes_on_search_fields_as_tsvector,
+                   algorithm: :concurrently
+    end
+
+    # Add back old unused indexes
+    unless index_name_exists?(:podcast_episodes, :index_podcast_episodes_on_body_as_tsvector)
+      add_index :podcast_episodes,
+                "to_tsvector('simple'::regconfig, COALESCE((body)::text, ''::text))",
+                using: :gin,
+                name: :index_podcast_episodes_on_body_as_tsvector,
+                algorithm: :concurrently
+    end
+
+    unless index_name_exists?(:podcast_episodes, :index_podcast_episodes_on_subtitle_as_tsvector)
+      add_index :podcast_episodes,
+                "to_tsvector('simple'::regconfig, COALESCE((subtitle)::text, ''::text))",
+                using: :gin,
+                name: :index_podcast_episodes_on_subtitle_as_tsvector,
+                algorithm: :concurrently
+    end
+
+    unless index_name_exists?(:podcast_episodes, :index_podcast_episodes_on_title_as_tsvector)
+      add_index :podcast_episodes,
+                "to_tsvector('simple'::regconfig, COALESCE((title)::text, ''::text))",
+                using: :gin,
+                name: :index_podcast_episodes_on_title_as_tsvector,
+                algorithm: :concurrently
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_26_165234) do
+ActiveRecord::Schema.define(version: 2021_04_28_190634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -892,9 +892,7 @@ ActiveRecord::Schema.define(version: 2021_04_26_165234) do
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.string "website_url"
-    t.index "to_tsvector('simple'::regconfig, COALESCE((subtitle)::text, ''::text))", name: "index_podcast_episodes_on_subtitle_as_tsvector", using: :gin
-    t.index "to_tsvector('simple'::regconfig, COALESCE((title)::text, ''::text))", name: "index_podcast_episodes_on_title_as_tsvector", using: :gin
-    t.index "to_tsvector('simple'::regconfig, COALESCE(body, ''::text))", name: "index_podcast_episodes_on_body_as_tsvector", using: :gin
+    t.index "(((to_tsvector('simple'::regconfig, COALESCE(body, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((subtitle)::text, ''::text))) || to_tsvector('simple'::regconfig, COALESCE((title)::text, ''::text))))", name: "index_podcast_episodes_on_search_fields_as_tsvector", using: :gin
     t.index ["guid"], name: "index_podcast_episodes_on_guid", unique: true
     t.index ["media_url"], name: "index_podcast_episodes_on_media_url", unique: true
     t.index ["podcast_id"], name: "index_podcast_episodes_on_podcast_id"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
The current query to search `PodcastEpisodes` is too slow in production. This PR changes
 the query to force a join over the preload to speed things up.
 
## Related Tickets & Documents
https://github.com/forem/forem/pull/13475

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
I'll sync with SRE to monitor performance and re-enable the feature flag.

## [optional] What gif best describes this PR or how it makes you feel?

![fingers_crossed_gif](https://media.giphy.com/media/1eChSPFlFeaAzsoB9v/giphy.gif)
