### PR TITLE
Remove input scroll from position

### DIFF
--- a/app/javascript/utilities/textAreaUtils.js
+++ b/app/javascript/utilities/textAreaUtils.js
@@ -17,8 +17,8 @@ export const getCursorXY = (input, selectionPoint) => {
   const bodyRect = document.body.getBoundingClientRect();
   const elementRect = input.getBoundingClientRect();
 
-  const inputY = elementRect.top - bodyRect.top;
-  const inputX = elementRect.left - bodyRect.left;
+  const inputY = elementRect.top - bodyRect.top - input.scrollTop;
+  const inputX = elementRect.left - bodyRect.left - input.scrollLeft;
 
   // create a dummy element with the computed style of the input
   const div = document.createElement('div');


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When an input has a scroll we remove its position from the overall position putting the mention popover in the right place

## Related Tickets & Documents
closes #13513

## QA Instructions, Screenshots, Recordings

![comment](https://user-images.githubusercontent.com/3534427/116457351-33d4b380-a85b-11eb-8d35-ed7618d0c705.png)
![post](https://user-images.githubusercontent.com/3534427/116457404-451dc000-a85b-11eb-8d02-49aed8b561bb.png)


### UI accessibility concerns?
N/A

## Added tests?

- [ ] Yes
- [x] No, and this is why:  existing tests will still work
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Doctor who pops his head over a wall appearing all sweaty](https://pa1.narvii.com/6021/4f933e5d3341c6c454cf650bc8c6d5c7175eeec7_hq.gif)

As a side note I finally installed a local copy of forem rather than just winging it 😅