### PR TITLE
Add react and reactjs to reserved words

### DIFF
--- a/config/initializers/reserved_words.rb
+++ b/config/initializers/reserved_words.rb
@@ -170,6 +170,8 @@ class ReservedWords
     questions
     rails
     reactions
+    react
+    reactjs
     readinglist
     repo
     report-abuse


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
We had an issue where a user was impersonating the React JS team and publishing posts as them. As per our [Terms of Service](https://dev.to/terms#reserved-names), we don't allow this.

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings
In `rails console`:
```ruby
user.update(username: 'react')
#=> should return false
user.update(username: 'reactjs')
#=> should return false
```

### UI accessibility concerns?
Nope

## Added tests?
- [x] Yes, automatic tests

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?
![Fred from Scooby Doo unmasks a ghost, who is a mustached imposter.](https://gifimage.net/wp-content/uploads/2018/11/scooby-doo-unmasking-gif-4.gif)
