### PR TITLE
[Hotfix] [Search 2.0] Optimize performance of listings and articles and fix bugs

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -51,6 +51,7 @@ class SearchController < ApplicationController
     :search_fields,
     :sort_by,
     :sort_direction,
+    :tag,
     :user_id,
     {
       tag_names: [],

--- a/app/queries/homepage/articles_query.rb
+++ b/app/queries/homepage/articles_query.rb
@@ -17,7 +17,7 @@ module Homepage
     ].freeze
     DEFAULT_PER_PAGE = 60
     MAX_PER_PAGE = 100
-    SORT_PARAMS = %i[hotness_score public_reactions_count].freeze
+    SORT_PARAMS = %i[hotness_score public_reactions_count published_at].freeze
 
     def self.call(...)
       new(...).call

--- a/app/services/search/postgres/article.rb
+++ b/app/services/search/postgres/article.rb
@@ -15,9 +15,9 @@ module Search
 
         relation = relation.search_articles(term) if term.present?
 
-        tag_flares = Homepage::FetchTagFlares.call(relation)
-
         relation = sort(relation, sort_by, sort_direction)
+
+        tag_flares = Homepage::FetchTagFlares.call(relation)
 
         # including user and organization as the last step as they are not needed
         # by the query that fetches tag flares, they are only needed by the serializer

--- a/db/migrate/20210429094116_add_tsvector_index_on_searchable_columns_to_listings.rb
+++ b/db/migrate/20210429094116_add_tsvector_index_on_searchable_columns_to_listings.rb
@@ -1,0 +1,35 @@
+class AddTsvectorIndexOnSearchableColumnnsToListings < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    return if index_name_exists?(:classified_listings, :index_classified_listings_on_search_fields_as_tsvector)
+
+    query = <<-SQL
+    (
+      to_tsvector('simple'::regconfig, COALESCE((body_markdown)::text, ''::text)) ||
+      to_tsvector('simple'::regconfig, COALESCE((cached_tag_list)::text, ''::text)) ||
+      to_tsvector('simple'::regconfig, COALESCE((location)::text, ''::text)) ||
+      to_tsvector('simple'::regconfig, COALESCE((slug)::text, ''::text)) ||
+      to_tsvector('simple'::regconfig, COALESCE((title)::text, ''::text))
+    )
+    SQL
+
+    add_index(
+      :classified_listings,
+      query,
+      using: :gin,
+      name: :index_classified_listings_on_search_fields_as_tsvector,
+      algorithm: :concurrently,
+    )
+  end
+
+  def down
+    return unless index_name_exists?(:classified_listings, :index_classified_listings_on_search_fields_as_tsvector)
+
+    remove_index(
+      :classified_listings,
+      name: :index_classified_listings_on_search_fields_as_tsvector,
+      algorithm: :concurrently,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_28_190634) do
+ActiveRecord::Schema.define(version: 2021_04_29_094116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -343,6 +343,7 @@ ActiveRecord::Schema.define(version: 2021_04_28_190634) do
     t.string "title"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.index "(((((to_tsvector('simple'::regconfig, COALESCE(body_markdown, ''::text)) || to_tsvector('simple'::regconfig, COALESCE((cached_tag_list)::text, ''::text))) || to_tsvector('simple'::regconfig, COALESCE((location)::text, ''::text))) || to_tsvector('simple'::regconfig, COALESCE((slug)::text, ''::text))) || to_tsvector('simple'::regconfig, COALESCE((title)::text, ''::text))))", name: "index_classified_listings_on_search_fields_as_tsvector", using: :gin
     t.index ["classified_listing_category_id"], name: "index_classified_listings_on_classified_listing_category_id"
     t.index ["organization_id"], name: "index_classified_listings_on_organization_id"
     t.index ["published"], name: "index_classified_listings_on_published"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR contains 2 performance improvements:

- **listings don't have a `tsvector` index**, thus we add one for it. There's a possibility that PostgreSQL will ignore it in its query plan but we can only know if we add it. I'm using [@jgaskins's technique](https://github.com/forem/forem/pull/13568#pullrequestreview-647417567) implemented by @atsmith813 yesterday [for podcast episodes](https://github.com/forem/forem/pull/13568) aka an index on the combined `tsvector`. I double checked the size of listings and we're way the 1mb limit (the biggest is ~ 800 bytes)

- the query that fetches article's tags to build "tag flares" is slow because it's using the implicit "ranking" order and recently we've had some performance issues due to the fact that rankings are computed at runtime and ordering on a computed calculation isn't fast. Additionally I submit an issue to the `pg_search` gem to see if ranking can be disabled when not needed. This will save us an `INNER JOIN` and a `ts_rank` call we're discarding anyway, see https://github.com/Casecommons/pg_search/issues/467

It also contains a couple of bug fixes described in the review comments

## Related Tickets & Documents

- https://github.com/forem/forem/pull/13568
- https://github.com/Casecommons/pg_search/issues/467
- https://github.com/Casecommons/pg_search#configuring-ranking-and-ordering

## Added tests?

- [ ] Yes
- [x] No, and this is why: the tests have to pass how they are
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
