### PR TITLE
[Search 2.0] Use body instead of body_text in serializer for podcast_episodes

### DIFF
--- a/app/serializers/search/postgres_podcast_episode_serializer.rb
+++ b/app/serializers/search/postgres_podcast_episode_serializer.rb
@@ -6,9 +6,10 @@ module Search
     end
 
     attribute :id, &:search_id
+    attribute :body_text, &:body
 
-    attributes :body_text, :comments_count, :path, :published_at, :quote,
-               :reactions_count, :subtitle, :summary, :title, :website_url
+    attributes :comments_count, :path, :published_at, :quote, :reactions_count,
+               :subtitle, :summary, :title, :website_url
 
     attribute :class_name, -> { "PodcastEpisode" }
     attribute :highlight, -> { { body_text: [] } } # We don't display highlights in the UI for Podcasts


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
In https://github.com/forem/forem/pull/13568 we fixed the performance of searching podcasts related to the query...but the full request was still slow. After some investigation, we found that we were calling `body_text` in the `PostgresPodcastEpisodeSerialzer`:

https://github.com/forem/forem/blob/5af33a63dd1fd6bc741a8d99d9ef11a8e42f894e/app/models/podcast_episode.rb#L82-L84

This santization on each `PodcastEpisode` was [slow](https://ui.honeycomb.io/thepracticaldev/datasets/rails/result/9fkf57uPaSA/trace/mJ54VQ9e2AB).

Since we don't display `body_text` or highlights in the UI when searching `PodcastEpisodes`, we don't really need to worry about the sanitization. To fix this, this PR maps the `body` field on `PodcastEpisodes` to the `body_text` key instead to skip sanitization altogether.

I used `Benchmark` locally to measure this:

**Before**
```7.215  (±13.9%) i/s - 36.000 in 5.075532s```

**After**
```290.186  (± 4.5%) i/s - 1.450k in 5.006207s```

## Related Tickets & Documents
https://github.com/forem/forem/pull/13568

## QA Instructions, Screenshots, Recordings
1. Make sure you have `PodcastEpisodes` and `Podcasts` locally.
2. Fire up a console and activate the feature flag (`FeatureFlag.enable(:search_2_podcast_episodes)`).
3. Log into an account (local admin or your own).
3. Go to search (http://localhost:3000/search).
4. Type a search term in the search box at the top related to the `body`, `title`, or `subtitle` of `PodcastEpisode` you have locally (`PodcastEpisode.last.body`). Then click the `Podcasts` filter on the left.
5. Verify your `PodcastEpisode` shows up in the search results.

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
Nope! The feature flag is currently enabled.

## [optional] What gif best describes this PR or how it makes you feel?

![kid_going_fast_in_car](https://media.giphy.com/media/mRPcH6QccB2ww/giphy.gif)
