### PR TITLE
[15 min fix] Fixed aria label for edit menu item of a comment

### DIFF
--- a/app/assets/javascripts/utilities/buildCommentHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildCommentHTML.js.erb
@@ -2,13 +2,13 @@ function buildCommentHTML(comment) {
   var iconSmallOverflowHorizontal = `<svg width="24" height="24" viewBox="0 0 24 24" class="crayons-icon pointer-events-none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M8.25 12a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zm5.25 0a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0zm3.75 1.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z" /></svg>`;
   var iconCollaspe = `<svg width="24" height="24" class="crayons-icon expanded" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 10.6771L8 6.93529L8.99982 6L12 8.80653L15.0002 6L16 6.93529L12 10.6771ZM12 15.1935L8.99982 18L8 17.0647L12 13.3229L16 17.0647L15.0002 17.9993L12 15.1935Z" /></svg>`;
   var iconExpand = `<svg width="24" height="24" class="crayons-icon collapsed" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 18L8 14.2287L8.99982 13.286L12 16.1147L15.0002 13.286L16 14.2287L12 18ZM12 7.88533L8.99982 10.714L8 9.77133L12 6L16 9.77133L15.0002 10.7133L12 7.88533Z" /></svg>`;
-  
+
   var depthClass = "";
   var customClass = "";
 
   var detailsStartHTML = "";
   var detailsEndHTML = "";
-  
+
   var commentHeader = "";
   var commentFooter = "";
   var commentAvatar = "";
@@ -19,7 +19,7 @@ function buildCommentHTML(comment) {
   } else {
     depthClass += "child "
   }
-  
+
   if ( comment.depth > 3 ) {
     depthClass += "comment--too-deep ";
   }
@@ -50,9 +50,9 @@ function buildCommentHTML(comment) {
     <a href="/${ comment.user.username }" class="crayons-link crayons-link--secondary flex items-center fw-medium">
       <span class="js-comment-username">${ comment.user.name }</span>
     </a>
-    
+
     <span class="color-base-30 px-2" role="presentation">&bull;</span>
-    
+
     <a href="${ comment.url }" class="comment-date crayons-link crayons-link--secondary fs-s">
       <time datetime="${ comment.published_timestamp }">
         ${ comment.readable_publish_date }
@@ -67,7 +67,7 @@ function buildCommentHTML(comment) {
         <li><a href="${ comment.url }" class="crayons-link crayons-link--block permalink-copybtn" aria-label="Copy link to ${ comment.user.name }'s comment" data-no-instant>Copy link</a></li>
         <li><a href="${ comment.url }/settings" class="crayons-link crayons-link--block" aria-label="Go to ${ comment.user.name }'s comment settings">Settings</a></li>
         <li><a href="/report-abuse?url=${ comment.url }" class="crayons-link crayons-link--block" aria-label="Report ${ comment.user.name }'s comment as abusive or violating our code of conduct and/or terms and conditions">Report abuse</a></li>
-        <li class="${ comment.newly_created ? '' : 'hidden' }"><a href="${ comment.url }/edit" class="crayons-link crayons-link--block" rel="nofollow" aria-label="Delete this comment">Edit</a></li>
+        <li class="${ comment.newly_created ? '' : 'hidden' }"><a href="${ comment.url }/edit" class="crayons-link crayons-link--block" rel="nofollow" aria-label="Edit this comment">Edit</a></li>
         <li class="${ comment.newly_created ? '' : 'hidden' }"><a data-no-instant="" href="${ comment.url }/delete_confirm" class="crayons-link crayons-link--block" rel="nofollow" aria-label="Delete this comment">Delete</a></li>
       </ul>
     </div>
@@ -118,7 +118,7 @@ function react(comment) {
   var num = 1;
   var iconSmallHeart = `<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" class="crayons-icon reaction-icon not-reacted"><path d="M18.884 12.595l.01.011L12 19.5l-6.894-6.894.01-.01A4.875 4.875 0 0112 5.73a4.875 4.875 0 016.884 6.865zM6.431 7.037a3.375 3.375 0 000 4.773L12 17.38l5.569-5.569a3.375 3.375 0 10-4.773-4.773L9.613 10.22l-1.06-1.062 2.371-2.372a3.375 3.375 0 00-4.492.25v.001z"/></svg>`;
   var iconSmallHeartFilled = `<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="crayons-icon reaction-icon--like reaction-icon reacted"><path d="M5.116 12.595a4.875 4.875 0 015.56-7.68h-.002L7.493 8.098l1.06 1.061 3.181-3.182a4.875 4.875 0 016.895 6.894L12 19.5l-6.894-6.894.01-.01z"/></svg>`;
-  
+
   if (!comment.newly_created && comment.heart_ids.indexOf(userData().id) > -1) {
     reactedClass = "reacted"
   }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

An `aria-label` attribute had the wrong value. The label is for the edit menu item, but the `aria-label` was referring to deletion. I came across this while getting E2E tests working in #13365.

![image](https://user-images.githubusercontent.com/833231/116638529-8635d300-a934-11eb-8679-e49697dde6ad.png)

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

1. Create a comment on a post.
2. Click on the the three dot menu at the top right of the comment you just created.

![image](https://user-images.githubusercontent.com/833231/116638689-d9a82100-a934-11eb-8eb0-37143dbbcd2b.png)

3. The available menu items appear.

![image](https://user-images.githubusercontent.com/833231/116638740-f04e7800-a934-11eb-9105-99c4df598e9d.png)

4. If in a Chromium based browser, use the dev tools to select the Edit menu item.

![image](https://user-images.githubusercontent.com/833231/116638793-052b0b80-a935-11eb-98af-e737980e812f.png)

5. You'll notice that it now says `Edit this comment`.

![image](https://user-images.githubusercontent.com/833231/116638864-37d50400-a935-11eb-8f49-725a688b1e3a.png)

6. If using Firefox, open the dev tools and switch to the Accessibility panel to view the fix.

![image](https://user-images.githubusercontent.com/833231/116639043-97331400-a935-11eb-943a-eca4469cdd5e.png)

7. You the Accessibility selector to select the Edit menu item.

![image](https://user-images.githubusercontent.com/833231/116639205-f4c76080-a935-11eb-8a63-54a51be2b80b.png)

8. The label in the accessibility tree now says "Edit this comment"

![image](https://user-images.githubusercontent.com/833231/116639162-dbbeaf80-a935-11eb-9e51-07e65a2602df.png)

### UI accessibility concerns?

As per the description, this fixes an issue when using a screen reader. The mislabeling most likely confused folks.

## Added tests?

- [ ] Yes
- [x] No, and this is why: The test for this is in #13365, which is where I came across this issue stabilizing a flaky test.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Video game character surfing](https://media.giphy.com/media/oX82gfuZgmWEKcSWZN/giphy.gif)
