### PR TITLE
15 min fix: make sure autocomplete dropdown occupies width

### DIFF
--- a/app/assets/stylesheets/components/autocomplete.scss
+++ b/app/assets/stylesheets/components/autocomplete.scss
@@ -8,12 +8,13 @@
   }
 
   &__popover {
-    min-width: 250px;
-    max-width: 250px;
     padding: var(--su-1);
     z-index: var(--z-elevate);
 
     &[data-reach-popover] {
+      // Reach UI adds a width directly to this element as an inline style. !important is needed to make sure the size is constrained.
+      width: 250px !important;
+
       @include generate-box(
         $level: 1,
         $bg: var(--card-bg),

--- a/app/assets/stylesheets/components/autocomplete.scss
+++ b/app/assets/stylesheets/components/autocomplete.scss
@@ -8,7 +8,8 @@
   }
 
   &__popover {
-    max-width: 300px;
+    min-width: 250px;
+    max-width: 250px;
     padding: var(--su-1);
     z-index: var(--z-elevate);
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Occasionally the autocomplete dropdown is getting into a bad state when a selection is made by clicking, instead of by keyboard. See video:

https://user-images.githubusercontent.com/20773163/116683681-ddc15680-a9a7-11eb-9da2-917d0cfe0654.mp4

You can see in the UI the dropdown is shrinking to a tiny width, causing the click event to be missed. It's pretty weird, but it seems like we can't rely on the reach UI CSS for the width of this component, and it's better for us to be explicit anyway. I've added a min-width for the dropdown to ensure it never shrinks like this.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

The regression risk on this is very small, since it's only a CSS change.

- We should test this in both the article comments and post editor sections.
- Try mentioning some users, always selecting the option by click with mouse
- The dropdown shouldn't shrink, and your selection should appear in the textarea

https://user-images.githubusercontent.com/20773163/116684011-49a3bf00-a9a8-11eb-857f-c81981e14732.mp4


### UI accessibility concerns?

This change makes sure the selectable area remains large enough to be clicked.

## Added tests?

- [ ] Yes
- [X] No, and this is why: This is CSS/visual only
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![good enough](https://i.giphy.com/media/3b8GDuWKKGZIyACVM0/giphy.webp)
