### PR TITLE
[15 min fix] Fix a timing issue in a cypress test (possibly) causing flakiness

### DIFF
--- a/cypress/integration/adminFlows/config/authenticationSection.spec.js
+++ b/cypress/integration/adminFlows/config/authenticationSection.spec.js
@@ -58,16 +58,17 @@ describe('Authentication Section', () => {
           cy.findByLabelText('Facebook enabled').should('not.be.visible');
           cy.findByLabelText('GitHub enabled').should('not.be.visible');
           cy.findByLabelText('Twitter enabled').should('not.be.visible');
+
+          cy.visit('/signout_confirm');
+
+          cy.findByRole('button', { name: 'Yes, sign out' }).click();
+          cy.findByRole('link', { name: 'Create account' }).click();
+
+          cy.findByLabelText('Sign up with Email').should('not.exist');
+          cy.findByLabelText('Sign up with Facebook').should('not.exist');
+          cy.contains('invite only').should('be.visible');
         });
       });
-      cy.visit('/signout_confirm');
-
-      cy.findByText('Yes, sign out').click();
-      cy.findByText('Create account').click();
-
-      cy.findByLabelText('Sign up with Email').should('not.exist');
-      cy.findByLabelText('Sign up with Facebook').should('not.exist');
-      cy.contains('invite only').should('be.visible');
     });
   });
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Very very occasionally we were seeing this Cypress spec fail in CI. I tried and failed to reproduce locally, but given the test was failing at the point of sign out, my best guess is that because this chunk of the test was outside of the Promise of the preceding test steps, it was occasionally running too early. 

One failure report:

![screenshot of the Travis build output stating that 'Create account' couldn't be found](https://user-images.githubusercontent.com/20773163/116707751-eecd9000-a9c6-11eb-9238-8c7b2201151a.png)


It's only hunch, but either way it makes sense to change it. If it keeps intermittently failing, then back to the drawing board!

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Nothing to do here other than to run the frontend tests build job a few times before deciding this is good.

### UI accessibility concerns?

N/A

## Added tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Jim Halpert looking unsure](https://i.giphy.com/media/e9naycep2pz7OHQ4n0/giphy.webp)
