### PR TITLE
Improve bash info for windows user

### DIFF
--- a/bin/container-setup
+++ b/bin/container-setup
@@ -61,7 +61,7 @@ elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 else
 
   echo "Oof! Sorry! This OS is unsupported! :("
-  echo "If your are on Windows OS and have Docker or Podman for windows installed:"
+  echo "If you're on Windows OS and have Docker or Podman for windows installed:"
   echo "Docker: https://docs.docker.com/docker-for-windows/install/"
   echo "Podman: https://podman.io/getting-started/installation"
   echo

--- a/bin/container-setup
+++ b/bin/container-setup
@@ -61,6 +61,15 @@ elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 else
 
   echo "Oof! Sorry! This OS is unsupported! :("
+  echo "If your are on Windows OS and have Docker or Podman for windows installed:"
+  echo "Docker: https://docs.docker.com/docker-for-windows/install/"
+  echo "Podman: https://podman.io/getting-started/installation"
+  echo
+  echo "Execute the following:"
+  echo "docker-compose build"
+  echo "docker-compose up"
+
+  exit 1
 
 fi
 

--- a/bin/container-setup
+++ b/bin/container-setup
@@ -61,7 +61,7 @@ elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 else
 
   echo "Oof! Sorry! This OS is unsupported! :("
-  echo "If you're on Windows OS and have Docker or Podman for windows installed:"
+  echo "If you're on Windows OS and have Docker or Podman for Windows installed:"
   echo "Docker: https://docs.docker.com/docker-for-windows/install/"
   echo "Podman: https://podman.io/getting-started/installation"
   echo


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Whilst following the setup guidelines on windows using container mothed, executing the [script](https://docs.forem.com/installation/containers/#running-forem-with-docker-via-docker-compose): `bin/container-setup` on windows OS, returns:

```sh
Oof! Sorry! This OS is unsupported! :(
Starting the Forem container stack...
```
So, I convert it to this as it is more informative to windows users like myself:
```sh
Oof! Sorry! This OS is unsupported! :(
If you are on Windows OS and have Docker or Podman for windows installed:
Docker: https://docs.docker.com/docker-for-windows/install/
Podman: https://podman.io/getting-started/installation

Execute the following:
docker-compose build
docker-compose up
```
and also exiting on failure so as not to echo `Starting the Forem container stack...`

## Related Tickets & Documents
None

## QA Instructions, Screenshots, Recordings

Run in git bash on windows: `bin/container-setup`

## Added tests?

- [ ] Yes
- [x] No, and this is why: it is related to a bash script for starting up containers
- [ ] I need help with writing tests

Better wordings suggestions
![hmmm](https://user-images.githubusercontent.com/16971163/116762030-1e08ef00-aa11-11eb-92ec-9b0bd81a98bd.gif)
