### PR TITLE
[15 min fix] Add a step to remove flake in a cypress test

### DIFF
--- a/cypress/integration/loginFlows/userLogout.spec.js
+++ b/cypress/integration/loginFlows/userLogout.spec.js
@@ -17,11 +17,14 @@ describe('User Logout', () => {
 
     // Sign out confirmation page is rendered
     cy.url().should('contains', '/signout_confirm');
-    cy.findByText('Yes, sign out').click();
+    cy.findByRole('button', { name: 'Yes, sign out' }).click();
 
     // User should be redirected to the homepage
     const { baseUrl } = Cypress.config();
     cy.url().should('equal', `${baseUrl}`);
+
+    // Make sure the state has updated to logged out
+    cy.findAllByRole('link', { name: 'Log in' });
 
     // User data should not exist on the document or in localStorage
     cy.document().should((doc) => {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This Cypress test flaked for me in CI recently. I haven't been able to reproduce locally, but it failed on asserting that the user info had been removed from the body element. My best guess is that it ran too fast for the body element to have updated(?) - it's just a hunch, but either way, the additional step added will either:

- Make sure we wait until the logged out state is updated, or
- Give us a better error if it fails here again (i.e. we'd know for sure if the user was seeing a logged out UI or not)

This is the failure I got, for reference:

<img width="1403" alt="screenshot of Travis failure, stating that this test failed because the user data was still in the body dataset" src="https://user-images.githubusercontent.com/20773163/116777963-3efc2f00-aa67-11eb-8fa3-a875dbd739c3.png">


## Related Tickets & Documents

N/A 

## QA Instructions, Screenshots, Recordings

This is just for a Cypress test so as long as the build goes green, we're all good

### UI accessibility concerns?

N/A

## Added tests?

- [X] Yes (updated)
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: I'm not aware of anyone else having spotted flake in this test so I think it must be very rare

