### PR TITLE
Organizations delete optimizations and refactoring

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -15,7 +15,7 @@ class Organization < ApplicationRecord
   before_validation :check_for_slug_change
   before_validation :evaluate_markdown
 
-  # TODO: [@rhymes] revisit this callback, `update_articles_cached_organization` and `article_sync`
+  # TODO: [@rhymes] revisit this callback and `update_articles_cached_organization`
   # when we remove Elasticsearch
   before_save :update_articles
   before_save :remove_at_from_usernames
@@ -26,7 +26,7 @@ class Organization < ApplicationRecord
   # This callback will eventually invoke Article.update_cached_user to update the organization.name
   # only when it has been changed, thus invoking the trigger on Article.reading_list_document
   after_update_commit :update_articles_cached_organization
-  after_destroy_commit :bust_cache, :article_sync
+  after_destroy_commit :bust_cache
 
   has_many :articles, dependent: :nullify
   has_many :collections, dependent: :nullify
@@ -160,10 +160,5 @@ class Organization < ApplicationRecord
     )
 
     errors.add(:slug, "is taken.") if slug_taken
-  end
-
-  def article_sync
-    # Syncs article cached organization and updates Elasticsearch docs
-    Article.where(id: cached_article_ids).find_each(&:save)
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -20,10 +20,6 @@ class Organization < ApplicationRecord
   before_save :update_articles
   before_save :remove_at_from_usernames
   before_save :generate_secret
-  # You have to put before_destroy callback BEFORE the dependent: :nullify
-  # to ensure they execute before the records are updated
-  # https://guides.rubyonrails.org/active_record_callbacks.html#destroying-an-object
-  before_destroy :cache_article_ids
 
   after_save :bust_cache
 
@@ -81,12 +77,6 @@ class Organization < ApplicationRecord
   alias_attribute :old_username, :old_slug
   alias_attribute :old_old_username, :old_old_slug
   alias_attribute :website_url, :url
-
-  attr_accessor :cached_article_ids
-
-  def cache_article_ids
-    self.cached_article_ids = articles.ids
-  end
 
   def check_for_slug_change
     return unless slug_changed?

--- a/app/services/organizations/delete.rb
+++ b/app/services/organizations/delete.rb
@@ -2,10 +2,10 @@ module Organizations
   class Delete
     def initialize(org)
       @org = org
+      @article_ids = org.article_ids
     end
 
     def call
-      self.article_ids = org.article_ids
       delete_notifications
       org.destroy
       articles_sync
@@ -17,8 +17,7 @@ module Organizations
 
     private
 
-    attr_reader :org
-    attr_accessor :article_ids
+    attr_reader :org, :article_ids
 
     def delete_notifications
       sql = <<-SQL.squish

--- a/app/services/organizations/delete.rb
+++ b/app/services/organizations/delete.rb
@@ -33,8 +33,8 @@ module Organizations
     end
 
     def articles_sync
-      # Syncs article cached organization and updates Elasticsearch docs
-      Article.where(id: article_ids).find_each(&:save)
+      # Syncs article cached organization
+      Article.where(id: article_ids).update_all(cached_organization: nil)
     end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -289,15 +289,6 @@ RSpec.describe Organization, type: :model do
 
           expect(article.reload.reading_list_document).to eq(old_reading_list_document)
         end
-
-        it "removes the organization name from the .reading_list_document after destroy" do
-          article = Article.find_by(organization_id: organization.id)
-
-          organization.update(name: "ACME")
-          organization.destroy
-
-          expect(article.reload.reading_list_document).not_to include("acme")
-        end
       end
       # rubocop:enable RSpec/NestedGroups
     end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -71,14 +71,6 @@ RSpec.describe Organization, type: :model do
     end
   end
 
-  context "when callbacks are triggered after commit" do
-    it "on destroy updates related article data" do
-      article = create(:article, organization: organization)
-      organization.destroy
-      expect(article.reload.cached_organization).to be_nil
-    end
-  end
-
   describe "#name" do
     it "rejects names with over 50 characters" do
       organization.name = "x" * 51

--- a/spec/services/organizations/delete_spec.rb
+++ b/spec/services/organizations/delete_spec.rb
@@ -2,9 +2,17 @@ require "rails_helper"
 
 RSpec.describe Organizations::Delete, type: :service do
   let(:org) { create(:organization) }
+  let(:org_id) { org.id }
 
   it "deletes an organization" do
     described_class.call(org)
-    expect(Organization.find_by(id: org.id)).to be_nil
+    expect(Organization.find_by(id: org_id)).to be_nil
+  end
+
+  it "deletes notifications" do
+    create_list(:notification, 5, organization_id: org.id)
+    expect(Notification.where(organization_id: org_id).count).to eq(5)
+    described_class.call(org)
+    expect(Notification.where(organization_id: org_id).count).to eq(0)
   end
 end

--- a/spec/services/organizations/delete_spec.rb
+++ b/spec/services/organizations/delete_spec.rb
@@ -34,13 +34,5 @@ RSpec.describe Organizations::Delete, type: :service do
 
       expect(article.reload.reading_list_document).not_to include("acme")
     end
-
-    it "updates related article data" do
-      drain_all_sidekiq_jobs
-      expect(article.elasticsearch_doc.dig("_source", "organization", "id")).to eq(org_id)
-      described_class.call(org)
-      sidekiq_perform_enqueued_jobs
-      expect(article.elasticsearch_doc.dig("_source", "organization")).to be_nil
-    end
   end
 end

--- a/spec/services/organizations/delete_spec.rb
+++ b/spec/services/organizations/delete_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Organizations::Delete, type: :service do
   end
 
   it "deletes notifications" do
-    create_list(:notification, 5, organization_id: org.id)
+    create_list(:notification, 5, organization_id: org_id)
     expect(Notification.where(organization_id: org_id).count).to eq(5)
     described_class.call(org)
     expect(Notification.where(organization_id: org_id).count).to eq(0)
   end
 
   context "with articles" do
-    let!(:article) { create(:article, organization_id: org.id) }
+    let!(:article) { create(:article, organization_id: org_id) }
 
     it "syncs articles" do
       expect(article.cached_organization.name).to eq(org.name)
@@ -37,7 +37,7 @@ RSpec.describe Organizations::Delete, type: :service do
 
     it "updates related article data" do
       drain_all_sidekiq_jobs
-      expect(article.elasticsearch_doc.dig("_source", "organization", "id")).to eq(org.id)
+      expect(article.elasticsearch_doc.dig("_source", "organization", "id")).to eq(org_id)
       described_class.call(org)
       sidekiq_perform_enqueued_jobs
       expect(article.elasticsearch_doc.dig("_source", "organization")).to be_nil


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
- delete org notifications in batches
- moved on destroy callback to the service

## Related Tickets & Documents
#12575 
#13388

## QA Instructions, Screenshots, Recordings
No changes in the logic, organization delete should work the same way as it used to.

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: no changes in the behavior