### PR TITLE
Retain registration form data on failed submission

### DIFF
--- a/app/views/shared/authentication/_email_registration_form.html.erb
+++ b/app/views/shared/authentication/_email_registration_form.html.erb
@@ -4,7 +4,7 @@
       <%= flash[:notice] %>
     </div>
   <% end %>
-  <%= form_for(User.new, as: :user, data: { testid: "registration-form" }, url: registration_path(:user)) do |f| %>
+  <%= form_for(@user, as: :user, data: { testid: "registration-form" }, url: registration_path(:user)) do |f| %>
     <% if defined?(resource) && resource&.errors&.any? %>
       <div class="crayons-card crayons-card--secondary crayons-notice crayons-notice--danger" role="alert" data-testid="signup-errors">
         <div class="crayons-card__header">

--- a/cypress/integration/registrationFlows/emailRegistration.spec.js
+++ b/cypress/integration/registrationFlows/emailRegistration.spec.js
@@ -6,15 +6,15 @@ describe('Sign up with email', () => {
 
   // Regression test for #11099
   it('should preserve the form data on unsuccesful submissions', () => {
-    cy.findByRole('link', {name: 'Sign up with Email'}).click();
+    cy.findByRole('link', { name: /Sign up with Email/ }).click();
 
-    cy.get('input[type="file"]').attachFile('images/admin-image.png');
+    cy.findByLabelText('Profile image').attachFile('images/admin-image.png');
     cy.findByLabelText('Name').type('Sloan');
     cy.findByLabelText('Username').type('s');
     cy.findByLabelText('Email').type('sloan@example.com');
     cy.findByLabelText('Password').type('password');
     cy.findByLabelText('Password confirmation').type('password');
-    cy.findByRole('button', {name: 'Sign up'})).click();
+    cy.findByRole('button', { name: 'Sign up' }).click();
 
     // The validation failed but the user's data is not lost
     cy.get('li')

--- a/cypress/integration/registrationFlows/emailRegistration.spec.js
+++ b/cypress/integration/registrationFlows/emailRegistration.spec.js
@@ -6,7 +6,7 @@ describe('Sign up with email', () => {
 
   // Regression test for #11099
   it('should preserve the form data on unsuccesful submissions', () => {
-    cy.get('a').contains('Sign up with Email').click();
+    cy.findByRole('link', {name: 'Sign up with Email'}).click();
 
     cy.get('input[type="file"]').attachFile('images/admin-image.png');
     cy.findByLabelText('Name').type('Sloan');
@@ -14,7 +14,7 @@ describe('Sign up with email', () => {
     cy.findByLabelText('Email').type('sloan@example.com');
     cy.findByLabelText('Password').type('password');
     cy.findByLabelText('Password confirmation').type('password');
-    cy.get('input').contains('Sign up').click();
+    cy.findByRole('button', {name: 'Sign up'})).click();
 
     // The validation failed but the user's data is not lost
     cy.get('li')

--- a/cypress/integration/registrationFlows/emailRegistration.spec.js
+++ b/cypress/integration/registrationFlows/emailRegistration.spec.js
@@ -9,19 +9,19 @@ describe('Sign up with email', () => {
     cy.get('a').contains('Sign up with Email').click();
 
     cy.get('input[type="file"]').attachFile('images/admin-image.png');
-    cy.getInputByLabel('Name').type('Sloan');
-    cy.getInputByLabel('Username').type('s');
-    cy.getInputByLabel('Email').type('sloan@example.com');
-    cy.getInputByLabel('Password').type('password');
-    cy.getInputByLabel('Password confirmation').type('password');
+    cy.findByLabelText('Name').type('Sloan');
+    cy.findByLabelText('Username').type('s');
+    cy.findByLabelText('Email').type('sloan@example.com');
+    cy.findByLabelText('Password').type('password');
+    cy.findByLabelText('Password confirmation').type('password');
     cy.get('input').contains('Sign up').click();
 
     // The validation failed but the user's data is not lost
     cy.get('li')
       .contains('Username is too short (minimum is 2 characters)')
       .should('be.visible');
-    cy.getInputByLabel('Name').should('have.value', 'Sloan');
-    cy.getInputByLabel('Username').should('have.value', 's');
-    cy.getInputByLabel('Email').should('have.value', 'sloan@example.com');
+    cy.findByLabelText('Name').should('have.value', 'Sloan');
+    cy.findByLabelText('Username').should('have.value', 's');
+    cy.findByLabelText('Email').should('have.value', 'sloan@example.com');
   });
 });

--- a/cypress/integration/registrationFlows/emailRegistration.spec.js
+++ b/cypress/integration/registrationFlows/emailRegistration.spec.js
@@ -1,0 +1,27 @@
+describe('Sign up with email', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.visit('/enter?state=new-user');
+  });
+
+  // Regression test for #11099
+  it('should preserve the form data on unsuccesful submissions', () => {
+    cy.get('a').contains('Sign up with Email').click();
+
+    cy.get('input[type="file"]').attachFile('images/admin-image.png');
+    cy.getInputByLabel('Name').type('Sloan');
+    cy.getInputByLabel('Username').type('s');
+    cy.getInputByLabel('Email').type('sloan@example.com');
+    cy.getInputByLabel('Password').type('password');
+    cy.getInputByLabel('Password confirmation').type('password');
+    cy.get('input').contains('Sign up').click();
+
+    // The validation failed but the user's data is not lost
+    cy.get('li')
+      .contains('Username is too short (minimum is 2 characters)')
+      .should('be.visible');
+    cy.getInputByLabel('Name').should('have.value', 'Sloan');
+    cy.getInputByLabel('Username').should('have.value', 's');
+    cy.getInputByLabel('Email').should('have.value', 'sloan@example.com');
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -216,19 +216,3 @@ Cypress.Commands.add('createResponseTemplate', ({ title, content }) => {
     `utf8=%E2%9C%93&response_template%5Btitle%5D=${encodedTitle}&response_template%5Bcontent%5D=${encodedContent}`,
   );
 });
-
-/**
- * Helper to get a form element by its label
- *
- * @param {string} label The form element's label.
- *
- * @returns {Cypress.Chainable<Element>} The form input element.
- */
-Cypress.Commands.add('getInputByLabel', (label) => {
-  return cy
-    .contains('label', label)
-    .invoke('attr', 'for')
-    .then((id) => {
-      cy.get('#' + id);
-    });
-});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -216,3 +216,19 @@ Cypress.Commands.add('createResponseTemplate', ({ title, content }) => {
     `utf8=%E2%9C%93&response_template%5Btitle%5D=${encodedTitle}&response_template%5Bcontent%5D=${encodedContent}`,
   );
 });
+
+/**
+ * Helper to get a form element by its label
+ *
+ * @param {string} label The form element's label.
+ *
+ * @returns {Cypress.Chainable<Element>} The form input element.
+ */
+Cypress.Commands.add('getInputByLabel', (label) => {
+  return cy
+    .contains('label', label)
+    .invoke('attr', 'for')
+    .then((id) => {
+      cy.get('#' + id);
+    });
+});

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -11,6 +11,7 @@ seeder = Seeder.new
 
 Settings::UserExperience.public = true
 SiteConfig.waiting_on_first_user = false
+Settings::Authentication.allow_email_password_registration = true
 
 ##############################################################################
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature
- [X] Bug Fix

## Description

Currently when registering via email the form gets cleared after an unsuccessful submission. This PR fixes that. Note that work on this was originally started in #11201 but since this PR has stalled I decided to tackle this myself and added an e2e regression test.

## Related Tickets & Documents

Closes  https://github.com/forem/forem/issues/11099

## QA Instructions, Screenshots, Recordings

1. Ensure that `Settings::Authentication::allow_email_password_registration` is set to `true`.
2. Log out any logged-in user
3. Go to http://localhost:3000/enter?state=new-user
4. Submit an invalid form (non-matching password or 1 character username).
5. You should see the validation error but the previously entered data (except for the passwords) should still be in the form.

### UI accessibility concerns?

None

## Added tests?

- [X] Yes, added an e2e test
- 
## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: Minor change