### PR TITLE
[15 min fix] fix accessible names of sign up options

### DIFF
--- a/app/views/shared/authentication/_providers_registration_form.html.erb
+++ b/app/views/shared/authentication/_providers_registration_form.html.erb
@@ -3,13 +3,13 @@
     <% next if provider.provider_name == :apple && !Flipper.enabled?(:apple_auth) %>
     <%= form_with url: provider.sign_in_path(state: "navbar_basic"), class: "flex w-100", local: true do |f| %>
       <%= f.button type: :submit, class: "crayons-btn crayons-btn--l crayons-btn--brand-#{provider.provider_name} crayons-btn--icon-left grow-1 whitespace-nowrap" do %>
-        <%= inline_svg_tag("#{provider.provider_name}.svg", aria: true, class: "crayons-icon", title: provider.provider_name) %>
+        <%= inline_svg_tag("#{provider.provider_name}.svg", aria_hidden: true, class: "crayons-icon", title: provider.provider_name) %>
         <%= params[:state] == "new-user" ? "Sign up" : "Continue" %> with <%= provider.official_name %>
       <% end %>
     <% end %>
   <% end %>
   <% if params[:state] == "new-user" && Settings::Authentication.allow_email_password_registration && !Settings::Authentication.invite_only_mode %>
-    <%= link_to "#{inline_svg_tag('email.svg', aria: true, class: 'crayons-icon', title: 'email')}Sign up with Email".html_safe,
+    <%= link_to "#{inline_svg_tag('email.svg', aria_hidden: true, class: 'crayons-icon', title: 'email')}Sign up with Email".html_safe,
                 request.params.merge(state: "email_signup").except("i"),
                 class: "crayons-btn crayons-btn--l crayons-btn--brand-email crayons-btn--icon-left whitespace-nowrap",
                 data: { no_instant: "" } %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On the sign up options page, each icon was being announced with the link e.g. "email Sign up with email" / "twitter Sign up with Twitter". This PR hides those icons so the accessible names are just e.g. "Sign up with email".

Behaviour before this fix:

https://user-images.githubusercontent.com/20773163/116853678-5dd8fd80-abee-11eb-8043-c236ea91bd48.mp4


## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

- Enable some different sign up options
- Log out and click the 'create account' button
- Using either the screen reader or the dev tools accessibility inspector, check the accessible names of each button/link 


VoiceOver on Safari:


https://user-images.githubusercontent.com/20773163/116853663-574a8600-abee-11eb-8140-638e669e4b3f.mp4


### UI accessibility concerns?

This is a minor improvement for anyone using a screen reader on the site

## Added tests?

- [ ] Yes
- [X] No, and this is why:a minor fix, that will eventually get swept up by end to end tests for the onboarding flow
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: minor fix
      shared_

