### PR TITLE
`deep_dup` the admin menu before modifying its content

### DIFF
--- a/app/models/admin_menu.rb
+++ b/app/models/admin_menu.rb
@@ -90,7 +90,7 @@ class AdminMenu
     # We default to creating a ITEMS constant with visibility set to false
     # and then simply amend the visibility of the feature flag when it's
     # turned on, instead of creating the payload dynamically each time.
-    menu_items = ITEMS.dup
+    menu_items = ITEMS.deep_dup
 
     if FeatureFlag.enabled?(:profile_admin)
       profile_hash = menu_items.dig(:customization, :children).detect { |item| item[:controller] == "profile_fields" }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The content of the `AdminMenu::ITEMS` hash values was being modified during execution if a feature flag was enabled. This was mostly a test time concern, it would only show in a production release if a feature flag were disabled (possibly until the app was restarted).

When we call `ITEMS.dup`, the values pointed to by the keys are not
duplicated (the hash is, but the keys and values are the same). This means modification of the values (setting profile fields visible, for example) is shared between calls to me

Because the FeatureFlag enabled path is mutating the values, this is interacting during tests.

`deep_dup` the ITEMS hash before mutating when the either of the two menu item feature flags are enabled.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

My failing context was this (it was seen a few times today by @vaidehijoshi ).

```
bundle exec rspec spec/requests/admin/nested_sidebar_spec.rb --order=random --format=documentation --seed=62634
```

This passes now.

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: 
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: tiny performance/memory cost, tiny correctness improvement.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

Look at that flakey goodness
![image](https://user-images.githubusercontent.com/1237369/116921104-25024e00-ac19-11eb-8e90-6ee2a44d2933.png)
