### PR TITLE
Migrate "static" profile fields into new columns

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -21,6 +21,6 @@ class ProfilesController < ApplicationController
   private
 
   def update_params
-    params.permit(profile: Profile.attributes, user: ALLOWED_USER_PARAMS)
+    params.permit(profile: Profile.attributes + Profile::STATIC_FIELDS, user: ALLOWED_USER_PARAMS)
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -21,6 +21,6 @@ class ProfilesController < ApplicationController
   private
 
   def update_params
-    params.permit(profile: Profile.attributes + Profile::STATIC_FIELDS, user: ALLOWED_USER_PARAMS)
+    params.permit(profile: Profile.attributes + Profile.static_fields, user: ALLOWED_USER_PARAMS)
   end
 end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -474,9 +474,9 @@ class StoriesController < ApplicationController
     # For further information on the sameAs property, please refer to this link:
     # https://schema.org/sameAs
     [
-      @user.twitter_username.presence ? "https://twitter.com/#{@user.twitter_username}" : nil,
-      @user.github_username.presence ? "https://github.com/#{@user.github_username}" : nil,
-      @user.profile.try(:website_url),
+      @user.twitter_username.present? ? "https://twitter.com/#{@user.twitter_username}" : nil,
+      @user.github_username.present? ? "https://github.com/#{@user.github_username}" : nil,
+      @user.website_url,
     ].reject(&:blank?)
   end
 

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -39,6 +39,9 @@ class Profile < ApplicationRecord
 
     ProfileField.find_each do |field|
       # Don't generate accessors for static fields stored on the table.
+      # TODO: [@jacobherrington] Remove this when ProfileFields for the static
+      # fields are dropped from production and the associated data is removed.
+      # https://github.com/forem/forem/pull/13641#discussion_r637641185
       next if STATIC_FIELDS.any?(field.attribute_name)
 
       store_attribute :data, field.attribute_name.to_sym, field.type
@@ -56,6 +59,10 @@ class Profile < ApplicationRecord
 
   def self.special_attributes
     SPECIAL_DISPLAY_ATTRIBUTES
+  end
+
+  def self.static_fields
+    STATIC_FIELDS
   end
 
   def custom_profile_attributes

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -9,6 +9,11 @@ class Profile < ApplicationRecord
 
   store_attribute :data, :custom_attributes, :json, default: {}
 
+  # Static fields are columns on the profiles table; they have no relationship
+  # to a ProfileField record. These are columns we can safely assume exist for
+  # any profile on a given Forem.
+  STATIC_FIELDS = %w[summary location website_url].freeze
+
   SPECIAL_DISPLAY_ATTRIBUTES = %w[
     summary
     employment_title
@@ -33,6 +38,9 @@ class Profile < ApplicationRecord
     return unless Database.table_available?("profiles")
 
     ProfileField.find_each do |field|
+      # Don't generator accessors for static fields stored on the table.
+      next if STATIC_FIELDS.any?(field.attribute_name)
+
       store_attribute :data, field.attribute_name.to_sym, field.type
     end
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -38,7 +38,7 @@ class Profile < ApplicationRecord
     return unless Database.table_available?("profiles")
 
     ProfileField.find_each do |field|
-      # Don't generator accessors for static fields stored on the table.
+      # Don't generate accessors for static fields stored on the table.
       next if STATIC_FIELDS.any?(field.attribute_name)
 
       store_attribute :data, field.attribute_name.to_sym, field.type

--- a/app/services/profiles/update.rb
+++ b/app/services/profiles/update.rb
@@ -26,7 +26,6 @@ module Profiles
       @profile = user.profile
       @updated_profile_attributes = updated_attributes[:profile] || {}
       @updated_user_attributes = updated_attributes[:user].to_h || {}
-      @updated_static_profile_attributes = @updated_profile_attributes.extract!(*Profile::STATIC_FIELDS)
       @errors = []
       @success = false
     end
@@ -62,7 +61,6 @@ module Profiles
 
       Profile.transaction do
         update_profile
-        @profile.update(**@updated_static_profile_attributes)
         @user.update!(@updated_user_attributes)
       end
       true

--- a/app/services/profiles/update.rb
+++ b/app/services/profiles/update.rb
@@ -26,6 +26,7 @@ module Profiles
       @profile = user.profile
       @updated_profile_attributes = updated_attributes[:profile] || {}
       @updated_user_attributes = updated_attributes[:user].to_h || {}
+      @updated_static_profile_attributes = @updated_profile_attributes.extract!(*Profile::STATIC_FIELDS)
       @errors = []
       @success = false
     end
@@ -61,6 +62,7 @@ module Profiles
 
       Profile.transaction do
         update_profile
+        @profile.update(**@updated_static_profile_attributes)
         @user.update!(@updated_user_attributes)
       end
       true

--- a/app/validators/profile_validator.rb
+++ b/app/validators/profile_validator.rb
@@ -40,7 +40,7 @@ class ProfileValidator < ActiveModel::Validator
     return if record.summary.blank?
 
     # Grandfather in people who had a too long summary before
-    previous_summary = record.data_was[SUMMARY_ATTRIBUTE]
+    previous_summary = record.data_was[SUMMARY_ATTRIBUTE] || record.summary_was
     return if previous_summary && previous_summary.size > MAX_SUMMARY_LENGTH
 
     record.summary.size > MAX_SUMMARY_LENGTH

--- a/app/validators/profile_validator.rb
+++ b/app/validators/profile_validator.rb
@@ -36,11 +36,15 @@ class ProfileValidator < ActiveModel::Validator
     # throws a NoMethodError
     return unless record.respond_to?(SUMMARY_ATTRIBUTE)
 
+    # TODO: [@jacobherrington] This will need to be addressed when the summary
+    # ProfileField is dropped from production.
     return unless ProfileField.exists?(attribute_name: SUMMARY_ATTRIBUTE)
     return if record.summary.blank?
 
     # Grandfather in people who had a too long summary before
-    previous_summary = record.data_was[SUMMARY_ATTRIBUTE] || record.summary_was
+    # TODO: [@jacobherrington] `record.data_was` can be removed when we delete
+    # the old data and drop the fields from `Profile.static_fields`.
+    previous_summary = record.summary_was || record.data_was[SUMMARY_ATTRIBUTE]
     return if previous_summary && previous_summary.size > MAX_SUMMARY_LENGTH
 
     record.summary.size > MAX_SUMMARY_LENGTH

--- a/db/migrate/20210503205816_add_static_profile_fields_to_profile.rb
+++ b/db/migrate/20210503205816_add_static_profile_fields_to_profile.rb
@@ -1,0 +1,7 @@
+class AddStaticProfileFieldsToProfile < ActiveRecord::Migration[6.1]
+  def change
+    add_column :profiles, :summary, :text
+    add_column :profiles, :location, :string
+    add_column :profiles, :website_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1014,8 +1014,11 @@ ActiveRecord::Schema.define(version: 2021_05_12_025422) do
   create_table "profiles", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.jsonb "data", default: {}, null: false
+    t.string "location"
+    t.text "summary"
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
+    t.string "website_url"
     t.index ["user_id"], name: "index_profiles_on_user_id", unique: true
   end
 

--- a/lib/data_update_scripts/20210503175027_move_summary_websiteurl_and_location_to_profile.rb
+++ b/lib/data_update_scripts/20210503175027_move_summary_websiteurl_and_location_to_profile.rb
@@ -1,0 +1,15 @@
+module DataUpdateScripts
+  class MoveSummaryWebsiteUrlAndLocationToProfile
+    def run
+      Profile.select(:id,
+                     :user_id,
+                     "data->'summary' as data_summary",
+                     "data->'location' as data_location",
+                     "data->'website_url' as data_website_url").find_each do |profile|
+        profile.update_columns(summary: profile.data_summary,
+                               location: profile.data_location,
+                               website_url: profile.data_website_url)
+      end
+    end
+  end
+end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -12,10 +12,11 @@ FactoryBot.define do
         employer_name: "DEV",
         employer_url: "http://dev.to",
         employment_title: "Software Engineer",
-        skills_languages: "Ruby",
-        summary: "I do things with computers",
-        website_url: "http://example.com"
+        skills_languages: "Ruby"
       }
     end
+    website_url { "http://example.com" }
+    location { "Halifax, Nova Scotia" }
+    summary { "I do things with computers" }
   end
 end

--- a/spec/system/user/user_edits_profile_spec.rb
+++ b/spec/system/user/user_edits_profile_spec.rb
@@ -80,5 +80,17 @@ RSpec.describe "User edits their profile", type: :system do
         expect(page).to have_text("pistachio")
       end
     end
+
+    it "respects static profile fields" do
+      fill_in "profile[summary]", with: "Star of hit 90s sitcom Horsin' Around"
+      fill_in "profile[location]", with: "Hollywoo"
+
+      click_button "Save"
+
+      visit "/#{user.username}"
+
+      expect(page).to have_text("Horsin' Around")
+      expect(page).to have_text("Hollywoo")
+    end
   end
 end

--- a/spec/system/user/user_edits_profile_spec.rb
+++ b/spec/system/user/user_edits_profile_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "User edits their profile", type: :system do
       end
     end
 
-    it "respects static profile fields" do
+    it "respects static profile fields", :aggregate_failures do
       fill_in "profile[summary]", with: "Star of hit 90s sitcom Horsin' Around"
       fill_in "profile[location]", with: "Hollywoo"
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Move static profile fields to profiles columns

In order to remove some ambiguity around the availability of certain
profile fields, we can designate certain fields as "static." These
fields are intended to exist on every Forem regardless of configuration;
they contain basic personal info that most Forem's will likely use.

Because these fields already exist on some Forems it is necessary to
migrate the data from existing profile's data column to their respective
columns.

This change should behave as expected irrespective of the existence of
the static fields having associated ProfileFields, however, the UI that
is rendered in a user's settings still depends on the presence of the
ProfileFields. We can address that in a future change when we are
prepared to delete those ProfileFields entirely. We should make sure the
migration occurs without issue before moving to that step, in my
opinion.

## Related Tickets & Documents

https://github.com/forem/forem/issues/12157

## QA Instructions, Screenshots, Recordings

1. Create some local users with profile data (summary, location, and website_url)
2. Run the data update script - all of the data should be present in the associated column
3. Update summary, location, and/or website_url in the UI - it should update the associated column, not the data column on that user's profile.
4. Check the Profile UI to ensure that the correct data is rendered.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [x] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

No, the data update script should take care of things. We *should not* delete the associate ProfileFields yet! That can be done in another data update script once we are confident in the results of this change.

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media1.giphy.com/media/26tP4gFBQewkLnMv6/giphy.gif?cid=ecf05e470195oqmx0uqviv2p4cssd6qkqtusv0mg3xi1g710&rid=giphy.gif&ct=g)
