### PR TITLE
Handle GitHub "Repository access blocked" error

### DIFF
--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -40,6 +40,8 @@ module GithubRepos
       rescue GitHub::Errors::ClientError => e
         if e.message.include? "Repository access blocked"
           repo.destroy
+        else
+          raise e
         end
       end
     end

--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -37,7 +37,7 @@ module GithubRepos
              Github::Errors::AccountSuspended,
              Github::Errors::RepositoryUnavailable
         repo.destroy
-      rescue GitHub::Errors::ClientError => e
+      rescue Github::Errors::ClientError => e
         if e.message.include? "Repository access blocked"
           repo.destroy
         else

--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -37,6 +37,10 @@ module GithubRepos
              Github::Errors::AccountSuspended,
              Github::Errors::RepositoryUnavailable
         repo.destroy
+      rescue GitHub::Errors::ClientError => e
+        if e.message.include? "Repository access blocked"
+          repo.destroy
+        end
       end
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We've been seeing a lot of these errors on DEV, and it's a pretty reasonable expectation that if we're being blocked from seeing them using the user's OAuth access token that this isn't temporary.

We already do something similar for other errors, this is mostly the same concept but the exception class is generic, so we can't simply add the client error to the same thing or we'd be dropping repos every time we had a temporary failure.

## Added tests?

- [ ] Yes
- [x] No, and this is why: I'm not sure we need them here, but if we do it's cool, I can add them
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

- Resolve [this error in Honeybadger](https://app.honeybadger.io/projects/66984/faults/70697380)
- Check error rates on [this Sidekiq worker](https://app.datadoghq.com/apm/resource/sidekiq/sidekiq.job/4c449f6e18d4cad6?end=1620149814136&env=production&index=apm-search&paused=false&query=env%3Aproduction%20service%3Asidekiq%20operation_name%3Asidekiq.job%20resource_name%3A%22GithubRepos%3A%3ARepoSyncWorker%22&start=1620063414136) (they should go down below 0.1%)