### PR TITLE
[15-min-fix] Remove badge slug field b/c auto-gen by title

### DIFF
--- a/app/controllers/admin/badges_controller.rb
+++ b/app/controllers/admin/badges_controller.rb
@@ -41,7 +41,7 @@ module Admin
     private
 
     def badge_params
-      params.require(:badge).permit(:title, :slug, :description, :badge_image, :credits_awarded)
+      params.require(:badge).permit(:title, :description, :badge_image, :credits_awarded)
     end
   end
 end

--- a/app/views/admin/badges/edit.html.erb
+++ b/app/views/admin/badges/edit.html.erb
@@ -11,7 +11,8 @@
     <div class="crayons-field mb-3">
       <%= form.label :title, "Title:", class: "crayons-field__label" %>
       <p class="crayons-field__description">
-        Badge's link is auto-generated based on the title.
+        Badge's link is auto-generated based on the title:
+        <%= link_to @badge.path, @badge.path %>
       </p>
       <%= form.text_field :title, class: "crayons-textfield" %>
     </div>

--- a/app/views/admin/badges/edit.html.erb
+++ b/app/views/admin/badges/edit.html.erb
@@ -6,29 +6,32 @@
   </div>
 </header>
 
-<div class="crayons-card p-6">
+<div class="crayons-card crayons-card--content-rows">
   <%= form_for [:admin, @badge], method: :patch do |form| %>
-    <div class="form-group">
-      <%= form.label :title %>
-      <%= form.text_field :title, class: "form-control" %>
+    <div class="crayons-field mb-3">
+      <%= form.label :title, "Title:", class: "crayons-field__label" %>
+      <p class="crayons-field__description">
+        Badge's link is auto-generated based on the title.
+      </p>
+      <%= form.text_field :title, class: "crayons-textfield" %>
     </div>
 
-    <div class="form-group">
-      <%= form.label :description, "Description:" %>
-      <%= form.text_field :description, class: "form-control" %>
+    <div class="crayons-field mb-3">
+      <%= form.label :description, "Description:", class: "crayons-field__label" %>
+      <%= form.text_field :description, class: "crayons-textfield" %>
     </div>
 
-    <div class="form-group">
-      <%= form.label :badge_image, "Badge Image:" %>
+    <div class="crayons-field mb-3">
+      <%= form.label :badge_image, "Badge Image:", class: "crayons-field__label" %>
       <% if @badge.badge_image %>
         <img class="mx-auto mt-3" width="60" height="60" src="<%= @badge.badge_image %>" alt="badge image">
       <% end %>
-      <%= form.file_field :badge_image, class: "form-control" %>
+      <%= form.file_field :badge_image %>
     </div>
 
-    <div class="form-group">
-      <%= form.label :credits_awarded, "Credits awarded:" %>
-      <%= form.text_field :credits_awarded, class: "form-control" %>
+    <div class="crayons-field mb-3">
+      <%= form.label :credits_awarded, "Credits awarded:", class: "crayons-field__label" %>
+      <%= form.text_field :credits_awarded, class: "crayons-textfield" %>
     </div>
     <%= submit_tag "Update Badge", class: "btn btn-primary" %>
   <% end %>

--- a/app/views/admin/badges/edit.html.erb
+++ b/app/views/admin/badges/edit.html.erb
@@ -14,8 +14,8 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :slug, "Slug:" %>
-      <%= form.text_field :slug, class: "form-control" %>
+      <%= form.label :slug, "Slug - auto generated based on the title." %>
+      <%= form.text_field :slug, class: "form-control", disabled: true %>
     </div>
 
     <div class="form-group">

--- a/app/views/admin/badges/edit.html.erb
+++ b/app/views/admin/badges/edit.html.erb
@@ -14,11 +14,6 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :slug, "Slug - auto generated based on the title." %>
-      <%= form.text_field :slug, class: "form-control", disabled: true %>
-    </div>
-
-    <div class="form-group">
       <%= form.label :description, "Description:" %>
       <%= form.text_field :description, class: "form-control" %>
     </div>

--- a/app/views/admin/badges/new.html.erb
+++ b/app/views/admin/badges/new.html.erb
@@ -3,13 +3,8 @@
 <div class="crayons-card p-6">
   <%= form_for [:admin, @badge], method: :post do |form| %>
     <div class="form-group">
-      <%= form.label :title %>
+      <%= form.label :title, "Title:" %>
       <%= form.text_field :title, class: "form-control" %>
-    </div>
-
-    <div class="form-group">
-      <%= form.label :slug, "Slug:" %>
-      <%= form.text_field :slug, class: "form-control" %>
     </div>
 
     <div class="form-group">

--- a/spec/requests/admin/badges_spec.rb
+++ b/spec/requests/admin/badges_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe "/admin/content_manager/badge_achievements", type: :request do
       expect do
         patch admin_badge_path(badge.id), params: params
       end.to change { badge.reload.title }.to("Hello, world!")
+      expect(badge.slug).to eq(CGI.escape(badge.title).parameterize)
     end
 
     it "successfully updates badge's credits_awarded" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature

## Description
Remove the slug form field because you can't edit it anyway -- it's auto-generated by the title. Added a description to the title.

## Related Tickets/Documents
https://github.com/forem/internalCommunity/issues/100

## QA Instructions, Screenshots, Recordings
Edit page:
![image](https://user-images.githubusercontent.com/17884966/117059749-1fc30300-acee-11eb-945f-2fe67b876629.png)


1. Go to /admin/content_manager/badges
2. Edit a badge
3. See that the slug is not update-able

### UI accessibility concerns?
Should be okay -- only updated the form text which is readable by a screen reader already.

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams (Community Success)

## [optional] Are there any post deployment tasks we need to perform?
No