### PR TITLE
[15 minute fix] Add data_updates:status rake task

### DIFF
--- a/lib/tasks/data_updates.rake
+++ b/lib/tasks/data_updates.rake
@@ -13,4 +13,16 @@ namespace :data_updates do
   task run: :environment do
     DataUpdateWorker.new.perform
   end
+
+  desc "Get data update status"
+  task status: :environment do
+    # rubocop:disable Style/FormatStringToken
+    puts format(" %-9s  %-14s  %-40s", "Status", "ID", "Description")
+    puts "-" * 80
+    DataUpdateScript.find_each do |dus|
+      id, file_name = dus.file_name.split("_", 2)
+      puts format("%+10s  %+14s  %-40s", dus.status, id, file_name.tr("_", " "))
+    end
+    # rubocop:enable Style/FormatStringToken
+  end
 end

--- a/lib/tasks/data_updates.rake
+++ b/lib/tasks/data_updates.rake
@@ -16,6 +16,9 @@ namespace :data_updates do
 
   desc "Get data update status"
   task status: :environment do
+    # Disable ActiveRecord logging for this task.
+    # See: https://github.com/forem/forem/pull/13653#discussion_r626278422
+    ActiveRecord::Base.logger = nil
     # rubocop:disable Style/FormatStringToken
     puts format(" %-9s  %-14s  %-40s", "Status", "ID", "Description")
     puts "-" * 80


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

Based on a recent discussion I thought it might be helpful to have a Rake task for quickly getting the status of data update update scripts, inspired by `rails db:migrate:status`. The task is called `rails data_updates:status` and produces output like this:

```
 Status     ID              Description
--------------------------------------------------------------------------------
 succeeded  20210405152916  invoke update reading list document trigger on articles
 succeeded  20210218041143  backfill usernames
 succeeded  20200821103718  remove orphaned display ads by organization
 succeeded  20201019163242  resave articles and comments for imgproxy
 succeeded  20210211164634  fix profile field edge cases
 succeeded  20200916202343  backfill co author ids for articles
 succeeded  20200826140317  remove orphaned articles by user
 succeeded  20201103050112  prepare for profile column drop
...
    failed  20201001173841  add navigation links
...
 succeeded  20200406213152  re index users to elasticsearch
 succeeded  20210504060704  move mascot settings backto site config
 succeeded  20210430043750  remove site config secondary logo
```

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Nothing specific, run the task, make sure it works

### UI accessibility concerns?

No UI

## Added tests?

- [X] No, and this is why: internal task, not particularly important

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
