### PR TITLE
🐛 Fix new comment dropdown issue

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -556,13 +556,16 @@ function listenForDetailsToggle() {
   }
 }
 
+/**
+ * Increment comment, stored in `.js-comments-count`, count by one.
+ */
 function updateCommentsCount() {
-  const commentsCountDiv = document.getElementsByClassName("js-comments-count")[0];
+  const commentsCountDiv = document.querySelector(".js-comments-count");
 
   // if there's nowhere to put the count return early.
   if(!commentsCountDiv) return;
 
-  const commentsCountData = parseInt(commentsCountDiv.dataset.commentsCount) + 1;
+  const commentsCountData = parseInt(commentsCountDiv.dataset.commentsCount, 10) + 1;
   commentsCountDiv.dataset.commentsCount = commentsCountData;
   commentsCountDiv.innerHTML = `(${commentsCountData})`
 }

--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -557,8 +557,12 @@ function listenForDetailsToggle() {
 }
 
 function updateCommentsCount() {
-  var commentsCountDiv = document.getElementsByClassName("js-comments-count")[0];
-  var commentsCountData = parseInt(commentsCountDiv.dataset.commentsCount) + 1;
+  const commentsCountDiv = document.getElementsByClassName("js-comments-count")[0];
+
+  // if there's nowhere to put the count return early.
+  if(!commentsCountDiv) return;
+
+  const commentsCountData = parseInt(commentsCountDiv.dataset.commentsCount) + 1;
   commentsCountDiv.dataset.commentsCount = commentsCountData;
   commentsCountDiv.innerHTML = `(${commentsCountData})`
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When you create a new comment on the comments page then try and access its menu no menu opens. This was caused by an error in JS.

## Related Tickets & Documents
Loosely related to #13365

## QA Instructions, Screenshots, Recordings

### Before
![forem_new-comment-issue](https://user-images.githubusercontent.com/3534427/117131120-ed221480-ad98-11eb-8f9e-3499dde9b336.gif)

### After
![forem_fix-new-comment](https://user-images.githubusercontent.com/3534427/117131134-f1e6c880-ad98-11eb-88ce-34277551a209.gif)


### UI accessibility concerns?
N/A

## Added tests?

- [ ] Yes
- [x] No, and this is why: old tests will still work
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Not a gross bug anymore](https://img.17qq.com/images/sscwewwaqx.jpeg)
