### PR TITLE
Clear the cached settings before testing the rate limiter

### DIFF
--- a/spec/requests/follows_create_spec.rb
+++ b/spec/requests/follows_create_spec.rb
@@ -20,9 +20,13 @@ RSpec.describe "Follows #create", type: :request do
     before do
       rate_limit_checker = RateLimitChecker.new(user)
 
+      allow(Settings::RateLimit)
+        .to receive(:follow_count_daily)
+        .and_return(23)
+
       allow(rate_limit_checker)
         .to receive(:user_today_follow_count)
-        .and_return(Settings::RateLimit.follow_count_daily + 1)
+        .and_return(24)
 
       allow(RateLimitChecker)
         .to receive(:new)

--- a/spec/requests/follows_create_spec.rb
+++ b/spec/requests/follows_create_spec.rb
@@ -14,19 +14,16 @@ RSpec.describe "Follows #create", type: :request do
 
   before do
     sign_in user
+    Settings::RateLimit.clear_cache
   end
 
   context "when rate limit has been hit" do
     before do
       rate_limit_checker = RateLimitChecker.new(user)
 
-      allow(Settings::RateLimit)
-        .to receive(:follow_count_daily)
-        .and_return(23)
-
       allow(rate_limit_checker)
         .to receive(:user_today_follow_count)
-        .and_return(24)
+        .and_return(Settings::RateLimit.follow_count_daily + 1)
 
       allow(RateLimitChecker)
         .to receive(:new)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

An interaction was occurring when the data update script test to move
these settings was run prior to the rate limit test - where the rate
limiter was created with the value 23 for the follow count, but the
settings module was reporting 500.

My first attempt was to stub out the database setting to an explicit value - and allow the
user follow count to be one more (so that we trigger the rate limit
and respond with a 429).

On looking more into the settings class itself - I noticed the comment regarding caching, and tested adding a clear cache before the context instead (which is a much smaller change and causes the settings to reload correctly instead of returning the modified version). 

I still don't fully understand why the rate limiter being created/injected and the settings object were differing in their worldview, but flushing the cache before execution fixed this. 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

```
bundle exec rspec  spec/lib/data_update_scripts/move_rate_limit_settings_spec.rb spec/requests/follows_create_spec.rb

# fails in main, passes in this branch
```

### UI accessibility concerns?

None, test only change

## Added tests?

- [ ] Yes
- [x] No, and this is why: maintenance on existing test 
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: update test setup only. 

## [optional] Are there any post deployment tasks we need to perform?
None

## [optional] What gif best describes this PR or how it makes you feel?

![check](https://user-images.githubusercontent.com/1237369/117178840-12625300-ad98-11eb-9d84-1ed8a9eab992.gif)

