### PR TITLE
Fix invalid form during Creator onboarding.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,6 +56,7 @@ class ApplicationController < ActionController::Base
     if api_action?
       authenticate!
     else
+      @user ||= User.new
       render template: "devise/registrations/new"
     end
   end

--- a/app/views/shared/authentication/_email_registration_form.html.erb
+++ b/app/views/shared/authentication/_email_registration_form.html.erb
@@ -4,7 +4,7 @@
       <%= flash[:notice] %>
     </div>
   <% end %>
-  <%= form_for(@user, as: :user, data: { testid: "registration-form" }, url: registration_path(:user)) do |f| %>
+  <%= form_for(@user || User.new, as: :user, data: { testid: "registration-form" }, url: registration_path(:user)) do |f| %>
     <% if defined?(resource) && resource&.errors&.any? %>
       <div class="crayons-card crayons-card--secondary crayons-notice crayons-notice--danger" role="alert" data-testid="signup-errors">
         <div class="crayons-card__header">

--- a/app/views/shared/authentication/_email_registration_form.html.erb
+++ b/app/views/shared/authentication/_email_registration_form.html.erb
@@ -4,7 +4,7 @@
       <%= flash[:notice] %>
     </div>
   <% end %>
-  <%= form_for(@user || User.new, as: :user, data: { testid: "registration-form" }, url: registration_path(:user)) do |f| %>
+  <%= form_for(@user, as: :user, data: { testid: "registration-form" }, url: registration_path(:user)) do |f| %>
     <% if defined?(resource) && resource&.errors&.any? %>
       <div class="crayons-card crayons-card--secondary crayons-notice crayons-notice--danger" role="alert" data-testid="signup-errors">
         <div class="crayons-card__header">

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -137,10 +137,11 @@ RSpec.describe "Registrations", type: :request do
         allow(FeatureFlag).to receive(:enabled?).with(:creator_onboarding).and_return(true)
         allow(FeatureFlag).to receive(:enabled?).with(:runtime_banner).and_return(false)
         allow(SiteConfig).to receive(:waiting_on_first_user).and_return(true)
+        allow(Settings::UserExperience).to receive(:public).and_return(false)
       end
 
       it "renders the creator onboarding form" do
-        get new_user_registration_path
+        get root_path
         expect(response.body).to include("Let's create an admin account for your community.")
         expect(response.body).to include("Create admin account")
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This PR resolves a bug that only happens during the Creator onboarding process; when Forem is newly generated without any user. The bug occurred because we are trying to render a shared template directly with a missing variable.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
1. Enable Creator onboarding mode by adding these two variables to your `.env`
   ```
    export MODE="STARTER"
	export FOREM_OWNER_SECRET="test"
   ```
2. For more straight forward  QA, please reset your database with `bin/rails db:reset && bin/setup`
3. You should be able to load homepage and sign up without an issue.

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: This is a bug fix.

## [optional] Are there any post deployment tasks we need to perform?
N/a
