### PR TITLE
Fix svg path error in e2e seed navigation link svg icon

### DIFF
--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -133,7 +133,7 @@ end
 seeder.create_if_doesnt_exist(NavigationLink, "url", "/contact") do
   icon = '<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'\
       '<path d="M12 1l9.5 5.5v11L12 23l-9.5-5.5v-11L12 1zm0 2.311L4.5 7.653v8.694l7.5 4.342'\
-      '7.5-4.342V7.653L12 3.311zM12 16a4 4 0 110-8 4 4 0 010 8zm0-2a2 2 0 100-4 2 2 0 000 4z\"/>'\
+      '7.5-4.342V7.653L12 3.311zM12 16a4 4 0 110-8 4 4 0 010 8zm0-2a2 2 0 100-4 2 2 0 000 4z"/>'\
     '</svg>'
   6.times do |i|
     NavigationLink.create!(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix (sort of)
- [ ] Optimization
- [ ] Documentation Update

## Description

I was seeing during testing this console error:

    "Error: <path> attribute d: Expected path command, "…0-4 2 2 0 000 4z\\".

Removing the `\"` and leaving just `"` seems like it corrected that (the error stops showing in console when running cypress tests, the icon is unchanged since the prior path was drawn before the error raised).

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Run bin/e2e and select the loginFlows/userLogout.spec.js test, when chrome opens show the console - confirm there are no instances of that error (if you're seeing this problem you'll see it multiple times since those dummy navigation items are commonly displayed).  

### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: icon literal in a test seed
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: cosmetic fix to seed data only used in testing


## [optional] What gif best describes this PR or how it makes you feel?

![noescape](https://user-images.githubusercontent.com/1237369/117320093-86146680-ae51-11eb-9530-6b27ae12fee6.gif)
