### PR TITLE
Read many values from the cache in a single call

### DIFF
--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -1,40 +1,42 @@
-<section id="comments" data-updated-at="<%= Time.current %>" class="text-padding mb-4 border-t-1 border-0 border-solid border-base-10">
-  <% if @article.show_comments %>
-    <header class="relative flex justify-between items-center mb-6">
-      <h2 class="crayons-subtitle-1">
-        Discussion
-        <span class="js-comments-count" data-comments-count="<%= @article.comments_count %>">
-          (<%= @article.comments_count %>)
-        </span>
-      </h2>
-      <div id="comment-subscription">
-        <div role="presentation" class="crayons-btn-group">
-          <span class="crayons-btn crayons-btn--outlined">Subscribe</span>
+<% cache("whole-comment-area-#{@article.id}-#{@article.last_comment_at}-#{@article.show_comments}", expires_in: 2.hours) do %>
+  <section id="comments" data-updated-at="<%= Time.current %>" class="text-padding mb-4 border-t-1 border-0 border-solid border-base-10">
+    <% if @article.show_comments %>
+      <header class="relative flex justify-between items-center mb-6">
+        <h2 class="crayons-subtitle-1">
+          Discussion
+          <span class="js-comments-count" data-comments-count="<%= @article.comments_count %>">
+            (<%= @article.comments_count %>)
+          </span>
+        </h2>
+        <div id="comment-subscription">
+          <div role="presentation" class="crayons-btn-group">
+            <span class="crayons-btn crayons-btn--outlined">Subscribe</span>
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
 
-    <div
-      id="comments-container"
-      data-testid="comments-container"
-      data-commentable-id="<%= @article.id %>"
-      data-commentable-type="Article"
-      data-has-recent-comment-activity="<%= @article.has_recent_comment_activity? %>">
-      <%= render "/comments/form", commentable: @article, commentable_type: "Article" %>
+      <div
+        id="comments-container"
+        data-testid="comments-container"
+        data-commentable-id="<%= @article.id %>"
+        data-commentable-type="Article"
+        data-has-recent-comment-activity="<%= @article.has_recent_comment_activity? %>">
+        <%= render "/comments/form", commentable: @article, commentable_type: "Article" %>
 
-      <div class="comments" id="comment-trees-container">
-        <% if @article.comments_count > 0 %>
-          <% Comment.tree_for(@article, @comments_to_show_count).tap do |comments| %>
-            <% keys = comments.keys.map { |comment| ["comment_root_cached_tree", comment] } %>
-            <% cache_multi(keys, expires_in: 2.hours) do |_prefix, comment| %>
-              <%= tree_for(comment, comments.fetch(comment), @article) %>
+        <div class="comments" id="comment-trees-container">
+          <% if @article.comments_count > 0 %>
+            <% Comment.tree_for(@article, @comments_to_show_count).tap do |comments| %>
+              <% keys = comments.keys.map { |comment| ["comment_root_cached_tree", comment] } %>
+              <% cache_multi(keys, expires_in: 2.hours) do |_prefix, comment| %>
+                <%= tree_for(comment, comments.fetch(comment), @article) %>
+              <% end %>
             <% end %>
           <% end %>
-        <% end %>
+        </div>
       </div>
-    </div>
 
-    <%= render "articles/comments_actions" %>
-  <% end %>
-</section>
+      <%= render "articles/comments_actions" %>
+    <% end %>
+  </section>
+<% end %>
 <% return if @warm_only %>

--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -1,36 +1,40 @@
-<% cache("whole-comment-area-#{@article.id}-#{@article.last_comment_at}-#{@article.show_comments}", expires_in: 2.hours) do %>
-  <section id="comments" data-updated-at="<%= Time.current %>" class="text-padding mb-4 border-t-1 border-0 border-solid border-base-10">
-    <% if @article.show_comments %>
-      <header class="relative flex justify-between items-center mb-6">
-        <h2 class="crayons-subtitle-1">Discussion <span class="js-comments-count" data-comments-count="<%= @article.comments_count %>">(<%= @article.comments_count %>)</span></h2>
-        <div id="comment-subscription">
-          <div role="presentation" class="crayons-btn-group">
-            <span class="crayons-btn crayons-btn--outlined">Subscribe</span>
-          </div>
-        </div>
-      </header>
-
-      <div
-        id="comments-container"
-        data-testid="comments-container"
-        data-commentable-id="<%= @article.id %>"
-        data-commentable-type="Article"
-        data-has-recent-comment-activity="<%= @article.has_recent_comment_activity? %>">
-        <%= render "/comments/form", commentable: @article, commentable_type: "Article" %>
-
-        <div class="comments" id="comment-trees-container">
-          <% if @article.comments_count > 0 %>
-            <% Comment.tree_for(@article, @comments_to_show_count).each do |comment, sub_comments| %>
-              <% cache ["comment_root_cached_tree", comment] do %>
-                <%= tree_for(comment, sub_comments, @article) %>
-              <% end %>
-            <% end %>
-          <% end %>
+<section id="comments" data-updated-at="<%= Time.current %>" class="text-padding mb-4 border-t-1 border-0 border-solid border-base-10">
+  <% if @article.show_comments %>
+    <header class="relative flex justify-between items-center mb-6">
+      <h2 class="crayons-subtitle-1">
+        Discussion
+        <span class="js-comments-count" data-comments-count="<%= @article.comments_count %>">
+          (<%= @article.comments_count %>)
+        </span>
+      </h2>
+      <div id="comment-subscription">
+        <div role="presentation" class="crayons-btn-group">
+          <span class="crayons-btn crayons-btn--outlined">Subscribe</span>
         </div>
       </div>
+    </header>
 
-      <%= render "articles/comments_actions" %>
-    <% end %>
-  </section>
-<% end %>
+    <div
+      id="comments-container"
+      data-testid="comments-container"
+      data-commentable-id="<%= @article.id %>"
+      data-commentable-type="Article"
+      data-has-recent-comment-activity="<%= @article.has_recent_comment_activity? %>">
+      <%= render "/comments/form", commentable: @article, commentable_type: "Article" %>
+
+      <div class="comments" id="comment-trees-container">
+        <% if @article.comments_count > 0 %>
+          <% Comment.tree_for(@article, @comments_to_show_count).tap do |comments| %>
+            <% keys = comments.keys.map { |comment| ["comment_root_cached_tree", comment] } %>
+            <% cache_multi(keys, expires_in: 2.hours) do |_prefix, comment| %>
+              <%= tree_for(comment, comments.fetch(comment), @article) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+
+    <%= render "articles/comments_actions" %>
+  <% end %>
+</section>
 <% return if @warm_only %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

On posts with many comments, we cache the rendered comments to avoid having to render all of them every time. Unfortunately, we're currently caching them individually, which leads to an unbounded number of cache queries, which each take time. Even if a cache query only takes 1-2ms, making 500 of them can feasibly take up to 1 second.

If this works well, I might extract this and try to push it upstream into Rails.

### Local performance difference:

Wrapped the changed section in a `Benchmark.measure` block.

Before: 230ms wall-clock time, 171ms CPU time

```
#<Benchmark::Tms:0x00000001213bc8c0
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=0.22847400000318885,
 @stime=0.0064150000000000595,
 @total=0.17133300000000018,
 @utime=0.16491800000000012>
```

After: 198ms wall-clock time, 144ms CPU time

```
#<Benchmark::Tms:0x0000000152ee12d8
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=0.19793399993795902,
 @stime=0.002200000000000202,
 @total=0.1444809999999972,
 @utime=0.142280999999997>
```

Not as drastic as I'd hoped, but this is also with both Rails and Redis running on the same machine. Adding network latency (even 1-2ms) would likely see more of a difference.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_