### PR TITLE
[15 min fix] Stop adding a false class in editor tabs

### DIFF
--- a/app/javascript/article-form/components/Tabs.jsx
+++ b/app/javascript/article-form/components/Tabs.jsx
@@ -11,7 +11,7 @@ export const Tabs = ({ onPreview, previewShowing }) => {
         <li>
           <button
             className={`crayons-tabs__item ${
-              !previewShowing && 'crayons-tabs__item--current'
+              previewShowing ? '' : 'crayons-tabs__item--current'
             }`}
             onClick={previewShowing && onPreview}
             type="button"
@@ -23,7 +23,7 @@ export const Tabs = ({ onPreview, previewShowing }) => {
         <li>
           <button
             className={`crayons-tabs__item ${
-              previewShowing && 'crayons-tabs__item--current'
+              previewShowing ? 'crayons-tabs__item--current' : ''
             }`}
             onClick={!previewShowing && onPreview}
             type="button"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When I added the accessibility enhancements for navigation tabs, I accidentally added code that would add a class of 'false' to the article editor tabs when it wasn't the current one. There was no negative effect, but it's better to clean this up.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

There's no user-facing change, and all should look and behave as before, except the "false" class shouldn't be added to either tab:

![screenshot showing the article editor, with the dev tools open. The relevant HTML is circled and neither tab has a class named 'false'](https://user-images.githubusercontent.com/20773163/117656839-bed57800-b190-11eb-8097-50968c414f50.png)


### UI accessibility concerns?

N/A

## Added tests?

- [ ] Yes
- [X] No, and this is why: there's no functional or UI change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: no change to functionality or look

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![oops](https://i.giphy.com/media/80TEu4wOBdPLG/giphy.webp)
