### PR TITLE
Add composite index to articles hotness_score and comments_count

### DIFF
--- a/db/migrate/20210511073505_add_index_on_articles_hotness_score_comments_count.rb
+++ b/db/migrate/20210511073505_add_index_on_articles_hotness_score_comments_count.rb
@@ -1,0 +1,15 @@
+class AddIndexOnArticlesHotnessScoreCommentsCount < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def up
+    columns = %i[hotness_score comments_count]
+
+    add_index :articles, columns, algorithm: :concurrently unless index_exists?(:articles, columns)
+  end
+
+  def down
+    columns = %i[hotness_score comments_count]
+
+    remove_index :articles, column: columns, algorithm: :concurrently if index_exists?(:articles, columns)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_30_094954) do
+ActiveRecord::Schema.define(version: 2021_05_11_073505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -161,6 +161,7 @@ ActiveRecord::Schema.define(version: 2021_04_30_094954) do
     t.index ["comments_count"], name: "index_articles_on_comments_count"
     t.index ["featured_number"], name: "index_articles_on_featured_number"
     t.index ["feed_source_url"], name: "index_articles_on_feed_source_url", unique: true
+    t.index ["hotness_score", "comments_count"], name: "index_articles_on_hotness_score_and_comments_count"
     t.index ["hotness_score"], name: "index_articles_on_hotness_score"
     t.index ["path"], name: "index_articles_on_path"
     t.index ["public_reactions_count"], name: "index_articles_on_public_reactions_count", order: :desc


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

In #13599 we added a single index on `articles.comments_count` but, as feared, it didn't improve the performance of the https://dev.to/search/ page - which [still stands at a p50 of over 1 second](https://ui.honeycomb.io/thepracticaldev/datasets/rails/result/6ZLjSXAqToH).

According to the PostgreSQL's docs on [Indexes and ORDER BY](https://www.postgresql.org/docs/11/indexes-ordering.html), this wouldn't have worked as we need a multi column index for `hotness_score DESC, comments_count DESC`:

> You might wonder why bother providing all four options, when two options together with the possibility of backward scan would cover all the variants of ORDER BY. In single-column indexes the options are indeed redundant, but in multicolumn indexes they can be useful. **Consider a two-column index on (x, y): this can satisfy ORDER BY x, y if we scan forward, or ORDER BY x DESC, y DESC if we scan backward.** But it might be that the application frequently needs to use ORDER BY x ASC, y DESC. There is no way to get that ordering from a plain index, but it is possible if the index is defined as (x ASC, y DESC) or (x DESC, y ASC).

With this I hope PostgreSQL will use the index and reduce query time.

## Related Tickets & Documents

#13599 

## Added tests?

- [ ] Yes
- [x] No, and this is why: an index change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
