### PR TITLE
Hide the correct email PII on Blazer

### DIFF
--- a/config/initializers/hypershield.rb
+++ b/config/initializers/hypershield.rb
@@ -17,7 +17,7 @@ if Rails.env.production? && ENV["ENV_AVAILABLE"] == "true"
           hide: [
             "ahoy_messages.content",
             "ahoy_messages.to",
-            "email",
+            "email_authorizations",
             "encrypted",
             "encrypted_password",
             "identities.auth_data_dump",
@@ -25,14 +25,18 @@ if Rails.env.production? && ENV["ENV_AVAILABLE"] == "true"
             "messages.message_markdown",
             "oauth_access_tokens.previous_refresh_token",
             "oauth_access_tokens.refresh_token",
+            "organizations.email",
             "password",
             "secret",
             "token",
+            "user_subscriptions.subscriber_email",
             "users.current_sign_in_ip",
+            "users.email",
             "users.last_sign_in_ip",
             "users.remember_token",
             "users.reset_password_token",
             "users.unconfirmed_email",
+            "users_gdpr_delete_requests.email",
           ]
         }
       }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Blazer hides PII through Hypershield.

Hypershield algorithm to match columns [is really basic](https://github.com/ankane/hypershield/blob/2c5fb02f65896f5a8c5d1604772ef177f29d210c/lib/hypershield.rb#L49), it uses `include?(string)`. 

This has the unfortunate side effect of matching every column that contains the word `email`, despite some of them being boolean settings that we need to access.

If you run `select email_comment_notifications from users limit 1` or `select email_badge_notifications from users_notification_settings limit 1` on Blazer you'll be met with an error.

This PR specifies exactly which email fields constitute PII, allowing all the boolean flags in turn.

Thanks @msarit for catching this!

## QA Instructions, Screenshots, Recordings

Can only be tested live when the view is refreshed
