### PR TITLE
Replace MAX_USER_MENTIONS with Settings::RateLimit.mention_creation

### DIFF
--- a/app/helpers/rate_limit_checker_helper.rb
+++ b/app/helpers/rate_limit_checker_helper.rb
@@ -68,6 +68,12 @@ module RateLimitCheckerHelper
       title: "Limit number of comments created by a new member",
       description: new_user_message("comments")
     },
+    mention_creation: {
+      min: 0,
+      placeholder: 7,
+      title: "Limit number of @-mentions in a post or comment",
+      description: "How many times can someone @-mention other users in a post or comment?"
+    },
     listing_creation: {
       min: 1,
       placeholder: 1,

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -25,9 +25,6 @@ class Article < ApplicationRecord
   counter_culture :user
   counter_culture :organization
 
-  # TODO: Vaidehi Joshi - Extract this into a constant or SiteConfig variable
-  # after https://github.com/forem/rfcs/pull/22 has been completed?
-  MAX_USER_MENTIONS = 7 # Explicitly set to 7 to accommodate DEV Top 7 Posts
   # The date that we began limiting the number of user mentions in an article.
   MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 4, 7).freeze
 
@@ -689,9 +686,9 @@ class Article < ApplicationRecord
 
     # The "mentioned-user" css is added by Html::Parser#user_link_if_exists
     mentions_count = Nokogiri::HTML(processed_html).css(".mentioned-user").size
-    return if mentions_count <= MAX_USER_MENTIONS
+    return if mentions_count <= Settings::RateLimit.mention_creation
 
-    errors.add(:base, "You cannot mention more than #{MAX_USER_MENTIONS} users in a post!")
+    errors.add(:base, "You cannot mention more than #{Settings::RateLimit.mention_creation} users in a post!")
   end
 
   def create_slug

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,9 +12,6 @@ class Comment < ApplicationRecord
   TITLE_DELETED = "[deleted]".freeze
   TITLE_HIDDEN = "[hidden by post author]".freeze
 
-  # TODO: Vaidehi Joshi - Extract this into a constant or SiteConfig variable
-  # after https://github.com/forem/rfcs/pull/22 has been completed?
-  MAX_USER_MENTIONS = 7 # Explicitly set to 7 to accommodate DEV Top 7 Posts
   # The date that we began limiting the number of user mentions in a comment.
   MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 3, 12).freeze
 
@@ -323,9 +320,9 @@ class Comment < ApplicationRecord
 
     # The "mentioned-user" css is added by Html::Parser#user_link_if_exists
     mentions_count = Nokogiri::HTML(processed_html).css(".mentioned-user").size
-    return if mentions_count <= MAX_USER_MENTIONS
+    return if mentions_count <= Settings::RateLimit.mention_creation
 
-    errors.add(:base, "You cannot mention more than #{MAX_USER_MENTIONS} users in a comment!")
+    errors.add(:base, "You cannot mention more than #{Settings::RateLimit.mention_creation} users in a comment!")
   end
 
   def record_field_test_event

--- a/app/models/settings/rate_limit.rb
+++ b/app/models/settings/rate_limit.rb
@@ -8,6 +8,8 @@ module Settings
 
     field :article_update, type: :integer, default: 30
     field :comment_antispam_creation, type: :integer, default: 1
+    # Explicitly defaults to 7 to accommodate DEV Top 7 Posts
+    field :mention_creation, type: :integer, default: 7
     field :comment_creation, type: :integer, default: 9
     field :email_recipient, type: :integer, default: 5
     field :feedback_message_creation, type: :integer, default: 5

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -140,8 +140,6 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_follow_count_daily, type: :integer, default: 500
   field :rate_limit_comment_creation, type: :integer, default: 9
   field :rate_limit_comment_antispam_creation, type: :integer, default: 1
-  # Explicitly defaults to 7 to accommodate DEV Top 7 Posts
-  field :rate_limit_mention_creation, type: :integer, default: 7
   field :rate_limit_listing_creation, type: :integer, default: 1
   field :rate_limit_published_article_creation, type: :integer, default: 9
   field :rate_limit_published_article_antispam_creation, type: :integer, default: 1

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -140,6 +140,8 @@ class SiteConfig < RailsSettings::Base
   field :rate_limit_follow_count_daily, type: :integer, default: 500
   field :rate_limit_comment_creation, type: :integer, default: 9
   field :rate_limit_comment_antispam_creation, type: :integer, default: 1
+  # Explicitly defaults to 7 to accommodate DEV Top 7 Posts
+  field :rate_limit_mention_creation, type: :integer, default: 7
   field :rate_limit_listing_creation, type: :integer, default: 1
   field :rate_limit_published_article_creation, type: :integer, default: 9
   field :rate_limit_published_article_antispam_creation, type: :integer, default: 1

--- a/app/services/edge_cache/bust/nginx.rb
+++ b/app/services/edge_cache/bust/nginx.rb
@@ -14,7 +14,7 @@ module EdgeCache
       end
 
       def self.nginx_available?
-        # TODO: (Vaidehi Joshi) - Right now, we are checking that nginx is
+        # TODO: Right now, we are checking that nginx is
         # available on every purge request/call to this bust service. If we are going
         # to bust multiple paths, we should be able to check that nginx is
         # available just once, and persist it on the class with @provider_available?.

--- a/app/services/rate_limit_checker.rb
+++ b/app/services/rate_limit_checker.rb
@@ -87,13 +87,13 @@ class RateLimitChecker
   end
 
   def check_published_article_creation_limit
-    # TODO: Vaidehi Joshi - We should make this time frame configurable.
+    # TODO: We should make this time frame configurable.
     user.articles.published.where("created_at > ?", 30.seconds.ago).size >
       Settings::RateLimit.published_article_creation
   end
 
   def check_published_article_antispam_creation_limit
-    # TODO: Vaidehi Joshi - We should make this time frame configurable.
+    # TODO: We should make this time frame configurable.
     user.articles.published.where("created_at > ?", 5.minutes.ago).size >
       Settings::RateLimit.published_article_antispam_creation
   end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,7 +9,7 @@
 <% elsif forem_creator_flow_enabled? %>
   <%= render "shared/authentication/forem_creator_signup" %>
 <% elsif waiting_on_first_user? %>
-  <%# TODO: Vaidehi Joshi - Delete this view once forem creator onboarding is shipped %>
+  <%# TODO: Delete this view once forem creator onboarding is shipped %>
   <%= render "shared/authentication/initial_account_wizard" %>
 <% else %>
   <%= render "devise/shared/authorization_error" %>

--- a/app/views/shared/authentication/_email_registration_form.html.erb
+++ b/app/views/shared/authentication/_email_registration_form.html.erb
@@ -21,7 +21,7 @@
         </div>
       </div>
     <% elsif forem_creator_flow_enabled? %>
-      <%# TODO: Vaidehi Joshi - Extract this into its own form %>
+      <%# TODO: Extract this into its own form %>
       <div class="align-center">
         <p class="pb-4 fw-bold">Almost there!</p>
         <p class="registration__description">Let's create an admin account for your community.</p>
@@ -109,7 +109,7 @@
     <% end %>
 
     <% if forem_creator_flow_enabled? %>
-      <%# TODO: Vaidehi Joshi - Extract this into its own form %>
+      <%# TODO: Extract this into its own form %>
       <div class="flex flex-col pt-3">
         <%= f.submit "Create admin account", class: "crayons-btn" %>
       </div>

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1219,7 +1219,6 @@ RSpec.describe Article, type: :model do
 
   describe "#user_mentions_in_markdown" do
     before do
-      stub_const("Settings::RateLimit.mention_creation", 7)
       stub_const("Article::MAX_USER_MENTION_LIVE_AT", 1.day.ago) # Set live_at date to a time in the past
     end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1219,7 +1219,7 @@ RSpec.describe Article, type: :model do
 
   describe "#user_mentions_in_markdown" do
     before do
-      stub_const("Article::MAX_USER_MENTIONS", 7)
+      stub_const("Settings::RateLimit.mention_creation", 7)
       stub_const("Article::MAX_USER_MENTION_LIVE_AT", 1.day.ago) # Set live_at date to a time in the past
     end
 
@@ -1227,20 +1227,20 @@ RSpec.describe Article, type: :model do
       # Explicitly set created_at date to a time before MAX_USER_MENTION_LIVE_AT
       article = create(:article, created_at: 3.days.ago)
 
-      article.body_markdown = "hi @#{user.username}! " * (Article::MAX_USER_MENTIONS + 1)
+      article.body_markdown = "hi @#{user.username}! " * (Settings::RateLimit.mention_creation + 1)
       expect(article).to be_valid
     end
 
     it "is valid with seven or fewer mentions if created after MAX_USER_MENTION_LIVE_AT date" do
-      article.body_markdown = "hi @#{user.username}! " * Article::MAX_USER_MENTIONS
+      article.body_markdown = "hi @#{user.username}! " * Settings::RateLimit.mention_creation
       expect(article).to be_valid
     end
 
     it "is invalid with more than seven mentions if created after MAX_USER_MENTION_LIVE_AT date" do
-      article.body_markdown = "hi @#{user.username}! " * (Article::MAX_USER_MENTIONS + 1)
+      article.body_markdown = "hi @#{user.username}! " * (Settings::RateLimit.mention_creation + 1)
       expect(article).not_to be_valid
       expect(article.errors[:base])
-        .to include("You cannot mention more than #{Article::MAX_USER_MENTIONS} users in a post!")
+        .to include("You cannot mention more than #{Settings::RateLimit.mention_creation} users in a post!")
     end
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -87,7 +87,6 @@ RSpec.describe Comment, type: :model do
 
     describe "#user_mentions_in_markdown" do
       before do
-        stub_const("Settings::RateLimit.mention_creation", 7)
         stub_const("Comment::MAX_USER_MENTION_LIVE_AT", 1.day.ago) # Set live_at date to a time in the past
       end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Comment, type: :model do
 
     describe "#user_mentions_in_markdown" do
       before do
-        stub_const("Comment::MAX_USER_MENTIONS", 7)
+        stub_const("Settings::RateLimit.mention_creation", 7)
         stub_const("Comment::MAX_USER_MENTION_LIVE_AT", 1.day.ago) # Set live_at date to a time in the past
       end
 
@@ -96,24 +96,24 @@ RSpec.describe Comment, type: :model do
         subject.created_at = 3.days.ago
         subject.commentable_type = "Article"
 
-        subject.body_markdown = "hi @#{user.username}! " * (Comment::MAX_USER_MENTIONS + 1)
+        subject.body_markdown = "hi @#{user.username}! " * (Settings::RateLimit.mention_creation + 1)
         expect(subject).to be_valid
       end
 
       it "is valid with seven or fewer mentions if created after MAX_USER_MENTION_LIVE_AT date" do
         subject.commentable_type = "Article"
 
-        subject.body_markdown = "hi @#{user.username}! " * Comment::MAX_USER_MENTIONS
+        subject.body_markdown = "hi @#{user.username}! " * Settings::RateLimit.mention_creation
         expect(subject).to be_valid
       end
 
       it "is invalid with more than seven mentions if created after MAX_USER_MENTION_LIVE_AT date" do
         subject.commentable_type = "Article"
 
-        subject.body_markdown = "hi @#{user.username}! " * (Comment::MAX_USER_MENTIONS + 1)
+        subject.body_markdown = "hi @#{user.username}! " * (Settings::RateLimit.mention_creation + 1)
         expect(subject).not_to be_valid
         expect(subject.errors[:base])
-          .to include("You cannot mention more than #{Comment::MAX_USER_MENTIONS} users in a comment!")
+          .to include("You cannot mention more than #{Settings::RateLimit.mention_creation} users in a comment!")
       end
     end
     # rubocop:enable RSpec/NamedSubject

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -588,6 +588,16 @@ RSpec.describe "/admin/customization/config", type: :request do
           end.to change(Settings::RateLimit, :comment_creation).from(default_value).to(3)
         end
 
+        it "updates mention_creation" do
+          default_value = Settings::RateLimit.get_default(:mention_creation)
+          expect do
+            post admin_settings_rate_limits_path, params: {
+              settings_rate_limit: { mention_creation: 10 },
+              confirmation: confirmation_message
+            }
+          end.to change(Settings::RateLimit, :mention_creation).from(default_value).to(10)
+        end
+
         it "updates published_article_creation" do
           default_value = Settings::RateLimit.get_default(:published_article_creation)
           expect do

--- a/spec/system/onboardings/user_completes_onboarding_spec.rb
+++ b/spec/system/onboardings/user_completes_onboarding_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Completing Onboarding", type: :system, js: true do
     end
   end
 
-  # TODO: Vaidehi Joshi - Extract this into a reusable helper
+  # TODO: Extract this into a reusable helper
   def log_in_user(user)
     fill_in("user_email", with: user.email)
     fill_in("user_password", with: user.password)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description

Addresses this `TODO` now that RFC #22 has been completed with https://github.com/forem/forem/pull/13367
https://github.com/forem/forem/blob/11bab732c0ff477b177495e4e1ee9b979c24be9b/app/models/article.rb#L28-L30

Also removes my name from all the `TODO`s I added previously for myself 😿 

## Related Tickets & Documents

Follow up task to [RFC #22](https://github.com/forem/rfcs/pull/22)

## QA Instructions, Screenshots, Recordings

1. Check that you _cannot_ create a post with more than 7 @-mentions (this is the default value for `Settings::RateLimit.mention_creation`):
<img width="1464" alt="Screen Shot 2021-05-11 at 2 41 53 PM" src="https://user-images.githubusercontent.com/6921610/117889810-fdd6fc80-b268-11eb-9517-4fd3382fcaa7.png">

2. Check that you _can_ create a post with 7 or fewer @-mentions:
<img width="1464" alt="Screen Shot 2021-05-11 at 2 42 01 PM" src="https://user-images.githubusercontent.com/6921610/117889852-134c2680-b269-11eb-86fe-9a3ff87169e9.png">

3. Check that you _cannot_ create a comment with more than 7 @-mentions
<img width="1464" alt="Screen Shot 2021-05-11 at 2 42 22 PM" src="https://user-images.githubusercontent.com/6921610/117889955-35de3f80-b269-11eb-85de-105307b2f397.png">

4. Check that you _can_ create a comment with 7 or fewer @-mentions:
<img width="1464" alt="Screen Shot 2021-05-11 at 2 42 37 PM" src="https://user-images.githubusercontent.com/6921610/117889993-41316b00-b269-11eb-9653-e7d2a1e4fce1.png">

5. Go to the admin view `/admin/customization/config`, and check that you can see the limit for @-mentions in a post or comment in the "rate limit and antispam" section:
<img width="1552" alt="Screen Shot 2021-05-11 at 2 43 39 PM" src="https://user-images.githubusercontent.com/6921610/117890046-53130e00-b269-11eb-8120-ccdc731e2393.png">

6. Try changing that value and updating the config:
<img width="948" alt="Screen Shot 2021-05-11 at 2 44 06 PM" src="https://user-images.githubusercontent.com/6921610/117890141-76d65400-b269-11eb-869e-1badb2bf5587.png">

You should now _only_ be able to create up to the new number of max mentions that you just set 😃 

### UI accessibility concerns?

_A backend change, so...none!_

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I've ~updated the README or~ added inline documentation
- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams

## Are there any post deployment tasks we need to perform?

I don't think we have any; `Settings::RateLimit`s are already in production, so everything _should_ Just Work™️ 
