### PR TITLE
Fix wrong `SiteConfig` mentions

### DIFF
--- a/app/helpers/rate_limit_checker_helper.rb
+++ b/app/helpers/rate_limit_checker_helper.rb
@@ -3,7 +3,7 @@ module RateLimitCheckerHelper
     "create within any 5 minute period?".freeze
 
   def self.new_user_message(thing)
-    timeframe = "day".pluralize(SiteConfig.user_considered_new_days)
+    timeframe = "day".pluralize(Settings::RateLimit.user_considered_new_days)
     format(NEW_USER_MESSAGE, thing: thing, timeframe: timeframe)
   end
 

--- a/app/lib/constants/settings/rate_limit.rb
+++ b/app/lib/constants/settings/rate_limit.rb
@@ -9,7 +9,7 @@ module Constants
         user_considered_new_days: {
           description: "The number of days a user is considered new. The default is 3 days, but you "\
             "can disable this entirely by inputting 0.",
-          placeholder: ::SiteConfig.user_considered_new_days
+          placeholder: ::Settings::RateLimit.user_considered_new_days
         }
       }.freeze
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

I noticed today that two places still accidentally reference `SiteConfig` instead of `Settings::RateLimit` and this PR fixes that.

## Related Tickets & Documents

RFC#126

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added tests?

- [X] No, and this is why: Once the values got removed from `SiteConfig` (see #13738) specs started failing all over the place. The problem here was just that they existed in two places.
