### PR TITLE
[15 Min Fix]: Remove any preexisting mention notifications when article is unpublished

### DIFF
--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -48,8 +48,8 @@ module Articles
                                     notifiable_type: "Comment")
           end
           if article.mentions.exists?
-            Notification.remove_all(notifiable_ids: article.comments.ids,
-                                    notifiable_type: "Article")
+            Notification.remove_all(notifiable_ids: article.mentions.ids,
+                                    notifiable_type: "Mention")
           end
         end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Shortly after https://github.com/forem/forem/pull/13367 was deployed to the fleet, @Zhao-Andy helped me test this feature out on a Forem instance, after which we discovered that mention notification were not deleting after a post was unpublished!

As it turns out, we _did_ have code for this in `Articles::Updater`:
https://github.com/forem/forem/blob/e53b6bff853a5f79bbebbf1ce8be98eae6a0b024/app/services/articles/updater.rb#L50-L53

...but there was a typo in the code (🤦🏽‍♀️) and because there were no _pre-existing tests_ for this in the `updater_spec.rb`, this bit of behavior was missed completely in the specs and wasn't caught in code review/QA! 🙈 

While fixing this, I realized that we also _don't_ have any tests for the "remove preexisting comment notifications" behavior for _comments_, either! 😅 

So, this PR does the following:
- [x] Fixes the typo that was not allowing preexisting mention notifications to be "removed" (_but not deleted_) when an article is unpublished
- [x] Adds specs for this behavior
- [x] Adds specs for the "removing preexisting comment notifications when an article is unpublished" behavior as well

## Related Tickets & Documents

Follow up fix for https://github.com/forem/forem/pull/13367.

## QA Instructions, Screenshots, Recordings

**To QA this PR, open up two browser windows, each with two different users. In this case, I have User A (Admin user) and User B (my user, vaidehijoshi).**

1. Create a post in User A's account, and mention User B:
<img width="1266" alt="Screen Shot 2021-05-12 at 11 16 51 AM" src="https://user-images.githubusercontent.com/6921610/118026560-c40fff80-b315-11eb-872b-c8e86e753f48.png">
2. Check that User B sees a notification for being @-mentioned:
<img width="293" alt="Screen Shot 2021-05-12 at 11 17 05 AM" src="https://user-images.githubusercontent.com/6921610/118026588-cf632b00-b315-11eb-8d4d-6f4f3c3c665e.png">
<img width="977" alt="Screen Shot 2021-05-12 at 11 17 12 AM" src="https://user-images.githubusercontent.com/6921610/118026594-d25e1b80-b315-11eb-81b9-ded46ddc86c4.png">
3. Go back to User A's account, and un-publish the entire post:
<img width="1266" alt="Screen Shot 2021-05-12 at 11 17 18 AM" src="https://user-images.githubusercontent.com/6921610/118026646-e275fb00-b315-11eb-90f2-b27ba91c52bc.png">
<img width="1266" alt="Screen Shot 2021-05-12 at 11 17 22 AM" src="https://user-images.githubusercontent.com/6921610/118026655-e570eb80-b315-11eb-92f1-79e673b6ec54.png">
4. Return to and reload User B's `/notifications` page; the previous @-mention notification should have disappeared!
<img width="977" alt="Screen Shot 2021-05-12 at 11 17 30 AM" src="https://user-images.githubusercontent.com/6921610/118026717-fae61580-b315-11eb-8aab-5480ffa89aaa.png">

### UI accessibility concerns?

_Backend only change, so nope!_

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: _this is a bugfix!_

## [optional] Are there any post deployment tasks we need to perform?

We'll want to deploy this to the fleet as soon as we can :) 
