### PR TITLE
Fix UI showing "Following" after unfollowing a user

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -113,7 +113,7 @@ class FollowsController < ApplicationController
     user_follow = current_user.stop_following(followable)
     Notification.send_new_follower_notification_without_delay(user_follow, is_read: true) if need_notification
 
-    Follows::DeleteCached.delete(current_user, followable_type, followable.id)
+    Follows::DeleteCached.call(current_user, followable_type, followable.id)
 
     "unfollowed"
   end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -67,7 +67,7 @@ class FollowsController < ApplicationController
     need_notification = Follow.need_new_follower_notification_for?(followable.class.name)
 
     @result = if params[:verb] == "unfollow"
-                unfollow(followable, need_notification: need_notification)
+                unfollow(followable, params[:followable_type], need_notification: need_notification)
               else
                 if rate_limiter.limit_by_action("follow_account")
                   render json: { error: "Daily account follow limit reached!" }, status: :too_many_requests
@@ -109,9 +109,11 @@ class FollowsController < ApplicationController
     "already followed"
   end
 
-  def unfollow(followable, need_notification: false)
+  def unfollow(followable, followable_type, need_notification: false)
     user_follow = current_user.stop_following(followable)
     Notification.send_new_follower_notification_without_delay(user_follow, is_read: true) if need_notification
+
+    Follows::CheckCached.delete(current_user, followable_type, followable.id)
 
     "unfollowed"
   end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -113,7 +113,7 @@ class FollowsController < ApplicationController
     user_follow = current_user.stop_following(followable)
     Notification.send_new_follower_notification_without_delay(user_follow, is_read: true) if need_notification
 
-    Follows::CheckCached.delete(current_user, followable_type, followable.id)
+    Follows::DeleteCached.delete(current_user, followable_type, followable.id)
 
     "unfollowed"
   end

--- a/app/services/follows/check_cached.rb
+++ b/app/services/follows/check_cached.rb
@@ -4,6 +4,10 @@ module Follows
       new(follower, followable_type, followable_id).call
     end
 
+    def self.delete(follower, followable_type, followable_id)
+      new(follower, followable_type, followable_id).delete
+    end
+
     def initialize(follower, followable_type, followable_id)
       @follower = follower
       @followable_type = followable_type
@@ -17,6 +21,13 @@ module Follows
       Rails.cache.fetch(cache_key, expires_in: 20.hours) do
         follower.following?(followable.find(followable_id))
       end
+    end
+
+    def delete
+      return false unless follower
+
+      cache_key = "user-#{follower.id}-#{follower.updated_at.rfc3339}/is_following_#{followable_type}_#{followable_id}"
+      Rails.cache.delete(cache_key)
     end
 
     private

--- a/app/services/follows/delete_cached.rb
+++ b/app/services/follows/delete_cached.rb
@@ -1,7 +1,7 @@
 module Follows
   class DeleteCached
-    def self.delete(follower, followable_type, followable_id)
-      new(follower, followable_type, followable_id).delete
+    def self.call(follower, followable_type, followable_id)
+      new(follower, followable_type, followable_id).call
     end
 
     def initialize(follower, followable_type, followable_id)
@@ -10,7 +10,7 @@ module Follows
       @followable_id = followable_id
     end
 
-    def delete
+    def call
       return false unless follower
 
       cache_key = "user-#{follower.id}-#{follower.updated_at.rfc3339}/is_following_#{followable_type}_#{followable_id}"
@@ -20,14 +20,5 @@ module Follows
     private
 
     attr_accessor :follower, :followable_type, :followable_id
-
-    def followable
-      case followable_type
-      when "Tag", "Organization", "Podcast"
-        followable_type.constantize
-      else
-        User
-      end
-    end
   end
 end

--- a/app/services/follows/delete_cached.rb
+++ b/app/services/follows/delete_cached.rb
@@ -1,7 +1,7 @@
 module Follows
-  class CheckCached
-    def self.call(follower, followable_type, followable_id)
-      new(follower, followable_type, followable_id).call
+  class DeleteCached
+    def self.delete(follower, followable_type, followable_id)
+      new(follower, followable_type, followable_id).delete
     end
 
     def initialize(follower, followable_type, followable_id)
@@ -10,13 +10,11 @@ module Follows
       @followable_id = followable_id
     end
 
-    def call
+    def delete
       return false unless follower
 
       cache_key = "user-#{follower.id}-#{follower.updated_at.rfc3339}/is_following_#{followable_type}_#{followable_id}"
-      Rails.cache.fetch(cache_key, expires_in: 20.hours) do
-        follower.following?(followable.find(followable_id))
-      end
+      Rails.cache.delete(cache_key)
     end
 
     private

--- a/cypress/integration/profileFlows/followUser.spec.js
+++ b/cypress/integration/profileFlows/followUser.spec.js
@@ -11,7 +11,7 @@ describe('Follow user from profile page', () => {
   });
 
   it('follows and unfollows a user', () => {
-    //   Wait for the button to be initialised
+    // Wait for the button to be initialised
     cy.get('[data-fetched="fetched"]');
 
     cy.findByRole('button', { name: 'Follow' }).click();

--- a/cypress/integration/profileFlows/followUser.spec.js
+++ b/cypress/integration/profileFlows/followUser.spec.js
@@ -1,0 +1,28 @@
+describe('Follow user from profile page', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.fixture('users/adminUser.json').as('user');
+
+    cy.get('@user').then((user) => {
+      cy.loginUser(user).then(() => {
+        cy.visit('/article_editor_v1_user');
+      });
+    });
+  });
+
+  it('follows and unfollows a user', () => {
+    //   Wait for the button to be initialised
+    cy.get('[data-fetched="fetched"]');
+
+    cy.findByRole('button', { name: 'Follow' }).click();
+    cy.findByRole('button', { name: 'Following' });
+
+    // Check that the update persists after reload
+    cy.reload();
+    cy.findByRole('button', { name: 'Following' }).click();
+    cy.findByRole('button', { name: 'Follow' });
+
+    // Check that the update persists after reload
+    cy.findByRole('button', { name: 'Follow' });
+  });
+});


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After unfollowing a user from their profile page, the UI would initially reflect the correct 'unfollowed' state, but on page refresh it would incorrectly show the UI that suggests you're following them (i.e. a button saying "Following"). Going to the dashboard > following users screen you could verify that the unfollow had been successfully processed, it's just the UI on the profile page was incorrect.

After a bit of investigation, it turned out this was because the call to `/follows/<userid>?followable_type=User` was cached in the backend, and kept returning the original 'followed' state.

As a small disclaimer - I'm not a backend dev 😅  I decided to give this a go since I'd already completed some investigation, but if this totally isn't the way we'd want to go about invalidating the cache on 'unfollow' then I'm very open to learning more and changing this!

## Related Tickets & Documents

Fixes #11533

## QA Instructions, Screenshots, Recordings

- Go to a user's profile other than your own
- If you don't follow them already, click to follow them
- Now click to unfollow them
- Notice the UI updates the button back to reading "Follow"
- Refresh the page
- The UI should still show the button reading "Follow"
- Click the Follow button and verify that it follows the user, showing the "Following" button
- Refresh the page and verify the correct "Following" button is shown

NB: I know the UI looks strange on page load, where you see a flash of the "Follow" button before it changes to "Following". This is a known issue, but separate to this bugfix, so please ignore for now!

https://user-images.githubusercontent.com/20773163/118129860-9f3e8980-b3f4-11eb-8b87-5a22388b20e3.mp4


### UI accessibility concerns?

No frontend/UI change here

## Added tests?

- [X] Yes - added a Cypress test

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![No idea what I'm doing](https://i.giphy.com/media/VXCPgZwEP7f1e/giphy.webp)
