### PR TITLE
[Travis] Only cache vendor/bundle and node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
   bundler: true
   directories:
     - node_modules
-    - ~/.cache/Cypress
 rvm:
   - 2.7.2
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ branches:
     - main
 language: ruby
 cache:
+  bundler: true
   directories:
-    - vendor/bundle
-    - ~/.cache
+    - node_modules
+    - ~/.cache/Cypress
 rvm:
   - 2.7.2
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ jobs:
         - bundle exec bundle-audit check --update
         - bin/test-console-check
         - yarn build-storybook
+        - yarn cypress install
         - bin/e2e-ci
 
     - stage: Deploy


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Our Travis cache is currently 2274.37MB . This PR would cut that down to 1221.85MB

I achieved this by going back to the default caching method, only caching `bundle` and `node_module`. The reason our cache size is so large could be because
- Cypress's binary is 800MB
- caching `~/.cache` may have picked up a lot more things that we would've wanted.

I understand that Cypress's documentation recommended Travis caching the binary, but this is still data that is downloaded from a source which is then uncompressed and compressed at the end of the build. Manually running `yarn cypress install` [only takes 16 seconds](https://travis-ci.com/github/forem/forem/jobs/505285944#L2738) and ensure that we are using only the latest binary. We also wouldn't be caching older versions of the binary which would normally slowly increase our cache size. 

I also noticed overall faster build (by 30 seconds) because of the smaller cache size. 

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
n/a

## Added tests?
- [x] No, and this is why: CI changes

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: CI Changes

## [optional] Are there any post deployment tasks we need to perform?
n/a
