### PR TITLE
[15 min fix] Fallback to the image URL if Cloudinary/Imgproxy are not configured

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -96,10 +96,10 @@ BUFFER_LISTINGS_PROFILE="Optional"
 
 # Cloudinary for image resizing and cache??
 # (https://cloudinary.com/documentation/rails_integration)
-CLOUDINARY_API_KEY="Optional"
-CLOUDINARY_API_SECRET="Optional"
-CLOUDINARY_CLOUD_NAME="Optional"
-CLOUDINARY_SECURE="Optional"
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_SECURE=
 
 # HTML/CSS to Image for generating social preview images
 # (https://docs.htmlcsstoimage.com/example-code/ruby)

--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -5,8 +5,10 @@ module Images
 
       if imgproxy_enabled?
         imgproxy(img_src, **kwargs)
-      else
+      elsif cloudinary_enabled?
         cloudinary(img_src, **kwargs)
+      else
+        img_src
       end
     end
 
@@ -57,6 +59,10 @@ module Images
 
     def self.imgproxy_enabled?
       Imgproxy.config.key.present? && Imgproxy.config.salt.present?
+    end
+
+    def self.cloudinary_enabled?
+      Cloudinary.config.cloud_name.present? && Cloudinary.config.api_key.present?
     end
 
     def self.get_imgproxy_endpoint

--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -62,7 +62,9 @@ module Images
     end
 
     def self.cloudinary_enabled?
-      Cloudinary.config.cloud_name.present? && Cloudinary.config.api_key.present?
+      config = Cloudinary.config
+
+      config.cloud_name.present? && config.api_key.present? && config.api_secret.present?
     end
 
     def self.get_imgproxy_endpoint

--- a/config/initializers/cloudinary.rb
+++ b/config/initializers/cloudinary.rb
@@ -1,5 +1,5 @@
 Cloudinary.config do |config|
-  config.cloud_name = Rails.env.test? ? "TEST-CLOUD" : ApplicationConfig["CLOUDINARY_CLOUD_NAME"]
+  config.cloud_name = ApplicationConfig["CLOUDINARY_CLOUD_NAME"]
   config.api_key = ApplicationConfig["CLOUDINARY_API_KEY"]
   config.api_secret = ApplicationConfig["CLOUDINARY_API_SECRET"]
   config.secure = ApplicationConfig["CLOUDINARY_SECURE"]

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#cloudinary" do
+  describe "#cloudinary", cloudinary: true do
     it "returns cloudinary-manipulated link" do
       image = helper.optimized_image_url(Faker::Placeholdit.image)
       expect(image).to start_with("https://res.cloudinary.com")
@@ -240,7 +240,7 @@ RSpec.describe ApplicationHelper, type: :helper do
   end
 
   describe "#optimized_image_tag" do
-    it "works just like cl_image_tag" do
+    it "works just like cl_image_tag", cloudinary: true do
       image_url = "https://i.imgur.com/fKYKgo4.png"
       cloudinary_image_tag = cl_image_tag(image_url,
                                           type: "fetch", crop: "imagga_scale",

--- a/spec/helpers/social_image_helper_spec.rb
+++ b/spec/helpers/social_image_helper_spec.rb
@@ -42,7 +42,7 @@ describe SocialImageHelper do
       expect(url).to eq article_social_preview_url(article, format: :png, host: "hello.com")
     end
 
-    it "returns the main image if set" do
+    it "returns the main image if set", cloudinary: true do
       article.main_image = Faker::CryptoCoin.url_logo
 
       url = helper.article_social_image_url(article)
@@ -66,7 +66,7 @@ describe SocialImageHelper do
       expect(url).to eq article_social_preview_url(article, format: :png, host: "hello.com")
     end
 
-    it "returns correct manipulation of cloudinary links" do
+    it "returns correct manipulation of cloudinary links", cloudinary: true do
       article.update_column(
         :main_image,
         "https://res.cloudinary.com/practicaldev/image/fetch/s--A-gun7rr--/c_imagga_scale,f_auto,fl_progressive,h_420,q_auto,w_1000/https://res.cloudinary.com/practicaldev/image/fetch/s--hcD8ZkbP--/c_imagga_scale%2Cf_auto%2Cfl_progressive%2Ch_420%2Cq_auto%2Cw_1000/https://dev-to-uploads.s3.amazonaws.com/i/th93d625o27nuz63oeen.png", # rubocop:disable Layout/LineLength

--- a/spec/models/html_variant_spec.rb
+++ b/spec/models/html_variant_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe HtmlVariant, type: :model do
     expect(described_class.find_for_test(["hello"]).id).to eq(html_variant.id)
   end
 
-  it "prefixes an image with cloudinary" do
+  it "prefixes an image with cloudinary", cloudinary: true do
     html = "<div><img src='https://devimages.com/image.jpg' /></div>"
     html_variant.update(approved: false, html: html)
     cloudinary_string = "/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_420/https://devimages.com/image.jpg"

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe Message, type: :model do
 
     describe "#message_html" do
       it "creates rich link with proper link for article" do
+        link = "http://#{ApplicationConfig['APP_DOMAIN']}#{article.path}"
+        message.message_markdown = "hello #{link}"
+        message.validate!
+
+        expect(message.message_html).to include(
+          article.title,
+          "sidecar-article",
+          link,
+        )
+      end
+
+      it "creates rich link with proper link for article when Cloudinary is enabled", cloudinary: true do
         message.message_markdown = "hello http://#{ApplicationConfig['APP_DOMAIN']}#{article.path}"
         message.validate!
 

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Message, type: :model do
 
     describe "#message_html" do
       it "creates rich link with proper link for article" do
-        link = "http://#{ApplicationConfig['APP_DOMAIN']}#{article.path}"
+        link = URL.article(article)
         message.message_markdown = "hello #{link}"
         message.validate!
 

--- a/spec/models/podcast_episode_spec.rb
+++ b/spec/models/podcast_episode_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe PodcastEpisode, type: :model do
       end
     end
 
-    describe "Cloudinary configuration and processing" do
+    describe "Cloudinary configuration and processing", cloudinary: true do
       it "prefixes an image URL with a path" do
         image_url = "https://dummyimage.com/10x10"
         podcast_episode.body = "<img src=\"#{image_url}\">"

--- a/spec/services/html/parser_spec.rb
+++ b/spec/services/html/parser_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Html::Parser, type: :service do
     end
 
     context "when an image is used" do
-      it "wraps the image with Cloudinary" do
+      it "wraps the image with Cloudinary", cloudinary: true do
         html = "<img src='https://image.com/image.jpg'>"
         parsed_html = described_class.new(html).prefix_all_images.html
         expect(parsed_html).to include("https://res.cloudinary.com")

--- a/spec/services/images/generate_social_image_spec.rb
+++ b/spec/services/images/generate_social_image_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Images::GenerateSocialImage, type: :labor do
     expect(described_class.call(article)).to eq(article.main_image)
   end
 
-  it "returns article social image" do
+  it "returns article social image", cloudinary: true do
     article.main_image = nil
     article.social_image = nil
     article.cached_tag_list = "discuss, hello, goodbye"

--- a/spec/services/images/optimizer_spec.rb
+++ b/spec/services/images/optimizer_spec.rb
@@ -84,18 +84,24 @@ RSpec.describe Images::Optimizer, type: :service do
   end
 
   describe "#cloudinary_enabled?" do
-    it "returns false if cloud_name and api_key are missing", :aggregate_failures do
-      allow(Cloudinary.config).to receive(:cloud_name).and_return(nil)
+    it "returns false if cloud_name, api_key or api_secret are missing", :aggregate_failures do
+      allow(Cloudinary.config).to receive(:cloud_name).and_return("")
       expect(described_class.cloudinary_enabled?).to be(false)
 
       allow(Cloudinary.config).to receive(:cloud_name).and_return("cloud name")
-      allow(Cloudinary.config).to receive(:api_key).and_return(nil)
+      allow(Cloudinary.config).to receive(:api_key).and_return("")
+      expect(described_class.cloudinary_enabled?).to be(false)
+
+      allow(Cloudinary.config).to receive(:cloud_name).and_return("cloud name")
+      allow(Cloudinary.config).to receive(:api_key).and_return("api key")
+      allow(Cloudinary.config).to receive(:api_secret).and_return("")
       expect(described_class.cloudinary_enabled?).to be(false)
     end
 
-    it "returns true if cloud_name and api_key are provided" do
+    it "returns true if cloud_name and api_key and api_secret are provided" do
       allow(Cloudinary.config).to receive(:cloud_name).and_return("cloud name")
       allow(Cloudinary.config).to receive(:api_key).and_return("api key")
+      allow(Cloudinary.config).to receive(:api_secret).and_return("api secret")
 
       expect(described_class.cloudinary_enabled?).to be(true)
     end

--- a/spec/services/images/optimizer_spec.rb
+++ b/spec/services/images/optimizer_spec.rb
@@ -51,9 +51,8 @@ RSpec.describe Images::Optimizer, type: :service do
     end
   end
 
-  describe "#cloudinary" do
+  describe "#cloudinary", cloudinary: true do
     it "performs exactly like cl_image_path" do
-      allow(described_class).to receive(:imgproxy_enabled?).and_return(false)
       cloudinary_url = cl_image_path(image_url,
                                      type: "fetch",
                                      width: 50, height: 50,
@@ -66,7 +65,6 @@ RSpec.describe Images::Optimizer, type: :service do
     end
 
     it "generates correct url by relying on DEFAULT_CL_OPTIONS" do
-      allow(described_class).to receive(:imgproxy_enabled?).and_return(false)
       cloudinary_url = cl_image_path(image_url,
                                      type: "fetch",
                                      quality: "auto",

--- a/spec/services/images/profile_spec.rb
+++ b/spec/services/images/profile_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Images::Profile, type: :services do
     end
 
     context "when user has no profile_image" do
-      it "returns backup image prefixed with Cloudinary" do
+      it "returns backup image prefixed with Cloudinary", cloudinary: true do
         user = build_stubbed(:user, profile_image: nil)
         correct_prefix = "/c_fill,f_auto,fl_progressive,h_120,q_auto,w_120/"
         expect(described_class.call(user.profile_image_url)).to include(correct_prefix + described_class::BACKUP_LINK)

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
       expect(generate_and_parse_markdown(markdown_with_img)).to include("<a")
     end
 
-    it "wraps the image with Cloudinary" do
+    it "wraps the image with Cloudinary", cloudinary: true do
       expect(generate_and_parse_markdown(markdown_with_img))
         .to include("https://res.cloudinary.com")
     end

--- a/spec/support/initializers/image_processing.rb
+++ b/spec/support/initializers/image_processing.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  config.before(:each, cloudinary: true) do |_example|
+    allow(Cloudinary.config).to receive(:cloud_name).and_return("CLOUD_NAME")
+    allow(Cloudinary.config).to receive(:api_key).and_return("API_KEY")
+    allow(Cloudinary.config).to receive(:api_secret).and_return("API_SECRET")
+    allow(Cloudinary.config).to receive(:secure).and_return("SECURE")
+  end
+end

--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Using the editor", type: :system do
       page.evaluate_script("window.onbeforeunload = function(){}")
     end
 
-    it "fills out form with rich content and click preview" do
+    it "fills out form with rich content and click preview", cloudinary: true do
       article_body = find("div.crayons-article__body")["innerHTML"]
       article_body.gsub!(%r{"https://res\.cloudinary\.com/.{1,}"}, "cloudinary_link")
 
@@ -58,7 +58,7 @@ RSpec.describe "Using the editor", type: :system do
   end
 
   describe "Submitting an article", js: true do
-    it "fill out form and submit" do
+    it "fill out form and submit", cloudinary: true do
       fill_markdown_with(read_from_file(raw_text))
       find("button", text: /\ASave changes\z/).click
       article_body = find(:xpath, "//div[@id='article-body']")["innerHTML"]

--- a/spec/view_objects/cloud_cover_url_spec.rb
+++ b/spec/view_objects/cloud_cover_url_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
-RSpec.describe CloudCoverUrl, type: :view_object do
+RSpec.describe CloudCoverUrl, type: :view_object, cloudinary: true do
   let(:article) { create(:article) }
-  let(:cloudinary_prefix) { "https://res.cloudinary.com/TEST-CLOUD/image/fetch/" }
+  let(:cloudinary_prefix) { "https://res.cloudinary.com/#{Cloudinary.config.cloud_name}/image/fetch/" }
 
   it "returns proper url" do
     expect(described_class.new(article.main_image).call)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently we tell people to copy `.env_sample` to `.env` but if they then try to link an external image (without uploading it) in a post, the `Images::Optimizer` will try to generate a Cloudinary URL and leave the user with a broken UX.

I think `Images::Optimizer` should just return the image URL verbatim if neither Cloudinary nor Imgproxy are configured and that we should have that as a default for new installs.

## QA Instructions, Screenshots, Recordings

1. set `CLOUDINARY_API_KEY` and `CLOUDINARY_CLOUD_NAME` back to `Optional` (or anything really), start the app, get a [image URL](https://media1.tenor.com/images/38764a3868c2dd4f8c1253c4e9ec896e/tenor.gif) and create a post with:

```markdown
![image](https://media1.tenor.com/images/38764a3868c2dd4f8c1253c4e9ec896e/tenor.gif)
```

2. Cloudinary will create a broken URL because
3. empty `CLOUDINARY_API_KEY` and `CLOUDINARY_CLOUD_NAME` again and restart the app, re-save the previous article or create a new one, now you'll see the image directly from where you've linked it.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
