### PR TITLE
Fix typo: 'upsteam' -> 'upstream'

### DIFF
--- a/docs/getting-started/workflow.md
+++ b/docs/getting-started/workflow.md
@@ -27,8 +27,8 @@ merge them into your current workspace.
 
 Use this:
 
-- to get commits from upsteam main into your branch
-- to sync with latest changes from upsteam main before continuing with a new
+- to get commits from upstream main into your branch
+- to sync with latest changes from upstream main before continuing with a new
   feature on your current branch
 
 After you've fetched new commits from upstream, run `./bin/setup`, and it will


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update

## Description

Fixing a typo in the "Suggested workflow" section of the documention, which states "upsteam" twice instead of "upstream".

## Related Tickets & Documents

None. 

## QA Instructions, Screenshots, Recordings

None. 

### UI accessibility concerns?

None. 

## Added tests?

- [ ] Yes
- [X] No, and this is why: This only changes 2 typos in the docs.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: 
This only changes 2 typos in the docs.

## [optional] Are there any post deployment tasks we need to perform?

No.
