### PR TITLE
✂✂✂ Remove `shop_url` from `SiteConfig` ✂✂✂

### DIFF
--- a/app/lib/constants/site_config.rb
+++ b/app/lib/constants/site_config.rb
@@ -95,10 +95,6 @@ module Constants
         description: "Determines how often periodic email digests are sent",
         placeholder: 2
       },
-      shop_url: {
-        description: "Used as the shop url of the community",
-        placeholder: "https://shop.url"
-      },
       sidebar_tags: {
         description: "Determines which tags are shown on the homepage righthand sidebar",
         placeholder: "List of valid, comma-separated tags e.g. help,discuss,explainlikeimfive,meta"

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -115,7 +115,6 @@ class SiteConfig < RailsSettings::Base
   field :payment_pointer, type: :string
   field :stripe_api_key, type: :string, default: ApplicationConfig["STRIPE_SECRET_KEY"]
   field :stripe_publishable_key, type: :string, default: ApplicationConfig["STRIPE_PUBLISHABLE_KEY"]
-  field :shop_url, type: :string
 
   # Newsletter
   # <https://mailchimp.com/developer/>

--- a/app/views/admin/configs/show.html.erb
+++ b/app/views/admin/configs/show.html.erb
@@ -822,14 +822,6 @@
                        } %>
           <div id="monetizationBodyContainer" class="card-body collapse hide" aria-labelledby="monetizationBodyContainer">
             <fieldset class="grid gap-4">
-              <div class="crayons-field">
-                <%= admin_config_label :shop_url, "Shop URL" %>
-                <%= admin_config_description Constants::SiteConfig::DETAILS[:shop_url][:description] %>
-                <%= f.text_field :shop_url,
-                                 class: "crayons-textfield",
-                                 value: SiteConfig.shop_url,
-                                 placeholder: Constants::SiteConfig::DETAILS[:shop_url][:placeholder] %>
-            </div>
 
             <div class="crayons-field">
               <%= admin_config_label :stripe_api_key, "Stripe API key" %>

--- a/app/views/pages/_privacy_text.html.erb
+++ b/app/views/pages/_privacy_text.html.erb
@@ -75,9 +75,6 @@
 <p><strong>Payment processing</strong>
   <br>
   <%= community_name %> does not process payments directly — we rely on third-party services such as Stripe, Shopify, and Paypal to receive payments and store any payment information.
-  <% if SiteConfig.shop_url.present? %>
-    <a href="<%= SiteConfig.shop_url %>">The <%= community_name %> Shop</a> is run through Shopify, a third-party e-commerce platform with their own Privacy Policy.
-  <% end %>
 </p>
 <p><strong>Third-Party Embeds</strong>
   <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -316,10 +316,6 @@ Rails.application.routes.draw do
     get "/page/post-a-job", to: "pages#post_a_job"
     get "/tag-moderation", to: "pages#tag_moderation"
 
-    # NOTE: can't remove the hardcoded URL here as SiteConfig is not available here, we should eventually
-    # setup dynamic redirects, see <https://github.com/thepracticaldev/dev.to/issues/7267>
-    get "/shop", to: redirect("https://shop.dev.to")
-
     get "/mod", to: "moderations#index", as: :mod
     get "/mod/:tag", to: "moderations#index"
 

--- a/lib/data_update_scripts/20210517091342_remove_shop_url_from_site_config.rb
+++ b/lib/data_update_scripts/20210517091342_remove_shop_url_from_site_config.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class RemoveShopUrlFromSiteConfig
+    def run
+      SiteConfig.delete_by(var: "shop_url")
+    end
+  end
+end

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -450,38 +450,6 @@ RSpec.describe "/admin/customization/config", type: :request do
           expect(SiteConfig.stripe_api_key).to eq("sk_live_yo")
           expect(SiteConfig.stripe_publishable_key).to eq("pk_live_haha")
         end
-
-        describe "Shop" do
-          it "rejects update to shop_url without proper confirmation" do
-            expected_shop_url = "https://qshop.dev.to"
-
-            expect do
-              params = { site_config: { shop_url: expected_shop_url }, confirmation: "Incorrect confirmation" }
-              post admin_config_path, params: params
-            end.to raise_error ActionController::BadRequest
-
-            expect(SiteConfig.shop_url).not_to eq(expected_shop_url)
-          end
-
-          it "sets shop_url to nil" do
-            previous_shop_url = "some-shop-url"
-            post admin_config_path, params: { site_config: { shop_url: "" }, confirmation: confirmation_message }
-            expect(SiteConfig.shop_url).to eq("")
-            get "/privacy"
-            expect(response.body).not_to include(previous_shop_url)
-            expect(response.body).not_to include("#{SiteConfig.community_name} Shop")
-          end
-
-          it "updates shop url" do
-            expected_shop_url = "https://qshop.dev.to"
-            post admin_config_path, params: { site_config: { shop_url: expected_shop_url },
-                                              confirmation: confirmation_message }
-            expect(SiteConfig.shop_url).to eq(expected_shop_url)
-            get "/privacy"
-            expect(response.body).to include(expected_shop_url)
-            expect(response.body).to include("#{SiteConfig.community_name} Shop")
-          end
-        end
       end
 
       describe "Newsletter" do

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -89,11 +89,8 @@ RSpec.describe "Pages", type: :request do
 
   describe "GET /privacy" do
     it "has proper headline" do
-      allow(SiteConfig).to receive(:shop_url).and_return("some-shop-url")
       get "/privacy"
       expect(response.body).to include("Privacy Policy")
-      expect(response.body).to include(SiteConfig.shop_url)
-      expect(response.body).to include("#{SiteConfig.community_name} Shop")
     end
   end
 

--- a/spec/routing/all_routes_spec.rb
+++ b/spec/routing/all_routes_spec.rb
@@ -35,14 +35,6 @@ RSpec.describe "all routes", type: :routing do
   context "when redirected routes" do
     include RSpec::Rails::RequestExampleGroup
 
-    it "redirects /shop to the default shop_url" do
-      # TODO: the hardcoded shop url needs to be removed from the routes in favor of a dynamic one.
-      allow(SiteConfig).to receive(:shop_url).and_return("https://shop.dev.to")
-      get shop_path
-
-      expect(response).to redirect_to(SiteConfig.shop_url)
-    end
-
     it "redirects /settings/integrations to /settings/extensions" do
       get user_settings_path(:integrations)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR removes `shop_url` from `SiteConfig` and also all the related code. This is better handled via a `NavigationLink`. 

## Related Tickets & Documents

#13583

## QA Instructions, Screenshots, Recordings

Nothing specific, just removing code.

### UI accessibility concerns?

None

## Added tests?

- [X] Yes: updated/deleted exsisting

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
