### PR TITLE
[15-minute fix] Remove mentions of creators.forem.com

### DIFF
--- a/app/views/admin/overview/index.html.erb
+++ b/app/views/admin/overview/index.html.erb
@@ -15,7 +15,7 @@
           <li class="mb-1 -ml-4">Read the <a href="https://forem.gitbook.io/forem-admin-guide/quick-start-guide" data-action="click->ahoy#trackOverviewLink">Quick Start Guide</a></li>
           <li class="mb-1 -ml-4"><%= link_to "Set up a Welcome Thread", admin_welcome_index_path, 'data-action': "click->ahoy#trackOverviewLink" %></li>
           <li class="mb-1 -ml-4">Browse the <a href="https://forem.gitbook.io/forem-admin-guide" data-action="click->ahoy#trackOverviewLink">Forem Admin Guide</a></li>
-          <li class="-ml-4">Join the private <a href="https://creators.forem.com">Creators Forem</a> (email <a href="mailto:support@forem.com" data-action="click->ahoy#trackOverviewLink">support@forem.com</a> if you need an invite)</li>
+          <li class="-ml-4">Join <a href="https://forem.dev">forem.dev</a> to learn from fellow Forem creators.</li>
         </ol>
         <div class="align-center">
           <a class="crayons-btn crayons-btn--ghost-brand" href="https://forem.gitbook.io/forem-admin-guide" data-action="click->ahoy#trackOverviewLink">Visit Forem Admin Guide</a>
@@ -51,14 +51,13 @@
       </section>
       <section class="crayons-card">
         <div class="crayons-card__header">
-          <h3 class="crayons-subtitle-2">Forem Creators Community</h3>
+          <h3 class="crayons-subtitle-2">Forem.dev</h3>
         </div>
         <div class="crayons-card__body flex flex-wrap" style="min-height: 150px;">
           <p class="mb-2">
-            Meet other creators using Forem so that you can share tips with
-            each other.
+            Meet other creators using Forem so that you can share tips with each other.
           </p>
-          <a role="button" href="https://creators.forem.com" class="crayons-btn mt-1 w-100 self-end" data-action="click->ahoy#trackOverviewLink">Join Community</a>
+          <a role="button" href="https://forem.dev" class="crayons-btn mt-1 w-100 self-end" data-action="click->ahoy#trackOverviewLink">Join Community</a>
         </div>
       </section>
     </article>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Copy update

## Description

In the admin check list we still referenced creators.forem.com which doesn't exist anymore. This PR updates the copy to forem.dev as requested by @michael-tharrington.

## Related Tickets & Documents

Closes https://github.com/forem/rfcs/issues/217

## QA Instructions, Screenshots, Recordings

![2021-05-17 11_51_50-Overview and 7 more pages - Personal - Microsoft​ Edge Beta](https://user-images.githubusercontent.com/47985/118434283-fe5b1180-b706-11eb-9c19-8c18b27a05ec.png)

### UI accessibility concerns?

None

## Added tests?

- [X] No, and this is why: copy-only change

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] This change does not need to be communicated, and this is why not: copy-only change
