### PR TITLE
#13759 : hide content in print mode

### DIFF
--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -1,4 +1,4 @@
-<div class="crayons-article-actions">
+<div class="crayons-article-actions print-hidden">
   <div class="crayons-article-actions__inner">
     <% if @article.published? %>
 

--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -3,7 +3,7 @@
     <% if @article.show_comments %>
       <header class="relative flex justify-between items-center mb-6">
         <h2 class="crayons-subtitle-1">Discussion <span class="js-comments-count" data-comments-count="<%= @article.comments_count %>">(<%= @article.comments_count %>)</span></h2>
-        <div id="comment-subscription">
+        <div id="comment-subscription" class="print-hidden">
           <div role="presentation" class="crayons-btn-group">
             <span class="crayons-btn crayons-btn--outlined">Subscribe</span>
           </div>

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -1,5 +1,5 @@
 <% @actor = @article.organization || @article.user %>
-<div class="crayons-article-sticky grid gap-4 break-word print-hidden" id="article-show-primary-sticky-nav">
+<div class="crayons-article-sticky grid gap-4 break-word" id="article-show-primary-sticky-nav">
   <div class="crayons-card crayons-card--secondary branded-7 p-4 pt-0 gap-4 grid" style="border-top-color: <%= Color::CompareHex.new([user_colors(@actor)[:bg], user_colors(@actor)[:text]]).brightness(0.88) %>;">
     <div class="-mt-4">
       <a href="<%= @actor.path %>" class="flex">
@@ -15,7 +15,7 @@
       </div>
     <% end %>
 
-    <div>
+    <div class="print-hidden">
       <%= follow_button(@actor, style = "", classes = "w-100") %>&nbsp;
     </div>
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -235,8 +235,8 @@
   <% end %>
 <% end %>
 
-<div class="mod-actions-menu"></div>
-<div id="mod-actions-menu-btn-area"></div>
+<div class="mod-actions-menu print-hidden"></div>
+<div id="mod-actions-menu-btn-area print-hidden"></div>
 <div data-testid="flag-user-modal-container" class="flag-user-modal-container hidden"></div>
 
 <div class="fullscreen-code js-fullscreen-code"></div>

--- a/app/views/comments/_comment_footer.html.erb
+++ b/app/views/comments/_comment_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="comment__footer">
+<footer class="comment__footer print-hidden">
   <button
     class="crayons-btn crayons-btn--ghost crayons-btn--icon-left crayons-btn--s mr-1 reaction-like inline-flex reaction-button"
     id="button-for-comment-<%= comment.id %>"

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -12,7 +12,7 @@
   </div>
 <% end %>
 
-<%= form_for(@comment, authenticity_token: false, html: { class: %w[comment-form print-hidden] }) do |f| %>
+<%= form_for(@comment, authenticity_token: false, html: { class: "comment-form print-hidden" }) do |f| %>
   <% if @article&.comment_template.present? && @comment.new_record? %>
     <div class="article-comment-form-preamble">
       This post comes with a comment template

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -12,7 +12,7 @@
   </div>
 <% end %>
 
-<%= form_for(@comment, authenticity_token: false, html: { class: "comment-form" }) do |f| %>
+<%= form_for(@comment, authenticity_token: false, html: { class: %w[comment-form print-hidden] }) do |f| %>
   <% if @article&.comment_template.present? && @comment.new_record? %>
     <div class="article-comment-form-preamble">
       This post comes with a comment template


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

This PR optimizes the print view of an article by hiding additional elements such as the moderation button (full list below).

## Related Tickets & Documents

Closes #13759

## QA Instructions, Screenshots, Recordings

All elements with a class `print-hidden` should now be hidden in the print preview of an article:

- Header
- Footer
- "Read next"
- Moderation button
- Moderation sidebar
- Article actions (favorite/bookmark/...)
- "Follow" button
- Input field for new comments
- Like/reply buttons for comments
- "Subscribe" button

All other elements should still be visible.

### UI accessibility concerns?

None.

## Added tests?

- [ ] Yes
- [X] No, and this is why: only classes were added in the HTML so it will not break any existing functionality.
- [ ] I need help with writing tests
