### PR TITLE
Add error handling to clipboard promise - post editor

### DIFF
--- a/app/assets/javascripts/initializers/runtime.js
+++ b/app/assets/javascripts/initializers/runtime.js
@@ -129,7 +129,7 @@ class Runtime {
             reject(e);
           });
       } else {
-        reject('Unsupported device unable to copy to clipboard');
+        reject('Unable to copy the text. Try reloading the page');
       }
     });
   }

--- a/app/javascript/article-form/components/EditorBody.jsx
+++ b/app/javascript/article-form/components/EditorBody.jsx
@@ -70,13 +70,6 @@ export const EditorBody = ({
     }
   });
 
-  // In some platforms we've seen `navigator.clipboard` return `undefined`
-  // despite `window.isSecureContext` being true. A refresh fixes the problem.
-  // It's important to only do this when isSecureContext (not in dev/test env)
-  if (navigator.clipboard == null && window.isSecureContext) {
-    window.location.reload();
-  }
-
   return (
     <div
       data-testid="article-form__body"

--- a/app/javascript/article-form/components/EditorBody.jsx
+++ b/app/javascript/article-form/components/EditorBody.jsx
@@ -70,6 +70,13 @@ export const EditorBody = ({
     }
   });
 
+  // In some platforms we've seen `navigator.clipboard` return `undefined`
+  // despite `window.isSecureContext` being true. A refresh fixes the problem.
+  // It's important to only do this when isSecureContext (not in dev/test env)
+  if (navigator.clipboard == null && window.isSecureContext) {
+    window.location.reload();
+  }
+
   return (
     <div
       data-testid="article-form__body"

--- a/app/javascript/article-form/components/ImageUploader.jsx
+++ b/app/javascript/article-form/components/ImageUploader.jsx
@@ -108,6 +108,7 @@ export const ImageUploader = () => {
           message: error,
           addCloseButton: true,
         });
+        Honeybadger.notify(error);
       });
   }
 

--- a/app/javascript/article-form/components/ImageUploader.jsx
+++ b/app/javascript/article-form/components/ImageUploader.jsx
@@ -4,6 +4,7 @@ import { h } from 'preact';
 import { useReducer } from 'preact/hooks';
 import { generateMainImage } from '../actions';
 import { validateFileInputs } from '../../packs/validateFileInputs';
+import { addSnackbarItem } from '../../Snackbar';
 import { ClipboardButton } from './ClipboardButton';
 import { Button, Spinner } from '@crayons';
 
@@ -96,11 +97,18 @@ export const ImageUploader = () => {
       'image-markdown-copy-link-input',
     );
 
-    Runtime.copyToClipboard(imageMarkdownInput.value).then(() => {
-      dispatch({
-        type: 'show_copied_image_message',
+    Runtime.copyToClipboard(imageMarkdownInput.value)
+      .then(() => {
+        dispatch({
+          type: 'show_copied_image_message',
+        });
+      })
+      .catch((error) => {
+        addSnackbarItem({
+          message: error,
+          addCloseButton: true,
+        });
       });
-    });
   }
 
   function handleInsertionImageUpload(e) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

When copying to the clipboard (uploaded image url) in the Editor Post sometimes the `navigator.clipboard` is `undefined`.

The promise chain wasn't handling exceptions so this PR adds a `catch` instead of silently failing.

## Related Tickets & Documents

closes https://github.com/forem/forem-ios/issues/55 https://github.com/forem/ForemWebView-ios/issues/26

## QA Instructions, Screenshots, Recordings

**Note/disclaimer:** If you don't have the iOS app to test this that's okay, a code review and a manual test this feature works on Desktop is also valuable 👍 

1. Open the Forem iOS app (kill app first for fresh start)
2. Go to the Editor as soon as the page loads
3. Upload an image
4. Click "Copy"
5. It should work or display a Snackbar message with the error

**Video of the Snackbar in action**

https://user-images.githubusercontent.com/6045239/118721802-8d8c2600-b7e8-11eb-8df5-ba1e17d4d1c1.MP4

### UI accessibility concerns?

None - It adds text but it's displayed via Snackbar

## Added tests?

- [x] No, and this is why: This is a very tricky situation to test. We need to make sure `navigator.clipboard` is `undefined` which will trigger the failure of the Promise when the "Copy" button is clicked (all of this after an image has been uploaded).
- [x] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: This is a bugfix

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![if at first you dont succeed try again](https://media.giphy.com/media/iqsUYfkKstdC0/giphy.gif)
