### PR TITLE
Add ability to lock discussions

### DIFF
--- a/app/assets/javascripts/initializePage.js
+++ b/app/assets/javascripts/initializePage.js
@@ -12,7 +12,7 @@
   initializeHeroBannerClose, initializeOnboardingTaskCard, initScrolling,
   nextPage:writable, fetching:writable, done:writable, adClicked:writable,
   initializePaymentPointers, initializeBroadcast, initializeDateHelpers,
-  initializeColorPicker, Runtime
+  initializeColorPicker, initializeDiscussionLockButtons, Runtime
 */
 
 function callInitializers() {
@@ -43,6 +43,7 @@ function callInitializers() {
   initializeOnboardingTaskCard();
   initializeDateHelpers();
   initializeColorPicker();
+  initializeDiscussionLockButtons();
 }
 
 function initializePage() {

--- a/app/assets/javascripts/initializers/initializeDiscussionLockButtons.js
+++ b/app/assets/javascripts/initializers/initializeDiscussionLockButtons.js
@@ -3,7 +3,7 @@ function initializeDiscussionLockButtons() {
   if (articleContainer) {
     const isDiscussionLocked = articleContainer.dataset.discussionLocked;
 
-    if (isDiscussionLocked == "true") {
+    if (isDiscussionLocked == 'true') {
       displayDiscussionLockReason();
       hideElementById('new_comment');
     } else {
@@ -16,11 +16,15 @@ function initializeDiscussionLockButtons() {
 }
 
 function displayDiscussionLockReason(reason) {
-  const discussionLockReason = document.getElementById('discussion-lock-reason');
+  const discussionLockReason = document.getElementById(
+    'discussion-lock-reason',
+  );
   if (discussionLockReason) {
     discussionLockReason.classList.remove('hidden');
 
-    const discussionLockReasonText = document.getElementById('discussion-lock-reason-text');
+    const discussionLockReasonText = document.getElementById(
+      'discussion-lock-reason-text',
+    );
     if (reason && discussionLockReasonText) {
       discussionLockReasonText.textContent = reason;
     }
@@ -28,12 +32,16 @@ function displayDiscussionLockReason(reason) {
 }
 
 function hideDiscussionLockReason() {
-  const discussionLockReason = document.getElementById('discussion-lock-reason');
+  const discussionLockReason = document.getElementById(
+    'discussion-lock-reason',
+  );
   if (discussionLockReason) {
     discussionLockReason.classList.add('hidden');
   }
 
-  const discussionLockReasonText = document.getElementById('discussion-lock-reason-text');
+  const discussionLockReasonText = document.getElementById(
+    'discussion-lock-reason-text',
+  );
   if (discussionLockReasonText) {
     discussionLockReasonText.textContent = '';
   }
@@ -42,11 +50,13 @@ function hideDiscussionLockReason() {
 function displayButtons() {
   var user = userData();
   var articleContainer = document.getElementById('article-show-container');
-  if (articleContainer) {
+  if (user && articleContainer) {
     var authorId = parseInt(articleContainer.dataset.authorId, 10);
 
     if (user.admin || authorId === user.id) {
-      var discussionLockButts = document.getElementsByClassName('discussion-lock-actions');
+      var discussionLockButts = document.getElementsByClassName(
+        'discussion-lock-actions',
+      );
 
       for (let i = 0; i < discussionLockButts.length; i += 1) {
         let butt = discussionLockButts[i];
@@ -59,44 +69,57 @@ function displayButtons() {
 function addConfirmationModalClickHandlers() {
   const discussionLockButton = document.getElementById('discussion-lock-btn');
   if (discussionLockButton) {
-    discussionLockButton.addEventListener('click', function(e) {
+    discussionLockButton.addEventListener('click', function (e) {
       showElementById('discussion-lock-confirmation-modal');
     });
   }
 
-  const discussionLockCancelBtn = document.getElementById('discussion-lock-cancel-btn');
+  const discussionLockCancelBtn = document.getElementById(
+    'discussion-lock-cancel-btn',
+  );
   if (discussionLockCancelBtn) {
-    discussionLockCancelBtn.addEventListener('click', function(e) {
+    discussionLockCancelBtn.addEventListener('click', function (e) {
       hideElementById('discussion-lock-confirmation-modal');
     });
   }
 
-  const closeDiscussionLockConfirmationModal = document.getElementById('close-discussion-lock-confirmation-modal');
+  const closeDiscussionLockConfirmationModal = document.getElementById(
+    'close-discussion-lock-confirmation-modal',
+  );
   if (closeDiscussionLockConfirmationModal) {
-    closeDiscussionLockConfirmationModal.addEventListener('click', function(e) {
-      hideElementById('discussion-lock-confirmation-modal');
-    });
+    closeDiscussionLockConfirmationModal.addEventListener(
+      'click',
+      function (e) {
+        hideElementById('discussion-lock-confirmation-modal');
+      },
+    );
   }
 
-  const discussionLockConfirmationBtn = document.getElementById('lock-discussion-btn')
+  const discussionLockConfirmationBtn = document.getElementById(
+    'lock-discussion-btn',
+  );
   if (discussionLockConfirmationBtn) {
-    discussionLockConfirmationBtn.addEventListener('click', function(e) {
+    discussionLockConfirmationBtn.addEventListener('click', function (e) {
       handleLockDiscussion();
     });
   }
-  
-  const reopenDiscussionBtn = document.getElementById('discussion-lock-reopen-btn')
+
+  const reopenDiscussionBtn = document.getElementById(
+    'discussion-lock-reopen-btn',
+  );
   if (reopenDiscussionBtn) {
-    reopenDiscussionBtn.addEventListener('click', function(e) {
+    reopenDiscussionBtn.addEventListener('click', function (e) {
       handleReopenDiscussion();
     });
   }
 }
 
 function submitDiscussionLock() {
-  const discussionLockConfirmationBtn = document.getElementById('lock-discussion-btn')
+  const discussionLockConfirmationBtn = document.getElementById(
+    'lock-discussion-btn',
+  );
   if (discussionLockConfirmationBtn) {
-    discussionLockConfirmationBtn.textContent = "Locking...";
+    discussionLockConfirmationBtn.textContent = 'Locking...';
     discussionLockConfirmationBtn.disabled = true;
   }
 
@@ -104,51 +127,56 @@ function submitDiscussionLock() {
     Accept: 'application/json',
     'X-CSRF-Token': window.csrfToken,
     'Content-Type': 'application/json',
-  }
+  };
 
   const articleBody = document.getElementById('article-body');
-  const articleId = (articleBody ? articleBody.dataset.articleId : null);
-  const reasonFieldValue = document.getElementById('discussion-lock-reason-field').value;
-  const discussionLockReason = reasonFieldValue === "" ? null : reasonFieldValue;
-  const body = JSON.stringify(
-    {
-      discussion_lock: {
-        article_id: articleId,
-        reason: discussionLockReason
-      }
-    }
-  )
+  const articleId = articleBody ? articleBody.dataset.articleId : null;
+  const reasonFieldValue = document.getElementById(
+    'discussion-lock-reason-field',
+  ).value;
+  const discussionLockReason =
+    reasonFieldValue === '' ? null : reasonFieldValue;
+  const body = JSON.stringify({
+    discussion_lock: {
+      article_id: articleId,
+      reason: discussionLockReason,
+    },
+  });
 
   return fetch('/discussion_locks', {
     method: 'POST',
     headers: discussionLockHeaders,
     credentials: 'same-origin',
     body: body,
-  }).then(function(response) {
+  }).then(function (response) {
     return response.json();
   });
 }
 
 function submitReopenDiscussion() {
-  const reopenDiscussionBtn = document.getElementById('discussion-lock-reopen-btn');
+  const reopenDiscussionBtn = document.getElementById(
+    'discussion-lock-reopen-btn',
+  );
   if (reopenDiscussionBtn) {
-    reopenDiscussionBtn.textContent = "Reopening...";
+    reopenDiscussionBtn.textContent = 'Reopening...';
     reopenDiscussionBtn.disabled = true;
   }
-  
+
   const discussionLockHeaders = {
     Accept: 'application/json',
     'X-CSRF-Token': window.csrfToken,
     'Content-Type': 'application/json',
-  }
+  };
 
-  const discussionLockId = reopenDiscussionBtn ? reopenDiscussionBtn.dataset.discussionLockId : null;
+  const discussionLockId = reopenDiscussionBtn
+    ? reopenDiscussionBtn.dataset.discussionLockId
+    : null;
 
   return fetch(`/discussion_locks/${discussionLockId}`, {
     method: 'DELETE',
     headers: discussionLockHeaders,
     credentials: 'same-origin',
-  }).then(function(response) {
+  }).then(function (response) {
     return response.json();
   });
 }
@@ -191,45 +219,55 @@ function showErrorMsg(elementId, msg) {
 }
 
 function reenableDiscussionLockConfirmationBtn() {
-  const discussionLockConfirmationBtn = document.getElementById('lock-discussion-btn');
+  const discussionLockConfirmationBtn = document.getElementById(
+    'lock-discussion-btn',
+  );
   if (discussionLockConfirmationBtn) {
-    discussionLockConfirmationBtn.textContent = "Lock discussion";
+    discussionLockConfirmationBtn.textContent = 'Lock discussion';
     discussionLockConfirmationBtn.disabled = false;
   }
 }
 
 function reenableReopenDiscussionBtn() {
-  const reopenDiscussionBtn = document.getElementById('discussion-lock-reopen-btn');
+  const reopenDiscussionBtn = document.getElementById(
+    'discussion-lock-reopen-btn',
+  );
   if (reopenDiscussionBtn) {
-    reopenDiscussionBtn.textContent = "Reopen";
+    reopenDiscussionBtn.textContent = 'Reopen';
     reopenDiscussionBtn.disabled = false;
   }
 }
 
 function updateReopenDiscussionData(data) {
-  const reopenDiscussionBtn = document.getElementById('discussion-lock-reopen-btn');
+  const reopenDiscussionBtn = document.getElementById(
+    'discussion-lock-reopen-btn',
+  );
   if (reopenDiscussionBtn) {
     reopenDiscussionBtn.setAttribute('data-discussion-lock-id', data.id);
   }
 }
 
 function clearReopenDiscussionData() {
-  const reopenDiscussionBtn = document.getElementById('discussion-lock-reopen-btn');
+  const reopenDiscussionBtn = document.getElementById(
+    'discussion-lock-reopen-btn',
+  );
   if (reopenDiscussionBtn) {
     reopenDiscussionBtn.setAttribute('data-discussion-lock-id', null);
   }
 }
 
 function clearDiscussionLockForm() {
-  const discussionLockReasonInput = document.getElementById('discussion-lock-reason-field');
-  
+  const discussionLockReasonInput = document.getElementById(
+    'discussion-lock-reason-field',
+  );
+
   if (discussionLockReasonInput) {
     discussionLockReasonInput.value = '';
   }
 }
 
 function handleLockDiscussion() {
-  submitDiscussionLock().then(function(response) {
+  submitDiscussionLock().then(function (response) {
     if (response.success) {
       hideErrorMsg('discussion-lock-error');
       hideElementById('discussion-lock-confirmation-modal');
@@ -237,7 +275,7 @@ function handleLockDiscussion() {
       // We "manually" update the DOM because we bust caches async, which can take time
       hideElementById('discussion-lock-btn');
       displayDiscussionLockReason(response.data.reason);
-      updateDiscussionLock("true");
+      updateDiscussionLock('true');
       updateReopenDiscussionData(response.data);
       hideElementById('new_comment');
       clearDiscussionLockForm();
@@ -251,14 +289,14 @@ function handleLockDiscussion() {
 }
 
 function handleReopenDiscussion() {
-  submitReopenDiscussion().then(function(response) {
+  submitReopenDiscussion().then(function (response) {
     if (response.success) {
       hideErrorMsg('reopen-discussion-error');
 
       // We "manually" update the DOM because we bust caches async, which can take time
       showElementById('discussion-lock-btn');
       hideDiscussionLockReason();
-      updateDiscussionLock("false");
+      updateDiscussionLock('false');
       clearReopenDiscussionData();
       showElementById('new_comment');
       reenableReopenDiscussionBtn();

--- a/app/assets/javascripts/initializers/initializeDiscussionLockButtons.js.erb
+++ b/app/assets/javascripts/initializers/initializeDiscussionLockButtons.js.erb
@@ -1,0 +1,271 @@
+function initializeDiscussionLockButtons() {
+  const articleContainer = document.getElementById('article-show-container');
+  if (articleContainer) {
+    const isDiscussionLocked = articleContainer.dataset.discussionLocked;
+
+    if (isDiscussionLocked == "true") {
+      displayDiscussionLockReason();
+      hideElementById('new_comment');
+    } else {
+      showElementById('discussion-lock-action');
+    }
+
+    displayButtons(articleContainer);
+  }
+  addConfirmationModalClickHandlers();
+}
+
+function displayDiscussionLockReason(reason) {
+  const discussionLockReason = document.getElementById('discussion-lock-reason');
+  if (discussionLockReason) {
+    discussionLockReason.classList.remove('hidden');
+
+    const discussionLockReasonText = document.getElementById('discussion-lock-reason-text');
+    if (reason && discussionLockReasonText) {
+      discussionLockReasonText.textContent = reason;
+    }
+  }
+}
+
+function hideDiscussionLockReason() {
+  const discussionLockReason = document.getElementById('discussion-lock-reason');
+  if (discussionLockReason) {
+    discussionLockReason.classList.add('hidden');
+  }
+
+  const discussionLockReasonText = document.getElementById('discussion-lock-reason-text');
+  if (discussionLockReasonText) {
+    discussionLockReasonText.textContent = '';
+  }
+}
+
+function displayButtons() {
+  var user = userData();
+  var articleContainer = document.getElementById('article-show-container');
+  if (articleContainer) {
+    var authorId = parseInt(articleContainer.dataset.authorId, 10);
+
+    if (user.admin || authorId === user.id) {
+      var discussionLockButts = document.getElementsByClassName('discussion-lock-actions');
+
+      for (let i = 0; i < discussionLockButts.length; i += 1) {
+        let butt = discussionLockButts[i];
+        butt.classList.remove('hidden');
+      }
+    }
+  }
+}
+
+function addConfirmationModalClickHandlers() {
+  const discussionLockButton = document.getElementById('discussion-lock-btn');
+  if (discussionLockButton) {
+    discussionLockButton.addEventListener('click', function(e) {
+      showElementById('discussion-lock-confirmation-modal');
+    });
+  }
+
+  const discussionLockCancelBtn = document.getElementById('discussion-lock-cancel-btn');
+  if (discussionLockCancelBtn) {
+    discussionLockCancelBtn.addEventListener('click', function(e) {
+      hideElementById('discussion-lock-confirmation-modal');
+    });
+  }
+
+  const closeDiscussionLockConfirmationModal = document.getElementById('close-discussion-lock-confirmation-modal');
+  if (closeDiscussionLockConfirmationModal) {
+    closeDiscussionLockConfirmationModal.addEventListener('click', function(e) {
+      hideElementById('discussion-lock-confirmation-modal');
+    });
+  }
+
+  const discussionLockConfirmationBtn = document.getElementById('lock-discussion-btn')
+  if (discussionLockConfirmationBtn) {
+    discussionLockConfirmationBtn.addEventListener('click', function(e) {
+      handleLockDiscussion();
+    });
+  }
+  
+  const reopenDiscussionBtn = document.getElementById('discussion-lock-reopen-btn')
+  if (reopenDiscussionBtn) {
+    reopenDiscussionBtn.addEventListener('click', function(e) {
+      handleReopenDiscussion();
+    });
+  }
+}
+
+function submitDiscussionLock() {
+  const discussionLockConfirmationBtn = document.getElementById('lock-discussion-btn')
+  if (discussionLockConfirmationBtn) {
+    discussionLockConfirmationBtn.textContent = "Locking...";
+    discussionLockConfirmationBtn.disabled = true;
+  }
+
+  const discussionLockHeaders = {
+    Accept: 'application/json',
+    'X-CSRF-Token': window.csrfToken,
+    'Content-Type': 'application/json',
+  }
+
+  const articleBody = document.getElementById('article-body');
+  const articleId = (articleBody ? articleBody.dataset.articleId : null);
+  const reasonFieldValue = document.getElementById('discussion-lock-reason-field').value;
+  const discussionLockReason = reasonFieldValue === "" ? null : reasonFieldValue;
+  const body = JSON.stringify(
+    {
+      discussion_lock: {
+        article_id: articleId,
+        reason: discussionLockReason
+      }
+    }
+  )
+
+  return fetch('/discussion_locks', {
+    method: 'POST',
+    headers: discussionLockHeaders,
+    credentials: 'same-origin',
+    body: body,
+  }).then(function(response) {
+    return response.json();
+  });
+}
+
+function submitReopenDiscussion() {
+  const reopenDiscussionBtn = document.getElementById('discussion-lock-reopen-btn');
+  if (reopenDiscussionBtn) {
+    reopenDiscussionBtn.textContent = "Reopening...";
+    reopenDiscussionBtn.disabled = true;
+  }
+  
+  const discussionLockHeaders = {
+    Accept: 'application/json',
+    'X-CSRF-Token': window.csrfToken,
+    'Content-Type': 'application/json',
+  }
+
+  const discussionLockId = reopenDiscussionBtn ? reopenDiscussionBtn.dataset.discussionLockId : null;
+
+  return fetch(`/discussion_locks/${discussionLockId}`, {
+    method: 'DELETE',
+    headers: discussionLockHeaders,
+    credentials: 'same-origin',
+  }).then(function(response) {
+    return response.json();
+  });
+}
+
+function hideElementById(elementId) {
+  const element = document.getElementById(elementId);
+  if (element) {
+    element.classList.add('hidden');
+  }
+}
+
+function showElementById(elementId) {
+  const element = document.getElementById(elementId);
+  if (element) {
+    element.classList.remove('hidden');
+  }
+}
+
+function updateDiscussionLock(isLocked) {
+  const articleContainer = document.getElementById('article-show-container');
+  if (articleContainer) {
+    articleContainer.setAttribute('discussion-locked', isLocked);
+  }
+}
+
+function hideErrorMsg(elementId) {
+  const errorMsg = document.getElementById(elementId);
+  if (errorMsg) {
+    errorMsg.classList.add('hidden');
+    errorMsg.textContent = '';
+  }
+}
+
+function showErrorMsg(elementId, msg) {
+  const errorMsg = document.getElementById(elementId);
+  if (errorMsg) {
+    errorMsg.classList.remove('hidden');
+    errorMsg.textContent = msg;
+  }
+}
+
+function reenableDiscussionLockConfirmationBtn() {
+  const discussionLockConfirmationBtn = document.getElementById('lock-discussion-btn');
+  if (discussionLockConfirmationBtn) {
+    discussionLockConfirmationBtn.textContent = "Lock discussion";
+    discussionLockConfirmationBtn.disabled = false;
+  }
+}
+
+function reenableReopenDiscussionBtn() {
+  const reopenDiscussionBtn = document.getElementById('discussion-lock-reopen-btn');
+  if (reopenDiscussionBtn) {
+    reopenDiscussionBtn.textContent = "Reopen";
+    reopenDiscussionBtn.disabled = false;
+  }
+}
+
+function updateReopenDiscussionData(data) {
+  const reopenDiscussionBtn = document.getElementById('discussion-lock-reopen-btn');
+  if (reopenDiscussionBtn) {
+    reopenDiscussionBtn.setAttribute('data-discussion-lock-id', data.id);
+  }
+}
+
+function clearReopenDiscussionData() {
+  const reopenDiscussionBtn = document.getElementById('discussion-lock-reopen-btn');
+  if (reopenDiscussionBtn) {
+    reopenDiscussionBtn.setAttribute('data-discussion-lock-id', null);
+  }
+}
+
+function clearDiscussionLockForm() {
+  const discussionLockReasonInput = document.getElementById('discussion-lock-reason-field');
+  
+  if (discussionLockReasonInput) {
+    discussionLockReasonInput.value = '';
+  }
+}
+
+function handleLockDiscussion() {
+  submitDiscussionLock().then(function(response) {
+    if (response.success) {
+      hideErrorMsg('discussion-lock-error');
+      hideElementById('discussion-lock-confirmation-modal');
+
+      // We "manually" update the DOM because we bust caches async, which can take time
+      hideElementById('discussion-lock-btn');
+      displayDiscussionLockReason(response.data.reason);
+      updateDiscussionLock("true");
+      updateReopenDiscussionData(response.data);
+      hideElementById('new_comment');
+      clearDiscussionLockForm();
+      reenableDiscussionLockConfirmationBtn();
+    } else {
+      console.error(`Discussion lock error: ${response.error}`);
+      showErrorMsg('discussion-lock-error', response.error);
+      reenableDiscussionLockConfirmationBtn();
+    }
+  });
+}
+
+function handleReopenDiscussion() {
+  submitReopenDiscussion().then(function(response) {
+    if (response.success) {
+      hideErrorMsg('reopen-discussion-error');
+
+      // We "manually" update the DOM because we bust caches async, which can take time
+      showElementById('discussion-lock-btn');
+      hideDiscussionLockReason();
+      updateDiscussionLock("false");
+      clearReopenDiscussionData();
+      showElementById('new_comment');
+      reenableReopenDiscussionBtn();
+    } else {
+      console.error(`Reopen discussion error: ${response.error}`);
+      showErrorMsg('reopen-discussion-error', response.error);
+      reenableReopenDiscussionBtn();
+    }
+  });
+}

--- a/app/controllers/discussion_locks_controller.rb
+++ b/app/controllers/discussion_locks_controller.rb
@@ -6,7 +6,9 @@ class DiscussionLocksController < ApplicationController
 
   def create
     @discussion_lock = DiscussionLock.new(discussion_lock_params)
-    # TODO: - authorize discussion lock
+
+    authorize @discussion_lock
+
     if @discussion_lock.save
       render json: { message: "success", success: true, data: @discussion_lock }, status: :ok
     else
@@ -15,7 +17,8 @@ class DiscussionLocksController < ApplicationController
   end
 
   def destroy
-    # TODO: - authorize discussion lock
+    authorize @discussion_lock
+
     if @discussion_lock.destroy
       render json: { message: "success", success: true }, status: :ok
     else

--- a/app/controllers/discussion_locks_controller.rb
+++ b/app/controllers/discussion_locks_controller.rb
@@ -1,0 +1,35 @@
+class DiscussionLocksController < ApplicationController
+  before_action :set_discussion_lock, only: %i[destroy]
+  before_action :authenticate_user!
+
+  DISCUSSION_LOCK_PARAMS = %i[article_id reason].freeze
+
+  def create
+    @discussion_lock = DiscussionLock.new(discussion_lock_params)
+    # TODO: - authorize discussion lock
+    if @discussion_lock.save
+      render json: { message: "success", success: true, data: @discussion_lock }, status: :ok
+    else
+      render json: { error: @discussion_lock.errors_as_sentence, success: false }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    # TODO: - authorize discussion lock
+    if @discussion_lock.destroy
+      render json: { message: "success", success: true }, status: :ok
+    else
+      render json: { error: @discussion_lock.errors_as_sentence, success: false }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_discussion_lock
+    @discussion_lock = DiscussionLock.find(params[:id])
+  end
+
+  def discussion_lock_params
+    params.require(:discussion_lock).permit(DISCUSSION_LOCK_PARAMS).merge!(user_id: current_user.id)
+  end
+end

--- a/app/controllers/discussion_locks_controller.rb
+++ b/app/controllers/discussion_locks_controller.rb
@@ -10,6 +10,7 @@ class DiscussionLocksController < ApplicationController
     authorize @discussion_lock
 
     if @discussion_lock.save
+      bust_article_cache_async(@discussion_lock.article_id)
       render json: { message: "success", success: true, data: @discussion_lock }, status: :ok
     else
       render json: { error: @discussion_lock.errors_as_sentence, success: false }, status: :unprocessable_entity
@@ -20,6 +21,7 @@ class DiscussionLocksController < ApplicationController
     authorize @discussion_lock
 
     if @discussion_lock.destroy
+      bust_article_cache_async(@discussion_lock.article_id)
       render json: { message: "success", success: true }, status: :ok
     else
       render json: { error: @discussion_lock.errors_as_sentence, success: false }, status: :unprocessable_entity
@@ -34,5 +36,9 @@ class DiscussionLocksController < ApplicationController
 
   def discussion_lock_params
     params.require(:discussion_lock).permit(DISCUSSION_LOCK_PARAMS).merge!(user_id: current_user.id)
+  end
+
+  def bust_article_cache_async(article_id)
+    Articles::BustCacheWorker.perform_async(article_id)
   end
 end

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -296,6 +296,7 @@ class StoriesController < ApplicationController
 
     @user = @article.user
     @organization = @article.organization
+    @discussion_lock = @article.discussion_lock
 
     if @article.collection
       @collection = @article.collection

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -28,6 +28,8 @@ class Article < ApplicationRecord
   # The date that we began limiting the number of user mentions in an article.
   MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 4, 7).freeze
 
+  has_one :discussion_lock, dependent: :destroy
+
   has_many :mentions, as: :mentionable, inverse_of: :mentionable, dependent: :destroy
   has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :nullify
   has_many :html_variant_successes, dependent: :nullify

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -40,6 +40,7 @@ class Comment < ApplicationRecord
   after_save :bust_cache
 
   validate :published_article, if: :commentable
+  validate :discussion_not_locked, if: :commentable
   validate :user_mentions_in_markdown
   validates :body_markdown, presence: true, length: { in: BODY_MARKDOWN_SIZE_RANGE }
   validates :body_markdown, uniqueness: { scope: %i[user_id ancestry commentable_id commentable_type] }
@@ -313,6 +314,12 @@ class Comment < ApplicationRecord
 
   def published_article
     errors.add(:commentable_id, "is not valid.") if commentable_type == "Article" && !commentable.published
+  end
+
+  def discussion_not_locked
+    return unless commentable_type == "Article" && commentable.discussion_lock
+
+    errors.add(:commentable_id, "the discussion is locked on this Article")
   end
 
   def user_mentions_in_markdown

--- a/app/models/discussion_lock.rb
+++ b/app/models/discussion_lock.rb
@@ -1,7 +1,7 @@
 class DiscussionLock < ApplicationRecord
   belongs_to :article
-  belongs_to :user
+  belongs_to :locking_user, class_name: "User"
 
   validates :article_id, presence: true, uniqueness: true
-  validates :user_id, presence: true
+  validates :locking_user_id, presence: true
 end

--- a/app/models/discussion_lock.rb
+++ b/app/models/discussion_lock.rb
@@ -1,0 +1,7 @@
+class DiscussionLock < ApplicationRecord
+  belongs_to :article
+  belongs_to :user
+
+  validates :article_id, presence: true, uniqueness: true
+  validates :user_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -135,6 +135,7 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :created_podcasts, class_name: "Podcast", foreign_key: :creator_id, inverse_of: :creator, dependent: :nullify
   has_many :credits, dependent: :destroy
+  has_many :discussion_locks, dependent: :destroy
   has_many :display_ad_events, dependent: :destroy
   has_many :email_authorizations, dependent: :delete_all
   has_many :email_messages, class_name: "Ahoy::Message", dependent: :destroy

--- a/app/policies/discussion_lock_policy.rb
+++ b/app/policies/discussion_lock_policy.rb
@@ -1,0 +1,23 @@
+class DiscussionLockPolicy < ApplicationPolicy
+  def create?
+    authorized_user?
+  end
+
+  def destroy?
+    create?
+  end
+
+  def permitted_attributes
+    %i[article_id reason]
+  end
+
+  private
+
+  def authorized_user?
+    user_author? || minimal_admin?
+  end
+
+  def user_author?
+    record.user_id == user.id
+  end
+end

--- a/app/policies/discussion_lock_policy.rb
+++ b/app/policies/discussion_lock_policy.rb
@@ -18,6 +18,6 @@ class DiscussionLockPolicy < ApplicationPolicy
   end
 
   def user_author?
-    record.user_id == user.id
+    record.locking_user_id == user.id
   end
 end

--- a/app/views/admin/articles/_individual_article.html.erb
+++ b/app/views/admin/articles/_individual_article.html.erb
@@ -130,6 +130,15 @@
           <button class="btn btn-primary float-right">Submit</button>
       </div>
     </div>
+    <div class="row">
+      <% if article.discussion_lock %>
+        Locked by: <%= article.discussion_lock.user_id %>
+        Locked: <%= article.discussion_lock.created_at %>
+        Reason: <%= article.discussion_lock.reason %>
+      <% else %>
+        <button class="btn btn-danger">Lock discussion</button>
+      <% end %>
+    </div>
     <% end %>
 
     <% if article.boosted_dev_digest_email %>

--- a/app/views/admin/articles/_individual_article.html.erb
+++ b/app/views/admin/articles/_individual_article.html.erb
@@ -130,15 +130,6 @@
           <button class="btn btn-primary float-right">Submit</button>
       </div>
     </div>
-    <div class="row">
-      <% if article.discussion_lock %>
-        Locked by: <%= article.discussion_lock.user_id %>
-        Locked: <%= article.discussion_lock.created_at %>
-        Reason: <%= article.discussion_lock.reason %>
-      <% else %>
-        <button class="btn btn-danger">Lock discussion</button>
-      <% end %>
-    </div>
     <% end %>
 
     <% if article.boosted_dev_digest_email %>

--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -1,8 +1,9 @@
-<% cache("whole-comment-area-#{@article.id}-#{@article.last_comment_at}-#{@article.show_comments}", expires_in: 2.hours) do %>
+<% cache("whole-comment-area-#{@article.id}-#{@article.last_comment_at}-#{@article.show_comments}-#{@discussion_lock&.updated_at}", expires_in: 2.hours) do %>
   <section id="comments" data-updated-at="<%= Time.current %>" class="text-padding mb-4 border-t-1 border-0 border-solid border-base-10">
     <% if @article.show_comments %>
       <header class="relative flex justify-between items-center mb-6">
         <h2 class="crayons-subtitle-1">Discussion <span class="js-comments-count" data-comments-count="<%= @article.comments_count %>">(<%= @article.comments_count %>)</span></h2>
+        <%= render "/comments/discussion_lock" %>
         <div id="comment-subscription">
           <div role="presentation" class="crayons-btn-group">
             <span class="crayons-btn crayons-btn--outlined">Subscribe</span>
@@ -16,6 +17,8 @@
         data-commentable-id="<%= @article.id %>"
         data-commentable-type="Article"
         data-has-recent-comment-activity="<%= @article.has_recent_comment_activity? %>">
+
+        <%= render "/comments/discussion_lock_reason" %>
         <%= render "/comments/form", commentable: @article, commentable_type: "Article" %>
 
         <div class="comments" id="comment-trees-container">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -114,7 +114,8 @@
         id="article-show-container"
         data-author-id="<%= @article.user_id %>"
         data-path="<%= @article.path %>"
-        data-published="<%= @article.published? %>">
+        data-published="<%= @article.published? %>"
+        data-discussion-locked="<%= @discussion_lock.present? %>">
         <header class="crayons-article__header" id="main-title">
           <% if @article.video.present? %>
             <%= render "articles/video_player", meta_tags: true, article: @article %>

--- a/app/views/comments/_discussion_lock.html.erb
+++ b/app/views/comments/_discussion_lock.html.erb
@@ -1,0 +1,42 @@
+<div id="discussion-lock-action" class="hidden">
+  <button class="crayons-btn crayons-btn--ghost-danger ml-5 discussion-lock-actions hidden" id="discussion-lock-btn">Lock discussion</button>
+  <div id="discussion-lock-confirmation-modal" class="hidden">
+    <div class="crayons-modal crayons-modal--s">
+      <div class="crayons-modal__box">
+        <header class="crayons-modal__box__header">
+          <h2 class="fs-l fw-bold mt-0 mb-0">
+            Are you sure?
+          </h2>
+          <button type="button" class="crayons-btn crayons-btn--icon-rounded crayons-btn--ghost" id="close-discussion-lock-confirmation-modal">
+            <svg width="24" height="24" viewBox="0 0 24 24" class="crayons-icon" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 10.586l4.95-4.95 1.414 1.414-4.95 4.95 4.95 4.95-1.414 1.414-4.95-4.95-4.95 4.95-1.414-1.414 4.95-4.95-4.95-4.95L7.05 5.636l4.95 4.95z" />
+            </svg>
+          </button>
+        </header>
+        <div class="crayons-modal__box__body">
+          <p id="confirmation-text" class="fs-base mb-4 mt-0">
+            Users will not be able to add new comments. This will <em class="fw-bold">not</em> remove existing comments.
+          </p>
+          <div class="mb-5">
+            <div class="crayons-field">
+              <%= label_tag :reason, "Reason for locking the discussion (optional) - this will be publicly displayed", class: "crayons-field__label" %>
+              <%= text_field_tag :reason,
+                                 nil,
+                                 placeholder: "The reason why you're locking this discussion.",
+                                 required: false,
+                                 class: "crayons-textfield",
+                                 id: "discussion-lock-reason-field",
+                                 'aria-label': "The reason why you're locking this discussion." %>
+            </div>
+            <div class="crayons-notice--danger fs-base w-100 hidden mb-5" aria-live="polite" id="discussion-lock-error"></div>
+          </div>
+          <div class="discussion-lock__confirmation-buttons mt-3">
+            <button class="crayons-btn crayons-btn--danger mr-1" id="lock-discussion-btn">Lock Discussion</button>
+            <button class="crayons-btn crayons-btn--secondary" id="discussion-lock-cancel-btn">Cancel</button>
+          </div>
+        </div>
+      </div>
+      <div class="crayons-modal__overlay"></div>
+    </div>
+  </div>
+</div>

--- a/app/views/comments/_discussion_lock_reason.html.erb
+++ b/app/views/comments/_discussion_lock_reason.html.erb
@@ -1,0 +1,15 @@
+<div class="crayons-notice mb-6 hidden" id="discussion-lock-reason" aria-live="polite">
+  <div class="crayons-notice--danger fs-base w-100 hidden mb-5" aria-live="polite" id="reopen-discussion-error"></div>
+  The discussion has been closed. New comments can't be added.
+  <div>
+    <em id="discussion-lock-reason-text">
+      <%= @discussion_lock&.reason %>
+    </em>
+  </div>
+  <button
+    class="crayons-btn crayons-btn--s crayons-btn--secondary float-right discussion-lock-actions hidden"
+    id="discussion-lock-reopen-btn"
+    data-discussion-lock-id="<%= @discussion_lock&.id %>">
+  Reopen
+  </button>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,6 +205,8 @@ Rails.application.routes.draw do
 
     resources :liquid_tags, only: %i[index], defaults: { format: :json }
 
+    resources :discussion_locks, only: %i[create update destroy]
+
     get "/verify_email_ownership", to: "email_authorizations#verify", as: :verify_email_authorizations
     get "/search/tags", to: "search#tags"
     get "/search/chat_channels", to: "search#chat_channels"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,7 +205,7 @@ Rails.application.routes.draw do
 
     resources :liquid_tags, only: %i[index], defaults: { format: :json }
 
-    resources :discussion_locks, only: %i[create update destroy]
+    resources :discussion_locks, only: %i[create destroy]
 
     get "/verify_email_ownership", to: "email_authorizations#verify", as: :verify_email_authorizations
     get "/search/tags", to: "search#tags"

--- a/db/migrate/20210517151144_create_discussion_locks.rb
+++ b/db/migrate/20210517151144_create_discussion_locks.rb
@@ -2,7 +2,7 @@ class CreateDiscussionLocks < ActiveRecord::Migration[6.1]
   def change
     create_table :discussion_locks do |t|
       t.references :article, null: false, foreign_key: true, index: { unique: true }
-      t.references :user, null: false, foreign_key: true
+      t.references :locking_user, references: :users, foreign_key: { to_table: :users }, null: false
       t.text :reason
 
       t.timestamps

--- a/db/migrate/20210517151144_create_discussion_locks.rb
+++ b/db/migrate/20210517151144_create_discussion_locks.rb
@@ -1,0 +1,11 @@
+class CreateDiscussionLocks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :discussion_locks do |t|
+      t.references :article, null: false, foreign_key: true, index: { unique: true }
+      t.references :user, null: false, foreign_key: true
+      t.text :reason
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -464,11 +464,11 @@ ActiveRecord::Schema.define(version: 2021_05_17_151144) do
   create_table "discussion_locks", force: :cascade do |t|
     t.bigint "article_id", null: false
     t.datetime "created_at", precision: 6, null: false
+    t.bigint "locking_user_id", null: false
     t.text "reason"
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id", null: false
     t.index ["article_id"], name: "index_discussion_locks_on_article_id", unique: true
-    t.index ["user_id"], name: "index_discussion_locks_on_user_id"
+    t.index ["locking_user_id"], name: "index_discussion_locks_on_locking_user_id"
   end
 
   create_table "display_ad_events", force: :cascade do |t|
@@ -1539,7 +1539,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_151144) do
   add_foreign_key "devices", "consumer_apps"
   add_foreign_key "devices", "users"
   add_foreign_key "discussion_locks", "articles"
-  add_foreign_key "discussion_locks", "users"
+  add_foreign_key "discussion_locks", "users", column: "locking_user_id"
   add_foreign_key "display_ad_events", "display_ads", on_delete: :cascade
   add_foreign_key "display_ad_events", "users", on_delete: :cascade
   add_foreign_key "display_ads", "organizations", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_12_025422) do
+ActiveRecord::Schema.define(version: 2021_05_17_151144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -459,6 +459,16 @@ ActiveRecord::Schema.define(version: 2021_05_12_025422) do
     t.bigint "user_id", null: false
     t.index ["consumer_app_id"], name: "index_devices_on_consumer_app_id"
     t.index ["user_id", "token", "platform", "consumer_app_id"], name: "index_devices_on_user_id_and_token_and_platform_and_app", unique: true
+  end
+
+  create_table "discussion_locks", force: :cascade do |t|
+    t.bigint "article_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.text "reason"
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.index ["article_id"], name: "index_discussion_locks_on_article_id", unique: true
+    t.index ["user_id"], name: "index_discussion_locks_on_user_id"
   end
 
   create_table "display_ad_events", force: :cascade do |t|
@@ -1528,6 +1538,8 @@ ActiveRecord::Schema.define(version: 2021_05_12_025422) do
   add_foreign_key "custom_profile_fields", "profiles", on_delete: :cascade
   add_foreign_key "devices", "consumer_apps"
   add_foreign_key "devices", "users"
+  add_foreign_key "discussion_locks", "articles"
+  add_foreign_key "discussion_locks", "users"
   add_foreign_key "display_ad_events", "display_ads", on_delete: :cascade
   add_foreign_key "display_ad_events", "users", on_delete: :cascade
   add_foreign_key "display_ads", "organizations", on_delete: :cascade

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -61,4 +61,8 @@ FactoryBot.define do
   trait :with_user_subscription_tag_role_user do
     after(:build) { |article| article.user.add_role(:restricted_liquid_tag, LiquidTags::UserSubscriptionTag) }
   end
+
+  trait :with_discussion_lock do
+    after(:build) { |article| build(:discussion_lock, user_id: article.user_id, article_id: article.id) }
+  end
 end

--- a/spec/factories/discussion_locks.rb
+++ b/spec/factories/discussion_locks.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :discussion_lock do
     association :article, factory: :article, strategy: :create
-    association :user, factory: :user, strategy: :create
+    association :locking_user, factory: :user, strategy: :create
 
     reason { "This post has too many off-topic comments" }
   end

--- a/spec/factories/discussion_locks.rb
+++ b/spec/factories/discussion_locks.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :discussion_lock do
+    association :article, factory: :article, strategy: :create
+    association :user, factory: :user, strategy: :create
+
+    reason { "This post has too many off-topic comments" }
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Article, type: :model do
     it { is_expected.to belong_to(:organization).optional }
     it { is_expected.to belong_to(:user) }
 
+    it { is_expected.to have_one(:discussion_lock).dependent(:destroy) }
+
     it { is_expected.to have_many(:comments).dependent(:nullify) }
     it { is_expected.to have_many(:mentions).dependent(:destroy) }
     it { is_expected.to have_many(:html_variant_successes).dependent(:nullify) }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe Comment, type: :model do
         expect(subject).not_to be_valid
       end
 
+      it "is invalid if commentable is an article and the discussion is locked" do
+        subject.commentable = build(:article, :with_discussion_lock)
+
+        expect(subject).not_to be_valid
+      end
+
       it "is valid without a commentable" do
         subject.commentable = nil
 

--- a/spec/models/discussion_lock_spec.rb
+++ b/spec/models/discussion_lock_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe DiscussionLock, type: :model do
+  let(:discussion_lock) { create(:discussion_lock) }
+
+  describe "relationships" do
+    it { is_expected.to belong_to(:article) }
+    it { is_expected.to belong_to(:user) }
+  end
+
+  describe "validations" do
+    subject { discussion_lock }
+
+    it { is_expected.to validate_presence_of(:article_id) }
+    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_uniqueness_of(:article_id) }
+  end
+end

--- a/spec/models/discussion_lock_spec.rb
+++ b/spec/models/discussion_lock_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe DiscussionLock, type: :model do
 
   describe "relationships" do
     it { is_expected.to belong_to(:article) }
-    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:locking_user) }
   end
 
   describe "validations" do
     subject { discussion_lock }
 
     it { is_expected.to validate_presence_of(:article_id) }
-    it { is_expected.to validate_presence_of(:user_id) }
+    it { is_expected.to validate_presence_of(:locking_user_id) }
     it { is_expected.to validate_uniqueness_of(:article_id) }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe User, type: :model do
       it { is_expected.to have_many(:collections).dependent(:destroy) }
       it { is_expected.to have_many(:comments).dependent(:destroy) }
       it { is_expected.to have_many(:credits).dependent(:destroy) }
+      it { is_expected.to have_many(:discussion_locks).dependent(:destroy) }
       it { is_expected.to have_many(:display_ad_events).dependent(:destroy) }
       it { is_expected.to have_many(:email_authorizations).dependent(:delete_all) }
       it { is_expected.to have_many(:email_messages).class_name("Ahoy::Message").dependent(:destroy) }

--- a/spec/policies/discussion_lock_policy_spec.rb
+++ b/spec/policies/discussion_lock_policy_spec.rb
@@ -1,40 +1,42 @@
 require "rails_helper"
 
 RSpec.describe DiscussionLockPolicy do
-  subject { described_class.new(user, article) }
+  subject { described_class.new(locking_user, discussion_lock) }
 
-  let!(:user) { create(:user) }
-  let(:article) { build_stubbed(:article) }
+  let!(:locking_user) { create(:user) }
+  let(:article) { build_stubbed(:article, user: locking_user) }
+  let(:discussion_lock) { build_stubbed(:discussion_lock, locking_user: locking_user, article: article) }
   let(:valid_attributes) { %i[article_id reason] }
 
-  before { allow(article).to receive(:published).and_return(true) }
-
   context "when user is not signed-in" do
-    let(:user) { nil }
+    let(:locking_user) { nil }
 
     it { within_block_is_expected.to raise_error(Pundit::NotAuthorizedError) }
   end
 
   context "when user is not the author" do
+    let(:user) { build_stubbed(:user) }
+    let(:discussion_lock) { build_stubbed(:discussion_lock, locking_user: user, article: article) }
+
     it { is_expected.to forbid_actions(%i[create destroy]) }
   end
 
   context "when user is the author" do
-    let(:article) { build_stubbed(:article, user: user) }
+    let(:article) { build_stubbed(:article, user: locking_user) }
 
     it { is_expected.to permit_actions(%i[create destroy]) }
     it { is_expected.to permit_mass_assignment_of(valid_attributes) }
   end
 
   context "when user is an admin" do
-    let(:user) { build(:user, :admin) }
+    let(:locking_user) { build(:user, :admin) }
 
     it { is_expected.to permit_actions(%i[create destroy]) }
     it { is_expected.to permit_mass_assignment_of(valid_attributes) }
   end
 
   context "when user is a super_admin" do
-    let(:user) { build(:user, :super_admin) }
+    let(:locking_user) { build(:user, :super_admin) }
 
     it { is_expected.to permit_actions(%i[create destroy]) }
     it { is_expected.to permit_mass_assignment_of(valid_attributes) }

--- a/spec/policies/discussion_lock_policy_spec.rb
+++ b/spec/policies/discussion_lock_policy_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe DiscussionLockPolicy do
+  subject { described_class.new(user, article) }
+
+  let!(:user) { create(:user) }
+  let(:article) { build_stubbed(:article) }
+  let(:valid_attributes) { %i[article_id reason] }
+
+  before { allow(article).to receive(:published).and_return(true) }
+
+  context "when user is not signed-in" do
+    let(:user) { nil }
+
+    it { within_block_is_expected.to raise_error(Pundit::NotAuthorizedError) }
+  end
+
+  context "when user is not the author" do
+    it { is_expected.to forbid_actions(%i[create destroy]) }
+  end
+
+  context "when user is the author" do
+    let(:article) { build_stubbed(:article, user: user) }
+
+    it { is_expected.to permit_actions(%i[create destroy]) }
+    it { is_expected.to permit_mass_assignment_of(valid_attributes) }
+  end
+
+  context "when user is an admin" do
+    let(:user) { build(:user, :admin) }
+
+    it { is_expected.to permit_actions(%i[create destroy]) }
+    it { is_expected.to permit_mass_assignment_of(valid_attributes) }
+  end
+
+  context "when user is a super_admin" do
+    let(:user) { build(:user, :super_admin) }
+
+    it { is_expected.to permit_actions(%i[create destroy]) }
+    it { is_expected.to permit_mass_assignment_of(valid_attributes) }
+  end
+end

--- a/spec/requests/discussion_locks_spec.rb
+++ b/spec/requests/discussion_locks_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "DiscussionLocks", type: :request do
     it "creates a DiscussionLock" do
       article = create(:article, user: user)
       reason = "Unproductice comments."
-      valid_attributes = { article_id: article.id, user_id: user.id, reason: reason }
+      valid_attributes = { article_id: article.id, locking_user_id: user.id, reason: reason }
       expect do
         post discussion_locks_path,
              headers: { "Content-Type" => "application/json" },
@@ -18,12 +18,12 @@ RSpec.describe "DiscussionLocks", type: :request do
 
       discussion_lock = DiscussionLock.last
       expect(discussion_lock.article_id).to eq article.id
-      expect(discussion_lock.user_id).to eq user.id
+      expect(discussion_lock.locking_user_id).to eq user.id
       expect(discussion_lock.reason).to eq reason
     end
 
     it "returns an error for an invalid Article" do
-      invalid_article_attributes = { article_id: "nonexistant-id", user_id: user.id }
+      invalid_article_attributes = { article_id: "nonexistant-id", locking_user_id: user.id }
       expect do
         post discussion_locks_path,
              headers: { "Content-Type" => "application/json" },
@@ -36,7 +36,7 @@ RSpec.describe "DiscussionLocks", type: :request do
 
     it "busts the cache for the article" do
       article = create(:article, user: user)
-      valid_attributes = { article_id: article.id, user_id: user.id }
+      valid_attributes = { article_id: article.id, locking_user_id: user.id }
 
       sidekiq_assert_enqueued_jobs(1, only: Articles::BustCacheWorker) do
         post discussion_locks_path,
@@ -49,7 +49,7 @@ RSpec.describe "DiscussionLocks", type: :request do
   describe "DELETE /discussion_locks/:id - DiscussionLocks#destroy" do
     it "destroys a DiscussionLock" do
       article = create(:article, user: user)
-      discussion_lock = create(:discussion_lock, article_id: article.id, user_id: user.id)
+      discussion_lock = create(:discussion_lock, article_id: article.id, locking_user_id: user.id)
       expect do
         delete discussion_lock_path(discussion_lock.id)
       end.to change(DiscussionLock, :count).by(-1)
@@ -57,7 +57,7 @@ RSpec.describe "DiscussionLocks", type: :request do
 
     it "busts the cache for the article" do
       article = create(:article, user: user)
-      discussion_lock = create(:discussion_lock, article_id: article.id, user_id: user.id)
+      discussion_lock = create(:discussion_lock, article_id: article.id, locking_user_id: user.id)
 
       sidekiq_assert_enqueued_jobs(1, only: Articles::BustCacheWorker) do
         delete discussion_lock_path(discussion_lock.id)

--- a/spec/requests/discussion_locks_spec.rb
+++ b/spec/requests/discussion_locks_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe "DiscussionLocks", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  describe "POST /discussion_locks - DiscussionLocks#create" do
+    it "creates a DiscussionLock" do
+      article = create(:article, user: user)
+      reason = "Unproductice comments."
+      valid_attributes = { article_id: article.id, user_id: user.id, reason: reason }
+      expect do
+        post discussion_locks_path,
+             headers: { "Content-Type" => "application/json" },
+             params: { discussion_lock: valid_attributes }.to_json
+      end.to change(DiscussionLock, :count).by(1)
+
+      discussion_lock = DiscussionLock.last
+      expect(discussion_lock.article_id).to eq article.id
+      expect(discussion_lock.user_id).to eq user.id
+      expect(discussion_lock.reason).to eq reason
+    end
+
+    it "returns an error for an invalid Article" do
+      invalid_article_attributes = { article_id: "nonexistant-id", user_id: user.id }
+      expect do
+        post discussion_locks_path,
+             headers: { "Content-Type" => "application/json" },
+             params: { discussion_lock: invalid_article_attributes }.to_json
+      end.to change(DiscussionLock, :count).by(0)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to include("Article must exist")
+    end
+
+    it "busts the cache for the article" do
+      article = create(:article, user: user)
+      valid_attributes = { article_id: article.id, user_id: user.id }
+
+      sidekiq_assert_enqueued_jobs(1, only: Articles::BustCacheWorker) do
+        post discussion_locks_path,
+             headers: { "Content-Type" => "application/json" },
+             params: { discussion_lock: valid_attributes }.to_json
+      end
+    end
+  end
+
+  describe "DELETE /discussion_locks/:id - DiscussionLocks#destroy" do
+    it "destroys a DiscussionLock" do
+      article = create(:article, user: user)
+      discussion_lock = create(:discussion_lock, article_id: article.id, user_id: user.id)
+      expect do
+        delete discussion_lock_path(discussion_lock.id)
+      end.to change(DiscussionLock, :count).by(-1)
+    end
+
+    it "busts the cache for the article" do
+      article = create(:article, user: user)
+      discussion_lock = create(:discussion_lock, article_id: article.id, user_id: user.id)
+
+      sidekiq_assert_enqueued_jobs(1, only: Articles::BustCacheWorker) do
+        delete discussion_lock_path(discussion_lock.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This PR introduces functionality to allow **article authors, admins, and super admins** to lock discussions which basically prevents the ability for users to add any further comments to an article. We've also added some logic to allow a permitted user to include a reason that will display publicly when a discussion is locked.

**I'm looking for feedback on this approach while I work through the remainder of the TODO list - this PR is _not_ ready yet.**

**TODO**
- [x] Specs
- [ ] Frontend tests (😭 )
- [x] ~Add CRUD functionality for discussion locks to Admin~ (~potentially~ a separate PR)
- [ ] Update/test error handling
- [ ] **Polish design (could use feedback here as well)**
- [x] Bust article cache after creating/destroying a discussion lock.
- [ ] **Fix keyboard navigation in the confirmation modal.**

A few things to note...
- **The JavaScript mess** - because we cache articles (somewhat aggressively) at the edge, adding "dynamic" functionality to articles becomes a bit of a pain. For example, once we lock a discussion, we'll bust the cache for the article which will update the markup. However, this is done asynchronously so we basically have to take care of all the updates in JS which is why we're always showing the markup and using JS to hide/show appropriately.
- **Naming** - we have different naming conventions flying around (comments, threads, discussions, etc.). We ultimately landed on **discussion** because 1) that's what we show in the UI and 2) that's what the customer success team liked the most.
- **Architecture** - for now, discussion locks are limited to Articles. We set this up in a way that allows it to be extensible in the future. We could make the `DiscussionLock` table and relationship polymorphic, write a `DataUpdateScript`, and then `DiscussionLocks` could be added to other domains in the future if needed. We also didn't want to further "crowd" the `Article` domain as it's quite large already.
- **MVP** - this was designed under the premise of a "quick win" more than it was a "perfect solution". There are many areas for improvement in the future. Things like allowing admins to assign any user they choose the ability to lock discussions, updating the UX, etc. We spoke with the customer success team to balance the "ideal" with the "quick and practical". If you go to the linked issue, you'll see we never really decided on a design, but we used that as a guide.
- **Single PR** - you may be wondering why this wasn't split into multiple PRs - great question. We've done that in the past and that approach carries some pros and cons. Splitting it makes reviews more "consumable", but it often leads to repetition of context that's lost between PRs. By keeping it in one PR, all the context is there and it can be easier to understand what's going on with everything in front of you. When starting this, we felt this feature would be right on the cusp of too big for a single PR.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/9619

## QA Instructions, Screenshots, Recordings
https://user-images.githubusercontent.com/15987080/118851863-36498c80-b8a0-11eb-816d-84e2c7a33f33.mp4

1. Pull down this branch and run migrations.
2. Fire up the app locally and sign in.
3. Write and publish a post.
4. Fire up your browser's dev tools/console and keep an eye on it over the remaining steps for any related errors. You'll likely see some Pusher and HoneyBadger errors - that's normal.
5. Lock the discussion on the post.
6. Unlock the discussion on the post.
7. Lock the discussion on the post again.
8. Unlock the discussion on the post again.

### UI accessibility concerns?
**I need help getting keyboard navigation to work on the modal.**

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams

![wedding_crashers_lock_it_up_gif](https://media.giphy.com/media/3ohzdFvSAgvmXq6n2o/giphy.gif)