### PR TITLE
[15-min-fix] Add option for triple tildes for fenced codeblocks

### DIFF
--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -114,7 +114,7 @@ module MarkdownProcessor
 
     def escape_liquid_tags_in_codeblock(content)
       # Escape codeblocks, code spans, and inline code
-      content.gsub(/[[:space:]]*`{3}.*?`{3}|`{2}.+?`{2}|`{1}.+?`{1}/m) do |codeblock|
+      content.gsub(/[[:space:]]*~{3}.*?~{3}|[[:space:]]*`{3}.*?`{3}|`{2}.+?`{2}|`{1}.+?`{1}/m) do |codeblock|
         codeblock.gsub!("{% endraw %}", "{----% endraw %----}")
         codeblock.gsub!("{% raw %}", "{----% raw %----}")
         if codeblock.match?(/[[:space:]]*`{3}/)

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     expect(generate_and_parse_markdown(code_block)).not_to include("----")
   end
 
+  it "escapes some triple backticks within a codeblock when using tildes" do
+    code_block = "~~~\nsome example\n/// ```\nneato\n/// ```\nright?~~~"
+    number_of_triple_backticks = generate_and_parse_markdown(code_block).scan("```").count
+    expect(number_of_triple_backticks).to eq(2)
+  end
+
   it "does not remove the non-'raw tag related' four dashes" do
     code_block = "```\n----\n```"
     expect(generate_and_parse_markdown(code_block)).to include("----")

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     expect(number_of_triple_backticks).to eq(2)
   end
 
+  # TODO: @zhao-andy this is a test for anyone tackling https://github.com/forem/forem/issues/13823
+  xit "escapes triple backticks within a codeblock when using tildes" do
+    code_block = "~~~\nsome example\n```\nneato\n```\nright?~~~"
+    number_of_triple_backticks = generate_and_parse_markdown(code_block).scan("```").count
+    expect(number_of_triple_backticks).to eq(2)
+  end
+
   it "does not remove the non-'raw tag related' four dashes" do
     code_block = "```\n----\n```"
     expect(generate_and_parse_markdown(code_block)).to include("----")

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -28,16 +28,16 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
   end
 
   it "escapes some triple backticks within a codeblock when using tildes" do
-    code_block = "~~~\nsome example\n/// ```\nneato\n/// ```\nright?~~~"
+    code_block = "​~~~\nhello\n// ```\nwhatever\n// ```\n~~~"
     number_of_triple_backticks = generate_and_parse_markdown(code_block).scan("```").count
     expect(number_of_triple_backticks).to eq(2)
   end
 
-  # TODO: @zhao-andy this is a test for anyone tackling https://github.com/forem/forem/issues/13823
-  xit "escapes triple backticks within a codeblock when using tildes" do
-    code_block = "~~~\nsome example\n```\nneato\n```\nright?~~~"
+  # TODO: @zhao-andy this should fail if this issue is solved: https://github.com/forem/forem/issues/13823
+  it "escapes triple backticks within a codeblock when using tildes" do
+    code_block = "~~~\nhello\n```\nwhatever\n```\n~~~"
     number_of_triple_backticks = generate_and_parse_markdown(code_block).scan("```").count
-    expect(number_of_triple_backticks).to eq(2)
+    expect(number_of_triple_backticks).to eq(0)
   end
 
   it "does not remove the non-'raw tag related' four dashes" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix

## Description
This allows us to do something like:
````
~~~
hello
```
me showing you how to do a codeblock with triple backticks, nested within triple tildes
```
~~~
````

This isn't a perfect solution, but I definitely went out of my time box for this. Wanted to fix this edge case at least so _some_ users can start using it. See QA instructions for code examples of what I'm talking about.

I think the bigger issue is that we parse codeblocks through Liquid `{% raw %}` tag, when maybe it should be parsed through our Markdown parser Redcarpet. Will make an issue out of it instead.


## Related Tickets & Documents
forem/internalCommunity#116
https://github.com/forem/forem/issues/13823

## QA Instructions, Screenshots, Recordings
1. Go to /new
2. Try this codeblock:
````
​~~~
hello
// ```
whatever
// ```
~~~
````
3. Then try this codeblock (which should NOT work) same as above, without the slashes:
````
~~~
hello
```
whatever
```
~~~
````

### UI accessibility concerns?
Backend parsing change, so nope!

## Added tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I'm not sure how best to communicate this change and need help

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![A kid riding a bike, with a caption that says, "We've got bigger problems."](https://media.giphy.com/media/xT1R9XZlMRCsAY6uek/giphy-downsized.gif)
