### PR TITLE
Disable cache while seeding to fix "invalid category error"

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,6 +21,9 @@ Settings::Authentication.providers = Authentication::Providers.available
 
 ##############################################################################
 
+# Disable Redis cache while seeding
+Rails.cache = ActiveSupport::Cache.lookup_store(:null_store)
+
 # Put forem into "starter mode"
 
 if ENV["MODE"] == "STARTER"
@@ -406,7 +409,7 @@ end
 ##############################################################################
 
 seeder.create_if_none(FeedbackMessage) do
-  mod = User.first
+  mod = User.with_role(:trusted).take
 
   FeedbackMessage.create!(
     reporter: User.last,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I had to reset my local development DB and this step kept failing with "Invalid category" because a non moderator was selected as the user to leave a `vomit` reaction.

While debugging this I noticed how I had the `Rails.cache` object pointing to Redis. `user.trusted` kept returning `false` even though the user was a moderator, the reason was the following:

https://github.com/forem/forem/blob/967c65557327f3962f12a492a424c36339e11998/app/models/user.rb#L426

I had data in the cache from the previous version. The alternative to bypassing the cache is to clear it. 
