### PR TITLE
Run user setting DUS per-user via Sidekiq

### DIFF
--- a/app/workers/migrate_user_settings_worker.rb
+++ b/app/workers/migrate_user_settings_worker.rb
@@ -1,0 +1,82 @@
+class MigrateUserSettingsWorker
+  include Sidekiq::Worker
+
+  SQL = <<~SQL.freeze
+    WITH settings_data AS (
+      SELECT
+        data ->> 'brand_color1' AS brand_color1,
+        data ->> 'brand_color2' AS brand_color2,
+        CASE WHEN config_font='default' THEN 0
+            WHEN config_font='comic_sans' THEN 1
+            WHEN config_font='monospace' THEN 2
+            WHEN config_font='open_dyslexic' THEN 3
+            WHEN config_font='sans_serif' THEN 4
+            WHEN config_font='serif' THEN 5
+            ELSE 0
+        END
+        config_font,
+        CASE WHEN config_navbar='default_navbar' THEN 0
+            WHEN config_navbar='static_navbar' THEN 1
+            ELSE 0
+        END
+        config_navbar,
+        CASE WHEN config_theme='default_theme' THEN 0
+            WHEN config_theme='minimal_light_theme' THEN 1
+            WHEN config_theme='night_theme' THEN 2
+            WHEN config_theme='pink_theme' THEN 3
+            WHEN config_theme='ten_x_hacker_theme' THEN 4
+            ELSE 0
+        END
+        config_theme,
+        COALESCE(display_announcements, true),
+        COALESCE((data ->> 'display_email_on_profile')::boolean, false) as display_email_on_profile,
+        COALESCE(display_sponsors, true),
+        CASE WHEN editor_version='v2' THEN 0
+              WHEN editor_version='v1' THEN 1
+              ELSE 0
+        END
+        editor_version,
+        experience_level,
+        COALESCE(feed_mark_canonical, false),
+        COALESCE(feed_referential_link, true),
+        feed_url,
+        inbox_guidelines,
+        CASE WHEN inbox_type='private' THEN 0
+              WHEN inbox_type='open' THEN 1
+              ELSE 0
+        END
+        inbox_type,
+        COALESCE(permit_adjacent_sponsors, true),
+        users.id AS user_id,
+        NOW(),
+        NOW()
+      FROM users
+      JOIN profiles
+        ON profiles.user_id = users.id
+    )
+    INSERT INTO users_settings (brand_color1, brand_color2, config_font, config_navbar, config_theme, display_announcements, display_email_on_profile, display_sponsors, editor_version, experience_level, feed_mark_canonical, feed_referential_link, feed_url, inbox_guidelines, inbox_type, permit_adjacent_sponsors, user_id, created_at, updated_at)
+      (SELECT * FROM settings_data WHERE user_id = $1)
+      ON CONFLICT (user_id) DO UPDATE
+        SET brand_color1 = EXCLUDED.brand_color1,
+            brand_color2 = EXCLUDED.brand_color2,
+            config_font = EXCLUDED.config_font,
+            config_navbar = EXCLUDED.config_navbar,
+            config_theme = EXCLUDED.config_theme,
+            display_announcements = EXCLUDED.display_announcements,
+            display_email_on_profile = EXCLUDED.display_email_on_profile,
+            display_sponsors = EXCLUDED.display_sponsors,
+            editor_version = EXCLUDED.editor_version,
+            experience_level = EXCLUDED.experience_level,
+            feed_mark_canonical = EXCLUDED.feed_mark_canonical,
+            feed_referential_link = EXCLUDED.feed_referential_link,
+            feed_url = EXCLUDED.feed_url,
+            inbox_guidelines = EXCLUDED.inbox_guidelines,
+            inbox_type = EXCLUDED.inbox_type,
+            permit_adjacent_sponsors = EXCLUDED.permit_adjacent_sponsors,
+            updated_at = NOW()
+  SQL
+
+  def perform(user_id)
+    Users::Setting.connection.exec_insert SQL, nil, [user_id]
+  end
+end

--- a/lib/data_update_scripts/20210423155327_migrate_relevant_fields_from_users_to_users_settings.rb
+++ b/lib/data_update_scripts/20210423155327_migrate_relevant_fields_from_users_to_users_settings.rb
@@ -1,86 +1,9 @@
 module DataUpdateScripts
   class MigrateRelevantFieldsFromUsersToUsersSettings
     def run
-      # rubocop:disable Metrics/BlockLength(RuboCop)
-      ActiveRecord::Base.transaction do
-        ActiveRecord::Base.connection.execute(
-          <<~SQL.squish,
-            WITH settings_data AS (
-              SELECT
-                data ->> 'brand_color1' AS brand_color1,
-                data ->> 'brand_color2' AS brand_color2,
-                CASE WHEN config_font='default' THEN 0
-                    WHEN config_font='comic_sans' THEN 1
-                    WHEN config_font='monospace' THEN 2
-                    WHEN config_font='open_dyslexic' THEN 3
-                    WHEN config_font='sans_serif' THEN 4
-                    WHEN config_font='serif' THEN 5
-                    ELSE 0
-                END
-                config_font,
-                CASE WHEN config_navbar='default_navbar' THEN 0
-                    WHEN config_navbar='static_navbar' THEN 1
-                    ELSE 0
-                END
-                config_navbar,
-                CASE WHEN config_theme='default_theme' THEN 0
-                    WHEN config_theme='minimal_light_theme' THEN 1
-                    WHEN config_theme='night_theme' THEN 2
-                    WHEN config_theme='pink_theme' THEN 3
-                    WHEN config_theme='ten_x_hacker_theme' THEN 4
-                    ELSE 0
-                END
-                config_theme,
-                COALESCE(display_announcements, true),
-                COALESCE((data ->> 'display_email_on_profile')::boolean, false) as display_email_on_profile,
-                COALESCE(display_sponsors, true),
-                CASE WHEN editor_version='v2' THEN 0
-                      WHEN editor_version='v1' THEN 1
-                      ELSE 0
-                END
-                editor_version,
-                experience_level,
-                COALESCE(feed_mark_canonical, false),
-                COALESCE(feed_referential_link, true),
-                feed_url,
-                inbox_guidelines,
-                CASE WHEN inbox_type='private' THEN 0
-                      WHEN inbox_type='open' THEN 1
-                      ELSE 0
-                END
-                inbox_type,
-                COALESCE(permit_adjacent_sponsors, true),
-                users.id AS user_id,
-                NOW(),
-                NOW()
-              FROM users
-              JOIN profiles
-                ON profiles.user_id = users.id
-            )
-            INSERT INTO users_settings (brand_color1, brand_color2, config_font, config_navbar, config_theme, display_announcements, display_email_on_profile, display_sponsors, editor_version, experience_level, feed_mark_canonical, feed_referential_link, feed_url, inbox_guidelines, inbox_type, permit_adjacent_sponsors, user_id, created_at, updated_at)
-              SELECT * FROM settings_data
-              ON CONFLICT (user_id) DO UPDATE
-                SET brand_color1 = EXCLUDED.brand_color1,
-                    brand_color2 = EXCLUDED.brand_color2,
-                    config_font = EXCLUDED.config_font,
-                    config_navbar = EXCLUDED.config_navbar,
-                    config_theme = EXCLUDED.config_theme,
-                    display_announcements = EXCLUDED.display_announcements,
-                    display_email_on_profile = EXCLUDED.display_email_on_profile,
-                    display_sponsors = EXCLUDED.display_sponsors,
-                    editor_version = EXCLUDED.editor_version,
-                    experience_level = EXCLUDED.experience_level,
-                    feed_mark_canonical = EXCLUDED.feed_mark_canonical,
-                    feed_referential_link = EXCLUDED.feed_referential_link,
-                    feed_url = EXCLUDED.feed_url,
-                    inbox_guidelines = EXCLUDED.inbox_guidelines,
-                    inbox_type = EXCLUDED.inbox_type,
-                    permit_adjacent_sponsors = EXCLUDED.permit_adjacent_sponsors,
-                    updated_at = NOW();
-          SQL
-        )
+      User.ids.each do |id|
+        MigrateUserSettingsWorker.perform_async id
       end
-      # rubocop:enable Metrics/BlockLength(RuboCop)
     end
   end
 end

--- a/spec/lib/data_update_scripts/migrate_relevant_fields_from_users_to_users_settings_spec.rb
+++ b/spec/lib/data_update_scripts/migrate_relevant_fields_from_users_to_users_settings_spec.rb
@@ -3,7 +3,7 @@ require Rails.root.join(
   "lib/data_update_scripts/20210423155327_migrate_relevant_fields_from_users_to_users_settings.rb",
 )
 
-describe DataUpdateScripts::MigrateRelevantFieldsFromUsersToUsersSettings do
+describe DataUpdateScripts::MigrateRelevantFieldsFromUsersToUsersSettings, sidekiq: :inline do
   let(:users_setting) { Users::Setting.last }
 
   before do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,6 +85,17 @@ RSpec.configure do |config|
     Warden::Manager._on_request.clear
   end
 
+  config.around do |example|
+    case example.metadata[:sidekiq]
+    when :inline
+      Sidekiq::Testing.inline! { example.run }
+    when :fake
+      Sidekiq::Testing.fake! { example.run }
+    when :disable
+      Sidekiq::Testing.disable! { example.run }
+    end
+  end
+
   config.before(:suite) do
     # Set the TZ ENV variable with the current random timezone from zonebie
     # which we can then use to properly set the browser time for Capybara specs


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Running this as a single query trips the query timeout beyond a certain quantity of users.

Since we still need to verify the behavior with the spec, we need to run the Sidekiq jobs inline in test. This PR adds a way to inline Sidekiq jobs using the `sidekiq: :inline` RSpec tag.

The tradeoff here is that the status of the DUS is potentially a lie because the data migration likely will not be complete before the DUS itself completes. The reason I still chose to do it this way is because even running relatively fast queries (~5ms avg) more than 600k times sequentially could take up to an hour and we likely don't want to block things that long. If we're trying to rerun this DUS from the admin/advanced UI, we _can't_ wait an hour for this to complete.

_NOTE: This is only for one of the 2 failed DUSs (DUSes? How do we pluralize the abbreviation here?). I will do the same for the other once we've gotten more eyes on the approach._

## Related Tickets & Documents

- #13390

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added tests?

- [ ] Yes
- [x] No, and this is why: We have existing tests for this
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

Ensure that `User.count` and `Users::Setting.count` are roughly equivalent

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
