### PR TITLE
When AWS_ID is the placeholder value, act as though AWS not setup

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -73,10 +73,10 @@ HONEYBADGER_API_KEY="Optional"
 HONEYBADGER_JS_API_KEY="Optional"
 
 # AWS for images storages
-AWS_ID="Optional"
-AWS_SECRET="Optional"
-AWS_BUCKET_NAME="Optional"
-AWS_UPLOAD_REGION=""
+AWS_ID=
+AWS_SECRET=
+AWS_BUCKET_NAME=
+AWS_UPLOAD_REGION=
 
 # AWS for video storage
 AWS_S3_INPUT_BUCKET="Optional"

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -50,7 +50,7 @@ Rails.application.reloader.to_prepare do
   if Rails.env.production? && ENV["FILE_STORAGE_LOCATION"] != "file"
     if ENV["FOREM_CONTEXT"] == "forem_cloud"
       forem_cloud_config
-    elsif ApplicationConfig["AWS_ID"].present? && ApplicationConfig["AWS_ID"] != "Optional"
+    elsif ApplicationConfig["AWS_ID"].present?
       standard_production_config
     else
       local_storage_config

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -50,7 +50,7 @@ Rails.application.reloader.to_prepare do
   if Rails.env.production? && ENV["FILE_STORAGE_LOCATION"] != "file"
     if ENV["FOREM_CONTEXT"] == "forem_cloud"
       forem_cloud_config
-    elsif ApplicationConfig["AWS_ID"].present?
+    elsif ApplicationConfig["AWS_ID"].present? && ApplicationConfig["AWS_ID"] != "Optional"
       standard_production_config
     else
       local_storage_config


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We have "Optional" as the placeholder in the .env_sample, if someone copied .env_sample to .env, they'd have AWS_ID present but not valid or meaningful.

~When that's the "final" value in the .env file, assume we're actually going to use local storage instead.~

~Because there are related guards around production mode this should have limited to no prod impact (outside of self-hosting, where I assume this is a net-improvement in usability). Forem clould has its own configuration. ~

~I'm surprised this hadn't been a bigger problem.~


## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Ensure `AWS_ID=` in your .env, then load the app

Change a user's profile image.
Ensure the new image is visible.

### UI accessibility concerns?

None, this _should_ be a develop/test only change.

## Added tests?

- [ ] Yes
- [x] No, and this is why: configuration change only.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: No one has noticed this, it seems like a bugfix for an unreported issue. 

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![smugly drinking coffee](https://user-images.githubusercontent.com/1237369/119408071-bd38a380-bcaa-11eb-801f-e6829fe8d053.png)
