### PR TITLE
Disable active record query cache for sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -43,6 +43,7 @@ Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add Sidekiq::HoneycombMiddleware
     chain.add SidekiqUniqueJobs::Middleware::Client
+    chain.add Sidekiq::DisableActiveRecordQueryCache
   end
 
   config.server_middleware do |chain|

--- a/lib/sidekiq/disable_active_record_query_cache.rb
+++ b/lib/sidekiq/disable_active_record_query_cache.rb
@@ -1,0 +1,7 @@
+module Sidekiq
+  class DisableActiveRecordQueryCache
+    def call(*_args, &block)
+      ActiveRecord::Base.connection.uncached(&block)
+    end
+  end
+end


### PR DESCRIPTION
In draft since my goal is to change the image on the self-host test instance to determine whether this is effective before merging to main.


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Disable ActiveRecord query caching for sidekiq worker processes. 

We're seeing memory use grow over time in the self-hosted test environment. The sidekiq troubleshooting docs point pretty consistently to AR caching being the likeliest cause of that.

This change adds a new middleware, which yields to the worker inside an "uncached" block to prevent accumulating an in-memory cache copy of the database as we process records in jobs.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

In local dev - I don't know what to say - I restarted sidekiq and in a console enqueued a number of jobs 
```ruby
Article.all.each {|a| a.send(:bust_cache) }
```
and the sidekiq process didn't fail horribly (start:done cycle looked normal).


### UI accessibility concerns?

None

## Added tests?

- [ ] Yes
- [x] No, and this is why: existing tests cover behavior - this is backend configuration only.
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![dontremember](https://user-images.githubusercontent.com/1237369/119689252-4f0cf180-be0e-11eb-98df-65a2181b5f27.gif)

