### PR TITLE
Remove assets folder from .yarnclean

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -9,7 +9,6 @@ docs
 doc
 website
 images
-assets
 
 # examples
 example


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Our `.yarnclean` is a bit too aggressive:

1. I noticed Travis builds log this:

```
        Failed to write coverage reports:
        ERROR: Error: ENOENT: no such file or directory, scandir '/home/travis/build/forem/forem/node_modules/istanbul-reports/lib/html/assets'
        STACK: Error: ENOENT: no such file or directory, scandir '/home/travis/build/forem/forem/node_modules/istanbul-reports/lib/html/assets'
    at Object.readdirSync (fs.js:1043:3)
    at /home/travis/build/forem/forem/node_modules/istanbul-reports/lib/html/index.js:331:16
    at Array.forEach (<anonymous>)
    at HtmlReport.onStart (/home/travis/build/forem/forem/node_modules/istanbul-reports/lib/html/index.js:328:25)
    at LcovReport.<computed> [as onStart] (/home/travis/build/forem/forem/node_modules/istanbul-reports/lib/lcov/index.js:28:23)
    at Visitor.value (/home/travis/build/forem/forem/node_modules/istanbul-lib-report/lib/tree.js:38:38)
    at ReportTree.visit (/home/travis/build/forem/forem/node_modules/istanbul-lib-report/lib/tree.js:126:17)
    at LcovReport.execute (/home/travis/build/forem/forem/node_modules/istanbul-lib-report/lib/report-base.js:12:44)
    at /home/travis/build/forem/forem/node_modules/@jest/reporters/build/CoverageReporter.js:252:12
    at Array.forEach (<anonymous>)
```

2. The other day I wasn't able to understand why one of the linters we had was claiming that a file in a `assets` folder inside its package in `node_modules` was missing. I didn't make the connection with `.yarnclean` :( See https://github.com/forem/forem/pull/13837#issuecomment-847155981

3. Rails's own `@rails/ujs` package installs the distribution files in `node_modules/@rails/ujs/dist/assets` and the directory is gone, which breaks the package (we plan to use it soon)

## Related Tickets & Documents

> Note: This command is considered for advanced use cases only. Unless you are experiencing issues with the amount of files that are installed as part of node_modules it is not recommended to use this command. It will permanently delete files in node_modules which could cause packages to stop working.

https://classic.yarnpkg.com/en/docs/cli/autoclean/
