### PR TITLE
Call `config.action_mailer.perform_caching = false` only once in development.rb

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,8 +77,6 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
-  config.action_mailer.perform_caching = false
-
   config.hosts << ENV["APP_DOMAIN"] unless ENV["APP_DOMAIN"].nil?
   if (gitpod_workspace_url = ENV["GITPOD_WORKSPACE_URL"])
     config.hosts << /.*#{URI.parse(gitpod_workspace_url).host}/


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In [development.rb](https://github.com/forem/forem/blob/main/config/environments/development.rb#L35), `config.action_mailer.perform_caching = false` are called twice, so I deleted one of them. Although I also check production.rb and test.rb in environments directroy, there is no same problem.

## Added tests?

- [ ] Yes
- [x] No
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?
![duplicate](https://user-images.githubusercontent.com/26132902/120101230-122f5a80-c180-11eb-86dd-07eeb6100aa7.gif)
