### PR TITLE
[15 min fix] Reduce flake in sidebar navigation spec

### DIFF
--- a/cypress/integration/navigationFlows/homePageLeftSidebar.spec.js
+++ b/cypress/integration/navigationFlows/homePageLeftSidebar.spec.js
@@ -9,7 +9,9 @@ describe('Home Page Left Sidebar', () => {
 
     // Click on the More... button in the nav
     cy.get('#page-content-inner').within(() => {
-      cy.findByText('More...').click().should('not.be.visible');
+      cy.findByRole('link', { name: 'More...' })
+        .click()
+        .should('not.be.visible');
       cy.findByText('Nav link 5').should('be.visible');
       // visit another page with InstantClick
       cy.findByText('Nav link 0').click();
@@ -20,9 +22,13 @@ describe('Home Page Left Sidebar', () => {
     cy.findAllByText('Home').last().click();
     cy.wait('@homepage');
 
+    // Wait for home page to load
+    cy.findByRole('heading', { name: 'Posts' });
     // repeat and assert
     cy.get('#page-content-inner').within(() => {
-      cy.findByText('More...').click().should('not.be.visible');
+      cy.findByRole('link', { name: 'More...' })
+        .click()
+        .should('not.be.visible');
       cy.findByText('Nav link 5').should('be.visible');
     });
   });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor


## Description

This spec has been giving us a bit of pain in CI recently - I finally managed to reproduce it failing locally and found that where we have "repeat and assert", we were getting a reference to `#page-content-inner` on the previous page, rather than the homepage. The test then fails because the "More" link it's looking for is no longer in the DOM (as it's on the previous page).

I've added a step to make sure we're back on the home page before we continue.

<img width="1691" alt="screenshot showing the cypress test step described above" src="https://user-images.githubusercontent.com/20773163/120450971-e16e4180-c388-11eb-83c9-7a95f0adc9fe.png">


## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

The spec passing in CI is QA enough on this one

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._N/A

## Added tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

