### PR TITLE
Optimise dropdowns for accessibility - Profile page

### DIFF
--- a/app/assets/javascripts/initializePage.js
+++ b/app/assets/javascripts/initializePage.js
@@ -7,7 +7,7 @@
   initializeCommentPreview, initializeRuntimeBanner,
   initializeTimeFixer, initializeDashboardSort, initializePWAFunctionality,
   initializeArchivedPostFilter, initializeCreditsPage,
-  initializeUserProfilePage, initializeProfileInfoToggle, initializePodcastPlayback,
+  initializeProfileInfoToggle, initializePodcastPlayback,
   initializeVideoPlayback, initializeDrawerSliders, initializeProfileBadgesToggle,
   initializeHeroBannerClose, initializeOnboardingTaskCard, initScrolling,
   nextPage:writable, fetching:writable, done:writable, adClicked:writable,
@@ -31,7 +31,6 @@ function callInitializers() {
   initializePWAFunctionality();
   initializeArchivedPostFilter();
   initializeCreditsPage();
-  initializeUserProfilePage();
   initializeProfileInfoToggle();
   initializeProfileBadgesToggle();
   initializePodcastPlayback();

--- a/app/assets/javascripts/initializers/initializeUserProfilePage.js
+++ b/app/assets/javascripts/initializers/initializeUserProfilePage.js
@@ -1,39 +1,5 @@
 'use strict';
 
-function initializeUserProfilePage() {
-  const profileDropdownDiv = document.getElementsByClassName(
-    'profile-dropdown',
-  )[0];
-  if (profileDropdownDiv) {
-    const currentUser = userData();
-    if (
-      currentUser &&
-      currentUser.username === profileDropdownDiv.dataset.username
-    ) {
-      profileDropdownDiv.hidden = true;
-    } else {
-      profileDropdownDiv.hidden = false;
-      const userProfileDropdownButton = document.getElementById(
-        'user-profile-dropdown',
-      );
-      if (userProfileDropdownButton) {
-        const userProfileDropdownMenu = document.getElementById(
-          'user-profile-dropdownmenu',
-        );
-        userProfileDropdownButton.addEventListener('click', () => {
-          userProfileDropdownMenu.classList.toggle('block');
-
-          // Add actual link location (SEO doesn't like these "useless" links, so adding in here instead of in HTML)
-          var reportAbuseLink = profileDropdownDiv.getElementsByClassName(
-            'report-abuse-link-wrapper',
-          )[0];
-          reportAbuseLink.innerHTML = `<a href="${reportAbuseLink.dataset.path}" class="crayons-link crayons-link--block">Report Abuse</a>`;
-        });
-      }
-    }
-  }
-}
-
 function initializeProfileInfoToggle() {
   const infoPanels = document.getElementsByClassName('js-user-info')[0];
   const trigger = document.getElementsByClassName('js-user-info-trigger')[0];

--- a/app/javascript/packs/profileDropdown.js
+++ b/app/javascript/packs/profileDropdown.js
@@ -22,7 +22,7 @@ function initDropdown() {
     (currentUser &&
       currentUser.username === profileDropdownDiv.dataset.username)
   ) {
-    // Hide this menu if not logged in, or when user views their own profile
+    // Hide this menu when user views their own profile
     return;
   }
 

--- a/app/javascript/packs/profileDropdown.js
+++ b/app/javascript/packs/profileDropdown.js
@@ -11,11 +11,16 @@ function initButtons() {
 
 function initDropdown() {
   const profileDropdownDiv = document.querySelector('.profile-dropdown');
+
+  if (profileDropdownDiv.dataset.dropdownInitialized === 'true') {
+    return;
+  }
   const currentUser = userData();
 
   if (
-    currentUser &&
-    currentUser.username === profileDropdownDiv.dataset.username
+    !profileDropdownDiv ||
+    (currentUser &&
+      currentUser.username === profileDropdownDiv.dataset.username)
   ) {
     // Hide this menu if not logged in, or when user views their own profile
     return;
@@ -33,12 +38,9 @@ function initDropdown() {
     '.report-abuse-link-wrapper',
   );
   reportAbuseLink.innerHTML = `<a href="${reportAbuseLink.dataset.path}" class="crayons-link crayons-link--block">Report Abuse</a>`;
+
+  initButtons();
+  profileDropdownDiv.dataset.dropdownInitialized = true;
 }
 
-window.InstantClick.on('change', () => {
-  initButtons();
-  initDropdown();
-});
-
-initButtons();
 initDropdown();

--- a/app/javascript/packs/profileDropdown.js
+++ b/app/javascript/packs/profileDropdown.js
@@ -1,13 +1,44 @@
 import { initBlock } from '../profileDropdown/blockButton';
 import { initFlag } from '../profileDropdown/flagButton';
+import { initializeDropdown } from '@utilities/dropdownUtils';
+
+/* global userData */
 
 function initButtons() {
   initBlock();
   initFlag();
 }
 
+function initDropdown() {
+  const profileDropdownDiv = document.querySelector('.profile-dropdown');
+  const currentUser = userData();
+
+  if (
+    currentUser &&
+    currentUser.username === profileDropdownDiv.dataset.username
+  ) {
+    // Hide this menu if not logged in, or when user views their own profile
+    return;
+  }
+
+  profileDropdownDiv.classList.remove('hidden');
+
+  initializeDropdown({
+    triggerElementId: 'user-profile-dropdown',
+    dropdownContentId: 'user-profile-dropdownmenu',
+  });
+
+  // Add actual link location (SEO doesn't like these "useless" links, so adding in here instead of in HTML)
+  const reportAbuseLink = profileDropdownDiv.querySelector(
+    '.report-abuse-link-wrapper',
+  );
+  reportAbuseLink.innerHTML = `<a href="${reportAbuseLink.dataset.path}" class="crayons-link crayons-link--block">Report Abuse</a>`;
+}
+
 window.InstantClick.on('change', () => {
   initButtons();
+  initDropdown();
 });
 
 initButtons();
+initDropdown();

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
           </span>
 
           <div class="profile-header__actions">
-            <div class="profile-dropdown mr-2 relative" data-username="<%= @user.username %>">
+            <div class="profile-dropdown mr-2 relative hidden" data-username="<%= @user.username %>">
               <button id="user-profile-dropdown" class="crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon">
                 <%= inline_svg_tag("overflow-horizontal.svg", class: "dropdown-icon crayons-icon", aria: true, title: "Toggle dropdown menu") %>
               </button>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -33,6 +33,7 @@
               </button>
 
               <div id="user-profile-dropdownmenu" class="crayons-dropdown top-100 right-0 p-1">
+                <%= javascript_packs_with_chunks_tag "profileDropdown", defer: true %>
                 <% if user_signed_in? %>
                   <a href="javascript:void(0);" id="user-profile-dropdownmenu-block-button" data-profile-user-id="<%= @user.id %>" class="border-none crayons-link crayons-link--block">Block @<%= @user.username %></a>
                   <a
@@ -44,7 +45,6 @@
                     class="border-none crayons-link crayons-link--block">
                     <%= @flag_status ? "Unflag" : "Flag" %> @<%= @user.username %>
                   </a>
-                  <%= javascript_packs_with_chunks_tag "profileDropdown", defer: true %>
                 <% end %>
                 <span class="report-abuse-link-wrapper" data-path="/report-abuse?url=<%= user_url(@user) %>"></span>
               </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,8 +28,8 @@
 
           <div class="profile-header__actions">
             <div class="profile-dropdown mr-2 relative hidden" data-username="<%= @user.username %>">
-              <button id="user-profile-dropdown" class="crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon">
-                <%= inline_svg_tag("overflow-horizontal.svg", class: "dropdown-icon crayons-icon", aria: true, title: "Toggle dropdown menu") %>
+              <button id="user-profile-dropdown" aria-expanded="false" aria-controls="user-profile-dropdownmenu" aria-haspopup="true" class="crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon">
+                <%= inline_svg_tag("overflow-horizontal.svg", class: "dropdown-icon crayons-icon", aria: true, title: "User actions") %>
               </button>
 
               <div id="user-profile-dropdownmenu" class="crayons-dropdown top-100 right-0 p-1">

--- a/cypress/integration/profileFlows/profileUserActionsMenu.spec.js
+++ b/cypress/integration/profileFlows/profileUserActionsMenu.spec.js
@@ -97,9 +97,18 @@ describe('Profile User Actions Menu', () => {
       cy.testSetup();
     });
 
-    it('should not show a dropdown menu when the user is not logged in', () => {
-      cy.visit('/admin_mcadmin');
-      cy.findByRole('button', { name: 'User actions' }).should('not.exist');
+    it('should show a dropdown menu with only the Report Abuse link when the user is not logged in', () => {
+      cy.visit('/article_editor_v1_user');
+      cy.findByRole('button', { name: 'User actions' }).click();
+
+      cy.findByRole('link', { name: 'Report Abuse' }).should('have.focus');
+
+      cy.findByRole('link', { name: 'Block @article_editor_v1_user' }).should(
+        'not.exist',
+      );
+      cy.findByRole('link', { name: 'Flag @article_editor_v1_user' }).should(
+        'not.exist',
+      );
     });
   });
 });

--- a/cypress/integration/profileFlows/profileUserActionsMenu.spec.js
+++ b/cypress/integration/profileFlows/profileUserActionsMenu.spec.js
@@ -1,0 +1,105 @@
+describe('Profile User Actions Menu', () => {
+  describe('Logged in users', () => {
+    beforeEach(() => {
+      cy.testSetup();
+      cy.fixture('users/adminUser.json').as('user');
+
+      cy.get('@user').then((user) => {
+        cy.loginUser(user).then(() => {
+          cy.visit('/');
+        });
+      });
+    });
+
+    it("should show a dropdown menu when a user views another user's profile", () => {
+      cy.visit('/article_editor_v1_user');
+
+      cy.findByRole('button', { name: 'User actions' }).as('dropdownButton');
+      cy.get('@dropdownButton').click();
+      cy.findByRole('link', { name: 'Block @article_editor_v1_user' }).should(
+        'have.focus',
+      );
+      cy.findByRole('link', { name: 'Flag @article_editor_v1_user' });
+      cy.findByRole('link', { name: 'Report Abuse' });
+
+      // Check the menu can be closed by click
+      cy.get('@dropdownButton').click();
+      cy.findByRole('link', { name: 'Block @article_editor_v1_user' }).should(
+        'not.exist',
+      );
+
+      // Check the menu can be closed by escape press
+      cy.get('@dropdownButton').click();
+      cy.findByRole('link', { name: 'Block @article_editor_v1_user' });
+      cy.get('body').type('{esc}');
+      cy.findByRole('link', { name: 'Block @article_editor_v1_user' }).should(
+        'not.exist',
+      );
+      cy.get('@dropdownButton').should('have.focus');
+    });
+
+    it('should not show a dropdown menu when a user views their own profile', () => {
+      cy.visit('/admin_mcadmin');
+      cy.findByRole('button', { name: 'User actions' }).should('not.exist');
+    });
+
+    it('should block and unblock a user', () => {
+      // Always accept the confirmation that pops up
+      cy.on('window:confirm', () => true);
+
+      cy.visit('/article_editor_v1_user');
+      cy.findByRole('button', { name: 'User actions' }).click();
+      cy.findByRole('link', { name: 'Block @article_editor_v1_user' }).click();
+
+      // Check that the menu option has updated, and unblock user
+      cy.findByRole('link', { name: 'Block @article_editor_v1_user' }).should(
+        'not.exist',
+      );
+      cy.findByRole('link', { name: 'Unblock' }).click();
+
+      cy.findByRole('link', { name: 'Unblock' }).should('not.exist');
+      cy.findByRole('link', { name: 'Block' });
+    });
+
+    it('should flag and unflag a user', () => {
+      // Always accept the confirmation that pops up
+      cy.on('window:confirm', () => true);
+
+      cy.visit('/article_editor_v1_user');
+      cy.findByRole('button', { name: 'User actions' }).click();
+      cy.findByRole('link', { name: 'Flag @article_editor_v1_user' }).click();
+
+      // Check that the menu option has updated
+      cy.findByRole('link', { name: 'Flag @article_editor_v1_user' }).should(
+        'not.exist',
+      );
+      cy.findByRole('link', { name: 'Unflag @article_editor_v1_user' }).click();
+
+      // Check that the menu option has updated
+      cy.findByRole('link', { name: 'Unflag @article_editor_v1_user' }).should(
+        'not.exist',
+      );
+      cy.findByRole('link', { name: 'Flag @article_editor_v1_user' });
+    });
+
+    it('should link to report abuse from user', () => {
+      cy.visit('/article_editor_v1_user');
+      cy.findByRole('button', { name: 'User actions' }).click();
+      cy.findByRole('link', { name: 'Report Abuse' }).click();
+
+      cy.url().should('contain', 'report-abuse');
+      cy.url().should('contain', 'article_editor_v1_user');
+    });
+  });
+
+  describe('Logged out users', () => {
+    beforeEach(() => {
+      cy.testSetup();
+    });
+
+    it('should not show a dropdown menu when the user is not logged in', () => {
+      cy.visit('/admin_mcadmin');
+      cy.findByRole('button', { name: 'User actions' }).should('not.exist');
+    });
+  });
+});


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR continues the work under #12297 - Optimise all dropdowns for accessibility. It applies the new dropdown initializer on the Profile page for the "flag/block user / report abuse" menu.

In doing this work, I've moved the relevant code to packs instead of initializers. I've also fixed a bug we had where once you'd visited a given profile page, we were attaching additional click listeners on every page navigation. This resulted in the confirmation alert being shown _N_ times when you clicked "flag/block", with _N_ being the number of pages you'd visited since the first time you were on the profile page.

## Related Tickets & Documents

#12297

## QA Instructions, Screenshots, Recordings

### Expected dropdown functionality

In all cases, the dropdowns mentioned below should function as follows:

- Opens and closes with a mouse click on the relevant button
- Button can be focused by keyboard, and pressing Enter opens and closes the dropdown
- Escape closes the dropdown when it's open
- Clicking anywhere outside of the dropdown closes it if it is open
- If activated by keyboard, visible focus is transferred to the first interactive item (e.g. link) in the dropdown when it opens
- If a user closes the dropdown by pressing Escape, focus is returned back to the button that opened it
- If a user closes the dropdown by clicking outside, focus is returned back to the button that opened it unless they clicked on some other interactive item (e.g. they clicked a button that exists elsewhere on the page)
- When the dropdown is open, if you use the Tab key or Shift + Tab (moves backwards) and tab past the first or last interactive item in the dropdown, the dropdown should close
- The button which activates the dropdown should have the attributes: `aria-expanded`, `aria-haspopup="true"`,` aria-controls="the_id_of_the_dropdown_content"`
- `aria-expanded` should be "true" when the dropdown is visible, and "false" otherwise

### When logged out

- Visiting any profile page, check the "three dots" menu appears
- Check the dropdown complies with the above requirements ☝️ 
- Check only the "Report abuse" option appears in the dropdown, and clicking on it takes you to the report abuse page

### When logged in, viewing **your own** profile

- Check that the dropdown button does not appear on this page

### When logged in, viewing **another user's** profile

- Check that the dropdown appears and complies with the above requirements ☝️ 
- Check that the "Flag user" / "Block user" / "Report Abuse" options are all present and function as before
- Check that if you navigate around the site, and revisit this same profile and "Flag/Block" the user, you are only shown the confirmation pop-up once

### UI accessibility concerns?

This PR adds behaviours and aria needed for accessibility. I'm not anticipating any new issues here, as the dropdown initializer has already been tested in various locations.

## Added tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: One part of a larger piece of work - we'll communicate the change as a whole when complete

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![tortoise slowly making progress](https://i.giphy.com/media/Ssk22FUqqVCX6/giphy.webp)
