### PR TITLE
[15-min-fix] Add quick fix to resolve input events not bubbling up

### DIFF
--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -124,6 +124,9 @@
   // See: https://css-tricks.com/slightly-careful-sub-elements-clickable-things/
   & > * {
     pointer-events: none;
+    + input {
+      pointer-events: revert;
+    }
   }
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This is a hacky way to fix an issue where we don't want click events to bubble up generally, with the exception of `<input>` elements.

## Related Tickets & Documents
Resolves https://github.com/forem/forem/issues/13917

## QA Instructions, Screenshots, Recordings
1. Go to /new
2. See that the "Add Cover Image" and "Upload Image" buttons open the file picker

### UI accessibility concerns?
I think not?

## Added tests?
- [x] No, and this is why: quick hot fix

## [Forem core team only] How will this change be communicated?
- [x] already communicated via Slack

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?

![A kid in black and white, film and clothing, blows a bubble with bubble gum.](https://media.giphy.com/media/eMIBci5Hb2HII/giphy.gif)
