### PR TITLE
[15-minute fix] Remove deprecated route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -321,10 +321,6 @@ Rails.application.routes.draw do
 
     get "/page/:slug", to: "pages#show"
 
-    # TODO: [forem/teamsmash] removed the /p/information view and added a redirect for SEO purposes.
-    # We need to remove this route in 2 months (11 January 2021).
-    get "/p/information", to: redirect("/about")
-
     scope "p" do
       pages_actions = %w[welcome editor_guide publishing_from_rss_guide markdown_basics badges].freeze
       pages_actions.each do |action|


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

While looking through our `routes.rb` file I noticed a comment that mentions that a specific route should be removed on January 11th. We are quite a long time past that and we don't have Team Smash anymore, so I decided to remove it in this PR.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

None

## Added tests?

- [X] No, and this is why: only removing a redirect route

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams