### PR TITLE
15 minute fix: Shorten long titles from feed items if needed

### DIFF
--- a/app/services/feeds/assemble_article_markdown.rb
+++ b/app/services/feeds/assemble_article_markdown.rb
@@ -16,7 +16,7 @@ module Feeds
     def call
       body = <<~HEREDOC
         ---
-        title: #{@title}
+        title: #{processed_title}
         published: false
         date: #{@item.published}
         tags: #{get_tags}
@@ -30,6 +30,10 @@ module Feeds
     end
 
     private
+
+    def processed_title
+      @title.size <= 128 ? @title : "#{@title[0..124]}..."
+    end
 
     def get_tags
       @categories.first(4).map do |tag|

--- a/app/services/feeds/assemble_article_markdown.rb
+++ b/app/services/feeds/assemble_article_markdown.rb
@@ -6,8 +6,8 @@ module Feeds
 
     def initialize(item, user, feed, feed_source_url)
       @item = item
-      @title = item[:title].strip
-      @categories = item[:categories] || []
+      @title = item.title.strip
+      @categories = item.categories || []
       @user = user
       @feed = feed
       @feed_source_url = feed_source_url
@@ -58,7 +58,7 @@ module Feeds
     end
 
     def get_content
-      @item[:content] || @item[:summary] || @item[:description]
+      @item.content || @item.summary || @item.description
     end
 
     def thorough_parsing(content, feed_url)

--- a/app/services/feeds/assemble_article_markdown.rb
+++ b/app/services/feeds/assemble_article_markdown.rb
@@ -32,7 +32,7 @@ module Feeds
     private
 
     def processed_title
-      @title.size <= 128 ? @title : "#{@title[0..124]}..."
+      @title.truncate(128, omission: "...", separator: " ")
     end
 
     def get_tags

--- a/spec/services/feeds/assemble_article_markdown_spec.rb
+++ b/spec/services/feeds/assemble_article_markdown_spec.rb
@@ -3,19 +3,18 @@ require "rails_helper"
 RSpec.describe Feeds::AssembleArticleMarkdown, type: :service do
   let(:user) { create(:user, feed_mark_canonical: true) }
   let(:feed_source_url) { "https://feed.source/url" }
-  let(:feed) { Struct.new(:url).new("https://feed.source/") }
+  let(:feed) { instance_double("Feedjira::Parser::RSS", url: "https://feed.source/") }
   let(:title) { "A title" }
   let(:content) { "Some content that came in with the item, should be the body" }
 
   let(:item) do
-    Struct
-      .new(:title, :categories, :published, :content)
-      .new(
-        title,
-        %w[tag1 tag2 tag3 tag4 tag5],
-        "2020-12-20",
-        content,
-      )
+    instance_double(
+      "Feedjira::Parser::RSSEntry",
+      title: title,
+      categories: %w[tag1 tag2 tag3 tag4 tag5],
+      published: "2020-12-20",
+      content: content,
+    )
   end
 
   let(:feeds_assemble_article_markdown) { described_class.new(item, user, feed, feed_source_url) }

--- a/spec/services/feeds/assemble_article_markdown_spec.rb
+++ b/spec/services/feeds/assemble_article_markdown_spec.rb
@@ -3,17 +3,19 @@ require "rails_helper"
 RSpec.describe Feeds::AssembleArticleMarkdown, type: :service do
   let(:user) { create(:user, feed_mark_canonical: true) }
   let(:feed_source_url) { "https://feed.source/url" }
-  let(:feed) { Struct.new(url: "https://feed.source/") }
+  let(:feed) { Struct.new(:url).new("https://feed.source/") }
   let(:title) { "A title" }
   let(:content) { "Some content that came in with the item, should be the body" }
 
   let(:item) do
-    Struct.new(
-      title: title,
-      categories: %w[tag1 tag2 tag3 tag4 tag5],
-      published: "2020-12-20",
-      content: content,
-    )
+    Struct
+      .new(:title, :categories, :published, :content)
+      .new(
+        title,
+        %w[tag1 tag2 tag3 tag4 tag5],
+        "2020-12-20",
+        content,
+      )
   end
 
   let(:feeds_assemble_article_markdown) { described_class.new(item, user, feed, feed_source_url) }

--- a/spec/services/feeds/assemble_article_markdown_spec.rb
+++ b/spec/services/feeds/assemble_article_markdown_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Feeds::AssembleArticleMarkdown, type: :service do
+  let(:user) { create(:user, feed_mark_canonical: true) }
+  let(:feed_source_url) { "https://feed.source/url" }
+  let(:feed) { Struct.new(url: "https://feed.source/") }
+  let(:title) { "A title" }
+  let(:content) { "Some content that came in with the item, should be the body" }
+
+  let(:item) do
+    Struct.new(
+      title: title,
+      categories: %w[tag1 tag2 tag3 tag4 tag5],
+      published: "2020-12-20",
+      content: content,
+    )
+  end
+
+  let(:feeds_assemble_article_markdown) { described_class.new(item, user, feed, feed_source_url) }
+
+  it "creates markdown head matter" do
+    body = feeds_assemble_article_markdown.call
+
+    expect(body).to include("title: A title")
+    expect(body).to include("date: 2020-12-20")
+  end
+
+  it "includes the content from the feed" do
+    body = feeds_assemble_article_markdown.call
+
+    expect(body).to include(content)
+  end
+
+  context "when item has a long title" do
+    let(:title) { "Words " * 25 }
+
+    it "limits the title to 128 characters by truncation" do
+      body = feeds_assemble_article_markdown.call
+
+      title_line = body.lines.detect { |line| line.starts_with?("title:") }
+      shortened_title = title_line.split(":").second.strip
+      # we expect 21 "Words" plus an ellipsis, total of 128 characters
+      expected_title = "Words Words Words Words Words Words Words Words Words Words Words Words Words Words Words Words Words Words Words Words Words..." # rubocop:disable Layout/LineLength
+
+      expect(shortened_title.size).to eq(128)
+      expect(shortened_title).to eq(expected_title)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When an rss feed includes items with long titles, the created Articles fail validation (silently) and no draft post is created in the dashboard. 

Following the pattern we follow for long article descriptions, if the title is too long, just truncate and add ellipsis. 

The author can fix this up if desired in the editor when setting `published: true`    

This didn't go through any RFC or product decision making process, it's the smallest fix I can think of to stop dropping imported content because of long titles. 

## Related Tickets & Documents

Fixes #13959

## QA Instructions, Screenshots, Recordings

I set the test user's feed_url to the reporter's rss feed - https://www.opennms.com/feed/
I then called `Feeds::Import.call(users: User.where(id: the_user_id))`, which is what the feed worker does internally on a refresh.

On main only 7 articles were created (with short enough titles). In this branch the remaining three were successfully imported and the titles were shortened as described:

```ruby
 [16] pry(main)> Article.last.attributes.slice("description", "title")
  Article Load (1.3ms)  SELECT "articles".* FROM "articles" ORDER BY "articles"."id" DESC LIMIT $1  [["LIMIT", 1]]                                                                                        
=> {"description"=>
  "Since last time, we did a bunch more documentation updates, plus worked on a number of bug fixes and...",
 "title"=>
  "OpenNMS On the Horizon – Documentation, Flows and Nephron, Docker Container Trust, Thresholding, Metadata, Time-Series API, M..."}
```

### UI accessibility concerns?

I don't think so.

## Added tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

None. If imports had been skipping recent articles because of title length, they should be added during the next refresh.
 
## [optional] What gif best describes this PR or how it makes you feel?

![wordpress post with title too long to be visible in the editor](https://user-images.githubusercontent.com/1237369/121588162-35b59900-c9fb-11eb-84f4-e71c509634cf.png)
