### PR TITLE
[15-min-fix] Remove check for blank mailchimp newsletter ID

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -546,7 +546,7 @@ class User < ApplicationRecord
 
   def subscribe_to_mailchimp_newsletter
     return unless registered && email.present?
-    return if Settings::General.mailchimp_api_key.blank? && Settings::General.mailchimp_newsletter_id.blank?
+    return if Settings::General.mailchimp_api_key.blank?
     return if saved_changes.key?(:unconfirmed_email) && saved_changes.key?(:confirmation_sent_at)
     return unless saved_changes.key?(:email) || saved_changes.key?(:email_newsletter)
 
@@ -574,7 +574,7 @@ class User < ApplicationRecord
 
   def unsubscribe_from_newsletters
     return if email.blank?
-    return if Settings::General.mailchimp_api_key.blank? && Settings::General.mailchimp_newsletter_id.blank?
+    return if Settings::General.mailchimp_api_key.blank?
 
     Mailchimp::Bot.new(self).unsubscribe_all_newsletters
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
I misunderstood our Mailchimp usage when I added this boolean -- this PR simplifies it a bit. We had a weird edge case where a Forem had a Mailchimp newsletter ID set, but no Mailchimp API key. Without an API key, we don't actually interact with the newsletter, and therefore should `return` early instead of also checking for the newsletter ID's blankiness.

## Related Tickets & Documents
https://github.com/forem/internalCommunity/issues/127

## QA Instructions, Screenshots, Recordings
None 😅 the tests should handle this.

### UI accessibility concerns?
Nope

## Added tests?
- [x] No, and this is why: already has tests

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: small backend bug fix

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?
![a bird floats in the air, wondering about things.](https://media.giphy.com/media/5QSIcVPpTj9r7RXbNb/giphy-downsized.gif)
