### PR TITLE
Call subscribe_to_mailchimp_newsletter after the transaction is commited

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -346,10 +346,10 @@ class User < ApplicationRecord
 
   # NOTE: @citizen428 Temporary while migrating to generalized profiles
   after_save { |user| user.profile&.save if user.profile&.changed? }
-  after_save :subscribe_to_mailchimp_newsletter
 
   after_create_commit :send_welcome_notification
 
+  after_commit :subscribe_to_mailchimp_newsletter
   after_commit :sync_users_settings_table, :sync_users_notification_settings_table, on: %i[create update]
   after_commit :bust_cache
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -435,7 +435,7 @@ RSpec.describe User, type: :model do
     end
   end
 
-  context "when callbacks are triggered after save" do
+  context "when callbacks are triggered after commit" do
     describe "subscribing to mailchimp newsletter" do
       let(:user) { build(:user) }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
`subscribe_to_mailchimp_newsletter` callback is called by `after_save`. `after_save` is called before the transaction is committed, so `Users::SubscribeToMailchimpNewsletterWorker` is called and find the user before the user setting is committed to the database.
https://github.com/forem/forem/blob/c842d1a0c6718f319f167e9ec13d4d7d5d6b6d39/app/workers/users/subscribe_to_mailchimp_newsletter_worker.rb#L6-L10

Thus, `Mailchimp::Bot`(instantiated by `Users::SubscribeToMailchimpNewsletterWorker`) might use **old** user data and send it to MailChimp in certain circumstances(e.g. the worker is not busy).
https://github.com/forem/forem/blob/6dfabd578f727cad8776ba65930a2889b1573faf/app/services/mailchimp/bot.rb#L28

Actually, when I set up MailChimp in the local environment and commented the following line to use Mailchimp, this problem happened sometimes.
https://github.com/forem/forem/blob/6dfabd578f727cad8776ba65930a2889b1573faf/app/services/mailchimp/bot.rb#L14

## Related Tickets & Documents
This might be related to https://github.com/forem/forem/issues/12021.
When a user checks `
Send me weekly newsletter emails` checkbox on the notification setting page and save it, there is a possibility for `Users::SubscribeToMailchimpNewsletterWorker` to use the user data before the notification setting is committed. If that happens,  on the user setting `email_newsletter` is true, but on MailChimp the user is `Unsubscribed` status.

## Added tests?

- [ ] Yes
- [x] No, and this is why: tests already exist.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
Maybe it is better to compare actual users' newsletter settings and their MailChimp subscription statuses.

## [optional] What gif best describes this PR or how it makes you feel?
![Amazing_62327b_183082](https://user-images.githubusercontent.com/26132902/121795881-bcfb4a80-cc4f-11eb-90be-b15ed3f3e841.gif)

