### PR TITLE
[15-minute fix] Change signature of Feeds::ImportArticlesWorker

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -375,7 +375,7 @@ class UsersController < ApplicationController
   def import_articles_from_feed(user)
     return if user.feed_url.blank?
 
-    Feeds::ImportArticlesWorker.perform_async(nil, user.id)
+    Feeds::ImportArticlesWorker.perform_async(user.id)
   end
 
   def profile_params

--- a/app/workers/feeds/import_articles_worker.rb
+++ b/app/workers/feeds/import_articles_worker.rb
@@ -7,7 +7,7 @@ module Feeds
     # NOTE: [@rhymes] we need to default earlier_than to `nil` because sidekiq-cron,
     # by using YAML to define jobs arguments does not support datetimes evaluated
     # at runtime
-    def perform(earlier_than = nil, user_ids = [])
+    def perform(user_ids = [], earlier_than = nil)
       if user_ids.present?
         users = User.where(id: user_ids)
         # we assume that forcing a single import should not take into account

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -340,11 +340,11 @@ RSpec.describe "UserSettings", type: :request do
       let(:user) { create(:user, feed_url: feed_url) }
 
       it "invokes Feeds::ImportArticlesWorker" do
-        allow(Feeds::ImportArticlesWorker).to receive(:perform_async).with(nil, user.id)
+        allow(Feeds::ImportArticlesWorker).to receive(:perform_async).with(user.id)
 
         put user_path(user.id), params: { user: { feed_url: feed_url } }
 
-        expect(Feeds::ImportArticlesWorker).to have_received(:perform_async).with(nil, user.id)
+        expect(Feeds::ImportArticlesWorker).to have_received(:perform_async).with(user.id)
       end
     end
   end

--- a/spec/workers/feeds/import_articles_worker_spec.rb
+++ b/spec/workers/feeds/import_articles_worker_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Feeds::ImportArticlesWorker, type: :worker do
       allow(Feeds::Import).to receive(:call)
 
       Timecop.freeze(Time.current) do
-        worker.perform(1.minute.ago)
+        worker.perform([], 1.minute.ago)
 
         expect(Feeds::Import).to have_received(:call).with(users: nil, earlier_than: 1.minute.ago)
       end
@@ -31,7 +31,7 @@ RSpec.describe Feeds::ImportArticlesWorker, type: :worker do
 
       allow(Feeds::Import).to receive(:call)
 
-      worker.perform(nil, [user.id])
+      worker.perform([user.id])
 
       expect(Feeds::Import).to have_received(:call).with(users: User.where(id: [user.id]), earlier_than: nil)
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

While reviewing a PR today I noticed the following call:

```ruby
Feeds::ImportArticlesWorker.perform_async(nil, users_setting.user_id)
```

I found this a bit hard to read so I looked at the method signature:

```ruby
def perform(earlier_than = nil, user_ids = [])
```

I'm not particularly fond of this signature for two reasons:

* It's not clear at all what `nil` represents
* If you want to specify user ids, you have to explicitly pass in `nil` and can't use the default

Originally I wanted to suggest `def perform(user_ids = [], earlier_than: nil)` but then remembered that this is a worker, so I just opted to reverse the argument order instead. 

The reason I decided to do this is that the above example is the only place where we explicitly pass in arguments so I think we should optimize for making this call nicer. The scheduled worker defaults the users to `nil` which seems to mean all and `earlier_than` to `4.hours.ago` and doesn't care about readability, so I think this makes sense.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Specs should be green

### UI accessibility concerns?

None

## Added tests?

- [X] Yes, updated existing ones

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: backend refactoring only
