### PR TITLE
[15 min fix] Flakey "change password" spec

### DIFF
--- a/cypress/integration/loginFlows/userChangePassword.spec.js
+++ b/cypress/integration/loginFlows/userChangePassword.spec.js
@@ -46,13 +46,17 @@ describe('User Change Password', () => {
     cy.intercept('/notifications?i=i').as('notificationsRequest');
     cy.intercept('/notifications/counts').as('countsRequest');
     cy.intercept('/async_info/base_data').as('baseDataRequest');
+    cy.intercept('/chat_channels**').as('chatRequest');
 
     // Submit the form
     cy.get('@loginForm').findByText('Continue').click();
 
-    cy.wait('@notificationsRequest');
-    cy.wait('@countsRequest');
-    cy.wait('@baseDataRequest');
+    cy.wait([
+      '@notificationsRequest',
+      '@countsRequest',
+      '@baseDataRequest',
+      '@chatRequest',
+    ]);
 
     const { baseUrl } = Cypress.config();
     cy.url().should('equal', `${baseUrl}settings/account?signin=true`);

--- a/cypress/integration/loginFlows/userChangePassword.spec.js
+++ b/cypress/integration/loginFlows/userChangePassword.spec.js
@@ -43,22 +43,24 @@ describe('User Change Password', () => {
 
     // We intercept these requests to make sure all async sign-in requests have completed before finishing the test.
     // This ensures async responses do not intefere with subsequent test setup
+    cy.intercept('/notifications?i=i').as('notificationsRequest');
     cy.intercept('/notifications/counts').as('countsRequest');
     cy.intercept('/async_info/base_data').as('baseDataRequest');
 
     // Submit the form
     cy.get('@loginForm').findByText('Continue').click();
 
+    cy.wait('@notificationsRequest');
     cy.wait('@countsRequest');
     cy.wait('@baseDataRequest');
 
     const { baseUrl } = Cypress.config();
     cy.url().should('equal', `${baseUrl}settings/account?signin=true`);
+    cy.findByRole('heading', { name: 'Set new password' });
   });
 
   it('should give an error if the new password/confirm new password fields do not match when changing the password of a user', () => {
     cy.fixture('users/changePasswordUser.json').as('user');
-    // cy.reload();
 
     cy.get('@user').then((user) => {
       cy.findByTestId('update-password-form').as('updatePasswordForm');


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The spec "should give an error if the new password/confirm new password fields do not match when changing the password of a user" was occasionally flaking both in CI and locally. After a bit of investigation, we figured out that the previous test was actually what was causing the issues.

The prior test "should change the password of a user" finishes with a sign-in action. Signing in results in a couple of async network requests for notification count and base user data firing off, and they were occasionally still in progress when the test finished. This seemed to be causing issues with running our `testSetup` steps, logging in the user for the next test.

I've used Cypress intercepts to identify those network requests and wait for them to be resolved before moving on. It doesn't significantly impact the duration of the test, but it just makes it wait that tiny bit longer to make sure the user is fully signed in before we try to clear cookies and re-login for the next test.

*This improves the reliability for me running locally, but I notice that if I throttle the network connection, I'm still seeing the same flakey behaviour.*

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Try running the Cypress test locally a few times and check you can no longer reproduce the failure.

### UI accessibility concerns?

N/A

## Added tests?

- [X] Yes - it is a test 😄 
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Tom Hanks says just wait](https://media.giphy.com/media/l0HlKrB02QY0f1mbm/giphy.gif)
