### PR TITLE
[15 min fix] Improve reliability of profile dropdown test

### DIFF
--- a/cypress/integration/profileFlows/profileUserActionsMenu.spec.js
+++ b/cypress/integration/profileFlows/profileUserActionsMenu.spec.js
@@ -1,4 +1,6 @@
 describe('Profile User Actions Menu', () => {
+  // We complete logged out tests first, as unfinished network requests relating to logged-in users can cause unexpected failures
+  // See: https://github.com/forem/forem/issues/13988
   describe('Logged out users', () => {
     beforeEach(() => {
       cy.testSetup();

--- a/cypress/integration/profileFlows/profileUserActionsMenu.spec.js
+++ b/cypress/integration/profileFlows/profileUserActionsMenu.spec.js
@@ -1,4 +1,27 @@
 describe('Profile User Actions Menu', () => {
+  describe('Logged out users', () => {
+    beforeEach(() => {
+      cy.testSetup();
+    });
+
+    it('should show a dropdown menu with only the Report Abuse link when the user is not logged in', () => {
+      cy.visit('/article_editor_v1_user');
+      // Make sure the dropdown has initialized
+      cy.get('[data-dropdown-initialized]');
+
+      cy.findByRole('button', { name: 'User actions' }).click();
+
+      cy.findByRole('link', { name: 'Report Abuse' }).should('have.focus');
+
+      cy.findByRole('link', { name: 'Block @article_editor_v1_user' }).should(
+        'not.exist',
+      );
+      cy.findByRole('link', { name: 'Flag @article_editor_v1_user' }).should(
+        'not.exist',
+      );
+    });
+  });
+
   describe('Logged in users', () => {
     beforeEach(() => {
       cy.testSetup();
@@ -104,29 +127,6 @@ describe('Profile User Actions Menu', () => {
 
       cy.url().should('contain', 'report-abuse');
       cy.url().should('contain', 'article_editor_v1_user');
-    });
-  });
-
-  describe('Logged out users', () => {
-    beforeEach(() => {
-      cy.testSetup();
-    });
-
-    it('should show a dropdown menu with only the Report Abuse link when the user is not logged in', () => {
-      cy.visit('/article_editor_v1_user');
-      // Make sure the dropdown has initialized
-      cy.get('[data-dropdown-initialized]');
-
-      cy.findByRole('button', { name: 'User actions' }).click();
-
-      cy.findByRole('link', { name: 'Report Abuse' }).should('have.focus');
-
-      cy.findByRole('link', { name: 'Block @article_editor_v1_user' }).should(
-        'not.exist',
-      );
-      cy.findByRole('link', { name: 'Flag @article_editor_v1_user' }).should(
-        'not.exist',
-      );
     });
   });
 });

--- a/cypress/integration/profileFlows/profileUserActionsMenu.spec.js
+++ b/cypress/integration/profileFlows/profileUserActionsMenu.spec.js
@@ -14,6 +14,9 @@ describe('Profile User Actions Menu', () => {
     it("should show a dropdown menu when a user views another user's profile", () => {
       cy.visit('/article_editor_v1_user');
 
+      // Make sure the dropdown has initialized
+      cy.get('[data-dropdown-initialized]');
+
       cy.findByRole('button', { name: 'User actions' }).as('dropdownButton');
       cy.get('@dropdownButton').click();
       cy.findByRole('link', { name: 'Block @article_editor_v1_user' }).should(
@@ -48,6 +51,10 @@ describe('Profile User Actions Menu', () => {
       cy.on('window:confirm', () => true);
 
       cy.visit('/article_editor_v1_user');
+
+      // Make sure the dropdown has initialized
+      cy.get('[data-dropdown-initialized]');
+
       cy.findByRole('button', { name: 'User actions' }).click();
       cy.findByRole('link', { name: 'Block @article_editor_v1_user' }).click();
 
@@ -66,6 +73,10 @@ describe('Profile User Actions Menu', () => {
       cy.on('window:confirm', () => true);
 
       cy.visit('/article_editor_v1_user');
+
+      // Make sure the dropdown has initialized
+      cy.get('[data-dropdown-initialized]');
+
       cy.findByRole('button', { name: 'User actions' }).click();
       cy.findByRole('link', { name: 'Flag @article_editor_v1_user' }).click();
 
@@ -84,6 +95,10 @@ describe('Profile User Actions Menu', () => {
 
     it('should link to report abuse from user', () => {
       cy.visit('/article_editor_v1_user');
+
+      // Make sure the dropdown has initialized
+      cy.get('[data-dropdown-initialized]');
+
       cy.findByRole('button', { name: 'User actions' }).click();
       cy.findByRole('link', { name: 'Report Abuse' }).click();
 
@@ -99,6 +114,9 @@ describe('Profile User Actions Menu', () => {
 
     it('should show a dropdown menu with only the Report Abuse link when the user is not logged in', () => {
       cy.visit('/article_editor_v1_user');
+      // Make sure the dropdown has initialized
+      cy.get('[data-dropdown-initialized]');
+
       cy.findByRole('button', { name: 'User actions' }).click();
 
       cy.findByRole('link', { name: 'Report Abuse' }).should('have.focus');


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After merging some new Cypress tests in #13916 there's been a couple of instances of flake in CI (I haven't been able to reproduce locally). After running in a debug build I could see the issue was similar to that in #13979 - the "logged out" user test runs last and previous unfinished network requests interfere with teardown/setup of that last test.

The screenshot grabbed from the failure shows the user was logged in, when we expected them to be logged out:

![screenshot of the profile dropdown menu showing the flag and block options](https://user-images.githubusercontent.com/20773163/122034603-98c37900-cdc9-11eb-8716-cba2c1ed785d.png)

For the moment, I've switched the order so that logged out tests happen first. I'm not totally happy with "fixing" by relying on a specific order of tests, but I think it makes sense generally to run 'logged out' tests before 'logged in' tests. 

We will need to look at this problem with test setup, but I think it would be worth doing that in a separate issue and taking time to find a generalised approach that could solve this for future tests.

I've also added a line in each test here to make sure the JS code has run and added the expected handlers to the dropdowns. It wasn't causing the flake, but seems like a good idea!

## Related Tickets & Documents

#13916

## QA Instructions, Screenshots, Recordings

We should see the build go green ✅ 

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: just a small test update

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Mr Kim saying wait for it](https://media.giphy.com/media/eudqDxqzUJfveIaEPy/giphy.gif)
