### PR TITLE
Add config to silence e2e babel warnings

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -56,6 +56,10 @@ module.exports = function (api) {
           pragma: 'h',
         },
       ],
+      [
+        '@babel/plugin-proposal-private-private-property-in-object',
+        { loose: true },
+      ],
     ].filter(Boolean),
   };
 };


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

While looking into e2e Travis logs I see plenty of warnings related to a babel config. If this configuration mismatch isn't a problem we are going to address it might be worth silencing the warning (we already have a few plugin configs in `babel.config.js`)
 
<img width="1056" alt="Screen Shot 2021-06-15 at 07 43 54" src="https://user-images.githubusercontent.com/6045239/122063386-7459a380-cdad-11eb-9faa-66da7933b14d.png">


## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Tests should continue to pass as usual

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: Only updating a config

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Test config update unrelated to the app itself

## [optional] What gif best describes this PR or how it makes you feel?

![warning](https://media.giphy.com/media/d2YWbtt6gIhaZfxK/giphy.gif)
