### PR TITLE
Don't use Honeycomb test mode in production

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -1,4 +1,4 @@
-if Rails.env.test? || ApplicationConfig["HONEYCOMB_API_KEY"].blank?
+if Rails.env.test?
   Honeycomb.configure do |config|
     config.client = Libhoney::TestClient.new
   end

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -18,7 +18,7 @@ else
   ].freeze
 
   Honeycomb.configure do |config|
-    config.write_key = honeycomb_api_key
+    config.write_key = honeycomb_api_key.presence
     if ENV["HONEYCOMB_DISABLE_AUTOCONFIGURE"]
       config.dataset = "background-work"
     else

--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -4,6 +4,7 @@ if Rails.env.test?
   end
 else
   honeycomb_api_key = ApplicationConfig["HONEYCOMB_API_KEY"]
+  release_footprint = ApplicationConfig["RELEASE_FOOTPRINT"]
 
   # Honeycomb automatic Rails integration
   notification_events = %w[
@@ -27,7 +28,7 @@ else
 
       # Scrub unused data to save space in Honeycomb
       config.presend_hook do |fields|
-        fields["global.build_id"] = ApplicationConfig["RELEASE_FOOTPRINT"]
+        fields["global.build_id"] = release_footprint
 
         if fields.key?("redis.command")
           fields["redis.command"] = fields["redis.command"].slice(0, 300)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Any production Forem instance that did not configure a Honeycomb API key experiences a memory leak. Anyone who's running on Heroku wouldn't see much impact without a lot of traffic since Heroku restarts all dynos every 24 hours, but anyone hosting it on other platforms would likely see it.

This was added in #4725 to avoid failures when a Honeycomb API key wasn't set. Newer versions of the gem appear not to need this workaround — they switch to the [`NullClient`](https://www.rubydoc.info/gems/libhoney/Libhoney/NullClient) automatically. I had no errors with this.

Shout out to @djuber for discovering where the leak was. I was looking in other areas for differences between self-host and official Forem production configs. I was in the middle of looking at the sitemap generation when Dan found this.

## Related Tickets & Documents

- #4725

## QA Instructions, Screenshots, Recordings

You can reproduce the issue in development by running 100k bogus Sidekiq workers:

```ruby
class BogusWorker
  include Sidekiq::Worker

  def perform
  end
end
```

And then in a Rails console:

```ruby
[1] pry(main)> 100_000.times { BogusWorker.perform_async }
```

After all 100k Sidekiq jobs have been processed, check the memory usage:

![Memory usage is 922MB](https://user-images.githubusercontent.com/108205/122131063-9e8b7f80-ce06-11eb-95ec-36f97863abab.png)

Then try it on this branch doing the same thing:

![Memory usage is 294MB](https://user-images.githubusercontent.com/108205/122131137-b82cc700-ce06-11eb-83b0-840d380cef68.png)

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Configuration update
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

- Re-deploy JDoss's self-host Forem on DO and see if it experiences the memory leak again
- Check to see if we even need this in the test environment or if we can remove the check _entirely_ to reduce memory consumption in tests.

## [optional] What gif best describes this PR or how it makes you feel?

![Stop leak](https://user-images.githubusercontent.com/108205/122131577-5de03600-ce07-11eb-9455-d3a1cf9d25f4.png)
