### PR TITLE
[15-minute fix] Remove navigation links from footer on private Forems

### DIFF
--- a/app/models/forem_instance.rb
+++ b/app/models/forem_instance.rb
@@ -27,4 +27,8 @@ class ForemInstance
   def self.smtp_enabled?
     (Settings::SMTP.user_name.present? && Settings::SMTP.password.present?) || ENV["SENDGRID_API_KEY"].present?
   end
+
+  def self.private?
+    Settings::Authentication.invite_only_mode?
+  end
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,22 +1,24 @@
 <footer class="crayons-footer print-hidden">
   <div id="footer-container" class="crayons-layout crayons-layout--limited-m crayons-footer__container">
-    <nav class="m:-mt-4" aria-label="Site information">
-      <a href="/" class="crayons-link inline-block p-2">Home</a>
-      <% NavigationLink.ordered.each do |link| %>
-        <% if !link.display_only_when_signed_in? || (link.display_only_when_signed_in? && user_signed_in?) %>
-          <a href="<%= link.url %>" class="crayons-link inline-block p-2"><%= link.name %></a>
+    <% unless ForemInstance.private? %>
+      <nav class="m:-mt-4" aria-label="Site information">
+          <a href="/" class="crayons-link inline-block p-2">Home</a>
+          <% NavigationLink.ordered.each do |link| %>
+            <% if !link.display_only_when_signed_in? || (link.display_only_when_signed_in? && user_signed_in?) %>
+              <a href="<%= link.url %>" class="crayons-link inline-block p-2"><%= link.name %></a>
+            <% end %>
+          <% end %>
+
+        <% unless user_signed_in? %>
+          <a href="<%= sign_up_path %>" class="crayons-link fw-bold inline-block p-2">Sign In/Up</a>
+        <% else %>
+          <a href="/new" class="crayons-link fw-bold inline-block p-2">Create Post</a>
         <% end %>
-      <% end %>
 
-      <% unless user_signed_in? %>
-        <a href="<%= sign_up_path %>" class="crayons-link fw-bold inline-block p-2">Sign In/Up</a>
-      <% else %>
-        <a href="/new" class="crayons-link fw-bold inline-block p-2">Create Post</a>
-      <% end %>
-
-      <div class="pt-4"><%= render partial: "layouts/social_media" %></div>
-    </nav>
-    <hr class="crayons-footer__divider">
+        <div class="pt-4"><%= render partial: "layouts/social_media" %></div>
+      </nav>
+      <hr class="crayons-footer__divider">
+    <% end %>
     <p class="fs-s crayons-footer__description"><a href="/" aria-label="<%= community_name %> Home" class="crayons-link"><%= community_name %></a> – <%= Settings::Community.community_description %></p>
     <div class="m:-mb-4 crayons-footer__description">
       <%# The following copy is necessary for compatibility with the Forem AGPL licence which requires instances to link back to the source. %>

--- a/spec/system/layout_spec.rb
+++ b/spec/system/layout_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Layout", type: :system do
+  context "when rendering the footer" do
+    it "displays navigation links for public Forems" do
+      allow(ForemInstance).to receive(:private?).and_return(false)
+      visit root_path
+      expect(page).to have_selector("footer nav")
+    end
+
+    it "does not display navigation links for private Forems" do
+      allow(ForemInstance).to receive(:private?).and_return(true)
+      visit root_path
+      expect(page).not_to have_selector("footer nav")
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR removes navigation links from the footer for private Forems.

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/14005

## QA Instructions, Screenshots, Recordings

**Before:**

![image](https://user-images.githubusercontent.com/47985/122335863-1fad5880-cf66-11eb-9c03-07015820c109.png)

**After:**

![image](https://user-images.githubusercontent.com/47985/122335973-4cfa0680-cf66-11eb-8f47-4e00b223f645.png)

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
