### PR TITLE
[15-minute fix] Remove DEV specific deeplink

### DIFF
--- a/app/controllers/deep_links_controller.rb
+++ b/app/controllers/deep_links_controller.rb
@@ -7,7 +7,6 @@ class DeepLinksController < ApplicationController
     # TODO: [@fdoxyz] Replace these hardcoded identifiers with configurations
     # creators can use to customize their Forems - `/admin/consumer_apps`
     supported_apps = ["R9SWHSQNV8.com.forem.app"]
-    supported_apps << "R9SWHSQNV8.to.dev.ios" if ForemInstance.dev_to?
     render json: {
       applinks: {
         apps: [],

--- a/spec/requests/universal_links_spec.rb
+++ b/spec/requests/universal_links_spec.rb
@@ -3,26 +3,9 @@ require "rails_helper"
 RSpec.describe "Universal Links (Apple)", type: :request do
   let(:aasa_route) { "/.well-known/apple-app-site-association" }
   let(:forem_app_id) { "R9SWHSQNV8.com.forem.app" }
-  let(:dev_app_id) { "R9SWHSQNV8.to.dev.ios" }
 
   describe "returns a valid Apple App Site Association file" do
-    context "with DEV app backwards compatibility" do
-      it "responds with applinks support for both" do
-        allow(ForemInstance).to receive(:dev_to?).and_return(true)
-        get aasa_route
-        json_response = JSON.parse(response.body)
-
-        both_app_ids = [forem_app_id, dev_app_id]
-        expect(response).to have_http_status(:ok)
-        expect(json_response.dig("applinks", "apps")).to be_empty
-        json_response.dig("applinks", "details").each do |hash|
-          expect(both_app_ids).to include(hash["appID"])
-          expect(hash["paths"]).to match_array(["/*"])
-        end
-      end
-    end
-
-    context "when non-DEV Forem instance" do
+    context "when public Forem instance" do
       it "responds with applinks support for Forem app" do
         get aasa_route
         json_response = JSON.parse(response.body)
@@ -36,7 +19,7 @@ RSpec.describe "Universal Links (Apple)", type: :request do
       end
     end
 
-    context "when non-public Forem instance" do
+    context "when private Forem instance" do
       it "responds with applinks support for Forem app", :aggregate_failures do
         allow(Settings::UserExperience).to receive(:public).and_return(false)
         get aasa_route


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR removes the deeplink for the old DEV  app. https://github.com/forem/forem/pull/14015 will allow admins to add additional apps so this hard-coded special case can be removed.

## Related Tickets & Documents

https://github.com/forem/internalEngineering/issues/434

## QA Instructions, Screenshots, Recordings

Nothing specific

### UI accessibility concerns?

None

## Added/updated tests?

- [X] No, and this is why: removing code that wasn't covered by tests.

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: internal change only, mobile team is aware.