### PR TITLE
[15-minute fix] Consistently use `ForemInstance.private?`

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,10 +95,6 @@ module ApplicationHelper
     end
   end
 
-  def invite_only_mode?
-    Settings::Authentication.invite_only_mode?
-  end
-
   def any_enabled_auth_providers?
     authentication_enabled_providers.any?
   end

--- a/app/helpers/authentication_helper.rb
+++ b/app/helpers/authentication_helper.rb
@@ -45,22 +45,22 @@ module AuthenticationHelper
     Settings::General.waiting_on_first_user
   end
 
-  def invite_only_mode_or_no_enabled_auth_options
-    Settings::Authentication.invite_only_mode ||
+  def private_forem_or_no_enabled_auth_options
+    ForemInstance.private? ||
       (authentication_enabled_providers.none? &&
        !Settings::Authentication.allow_email_password_registration)
   end
 
   def tooltip_class_on_auth_provider_enablebtn
-    invite_only_mode_or_no_enabled_auth_options ? "crayons-tooltip" : ""
+    private_forem_or_no_enabled_auth_options ? "crayons-tooltip" : ""
   end
 
   def disabled_attr_on_auth_provider_enable_btn
-    invite_only_mode_or_no_enabled_auth_options ? "disabled" : ""
+    private_forem_or_no_enabled_auth_options ? "disabled" : ""
   end
 
   def tooltip_text_email_or_auth_provider_btns
-    if invite_only_mode_or_no_enabled_auth_options
+    if private_forem_or_no_enabled_auth_options
       "You cannot do this until you disable Invite Only Mode"
     else
       ""

--- a/app/services/authentication/providers.rb
+++ b/app/services/authentication/providers.rb
@@ -44,7 +44,7 @@ module Authentication
     # TODO: [@forem/oss] ideally this should be "available - disabled"
     # we can get there once we have feature flags
     def self.enabled
-      return [] if Settings::Authentication.invite_only_mode
+      return [] if ForemInstance.private?
 
       Settings::Authentication.providers.map(&:to_sym).sort
     end

--- a/app/views/admin/settings/forms/_authentication.html.erb
+++ b/app/views/admin/settings/forms/_authentication.html.erb
@@ -13,10 +13,10 @@
           General settings
         </h3>
         <div
-            class="crayons-field crayons-field--checkbox <%= invite_only_mode_or_no_enabled_auth_options ? "crayons-tooltip" : "" %>"
+            class="crayons-field crayons-field--checkbox <%= private_forem_or_no_enabled_auth_options ? "crayons-tooltip" : "" %>"
             data-tooltip="Unchecking this will enable Email Registration">
             <%= f.check_box :invite_only_mode,
-                            checked: invite_only_mode_or_no_enabled_auth_options,
+                            checked: private_forem_or_no_enabled_auth_options,
                             data: { action: "config#adjustAuthenticationOptions", "config-target": "inviteOnlyMode" },
                             class: "crayons-checkbox" %>
             <div class="mt-0">

--- a/app/views/devise/registrations/_registration_form.html.erb
+++ b/app/views/devise/registrations/_registration_form.html.erb
@@ -2,7 +2,7 @@
   <div class="registration crayons-card">
     <div class="registration__content">
       <h1 class="registration__title">
-        <% if params[:state] == "new-user" && invite_only_mode? %>
+        <% if params[:state] == "new-user" && ForemInstance.private? %>
           <%= community_name %> is invite only.
         <% else %>
           Welcome to <%= community_name %>

--- a/app/views/shared/authentication/_providers_registration_form.html.erb
+++ b/app/views/shared/authentication/_providers_registration_form.html.erb
@@ -8,7 +8,7 @@
       <% end %>
     <% end %>
   <% end %>
-  <% if params[:state] == "new-user" && Settings::Authentication.allow_email_password_registration && !Settings::Authentication.invite_only_mode %>
+  <% if params[:state] == "new-user" && Settings::Authentication.allow_email_password_registration && !ForemInstance.private? %>
     <%= link_to "#{inline_svg_tag('email.svg', aria_hidden: true, class: 'crayons-icon', title: 'email')}Sign up with Email".html_safe,
                 request.params.merge(state: "email_signup").except("i"),
                 class: "crayons-btn crayons-btn--l crayons-btn--brand-email crayons-btn--icon-left whitespace-nowrap",

--- a/spec/helpers/authentication_helper_spec.rb
+++ b/spec/helpers/authentication_helper_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe AuthenticationHelper, type: :helper do
 
   describe "#authentication_provider_enabled?" do
     before do
-      allow(Settings::Authentication).to receive(:invite_only_mode).and_return(false)
+      allow(ForemInstance).to receive(:private?).and_return(false)
       allow(Settings::Authentication).to receive(:providers).and_return(%i[twitter github])
     end
 
@@ -76,7 +76,7 @@ RSpec.describe AuthenticationHelper, type: :helper do
   describe "tooltip classes, attributes and content" do
     context "when invite-only-mode enabled and no enabled registration options" do
       before do
-        allow(Settings::Authentication).to receive(:invite_only_mode).and_return(true)
+        allow(ForemInstance).to receive(:private?).and_return(true)
         allow(Settings::Authentication).to receive(:providers).and_return([])
         allow(Settings::Authentication).to receive(:allow_email_password_registration).and_return(false)
       end

--- a/spec/system/authentication/creator_config_edit_spec.rb
+++ b/spec/system/authentication/creator_config_edit_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Creator config edit", type: :system, js: true do
   context "when a creator browses /admin/customization/config" do
     before do
       sign_in admin
-      allow(Settings::Authentication).to receive(:invite_only_mode).and_return(false)
+      allow(ForemInstance).to receive(:private?).and_return(false)
     end
 
     it "presents all available OAuth providers" do

--- a/spec/system/authentication/user_logs_in_with_email_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_email_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe "Authenticating with Email" do
 
   context "when community is in invite only mode" do
     before do
-      allow(Settings::Authentication).to receive(:invite_only_mode).and_return(true)
+      allow(ForemInstance).to receive(:private?).and_return(true)
     end
 
     it "doesn't present the authentication option" do

--- a/spec/system/authentication/user_logs_in_with_facebook_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_facebook_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe "Authenticating with Facebook" do
 
   context "when community is in invite only mode" do
     before do
-      allow(Settings::Authentication).to receive(:invite_only_mode).and_return(true)
+      allow(ForemInstance).to receive(:private?).and_return(true)
     end
 
     it "doesn't present the authentication option" do

--- a/spec/system/authentication/user_logs_in_with_github_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_github_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe "Authenticating with GitHub" do
 
   context "when community is in invite only mode" do
     before do
-      allow(Settings::Authentication).to receive(:invite_only_mode).and_return(true)
+      allow(ForemInstance).to receive(:private?).and_return(true)
     end
 
     it "doesn't present the authentication option" do

--- a/spec/system/authentication/user_logs_in_with_twitter_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_twitter_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe "Authenticating with Twitter" do
 
   context "when community is in invite only mode" do
     before do
-      allow(Settings::Authentication).to receive(:invite_only_mode).and_return(true)
+      allow(ForemInstance).to receive(:private?).and_return(true)
     end
 
     it "doesn't present the authentication option" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

#14006 introduced a new helper method, `ForemInstance.private?`. This PR tries to standardize usage across the codebase so we don't check `Settings::Authentication.invite_only_mode` directly. It's also an attempt to unify the domain language we use as I've seen both "invite only mode" and "private" used interchangeably.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Nothing specific, all existing specs should still be green.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [ ] This change does not need to be communicated, and this is why not: internal refactoring only
