### PR TITLE
Always show preview card on hover

### DIFF
--- a/app/assets/stylesheets/profile-preview-card.scss
+++ b/app/assets/stylesheets/profile-preview-card.scss
@@ -6,11 +6,13 @@
     left: 0;
   }
 
+  // Dropdown hidden state is controlled by an inline style,
+  // !important is valid in this context to override any 'normal' dropdown behaviors
   &__content.crayons-dropdown:hover {
-    display: block;
+    display: block !important;
   }
 
   &__trigger:hover + .profile-preview-card__content.crayons-dropdown {
-    display: block;
+    display: block !important;
   }
 }

--- a/app/assets/stylesheets/profile-preview-card.scss
+++ b/app/assets/stylesheets/profile-preview-card.scss
@@ -6,13 +6,11 @@
     left: 0;
   }
 
-  // Dropdown hidden state is controlled by an inline style,
-  // !important is valid in this context to override any 'normal' dropdown behaviors
   &__content.crayons-dropdown:hover {
-    display: block !important;
+    display: block;
   }
 
   &__trigger:hover + .profile-preview-card__content.crayons-dropdown {
-    display: block !important;
+    display: block;
   }
 }

--- a/app/javascript/utilities/dropdownUtils.js
+++ b/app/javascript/utilities/dropdownUtils.js
@@ -120,7 +120,8 @@ const closeDropdown = ({ triggerElementId, dropdownContentId, onClose }) => {
     .getElementById(triggerElementId)
     ?.setAttribute('aria-expanded', 'false');
 
-  dropdownContent.style.display = 'none';
+  // Remove the inline style added when we opened the dropdown
+  dropdownContent.style.removeProperty('display');
 
   document.removeEventListener(
     'keyup',


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes a small issue in the Profile Preview Card work, where after a user has activated a preview card with a click, the hover functionality no longer worked.

**This is it before:**

https://user-images.githubusercontent.com/20773163/122761189-de81b500-d293-11eb-9c3c-737ca0f8b3e9.mp4

**And this is it now:**

https://user-images.githubusercontent.com/20773163/122761214-e3deff80-d293-11eb-981f-fb28b86864ba.mp4


## Related Tickets & Documents

#13990

## QA Instructions, Screenshots, Recordings

- Go to an article on desktop
- Hover over the author name, and check the preview card appears
- Open the preview card fully by clicking on the author name
- Click the button again to close the preview card (or click outside / press Escape)
- Hover over the author name again to check the preview card appears

### UI accessibility concerns?

N/A - the core functionality of the preview card is keyboard accessible, opening and closing a dropdown on click. The hover effect is supplemental and doesn't affect the core accessibility of the feature.


## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: [Cypress is not able to simulate a hover](https://docs.cypress.io/api/commands/hover)
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: Quick fix to very recently deployed code

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![woops - simba accidentally thrown off the cliff edge](https://media.giphy.com/media/l9i2ToniLpGE0/giphy.gif)
