### PR TITLE
Fix sitemap for self host, including memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ package-lock.json
 
 #sitemap
 /public/sitemap.xml.gz
+/public/sitemaps/
 
 # Development Docker storage location
 _docker-storage/

--- a/app/workers/sitemap_refresh_worker.rb
+++ b/app/workers/sitemap_refresh_worker.rb
@@ -1,11 +1,11 @@
+Rails.application.load_tasks
+
 class SitemapRefreshWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: :low_priority, retry: 10
 
   def perform
-    Rails.application.load_tasks
-
     sitemap_task = ForemInstance.local? ? "sitemap:refresh:no_ping" : "sitemap:refresh"
 
     Rake::Task[sitemap_task].invoke

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -4,29 +4,34 @@ require "sitemap_generator/s3_adapter"
 
 if Rails.env.production?
   region = ApplicationConfig["AWS_UPLOAD_REGION"].presence || ApplicationConfig["AWS_DEFAULT_REGION"]
-  config_hash = if ENV["FOREM_CONTEXT"] == "forem_cloud" # @forem/systems jdoss's special sauce.
-                  # Excluding the aws_access_key_id and aws_secret_access_key causes use_iam_profile
-                  # to be set to true by the S3Adapter
-                  # https://github.com/kjvarga/sitemap_generator/blob/0b847f1e7a544ea8ef87bb643a732e30a07a14c9/lib/sitemap_generator/adapters/s3_adapter.rb#L39
-                  {
-                    fog_provider: "AWS",
-                    fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
-                    fog_region: "us-east-2",
-                    fog_public: false
-                  }
-                else
-                  {
-                    fog_provider: "AWS",
-                    aws_access_key_id: ApplicationConfig["AWS_ID"],
-                    aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
-                    fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
-                    fog_region: region
-                  }
-                end
+  s3_config_hash = if ENV["FOREM_CONTEXT"] == "forem_cloud" # @forem/systems jdoss's special sauce.
+                     # Excluding the aws_access_key_id and aws_secret_access_key causes use_iam_profile
+                     # to be set to true by the S3Adapter
+                     # https://github.com/kjvarga/sitemap_generator/blob/0b847f1e7a544ea8ef87bb643a732e30a07a14c9/lib/sitemap_generator/adapters/s3_adapter.rb#L39
+                     {
+                       fog_provider: "AWS",
+                       fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
+                       fog_region: "us-east-2",
+                       fog_public: false
+                     }
+                   elsif %w[AWS_ID AWS_SECRET AWS_BUCKET_NAME].all? { |key| ApplicationConfig[key] }
+                     {
+                       fog_provider: "AWS",
+                       aws_access_key_id: ApplicationConfig["AWS_ID"],
+                       aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
+                       fog_directory: ApplicationConfig["AWS_BUCKET_NAME"],
+                       fog_region: region
+                     }
+                   end
 
-  SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(config_hash)
-  SitemapGenerator::Sitemap.sitemaps_host = "https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/"
-  SitemapGenerator::Sitemap.public_path = "tmp/"
+  if s3_config_hash
+    SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(config_hash)
+    SitemapGenerator::Sitemap.sitemaps_host = "https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/"
+    SitemapGenerator::Sitemap.public_path = "tmp/"
+  else
+    SitemapGenerator::Sitemap.adapter = SitemapGenerator::FileAdapter.new
+    SitemapGenerator::Sitemap.public_path = "public/"
+  end
   SitemapGenerator::Sitemap.sitemaps_path = "sitemaps/"
 end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The memory leak we thought we fixed in #13997 definitely slowed the leak by a lot, but it turns out there was another leak due to 2 different factors:

1. We were [loading the Rake tasks on every invocation of the `SitemapRefreshWorker`](https://github.com/forem/forem/blob/5a75e303bded8de02ddf5d9c1a4fb5623e2f7873/app/workers/sitemap_refresh_worker.rb#L7)
2. `SitemapRefreshWorker` was failing if [AWS credentials were not provided to store the sitemap](thttps://github.com/forem/forem/blob/5a75e303bded8de02ddf5d9c1a4fb5623e2f7873/app/workers/sitemap_refresh_worker.rb#L7), causing the job to be retried 10x beyond each time it was invoked on purpose

To test this, I ran `SitemapRefreshWorker` 1000x before and after this change.

### Before

<img width="337" alt="Sidekiq uses 2.8GB of RAM" src="https://user-images.githubusercontent.com/108205/122815588-a71b0480-d2a3-11eb-97f5-9db2c7da705f.png">


### After

<img width="346" alt="Sidekiq uses 297MB of RAM" src="https://user-images.githubusercontent.com/108205/122815143-117f7500-d2a3-11eb-9b61-6208e4174dfb.png">

## Related Tickets & Documents

- #13997 

## QA Instructions, Screenshots, Recordings

Run `SitemapRefreshWorker` a few thousand times in the `production` Rails environment with and without this change. You'll need to set the following environment variables:

```sh
RAILS_ENV=production
DATABASE_URL=postgres:///Forem_development
ASSETS_URL=https://example.com
APP_PROTOCOL=http://
APP_DOMAIN=example.com
SECRET_KEY_BASE=abc123omglol
```

I put them on the command line to run Sidekiq:

```
RAILS_ENV=production DATABASE_URL=postgres:///Forem_development ASSETS_URL=https://example.com APP_PROTOCOL=http:// APP_DOMAIN=jgaskins.wtf SECRET_KEY_BASE=abc123omglol REDIS_SIDEKIQ_URL=redis:///1 bundle exec sidekiq
```

You may be able to ignore the `REDIS_SIDEKIQ_URL` setting. For some reason I haven't pinned down, I have to specify `REDIS_SIDEKIQ_URL` but only for the Sidekiq consumer. The Rails side of it already points at Redis slot 1. Your config may not require this.

To enqueue the jobs, run this in the Rails console:

```ruby
[1] pry(main)> 100_000.times { SitemapRefreshWorker.perform_async }
```

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Configuration change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_