### PR TITLE
[15-min-fix] Ensure mention worker delivers email

### DIFF
--- a/app/workers/mentions/send_email_notification_worker.rb
+++ b/app/workers/mentions/send_email_notification_worker.rb
@@ -7,7 +7,7 @@ module Mentions
       mention = Mention.find_by(id: mention_id)
       return unless mention
 
-      NotifyMailer.with(mention: mention).new_mention_email
+      NotifyMailer.with(mention: mention).new_mention_email.deliver_now
     end
   end
 end

--- a/spec/workers/mentions/send_email_notification_worker_spec.rb
+++ b/spec/workers/mentions/send_email_notification_worker_spec.rb
@@ -1,16 +1,21 @@
 require "rails_helper"
 
 RSpec.shared_examples "a valid mentionable" do
+  let(:mailer_class) { NotifyMailer }
   let(:mailer) { double }
   let(:message_delivery) { double }
 
   context "with a mention" do
     it "calls on NotifyMailer" do
-      worker.perform(mention.id) do
-        expect(NotifyMailer).to have_received(:new_mention_email).with(mention)
-        expect(mailer).to have_received(:new_reply_email)
-        expect(message_delivery).to have_received(:deliver_now)
-      end
+      allow(mailer_class).to receive(:with).and_return(mailer)
+      allow(mailer).to receive(:new_mention_email).and_return(message_delivery)
+      allow(message_delivery).to receive(:deliver_now)
+
+      worker.perform(mention.id)
+
+      expect(mailer_class).to have_received(:with).with(mention: mention)
+      expect(mailer).to have_received(:new_mention_email)
+      expect(message_delivery).to have_received(:deliver_now)
     end
   end
 

--- a/spec/workers/mentions/send_email_notification_worker_spec.rb
+++ b/spec/workers/mentions/send_email_notification_worker_spec.rb
@@ -1,10 +1,15 @@
 require "rails_helper"
 
 RSpec.shared_examples "a valid mentionable" do
+  let(:mailer) { double }
+  let(:message_delivery) { double }
+
   context "with a mention" do
     it "calls on NotifyMailer" do
       worker.perform(mention.id) do
         expect(NotifyMailer).to have_received(:new_mention_email).with(mention)
+        expect(mailer).to have_received(:new_reply_email)
+        expect(message_delivery).to have_received(:deliver_now)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This adds `.deliver_now` to the mention email notification worker, which previously was not sending any mention emails.

## QA Instructions, Screenshots, Recordings
Run the tests 😎 
```
rspec spec/workers/mentions/send_email_notification_worker_spec.rb
```

### UI accessibility concerns?
Nope, backend change

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [ ] This change does not need to be communicated, and this is why not: bug fix

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?

![Drew Barrymore says, "Oopsies."](https://media.giphy.com/media/67urFpVn7qwcd2gWIl/giphy-downsized.gif)
