### PR TITLE
Add container tag expiration

### DIFF
--- a/scripts/build_containers.sh
+++ b/scripts/build_containers.sh
@@ -21,6 +21,7 @@ function create_pr_containers {
   docker build --target builder \
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":builder \
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":builder-"${PULL_REQUEST}" \
+               --label quay.expires-after=8w \
                --tag "${CONTAINER_REPO}"/"${CONTAINER_APP}":builder-"${PULL_REQUEST}" .
 
   # Build the pull request image
@@ -37,6 +38,7 @@ function create_pr_containers {
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":builder-"${PULL_REQUEST}" \
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":pr-"${PULL_REQUEST}" \
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":testing-"${PULL_REQUEST}" \
+               --label quay.expires-after=8w \
                --tag "${CONTAINER_REPO}"/"${CONTAINER_APP}":testing-"${PULL_REQUEST}" .
 
   # Push images to Quay

--- a/scripts/build_containers.sh
+++ b/scripts/build_containers.sh
@@ -28,6 +28,7 @@ function create_pr_containers {
   docker build --target production \
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":builder-"${PULL_REQUEST}" \
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":pr-"${PULL_REQUEST}" \
+               --label quay.expires-after=8w \
                --tag "${CONTAINER_REPO}"/"${CONTAINER_APP}":pr-"${PULL_REQUEST}" .
 
   # Build the testing image


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature and bugfix

## Description
To help alleviate tag fetching speeds, we're going to auto-expire/delete a container tag after 8 weeks. That should be ample time and if a certain PR needs more time, a commit is all that is needed to create a new tag. shoutout to @jdoss for the intructions.
 
## Related Tickets & Documents
https://access.redhat.com/documentation/en-us/red_hat_quay/3/html/use_red_hat_quay/working_with_tags
## QA Instructions, Screenshots, Recordings
N/A

## Added/updated tests?
- [x] No, and this is why: container changes

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: container changes

## [optional] Are there any post deployment tasks we need to perform?
n/a