### PR TITLE
Add explicit loose configuration for babel plugins

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -51,10 +51,10 @@ module.exports = function (api) {
         },
       ],
       [
-	'@babel/plugin-proposal-private-property-in-object',
-	{
-	  loose: true
-	}
+        '@babel/plugin-proposal-private-property-in-object',
+        {
+          loose: true
+        }
       ],
       [
         '@babel/plugin-transform-react-jsx',

--- a/babel.config.js
+++ b/babel.config.js
@@ -42,6 +42,7 @@ module.exports = function (api) {
         '@babel/plugin-proposal-class-properties',
         {
           spec: true,
+          loose: true,
         },
       ],
       [
@@ -53,7 +54,13 @@ module.exports = function (api) {
       [
         '@babel/plugin-proposal-private-property-in-object',
         {
-          loose: true
+          loose: true,
+        }
+      ],
+      [
+        '@babel/plugin-proposal-private-methods',
+        {
+          loose: true,
         }
       ],
       [

--- a/babel.config.js
+++ b/babel.config.js
@@ -29,6 +29,7 @@ module.exports = function (api) {
           exclude: ['transform-regenerator'],
           bugfixes: true,
           forceAllTransforms: true,
+          loose: true
         },
         'preact',
       ],
@@ -42,7 +43,6 @@ module.exports = function (api) {
         '@babel/plugin-proposal-class-properties',
         {
           spec: true,
-          loose: true,
         },
       ],
       [
@@ -50,18 +50,6 @@ module.exports = function (api) {
         {
           useBuiltIns: true,
         },
-      ],
-      [
-        '@babel/plugin-proposal-private-property-in-object',
-        {
-          loose: true,
-        }
-      ],
-      [
-        '@babel/plugin-proposal-private-methods',
-        {
-          loose: true,
-        }
       ],
       [
         '@babel/plugin-transform-react-jsx',

--- a/babel.config.js
+++ b/babel.config.js
@@ -51,6 +51,12 @@ module.exports = function (api) {
         },
       ],
       [
+	'@babel/plugin-proposal-private-property-in-object',
+	{
+	  loose: true
+	}
+      ],
+      [
         '@babel/plugin-transform-react-jsx',
         {
           pragma: 'h',

--- a/babel.config.js
+++ b/babel.config.js
@@ -29,7 +29,6 @@ module.exports = function (api) {
           exclude: ['transform-regenerator'],
           bugfixes: true,
           forceAllTransforms: true,
-          loose: true
         },
         'preact',
       ],
@@ -43,6 +42,7 @@ module.exports = function (api) {
         '@babel/plugin-proposal-class-properties',
         {
           spec: true,
+          loose: true,
         },
       ],
       [
@@ -50,6 +50,18 @@ module.exports = function (api) {
         {
           useBuiltIns: true,
         },
+      ],
+      [
+        '@babel/plugin-proposal-private-property-in-object',
+        {
+          loose: true,
+        }
+      ],
+      [
+        '@babel/plugin-proposal-private-methods',
+        {
+          loose: true,
+        }
       ],
       [
         '@babel/plugin-transform-react-jsx',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Squelch this warning that happens a few dozen times during CI by
following the instructions:

```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-private-methods.

The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding

	["@babel/plugin-proposal-private-property-in-object", { "loose": true }]

to the "plugins" section of your Babel config.
```



## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

```
yarn build-storybook
```

If you see 800 or more lines of the quoted configuration warning, this didn't take (example in travis at https://travis-ci.com/github/forem/forem/jobs/517716970#L201-L976) 

```
rm public/packs/manifest.json
bundle exec webpacker:compile
echo $?
```

if this fails to give 0 (for example, if you see ERROR and a echo shows `1`) then builds will not work correctly.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: configuration change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: This appears to be making the current behavior explicit in the configuration - the warning was that the conflicting configuration was ineffective.

## [optional] Are there any post deployment tasks we need to perform?

none

## [optional] What gif best describes this PR or how it makes you feel?

![man on the grass](https://user-images.githubusercontent.com/1237369/122968570-4ba75000-d351-11eb-87be-b28bbe9d28b7.png)
