### PR TITLE
Resolve sitemap's undefined variable

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -25,7 +25,7 @@ if Rails.env.production?
                    end
 
   if s3_config_hash
-    SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(config_hash)
+    SitemapGenerator::Sitemap.adapter = SitemapGenerator::S3Adapter.new(s3_config_hash)
     SitemapGenerator::Sitemap.sitemaps_host = "https://#{ApplicationConfig['AWS_BUCKET_NAME']}.s3.amazonaws.com/"
     SitemapGenerator::Sitemap.public_path = "tmp/"
   else


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
Rename a variable that was missed.

Resolves the following sidekiq error
```
NameError: undefined local variable or method `config_hash' for #<SitemapGenerator::Interpreter:0x00007fa7c6830d68> Did you mean? s3_config_hash
```
## Related Tickets & Documents
https://github.com/forem/forem/pull/14036
## QA Instructions, Screenshots, Recordings
eh
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a