### PR TITLE
[15-Minute Fix] Fix Broken Admin Tags "Remove" Mod Button

### DIFF
--- a/app/views/admin/tags/edit.html.erb
+++ b/app/views/admin/tags/edit.html.erb
@@ -20,7 +20,7 @@
           <% @tag_moderators.each do |user| %>
               <li class="flex justify-between mb-2">
                 <a href="<%= URL.user(user) %>" target="_blank" rel="noopener noreferer">@<%= user.username %></a>
-                <%= form_with url: admin_tag_moderator_path(@tag.id), model: [:admin, @tag], method: :delete do |f| %>
+                <%= form_with url: admin_tag_moderator_path(@tag.id), model: [:admin, @tag], method: :delete, local: true do |f| %>
                   <%= f.hidden_field :user_id, value: user.id %>
                   <%= f.submit "Remove", class: "crayons-btn crayons-btn--danger crayons-btn--s" %>
                 <% end %>

--- a/spec/system/admin/admin_creates_new_tag_spec.rb
+++ b/spec/system/admin/admin_creates_new_tag_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "Admin creates new tag", type: :system do
     visit new_admin_tag_path
   end
 
-  def create_and_publish_tag
-    fill_in("Name", with: "Tag Name")
+  def create_and_publish_tag(tag_name)
+    fill_in("Name", with: tag_name)
     check "Supported"
     fill_in("Short summary", with: "This is a tag")
     click_button("Create Tag")
@@ -17,7 +17,7 @@ RSpec.describe "Admin creates new tag", type: :system do
 
   it "creates a new tag", :aggregate_failures do
     expect(page).to have_content("New Tag")
-    create_and_publish_tag
-    expect(page.driver.status_code).to eq(200)
+    create_and_publish_tag("tag1")
+    expect(page).to have_text("tag1 has been created!")
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR fixes a broken "Remove" button on `/admin/content_manager/tags/:id/edit` that enables Admins to remove moderators from tags by adding `local: true` to the form that handles this, `/admin/tags/edit.html.erb`. Additionally, this PR refactors `admin_creates_new_tag_spec.rb`.

## Related Tickets & Documents
Relates to PR #14049 

## QA Instructions, Screenshots, Recordings
#### To QA this PR, please first ensure that you have an `admin`-based role and then navigate to `/admin/content_manager/tags` to do the following:

- Click on the name of an existing tag on the `/admin/content_manager/tags` page:
<img width="1044" alt="Screen Shot 2021-06-23 at 10 05 00 AM" src="https://user-images.githubusercontent.com/32834804/123130977-7b665e80-d40a-11eb-9011-cc292bfc8511.png">

- Add a moderator to your tag by inputting the ID of a moderator and by clicking the "Add Moderator" button while on the tag's edit and observe that upon clicking the "Add Moderator" button that you are properly redirected to the tag's edit page where you are shown a flash message indicating that the creation was a success!:
<img width="1065" alt="Screen Shot 2021-06-23 at 10 05 34 AM" src="https://user-images.githubusercontent.com/32834804/123131045-8f11c500-d40a-11eb-8377-78c48a655c64.png">

- Now, test that you are able to remove the moderator that you added by clicking the "Remove" button next to the moderator's name. Upon removing the moderator, you should be properly redirected to the tag's edit page where you are shown a flash message indicating that the creation was a success!:
<img width="1071" alt="Screen Shot 2021-06-23 at 10 05 56 AM" src="https://user-images.githubusercontent.com/32834804/123131099-9b961d80-d40a-11eb-9052-1e589f75a2f8.png">

- Try to break things! 🛠️ 

### UI accessibility concerns?
N/A

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://forem.gitbook.io/forem-admin-guide/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Dexter's Laboratory pressing a big red button](https://media.giphy.com/media/aOzFWT8lRj41q/giphy.gif)
