### PR TITLE
Expire the SHA tag after 2 months.

### DIFF
--- a/scripts/build_containers.sh
+++ b/scripts/build_containers.sh
@@ -67,9 +67,14 @@ function create_production_containers {
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":builder \
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":production \
                --tag "${CONTAINER_REPO}"/"${CONTAINER_APP}":$(date +%Y%m%d) \
-               --tag "${CONTAINER_REPO}"/"${CONTAINER_APP}":${BUILDKITE_COMMIT:0:7} \
                --tag "${CONTAINER_REPO}"/"${CONTAINER_APP}":production \
                --tag "${CONTAINER_REPO}"/"${CONTAINER_APP}":latest .
+
+  docker build --target production \
+               --label quay.expires-after=8w \
+               --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":builder \
+               --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":production \
+              "${CONTAINER_REPO}"/"${CONTAINER_APP}":${BUILDKITE_COMMIT:0:7} .
 
   # Build the testing image
   docker build --target testing \

--- a/scripts/build_containers.sh
+++ b/scripts/build_containers.sh
@@ -74,7 +74,7 @@ function create_production_containers {
                --label quay.expires-after=8w \
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":builder \
                --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":production \
-              "${CONTAINER_REPO}"/"${CONTAINER_APP}":${BUILDKITE_COMMIT:0:7} .
+               --tag "${CONTAINER_REPO}"/"${CONTAINER_APP}":${BUILDKITE_COMMIT:0:7} .
 
   # Build the testing image
   docker build --target testing \


### PR DESCRIPTION
This expires the SHA256 tag after 2 months leaving the other production tags alone. 