### PR TITLE
Don't show "Skip to content" link for searches

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -123,9 +123,14 @@ var instantClick
     prog.classList.remove("showing");
 
     if (newUrl) {
-      const skipLink = document.querySelector('.skip-content-link');
-      if (skipLink) {
-        skipLink.focus();
+      // We skip showing the "Skip to content" button for the search page, see
+      // https://github.com/forem/forem/issues/13876
+      var path = new URL(newUrl).pathname;
+      if (path != '/search') {
+        const skipLink = document.querySelector('.skip-content-link');
+        if (skipLink) {
+          skipLink.focus();
+        }
       }
       history.pushState(null, null, newUrl.replace("?samepage=true","").replace("&samepage=true",""))
 

--- a/cypress/integration/searchFlows/skipToContent.spec.js
+++ b/cypress/integration/searchFlows/skipToContent.spec.js
@@ -1,0 +1,14 @@
+// Regression test for https://github.com/forem/forem/issues/13876
+describe('Search on homepage', () => {
+  it('Does not show the "Skip to content" link', () => {
+    cy.visit('/');
+
+    cy.get('#header-search')
+      .get('form')
+      .findByPlaceholderText('Search...')
+      .type('admin mcadmin{enter}');
+
+    cy.url().should('include', '/search');
+    cy.get('.skip-content-link').should('not.be.visible');
+  });
+});


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Right now when triggering a search with enter we wrongly show the "Skip to content" link intended for keyboard navigation. This PR adds an exception for the `/search` page as suggested by @aitchiss.

## Related Tickets & Documents

Closes #13876

## QA Instructions, Screenshots, Recordings

1. Start a local server
2. Go to the homepage
3. Type something in the search bar and hit enter
4. You should **not** see the "Skip to content" link shown in this screenshot
    <img width="1024" alt="Screen Shot 2021-05-28 at 10 35 26 AM" src="https://user-images.githubusercontent.com/3102842/120000078-6da2f200-bfa0-11eb-9634-967843735b3f.png">

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: minor bug fix, doesn't affect admins or creators