### PR TITLE
Prevent occasional matching on random name by specifying one

### DIFF
--- a/spec/services/search/username_spec.rb
+++ b/spec/services/search/username_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Search::Username, type: :service do
     it "finds multiple users whose names have common parts", :aggregate_failures do
       alex = create(:user, username: "alex")
       alexsmith = create(:user, name: "alexsmith")
-      rhymes = create(:user, username: "rhymes")
+      rhymes = create(:user, username: "rhymes", name: "Non-matching Name")
 
       result = described_class.search_documents("ale")
       usernames = result.pluck(:username)


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes flaky search test case

```
  1) Search::Username::search_documents finds multiple users whose names have common parts

     Failure/Error: expect(usernames).not_to include(rhymes.username)
       expected ["alex", "username2222", "rhymes"] not to include "rhymes"
```

We could mistakenly be picking up matches on user "name" rather than
user username due to faker giving a name like "Gale" or "Haley" or
"Annalee" which match the search term "ale".

Give an explicitly non-matching pattern for the name string to prevent
this.

Sampling from Faker::Name.name and filtering for case insensitive
matching against the search term shows slightly higher than 1% of
results will match this "ale" triple. Low enough to go unnoticed for a
long time, high enough to happen every week or two forcing a re-run.

## QA Instructions, Screenshots, Recordings

Test only change. Acceptance criterion should be "tests still pass".

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: fixed existing test setup.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: tiny change.

## [optional] What gif best describes this PR or how it makes you feel?

![fakename](https://user-images.githubusercontent.com/1237369/123650141-ebe8f300-d7ef-11eb-85fd-28f7197da6d0.png)
