### PR TITLE
Chat: disconnect IntersectionObserver to avoid leaking memory

### DIFF
--- a/app/javascript/chat/util.js
+++ b/app/javascript/chat/util.js
@@ -53,7 +53,18 @@ export function setupObserver(callback) {
   const somethingObserver = new IntersectionObserver(callback, {
     threshold: [0, 1],
   });
+
   somethingObserver.observe(sentinel);
+
+  window.addEventListener('beforeunload', () => {
+    somethingObserver.disconnect();
+  });
+
+  if (typeof instantClick !== 'undefined') {
+    InstantClick.on('change', () => {
+      somethingObserver.disconnect();
+    });
+  }
 }
 
 export function hideMessages(messages, userId) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Thanks to [this tweet](https://twitter.com/jaffathecake/status/1405437361643790337) I found out that resize and inteserction observers leak memory in certain browsers if they aren't manually disconnected, which we do everywhere except in the chat.

Apparently most browsers have in the meantime fixed it upstream but because we want to be good citizens and we can't predict if our users have the latest version already, we should close the loop and cleanup.

## QA Instructions, Screenshots, Recordings

1. Load the chat
2. Click on the Forem logo at the top
3. make sure nothing breaks in the console
