### PR TITLE
Make smtp "domain" setting explicit

### DIFF
--- a/spec/models/settings/smtp_spec.rb
+++ b/spec/models/settings/smtp_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Settings::SMTP do
       described_class.authentication = "plain"
       described_class.user_name = "username"
       described_class.password = "password"
+      described_class.domain = "forem.local"
 
       expect(described_class.settings).to eq({
                                                address: "smtp.google.com",
@@ -37,7 +38,7 @@ RSpec.describe Settings::SMTP do
                                                authentication: "plain",
                                                user_name: "username",
                                                password: "password",
-                                               domain: ""
+                                               domain: "forem.local"
                                              })
     end
   end


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

When running tests locally (with an older version of the .env_sample file as .env, which did not have `SMTP_DOMAIN`) I was seeing nil, rather than the empty string, when running this spec. I determined the issue is that env vars provided (but blank) are represented as empty strings, while env vars not provided are returned as nil, and to avoid this dependence on the environment file (at test time) it's better to provide the data you're expecting (as we did for the other keys in the settings hash).

It looks like this passes in CI because a fresh .env file is [copied](https://github.com/forem/forem/blob/main/.travis.yml#L46) during the setup steps, so changing the .env_sample during the PR makes these changes immediate for automatic tests (only local testing would/was affected).

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Test only change.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: existing test change only
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: no new behavior

## [optional] Are there any post deployment tasks we need to perform?

None
