### PR TITLE
Add 'Work' profile field

### DIFF
--- a/app/workers/migrate_data_to_work_field_worker.rb
+++ b/app/workers/migrate_data_to_work_field_worker.rb
@@ -1,0 +1,13 @@
+# NOTE: we can remove this once the DUS using it finished
+class MigrateDataToWorkFieldWorker
+  include Sidekiq::Worker
+
+  def perform(profile_id)
+    profile = Profile.find_by(id: profile_id)
+    return unless profile
+
+    work_info = profile.employment_title
+    work_info << " at #{profile.employer_name}" if profile.employer_name.present?
+    profile.update(work: work_info)
+  end
+end

--- a/lib/data_update_scripts/20210630034523_add_work_profile_field.rb
+++ b/lib/data_update_scripts/20210630034523_add_work_profile_field.rb
@@ -1,0 +1,12 @@
+module DataUpdateScripts
+  class AddWorkProfileField
+    def run
+      ProfileField.find_or_create_by(
+        label: "Work",
+        placeholder_text: "What do you do? Example: Software Engineer at Forem",
+        input_type: :text_field,
+        display_area: :header,
+      )
+    end
+  end
+end

--- a/lib/data_update_scripts/20210630034523_add_work_profile_field.rb
+++ b/lib/data_update_scripts/20210630034523_add_work_profile_field.rb
@@ -3,7 +3,7 @@ module DataUpdateScripts
     def run
       ProfileField.find_or_create_by(
         label: "Work",
-        placeholder_text: "What do you do? Example: Software Engineer at Forem",
+        placeholder_text: "What do you do? Example: CEO at ACME Inc.",
         input_type: :text_field,
         display_area: :header,
       )

--- a/lib/data_update_scripts/20210630041322_migrate_data_to_work_field.rb
+++ b/lib/data_update_scripts/20210630041322_migrate_data_to_work_field.rb
@@ -1,0 +1,15 @@
+module DataUpdateScripts
+  class MigrateDataToWorkField
+    QUERY = "data->>'employment_title' IS NOT NULL AND data->>'employment_title' <> ''".freeze
+
+    def run
+      Profile.where(QUERY).find_each do |profile|
+        next if profile.work.present?
+
+        work_info = profile.employment_title
+        work_info << " at #{profile.employer_name}" if profile.employer_name.present?
+        profile.update(work: work_info)
+      end
+    end
+  end
+end

--- a/lib/data_update_scripts/20210630041322_migrate_data_to_work_field.rb
+++ b/lib/data_update_scripts/20210630041322_migrate_data_to_work_field.rb
@@ -1,10 +1,10 @@
 module DataUpdateScripts
   class MigrateDataToWorkField
-    QUERY = "data->>'employment_title' <> '' AND data->'work' IS NULL".freeze
+    QUERY = "data->>'employment_title' <> '' AND data->>'work' IS NULL".freeze
 
     def run
-      Profile.where(QUERY).ids.each do |profile_id|
-        MigrateDataToWorkFieldWorker.perform_async(profile_id)
+      Profile.where(QUERY).select(:id).find_each do |profile|
+        MigrateDataToWorkFieldWorker.perform_async(profile.id)
       end
     end
   end

--- a/lib/data_update_scripts/20210630041322_migrate_data_to_work_field.rb
+++ b/lib/data_update_scripts/20210630041322_migrate_data_to_work_field.rb
@@ -1,5 +1,13 @@
 module DataUpdateScripts
   class MigrateDataToWorkField
+    # NOTE: data->>'employment_title' <> '' takes care of both null and empty strings.
+    # This works for two reasons:
+    # 1. We use the JSONB ->> operator, which coerces the result to text. This also
+    # turns JSONB `null` into "Postgres" `null`.
+    # See: https://www.postgresql.org/docs/13/functions-json.html
+    # 2. `null` is neither equal to nor unequal to any string. For this reason
+    # `stringexpression <> ''` can be used to filter both `null`s and empty strings.
+    # See: https://stackoverflow.com/questions/23766084/best-way-to-check-for-empty-or-null-value
     QUERY = "data->>'employment_title' <> '' AND data->>'work' IS NULL".freeze
 
     def run

--- a/lib/data_update_scripts/20210630041322_migrate_data_to_work_field.rb
+++ b/lib/data_update_scripts/20210630041322_migrate_data_to_work_field.rb
@@ -1,14 +1,10 @@
 module DataUpdateScripts
   class MigrateDataToWorkField
-    QUERY = "data->>'employment_title' IS NOT NULL AND data->>'employment_title' <> ''".freeze
+    QUERY = "data->>'employment_title' <> '' AND data->'work' IS NULL".freeze
 
     def run
-      Profile.where(QUERY).find_each do |profile|
-        next if profile.work.present?
-
-        work_info = profile.employment_title
-        work_info << " at #{profile.employer_name}" if profile.employer_name.present?
-        profile.update(work: work_info)
+      Profile.where(QUERY).ids.each do |profile_id|
+        MigrateDataToWorkFieldWorker.perform_async(profile_id)
       end
     end
   end

--- a/spec/lib/data_update_scripts/add_work_profile_field_spec.rb
+++ b/spec/lib/data_update_scripts/add_work_profile_field_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20210630034523_add_work_profile_field.rb",
+)
+
+describe DataUpdateScripts::AddWorkProfileField do
+  it "adds a new profile field" do
+    expect { described_class.new.run }.to change(ProfileField, :count).by(1)
+  end
+end

--- a/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
+++ b/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20210630041322_migrate_data_to_work_field.rb",
+)
+
+describe DataUpdateScripts::MigrateDataToWorkField do
+  let!(:user) { create(:user) }
+  let(:profile) { user.profile }
+
+  # Since we have use_transactional_fixtures enabled changes in before(:all)
+  # will not automatically be rolled back.
+  # rubocop:disable RSpec/BeforeAfterAll
+  before(:all) do
+    ProfileField.find_or_create_by(label: "Work", input_type: :text_field)
+    Profile.refresh_attributes!
+  end
+
+  after(:all) { ProfileField.destroy_by(label: "Work") }
+  # rubocop:enable RSpec/BeforeAfterAll
+
+  it "migrates employment titles without employer name" do
+    profile.update(employment_title: "Tester")
+    expect { described_class.new.run }
+      .to change { profile.reload.work }.from(nil).to("Tester")
+  end
+
+  it "migrates employment titles and employer name" do
+    profile.update(employment_title: "Tester", employer_name: "ACME Inc.")
+    expect { described_class.new.run }
+      .to change { profile.reload.work }.from(nil).to("Tester at ACME Inc.")
+  end
+
+  it "ignores blank employment titles" do
+    profile.update(employment_title: "", employer_name: "ACME Inc.")
+    expect { described_class.new.run }.not_to change { profile.reload.work }
+  end
+
+  it "ignores blank employer names" do
+    profile.update(employment_title: "Tester", employer_name: "")
+    expect { described_class.new.run }
+      .to change { profile.reload.work }.from(nil).to("Tester")
+  end
+end

--- a/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
+++ b/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
@@ -11,7 +11,7 @@ describe DataUpdateScripts::MigrateDataToWorkField, sidekiq: :inline do
   # will not automatically be rolled back.
   # rubocop:disable RSpec/BeforeAfterAll
   before(:all) do
-    ProfileField.find_or_create_by(label: "Work", input_type: :text_field)
+    ProfileField.find_or_create_by!(label: "Work", input_type: :text_field)
     Profile.refresh_attributes!
   end
 

--- a/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
+++ b/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
@@ -31,7 +31,7 @@ describe DataUpdateScripts::MigrateDataToWorkField, sidekiq: :inline do
   end
 
   it "ignores blank employment titles" do
-    profile.update(employment_title: "", employer_name: "ACME Inc.")
+    profile.update!(employment_title: "", employer_name: "ACME Inc.")
     expect { described_class.new.run }.not_to change { profile.reload.work }
   end
 

--- a/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
+++ b/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
@@ -3,7 +3,7 @@ require Rails.root.join(
   "lib/data_update_scripts/20210630041322_migrate_data_to_work_field.rb",
 )
 
-describe DataUpdateScripts::MigrateDataToWorkField do
+describe DataUpdateScripts::MigrateDataToWorkField, sidekiq: :inline do
   let!(:user) { create(:user) }
   let(:profile) { user.profile }
 

--- a/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
+++ b/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
@@ -25,7 +25,7 @@ describe DataUpdateScripts::MigrateDataToWorkField, sidekiq: :inline do
   end
 
   it "migrates employment titles and employer name" do
-    profile.update(employment_title: "Tester", employer_name: "ACME Inc.")
+    profile.update!(employment_title: "Tester", employer_name: "ACME Inc.")
     expect { described_class.new.run }
       .to change { profile.reload.work }.from(nil).to("Tester at ACME Inc.")
   end

--- a/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
+++ b/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
@@ -7,16 +7,10 @@ describe DataUpdateScripts::MigrateDataToWorkField, sidekiq: :inline do
   let!(:user) { create(:user) }
   let(:profile) { user.profile }
 
-  # Since we have use_transactional_fixtures enabled changes in before(:all)
-  # will not automatically be rolled back.
-  # rubocop:disable RSpec/BeforeAfterAll
-  before(:all) do
+  before do
     ProfileField.find_or_create_by!(label: "Work", input_type: :text_field)
     Profile.refresh_attributes!
   end
-
-  after(:all) { ProfileField.destroy_by(label: "Work") }
-  # rubocop:enable RSpec/BeforeAfterAll
 
   it "migrates employment titles without employer name" do
     profile.update!(employment_title: "Tester")

--- a/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
+++ b/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
@@ -36,7 +36,7 @@ describe DataUpdateScripts::MigrateDataToWorkField, sidekiq: :inline do
   end
 
   it "ignores blank employer names" do
-    profile.update(employment_title: "Tester", employer_name: "")
+    profile.update!(employment_title: "Tester", employer_name: "")
     expect { described_class.new.run }
       .to change { profile.reload.work }.from(nil).to("Tester")
   end

--- a/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
+++ b/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
@@ -19,7 +19,7 @@ describe DataUpdateScripts::MigrateDataToWorkField, sidekiq: :inline do
   # rubocop:enable RSpec/BeforeAfterAll
 
   it "migrates employment titles without employer name" do
-    profile.update(employment_title: "Tester")
+    profile.update!(employment_title: "Tester")
     expect { described_class.new.run }
       .to change { profile.reload.work }.from(nil).to("Tester")
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature

## Description

After talking to @benhalpern we decided that we will get rid of the separate work-related columns. Instead, there will be a single profile field for all work info. This PR adds that field as well as a data update script for migrating existing data, all other related work will be done in #14079.

## Related Tickets & Documents

Profile generalization

## QA Instructions, Screenshots, Recordings

Nothing specific to QA here, should be covered by tests.

### UI accessibility concerns?

n/a

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: this is an internal task, I'll notify the appropriate teams once we get closer to merging the other PR.