### PR TITLE
Track Profile count in RecordDataCountsWorker

### DIFF
--- a/app/workers/metrics/record_data_counts_worker.rb
+++ b/app/workers/metrics/record_data_counts_worker.rb
@@ -4,7 +4,8 @@ module Metrics
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform
-      models = [User, Article, Organization, Comment, Podcast, PodcastEpisode, Listing, PageView, Notification, Message]
+      models = [User, Article, Organization, Comment, Podcast, PodcastEpisode, Listing, PageView, Notification,
+                Message, Profile]
       models.each do |model|
         db_count = begin
           model.count


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
I would like to create a monitor for tracking parity between User and Profile but we are currently not tracking any Profile counts. This fixes that.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
n/a

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a