### PR TITLE
Explicitly configure libhoney null client when no api key detected

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -20,6 +20,12 @@ else
 
   Honeycomb.configure do |config|
     config.write_key = honeycomb_api_key.presence
+
+    # libhoney client will automatically fall back to using a null transmission
+    # when no write key is provided, but it will log a warning (visible in a few places)
+    # explicitly override the client to disable the warning
+    config.client = Libhoney::NullClient.new unless config.write_key
+
     if ENV["HONEYCOMB_DISABLE_AUTOCONFIGURE"]
       config.dataset = "background-work"
     else


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This configures the fallback behavior we're relying on in self-hosted
forems, and disables a warning that the fallback is happening.

https://github.com/forem/forem/pull/13997 changed the initializer to not use test mode (which was leading to a sidekiq memory problem in self-hosted forems without honeycomb configured, as well as affecting long running local sidekiq servers in development). 

[The warning](https://github.com/honeycombio/libhoney-rb/blob/main/lib/libhoney/client.rb#L91-L99) is happening here when `transmission` defaults to nil, in the Libhoney::Client, which is the default when Honeycomb is creating a client. [NullClient](https://github.com/honeycombio/libhoney-rb/blob/main/lib/libhoney/null_client.rb) sets transmission to NullTransmission (the situation that's not warning about a misconfiguration since you made a choice during configuration time).


## Related Tickets & Documents

#13997 

## QA Instructions, Screenshots, Recordings

In test we expect to still use the TestClient (captures events to an array for inspection/verification)
In production we expect to either use NullClient (when api key is absent) or continue using the honeycomb api.
In development we expect the warning message, `Libhoney::Client: no writekey configured, disabling sending events`, to be silenced.

### UI accessibility concerns?
None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: configuration change, excluding test environment
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: Configuration change.

## [optional] Are there any post deployment tasks we need to perform?

It would make me feel good if we verified honeycomb continued to receive events post deploy.
