### PR TITLE
[15-min-fix] Add org id to admin listings form

### DIFF
--- a/app/controllers/admin/listings_controller.rb
+++ b/app/controllers/admin/listings_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class ListingsController < Admin::ApplicationController
     include ListingsToolkit
     ALLOWED_PARAMS = %i[
-      published body_markdown title category listing_category_id tag_list action
+      published body_markdown title category listing_category_id tag_list action organization_id
     ].freeze
     layout "admin"
 

--- a/app/views/admin/listings/edit.html.erb
+++ b/app/views/admin/listings/edit.html.erb
@@ -30,6 +30,10 @@
       <%= form.text_field :tag_list, value: @listing.cached_tag_list, size: 100, class: "form-control" %>
     </div>
     <div class="form-group">
+      <%= form.label :organization_id, "Organization ID (Optional)" %>
+      <%= form.text_field :organization_id, value: @listing.organization_id, class: "form-control" %>
+    </div>
+    <div class="form-group">
       <%= form.label :listing_category_id %>
       <%= form.select :listing_category_id, select_options_for_categories %>
     </div>

--- a/app/views/admin/listings/edit.html.erb
+++ b/app/views/admin/listings/edit.html.erb
@@ -15,7 +15,7 @@
 </header>
 
 <div class="crayons-card p-6">
-  <%= form_with model: [:admin, @listing], method: :patch do |form| %>
+  <%= form_with model: [:admin, @listing], method: :patch, local: true do |form| %>
     <div class="form-group">
       <%= form.label :title %>
       <%= form.text_field :title, size: 100, maxlength: 128, class: "form-control" %>

--- a/spec/requests/admin/listings_spec.rb
+++ b/spec/requests/admin/listings_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "/admin/app/listings", type: :request do
+RSpec.describe "/admin/apps/listings", type: :request do
   let(:admin) { create(:user, :super_admin) }
   let!(:listing) { create(:listing, user_id: admin.id) }
 
@@ -16,6 +16,15 @@ RSpec.describe "/admin/app/listings", type: :request do
       }
       sidekiq_perform_enqueued_jobs
       expect(EdgeCache::BustListings).to have_received(:call)
+    end
+
+    it "updates the organization ID" do
+      org = create(:organization)
+      put admin_listing_path(id: listing.id), params: {
+        listing: { organization_id: org.id }
+      }
+      sidekiq_perform_enqueued_jobs
+      expect(listing.reload.organization_id).to eq org.id
     end
 
     describe "GET /admin/app/listings" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
This allows admins to add organization IDs to listings via the admin listings form.

## Related Tickets & Documents
https://github.com/forem/internalCommunity/issues/142

## QA Instructions, Screenshots, Recordings
1. Visit http://localhost:3000/admin/apps/listings
2. Click on a listing (Might need to check the "Include unpublished" option)
3. Add an organization ID `1` or something
4. See that it persisted on the listing

### UI accessibility concerns?
Nope

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- I will communicate with the relevant teams

## [optional] What gif best describes this PR or how it makes you feel?

![A check marks itself](https://media.giphy.com/media/tf9jjMcO77YzV4YPwE/giphy.gif)
