### PR TITLE
Delay DUS scripts via WORKERS_DATA_UPDATE_DELAY_SECONDS in rake otherwise default run them immediately

### DIFF
--- a/lib/tasks/data_updates.rake
+++ b/lib/tasks/data_updates.rake
@@ -12,7 +12,7 @@ namespace :data_updates do
 
       # Use the env variable to delay running data update scripts if your
       # deploy strategy requires it
-      DataUpdateWorker.perform_in(ENV["DATA_UPDATE_WORKER_DELAY_SECONDS"] || default_delay)
+      DataUpdateWorker.perform_in(ENV["WORKERS_DATA_UPDATE_DELAY_SECONDS"] || default_delay)
     end
   end
 

--- a/lib/tasks/data_updates.rake
+++ b/lib/tasks/data_updates.rake
@@ -4,8 +4,9 @@ namespace :data_updates do
     if Rails.env.development?
       Rake::Task["data_updates:run"].execute
     else
-      # Ensure new code has been deployed before we run our update scripts
-      DataUpdateWorker.perform_in(ENV["DATA_UPDATE_WORKER_DELAY"] || 0)
+      # Use the env variable to delay running data update scripts if your
+      # deploy strategy requires it
+      DataUpdateWorker.perform_in(ENV["DATA_UPDATE_WORKER_DELAY_SECONDS"] || 0)
     end
   end
 

--- a/lib/tasks/data_updates.rake
+++ b/lib/tasks/data_updates.rake
@@ -4,9 +4,15 @@ namespace :data_updates do
     if Rails.env.development?
       Rake::Task["data_updates:run"].execute
     else
+      # @mstruve: Due to many folks already hosting their Forems on Heroku lets
+      # set a friendly default for them. Ideally we get everyone to use
+      # the ENV variable below but until we can do a hard cut over with
+      # a version I think this is a good compromise
+      default_delay = ENV["HEROKU_SLUG_COMMIT"].present? ? 10.minutes : 0
+
       # Use the env variable to delay running data update scripts if your
       # deploy strategy requires it
-      DataUpdateWorker.perform_in(ENV["DATA_UPDATE_WORKER_DELAY_SECONDS"] || 0)
+      DataUpdateWorker.perform_in(ENV["DATA_UPDATE_WORKER_DELAY_SECONDS"] || default_delay)
     end
   end
 

--- a/lib/tasks/data_updates.rake
+++ b/lib/tasks/data_updates.rake
@@ -5,7 +5,7 @@ namespace :data_updates do
       Rake::Task["data_updates:run"].execute
     else
       # Ensure new code has been deployed before we run our update scripts
-      DataUpdateWorker.perform_in(10.minutes)
+      DataUpdateWorker.perform_in(ENV["DATA_UPDATE_WORKER_DELAY"] || 0)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When a self hosted Forem updates its code it will then reboot. During this process the data update rake task is run to kick off any data update scripts. The problem with the current approach is that those scripts run on a delay. This delay was set to account for the time it takes Heroku to rolling restart dynos with new code. However, for self hosted and other Forems, this delay is unnecessary and really only stands to cause potential downtime. This change will allow us to set an ENV variable on Heroku and BenHalpern Community to ensure the DUS scripts are delayed while everyone else can get them run immediately. 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
Grab the line of code from the rake task and put it in a console. Watch the logs as it runs a job immediately if no variable is set.
Set the variable to the number of seconds you want the delay, restart your console and run the same line of code again. You should see the job in the [schedule tab of Sidekiq](http://localhost:3000/sidekiq/scheduled) delayed. 

## Added/updated tests?
- [x] No since this is a production only task. I tested it manually

## [Forem core team only] How will this change be communicated?
We should communicate this to Lee as well as on forem.dev for those hosting on Heroku. I set a Heroku friendly default but if possible we should get folks to use the ENV variable. In the future I think we can do a major version update to officially pull out the Heroku default. 

## Are there any ~post~ pre deployment tasks we need to perform?
Set `WORKERS_DATA_UPDATE_DELAY_SECONDS ` on all Heroku Forems

## [optional] What gif best describes this PR or how it makes you feel?

![delay SNL gif](https://media0.giphy.com/media/YTQbmi34RovJrGkHKS/giphy.gif)
