### PR TITLE
[Fix] NoMethodError caused because no mascot account exists in a development environment

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -153,6 +153,8 @@ seeder.create_if_doesnt_exist(User, "email", "admin@forem.local") do
   user.add_role(:tech_admin)
 end
 
+Users::CreateMascotAccount.call unless Settings::General.mascot_user_id
+
 ##############################################################################
 
 seeder.create_if_none(Tag) do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I encountered `NoMethodError` after created the user from the application. The detailed log is below.

```
14:03:44 sidekiq.1   | 2021-07-07T05:03:44.594Z pid=7738 tid=3366 class=Notifications::WelcomeNotificationWorker jid=284e62301d2db0968d084069 INFO: start
14:03:44 sidekiq.1   | 2021-07-07T05:03:44.611Z pid=7738 tid=3366 class=Notifications::WelcomeNotificationWorker jid=284e62301d2db0968d084069 elapsed=0.017 INFO: fail
14:03:44 sidekiq.1   | 2021-07-07T05:03:44.611Z pid=7738 tid=3366 WARN: {"context":"Job raised exception","job":{"retry":10,"queue":"low_priority","class":"Notifications::WelcomeNotificationWorker","args":[12,1],"jid":"284e62301d2db0968d084069","created_at":1625633981.08381,"enqueued_at":1625634224.5929441,"error_message":"undefined method `id' for nil:NilClass","error_class":"NoMethodError","failed_at":1625634158.301845,"retry_count":1,"retried_at":1625634200.758991},"jobstr":"{\"retry\":10,\"queue\":\"low_priority\",\"class\":\"Notifications::WelcomeNotificationWorker\",\"args\":[12,1],\"jid\":\"284e62301d2db0968d084069\",\"created_at\":1625633981.08381,\"enqueued_at\":1625634224.5929441,\"error_message\":\"undefined method `id' for nil:NilClass\",\"error_class\":\"NoMethodError\",\"failed_at\":1625634158.301845,\"retry_count\":1,\"retried_at\":1625634200.758991}"}
14:03:44 sidekiq.1   | 2021-07-07T05:03:44.611Z pid=7738 tid=3366 WARN: NoMethodError: undefined method `id' for nil:NilClass
14:03:44 sidekiq.1   | 2021-07-07T05:03:44.611Z pid=7738 tid=3366 WARN: /path/to/forem/app/services/notifications.rb:4:in `user_data'
14:03:44 sidekiq.1   | /path/to/forem/app/services/notifications/welcome_notification/send.rb:10:in `user_data'
14:03:44 sidekiq.1   | /path/to/forem/app/services/notifications/welcome_notification/send.rb:19:in `call'
14:03:44 sidekiq.1   | /path/to/forem/app/services/notifications/welcome_notification/send.rb:13:in `call'
14:03:44 sidekiq.1   | /path/to/forem/app/workers/notifications/welcome_notification_worker.rb:9:in `perform'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:196:in `execute_job'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:164:in `block (2 levels) in process'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/middleware/chain.rb:138:in `block in invoke'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/ddtrace-0.50.0/lib/ddtrace/contrib/sidekiq/server_tracer.rb:42:in `block in call'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/ddtrace-0.50.0/lib/ddtrace/tracer.rb:291:in `trace'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/ddtrace-0.50.0/lib/ddtrace/contrib/sidekiq/server_tracer.rb:23:in `call'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-unique-jobs-7.1.2/lib/sidekiq_unique_jobs/middleware.rb:36:in `call'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-unique-jobs-7.1.2/lib/sidekiq_unique_jobs/middleware.rb:36:in `call'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
14:03:44 sidekiq.1   | /path/to/forem/lib/sidekiq/honeycomb_middleware.rb:16:in `block in call'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/honeycomb-beeline-2.4.2/lib/honeycomb/client.rb:70:in `start_span'
14:03:44 sidekiq.1   | /Users/yoshida/.rbenv/versions/2.7.2/lib/ruby/2.7.0/forwardable.rb:235:in `start_span'
14:03:44 sidekiq.1   | /path/to/forem/lib/sidekiq/honeycomb_middleware.rb:8:in `call'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/honeybadger-4.9.0/lib/honeybadger/plugins/sidekiq.rb:10:in `call'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/middleware/chain.rb:140:in `block in invoke'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/middleware/chain.rb:143:in `invoke'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:163:in `block in process'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:136:in `block (6 levels) in dispatch'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/job_retry.rb:112:in `local'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:135:in `block (5 levels) in dispatch'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/rails.rb:14:in `block in call'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4/lib/active_support/execution_wrapper.rb:88:in `wrap'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4/lib/active_support/reloader.rb:72:in `block in wrap'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4/lib/active_support/execution_wrapper.rb:88:in `wrap'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4/lib/active_support/reloader.rb:71:in `wrap'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/rails.rb:13:in `call'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:131:in `block (4 levels) in dispatch'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:257:in `stats'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:126:in `block (3 levels) in dispatch'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/job_logger.rb:13:in `call'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:125:in `block (2 levels) in dispatch'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/job_retry.rb:79:in `global'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:124:in `block in dispatch'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/logger.rb:11:in `with'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/job_logger.rb:33:in `prepare'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:123:in `dispatch'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:162:in `process'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:78:in `process_one'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/processor.rb:68:in `run'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/util.rb:43:in `watchdog'
14:03:44 sidekiq.1   | /path/to/forem/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.2.1/lib/sidekiq/util.rb:52:in `block in safe_thread'

```

This is occurred by the following code of `Notifications::WelcomeNotification::Send` class because there is no `User.mascot_account`.(nil is passed to user_data method.)
https://github.com/forem/forem/blob/d3559e921b73594b149ecce90304b4f5542bce6a/app/services/notifications/welcome_notification/send.rb#L16-L19

The mascot user is created by `Users::CreateMascotAccount.call` when the first user is created. But in a development environment, a developer misses the chance for creating the first user from the application because some user is already created by seed.
https://github.com/forem/forem/blob/d3559e921b73594b149ecce90304b4f5542bce6a/app/controllers/registrations_controller.rb#L42-L50

To fix this, I added the line to create the mascot user in the seed file.

## Related Tickets & Documents
Nothing

## QA Instructions, Screenshots, Recordings

1. Run `rails db:reset`
2. Run `bin/startup`
3. Create a user from the Application.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Only the seed file is changed.
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![tenor](https://user-images.githubusercontent.com/26132902/124746641-13605e00-df5c-11eb-9624-f60740e8e417.gif)
