### PR TITLE
Fix bug in preview card controller

### DIFF
--- a/app/controllers/profile_preview_card_controller.rb
+++ b/app/controllers/profile_preview_card_controller.rb
@@ -2,7 +2,6 @@ class ProfilePreviewCardController < ApplicationController
   layout false
 
   def show
-    @actor = User.find_by(id: params[:user_id])
-    @preview_id = params[:preview_card_id]
+    @actor = User.find_by(id: params[:id])
   end
 end

--- a/app/javascript/packs/commentDropdowns.js
+++ b/app/javascript/packs/commentDropdowns.js
@@ -59,18 +59,20 @@ const initializeArticlePageDropdowns = () => {
  * @param {HTMLElement} placeholderElement The <span> placeholder element to be replaced by the preview dropdown
  */
 const fetchMissingProfilePreviewCard = async (placeholderElement) => {
-  const response = await window.fetch(
-    `/profile_preview_card/show?user_id=${placeholderElement.dataset.jsCommentUserId}&preview_card_id=${placeholderElement.dataset.jsDropdownContentId}`,
-  );
+  const {
+    jsCommentUserId: commentUserId,
+    jsDropdownContentId: dropdownContentId,
+  } = placeholderElement.dataset;
+  const response = await window.fetch(`/profile_preview_card/${commentUserId}`);
   const htmlContent = await response.text();
 
   const generatedElement = document.createElement('div');
   generatedElement.innerHTML = htmlContent;
 
-  placeholderElement.parentNode.replaceChild(
-    generatedElement.firstElementChild,
-    placeholderElement,
-  );
+  const { firstElementChild: previewCard } = generatedElement;
+  previewCard.id = dropdownContentId;
+
+  placeholderElement.parentNode.replaceChild(previewCard, placeholderElement);
 
   // Make sure the button inside the dropdown is initialized
   initializeAllFollowButts();

--- a/app/views/profile_preview_card/show.html.erb
+++ b/app/views/profile_preview_card/show.html.erb
@@ -1,1 +1,1 @@
-<%= render "shared/profile_preview_card", actor: @actor, id: @preview_id %>
+<%= render "shared/profile_preview_card", actor: @actor, id: nil %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The preview card controller introduced in https://github.com/forem/forem/pull/14056 appeared to work locally but was always erroring in production. The impact of this may have been minimal on users, as the controller is currently only used to generate the preview card after a user adds a new comment to a discussion (and they are unlikely to want to view their own preview card).

The errors were due to reliance on query parameters which were stripped out by Fastly. In this PR I've removed the use of those query params, relying instead on the userId in the path, and the preview card ID being added client-side once the card has been generated (we did feel before that passing the preview card ID in a query param was a bit funky, and it feels cleaner this way). 

## Related Tickets & Documents

Relates to preview card work completed in https://github.com/forem/forem/pull/14056

## QA Instructions, Screenshots, Recordings

Locally we can test this by:

- Viewing an article
- Adding a comment
- Checking that your newly added comment has a profile preview card that appears when you hover or click on your name


https://user-images.githubusercontent.com/20773163/124897116-e6509180-dfd5-11eb-8d03-824acc95246a.mp4



### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: The existing tests continue to validate this feature
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: This bug is pretty low visibility and users haven't reported it yet

## [optional] Are there any post deployment tasks we need to perform?

We should check this is now working as expected once live on DEV, although I don't anticipate any issues since we no longer rely on query params

## [optional] What gif best describes this PR or how it makes you feel?

![You learn something new every day](https://i.giphy.com/media/1kenyYNFG9wTUyHMjk/giphy.webp)
