### PR TITLE
Only update GithubRepos once in RepoSyncWorker

### DIFF
--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -27,8 +27,10 @@ module GithubRepos
           watchers_count: fetched_repo.watchers,
           stargazers_count: fetched_repo.stargazers_count,
           info_hash: fetched_repo.to_hash,
+          # Touch `updated_at` even if nothing here was updated. See PR #12853
+          # for more details.
+          updated_at: Time.current,
         )
-        repo.touch(:updated_at)
         if repo.user&.github_repos_updated_at&.before?(TOUCH_USER_COOLDOWN.ago)
           repo.user.touch(:github_repos_updated_at)
         end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Touching the GithubRepo invokes GithubRepo#clear_caches, so calling `update` and then `touch` [calls `clear_caches` *twice*](https://github.com/forem/forem/blob/fb6e2e231153b2489f7a416efe7e74f9be64b63e/app/models/github_repo.rb#L13). This pulls it back to calling it once.

## Related Tickets & Documents

- #12853

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: We _could_ test it, but I'm not sure how useful it'd be as a regression test
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: Simple optimization

## [optional] Are there any post deployment tasks we need to perform?

Check to see that latency of `GithubRepos::RepoSyncWorker` goes down on DEV.