### PR TITLE
Add follow-user class to follow user buttons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,6 +122,8 @@ module ApplicationHelper
   def follow_button(followable, style = "full", classes = "")
     return if followable == DELETED_USER
 
+    user_follow = followable.instance_of?(User) ? "follow-user" : ""
+
     tag.button(
       "Follow",
       name: :button,
@@ -133,7 +135,7 @@ module ApplicationHelper
           style: style
         }
       },
-      class: "crayons-btn follow-action-button whitespace-nowrap #{classes}",
+      class: "crayons-btn follow-action-button whitespace-nowrap #{classes} #{user_follow}",
     )
   end
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -54,7 +54,7 @@
                 <button class="chat-action-button crayons-btn crayons-btn--outlined hidden" id="modal-opener">Chat</button>
               </a>
             <% end %>
-            <button id="user-follow-butt" class="crayons-btn whitespace-nowrap follow-action-button user-profile-follow-button" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>"}'>Follow</button>
+            <button id="user-follow-butt" class="crayons-btn whitespace-nowrap follow-action-button user-profile-follow-button follow-user" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>"}'>Follow</button>
           </div>
         </div>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
@nickytonline noticed recently that our post pages were making a lot of individual requests to our `follows/ID` endpoint. Knowing that we had previously optimized that request to use `follows/bulk_show` I went investigating. It turns out some of our new follow buttons for users were missing the `follow-user` class which is what ensures they are included in this bulk lookup. Without that class we try to gather their follow information individually. This PR adds that class to a couple of places it was missing. 

## QA Instructions, Screenshots, Recordings
Load some pages and ensure follow buttons behave accordingly.

### UI accessibility concerns?
N/A

## Added/updated tests?

- [x] No, this was simply a implementation change and not a behavior change.

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media0.giphy.com/media/xUPGcx1uyYdLB9SJs4/giphy.gif)
