### PR TITLE
Add SocketError to GetMediaUrl's exception rescue

### DIFF
--- a/app/services/podcasts/feed.rb
+++ b/app/services/podcasts/feed.rb
@@ -9,7 +9,7 @@ module Podcasts
 
     def get_episodes(limit: 100, force_update: false)
       # increased the redirect limit from 5 (default) to 7 to be able to handle such urls
-      rss = HTTParty.get("https://www.codeprep.io/podcast/feed/podcast/", limit: 7).body.to_s
+      rss = HTTParty.get(podcast.feed_url, limit: 7).body.to_s
       feed = RSS::Parser.parse(rss, false)
 
       set_unreachable(status: :unparsable, force_update: force_update) && return unless feed

--- a/app/services/podcasts/feed.rb
+++ b/app/services/podcasts/feed.rb
@@ -9,7 +9,7 @@ module Podcasts
 
     def get_episodes(limit: 100, force_update: false)
       # increased the redirect limit from 5 (default) to 7 to be able to handle such urls
-      rss = HTTParty.get(podcast.feed_url, limit: 7).body
+      rss = HTTParty.get("https://www.codeprep.io/podcast/feed/podcast/", limit: 7).body.to_s
       feed = RSS::Parser.parse(rss, false)
 
       set_unreachable(status: :unparsable, force_update: force_update) && return unless feed

--- a/app/services/podcasts/get_media_url.rb
+++ b/app/services/podcasts/get_media_url.rb
@@ -1,5 +1,13 @@
 module Podcasts
   class GetMediaUrl
+    HANDLED_ERRORS = [
+      Addressable::URI::InvalidURIError,
+      Net::OpenTimeout,
+      SocketError,
+      SystemCallError,
+      URI::InvalidURIError,
+    ].freeze
+
     def initialize(enclosure_url)
       @enclosure_url = enclosure_url.to_s
     end
@@ -35,7 +43,7 @@ module Podcasts
     def url_reachable?(url)
       url = Addressable::URI.parse(url).normalize.to_s
       HTTParty.head(url).code == 200
-    rescue Net::OpenTimeout, SystemCallError, URI::InvalidURIError, Addressable::URI::InvalidURIError, SocketError
+    rescue *HANDLED_ERRORS
       false
     end
   end

--- a/app/services/podcasts/get_media_url.rb
+++ b/app/services/podcasts/get_media_url.rb
@@ -35,7 +35,7 @@ module Podcasts
     def url_reachable?(url)
       url = Addressable::URI.parse(url).normalize.to_s
       HTTParty.head(url).code == 200
-    rescue Net::OpenTimeout, SystemCallError, URI::InvalidURIError, Addressable::URI::InvalidURIError
+    rescue Net::OpenTimeout, SystemCallError, URI::InvalidURIError, Addressable::URI::InvalidURIError, SocketError
       false
     end
   end

--- a/spec/services/podcasts/get_media_url_spec.rb
+++ b/spec/services/podcasts/get_media_url_spec.rb
@@ -83,4 +83,13 @@ RSpec.describe Podcasts::GetMediaUrl, type: :service do
     expect(result.reachable).to be false
     expect(result.url).to eq(http_url)
   end
+
+  it "marks socket errors as invalid url exception" do
+    allow(HTTParty).to receive(:head).with(https_url).and_raise(SocketError)
+    allow(HTTParty).to receive(:head).with(http_url).and_raise(SocketError)
+    result = described_class.call(http_url)
+    expect(result.https).to be false
+    expect(result.reachable).to be false
+    expect(result.url).to eq(http_url)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Bug

## Description
I've noticed this error on a certain podcast and it's being retried countless time, wasting precious computation resources.
> SocketError: Failed to open TCP connection to [redacted]:443 (getaddrinfo: Name or service not known)

This adds that error to our ignore list.

## Related Tickets & Documents
https://app.honeybadger.io/fault/66984/605b63f08603e2ba1d9476db3b5a54c8
## QA Instructions, Screenshots, Recordings
The specs should be enough
## Added tests?
- yes

## Added to documentation?
- n/a

## [optional] Are there any post deployment tasks we need to perform?
n/a