### PR TITLE
Filter by user IDs when sending comment notifications

### DIFF
--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -36,7 +36,7 @@ module Notifications
 
         # Send PNs using Rpush - respecting users' notificaton delivery settings
         targets = User.joins(:notification_setting)
-          .where(notification_setting: { mobile_comment_notifications: true }).ids
+          .where(id: user_ids, notification_setting: { mobile_comment_notifications: true }).ids
 
         PushNotifications::Send.call(
           user_ids: targets,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
The user_ids scope got accidentally removed in the final [UserSettings PR](https://github.com/forem/forem/pull/14121). This puts it back. I will followup with a test for this. 

