### PR TITLE
Add spec to ensure we filter by proper user IDs for mobile push notifications

### DIFF
--- a/spec/services/notifications/new_comment/send_spec.rb
+++ b/spec/services/notifications/new_comment/send_spec.rb
@@ -97,4 +97,16 @@ RSpec.describe Notifications::NewComment::Send, type: :service do
     expect(Notification.where(notifiable_type: "Comment", notifiable_id: child_comment.id,
                               organization_id: organization.id)).to be_any
   end
+
+  it "properly filters users for sending mobile push notifications" do
+    user.notification_setting.update(mobile_comment_notifications: true)
+    user2.notification_setting.update(mobile_comment_notifications: true)
+    user3.notification_setting.update(mobile_comment_notifications: true)
+    allow(PushNotifications::Send).to receive(:call)
+
+    described_class.call(comment)
+    expect(PushNotifications::Send).to have_received(:call).with hash_including(
+      user_ids: [author_comment.user_id],
+    )
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Add Spec

## Description
We had to push out a hotfix for sending users push notifications for comments https://github.com/forem/forem/pull/14186 This is the followup spec that will ensure it does not happen again. I confirmed the spec fails with the old code but passes with the new code :) 


![alt_text](https://thumbs.gfycat.com/CreepyWetGopher-size_restricted.gif)
