### PR TITLE
Added aria-pressed values to post reaction buttons

### DIFF
--- a/app/assets/javascripts/initializers/initializeArticleReactions.js
+++ b/app/assets/javascripts/initializers/initializeArticleReactions.js
@@ -37,6 +37,7 @@ function showUserReaction(reactionName, animatedClass) {
     'aria-label',
     getReactionAriaLabel(reactionName, true),
   );
+  reactionButton.setAttribute('aria-pressed', 'true');
 }
 
 function hideUserReaction(reactionName) {
@@ -48,6 +49,7 @@ function hideUserReaction(reactionName) {
     'aria-label',
     getReactionAriaLabel(reactionName, false),
   );
+  reactionButton.setAttribute('aria-pressed', 'false');
 }
 
 function hasUserReacted(reactionName) {

--- a/app/views/articles/_reaction_button.html.erb
+++ b/app/views/articles/_reaction_button.html.erb
@@ -1,6 +1,7 @@
 <button
   id="reaction-butt-<%= category %>"
   aria-label="<%= aria_label %>"
+  aria-pressed="false"
   class="crayons-reaction crayons-reaction--<%= category %>"
   data-category="<%= category %>"
   title="<%= description %>">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- Added aria-pressed attribute to reaction buttons
## Related Tickets & Documents
#14182 

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [x] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/Od0QRnzwRBYmDU3eEO/giphy.gif)
