### PR TITLE
Enforce Uniqueness for Feed Import and Push Notification Cleanup Workers

### DIFF
--- a/app/workers/feeds/import_articles_worker.rb
+++ b/app/workers/feeds/import_articles_worker.rb
@@ -2,7 +2,7 @@ module Feeds
   class ImportArticlesWorker
     include Sidekiq::Worker
 
-    sidekiq_options queue: :medium_priority, retry: 10
+    sidekiq_options queue: :medium_priority, retry: 10, lock: :until_and_while_executing
 
     # NOTE: [@rhymes] we need to default earlier_than to `nil` because sidekiq-cron,
     # by using YAML to define jobs arguments does not support datetimes evaluated

--- a/app/workers/push_notifications/cleanup_worker.rb
+++ b/app/workers/push_notifications/cleanup_worker.rb
@@ -2,7 +2,7 @@ module PushNotifications
   class CleanupWorker
     include Sidekiq::Worker
 
-    sidekiq_options queue: :low_priority, retry: 10
+    sidekiq_options queue: :low_priority, retry: 10, lock: :until_and_while_executing
 
     def perform
       redis = Redis.new(url: ENV["REDIS_RPUSH_URL"] || ENV["REDIS_URL"])


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
During the incident the other day I noticed that we were enqueueing multiple of these long running jobs unnecessarily. This change ensures that we are not enqueueing and/or executing multiple of these jobs at once. This will prevent duplicate work from being done at the same time. 

## QA Instructions, Screenshots, Recordings
Ensure you can not enqueue multiple jobs for these two workers when they are already enqueued or while they are executing,

## Added/updated tests?
- [x] No, bc we are using functionality provided by a gem that is already being tested by that gem

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated since its a minor optimization.

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.tenor.com/images/365ca21ea3aef10038f62ae9244d5181/tenor.gif)
