### PR TITLE
Fix data update script for work field migration

### DIFF
--- a/app/workers/migrate_data_to_work_field_worker.rb
+++ b/app/workers/migrate_data_to_work_field_worker.rb
@@ -8,7 +8,7 @@ class MigrateDataToWorkFieldWorker
     profile = Profile.find_by(id: profile_id)
     return unless profile
 
-    work_info = profile.employment_title
+    work_info = profile.employment_title.dup
     work_info << " at #{profile.employer_name}" if profile.employer_name.present?
 
     # NOTE: This worker is only concerned with updating "work", an unvalidated

--- a/app/workers/migrate_data_to_work_field_worker.rb
+++ b/app/workers/migrate_data_to_work_field_worker.rb
@@ -8,8 +8,8 @@ class MigrateDataToWorkFieldWorker
     profile = Profile.find_by(id: profile_id)
     return unless profile
 
-    work_info = profile.employment_title.dup
-    work_info << " at #{profile.employer_name}" if profile.employer_name.present?
+    work_info = profile.employment_title
+    work_info += " at #{profile.employer_name}" if profile.employer_name.present?
 
     # NOTE: This worker is only concerned with updating "work", an unvalidated
     # key in the JSONB data object. We don't want this to fail, even if e.g.

--- a/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
+++ b/spec/lib/data_update_scripts/migrate_data_to_work_field_spec.rb
@@ -34,4 +34,10 @@ describe DataUpdateScripts::MigrateDataToWorkField, sidekiq: :inline do
     expect { described_class.new.run }
       .to change { profile.reload.work }.from(nil).to("Tester")
   end
+
+  # Regression spec for https://github.com/forem/forem/issues/14188
+  it "does not accidentally update employment_title" do
+    profile.update!(employment_title: "Tester", employer_name: "ACME Inc.")
+    expect { described_class.new.run }.not_to change { profile.reload.employment_title }
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix
 
## Description

The original DUS for this (added in https://github.com/forem/forem/pull/14106) unfortunately contains a bug:

```ruby
profile = Profile.find_by(id: profile_id)
return unless profile

work_info = profile.employment_title
work_info << " at #{profile.employer_name}" if profile.employer_name.present?
profile.data[:work] = work_info
profile.save(validate: false)
```

While this sets the `work `attribute correctly, it ALSO updates `employment_title` because `work_info` is actually a reference to the same object, a fact we didn't catch during PR review. Here's a `rails console` session illustrating the problem:

```ruby
profile = Profile.last
work_info =  profile.employment_title
work_info.object_id == profile.employment_title.object_id
#=> true
```

So the shovel operator (`<<`) ends up modifying the original employment title which we then persist when calling save on profile

## Related Tickets & Documents

https://github.com/forem/forem/issues/14188

## QA Instructions, Screenshots, Recordings

The specs should pass

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes, added a regression test. Red before adding the `.dup` call, green after.

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
