### PR TITLE
Keep aria-label values static for post reaction buttons

### DIFF
--- a/app/assets/javascripts/initializers/initializeArticleReactions.js
+++ b/app/assets/javascripts/initializers/initializeArticleReactions.js
@@ -17,26 +17,11 @@ function setReactionCount(reactionName, newCount) {
   }
 }
 
-function getReactionAriaLabel(reactionName, reacted) {
-  switch (reactionName) {
-    case 'readinglist':
-      return reacted ? 'Remove from reading list' : 'Add to reading list';
-    case 'unicorn':
-      return reacted ? 'Remove unicorn reaction' : 'React with unicorn';
-    case 'like':
-      return reacted ? 'Unlike' : 'Like';
-  }
-}
-
 function showUserReaction(reactionName, animatedClass) {
   const reactionButton = document.getElementById(
     'reaction-butt-' + reactionName,
   );
   reactionButton.classList.add('user-activated', animatedClass);
-  reactionButton.setAttribute(
-    'aria-label',
-    getReactionAriaLabel(reactionName, true),
-  );
   reactionButton.setAttribute('aria-pressed', 'true');
 }
 
@@ -45,10 +30,6 @@ function hideUserReaction(reactionName) {
     'reaction-butt-' + reactionName,
   );
   reactionButton.classList.remove('user-activated', 'user-animated');
-  reactionButton.setAttribute(
-    'aria-label',
-    getReactionAriaLabel(reactionName, false),
-  );
   reactionButton.setAttribute('aria-pressed', 'false');
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
 When the state of the post reaction button changes we change the button label e.g. from "Like" to "Unlike". This is OK, but a screen reader user won't know that the button name has changed unless they Tab away from it, and then Tab back to it.

This PR removes all setAttribute methods for aria-label and keeps aria-label static for all post reaction buttons.

## Related Tickets & Documents
#14182 

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Not sure if tests needed.
- [ ] I need help with writing tests


## [Forem core team only] How will this change be communicated?
Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it.



- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: Very small change

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/eIUpSyzwGp0YhAMTKr/giphy.gif)
