### PR TITLE
add cypress-failed-log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ app/javascript/generated_stories/
 # Cypress test run artifacts
 cypress/videos
 cypress/screenshots
+cypress/logs
 
 # PostCSS error log
 postcss_error.log

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -25,5 +25,9 @@ module.exports = (on, config) => {
     ...process.env,
   };
 
+  on('task', {
+    failed: require('cypress-failed-log/src/failed')(),
+  });
+
   return config;
 };

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -16,6 +16,7 @@
 // For Testing Library APIs https://github.com/testing-library/cypress-testing-library
 import '@testing-library/cypress/add-commands';
 import 'cypress-file-upload';
+import 'cypress-failed-log';
 
 // Import commands.js using ES2015 syntax:
 import './commands';

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "css-loader": "^5.2.6",
     "cssom": "^0.4.4",
     "cypress": "^7.4.0",
+    "cypress-failed-log": "^2.9.2",
     "cypress-file-upload": "^5.0.8",
     "eslint": "^7.30.0",
     "eslint-config-preact": "^1.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6297,7 +6297,7 @@ ccount@^1.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.1.0.tgz#246687debb6014735131be8abab2d93898f8d043"
   integrity sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==
 
-chalk@2.4.2, chalk@^2.0, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -7422,6 +7422,14 @@ cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+
+cypress-failed-log@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/cypress-failed-log/-/cypress-failed-log-2.9.2.tgz#136727f1a9317a44981abb144d5775963c4d384c"
+  integrity sha512-Gu06nXsQBxDv3bTRQG05753Z9/DHiOSVW4IUouoOSZVL8DfBdxRkbCgKJjfkZZJRRcewn6K7GOYp2qQD+AHCuw==
+  dependencies:
+    debug "4.3.2"
+    logdown "3.3.1"
 
 cypress-file-upload@^5.0.8:
   version "5.0.8"
@@ -12278,6 +12286,13 @@ log-update@^4.0.0:
     cli-cursor "^3.1.0"
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
+
+logdown@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/logdown/-/logdown-3.3.1.tgz#836d5a195b5949c6db631ccc9fecce0492e01d10"
+  integrity sha512-pjX0vlIJsYQlgVzFba2amXI1wZZnhrEorL68MdLI7B0/sN1TNUozBNFaHfcPHMM3A+INZ0OXFDxtnoaEgOmGjQ==
+  dependencies:
+    chalk "^2.3.0"
 
 loglevel@^1.6.8:
   version "1.7.1"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [X] Developer experience

## Description

Sometimes the error messages we get in CI for Cypress are a little opaque, especially when the screenshots aren't readily accessible. This dev dependency outputs the complete test steps and `cy.log()`s for failed tests.

I think this will be helpful in debugging exactly where Cypress tests fail.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

You can test this out locally by
- changing `cypress:open` to `cypress:run` in `bin/e2e`
- changing a test to make it deliberately fail

When the test fails, you should see the steps it took prior to the failure output in your terminal. For example:

```
 2) "before each" hook for "should show the discussion lock reason on an article"
clearCookies 
getCookies 
request 
get @user
request 
log Login failed. Attempting one more login.
wait 500
request 
saved as log in: cypress/logs/failed-lock-discussion-lock-discussion-when-an-article-has-its-discussion-locked-should-show-the-discussion-lock-reason-on-an-article.json
```

### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: not required
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

