### PR TITLE
Quickfix for duplicate work display

### DIFF
--- a/app/views/users/_metadata.html.erb
+++ b/app/views/users/_metadata.html.erb
@@ -2,6 +2,7 @@
   <div class="profile-header__bottom fs-base">
     <% header_fields.each do |title, value| %>
       <% next if Profile.special_attributes.include?(title) %>
+      <% next if title == "work" %>
       <div class="crayons-definition">
         <strong class="crayons-definition__title">
           <%= sanitized_sidebar title.titleize %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Since the [proper fix](https://github.com/forem/forem/pull/14210) is taking a bit longer than anticipated, this PR introduces a quick fix for the duplicated display of work information:

![updated profile edit form](https://user-images.githubusercontent.com/47985/125418654-5101b473-a3ec-4f5d-a94f-6eee5db97151.png)

## Related Tickets & Documents

https://github.com/forem/forem/issues/14188

## QA Instructions, Screenshots, Recordings

1. Update a user to replicate the current state of our production DB, e.g. 
    ```ruby
    user.profile.update(
      work: "Dev at Forem",
      employer_name: "Forem",
      employer_url: "https://forem.com",
      employment_title: "Dev"
    )
    ```
2. Go to `localhost:3000/:username` you should only see the "old" work info with the employer name being a link:

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] No, and this is why: this is supposed to be the quickest possible fix until the proper one gets merged, I only tested manually.

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: it's just a quick fix to take some pressure off the proper fix.