### PR TITLE
Remove `color_field` input type from profiles

### DIFF
--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -5,8 +5,7 @@ class ProfileField < ApplicationRecord
   enum input_type: {
     text_field: 0,
     text_area: 1,
-    check_box: 2,
-    color_field: 3
+    check_box: 2
   }
 
   enum display_area: {

--- a/app/validators/profile_validator.rb
+++ b/app/validators/profile_validator.rb
@@ -42,10 +42,6 @@ class ProfileValidator < ActiveModel::Validator
     true # checkboxes are always valid
   end
 
-  def color_field_valid?(_record, _attribute)
-    true # we do not currently validate color fields here
-  end
-
   def text_area_valid?(record, attribute)
     text = record.public_send(attribute)
     text.nil? || text.size <= MAX_TEXT_AREA_LENGTH

--- a/app/validators/profile_validator.rb
+++ b/app/validators/profile_validator.rb
@@ -20,10 +20,7 @@ class ProfileValidator < ActiveModel::Validator
       attribute = field.attribute_name
       next if attribute == SUMMARY_ATTRIBUTE # validated above
       next unless record.respond_to?(attribute) # avoid caching issues
-
-      validation_method = "#{field.input_type}_valid?"
-      next unless record.respond_to?(validation_method)
-      next if __send__(validation_method, record, attribute)
+      next if __send__("#{field.input_type}_valid?", record, attribute)
 
       record.errors.add(attribute, ERRORS[field.input_type])
     end
@@ -43,6 +40,10 @@ class ProfileValidator < ActiveModel::Validator
 
   def check_box_valid?(_record, _attribute)
     true # checkboxes are always valid
+  end
+
+  def color_field_valid?(_record, _attribute)
+    true # we do not currently validate color fields here
   end
 
   def text_area_valid?(record, attribute)

--- a/app/validators/profile_validator.rb
+++ b/app/validators/profile_validator.rb
@@ -20,7 +20,10 @@ class ProfileValidator < ActiveModel::Validator
       attribute = field.attribute_name
       next if attribute == SUMMARY_ATTRIBUTE # validated above
       next unless record.respond_to?(attribute) # avoid caching issues
-      next if __send__("#{field.input_type}_valid?", record, attribute)
+
+      validation_method = "#{field.input_type}_valid?"
+      next unless record.respond_to?(validation_method)
+      next if __send__(validation_method, record, attribute)
 
       record.errors.add(attribute, ERRORS[field.input_type])
     end
@@ -40,10 +43,6 @@ class ProfileValidator < ActiveModel::Validator
 
   def check_box_valid?(_record, _attribute)
     true # checkboxes are always valid
-  end
-
-  def color_field_valid?(_record, _attribute)
-    true # we do not currently validate color fields here
   end
 
   def text_area_valid?(record, attribute)

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -107,20 +107,6 @@
             <label class="crayons-field__label" for="<%= "profile[#{field.attribute_name}]" %>">
               <%= field.label %>
             </label>
-          <% elsif field["input_type"] == "color_field" %>
-            <label class="crayons-field__label" for="<%= "profile[#{field.attribute_name}]" %>">
-              <%= field.label %>
-            </label>
-            <div class="flex items-center w-100 m:w-50">
-              <%= f.public_send("text_field", "profile[#{field.attribute_name}]",
-                                value: profile.public_send(field.attribute_name),
-                                placeholder: field["placeholder_text"],
-                                class: "crayons-textfield js-color-field") %>
-              <%= f.public_send(field["input_type"],
-                                "profile[#{field.attribute_name}]",
-                                value: profile.public_send(field.attribute_name),
-                                class: "crayons-color-selector js-color-field ml-2") %>
-            </div>
           <% else %>
             <label class="crayons-field__label" for="<%= "profile[#{field.attribute_name}]" %>">
               <%= field.label %>

--- a/spec/fixtures/files/profile_fields.csv
+++ b/spec/fixtures/files/profile_fields.csv
@@ -1,4 +1,4 @@
+Full test,text_field,Test,Test field,Basic,header,true
 Test name,text_field,John Doe,,Basic,header,false
-Test languages,text_area,,Programming languages,Coding,left_sidebar,false
 
-Test color,color_field,#000000,"Used for backgrounds, borders etc.",Branding,settings_only,false
+Test languages,text_area,,"Programming languages, frameworks, etc.",Coding,left_sidebar,false

--- a/spec/services/profile_fields/import_from_csv_spec.rb
+++ b/spec/services/profile_fields/import_from_csv_spec.rb
@@ -10,31 +10,29 @@ RSpec.describe ProfileFields::ImportFromCsv do
   context "when missing attributes" do
     before { described_class.call(file_fixture("profile_fields.csv")) }
 
-    it "handles missing descriptions", :aggregate_failures do
-      field = ProfileField.find_by!(label: "Test name")
+    it "imports fields" do
+      field = ProfileField.find_by!(label: "Full test")
       expect(field.input_type).to eq "text_field"
-      expect(field.placeholder_text).to eq "John Doe"
-      expect(field.description).to be_nil
+      expect(field.placeholder_text).to eq "Test"
+      expect(field.description).to eq "Test field"
       expect(field.profile_field_group.name).to eq "Basic"
       expect(field.display_area).to eq "header"
+      expect(field.show_in_onboarding).to be true
     end
 
-    it "handles missing placeholder_texts", :aggregate_failures do
+    it "handles missing descriptions" do
+      field = ProfileField.find_by!(label: "Test name")
+      expect(field.description).to be_nil
+    end
+
+    it "handles missing placeholder_texts" do
       field = ProfileField.find_by!(label: "Test languages")
-      expect(field.input_type).to eq "text_area"
       expect(field.placeholder_text).to be_nil
-      expect(field.description).to eq "Programming languages"
-      expect(field.profile_field_group.name).to eq "Coding"
-      expect(field.display_area).to eq "left_sidebar"
     end
 
-    it "handles commas in correctly quoted fields", :aggregate_failures do
-      field = ProfileField.find_by!(label: "Test color")
-      expect(field.input_type).to eq "color_field"
-      expect(field.placeholder_text).to eq "#000000"
-      expect(field.description).to eq "Used for backgrounds, borders etc."
-      expect(field.profile_field_group.name).to eq "Branding"
-      expect(field.display_area).to eq "settings_only"
+    it "handles commas in correctly quoted fields" do
+      field = ProfileField.find_by!(label: "Test languages")
+      expect(field.description).to eq "Programming languages, frameworks, etc."
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Clean up

## Description

Not that we have `Users::Setting` we no longer need color inputs for profiles. After talking to @benhalpern we decided to remove them.

## Related Tickets & Documents

https://github.com/forem/forem/pull/14206

## QA Instructions, Screenshots, Recordings

Nothing specific, color fields will get removed in the other PR.

### UI accessibility concerns?

n/a

## Added/updated tests?

- [X] Yes
 
## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: this is pretty much an implementation detail at this point since customizable profiles have not been enabled for other Forems yet.