### PR TITLE
Fix shorten_urls to not strip out text formatting in comments

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,6 +12,8 @@ class Comment < ApplicationRecord
   TITLE_DELETED = "[deleted]".freeze
   TITLE_HIDDEN = "[hidden by post author]".freeze
 
+  URI_REGEXP = %r{(?<scheme>https?://)?(?<host>.+?)(?<port>:\d+)?$}.freeze
+
   # The date that we began limiting the number of user mentions in a comment.
   MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 3, 12).freeze
 
@@ -202,9 +204,12 @@ class Comment < ApplicationRecord
   def shorten_urls!
     doc = Nokogiri::HTML.fragment(processed_html)
     doc.css("a").each do |anchor|
-      unless anchor.to_s.include?("<img") || anchor.to_s.include?("<del") || anchor.attr("class")&.include?("ltag")
-        anchor.content = strip_url(anchor.content) unless anchor.to_s.include?("<img") # rubocop:disable Style/SoleNestedConditional
+      anchor_inner_html = anchor.inner_html
+      urls = anchor_inner_html.scan(URI_REGEXP).flatten.compact
+      urls.each do |url|
+        anchor_inner_html.sub!(/#{Regexp.escape(url)}/, strip_url(url))
       end
+      anchor.inner_html = anchor_inner_html
     end
     self.processed_html = doc.to_html.html_safe # rubocop:disable Rails/OutputSafety
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1647,4 +1647,3 @@ NEW.reading_list_document :=
   end
 
 end
-

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1647,3 +1647,4 @@ NEW.reading_list_document :=
   end
 
 end
+

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -184,11 +184,20 @@ RSpec.describe Comment, type: :model do
         expect(comment.processed_html.include?("Hello <a")).to be(true)
       end
 
-      it "shortens long urls" do
-        comment.body_markdown = "Hello https://longurl.com/#{'x' * 100}?#{'y' * 100}"
+      it "shortens long urls does not strips out only urls" do
+        long_url = "https://longurl.com/#{'x' * 100}?#{'y' * 100}"
+        comment.body_markdown = "Hello #{long_url}"
         comment.validate!
-        expect(comment.processed_html.include?("...</a>")).to be(true)
+        expect(comment.processed_html.include?("...")).to be(true)
         expect(comment.processed_html.size < 450).to be(true)
+
+        comment.body_markdown = "Hello [**#{long_url}**](#{long_url})"
+        comment.validate!
+        expect(comment.processed_html.include?("...</strong>")).to be(true)
+
+        comment.body_markdown = "Hello ![Alt-text](#{long_url})"
+        comment.validate!
+        expect(comment.processed_html.include?("<img")).to be(true)
       end
 
       # rubocop:disable RSpec/ExampleLength

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe Comment, type: :model do
         expect(comment.processed_html.include?("Hello <a")).to be(true)
       end
 
-      it "shortens long urls does not strips out only urls" do
+      it "shortens long urls without removing formatting", :aggregate_failures do
         long_url = "https://longurl.com/#{'x' * 100}?#{'y' * 100}"
         comment.body_markdown = "Hello #{long_url}"
         comment.validate!


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
As discussed in  #14114, text formatting (bold, italics etc) does not render within custom link text in comments. This issue stems from the fact that `shorten_urls!` method in `app/models/comment.rb`, shortens not only URLs but also custom text inside anchor text. This PR fixes the method, so that it detects URLs in text and strips only those out. 
 
## Related Tickets & Documents
- Resolves #14114 

## QA Instructions, Screenshots, Recordings
Text formatting gets rendered correctly -
![image](https://user-images.githubusercontent.com/59063821/125741469-87de9cfb-e5ea-455e-a295-48592f5d9fe7.png)

## Added/updated tests?

- [x] Yes