### PR TITLE
Don't try to subscribe users without emails

### DIFF
--- a/app/workers/users/subscribe_to_mailchimp_newsletter_worker.rb
+++ b/app/workers/users/subscribe_to_mailchimp_newsletter_worker.rb
@@ -6,7 +6,7 @@ module Users
     def perform(user_id)
       user = User.find_by(id: user_id)
 
-      Mailchimp::Bot.new(user).upsert if user
+      Mailchimp::Bot.new(user).upsert if user&.email
     end
   end
 end

--- a/spec/workers/users/subscribe_to_mailchimp_newsletter_worker_spec.rb
+++ b/spec/workers/users/subscribe_to_mailchimp_newsletter_worker_spec.rb
@@ -16,5 +16,16 @@ RSpec.describe Users::SubscribeToMailchimpNewsletterWorker, type: :worker do
 
       expect(mailchimp_bot).to have_received(:upsert)
     end
+
+    it "does not subscribe the user if they don't have an email" do
+      mailchimp_bot = double
+      allow(Mailchimp::Bot).to receive(:new).and_return(mailchimp_bot)
+      allow(mailchimp_bot).to receive(:upsert)
+      user.update! email: nil
+
+      worker.perform(user.id)
+
+      expect(mailchimp_bot).not_to have_received(:upsert)
+    end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `Users::SubscribeToMailchimpNewsletterWorker` is failing anywhere from 20-70% of the time (depending on the time window). Turns out we have over 13k users without email addresses on DEV, and we have no guarantees either in the code or in DB constraints that the user record has the `email` attribute populated, so the assumption in this worker that "if the user exists, the email address exists" is misguided.

## Related Tickets & Documents

- https://app.honeybadger.io/projects/66984/faults/80341044
- [`Users::SubscribeToMailchimpNewsLetterWorker` on Datadog](https://app.datadoghq.com/apm/resource/sidekiq/sidekiq.job/4b7a336009623067?query=env%3Aproduction%20service%3Asidekiq%20operation_name%3Asidekiq.job%20resource_name%3A%22Users%3A%3ASubscribeToMailchimpNewsletterWorker%22&env=production&index=apm-search&spanID=958820710178025149&wend=1626355961809&wstart=1626183161809&start=1625752725793&end=1626357525793&paused=true)

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: I've already bugged people about it