### PR TITLE
Escape organization name in LinkTag's spec

### DIFF
--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe LinkTag, type: :liquid_tag do
         <a href='#{article.path}' class='ltag__link__link'>
           <div class='ltag__link__content'>
             <h2>#{CGI.escapeHTML(article.title)}</h2>
-            <h3>#{CGI.escapeHTML(article.user.name)} for #{article.organization.name} ・ #{article.readable_publish_date} ・ #{article.reading_time} min read</h3>
+            <h3>#{CGI.escapeHTML(article.user.name)} for #{CGI.escapeHTML(article.organization.name)} ・ #{article.readable_publish_date} ・ #{article.reading_time} min read</h3>
             <div class='ltag__link__taglist'>
               #{tags}
             </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- Flaky spec

## Description
Just fixing some flaky spec

## Related Tickets & Documents
Resolves https://github.com/forem/forem/issues/14245
## QA Instructions, Screenshots, Recordings
n/a

## Added tests?
- [x] no, because this is a flaky spec fix

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a