### PR TITLE
Revert "Fix shorten_urls to not strip out text formatting in comments…

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,8 +12,6 @@ class Comment < ApplicationRecord
   TITLE_DELETED = "[deleted]".freeze
   TITLE_HIDDEN = "[hidden by post author]".freeze
 
-  URI_REGEXP = %r{(?<scheme>https?://)?(?<host>.+?)(?<port>:\d+)?$}.freeze
-
   # The date that we began limiting the number of user mentions in a comment.
   MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 3, 12).freeze
 
@@ -204,12 +202,9 @@ class Comment < ApplicationRecord
   def shorten_urls!
     doc = Nokogiri::HTML.fragment(processed_html)
     doc.css("a").each do |anchor|
-      anchor_inner_html = anchor.inner_html
-      urls = anchor_inner_html.scan(URI_REGEXP).flatten.compact
-      urls.each do |url|
-        anchor_inner_html.sub!(/#{Regexp.escape(url)}/, strip_url(url))
+      unless anchor.to_s.include?("<img") || anchor.to_s.include?("<del") || anchor.attr("class")&.include?("ltag")
+        anchor.content = strip_url(anchor.content) unless anchor.to_s.include?("<img") # rubocop:disable Style/SoleNestedConditional
       end
-      anchor.inner_html = anchor_inner_html
     end
     self.processed_html = doc.to_html.html_safe # rubocop:disable Rails/OutputSafety
   end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -184,20 +184,11 @@ RSpec.describe Comment, type: :model do
         expect(comment.processed_html.include?("Hello <a")).to be(true)
       end
 
-      it "shortens long urls without removing formatting", :aggregate_failures do
-        long_url = "https://longurl.com/#{'x' * 100}?#{'y' * 100}"
-        comment.body_markdown = "Hello #{long_url}"
+      it "shortens long urls" do
+        comment.body_markdown = "Hello https://longurl.com/#{'x' * 100}?#{'y' * 100}"
         comment.validate!
-        expect(comment.processed_html.include?("...")).to be(true)
+        expect(comment.processed_html.include?("...</a>")).to be(true)
         expect(comment.processed_html.size < 450).to be(true)
-
-        comment.body_markdown = "Hello [**#{long_url}**](#{long_url})"
-        comment.validate!
-        expect(comment.processed_html.include?("...</strong>")).to be(true)
-
-        comment.body_markdown = "Hello ![Alt-text](#{long_url})"
-        comment.validate!
-        expect(comment.processed_html.include?("<img")).to be(true)
       end
 
       # rubocop:disable RSpec/ExampleLength


### PR DESCRIPTION
… (#14240)"

This reverts commit 315f1ec4cfd7fa2adee3fb95955c150afbc71861.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix / Revert
- [ ] Optimization
- [ ] Documentation Update

## Description

The changes implemented in #14240 unfortunately resulted in comment images not rendering correctly. The image URL was being prefixed by the post author's profile URL, which resulted in 404s for images and alt text being displayed instead. This seems to have only been happening on comment replies.

![screenshot showing alt text being shown as a link instead of an image](https://user-images.githubusercontent.com/20773163/125953858-cff8a888-e620-418a-82c4-5a36c99025cb.png)

![screenshot of the devtools network tab showing the gif URL has been prefixed with localhost](https://user-images.githubusercontent.com/20773163/125953863-b775f6ff-4518-42c0-815a-ecba08f431b0.png)


## Related Tickets & Documents

#14240

## QA Instructions, Screenshots, Recordings

- Run the app locally
- Add a comment
- Reply to the comment, using a linked image or gif
- View the preview, and make sure the image shows correctly
- Submit the comment reply
- View the comment and make sure the image shows correctly

### UI accessibility concerns?

N/A - fixes a bug for all users

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: reverting a change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


