### PR TITLE
remove use of async attribute on inline scripts

### DIFF
--- a/app/views/articles/_block.html.erb
+++ b/app/views/articles/_block.html.erb
@@ -1,6 +1,6 @@
 <div class="block" id="block-index-<%= i %>">
   <% if show_published %>
-    <script async>
+    <script>
       <%== block.published_javascript %>
     </script>
     <%= tag.style block.published_css, escape_attributes: false %>
@@ -8,7 +8,7 @@
       <%= sanitize block.published_html %>
     </div>
   <% else %>
-    <script async>
+    <script>
       <%== block.processed_javascript %>
     </script>
     <%= tag.style block.processed_css, escape_attributes: false %>

--- a/app/views/articles/_fitvids.html.erb
+++ b/app/views/articles/_fitvids.html.erb
@@ -1,4 +1,4 @@
-<script async>
+<script>
   if (document.getElementsByClassName('fluidvids').length === 0) {
     window.Fluidvids=function(a,b){"use strict";var c,d,e=b.head||b.head,f=".fluidvids-elem{position:absolute;top:0px;left:0px;width:100%;height:100%;border:none;}.fluidvids{width:100%;position:relative;}",g=function(a){return c=new RegExp("^(https?:)?//(?:"+d.join("|")+").*$","i"),c.test(a)},h=function(a){var c=b.createElement("div"),d=a.parentNode,e=100*(parseInt(a.height?a.height:a.offsetHeight,10)/parseInt(a.width?a.width:a.offsetWidth,10));d.insertBefore(c,a),a.className+=" fluidvids-elem",c.className+=" fluidvids",c.style.paddingTop=e+"%",c.appendChild(a)},i=function(){var a=b.createElement("div");a.innerHTML="<p>x</p><style>"+f+"</style>",e.appendChild(a.childNodes[1])},j=function(a){var c=a||{},e=c.selector||"iframe";d=c.players||["www.youtube.com","player.vimeo.com","clips.twitch.tv"];for(var f=b.querySelectorAll(e),j=0;j<f.length;j++){var k=f[j];g(k.src)&&h(k)}i()};return{init:j}}(window,document);
     Fluidvids.init({

--- a/app/views/articles/_v2_form.html.erb
+++ b/app/views/articles/_v2_form.html.erb
@@ -104,6 +104,6 @@
   <%= render "pages/editor_frontmatter_help" %>
 </div>
 
-<script async>
+<script>
   <%== RunkitTag.script %>
 </script>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -231,7 +231,7 @@
 <div class="fullscreen-code js-fullscreen-code"></div>
 
 <% cache("article-show-scripts", expires_in: 8.hours) do %>
-  <script async>
+  <script>
     <%# we consider these scripts safe for embedding as they come from our code %>
     <%== PodcastTag.script %>
     <%== PollTag.script %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -154,7 +154,7 @@
 
 <div class="fullscreen-code js-fullscreen-code"></div>
 
-<script async>
+<script>
   <%== TweetTag.script %>
   <%== YoutubeTag.script %>
   <%== PodcastTag.script %>

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -66,7 +66,7 @@
     </div>
   </div>
   <% if user_signed_in? %>
-    <script async>
+    <script>
       // Here we have some scripts we want to get working on before
       // waiting for the page to stream in.
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR removes attribute `async` on small inline js where, IMHO, it's not worth creating a new js file, or where there are dynamic rails parameters passed to the js.

## Related Tickets & Documents

This PR closes https://github.com/forem/forem/issues/13389

As requested during the review of https://github.com/forem/forem/pull/14234, there's no replacement of  `var` with `const` or `let`, the code remains as it is. 