### PR TITLE
Validate profile field "website url" is in fact a url (don't generate local path links).

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,9 +4,7 @@ class Profile < ApplicationRecord
   validates :data, presence: true
   validates :user_id, uniqueness: true
   validates :location, :website_url, length: { maximum: 100 }
-  validates :website_url,
-    format: { with: URI::DEFAULT_PARSER.make_regexp(%w[https http]) },
-    if: Proc.new {|p| p.website_url.present? }
+  validates :website_url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
   validates_with ProfileValidator
 
   has_many :custom_profile_fields, dependent: :destroy

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,6 +4,7 @@ class Profile < ApplicationRecord
   validates :data, presence: true
   validates :user_id, uniqueness: true
   validates :location, :website_url, length: { maximum: 100 }
+  validates_format_of :website_url, with: URI::regexp
   validates_with ProfileValidator
 
   has_many :custom_profile_fields, dependent: :destroy

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,7 +4,7 @@ class Profile < ApplicationRecord
   validates :data, presence: true
   validates :user_id, uniqueness: true
   validates :location, :website_url, length: { maximum: 100 }
-  validates_format_of :website_url, with: URI::regexp
+  validates_format_of :website_url, with: URI::regexp(["https", "http"])
   validates_with ProfileValidator
 
   has_many :custom_profile_fields, dependent: :destroy

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,7 +4,9 @@ class Profile < ApplicationRecord
   validates :data, presence: true
   validates :user_id, uniqueness: true
   validates :location, :website_url, length: { maximum: 100 }
-  validates :website_url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[https http]) }
+  validates :website_url,
+    format: { with: URI::DEFAULT_PARSER.make_regexp(%w[https http]) },
+    if: Proc.new {|p| p.website_url.present? }
   validates_with ProfileValidator
 
   has_many :custom_profile_fields, dependent: :destroy

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -4,7 +4,7 @@ class Profile < ApplicationRecord
   validates :data, presence: true
   validates :user_id, uniqueness: true
   validates :location, :website_url, length: { maximum: 100 }
-  validates_format_of :website_url, with: URI::regexp(["https", "http"])
+  validates :website_url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[https http]) }
   validates_with ProfileValidator
 
   has_many :custom_profile_fields, dependent: :destroy

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -50,7 +50,7 @@
       <label class="crayons-field__label" for="profile[website_url]">
         Website URL
       </label>
-      <%= f.text_field "profile[website_url]",
+      <%= f.url_field "profile[website_url]",
                        value: profile.website_url,
                        placeholder: "https://yoursite.com",
                        class: "crayons-textfield js-color-field" %>

--- a/lib/data_update_scripts/20210722135549_profile_website_url_format.rb
+++ b/lib/data_update_scripts/20210722135549_profile_website_url_format.rb
@@ -1,0 +1,29 @@
+module DataUpdateScripts
+  class ProfileWebsiteUrlFormat
+    def run
+      profiles_to_fix.each do |profile|
+        fix_or_clear_website_url(profile)
+        profile.save || log_failure(profile)
+      end
+    end
+
+    def fix_or_clear_website_url(profile)
+      profile.website_url =
+        begin
+          new_url = "https://#{profile.website_url}"
+          uri = URI.parse(new_url)
+          uri.scheme.present? && uri.host.present? && new_url || ""
+        end
+    end
+
+    def log_failure(profile)
+      Rails.logger.warn("Attempted to update website_url for profile #{profile.id} but failed with #{profile.errors}")
+    end
+
+    def profiles_to_fix
+      Profile
+        .where.not("website_url like 'http__/%'")
+        .where.not(website_url: [nil, ""])
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/profile_website_url_format_spec.rb
+++ b/spec/lib/data_update_scripts/profile_website_url_format_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20210722135549_profile_website_url_format.rb",
+)
+
+describe DataUpdateScripts::ProfileWebsiteUrlFormat do
+  let(:nil_profile) { create(:profile, website_url: nil) }
+  let(:empty_profile) { create(:profile, website_url: "") }
+  let(:valid_profile) { create(:profile, website_url: "https://www.example.com") }
+
+  let(:invalid_profile) do
+    create(:profile).tap do |profile|
+      profile.update_column(:website_url, "www.example.com")
+    end
+  end
+
+  let(:unfixable_profile) do
+    create(:profile).tap do |profile|
+      profile.update_column(:website_url, "/local.html")
+    end
+  end
+
+  it "does not modify profiles where website url is null" do
+    expect { described_class.new.run }.not_to change(nil_profile, :website_url)
+  end
+
+  it "does not modify profiles where website url is empty" do
+    expect { described_class.new.run }.not_to change(empty_profile, :website_url)
+  end
+
+  it "does not modify profiles where website url is valid" do
+    expect { described_class.new.run }.not_to change(valid_profile, :website_url)
+  end
+
+  it "prepends https:// to invalid urls to make a valid url from hostnames" do
+    expect { described_class.new.run }
+      .to change { invalid_profile.reload.website_url }
+      .from("www.example.com")
+      .to("https://www.example.com")
+  end
+
+  it "clears websites that don't form valid urls by prepending" do
+    expect { described_class.new.run }
+      .to change { unfixable_profile.reload.website_url }
+      .from("/local.html")
+      .to("")
+  end
+end

--- a/spec/lib/data_update_scripts/profile_website_url_format_spec.rb
+++ b/spec/lib/data_update_scripts/profile_website_url_format_spec.rb
@@ -9,14 +9,14 @@ describe DataUpdateScripts::ProfileWebsiteUrlFormat do
   let(:valid_profile) { create(:profile, website_url: "https://www.example.com") }
 
   let(:invalid_profile) do
-    create(:profile).tap do |profile|
-      profile.update_column(:website_url, "www.example.com")
+    build(:profile, website_url: "www.example.com").tap do |profile|
+      profile.save(validate: false)
     end
   end
 
   let(:unfixable_profile) do
-    create(:profile).tap do |profile|
-      profile.update_column(:website_url, "/local.html")
+    build(:profile, website_url: "/local.html").tap do |profile|
+      profile.save(validate: false)
     end
   end
 

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Profile, type: :model do
       it "is invalid with an incomplete url" do
         profile.website_url = "dev.to"
         expect(profile).not_to be_valid
-        expect(profile.errors_as_sentence).to eq "Website url is invalid"
+        expect(profile.errors_as_sentence).to eq "Website url is not a valid URL"
       end
     end
   end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -58,6 +58,19 @@ RSpec.describe Profile, type: :model do
         expect(profile.errors_as_sentence).to eq "Location is too long (maximum is 100 characters)"
       end
     end
+
+    describe "validating website_url" do
+      it "is valid with a complete url" do
+        profile.website_url = "https://dev.to"
+        expect(profile).to be_valid
+      end
+
+      it "is invalid with an incomplete url" do
+        profile.website_url = "dev.to"
+        expect(profile).not_to be_valid
+        expect(profile.errors_as_sentence).to eq "Website url is invalid"
+      end
+    end
   end
 
   context "when accessing profile fields" do

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe Profile, type: :model do
     end
 
     describe "validating website_url" do
+      it "is valid if blank" do
+        profile.website_url = nil
+        expect(profile).to be_valid
+      end
       it "is valid with a complete url" do
         profile.website_url = "https://dev.to"
         expect(profile).to be_valid


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When accepting user supplied website urls for the profile, ensure the input is in fact a url (and not just a string like a domain or hostname). This is needed to prevent generating local path links on the user profile (for example, https://dev.to/www.example.com is almost certainly not what the user intended to show).

The reporter did additionally point out that the full "https://my.web.site" format might not have been what they wanted to show on their profile. I didn't attempt to change the generated link to separate the href from the text (currently they're both the same) - we might consider making a "friendly" display for the link text, that feels like it's out of scope for the reported issue but might have been a reason to omit the https:// scheme from the url when prompted.

*Side-effect*: this data update script will "fix", possibly "remove", user supplied website urls. The choice (arbitrary,  possibly wrong) to remap to https:// urls may cause the (already broken) link to be invalid, if their site does not have https. The fallback is to replace the website url with the empty string (which is the default if the form is not filled in), which might remove user supplied information. These choices might be unwelcome.

## Related Tickets & Documents

https://github.com/forem/forem/issues/14300

## QA Instructions, Screenshots, Recordings

Filling in the website url field on the user's profile page (https://localhost:3000/settings) 

Scenario 1
Input a non-url for the website url on your profile, like "example.com"
Form should not accept the input (there's both javascript validation and model validation to enforce this).

Scenario 2
Input a url that's not a web link, like "telnet://localhost" or "mailto:yo@dev.to"
While the url field accepts this valid url, the model validation should reject the input (and display errors on the form after submission).

Scenario 3 (happy path)
Add a website url that's well formed, like "https://github.com/forem"
Profile should update successfully, this should be shown on the user's profile.

### UI accessibility concerns?

Changing the text field to "type=url" hopefully should improve accessibility, the placeholder text remains as well.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [x] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

A data  update script will run to "correct" profiles which would be otherwise invalid (and would fail to save if updated or touched). This could log errors if other validation issues occurred.

## [optional] What gif best describes this PR or how it makes you feel?

![shrug](https://user-images.githubusercontent.com/1237369/126673271-f0e33827-ee7d-4e13-99dc-fc1814274853.gif)
