### PR TITLE
[15-minute fix] Fix brand color validation

### DIFF
--- a/app/models/users/setting.rb
+++ b/app/models/users/setting.rb
@@ -17,7 +17,8 @@ module Users
 
     validates :brand_color1,
               :brand_color2,
-              format: { with: HEX_COLOR_REGEXP, message: "is not a valid hex color" }
+              format: { with: HEX_COLOR_REGEXP, message: "is not a valid hex color" },
+              allow_nil: true
     validates :user_id, presence: true
     validates :experience_level, numericality: { less_than_or_equal_to: 10 }, allow_blank: true
     validates :feed_referential_link, inclusion: { in: [true, false] }

--- a/spec/models/users/setting_spec.rb
+++ b/spec/models/users/setting_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe Users::Setting, type: :model do
         expect(setting).to be_valid
       end
 
+      it "is valid if the brand color is nil" do
+        setting.brand_color1 = nil
+        expect(setting).to be_valid
+      end
+
       it "is invalid if the field is too long" do
         setting.brand_color1 = "#deadbeef"
         expect(setting).not_to be_valid


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

When we recently moved the brand color validation from `profiles` to `users_settings` the fact that `nil` is a valid value got lost. The old validation in `ProfileValidator` looked like this:

```ruby
hex_value = record.public_send(attribute)
hex_value.nil? || hex_value.match?(HEX_COLOR_REGEXP) # This is where we consider nil valid
```

To restore the old behavior I added `allow_nil: true` to the new validation in `Users::Setting` and added the missing spec which would have helped in preventing this problem.

## Related Tickets & Documents

Closes #14299

## QA Instructions, Screenshots, Recordings

In a Rails console, set either brand color to `nil` and verify the the settings record is still valid. Example:

```ruby
user.setting.brand_color1 = nil
user.setting.valid?
#=> true
```

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
