### PR TITLE
[hotfix] website_url update script should handle parse errors

### DIFF
--- a/lib/data_update_scripts/20210722135549_profile_website_url_format.rb
+++ b/lib/data_update_scripts/20210722135549_profile_website_url_format.rb
@@ -35,7 +35,7 @@ module DataUpdateScripts
     def acceptable_uri?(uri)
       uri.scheme.present? &&
         uri.host.present? &&
-        ! uri.user.present?
+        uri.user.blank?
     end
   end
 end

--- a/lib/data_update_scripts/20210722160452_profile_website_url_format_fixup.rb
+++ b/lib/data_update_scripts/20210722160452_profile_website_url_format_fixup.rb
@@ -1,5 +1,5 @@
 module DataUpdateScripts
-  class ProfileWebsiteUrlFormat
+  class ProfileWebsiteUrlFormatFixup
     def run
       profiles_to_fix.each do |profile|
         fix_or_clear_website_url(profile)

--- a/lib/data_update_scripts/20210722160452_profile_website_url_format_fixup.rb
+++ b/lib/data_update_scripts/20210722160452_profile_website_url_format_fixup.rb
@@ -35,7 +35,7 @@ module DataUpdateScripts
     def acceptable_uri?(uri)
       uri.scheme.present? &&
         uri.host.present? &&
-        ! uri.user.present?
+        uri.user.blank?
     end
   end
 end

--- a/spec/lib/data_update_scripts/profile_website_url_format_fixup_spec.rb
+++ b/spec/lib/data_update_scripts/profile_website_url_format_fixup_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20210722160452_profile_website_url_format_fixup.rb",
+)
+
+describe DataUpdateScripts::ProfileWebsiteUrlFormatFixup do
+  let(:nil_profile) { create(:profile, website_url: nil) }
+  let(:invalid_profile) { make_profile_for("www.example.com") }
+  let(:unfixable_profile) { make_profile_for("/local.html") }
+  let(:email_profile) { make_profile_for("dan@forem.com") }
+  let(:spacey_profile) { make_profile_for("  example.com  ") }
+  let(:unparseable_profile) { make_profile_for("this will not parse") }
+  let(:empty_profile) { create(:profile, website_url: "") }
+  let(:valid_profile) { create(:profile, website_url: "https://www.example.com") }
+
+  def make_profile_for(website_url)
+    build(:profile, website_url: website_url).tap do |profile|
+      profile.save(validate: false)
+    end
+  end
+
+  it "does not modify profiles where website url is null" do
+    expect { described_class.new.run }.not_to change(nil_profile, :website_url)
+  end
+
+  it "does not modify profiles where website url is empty" do
+    expect { described_class.new.run }.not_to change(empty_profile, :website_url)
+  end
+
+  it "does not modify profiles where website url is valid" do
+    expect { described_class.new.run }.not_to change(valid_profile, :website_url)
+  end
+
+  it "prepends https:// to invalid urls to make a valid url from hostnames" do
+    expect { described_class.new.run }
+      .to change { invalid_profile.reload.website_url }
+      .from("www.example.com")
+      .to("https://www.example.com")
+  end
+
+  it "clears websites that don't form valid urls by prepending" do
+    expect { described_class.new.run }
+      .to change { unfixable_profile.reload.website_url }
+      .from("/local.html")
+      .to("")
+  end
+
+  it "rejects users in the link" do
+    # what was meant to be an email address is actually a valid user@host url
+    # we just don't want to do this
+    expect { described_class.new.run }
+      .to change { email_profile.reload.website_url }
+      .from("dan@forem.com")
+      .to("")
+  end
+
+  it "trims the input to help parsing" do
+    expect { described_class.new.run }
+      .to change { spacey_profile.reload.website_url }
+      .from("  example.com  ")
+      .to("https://example.com")
+  end
+
+  it "handles parse errors by clearing the website url" do
+    expect { described_class.new.run }
+      .to change { unparseable_profile.reload.website_url }
+      .from("this will not parse")
+      .to("")
+  end
+end

--- a/spec/lib/data_update_scripts/profile_website_url_format_spec.rb
+++ b/spec/lib/data_update_scripts/profile_website_url_format_spec.rb
@@ -1,24 +1,24 @@
 require "rails_helper"
 require Rails.root.join(
-  "lib/data_update_scripts/20210722135549_profile_website_url_format.rb",
+  "lib/data_update_scripts/20210722160452_profile_website_url_format.rb",
 )
 
-describe DataUpdateScripts::ProfileWebsiteUrlFormat do
+describe DataUpdateScripts::ProfileWebsiteUrlFormatFixup do
   let(:nil_profile) { create(:profile, website_url: nil) }
   let(:empty_profile) { create(:profile, website_url: "") }
   let(:valid_profile) { create(:profile, website_url: "https://www.example.com") }
 
-  let(:invalid_profile) do
-    build(:profile, website_url: "www.example.com").tap do |profile|
+  def make_profile_for(website_url)
+    build(:profile, website_url: website_url).tap do |profile|
       profile.save(validate: false)
     end
   end
 
-  let(:unfixable_profile) do
-    build(:profile, website_url: "/local.html").tap do |profile|
-      profile.save(validate: false)
-    end
-  end
+  let(:invalid_profile) { make_profile_for("www.example.com") }
+  let(:unfixable_profile) { make_profile_for("/local.html") }
+  let(:email_profile) { make_profile_for("dan@forem.com") }
+  let(:spacey_profile) { make_profile_for("  example.com  ") }
+  let(:unparseable_profile) { make_profile_for("this will not parse") }
 
   it "does not modify profiles where website url is null" do
     expect { described_class.new.run }.not_to change(nil_profile, :website_url)
@@ -43,6 +43,29 @@ describe DataUpdateScripts::ProfileWebsiteUrlFormat do
     expect { described_class.new.run }
       .to change { unfixable_profile.reload.website_url }
       .from("/local.html")
+      .to("")
+  end
+
+  it "rejects users in the link" do
+    # what was meant to be an email address is actually a valid user@host url
+    # we just don't want to do this
+    expect { described_class.new.run }
+      .to change { email_profile.reload.website_url }
+      .from("dan@forem.com")
+      .to("")
+  end
+
+  it "trims the input to help parsing" do
+    expect { described_class.new.run }
+      .to change { spacey_profile.reload.website_url }
+      .from("  example.com  ")
+      .to("https://example.com")
+  end
+
+  it "handles parse errors by clearing the website url" do
+    expect { described_class.new.run }
+      .to change { unparseable_profile.reload.website_url }
+      .from("this will not parse")
       .to("")
   end
 end

--- a/spec/lib/data_update_scripts/profile_website_url_format_spec.rb
+++ b/spec/lib/data_update_scripts/profile_website_url_format_spec.rb
@@ -1,10 +1,15 @@
 require "rails_helper"
 require Rails.root.join(
-  "lib/data_update_scripts/20210722160452_profile_website_url_format.rb",
+  "lib/data_update_scripts/20210722135549_profile_website_url_format.rb",
 )
 
-describe DataUpdateScripts::ProfileWebsiteUrlFormatFixup do
+describe DataUpdateScripts::ProfileWebsiteUrlFormat do
   let(:nil_profile) { create(:profile, website_url: nil) }
+  let(:invalid_profile) { make_profile_for("www.example.com") }
+  let(:unfixable_profile) { make_profile_for("/local.html") }
+  let(:email_profile) { make_profile_for("dan@forem.com") }
+  let(:spacey_profile) { make_profile_for("  example.com  ") }
+  let(:unparseable_profile) { make_profile_for("this will not parse") }
   let(:empty_profile) { create(:profile, website_url: "") }
   let(:valid_profile) { create(:profile, website_url: "https://www.example.com") }
 
@@ -13,12 +18,6 @@ describe DataUpdateScripts::ProfileWebsiteUrlFormatFixup do
       profile.save(validate: false)
     end
   end
-
-  let(:invalid_profile) { make_profile_for("www.example.com") }
-  let(:unfixable_profile) { make_profile_for("/local.html") }
-  let(:email_profile) { make_profile_for("dan@forem.com") }
-  let(:spacey_profile) { make_profile_for("  example.com  ") }
-  let(:unparseable_profile) { make_profile_for("this will not parse") }
 
   it "does not modify profiles where website url is null" do
     expect { described_class.new.run }.not_to change(nil_profile, :website_url)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Update the profile website url fixup script to handle parse errors - we saw a user with a trailing space in the input which raised an error during parsing, rather than giving a generic uri with no scheme, which caused the script to abort.

Attempt to strip spaces from input before building the new url, and handle URI parse errors by clearing the url.

Additionally, if the user had given an email address, check to see if the http user is in the url, and reject those cases.

Rename script class and file. Copy tests and load the new class to test it.
  

## Related Tickets & Documents

https://app.honeybadger.io/projects/66984/faults/80557297
#14302 

## QA Instructions, Screenshots, Recordings

Tests should be sufficient.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
