### PR TITLE
[15 min fix] Added support for the --no-seed argument to bin/e2e command 

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -29,4 +29,10 @@ fi
 printf "Starting the test runner...\n\n"
 
 bundle exec rails assets:precompile;
-CYPRESS_RAILS_CYPRESS_OPTS="--config-file cypress.dev.json" RAILS_ENV=test E2E=true bundle exec rake cypress:open
+
+if [ $1 = "--no-seed" ]; then
+   echo "Running E2E tests without seed data"
+   CYPRESS_RAILS_CYPRESS_OPTS="--config-file cypress.dev.json" RAILS_ENV=test E2E=true SKIP_SEED_DATA=1 E2E_FOLDER=nonSeededFlows bundle exec rake cypress:open
+else
+   CYPRESS_RAILS_CYPRESS_OPTS="--config-file cypress.dev.json" RAILS_ENV=test E2E=true bundle exec rake cypress:open
+fi

--- a/docs/tests/e2e-tests.md
+++ b/docs/tests/e2e-tests.md
@@ -43,6 +43,10 @@ coordinate all this work.
 
 ### 1. From the command line, run `yarn e2e`
 
+Note: If you want to run E2E tests that do not require seeded data, run
+`yarn e2e:noseed`. Some tests, like the admin onboarding require there to be no
+seeded data.
+
 Some initial setup and checks will automatically run as part of this command:
 
 - `bundle check`: You will be prompted to run `bundle install` if gems for the

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test": "jest app/javascript/ bin/ --coverage",
     "test:watch": "jest app/javascript/ bin/ --watch",
     "postcss": "postcss public/assets/*.css -d public/assets 2> postcss_error.log",
-    "e2e": "bin/e2e"
+    "e2e": "bin/e2e",
+    "e2e:noseed": "yarn run e2e --no-seed"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update
- [x] DX

## Description

Adds support for running end to end (E2E) tests that do not require seeded data. If a developer wants to run E2E tests that do not use seeded data, they add the `--no-seed` argument, e.g. `bin/e2e --no-seed`.  There are also a npm script to handle this, `yarn e2e:noseed`.

## Related Tickets & Documents

#14285

## QA Instructions, Screenshots, Recordings

1. Open a terminal in the root folder of the Forem repository and run `yarn e2e:noseed`.
2. Once the checks are verified, it will output `"Running E2E tests without seed data"` before starting Cypress.

```bash
...
[84] ./app/javascript/packs/dashboardTagsDisableUnchangedButtons.js 754 bytes {26} [built]
    + 112 hidden modules

Running E2E tests without seed data

cypress-rails configuration:
============================
 CYPRESS_RAILS_DIR....................."/Users/nickytonline/dev/forem"
 CYPRESS_RAILS_HOST...................."127.0.0.1"
...
```

3. The Cypress test runner will launch with tests that required the database to not be seeded.

![image](https://user-images.githubusercontent.com/833231/126697982-fafe6021-d711-4878-b136-5858cd99121a.png)

### UI accessibility concerns?

N/A Testing infrastructure

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: N/A Testing infrastructure
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![A character from Adventure Time saying "Nice!"](https://media.giphy.com/media/qPcX2mzk3NmjC/giphy.gif)
