### PR TITLE
Add separate section for article link to improve accessibility in the mod center

### DIFF
--- a/app/assets/stylesheets/views/mod-center.scss
+++ b/app/assets/stylesheets/views/mod-center.scss
@@ -43,19 +43,22 @@
   align-items: center;
   background-color: var(--base-inverted);
   color: var(--base-100);
-  display: grid;
-  grid-column-gap: var(--su-2);
-  grid-template-columns: 1fr;
-  grid-template-rows: auto;
-  grid-row-gap: var(--su-1);
   padding: var(--su-4);
   text-align: left;
   width: 100%;
 
-  @media (min-width: $breakpoint-m) {
-    grid-template-columns: 4fr 2fr 1fr;
-    grid-row-gap: 0;
-    grid-template-rows: 1fr;
+  > summary {
+    display: grid;
+    grid-column-gap: var(--su-2);
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    grid-row-gap: var(--su-1);
+
+    @media (min-width: $breakpoint-m) {
+      grid-template-columns: 4fr 2fr 1fr;
+      grid-row-gap: 0;
+      grid-template-rows: 1fr;
+    }
   }
 
   &:hover {

--- a/app/assets/stylesheets/views/mod-center.scss
+++ b/app/assets/stylesheets/views/mod-center.scss
@@ -48,16 +48,26 @@
   width: 100%;
 
   > summary {
-    display: grid;
-    grid-column-gap: var(--su-2);
-    grid-template-columns: 1fr;
-    grid-template-rows: auto;
-    grid-row-gap: var(--su-1);
+    &::-webkit-details-marker {
+      display: none;
+    }
 
-    @media (min-width: $breakpoint-m) {
-      grid-template-columns: 4fr 2fr 1fr;
-      grid-row-gap: 0;
-      grid-template-rows: 1fr;
+    &::marker {
+      content: '';
+    }
+
+    .article-details-container {
+      display: grid;
+      grid-column-gap: var(--su-2);
+      grid-template-columns: 1fr;
+      grid-template-rows: auto;
+      grid-row-gap: var(--su-1);
+
+      @media (min-width: $breakpoint-m) {
+        grid-template-columns: 4fr 2fr 1fr;
+        grid-row-gap: 0;
+        grid-template-rows: 1fr;
+      }
     }
   }
 

--- a/app/assets/stylesheets/views/mod-center.scss
+++ b/app/assets/stylesheets/views/mod-center.scss
@@ -105,6 +105,7 @@
     grid-column-end: 4;
     width: 100%;
     display: flex;
+    flex-direction: column;
 
     &.opened {
       margin-top: var(--su-4);
@@ -116,14 +117,25 @@
       border: none;
     }
 
-    .article-iframe {
+    .article-referrer-heading {
+      padding: var(--su-4);
       width: 100%;
-      height: 650px; // height is arbitrary, will be removed for modal-esque view
     }
 
-    .actions-panel-iframe {
-      width: 60%;
-      height: 650px; // height is arbitrary, will be removed for modal-esque view
+    .iframes-container {
+      display: flex;
+      height: 650px;
+      width: 100%;
+
+      .article-iframe {
+        width: 100%;
+        height: 650px; // height is arbitrary, will be removed for modal-esque view
+      }
+
+      .actions-panel-iframe {
+        width: 60%;
+        height: 650px; // height is arbitrary, will be removed for modal-esque view
+      }
     }
   }
 }

--- a/app/assets/stylesheets/views/mod-center.scss
+++ b/app/assets/stylesheets/views/mod-center.scss
@@ -43,7 +43,6 @@
   align-items: center;
   background-color: var(--base-inverted);
   color: var(--base-100);
-  padding: var(--su-4);
   text-align: left;
   width: 100%;
 
@@ -57,11 +56,13 @@
     }
 
     .article-details-container {
+      cursor: pointer;
       display: grid;
       grid-column-gap: var(--su-2);
       grid-template-columns: 1fr;
       grid-template-rows: auto;
       grid-row-gap: var(--su-1);
+      padding: var(--su-4);
 
       @media (min-width: $breakpoint-m) {
         grid-template-columns: 4fr 2fr 1fr;

--- a/app/javascript/modCenter/__tests__/moderationArticles.test.jsx
+++ b/app/javascript/modCenter/__tests__/moderationArticles.test.jsx
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { render, fireEvent } from '@testing-library/preact';
+import { render, fireEvent, waitFor } from '@testing-library/preact';
 import { ModerationArticles } from '../moderationArticles';
 
 const getTestArticles = () => {
@@ -20,8 +20,7 @@ const getTestArticles = () => {
       id: 2,
       title:
         'An article title that is quite very actually rather extremely long with all things considered',
-      path:
-        'an-article-title-that-is-quite-very-actually-rather-extremely-long-with-all-things-considered-fi8',
+      path: 'an-article-title-that-is-quite-very-actually-rather-extremely-long-with-all-things-considered-fi8',
       published_at: '2019-06-24T09:32:10.590Z',
       cached_tag_list: '',
       user: {
@@ -59,29 +58,37 @@ describe('<ModerationArticles />', () => {
     expect(listOfArticles.length).toEqual(2);
   });
 
-  it('renders the iframes on click', () => {
+  it('renders the iframes on click', async () => {
     const { getByTestId } = render(<ModerationArticles />);
     const singleArticle = getByTestId('mod-article-1');
-    singleArticle.click();
-    const iframes = singleArticle.getElementsByTagName('iframe');
-    expect(iframes.length).toEqual(2);
+    const summarySection = singleArticle.getElementsByTagName('summary')[0];
+    summarySection.click();
+    await waitFor(() => {
+      const iframes = singleArticle.getElementsByTagName('iframe');
+      expect(iframes.length).toEqual(2);
+    });
   });
 
-  it('toggles the "opened" class when opening or closing an article', () => {
+  it('toggles the "opened" class when opening or closing an article', async () => {
     const { getByTestId } = render(<ModerationArticles />);
     const singleArticle = getByTestId('mod-article-2');
+    const summarySection = singleArticle.getElementsByTagName('summary')[0];
 
-    fireEvent.click(singleArticle);
-    expect(
-      singleArticle.getElementsByClassName('article-iframes-container')[0]
-        .classList,
-    ).toContain('opened');
+    fireEvent.click(summarySection);
+    await waitFor(() => {
+      expect(
+        singleArticle.getElementsByClassName('article-iframes-container')[0]
+          .classList,
+      ).toContain('opened');
+    });
 
-    fireEvent.click(singleArticle);
-    expect(
-      singleArticle.getElementsByClassName('article-iframes-container')[0]
-        .classList,
-    ).not.toContain('opened');
+    fireEvent.click(summarySection);
+    await waitFor(() => {
+      expect(
+        singleArticle.getElementsByClassName('article-iframes-container')[0]
+          .classList,
+      ).not.toContain('opened');
+    });
   });
 
   it('adds the FlagUser Modal HTML associated with author when article opened', async () => {
@@ -93,8 +100,9 @@ describe('<ModerationArticles />', () => {
     ).toBeNull();
 
     const singleArticle = getByTestId(`mod-article-${expectedArticleId}`);
+    const summarySection = singleArticle.getElementsByTagName('summary')[0];
 
-    singleArticle.click();
+    summarySection.click();
 
     // We need the iframe to load first before checking for the modal having been loaded.
     await findByTestId(`mod-iframe-${expectedArticleId}`);

--- a/app/javascript/modCenter/moderationArticles.jsx
+++ b/app/javascript/modCenter/moderationArticles.jsx
@@ -13,32 +13,24 @@ export class ModerationArticles extends Component {
     const { prevSelectedArticleId } = this.state;
     const selectedArticle = document.getElementById(`article-iframe-${id}`);
     const selectedDetailsPanel = document.querySelector(
-      `details[data-testid='mod-article-${id}']`
+      `details[data-id='mod-article-${id}']`,
     );
 
     if (prevSelectedArticleId > 0) {
-      if (
-        selectedDetailsPanel.getAttribute("open") !== null
-      ) {
+      if (selectedDetailsPanel.getAttribute('open') !== null) {
         if (prevSelectedArticleId !== id) {
-          const previousOpenDetailsPanel = document.querySelector(
-            `details[data-testid='mod-article-${prevSelectedArticleId}']`
-          );
-        
-          if (previousOpenDetailsPanel.getAttribute("open") !== null) {
-            previousOpenDetailsPanel.removeAttribute("open")
-          }
+          document
+            .querySelector(
+              `details[data-id='mod-article-${prevSelectedArticleId}']`,
+            )
+            ?.removeAttribute('open');
         }
       } else {
-        document.getElementById(
-          `article-iframe-${id}`,
-        ).innerHTML = "";
+        document.getElementById(`article-iframe-${id}`).innerHTML = '';
       }
     }
 
-    if (
-      selectedDetailsPanel.getAttribute("open") !== null
-    ) {
+    if (selectedDetailsPanel.getAttribute('open') !== null) {
       selectedArticle.innerHTML = `
       <div class="article-referrer-heading">
         <a class="article-title-link fw-bold" href=${path}>
@@ -47,12 +39,14 @@ export class ModerationArticles extends Component {
       </div>
       <div class="iframes-container">
         <iframe class="article-iframe" src="${path}"></iframe>
-        <iframe data-testid="mod-iframe-${id}" class="actions-panel-iframe" id="mod-iframe-${id}" src="${path}/actions_panel"></iframe>
+        <iframe data-testid="mod-iframe-${id}" data-id="mod-iframe-${id}" class="actions-panel-iframe" id="mod-iframe-${id}" src="${path}/actions_panel"></iframe>
       </div>`;
 
-      this.setState({prevSelectedArticleId: id});
+      this.setState({ prevSelectedArticleId: id });
     } else {
-      document.getElementById(`article-iframe-${id}`).classList.remove("opened");
+      document
+        .getElementById(`article-iframe-${id}`)
+        .classList.remove('opened');
     }
   };
 

--- a/app/javascript/modCenter/moderationArticles.jsx
+++ b/app/javascript/modCenter/moderationArticles.jsx
@@ -13,16 +13,14 @@ export class ModerationArticles extends Component {
     const { prevSelectedArticleId } = this.state;
     const selectedArticle = document.getElementById(`article-iframe-${id}`);
     const selectedDetailsPanel = document.querySelector(
-      `details[data-id='mod-article-${id}']`,
+      `details[id='mod-article-${id}']`,
     );
 
     if (prevSelectedArticleId > 0) {
       if (selectedDetailsPanel.getAttribute('open') !== null) {
         if (prevSelectedArticleId !== id) {
           document
-            .querySelector(
-              `details[data-id='mod-article-${prevSelectedArticleId}']`,
-            )
+            .querySelector(`details[id='mod-article-${prevSelectedArticleId}']`)
             ?.removeAttribute('open');
         }
       } else {
@@ -39,7 +37,7 @@ export class ModerationArticles extends Component {
       </div>
       <div class="iframes-container">
         <iframe class="article-iframe" src="${path}"></iframe>
-        <iframe data-testid="mod-iframe-${id}" data-id="mod-iframe-${id}" class="actions-panel-iframe" id="mod-iframe-${id}" src="${path}/actions_panel"></iframe>
+        <iframe data-testid="mod-iframe-${id}" id="mod-iframe-${id}" class="actions-panel-iframe" id="mod-iframe-${id}" src="${path}/actions_panel"></iframe>
       </div>`;
 
       this.setState({ prevSelectedArticleId: id });

--- a/app/javascript/modCenter/moderationArticles.jsx
+++ b/app/javascript/modCenter/moderationArticles.jsx
@@ -12,15 +12,13 @@ export class ModerationArticles extends Component {
   toggleArticle = (id, title, path) => {
     const { prevSelectedArticleId } = this.state;
     const selectedArticle = document.getElementById(`article-iframe-${id}`);
-    const selectedDetailsPanel = document.querySelector(
-      `details[id='mod-article-${id}']`,
-    );
+    const selectedDetailsPanel = document.getElementById(`mod-article-${id}`);
 
     if (prevSelectedArticleId > 0) {
       if (selectedDetailsPanel.getAttribute('open') !== null) {
         if (prevSelectedArticleId !== id) {
           document
-            .querySelector(`details[id='mod-article-${prevSelectedArticleId}']`)
+            .getElementById(`mod-article-${prevSelectedArticleId}`)
             ?.removeAttribute('open');
         }
       } else {

--- a/app/javascript/modCenter/moderationArticles.jsx
+++ b/app/javascript/modCenter/moderationArticles.jsx
@@ -31,7 +31,12 @@ export class ModerationArticles extends Component {
     }
 
     selectedArticle.classList.add('opened');
-    selectedArticle.innerHTML = `<iframe class="article-iframe" src="${path}"></iframe><iframe data-testid="mod-iframe-${id}" class="actions-panel-iframe" id="mod-iframe-${id}" src="${path}/actions_panel"></iframe>`;
+    selectedArticle.innerHTML = `
+    <div class="article-referrer-heading"></div>
+    <div class="iframes-container">
+      <iframe class="article-iframe" src="${path}"></iframe>
+      <iframe data-testid="mod-iframe-${id}" class="actions-panel-iframe" id="mod-iframe-${id}" src="${path}/actions_panel"></iframe>
+    </div>`;
   };
 
   render() {

--- a/app/javascript/modCenter/moderationArticles.jsx
+++ b/app/javascript/modCenter/moderationArticles.jsx
@@ -7,44 +7,57 @@ export class ModerationArticles extends Component {
       document.getElementById('mod-index-list').dataset.articles,
     ),
     prevSelectedArticleId: undefined,
-    selectedArticleId: undefined,
   };
 
   toggleArticle = (id, title, path) => {
     const { prevSelectedArticleId } = this.state;
     const selectedArticle = document.getElementById(`article-iframe-${id}`);
+    const selectedDetailsPanel = document.querySelector(
+      `details[data-testid='mod-article-${id}']`
+    );
 
     if (prevSelectedArticleId > 0) {
-      document.getElementById(
-        `article-iframe-${prevSelectedArticleId}`,
-      ).innerHTML = '';
+      if (
+        selectedDetailsPanel.getAttribute("open") !== null
+      ) {
+        if (prevSelectedArticleId !== id) {
+          const previousOpenDetailsPanel = document.querySelector(
+            `details[data-testid='mod-article-${prevSelectedArticleId}']`
+          );
+        
+          if (previousOpenDetailsPanel.getAttribute("open") !== null) {
+            previousOpenDetailsPanel.removeAttribute("open")
+          }
+        }
+      } else {
+        document.getElementById(
+          `article-iframe-${id}`,
+        ).innerHTML = "";
+      }
     }
-
-    this.setState({ selectedArticleId: id, prevSelectedArticleId: id });
 
     if (
-      id === prevSelectedArticleId &&
-      document.getElementsByClassName('opened').length > 0
+      selectedDetailsPanel.getAttribute("open") !== null
     ) {
-      selectedArticle.classList.remove('opened');
-      return;
-    }
+      selectedArticle.innerHTML = `
+      <div class="article-referrer-heading">
+        <a class="article-title-link fw-bold" href=${path}>
+          ${title}
+        </a>
+      </div>
+      <div class="iframes-container">
+        <iframe class="article-iframe" src="${path}"></iframe>
+        <iframe data-testid="mod-iframe-${id}" class="actions-panel-iframe" id="mod-iframe-${id}" src="${path}/actions_panel"></iframe>
+      </div>`;
 
-    selectedArticle.classList.add('opened');
-    selectedArticle.innerHTML = `
-    <div class="article-referrer-heading">
-      <a class="article-title-link fw-bold" href=${path}>
-        ${title}
-      </a>
-    </div>
-    <div class="iframes-container">
-      <iframe class="article-iframe" src="${path}"></iframe>
-      <iframe data-testid="mod-iframe-${id}" class="actions-panel-iframe" id="mod-iframe-${id}" src="${path}/actions_panel"></iframe>
-    </div>`;
+      this.setState({prevSelectedArticleId: id});
+    } else {
+      document.getElementById(`article-iframe-${id}`).classList.remove("opened");
+    }
   };
 
   render() {
-    const { articles, selectedArticleId } = this.state;
+    const { articles, prevSelectedArticleId } = this.state;
 
     return (
       <div className="moderation-articles-list">
@@ -66,7 +79,7 @@ export class ModerationArticles extends Component {
               key={id}
               publishedAt={publishedAt}
               user={user}
-              articleOpened={id === selectedArticleId}
+              articleOpened={id === prevSelectedArticleId}
               toggleArticle={this.toggleArticle}
             />
           );

--- a/app/javascript/modCenter/moderationArticles.jsx
+++ b/app/javascript/modCenter/moderationArticles.jsx
@@ -10,7 +10,7 @@ export class ModerationArticles extends Component {
     selectedArticleId: undefined,
   };
 
-  toggleArticle = (id, path) => {
+  toggleArticle = (id, title, path) => {
     const { prevSelectedArticleId } = this.state;
     const selectedArticle = document.getElementById(`article-iframe-${id}`);
 
@@ -32,7 +32,11 @@ export class ModerationArticles extends Component {
 
     selectedArticle.classList.add('opened');
     selectedArticle.innerHTML = `
-    <div class="article-referrer-heading"></div>
+    <div class="article-referrer-heading">
+      <a class="article-title-link fw-bold" href=${path}>
+        ${title}
+      </a>
+    </div>
     <div class="iframes-container">
       <iframe class="article-iframe" src="${path}"></iframe>
       <iframe data-testid="mod-iframe-${id}" class="actions-panel-iframe" id="mod-iframe-${id}" src="${path}/actions_panel"></iframe>

--- a/app/javascript/modCenter/singleArticle/__tests__/singleArticle.test.jsx
+++ b/app/javascript/modCenter/singleArticle/__tests__/singleArticle.test.jsx
@@ -197,8 +197,9 @@ describe('<SingleArticle />', () => {
       </Fragment>,
     );
 
-    const button = getByTestId(`mod-article-${article.id}`);
-    button.click();
+    const detailsElement = getByTestId(`mod-article-${article.id}`);
+    const summarySection = detailsElement.getElementsByTagName("summary")[0];
+    summarySection.click();
 
     expect(toggleArticle).toHaveBeenCalledTimes(1);
   });

--- a/app/javascript/modCenter/singleArticle/__tests__/singleArticle.test.jsx
+++ b/app/javascript/modCenter/singleArticle/__tests__/singleArticle.test.jsx
@@ -63,7 +63,7 @@ describe('<SingleArticle />', () => {
       </Fragment>,
     );
     const text = getNodeText(
-      container.getElementsByClassName('article-title-link')[0],
+      container.getElementsByClassName('article-title-heading')[0],
     );
     expect(text).toContain(getTestArticle().title);
   });

--- a/app/javascript/modCenter/singleArticle/__tests__/singleArticle.test.jsx
+++ b/app/javascript/modCenter/singleArticle/__tests__/singleArticle.test.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable jest/expect-expect */
 import { h, Fragment } from 'preact';
 import { axe } from 'jest-axe';
-import { render, getNodeText } from '@testing-library/preact';
+import { render, getNodeText, waitFor } from '@testing-library/preact';
 import { SingleArticle } from '../index';
 
 const getTestArticle = () => ({
@@ -198,9 +198,9 @@ describe('<SingleArticle />', () => {
     );
 
     const detailsElement = getByTestId(`mod-article-${article.id}`);
-    const summarySection = detailsElement.getElementsByTagName("summary")[0];
+    const summarySection = detailsElement.getElementsByTagName('summary')[0];
     summarySection.click();
 
-    expect(toggleArticle).toHaveBeenCalledTimes(1);
+    waitFor(() => expect(toggleArticle).toHaveBeenCalledTimes(1));
   });
 });

--- a/app/javascript/modCenter/singleArticle/index.jsx
+++ b/app/javascript/modCenter/singleArticle/index.jsx
@@ -55,21 +55,23 @@ export class SingleArticle extends Component {
           onToggle={this.activateToggle}
         >
           <summary>
-            <span className="article-title">
-              <header>
-                <h3 className="fs-base fw-bold lh-tight article-title-heading">
-                  {title}
-                </h3>
-              </header>
-              {tags}
-            </span>
-            <span className="article-author">
-              {newAuthorNotification}
-              {user.name}
-            </span>
-            <span className="article-published-at">
-              <time dateTime={publishedAt}>{formatDate(publishedAt)}</time>
-            </span>
+            <div className="article-details-container">
+              <span className="article-title">
+                <header>
+                  <h3 className="fs-base fw-bold lh-tight article-title-heading">
+                    {title}
+                  </h3>
+                </header>
+                {tags}
+              </span>
+              <span className="article-author">
+                {newAuthorNotification}
+                {user.name}
+              </span>
+              <span className="article-published-at">
+                <time dateTime={publishedAt}>{formatDate(publishedAt)}</time>
+              </span>
+            </div>
           </summary>
           <div
             className={`article-iframes-container${

--- a/app/javascript/modCenter/singleArticle/index.jsx
+++ b/app/javascript/modCenter/singleArticle/index.jsx
@@ -5,8 +5,7 @@ import { FlagUserModal } from '../../packs/flagUserModal';
 import { formatDate } from './util';
 
 export class SingleArticle extends Component {
-  activateToggle = (e) => {
-    e.preventDefault();
+  activateToggle = () => {
     const { id, title, path, toggleArticle } = this.props;
 
     toggleArticle(id, title, path);
@@ -50,34 +49,35 @@ export class SingleArticle extends Component {
             <FlagUserModal moderationUrl={path} authorId={user.id} />,
             document.getElementsByClassName('flag-user-modal-container')[0],
           )}
-        <button
+        <details
           data-testid={`mod-article-${id}`}
-          type="button"
           className="moderation-single-article"
-          onClick={this.activateToggle}
+          onToggle={this.activateToggle}
         >
-          <span className="article-title">
-            <header>
-              <h3 className="fs-base fw-bold lh-tight article-title-heading">
-                {title}
-              </h3>
-            </header>
-            {tags}
-          </span>
-          <span className="article-author">
-            {newAuthorNotification}
-            {user.name}
-          </span>
-          <span className="article-published-at">
-            <time dateTime={publishedAt}>{formatDate(publishedAt)}</time>
-          </span>
+          <summary>
+            <span className="article-title">
+              <header>
+                <h3 className="fs-base fw-bold lh-tight article-title-heading">
+                  {title}
+                </h3>
+              </header>
+              {tags}
+            </span>
+            <span className="article-author">
+              {newAuthorNotification}
+              {user.name}
+            </span>
+            <span className="article-published-at">
+              <time dateTime={publishedAt}>{formatDate(publishedAt)}</time>
+            </span>
+          </summary>
           <div
-            className={`article-iframes-container ${
-              articleOpened ? 'opened' : ''
+            className={`article-iframes-container${
+              articleOpened ? ' opened' : ''
             }`}
             id={`article-iframe-${id}`}
           />
-        </button>
+        </details>
       </Fragment>
     );
   }

--- a/app/javascript/modCenter/singleArticle/index.jsx
+++ b/app/javascript/modCenter/singleArticle/index.jsx
@@ -50,6 +50,7 @@ export class SingleArticle extends Component {
             document.getElementsByClassName('flag-user-modal-container')[0],
           )}
         <details
+          data-id={`mod-article-${id}`}
           data-testid={`mod-article-${id}`}
           className="moderation-single-article"
           onToggle={this.activateToggle}

--- a/app/javascript/modCenter/singleArticle/index.jsx
+++ b/app/javascript/modCenter/singleArticle/index.jsx
@@ -7,9 +7,9 @@ import { formatDate } from './util';
 export class SingleArticle extends Component {
   activateToggle = (e) => {
     e.preventDefault();
-    const { id, path, toggleArticle } = this.props;
+    const { id, title, path, toggleArticle } = this.props;
 
-    toggleArticle(id, path);
+    toggleArticle(id, title, path);
   };
 
   tagsFormat = (tag, key) => {
@@ -58,10 +58,8 @@ export class SingleArticle extends Component {
         >
           <span className="article-title">
             <header>
-              <h3 className="fs-base fw-bold lh-tight">
-                <a className="article-title-link" href={path}>
-                  {title}
-                </a>
+              <h3 className="fs-base fw-bold lh-tight article-title-heading">
+                {title}
               </h3>
             </header>
             {tags}

--- a/app/javascript/modCenter/singleArticle/index.jsx
+++ b/app/javascript/modCenter/singleArticle/index.jsx
@@ -50,7 +50,7 @@ export class SingleArticle extends Component {
             document.getElementsByClassName('flag-user-modal-container')[0],
           )}
         <details
-          data-id={`mod-article-${id}`}
+          id={`mod-article-${id}`}
           data-testid={`mod-article-${id}`}
           className="moderation-single-article"
           onToggle={this.activateToggle}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This pull requests tries to make the articles' list more accessible by introducing a separate section for article links and remove their usage from being inside a `button` element.

## Related Tickets & Documents
Fixes #14100 

## QA Instructions, Screenshots, Recordings
![image](https://user-images.githubusercontent.com/47032027/126812579-a447d312-e69e-48d0-a418-032c8b54ff9f.png)
![image](https://user-images.githubusercontent.com/47032027/126812712-1b8921e3-6980-4232-a54f-163ffa80c119.png)

### UI accessibility concerns?
This improves upon the accessibility of the articles' list so that the article link anchor tag is accessibile to the screen readers as well.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
