### PR TITLE
[15-min fix] Show the navigation options regardless of screen size

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -62,7 +62,7 @@
             </li>
             <%= render "admin/shared/nested_sidebar", menu_items: AdminMenu.navigation_items %>
             <li class="block s:hidden">
-              <a class="crayons-link crayons-link--block <%= "crayons-link--current" if controller.controller_name == "overview" %>" href="<%= admin_path %>" aria-current "<%= "page" if controller.controller_name == "overview" %>">
+              <a class="crayons-link crayons-link--block" href="/">
                 <%= inline_svg_tag("website.svg", aria: true, class: "dropdown-icon crayons-icon") %>
                 Go to <%= community_name %> home page
               </a>
@@ -70,7 +70,7 @@
           </ul>
       </nav>
     </div>
-    <main class="crayons-layout__content min-w-0">
+    <main class="crayons-layout__content min-w-0 p-2">
       <% flash.each do |type, message| %>
         <div class="alert alert-<%= type == "notice" || type == "success" ? "success" : "danger" %>">
           <button class="close" data-dismiss="alert" aria-label="Close">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -61,6 +61,12 @@
               </a>
             </li>
             <%= render "admin/shared/nested_sidebar", menu_items: AdminMenu.navigation_items %>
+            <li class="block s:hidden">
+              <a class="crayons-link crayons-link--block <%= "crayons-link--current" if controller.controller_name == "overview" %>" href="<%= admin_path %>" aria-current "<%= "page" if controller.controller_name == "overview" %>">
+                <%= inline_svg_tag("website.svg", aria: true, class: "dropdown-icon crayons-icon") %>
+                Go to <%= community_name %> home page
+              </a>
+            </li>
           </ul>
       </nav>
     </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -70,7 +70,7 @@
           </ul>
       </nav>
     </div>
-    <main class="crayons-layout__content min-w-0 p-2">
+    <main class="crayons-layout__content min-w-0">
       <% flash.each do |type, message| %>
         <div class="alert alert-<%= type == "notice" || type == "success" ? "success" : "danger" %>">
           <button class="close" data-dismiss="alert" aria-label="Close">

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -52,7 +52,7 @@
 
   <div class="crayons-layout crayons-layout--2-cols">
     <div class="admin__left-sidebar crayons-layout__left-sidebar" data-controller="sidebar" data-action="load@window->sidebar#disableCurrentNavItem">
-      <nav class="hidden m:block">
+      <nav>
           <ul>
             <li>
               <a class="crayons-link crayons-link--block <%= "crayons-link--current" if controller.controller_name == "overview" %>" href="<%= admin_path %>" aria-current "<%= "page" if controller.controller_name == "overview" %>">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

This is not the final solution to be implemented for small screen navigation, but instead is a quick fix so the navigation options are available in the mean time the definitive solution is implemented.

## Related Tickets & Documents

- #13826
- https://github.com/forem/rfcs/pull/264

## QA Instructions, Screenshots, Recordings

1. Boot app locally
2. Browse the admin area with a mobile device (or alternatively with the dev tools mobile screen option enabled)

**In bigger screens (things remain the same):**

<img width="1025" alt="Screen Shot 2021-07-23 at 11 23 47" src="https://user-images.githubusercontent.com/6045239/126819076-35881c99-17ed-4fc6-b247-f11ce101d638.png">

**In small screens the navigation must appear visible:** 

<img width="1023" alt="Screen Shot 2021-07-23 at 11 23 54" src="https://user-images.githubusercontent.com/6045239/126819142-b3befb42-c466-4bb8-892c-29e329c18961.png">

### UI accessibility concerns?

None - No changes have been made to the page

## Added/updated tests?

- [x] No, and this is why: Nothing has changed other than making the navigation visible on small screens

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Small fix and the navigation will be refactored when https://github.com/forem/rfcs/pull/264 is implemented

## [optional] What gif best describes this PR or how it makes you feel?

![surprise](https://media.giphy.com/media/TGqRxknWgUFypgTD2l/giphy.gif)
