### PR TITLE
Fix constant lookup in Admin::WelcomeController

### DIFF
--- a/app/controllers/admin/welcome_controller.rb
+++ b/app/controllers/admin/welcome_controller.rb
@@ -25,7 +25,7 @@ module Admin
         tags: welcome
         ---
 
-        Hey there! Welcome to #{Settings::Community.community_name}!
+        Hey there! Welcome to #{::Settings::Community.community_name}!
 
         ![WELCOME TO THE INTERNET](https://slack-imgs.com/?c=1&url=http%3A%2F%2Fmedia0.giphy.com%2Fmedia%2FzhbrTTpmSCYog%2Fgiphy-downsized.gif)
 

--- a/spec/requests/admin/welcome_spec.rb
+++ b/spec/requests/admin/welcome_spec.rb
@@ -54,4 +54,17 @@ RSpec.describe "/admin/apps/welcome", type: :request do
       end.to raise_error(Pundit::NotAuthorizedError)
     end
   end
+
+  # Regression test for https://github.com/forem/forem/issues/14315
+  it "renders the editor to create a welcome thread" do
+    admin = create(:user, :super_admin)
+    sign_in admin
+    allow(Settings::Community).to receive(:staff_user_id).and_return(admin.id)
+
+    post admin_welcome_index_path
+
+    expect(response).to have_http_status(:found)
+    follow_redirect!
+    expect(response.body).to match(/Introduce yourself to the community/)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

When trying to create welcome threads Forem admins currently experience an exception. This PR adds the fix for that. 

## Related Tickets & Documents

https://github.com/forem/forem/issues/14315

## QA Instructions, Screenshots, Recordings

* Go to http://localhost:3000/admin/apps/welcome
* Click the "Create A New Welcome Thread" button
* You should see the editor with some text preloaded, not an exception about `Admin::Settings::Community`

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes, added a regression test

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
