### PR TITLE
[15-minute fix] Rename User.dev_account to User.staff_account

### DIFF
--- a/app/controllers/admin/welcome_controller.rb
+++ b/app/controllers/admin/welcome_controller.rb
@@ -9,7 +9,7 @@ module Admin
     def create
       welcome_thread = Article.create(
         body_markdown: welcome_thread_content,
-        user: User.dev_account,
+        user: User.staff_account,
       )
       redirect_to "#{URI.parse(welcome_thread.path).path}/edit"
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -281,7 +281,7 @@ class User < ApplicationRecord
   after_commit :subscribe_to_mailchimp_newsletter
   after_commit :bust_cache
 
-  def self.dev_account
+  def self.staff_account
     find_by(id: Settings::Community.staff_user_id)
   end
 

--- a/app/services/notifications/moderation/send.rb
+++ b/app/services/notifications/moderation/send.rb
@@ -20,7 +20,7 @@ module Notifications
         # do not create the notification if the comment was created by the moderator
         return if moderator == notifiable.user
 
-        json_data = { user: user_data(User.dev_account) }
+        json_data = { user: user_data(User.staff_account) }
         json_data[notifiable.class.name.downcase] = public_send "#{notifiable.class.name.downcase}_data", notifiable
         new_notification = Notification.create!(
           user_id: moderator.id,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -346,7 +346,7 @@ seeder.create_if_none(Broadcast) do
 
   Article.create!(
     body_markdown: welcome_thread_content,
-    user: User.dev_account || User.first,
+    user: User.staff_account || User.first,
   )
 end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -738,15 +738,15 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe ".dev_account" do
+  describe ".staff_account" do
     it "returns nil if the account does not exist" do
-      expect(described_class.dev_account).to be_nil
+      expect(described_class.staff_account).to be_nil
     end
 
     it "returns the user if the account exists" do
       allow(Settings::Community).to receive(:staff_user_id).and_return(user.id)
 
-      expect(described_class.dev_account).to eq(user)
+      expect(described_class.staff_account).to eq(user)
     end
   end
 

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Moderations", type: :request do
   let(:trusted_user) { create(:user, :trusted) }
   let(:article) { create(:article) }
   let(:comment) { create(:comment, commentable: article) }
-  let(:dev_account) { create(:user) }
+  let(:staff_account) { create(:user) }
 
   it_behaves_like "an elevated privilege required request", "/username/random-article/mod"
   it_behaves_like "an elevated privilege required request", "/username/comment/1/mod"
@@ -39,7 +39,7 @@ RSpec.describe "Moderations", type: :request do
   context "when user is trusted" do
     before do
       sign_in trusted_user
-      allow(User).to receive(:dev_account).and_return(dev_account)
+      allow(User).to receive(:staff_account).and_return(staff_account)
     end
 
     it "grants access to comment moderation" do

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe "NotificationsIndex", type: :request do
   include ActionView::Helpers::DateHelper
 
-  let(:dev_account) { create(:user) }
+  let(:staff_account) { create(:user) }
   let(:mascot_account) { create(:user) }
   let(:user) { create(:user) }
   let(:organization) { create(:organization) }
 
   before do
-    allow(User).to receive(:dev_account).and_return(dev_account)
+    allow(User).to receive(:staff_account).and_return(staff_account)
     allow(User).to receive(:mascot_account).and_return(mascot_account)
   end
 

--- a/spec/services/notifications/moderation/send_spec.rb
+++ b/spec/services/notifications/moderation/send_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Notifications::Moderation::Send, type: :service do
   let(:last_moderation_time) { Time.zone.now - Notifications::Moderation::MODERATORS_AVAILABILITY_DELAY - 1.week }
-  let(:dev_account) { create(:user) }
+  let(:staff_account) { create(:user) }
   let(:user) { create(:user) }
   let(:article) { create(:article, user_id: user.id) }
   let(:comment) { create(:comment, user: user, commentable: article) }
@@ -12,7 +12,7 @@ RSpec.describe Notifications::Moderation::Send, type: :service do
   before do
     u = create(:user, :trusted, last_moderation_notification: last_moderation_time)
     u.notification_setting.update(mod_roundrobin_notifications: true)
-    allow(User).to receive(:dev_account).and_return(dev_account)
+    allow(User).to receive(:staff_account).and_return(staff_account)
     # Creating a comment calls moderation job which itself call moderation service
     Comment.skip_callback(:commit, :after, :send_to_moderator)
   end

--- a/spec/system/notifications/notifications_page_spec.rb
+++ b/spec/system/notifications/notifications_page_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Notifications page", type: :system, js: true do
   context "when user is trusted" do
     before do
       dev_user = create(:user)
-      allow(User).to receive(:dev_account).and_return(dev_user)
+      allow(User).to receive(:staff_account).and_return(dev_user)
       alex.add_role(:trusted)
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

While working on https://github.com/forem/forem/pull/14320 I noticed the `User.dev_account` method. Since this looks for a user with via the `staff_user_id` I decided to rename this method to `User.staff_account` which seems like a better name and less DEV specific.

## Related Tickets & Documents

Generalization

## QA Instructions, Screenshots, Recordings

Nothing specific, specs should still pass this was search/replace type of PR.

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: code refactoring only