### PR TITLE
Revert "Clear recent articles cache on updating tags (#14298)"

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -35,8 +35,7 @@ class Tag < ActsAsTaggableOn::Tag
   before_save :mark_as_updated
 
   after_commit :bust_cache
-  after_update_commit :bust_articles_cache
-  
+
   pg_search_scope :search_by_name,
                   against: :name,
                   using: { tsearch: { prefix: true } }
@@ -100,13 +99,6 @@ class Tag < ActsAsTaggableOn::Tag
 
   def bust_cache
     Tags::BustCacheWorker.perform_async(name)
-  end
-
-  def bust_articles_cache
-    article_ids = articles.published.order(created_at: :desc).limit(100).ids
-    article_ids.each_slice(10) do |ids|
-      Articles::BustMultipleCachesWorker.perform_async(ids)
-    end
   end
 
   def validate_alias_for

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -122,17 +122,6 @@ RSpec.describe Tag, type: :model do
     end
   end
 
-  it "triggers articles cache busting on save" do
-    sidekiq_perform_enqueued_jobs do
-      tag.save
-    end
-    first = create(:article, tags: tag.name, published: true)
-    second = create(:article, tags: tag.name, published: true)
-    sidekiq_assert_enqueued_with(job: Articles::BustMultipleCachesWorker, args: [[second.id, first.id]]) do
-      tag.save
-    end
-  end
-
   it "finds mod chat channel" do
     channel = create(:chat_channel)
     tag.mod_chat_channel_id = channel.id


### PR DESCRIPTION
This reverts commit 71591994029d1cb861b1c82906acd0ba92c4f112.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

See https://github.com/forem/forem/issues/12486#issuecomment-886496687
