### PR TITLE
Tests: Initialize follow buttons in article liquid tags

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -64,7 +64,7 @@
   <% end %>
 <% end %>
 
-<div class="crayons-layout crayons-layout--3-cols crayons-layout--article">
+<div class="crayons-layout crayons-layout--3-cols crayons-layout--article" data-follow-button-container="true">
   <aside class="crayons-layout__sidebar-left" aria-label="Article actions">
     <%= render "articles/actions" %>
   </aside>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -69,7 +69,7 @@
     <%= render "articles/actions" %>
   </aside>
 
-  <main id="main-content" class="crayons-layout__content grid gap-4" data-follow-button-container="true">
+  <main id="main-content" class="crayons-layout__content grid gap-4">
     <div class="article-wrapper">
       <% if !@article.published %>
         <div class="crayons-notice crayons-notice--danger mb-4" aria-live="polite">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -64,12 +64,12 @@
   <% end %>
 <% end %>
 
-<div class="crayons-layout crayons-layout--3-cols crayons-layout--article" data-follow-button-container="true">
+<div class="crayons-layout crayons-layout--3-cols crayons-layout--article">
   <aside class="crayons-layout__sidebar-left" aria-label="Article actions">
     <%= render "articles/actions" %>
   </aside>
 
-  <main id="main-content" class="crayons-layout__content grid gap-4">
+  <main id="main-content" class="crayons-layout__content grid gap-4" data-follow-button-container="true">
     <div class="article-wrapper">
       <% if !@article.published %>
         <div class="crayons-notice crayons-notice--danger mb-4" aria-live="polite">

--- a/cypress/fixtures/users/liquidTagsUser.json
+++ b/cypress/fixtures/users/liquidTagsUser.json
@@ -1,0 +1,5 @@
+{
+  "username": "liquid_tags_user",
+  "email": "liquid-tags-user@forem.local",
+  "password": "password"
+}

--- a/cypress/integration/seededFlows/articleFlows/followFromArticleLiquidTag.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/followFromArticleLiquidTag.spec.js
@@ -1,0 +1,47 @@
+describe('Follow from article liquid tag', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.fixture('users/articleEditorV2User.json').as('user');
+
+    cy.get('@user').then((user) => {
+      cy.loginUser(user).then(() => {
+        cy.createArticle({
+          title: 'Follow from liquid tag Article',
+          tags: ['beginner', 'ruby', 'go'],
+          content: `{% user admin_mcadmin %}\n {% tag tag1 %}`,
+          published: true,
+        }).then((response) => {
+          cy.visitAndWaitForUserSideEffects(response.body.current_state_path);
+          // Wait for page to load
+          cy.findByRole('heading', { name: 'Follow from liquid tag Article' });
+        });
+      });
+    });
+  });
+
+  it('Follows a user from an article liquid tag', () => {
+    cy.findByRole('main').within(() => {
+      cy.findAllByRole('button', { name: 'Follow' })
+        .first()
+        .as('followUserButton');
+      cy.get('@followUserButton').should('have.text', 'Follow');
+      cy.get('@followUserButton').click();
+      cy.get('@followUserButton').should('have.text', 'Following');
+      cy.get('@followUserButton').click();
+      cy.get('@followUserButton').should('have.text', 'Follow');
+    });
+  });
+
+  it('Follows a tag from an article liquid tag', () => {
+    cy.findByRole('main').within(() => {
+      cy.findAllByRole('button', { name: 'Follow' })
+        .last()
+        .as('followUserButton');
+      cy.get('@followUserButton').should('have.text', 'Follow');
+      cy.get('@followUserButton').click();
+      cy.get('@followUserButton').should('have.text', 'Following');
+      cy.get('@followUserButton').click();
+      cy.get('@followUserButton').should('have.text', 'Follow');
+    });
+  });
+});

--- a/cypress/integration/seededFlows/articleFlows/followFromArticleLiquidTag.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/followFromArticleLiquidTag.spec.js
@@ -1,47 +1,118 @@
 describe('Follow from article liquid tag', () => {
-  beforeEach(() => {
-    cy.testSetup();
-    cy.fixture('users/articleEditorV2User.json').as('user');
+  describe('follow user from liquid tag', () => {
+    describe('follow', () => {
+      beforeEach(() => {
+        cy.testSetup();
+        cy.fixture('users/articleEditorV2User.json').as('user');
 
-    cy.get('@user').then((user) => {
-      cy.loginUser(user).then(() => {
-        cy.createArticle({
-          title: 'Follow from liquid tag Article',
-          tags: ['beginner', 'ruby', 'go'],
-          content: `{% user admin_mcadmin %}\n {% tag tag1 %}`,
-          published: true,
-        }).then((response) => {
-          cy.visitAndWaitForUserSideEffects(response.body.current_state_path);
-          // Wait for page to load
-          cy.findByRole('heading', { name: 'Follow from liquid tag Article' });
+        cy.get('@user').then((user) => {
+          cy.loginUser(user).then(() => {
+            cy.createArticle({
+              title: 'Follow from liquid tag Article',
+              tags: ['beginner', 'ruby', 'go'],
+              content: `{% user admin_mcadmin %}\n {% tag tag1 %}`,
+              published: true,
+            }).then((response) => {
+              cy.visitAndWaitForUserSideEffects(
+                response.body.current_state_path,
+              );
+              // Wait for page to load
+              cy.findByRole('heading', {
+                name: 'Follow from liquid tag Article',
+              });
+            });
+          });
+        });
+      });
+
+      it('Follows a user from an article liquid tag', () => {
+        cy.findByRole('main').within(() => {
+          cy.findAllByRole('button', { name: 'Follow' })
+            .first()
+            .as('followUserButton');
+          cy.get('@followUserButton').should('have.text', 'Follow');
+          cy.get('@followUserButton').click();
+          cy.get('@followUserButton').should('have.text', 'Following');
+          cy.get('@followUserButton').click();
+          cy.get('@followUserButton').should('have.text', 'Follow');
+        });
+      });
+    });
+
+    describe('follow back', () => {
+      beforeEach(() => {
+        cy.testSetup();
+        cy.fixture('users/liquidTagsUser.json').as('user');
+
+        cy.get('@user').then((user) => {
+          cy.loginUser(user).then(() => {
+            cy.createArticle({
+              title: 'Follow from liquid tag Article',
+              tags: ['beginner', 'ruby', 'go'],
+              content: `{% user admin_mcadmin %}\n {% tag tag1 %}`,
+              published: true,
+            }).then((response) => {
+              cy.visitAndWaitForUserSideEffects(
+                response.body.current_state_path,
+              );
+              // Wait for page to load
+              cy.findByRole('heading', {
+                name: 'Follow from liquid tag Article',
+              });
+            });
+          });
+        });
+      });
+
+      it('Follows a user from an article liquid tag', () => {
+        cy.findByRole('main').within(() => {
+          cy.findAllByRole('button', { name: 'Follow back' })
+            .first()
+            .as('followUserButton');
+          cy.get('@followUserButton').should('have.text', 'Follow back');
+          cy.get('@followUserButton').click();
+          cy.get('@followUserButton').should('have.text', 'Following');
+          cy.get('@followUserButton').click();
+          cy.get('@followUserButton').should('have.text', 'Follow');
         });
       });
     });
   });
 
-  it('Follows a user from an article liquid tag', () => {
-    cy.findByRole('main').within(() => {
-      cy.findAllByRole('button', { name: 'Follow' })
-        .first()
-        .as('followUserButton');
-      cy.get('@followUserButton').should('have.text', 'Follow');
-      cy.get('@followUserButton').click();
-      cy.get('@followUserButton').should('have.text', 'Following');
-      cy.get('@followUserButton').click();
-      cy.get('@followUserButton').should('have.text', 'Follow');
-    });
-  });
+  describe('Follow tag from article liquid tag', () => {
+    beforeEach(() => {
+      cy.testSetup();
+      cy.fixture('users/liquidTagsUser.json').as('user');
 
-  it('Follows a tag from an article liquid tag', () => {
-    cy.findByRole('main').within(() => {
-      cy.findAllByRole('button', { name: 'Follow' })
-        .last()
-        .as('followTagButton');
-      cy.get('@followTagButton').should('have.text', 'Follow');
-      cy.get('@followTagButton').click();
-      cy.get('@followTagButton').should('have.text', 'Following');
-      cy.get('@followTagButton').click();
-      cy.get('@followTagButton').should('have.text', 'Follow');
+      cy.get('@user').then((user) => {
+        cy.loginUser(user).then(() => {
+          cy.createArticle({
+            title: 'Follow from liquid tag Article',
+            tags: ['beginner', 'ruby', 'go'],
+            content: `{% user admin_mcadmin %}\n {% tag tag1 %}`,
+            published: true,
+          }).then((response) => {
+            cy.visitAndWaitForUserSideEffects(response.body.current_state_path);
+            // Wait for page to load
+            cy.findByRole('heading', {
+              name: 'Follow from liquid tag Article',
+            });
+          });
+        });
+      });
+    });
+
+    it('Follows a tag from an article liquid tag', () => {
+      cy.findByRole('main').within(() => {
+        cy.findAllByRole('button', { name: 'Follow' })
+          .last()
+          .as('followTagButton');
+        cy.get('@followTagButton').should('have.text', 'Follow');
+        cy.get('@followTagButton').click();
+        cy.get('@followTagButton').should('have.text', 'Following');
+        cy.get('@followTagButton').click();
+        cy.get('@followTagButton').should('have.text', 'Follow');
+      });
     });
   });
 });

--- a/cypress/integration/seededFlows/articleFlows/followFromArticleLiquidTag.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/followFromArticleLiquidTag.spec.js
@@ -36,12 +36,12 @@ describe('Follow from article liquid tag', () => {
     cy.findByRole('main').within(() => {
       cy.findAllByRole('button', { name: 'Follow' })
         .last()
-        .as('followUserButton');
-      cy.get('@followUserButton').should('have.text', 'Follow');
-      cy.get('@followUserButton').click();
-      cy.get('@followUserButton').should('have.text', 'Following');
-      cy.get('@followUserButton').click();
-      cy.get('@followUserButton').should('have.text', 'Follow');
+        .as('followTagButton');
+      cy.get('@followTagButton').should('have.text', 'Follow');
+      cy.get('@followTagButton').click();
+      cy.get('@followTagButton').should('have.text', 'Following');
+      cy.get('@followTagButton').click();
+      cy.get('@followTagButton').should('have.text', 'Follow');
     });
   });
 });

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -247,6 +247,30 @@ end
 
 ##############################################################################
 
+seeder.create_if_doesnt_exist(User, "email", "liquid-tags-user@forem.com") do
+  liquid_tags_user = User.create!(
+    name: "Liquid tags User",
+    email: "liquid-tags-user@forem.local",
+    username: "liquid_tags_user",
+    summary: Faker::Lorem.paragraph_by_chars(number: 199, supplemental: false),
+    profile_image: File.open(Rails.root.join("app/assets/images/#{rand(1..40)}.png")),
+    website_url: Faker::Internet.url,
+    confirmed_at: Time.current,
+    password: "password",
+    password_confirmation: "password",
+    saw_onboarding: true,
+    checked_code_of_conduct: true,
+    checked_terms_and_conditions: true,
+  )
+  liquid_tags_user.notification_setting.update(
+    email_comment_notifications: false,
+    email_follower_notifications: false,
+  )
+
+  admin_user.follows.create!(followable: liquid_tags_user)
+end
+##############################################################################
+
 seeder.create_if_doesnt_exist(ChatChannel, "channel_name", "test chat channel") do
   channel = ChatChannel.create(
     channel_type: "open",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After merging https://github.com/forem/forem/pull/14246 I realised follow buttons inside liquid tags hadn't been accounted for - they actually are working OK because we expect other follow buttons on the article page, but this PR now adds tests for this.

(NB: there is a "follow button" for the podcast liquid tag, but it is actually a link to the podcast rather than a 'follow button' like these others. This is why it doesn't appear in the e2e test cases, as it wasn't impacted)

## Related Tickets & Documents

Follow up from #14246

## QA Instructions, Screenshots, Recordings

- Create an article with a user liquid tag (e.g. `{% user admin_mcadmin%}`) and a tag liquid tag (e.g. `{% tag beginners %}`)
- Save as draft, or publish
- View the article and try interacting with the follow buttons
- Check that `Follow` updates to `Following` and vice versa
- Check that clicking the button triggers the `follows` network request


https://user-images.githubusercontent.com/20773163/127148093-28aad9c0-316e-4e04-9eab-9d2858182a3d.mp4


### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: picked this up immediately after the original change was merged, unlikely to have been noticed by users at this point

## [optional] Are there any post deployment tasks we need to perform?

N/A


