### PR TITLE
Only change textContent for element if exists

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -132,7 +132,9 @@ var instantClick
           skipLink.focus();
         }
       }
-      document.getElementById('page-route-change').textContent = title;
+      if (document.getElementById('page-route-change')) {
+        document.getElementById('page-route-change').textContent = title;
+      }
       history.pushState(null, null, newUrl.replace("?samepage=true","").replace("&samepage=true",""))
 
       var hashIndex = newUrl.indexOf('#'),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fix an error with the search page, and possibly any other page, where `document.getElementById('page-route-change')` does not exist.

## Related Tickets & Documents
https://github.com/forem/forem/pull/14284

## QA Instructions, Screenshots, Recordings
1. Make a search
2. See that you get results

### UI accessibility concerns?
Nope

## Added tests?
- [x] No, and this is why: hot-fix.
-
## [Forem core team only] How will this change be communicated?
No, hot-fix

## [optional] Are there any post deployment tasks we need to perform?
No