### PR TITLE
Change Travis to use Focal Fossa and Postgresql 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
     debug: true
 env:
   global:
+    - PGVERSION=12
     - RAILS_ENV=test
     - DATABASE_URL=postgres://travis@localhost:5433/Forem_prod_test
     - DATABASE_NAME=Forem_prod_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
     - COVERAGE_REPORTS_TOTAL=4
     - FOREM_OWNER_SECRET="secret" # test secret so e2e tests can run properly.
 before_install:
-  - "if [ ! -z $PGVERSION ]; then sudo cp /etc/postgresql/{$PGVERSION}/main/pg_hba.conf; fi"
+  - "if [ ! -z $PGVERSION ]; then sudo cp /etc/postgresql/$PGVERSION/main/pg_hba.conf; fi"
   - "if [ ! -z $PGVERSION ]; then sudo service postgresql restart $PGVERSION; fi"
   - gem install bundler:"<2.3"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ env:
     - COVERAGE_REPORTS_TOTAL=4
     - FOREM_OWNER_SECRET="secret" # test secret so e2e tests can run properly.
 before_install:
+  - "if [ ! -z $PGVERSION ]; then sudo cp /etc/postgresql/{$PGVERSION}/main/pg_hba.conf; fi"
+  - "if [ ! -z $PGVERSION ]; then sudo service postgresql restart $PGVERSION; fi"
   - gem install bundler:"<2.3"
 install:
   - date --rfc-3339=seconds

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ cache:
 rvm:
   - 2.7.2
 addons:
-  postgresql: '12.2' # Travis does not work out of the box with Postgres 11 yet
+  postgresql: '12' # Travis does not work out of the box with Postgres 11 yet
   apt:
     packages:
-      - postgresql-12.2
-      - postgresql-client-12.2
+      - postgresql-12
+      - postgresql-client-12
   chrome: 'stable'
   artifacts:
     paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,11 @@ addons:
     debug: true
 env:
   global:
-    - PGPORT=5433
-    - PGUSER=travis
+    - PGPORT=5432
     - RAILS_ENV=test
-    - DATABASE_URL=postgres://travis@localhost/Forem_prod_test
+    - DATABASE_URL=postgres://postgres@localhost/Forem_prod_test
     - DATABASE_NAME=Forem_prod_test
-    - DATABASE_URL_TEST=postgres://travis@localhost/Forem_test
+    - DATABASE_URL_TEST=postgres://postgres@localhost/Forem_test
     - DATABASE_NAME_TEST=Forem_test
     # Dummy values needed to verify the app boots via "rails runner"
     - APP_PROTOCOL=http://

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ cache:
 rvm:
   - 2.7.2
 addons:
-  postgresql: '12' # Travis does not work out of the box with Postgres 11 yet
+  postgresql: '11'
   apt:
     packages:
-      - postgresql-12
-      - postgresql-client-12
+      - postgresql-11
+      - postgresql-client-11
   chrome: 'stable'
   artifacts:
     paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 branches:
   only:
     - main

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,10 @@ addons:
     debug: true
 env:
   global:
-    - PGPORT=5432
     - RAILS_ENV=test
-    - DATABASE_URL=postgres://postgres@localhost/Forem_prod_test
+    - DATABASE_URL=postgres://travis@localhost:5433/Forem_prod_test
     - DATABASE_NAME=Forem_prod_test
-    - DATABASE_URL_TEST=postgres://postgres@localhost/Forem_test
+    - DATABASE_URL_TEST=postgres://travis@localhost:5433/Forem_test
     - DATABASE_NAME_TEST=Forem_test
     # Dummy values needed to verify the app boots via "rails runner"
     - APP_PROTOCOL=http://

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ addons:
     debug: true
 env:
   global:
-    - PGVERSION=12
     - RAILS_ENV=test
     - DATABASE_URL=postgres://travis@localhost:5433/Forem_prod_test
     - DATABASE_NAME=Forem_prod_test
@@ -44,8 +43,13 @@ env:
     - COVERAGE_REPORTS_TOTAL=4
     - FOREM_OWNER_SECRET="secret" # test secret so e2e tests can run properly.
 before_install:
-  - "if [ ! -z $PGVERSION ]; then sudo cp /etc/postgresql/$PGVERSION/main/pg_hba.conf; fi"
-  - "if [ ! -z $PGVERSION ]; then sudo service postgresql restart $PGVERSION; fi"
+  - >-
+    sudo sed -i
+    -e '/local.*peer/s/postgres/all/'
+    -e 's/peer\|md5/trust/g'
+    /etc/postgresql/12/main/pg_hba.conf
+  # Restart the PostgreSQL service:
+  - sudo service postgresql@12-main restart
   - gem install bundler:"<2.3"
 install:
   - date --rfc-3339=seconds

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ before_install:
     -e '/local.*peer/s/postgres/all/'
     -e 's/peer\|md5/trust/g'
     /etc/postgresql/12/main/pg_hba.conf
-  # Restart the PostgreSQL service:
   - sudo service postgresql@12-main restart
   - gem install bundler:"<2.3"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ env:
     - PGPORT=5433
     - PGUSER=travis
     - RAILS_ENV=test
-    - DATABASE_URL=postgres://postgres@localhost/Forem_prod_test
+    - DATABASE_URL=postgres://travis@localhost/Forem_prod_test
     - DATABASE_NAME=Forem_prod_test
-    - DATABASE_URL_TEST=postgres://postgres@localhost/Forem_test
+    - DATABASE_URL_TEST=postgres://travis@localhost/Forem_test
     - DATABASE_NAME_TEST=Forem_test
     # Dummy values needed to verify the app boots via "rails runner"
     - APP_PROTOCOL=http://

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,7 @@ cache:
 rvm:
   - 2.7.2
 addons:
-  apt:
-    sources:
-      - sourceline: 'deb http://dl.google.com/linux/chrome/deb/ stable main'
-  postgresql: '10' # Travis does not work out of the box with Postgres 11 yet
+  postgresql: '12.2' # Travis does not work out of the box with Postgres 11 yet
   chrome: 'stable'
   artifacts:
     paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ cache:
 rvm:
   - 2.7.2
 addons:
+  apt:
+    sources:
+      - sourceline: 'deb http://dl.google.com/linux/chrome/deb/ stable main'
   postgresql: '10' # Travis does not work out of the box with Postgres 11 yet
   chrome: 'stable'
   artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ cache:
 rvm:
   - 2.7.2
 addons:
-  postgresql: '11'
+  postgresql: '12'
   apt:
     packages:
-      - postgresql-11
-      - postgresql-client-11
+      - postgresql-12
+      - postgresql-client-12
   chrome: 'stable'
   artifacts:
     paths:
@@ -25,6 +25,8 @@ addons:
     debug: true
 env:
   global:
+    - PGPORT=5433
+    - PGUSER=travis
     - RAILS_ENV=test
     - DATABASE_URL=postgres://postgres@localhost/Forem_prod_test
     - DATABASE_NAME=Forem_prod_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ rvm:
   - 2.7.2
 addons:
   postgresql: '12.2' # Travis does not work out of the box with Postgres 11 yet
+  apt:
+    packages:
+      - postgresql-12.2
+      - postgresql-client-12.2
   chrome: 'stable'
   artifacts:
     paths:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] CI improvement

## Description
Default Travis build uses Ubuntu 16. This changes it to 20.04 so we get all the benefits of using the newer OS. Along with that, update the PSQL version.

## Related Tickets & Documents
Shoutout to @djuber for helping me out.

References
- https://alphahydrae.com/2021/02/how-to-run-postgresql-13-on-travis-ci/
- https://docs.travis-ci.com/user/database-setup/#using-a-different-postgresql-version
## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a