### PR TITLE
ProfilePreviewCard serializes the user's created at, not the profile's

### DIFF
--- a/spec/requests/profile_preview_cards_spec.rb
+++ b/spec/requests/profile_preview_cards_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "ProfilePreviewCards", type: :request do
         expect(preview_card["work"]).to eq(profile.work)
         expect(preview_card["location"]).to eq(profile.location)
         expect(preview_card["education"]).to eq(profile.education)
-        expect(preview_card["created_at"]).to eq(profile.created_at.utc.iso8601)
+        expect(preview_card["created_at"]).to eq(user.created_at.utc.iso8601)
       end
 
       it "has the correct card color" do
@@ -117,7 +117,7 @@ RSpec.describe "ProfilePreviewCards", type: :request do
         expect(preview_card["work"]).to eq(profile.work)
         expect(preview_card["location"]).to eq(profile.location)
         expect(preview_card["education"]).to eq(profile.education)
-        expect(preview_card["created_at"]).to eq(profile.created_at.utc.iso8601)
+        expect(preview_card["created_at"]).to eq(user.created_at.utc.iso8601)
       end
 
       it "has the correct card color" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Update the test cases to assert the profile preview is showing the
user's `created_at` timestamp, not the profile's.

This matches what happens for the [html preview](https://github.com/forem/forem/blob/main/app/views/shared/_profile_card_content.html.erb#L55-L62) where "Joined" is the user's
created_at timestamp, and what the [json builder](https://github.com/forem/forem/blob/main/app/views/profile_preview_cards/show.json.jbuilder#L14) does:

    json.created_at utc_iso_timestamp(@user.created_at)


Since these are almost always the same thing, we didn't notice
this. However, if a user is created just before the second boundary,
and their profile created immediately after the second boundary (so
that the iso8601 values have distinct seconds) this could fail when
looking at the wrong objects timestamp.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

To test this locally I modified the user let block to update the
timestamp to be a day earlier (this would not have happened in
practice but was sufficient to cover the use case).

     let(:user) { create(:profile).user.tap {|u| u.update(created_at: 1.day.ago) } }

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: bugfix in the test case.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
