### PR TITLE
[15 min fix] Initialize follow buttons on comment index page

### DIFF
--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -42,7 +42,7 @@
   <% end %>
 <% end %>
 
-<%= javascript_packs_with_chunks_tag "commentDropdowns", defer: true %>
+<%= javascript_packs_with_chunks_tag "commentDropdowns", "followButtons", defer: true %>
 
 <div class="crayons-layout crayons-layout--limited-l gap-0">
   <% if @commentable.class.name == "Article" %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -44,7 +44,7 @@
 
 <%= javascript_packs_with_chunks_tag "commentDropdowns", "followButtons", defer: true %>
 
-<div class="crayons-layout crayons-layout--limited-l gap-0">
+<div class="crayons-layout crayons-layout--limited-l gap-0" data-follow-button-container="true">
   <% if @commentable.class.name == "Article" %>
     <%= render "shared/payment_pointer", user: @commentable.user %>
     <span id="comment-article-indicator" data-article-id="<%= @commentable.id %>"></span>
@@ -159,5 +159,6 @@
   <%== YoutubeTag.script %>
   <%== PodcastTag.script %>
   <%== GistTag.script %>
+  <%== RunkitTag.script %>
 </script>
 <%== TwitterTimelineTag.script %>

--- a/cypress/integration/seededFlows/articleFlows/viewArticleDiscussion.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/viewArticleDiscussion.spec.js
@@ -5,13 +5,12 @@ describe('View article discussion', () => {
 
     cy.get('@user').then((user) => {
       cy.loginAndVisit(user, '/admin_mcadmin/test-article-slug/comments');
+      // Make sure the page has loaded
+      cy.findByRole('heading', { name: 'Test article' });
     });
   });
 
   it('follows and unfollows a user from a comment preview card', () => {
-    // Make sure the page has loaded
-    cy.findByRole('link', { name: 'Read full post' });
-
     // Make sure the preview card is ready to be interacted with
     cy.get('[data-initialized]');
     cy.findByRole('button', { name: 'Admin McAdmin profile details' }).click();
@@ -27,5 +26,24 @@ describe('View article discussion', () => {
       cy.get('@userFollowButton').click();
       cy.get('@userFollowButton').should('have.text', 'Follow');
     });
+  });
+
+  it('initializes the follow button when a new comment is added', () => {
+    cy.findByRole('textbox', { name: 'Add a comment to the discussion' }).type(
+      'New comment',
+    );
+    cy.findByRole('button', { name: 'Submit' }).click();
+
+    cy.findByRole('button', {
+      name: 'Article Editor v1 User profile details',
+    }).as('previewButton');
+
+    // Make sure the newly added button is ready for interaction
+    cy.get('@previewButton').should('have.attr', 'data-initialized');
+    cy.get('@previewButton').click();
+
+    cy.findAllByTestId('profile-preview-card')
+      .first()
+      .findByRole('button', { name: 'Edit profile' });
   });
 });

--- a/cypress/integration/seededFlows/articleFlows/viewArticleDiscussion.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/viewArticleDiscussion.spec.js
@@ -1,0 +1,31 @@
+describe('View article discussion', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.fixture('users/articleEditorV1User.json').as('user');
+
+    cy.get('@user').then((user) => {
+      cy.loginAndVisit(user, '/admin_mcadmin/test-article-slug/comments');
+    });
+  });
+
+  it('follows and unfollows a user from a comment preview card', () => {
+    // Make sure the page has loaded
+    cy.findByRole('link', { name: 'Read full post' });
+
+    // Make sure the preview card is ready to be interacted with
+    cy.get('[data-initialized]');
+    cy.findByRole('button', { name: 'Admin McAdmin profile details' }).click();
+
+    cy.findByTestId('profile-preview-card').within(() => {
+      cy.findByRole('button', { name: 'Follow' }).as('userFollowButton');
+      cy.get('@userFollowButton').click();
+
+      // Confirm the follow button has been updated
+      cy.get('@userFollowButton').should('have.text', 'Following');
+
+      // Repeat and check the button changes back to 'Follow'
+      cy.get('@userFollowButton').click();
+      cy.get('@userFollowButton').should('have.text', 'Follow');
+    });
+  });
+});

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -342,6 +342,7 @@ seeder.create_if_doesnt_exist(Article, "title", "Test article") do
     featured: true,
     show_comments: true,
     user_id: admin_user.id,
+    slug: "test-article-slug",
   )
 
   comment_attributes = {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When I merged the work to refactor follow buttons (https://github.com/forem/forem/pull/14246), I missed a page that needed the new `followButtons` pack. This PR adds the pack to the comments index page, and adds an E2E test to make sure that functionality doesn't regress.

## Related Tickets & Documents

Fixes #14415

## QA Instructions, Screenshots, Recordings

- Visit an article with comments, and add `/comments` onto the end of the URL to view the comments index page
- Hover or click on a comment author name and click the "Follow" button
- Check the UI updates to "Following"
- Refresh the page, and check the same author's preview card, making sure that the "Following" state is still reflected
- Click the button again to unfollow, and repeat the previous steps to make sure the UI changes back to "Follow" and persists on reload
- Add a new comment to the discussion
- Check that when you hover your username, the "Follow" button says "Edit profile"

### UI accessibility concerns?

Accessibility of this work was tested under the PRs which introduced the UI. This just rolls out the same behaviour to the new page.

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Bugs bunny patching up a hole with bricks](https://media.giphy.com/media/PpF1xUyl56jMk/giphy.gif)
