### PR TITLE
Separate -v and -z into two separate commands

### DIFF
--- a/scripts/build_containers.sh
+++ b/scripts/build_containers.sh
@@ -139,7 +139,7 @@ function create_release_containers {
 
   # If the env var for the git tag doesn't exist or is an empty string, then we
   # won't build a container image for a cut release.
-  if [ -v BUILDKITE_TAG || ! -z "${BUILDKITE_TAG}" ]; then
+  if [ -v BUILDKITE_TAG ] || [ ! -z "${BUILDKITE_TAG}" ]; then
     docker build --target production \
                  --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":builder \
                  --cache-from="${CONTAINER_REPO}"/"${CONTAINER_APP}":production \


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The container build script [is failing](https://buildkite.com/forem/build-containers/builds/6845#5a2cbc5d-f610-4bba-9238-2bb2ff51e437/128-5448) because apparently we can't run `-v` and `-z` inside the same `[ ... ]` expression. Somehow we missed this before merging the versioning branch.

<img width="591" alt="Screenshot of the Buildkite failure at the above link" src="https://user-images.githubusercontent.com/108205/128241274-646dfdae-cd11-4406-a8a0-9cc0969c36c9.png">

## QA Instructions, Screenshots, Recordings

- Buildkite builds pass on [this branch](https://buildkite.com/forem/build-containers/builds?branch=fix-container-build-script)

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: if the container builds, we're in business
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: We aren't relying on it at the moment and I'm the one that broke it in the first place.

## [optional] What gif best describes this PR or how it makes you feel?

![Oops I did it again](https://media.tenor.com/images/593daf05dedef31642140cc002fa0bcd/tenor.gif)
