### PR TITLE
Fix readline key bindings for comments on macOS

### DIFF
--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -410,7 +410,14 @@ var KEY_CODE_K = 75;
 var ENTER_KEY_CODE = 13;
 
 function handleKeyDown(event) {
-  if (event.ctrlKey || event.metaKey) {
+  var modifier;
+  if (navigator.userAgent.indexOf('Mac OS X') != -1) {
+    modifier = event.metaKey;
+  } else {
+    modifier = event.ctrlKey;
+  }
+
+  if (modifier) {
     switch (event.keyCode) {
       case KEY_CODE_B:
         event.preventDefault();

--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -410,14 +410,7 @@ var KEY_CODE_K = 75;
 var ENTER_KEY_CODE = 13;
 
 function handleKeyDown(event) {
-  var modifier;
-  if (navigator.userAgent.indexOf('Mac OS X') != -1) {
-    modifier = event.metaKey;
-  } else {
-    modifier = event.ctrlKey;
-  }
-
-  if (modifier) {
+  if (Runtime.hasOSSpecificModifier(event)) {
     switch (event.keyCode) {
       case KEY_CODE_B:
         event.preventDefault();

--- a/app/assets/javascripts/initializers/runtime.js
+++ b/app/assets/javascripts/initializers/runtime.js
@@ -133,4 +133,19 @@ class Runtime {
       }
     });
   }
+
+  /**
+   * Returns true if the supplied KeyboardEvent includes the OS-specific
+   * modifier key. For example, the Cmd key on Apple platforms or the Ctrl key
+   * on others.
+   *
+   * @param {KeyboardEvent} The event to check for the OS-specific modifier key
+   *
+   * @returns {Boolean} true if the event was fired with the OS-specific
+   *                    modifier key, false otherwise. Also returns false if
+   *                    the event is not a KeyboardEvent.
+   */
+  static hasOSSpecificModifier(event) {
+    return navigator.userAgent.indexOf('Mac OS X') != -1;
+  }
 }

--- a/app/assets/javascripts/initializers/runtime.js
+++ b/app/assets/javascripts/initializers/runtime.js
@@ -146,6 +146,10 @@ class Runtime {
    *                    the event is not a KeyboardEvent.
    */
   static hasOSSpecificModifier(event) {
-    return navigator.userAgent.indexOf('Mac OS X') != -1;
+    if (navigator.userAgent.indexOf('Mac OS X') != -1) {
+      return event.metaKey;
+    } else {
+      return event.ctrlKey;
+    }
   }
 }

--- a/app/assets/javascripts/initializers/runtime.js
+++ b/app/assets/javascripts/initializers/runtime.js
@@ -146,7 +146,11 @@ class Runtime {
    *                    the event is not a KeyboardEvent.
    */
   static hasOSSpecificModifier(event) {
-    if (navigator.userAgent.indexOf('Mac OS X') != -1) {
+    if (!(event instanceof KeyboardEvent)) {
+      return false;
+    }
+
+    if (navigator.userAgent.indexOf('Mac OS X') >= 0) {
       return event.metaKey;
     } else {
       return event.ctrlKey;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In #5034 @JoshCheek pointed out that `readline` keybindings (supported in all web and native text inputs on macOS) are broken in the Forem editor on macOS because we treat Ctrl and Cmd keyboard modifiers as equivalent. This sort of native functionality of the browser [should be respected](http://jgaskins.org/blog/2016/07/30/don-t-change-perceived-browser-functionality).

Josh's suggested solution was to check the return value of `navigator.platform`, which sounded like a much better idea than user-agent sniffing, but unfortunately [it's been deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform), so this PR implements it in terms of user-agent sniffing.

<img width="948" alt="Screenshot from the Mozilla Developer Network: Navigator.platform is deprecated" src="https://user-images.githubusercontent.com/108205/128371939-83dfec07-b0e0-4661-8e36-1f947d80e460.png">

## Related Tickets & Documents

- https://github.com/forem/forem/issues/5034

## QA Instructions, Screenshots, Recordings

To see current behavior:

- Head to the DEV homepage on a Mac
- Click the top post
- Scroll to the reply box (or hit Tab 10x or so)
- Type "hello" and press Ctrl-B — you will get `hello**<cursor>**`

To verify new behavior:

- Checkout this PR on your machine (`gh pr checkout 14423` with [the GitHub CLI](https://cli.github.com/)) and load the Rails server
- Head to http://localhost:3000 on a Mac
- Click the top post
- Scroll to the reply box (or hit Tab 10x or so)
- Type "hello" and press Ctrl-B — you will get `hell<cursor>o`, which is expected behavior when `readline` keybindings are being respected.
- Move the cursor back to the end of the line and press Cmd-B — you will get `hello**<cursor>**`

### UI accessibility concerns?

- I'm not sure.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

There are several other places in the app that may need to be updated with this functionality, which may involve extracting this check to a utility function.

<details>
<summary>Results of searching for <code>metaKey</code> in the app</summary>

```
➜  forem git:(fix-readline-key-bindings-on-mac-os) ✗ ag ctrlKey app
app/javascript/chat/chat.jsx
951:      e.ctrlKey ||

app/javascript/articles/Article.jsx
68:            if (event.which > 1 || event.metaKey || event.ctrlKey) {

app/javascript/articles/components/CommentListItem.jsx
16:      if (_event.which > 1 || _event.metaKey || _event.ctrlKey) {

app/javascript/shared/components/useKeyboardShortcuts.js
130:      const keys = `${e.ctrlKey || e.metaKey ? 'ctrl+' : ''}${
132:      }${(e.ctrlKey || e.metaKey || e.altKey) && e.shiftKey ? 'shift+' : ''}`;

app/javascript/Search/Search.jsx
73:    return event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;

app/assets/javascripts/base.js.erb
286:      if (e.which > 1 || e.metaKey || e.ctrlKey) { // Opening in new tab

app/assets/javascripts/initializers/initializeCommentsPage.js.erb
417:    modifier = event.ctrlKey;
```

</details>

## [optional] What gif best describes this PR or how it makes you feel?

![Control](https://www.gamerroof.com/wp-content/uploads/2019/05/Control-Full-Version-Free-Download.jpg)
