### PR TITLE
Only define store_attributes if Profile doesn't already have a method defined

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -31,6 +31,7 @@ class Profile < ApplicationRecord
       # fields are dropped from production and the associated data is removed.
       # https://github.com/forem/forem/pull/13641#discussion_r637641185
       next if STATIC_FIELDS.any?(field.attribute_name)
+      next if method_defined?(field.attribute_name)
 
       store_attribute :data, field.attribute_name.to_sym, field.type
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When running tests in CI (using KnapsackPro in Queue mode) RSpec is run multiple times. Each time we call Profile.refresh_attributes! additional delegations are added to the data attribute (visible via  `@attributes['data'].type` which becomes a tower of ActiveRecord::Type::TypedStore objects, delegating to the next in line.

We start failing once there are a few thousand of these with SystemStackError messages (the specific paths vary, but printing the fields from a profile usually are sufficient).

I was able to test this using some temporary code to demonstrate that (1) calling `Profile.refresh_attributes!` adds to the nested depth of the store attribute delegation list, by the number of ProfileFields present in the database at that time, (2) spec_helper calls refresh_attributes! after running the ProfileFields::ImportFromCsv, causing each invocation of RSpec to increase the depth by 6 when running tests.

This change asks Profile if there is already a defined accessor for this symbol, and skips storing it.

I believe this will cause issues when we have modifications to an existing profile field's type (if we changed from string to number for example?) - I am looking to see if there's a cleaner way to reset the data attribute's delegation completely in refresh_attributes (this also has the benefit of undefining any methods that were associated with profile fields that have been removed if the ProfileFields::Remove service was not used). 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?


## [optional] What gif best describes this PR or how it makes you feel?

![nesting-dolls](https://user-images.githubusercontent.com/1237369/128553270-5f116b36-29bd-4659-8cca-4eb4008fe726.jpg)
