### PR TITLE
Remove button from allowed tags

### DIFF
--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -4,7 +4,7 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
     super
 
     self.tags = %w[
-      a abbr add b blockquote br button center cite code col colgroup dd del dl dt em figcaption
+      a abbr add b blockquote br center cite code col colgroup dd del dl dt em figcaption
       h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
       tbody td tfoot th thead time tr u ul video
     ]

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     expect(generate_and_parse_markdown(code_block)).to include("{% raw %}", "{% endraw %}")
   end
 
+  it "does not allow button tag" do
+    button = "<button>no</button>"
+    expect(generate_and_parse_markdown(button)).not_to include("button")
+  end
+
   it "does not render the escaped dashes when using a `raw` Liquid tag in codeblocks with syntax highlighting" do
     code_block = "```js\n{% raw %}some text{% endraw %}\n```"
     expect(generate_and_parse_markdown(code_block)).not_to include("----")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug fix

## Description
I don't recall why we are allowing button tag on markdown. I would think this is just an oversight.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a