### PR TITLE
[15-minute fix] Add `created_at` to listings API response

### DIFF
--- a/app/controllers/api/v0/listings_controller.rb
+++ b/app/controllers/api/v0/listings_controller.rb
@@ -18,7 +18,7 @@ module Api
       # actual column name for the listing category, prefixed with classified_.
       ATTRIBUTES_FOR_SERIALIZATION = %i[
         id user_id organization_id title slug body_markdown cached_tag_list
-        classified_listing_category_id processed_html published
+        classified_listing_category_id processed_html published created_at
       ].freeze
       private_constant :ATTRIBUTES_FOR_SERIALIZATION
 

--- a/app/controllers/api/v0/organizations_controller.rb
+++ b/app/controllers/api/v0/organizations_controller.rb
@@ -17,7 +17,7 @@ module Api
 
       LISTINGS_FOR_SERIALIZATION = %i[
         id user_id organization_id title slug body_markdown cached_tag_list
-        classified_listing_category_id processed_html published
+        classified_listing_category_id processed_html published created_at
       ].freeze
       private_constant :LISTINGS_FOR_SERIALIZATION
 

--- a/app/views/api/v0/shared/_listing.json.jbuilder
+++ b/app/views/api/v0/shared/_listing.json.jbuilder
@@ -14,3 +14,4 @@ json.extract!(
 json.listing_category_id listing.classified_listing_category_id
 json.tag_list            listing.cached_tag_list
 json.tags                listing.tag_list
+json.created_at          utc_iso_timestamp(listing.created_at)

--- a/spec/requests/api/v0/listings_spec.rb
+++ b/spec/requests/api/v0/listings_spec.rb
@@ -106,6 +106,13 @@ RSpec.describe "Api::V0::Listings", type: :request do
       get api_listings_path
       expect(response.parsed_body.detect { |l| l["published"] == false }).to be_nil
     end
+
+    # Regression test for https://github.com/forem/forem/issues/14436
+    it "includes the created at timestamp for listings" do
+      get api_listings_path
+      listing = response.parsed_body.first
+      expect(listing["created_at"]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/)
+    end
   end
 
   describe "GET /api/listings/category/:category" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Our API docs specify that listings responses will include a `created_at` attribute but that was not the case.

## Related Tickets & Documents

Closes #14436

## QA Instructions, Screenshots, Recordings

Tests should be sufficient. For manual testing make an API request to the listings endpoint and ensure that the `created_at` attribute is present.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Minor change in API response