### PR TITLE
increase ruby stack depth in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ addons:
 env:
   global:
     - RAILS_ENV=test
+    - RUBY_THREAD_VM_STACK_SIZE=5242880
     - DATABASE_URL=postgres://travis@localhost:5433/Forem_prod_test
     - DATABASE_NAME=Forem_prod_test
     - DATABASE_URL_TEST=postgres://travis@localhost:5433/Forem_test


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

From the discussion at https://github.com/forem/forem/pull/14433#issuecomment-894947918 - raise the ruby vm stack depth from default 1MB to 5MB. This was tested against the worse-than-worst case scenario of a single CI node running each spec file individually in Knapsack Queue mode - while it did fail eventually with stack level errors, it made it through all but the last few system tests successfully (roughly 2-2.5x as many rspec runs as we see in failing cases currently).

This should alleviate any SystemStackErrors seen in travis for a substantial period of time.

## Related Tickets & Documents

#14433 was an alternate suggestion to prevent the stack from growing (with only partially considered impact on correctness).


## QA Instructions, Screenshots, Recordings

While it _is_ possible to test this, the setup is non-obvious. My local work-around to demonstrate the behavior involves changing the KnapsackPro::Client::Connection to just return items from a static list, a reasonable reproduction would read from a file, then invoke/call the rake task each queue group (basically what knapsack pro is doing, without the client or timing or reporting). 

My worst case test was each spec file in `spec/**/*_spec.rb` was called individually. That situation did still overrun the system stack (Profile's stored attributes in `:data` is a tower of delegations, and grows in depth each time the Import from CSV code is run). 

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: change to test configuration
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: Change to test setup only

