### PR TITLE
Handle users in Reaction#skip_notifications_for

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -66,7 +66,14 @@ class Reaction < ApplicationRecord
   # - receiver is the same user as the one who reacted
   # - receive_notification is disabled
   def skip_notification_for?(_receiver)
-    points.negative? || (user_id == reactable.user_id)
+    reactor_id = case reactable
+                 when User
+                   reactable.id
+                 else
+                   reactable.user_id
+                 end
+
+    points.negative? || (user_id == reactor_id)
   end
 
   def vomit_on_user?

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -125,6 +125,21 @@ RSpec.describe Reaction, type: :model do
         expect(reaction.skip_notification_for?(user)).to be(true)
       end
     end
+
+    context "when reactable is a user" do
+      let(:user) { create(:user) }
+      let(:reaction) { build(:reaction, reactable: user, user: nil) }
+
+      it "returns true if the reactable is the user that reacted" do
+        reaction.user_id = user.id
+        expect(reaction.skip_notification_for?(receiver)).to be(true)
+      end
+
+      it "returns false if the reactable is not the user that reacted" do
+        reaction.user_id = create(:user).id
+        expect(reaction.skip_notification_for?(receiver)).to be(false)
+      end
+    end
   end
 
   describe ".count_for_article" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This method previously assumed that a reaction's `reactable` had a `user_id` attribute, but if the reactable was a User, it wouldn't have a `user_id`. The user id would just be `reactable.id`.

## Related Tickets & Documents

- https://app.honeybadger.io/projects/66984/faults/80839653#notice-params

## QA Instructions, Screenshots, Recordings

~~We aren't even sure how this is happening. According to @djuber it's not happening for him locally.~~

Turns out it's because both creating a reaction and deleting it go through [the same endpoint](https://github.com/forem/forem/blob/a24dee8e46a1b15911f879fb499882706fa54e41/app/controllers/reactions_controller.rb#L75-L77), so adding a reaction to a user and then taking that reaction back should reproduce the problem on `main`, but not on this branch.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

Probably gonna cry a little bit