### PR TITLE
Optimize tagged articles under feature flag

### DIFF
--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -28,7 +28,17 @@ module Articles
       end
 
       def published_articles_by_tag
-        articles = @tag.present? ? Tag.find_by(name: @tag).articles : Article
+        articles =
+          if @tag.present?
+            if FeatureFlag.enabled?(:optimize_article_tag_query)
+              Article.cached_tagged_with_any(@tag)
+            else
+              Tag.find_by(name: @tag).articles
+            end
+          else
+            Article.all
+          end
+
         articles.published.limited_column_select
           .includes(top_comments: :user)
           .page(@page).per(@number_of_articles)

--- a/spec/requests/stories/tagged_articles_spec.rb
+++ b/spec/requests/stories/tagged_articles_spec.rb
@@ -1,216 +1,224 @@
 require "rails_helper"
 
 RSpec.describe "Stories::TaggedArticlesIndex", type: :request do
-  describe "GET /tag/:tag" do
-    let(:user) { create(:user) }
-    let(:tag) { create(:tag) }
-    let(:org) { create(:organization) }
-
-    def create_live_sponsor(org, tag)
-      create(
-        :sponsorship,
-        level: :tag,
-        blurb_html: "<p>Oh Yeah!!!</p>",
-        status: "live",
-        organization: org,
-        sponsorable: tag,
-        expires_at: 30.days.from_now,
-      )
-    end
-
-    context "with caching headers" do
-      it "renders page and sets proper headers", :aggregate_failures do
-        get "/t/#{tag.name}"
-
-        renders_page
-        sets_fastly_headers
-        sets_nginx_headers
-      end
-
-      def renders_page
-        expect(response.status).to eq(200)
-        expect(response.body).to include(tag.name)
-      end
-
-      def sets_fastly_headers
-        expected_cache_control_headers = %w[public no-cache]
-        expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
-
-        expected_surrogate_control_headers = %w[max-age=600 stale-while-revalidate=30 stale-if-error=86400]
-        expect(response.headers["Surrogate-Control"].split(", ")).to match_array(expected_surrogate_control_headers)
-
-        expected_surrogate_key_headers = %W[articles-#{tag}]
-        expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
-      end
-
-      def sets_nginx_headers
-        expect(response.headers["X-Accel-Expires"]).to eq("600")
-      end
-    end
-
-    it "renders page with top/week etc." do
-      get "/t/#{tag.name}/top/week"
-      expect(response.body).to include(tag.name)
-      get "/t/#{tag.name}/top/month"
-      expect(response.body).to include(tag.name)
-      get "/t/#{tag.name}/top/year"
-      expect(response.body).to include(tag.name)
-      get "/t/#{tag.name}/top/infinity"
-      expect(response.body).to include(tag.name)
-    end
-
-    it "renders tag after alias change" do
-      tag2 = create(:tag, alias_for: tag.name)
-      get "/t/#{tag2.name}"
-      expect(response.body).to redirect_to "/t/#{tag.name}"
-      expect(response).to have_http_status(:moved_permanently)
-    end
-
-    it "does not render sponsor if not live" do
-      sponsorship = create(
-        :sponsorship, level: :tag, tagline: "Oh Yeah!!!", status: "pending", organization: org, sponsorable: tag
-      )
-
-      get "/t/#{tag.name}"
-      expect(response.body).not_to include("is sponsored by")
-      expect(response.body).not_to include(sponsorship.tagline)
-    end
-
-    it "renders live sponsor" do
-      sponsorship = create_live_sponsor(org, tag)
-      get "/t/#{tag.name}"
-      expect(response.body).to include("is sponsored by")
-      expect(response.body).to include(sponsorship.blurb_html)
-    end
-
-    it "shows meta keywords if set" do
-      allow(Settings::General).to receive(:meta_keywords).and_return({ tag: "software engineering, ruby" })
-      get "/t/#{tag.name}"
-      expect(response.body).to include("<meta name=\"keywords\" content=\"software engineering, ruby, #{tag.name}\">")
-    end
-
-    it "does not show meta keywords if not set" do
-      allow(Settings::General).to receive(:meta_keywords).and_return({ tag: "" })
-      get "/t/#{tag.name}"
-      expect(response.body).not_to include(
-        "<meta name=\"keywords\" content=\"software engineering, ruby, #{tag.name}\">",
-      )
-    end
-
-    context "with user signed in" do
+  %i[enable disable].each do |method|
+    context "when :optimize_article_tag_query is #{method}d" do
       before do
-        sign_in user
+        FeatureFlag.public_send method, :optimize_article_tag_query
       end
 
-      it "shows tags and renders properly", :aggregate_failures do
-        get "/t/#{tag.name}"
-        expect(response.body).to include("crayons-tabs__item crayons-tabs__item--current")
-        has_mod_action_button
-        does_not_paginate
-        sets_remember_token
-      end
+      describe "GET /tag/:tag" do
+        let(:user) { create(:user) }
+        let(:tag) { create(:tag) }
+        let(:org) { create(:organization) }
 
-      def has_mod_action_button
-        expect(response.body).to include('class="crayons-btn crayons-btn--outlined mod-action-button fs-s"')
-      end
+        def create_live_sponsor(org, tag)
+          create(
+            :sponsorship,
+            level: :tag,
+            blurb_html: "<p>Oh Yeah!!!</p>",
+            status: "live",
+            organization: org,
+            sponsorable: tag,
+            expires_at: 30.days.from_now,
+          )
+        end
 
-      def does_not_paginate
-        expect(response.body).not_to include('<span class="olderposts-pagenumber">')
-      end
+        context "with caching headers" do
+          it "renders page and sets proper headers", :aggregate_failures do
+            get "/t/#{tag.name}"
 
-      def sets_remember_token
-        expect(response.cookies["remember_user_token"]).not_to be nil
-      end
+            renders_page
+            sets_fastly_headers
+            sets_nginx_headers
+          end
 
-      it "renders properly even if site config is private" do
-        allow(Settings::UserExperience).to receive(:public).and_return(false)
-        get "/t/#{tag.name}"
-        expect(response.body).to include("crayons-tabs__item crayons-tabs__item--current")
-      end
+          def renders_page
+            expect(response.status).to eq(200)
+            expect(response.body).to include(tag.name)
+          end
 
-      it "does not render pagination even with many posts" do
-        create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
-        get "/t/#{tag.name}"
-        expect(response.body).not_to include('<span class="olderposts-pagenumber">')
-      end
-    end
+          def sets_fastly_headers
+            expected_cache_control_headers = %w[public no-cache]
+            expect(response.headers["Cache-Control"].split(", ")).to match_array(expected_cache_control_headers)
 
-    context "without user signed in" do
-      let(:tag) { create(:tag) }
+            expected_surrogate_control_headers = %w[max-age=600 stale-while-revalidate=30 stale-if-error=86400]
+            expect(response.headers["Surrogate-Control"].split(", ")).to match_array(expected_surrogate_control_headers)
 
-      it "renders tag index properly with many posts", :aggregate_failures do
-        stub_const("Stories::TaggedArticlesController::SIGNED_OUT_RECORD_COUNT", 10)
-        create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
-        get "/t/#{tag.name}"
+            expected_surrogate_key_headers = %W[articles-#{tag}]
+            expect(response.headers["Surrogate-Key"].split(", ")).to match_array(expected_surrogate_key_headers)
+          end
 
-        shows_sign_in_notice
-        does_not_include_current_page_link(tag)
-        does_not_set_remember_token
-        renders_pagination
-      end
+          def sets_nginx_headers
+            expect(response.headers["X-Accel-Expires"]).to eq("600")
+          end
+        end
 
-      def shows_sign_in_notice
-        expect(response.body).not_to include("crayons-tabs__item crayons-tabs__item--current")
-        expect(response.body).to include("for the ability sort posts by")
-      end
+        it "renders page with top/week etc." do
+          get "/t/#{tag.name}/top/week"
+          expect(response.body).to include(tag.name)
+          get "/t/#{tag.name}/top/month"
+          expect(response.body).to include(tag.name)
+          get "/t/#{tag.name}/top/year"
+          expect(response.body).to include(tag.name)
+          get "/t/#{tag.name}/top/infinity"
+          expect(response.body).to include(tag.name)
+        end
 
-      def does_not_include_current_page_link(tag)
-        expect(response.body).to include('<span class="olderposts-pagenumber">1')
-        expect(response.body).not_to include("<a href=\"/t/#{tag.name}/page/1")
-        expect(response.body).not_to include("<a href=\"/t/#{tag.name}/page/3")
-      end
+        it "renders tag after alias change" do
+          tag2 = create(:tag, alias_for: tag.name)
+          get "/t/#{tag2.name}"
+          expect(response.body).to redirect_to "/t/#{tag.name}"
+          expect(response).to have_http_status(:moved_permanently)
+        end
 
-      def does_not_set_remember_token
-        expect(response.cookies["remember_user_token"]).to be nil
-      end
+        it "does not render sponsor if not live" do
+          sponsorship = create(
+            :sponsorship, level: :tag, tagline: "Oh Yeah!!!", status: "pending", organization: org, sponsorable: tag
+          )
 
-      def renders_pagination
-        expect(response.body).to include('<span class="olderposts-pagenumber">')
-      end
+          get "/t/#{tag.name}"
+          expect(response.body).not_to include("is sponsored by")
+          expect(response.body).not_to include(sponsorship.tagline)
+        end
 
-      it "renders tag index without pagination when not needed" do
-        get "/t/#{tag.name}"
+        it "renders live sponsor" do
+          sponsorship = create_live_sponsor(org, tag)
+          get "/t/#{tag.name}"
+          expect(response.body).to include("is sponsored by")
+          expect(response.body).to include(sponsorship.blurb_html)
+        end
 
-        expect(response.body).not_to include('<span class="olderposts-pagenumber">')
-      end
+        it "shows meta keywords if set" do
+          allow(Settings::General).to receive(:meta_keywords).and_return({ tag: "software engineering, ruby" })
+          get "/t/#{tag.name}"
+          expect(response.body).to include("<meta name=\"keywords\" content=\"software engineering, ruby, #{tag.name}\">")
+        end
 
-      it "does not include sidebar for page tag" do
-        create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
-        get "/t/#{tag.name}/page/2"
-        expect(response.body).not_to include('<div id="sidebar-wrapper-right"')
-      end
+        it "does not show meta keywords if not set" do
+          allow(Settings::General).to receive(:meta_keywords).and_return({ tag: "" })
+          get "/t/#{tag.name}"
+          expect(response.body).not_to include(
+            "<meta name=\"keywords\" content=\"software engineering, ruby, #{tag.name}\">",
+          )
+        end
 
-      it "renders proper page 1", :aggregate_failures do
-        create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
-        get "/t/#{tag.name}/page/1"
+        context "with user signed in" do
+          before do
+            sign_in user
+          end
 
-        renders_title(tag)
-        renders_canonical_url(tag)
-      end
+          it "shows tags and renders properly", :aggregate_failures do
+            get "/t/#{tag.name}"
+            expect(response.body).to include("crayons-tabs__item crayons-tabs__item--current")
+            has_mod_action_button
+            does_not_paginate
+            sets_remember_token
+          end
 
-      def renders_title(tag)
-        expect(response.body).to include("<title>#{tag.name.capitalize} - ")
-      end
+          def has_mod_action_button
+            expect(response.body).to include('class="crayons-btn crayons-btn--outlined mod-action-button fs-s"')
+          end
 
-      def renders_canonical_url(tag)
-        expect(response.body).to include("<link rel=\"canonical\" href=\"http://localhost:3000/t/#{tag.name}\" />")
-      end
+          def does_not_paginate
+            expect(response.body).not_to include('<span class="olderposts-pagenumber">')
+          end
 
-      it "renders proper page 2", :aggregate_failures do
-        create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
-        get "/t/#{tag.name}/page/2"
+          def sets_remember_token
+            expect(response.cookies["remember_user_token"]).not_to be nil
+          end
 
-        renders_page_2_title(tag)
-        renders_page_2_canonical_url(tag)
-      end
+          it "renders properly even if site config is private" do
+            allow(Settings::UserExperience).to receive(:public).and_return(false)
+            get "/t/#{tag.name}"
+            expect(response.body).to include("crayons-tabs__item crayons-tabs__item--current")
+          end
 
-      def renders_page_2_title(tag)
-        expect(response.body).to include("<title>#{tag.name.capitalize} Page 2 - ")
-      end
+          it "does not render pagination even with many posts" do
+            create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
+            get "/t/#{tag.name}"
+            expect(response.body).not_to include('<span class="olderposts-pagenumber">')
+          end
+        end
 
-      def renders_page_2_canonical_url(tag)
-        expected_tag = "<link rel=\"canonical\" href=\"http://localhost:3000/t/#{tag.name}/page/2\" />"
-        expect(response.body).to include(expected_tag)
+        context "without user signed in" do
+          let(:tag) { create(:tag) }
+
+          it "renders tag index properly with many posts", :aggregate_failures do
+            stub_const("Stories::TaggedArticlesController::SIGNED_OUT_RECORD_COUNT", 10)
+            create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
+            get "/t/#{tag.name}"
+
+            shows_sign_in_notice
+            does_not_include_current_page_link(tag)
+            does_not_set_remember_token
+            renders_pagination
+          end
+
+          def shows_sign_in_notice
+            expect(response.body).not_to include("crayons-tabs__item crayons-tabs__item--current")
+            expect(response.body).to include("for the ability sort posts by")
+          end
+
+          def does_not_include_current_page_link(tag)
+            expect(response.body).to include('<span class="olderposts-pagenumber">1')
+            expect(response.body).not_to include("<a href=\"/t/#{tag.name}/page/1")
+            expect(response.body).not_to include("<a href=\"/t/#{tag.name}/page/3")
+          end
+
+          def does_not_set_remember_token
+            expect(response.cookies["remember_user_token"]).to be nil
+          end
+
+          def renders_pagination
+            expect(response.body).to include('<span class="olderposts-pagenumber">')
+          end
+
+          it "renders tag index without pagination when not needed" do
+            get "/t/#{tag.name}"
+
+            expect(response.body).not_to include('<span class="olderposts-pagenumber">')
+          end
+
+          it "does not include sidebar for page tag" do
+            create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
+            get "/t/#{tag.name}/page/2"
+            expect(response.body).not_to include('<div id="sidebar-wrapper-right"')
+          end
+
+          it "renders proper page 1", :aggregate_failures do
+            create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
+            get "/t/#{tag.name}/page/1"
+
+            renders_title(tag)
+            renders_canonical_url(tag)
+          end
+
+          def renders_title(tag)
+            expect(response.body).to include("<title>#{tag.name.capitalize} - ")
+          end
+
+          def renders_canonical_url(tag)
+            expect(response.body).to include("<link rel=\"canonical\" href=\"http://localhost:3000/t/#{tag.name}\" />")
+          end
+
+          it "renders proper page 2", :aggregate_failures do
+            create_list(:article, 20, user: user, featured: true, tags: [tag.name], score: 20)
+            get "/t/#{tag.name}/page/2"
+
+            renders_page_2_title(tag)
+            renders_page_2_canonical_url(tag)
+          end
+
+          def renders_page_2_title(tag)
+            expect(response.body).to include("<title>#{tag.name.capitalize} Page 2 - ")
+          end
+
+          def renders_page_2_canonical_url(tag)
+            expected_tag = "<link rel=\"canonical\" href=\"http://localhost:3000/t/#{tag.name}/page/2\" />"
+            expect(response.body).to include(expected_tag)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The `Articles::Feeds::LargeForemExperimental` service queries articles under a given tag by traversing the relations via `tags`->`taggings`->`articles` using nested subqueries and `INNER JOIN`s. This may be slower than we'd like, so we're trying the [`Article.cached_tagged_with_any` scope](https://github.com/forem/forem/blob/a24dee8e46a1b15911f879fb499882706fa54e41/app/models/article.rb#L215-L228) to see if we can streamline that query since Postgres is often much faster at filtering a single relation than joining multiple relations and filtering them.

## Related Tickets & Documents

Unfortunately, neither of these are public 😕 

- [Slack conversation](https://forem-team.slack.com/archives/CPGJMAX5F/p1628539914025700?thread_ts=1628539235.023500&cid=CPGJMAX5F) 
- [Datadog trace for the `Stories::TaggedArticles#index` endpoint](https://app.datadoghq.com/apm/resource/practical_developer/rack.request/12440bd8fdb330da?query=env%3Aproduction%20service%3Apractical_developer%20operation_name%3Arack.request%20resource_name%3A%22Stories%3A%3ATaggedArticlesController%23index%22&env=production&event=AQAAAXss0s3wTrKc5gAAAABBWHNzMHRPMEFBRGRFNkstTXR1eGRXWW0&index=apm-search&spanID=637371830771085740&topGraphs=latency%3Alatency%2CbreakdownAs%3Apercentage%2Cerrors%3Aversion_count%2Chits%3Acount&traceID=2767134021394939110&start=1628543406349&end=1628547006349&paused=false)

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

- Enable feature flag
  - Visit https://dev.to/admin/feature_flags/features/optimize_article_tag_query
  - Click the green "Fully Enable" button
- Check above-linked Datadog traces from before and after the feature flag is enabled
  - If this is faster, submit a followup PR that removes the `else` clause of the feature flag check and reverts the change to the spec file in this PR.