### PR TITLE
[15-minute fix] Increase Ruby stack size for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ env:
     - KNAPSACK_PRO_CI_NODE_TOTAL=3
     - COVERAGE_REPORTS_TOTAL=4
     - FOREM_OWNER_SECRET="secret" # test secret so e2e tests can run properly.
+    - RUBY_THREAD_VM_STACK_SIZE=5242880
 before_install:
   - >-
     sudo sed -i


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Developer experience/CI

## Description

This PR is a result of the discussion in https://github.com/forem/forem/pull/14433: the way profiles currently work, repeated calls to `Profile.refresh_attributes!` can eventually lead to a `SystemStackError`. So far this has only happened on CI. To reduce the risk of failed builds while working on a proper fix we are temporarily increasing the Ruby VM's stack size from 1 to 5 MB.

## Related Tickets & Documents

https://github.com/forem/forem/pull/14433

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added/updated tests?

- [X] No, and this is why: only CI config changed

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
