### PR TITLE
Make header fields in profile preview card dynamic

### DIFF
--- a/app/views/profile_preview_cards/show.json.jbuilder
+++ b/app/views/profile_preview_cards/show.json.jbuilder
@@ -1,5 +1,3 @@
-# TODO: @citizen428 - We shouldn't use education and work directly here, since
-# we can't guarantee that these profile fields will exist on all Forems.
 json.extract!(
   @user.profile,
   :summary, :location
@@ -13,6 +11,7 @@ json.email @user.email if @user.setting.display_email_on_profile
 
 json.created_at utc_iso_timestamp(@user.created_at)
 
+# Dynamically add the information for the header fields (maximum of 3 fields)
 header_fields = @user.profile.decorate.ui_attributes_for(area: :header)
 header_fields.each do |title, value|
   json.set! title, value

--- a/app/views/profile_preview_cards/show.json.jbuilder
+++ b/app/views/profile_preview_cards/show.json.jbuilder
@@ -2,7 +2,7 @@
 # we can't guarantee that these profile fields will exist on all Forems.
 json.extract!(
   @user.profile,
-  :summary, :location, :education, :work
+  :summary, :location
 )
 
 json.card_color(
@@ -12,3 +12,8 @@ json.card_color(
 json.email @user.email if @user.setting.display_email_on_profile
 
 json.created_at utc_iso_timestamp(@user.created_at)
+
+header_fields = @user.profile.decorate.ui_attributes_for(area: :header)
+header_fields.each do |title, value|
+  json.set! title, value
+end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -12,7 +12,8 @@ FactoryBot.define do
         employer_name: "DEV",
         employer_url: "http://dev.to",
         employment_title: "Software Engineer",
-        skills_languages: "Ruby"
+        skills_languages: "Ruby",
+        work: "Forem"
       }
     end
     website_url { "http://example.com" }

--- a/spec/requests/profile_preview_cards_spec.rb
+++ b/spec/requests/profile_preview_cards_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "ProfilePreviewCards", type: :request do
-  let(:user) { create(:profile).user }
+  let(:user) { create(:profile, :with_DEV_info).user }
 
   describe "GET /:id" do
     context "when signed out" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

Currently, the JSON generated for the profile preview cards still relies on hard-coded `work` and `education` profile fields. This PR changes this to be dynamic, as described in [this comment](https://github.com/forem/forem/pull/14210#discussion_r674494314).

## Related Tickets & Documents

Profile generalization

## QA Instructions, Screenshots, Recordings

Existing tests should be green.

For manual tests:

* Make sure a user has `work` and `education` information in their profiles
* Start a local rails server
* Make a `GET` request to http://localhost:3000/profile_preview_cards/<user_id>.json. The returned JSON document should include the work and education keys and corresponding values.

### UI accessibility concerns?

n/a

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: implementation detail