### PR TITLE
Add horizontal padding on preview card trigger button

### DIFF
--- a/app/assets/javascripts/utilities/buildCommentHTML.js.erb
+++ b/app/assets/javascripts/utilities/buildCommentHTML.js.erb
@@ -46,15 +46,15 @@ function buildCommentHTML(comment) {
     <img class="crayons-avatar__image" width="32" height="32" src="${ comment.user.profile_pic }" alt="${ comment.user.username } profile" />
   </a>`;
 
-  commentHeader = `<div class="comment__header" >
+  commentHeader = `<div class="comment__header m:pl-1" >
     <a href="/${ comment.user.username }" class="crayons-link crayons-link--secondary flex items-center fw-medium m:hidden">
       <span class="js-comment-username">${ comment.user.name }</span>
     </a>
     <div class="profile-preview-card relative mb-4 s:mb-0 fw-medium hidden m:block">
-      <button id="comment-profile-preview-trigger-${comment.id}" aria-controls="comment-profile-preview-content-${comment.id}" class="profile-preview-card__trigger px-0 crayons-btn crayons-btn--ghost" aria-label="${comment.user.name} profile details">${comment.user.name}</button>
+      <button id="comment-profile-preview-trigger-${comment.id}" aria-controls="comment-profile-preview-content-${comment.id}" class="profile-preview-card__trigger px-2 crayons-btn crayons-btn--ghost" aria-label="${comment.user.name} profile details">${comment.user.name}</button>
       <span data-js-comment-user-id="${comment.user.id}" data-js-dropdown-content-id="comment-profile-preview-content-${comment.id}" class="preview-card-placeholder"></span>
     </div>
-    <span class="color-base-30 px-2" role="presentation">&bull;</span>
+    <span class="color-base-30 px-2 m:pl-0" role="presentation">&bull;</span>
 
     <a href="${ comment.url }" class="comment-date crayons-link crayons-link--secondary fs-s">
       <time datetime="${ comment.published_timestamp }">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -135,12 +135,12 @@
             <% end %>
 
             <div class="crayons-article__subheader">
-              <a href="/<%= @user.username %>" class="flex items-center mr-2 mb-4 s:mb-0 fw-medium crayons-link">
-                <span class="crayons-avatar crayons-avatar--l mr-2"><img class="crayons-avatar__image" src="<%= Images::Profile.call(@user.profile_image_url, length: 50) %>" alt="" /></span>
+              <a href="/<%= @user.username %>" class="flex items-center mr-2 m:mr-1 mb-4 s:mb-0 fw-medium crayons-link">
+                <span class="crayons-avatar crayons-avatar--l mr-2 m:mr-1"><img class="crayons-avatar__image" src="<%= Images::Profile.call(@user.profile_image_url, length: 50) %>" alt="" /></span>
                 <span class="block m:hidden"><%= @user.name %></span>
               </a>
-              <div class="profile-preview-card relative mr-4 mb-4 s:mb-0 fw-medium">
-                <button id="profile-preview-trigger" class="profile-preview-card__trigger px-0 crayons-btn crayons-btn--ghost hidden m:block" aria-label="<%= @user.name %> profile details"><%= @user.name %></button>
+              <div class="profile-preview-card relative mr-2 mb-4 s:mb-0 fw-medium">
+                <button id="profile-preview-trigger" class="profile-preview-card__trigger crayons-btn crayons-btn--ghost px-2 hidden m:block" aria-label="<%= @user.name %> profile details"><%= @user.name %></button>
                 <%= render "/shared/profile_preview_card", actor: @user, id: "profile-preview-content" %>
               </div>
 

--- a/app/views/comments/_comment_date.erb
+++ b/app/views/comments/_comment_date.erb
@@ -1,4 +1,4 @@
-<span class="color-base-30 px-2" role="presentation">&bull;</span>
+<span class="color-base-30 px-2 m:pl-0" role="presentation">&bull;</span>
 
 <a href="<%= URL.comment(decorated_comment) %>" class="comment-date crayons-link crayons-link--secondary fs-s">
   <time datetime="<%= decorated_comment.published_timestamp %>">

--- a/app/views/comments/_comment_header.html.erb
+++ b/app/views/comments/_comment_header.html.erb
@@ -1,4 +1,4 @@
-<div class="comment__header">
+<div class="comment__header m:pl-1">
   <a href="<%= URL.user(comment.user) %>" class="crayons-link crayons-link--secondary flex items-center fw-medium m:hidden">
     <span class="js-comment-username"><%= comment.user.name %></span>
     <% if commentable_author_is_op?(commentable, comment) %>
@@ -8,7 +8,7 @@
     <% end %>
   </a>
   <div class="profile-preview-card relative mb-4 s:mb-0 fw-medium hidden m:block">
-    <button id="comment-profile-preview-trigger-<%= comment.id %>" aria-controls="comment-profile-preview-content-<%= comment.id %>" class="profile-preview-card__trigger px-0 crayons-btn crayons-btn--ghost" aria-label="<%= comment.user.name %> profile details">
+    <button id="comment-profile-preview-trigger-<%= comment.id %>" aria-controls="comment-profile-preview-content-<%= comment.id %>" class="profile-preview-card__trigger px-2 crayons-btn crayons-btn--ghost" aria-label="<%= comment.user.name %> profile details">
       <%= comment.user.name %>
     </button>
     <%= render "/shared/profile_preview_card", actor: comment.user, id: "comment-profile-preview-content-#{comment.id}" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR tweaks the padding on preview card trigger buttons that are already in the codebase (comments, author byline). Previously they didn't have any horizontal padding which looked a bit off. For example:

<img width="613" alt="screenshot of an existing preview trigger button from forem.dev. A grey highlight is behind the hovered button, but the grey highlight only extends above and below the button text" src="https://user-images.githubusercontent.com/20773163/129018503-f4bf5016-f623-4e47-9e40-fa837ea729c3.png">

This PR makes adjustments to the padding of both the button and the surrounding elements where they are placed so that when unhovered it visually looks the same as before, and when hovered, there's a more conventional all-round padding on the element.

## Related Tickets & Documents

https://github.com/forem/rfcs/pull/222

## QA Instructions, Screenshots, Recordings

We need to check that the layouts look correct in both mobile (where not preview trigger button exists) and on desktop.

- Visit an article page, and hover over the author byline name. Check the button padding highlight looks OK. Check that when you're not hovering over it, the layout still looks as it did before.
- Repeat this process for an _existing_ comment on an article
- Add a _new_ comment to the article and repeat the check
- Go to the article's comment index page (`article_url/comments`) and repeat the same check

- On mobile, check these same locations in the app still look the same as before


https://user-images.githubusercontent.com/20773163/129019074-05021524-647b-493e-9d59-419fa6d454a5.mp4



### UI accessibility concerns?

Not particularly - it might be slightly better for accessibility to have the focus highlight occupy more horizontal space, making it easier to see

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: Existing preview card tests cover the functionality here
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

