### PR TITLE
Change preview card position depending on viewport

### DIFF
--- a/app/assets/stylesheets/components/dropdowns.scss
+++ b/app/assets/stylesheets/components/dropdowns.scss
@@ -29,4 +29,10 @@
       top: 0;
     }
   }
+
+  &.reverse {
+    // Flips the dropdown to drop-upwards when set
+    bottom: 100%;
+    top: unset;
+  }
 }

--- a/app/javascript/packs/articlePage.jsx
+++ b/app/javascript/packs/articlePage.jsx
@@ -3,7 +3,11 @@ import ahoy from 'ahoy.js';
 import { Snackbar, addSnackbarItem } from '../Snackbar';
 import { addFullScreenModeControl } from '../utilities/codeFullscreenModeSwitcher';
 import { embedGists } from '../utilities/gist';
-import { initializeDropdown } from '@utilities/dropdownUtils';
+import {
+  initializeDropdown,
+  getDropdownRepositionListener,
+} from '../utilities/dropdownUtils';
+import { getInstantClick } from '../topNavigation/utilities';
 
 /* global Runtime */
 
@@ -188,3 +192,18 @@ if (profilePreviewTrigger?.dataset.initialized !== 'true') {
 
 const targetNode = document.querySelector('#comments');
 targetNode && embedGists(targetNode);
+
+// Preview card dropdowns reposition on scroll
+const dropdownRepositionListener = getDropdownRepositionListener();
+
+document.addEventListener('scroll', dropdownRepositionListener);
+
+getInstantClick().then((ic) => {
+  ic.on('change', () => {
+    document.removeEventListener('scroll', dropdownRepositionListener);
+  });
+});
+
+window.addEventListener('beforeunload', () => {
+  document.removeEventListener('scroll', dropdownRepositionListener);
+});

--- a/app/javascript/packs/commentDropdowns.js
+++ b/app/javascript/packs/commentDropdowns.js
@@ -1,5 +1,8 @@
 import { addSnackbarItem } from '../Snackbar';
-import { initializeDropdown } from '@utilities/dropdownUtils';
+import {
+  initializeDropdown,
+  getDropdownRepositionListener,
+} from '@utilities/dropdownUtils';
 
 /* global Runtime   */
 
@@ -122,12 +125,18 @@ observer.observe(document.getElementById('comment-trees-container'), {
   subtree: true,
 });
 
+// Preview card dropdowns reposition on scroll
+const dropdownRepositionListener = getDropdownRepositionListener();
+document.addEventListener('scroll', dropdownRepositionListener);
+
 InstantClick.on('change', () => {
   observer.disconnect();
+  document.removeEventListener('scroll', dropdownRepositionListener);
 });
 
 window.addEventListener('beforeunload', () => {
   observer.disconnect();
+  document.removeEventListener('scroll', dropdownRepositionListener);
 });
 
 initializeArticlePageDropdowns();

--- a/app/javascript/utilities/dropdownUtils.js
+++ b/app/javascript/utilities/dropdownUtils.js
@@ -1,3 +1,50 @@
+import { isInViewport } from '@utilities/viewport';
+import { debounceAction } from '@utilities/debounceAction';
+
+/**
+ * Helper function designed to be used on scroll to detect when dropdowns should switch from dropping downwards/upwards.
+ * The action is debounced since scroll events are usually fired several at a time.
+ *
+ * @returns {Function} a debounced function that handles the repositioning of dropdowns
+ * @example
+ *
+ * document.addEventListener('scroll', getDropdownRepositionListener());
+ */
+export const getDropdownRepositionListener = () =>
+  debounceAction(handleDropdownRepositions);
+
+/**
+ * Checks for all dropdowns on the page which have the attribute 'data-repositioning-dropdown', signalling
+ * they should dynamically change between dropping downwards or upwards, depending on viewport position.
+ *
+ * Any dropdowns not fully in view when dropping down will be switched to dropping upwards.
+ */
+const handleDropdownRepositions = () => {
+  // Select all of the dropdowns which should reposition
+  const allRepositioningDropdowns = document.querySelectorAll(
+    '[data-repositioning-dropdown]',
+  );
+
+  for (const element of allRepositioningDropdowns) {
+    // Default to dropping downwards
+    element.classList.remove('reverse');
+
+    // We can't determine position on an element with display:none, so we "show" the dropdown with 0 opacity very temporarily
+    element.style.opacity = 0;
+    element.style.display = 'block';
+    const isWithinViewport = isInViewport({ element });
+
+    // Revert the temporary changes to determine position
+    element.style.removeProperty('display');
+    element.style.removeProperty('opacity');
+
+    if (!isWithinViewport) {
+      // If the element isn't fully visible when dropping down, reverse the direction
+      element.classList.add('reverse');
+    }
+  }
+};
+
 /**
  * Helper query string to identify interactive/focusable HTML elements
  */

--- a/app/views/shared/_profile_preview_card.html.erb
+++ b/app/views/shared/_profile_preview_card.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= id %>" class="profile-preview-card__content crayons-dropdown" style="--card-color: <%= Color::CompareHex.new([user_colors(actor)[:bg], user_colors(actor)[:text]]).brightness(0.88) %>; border-top: var(--su-7) solid var(--card-color);" data-testid="profile-preview-card">
+<div id="<%= id %>" class="profile-preview-card__content crayons-dropdown" style="--card-color: <%= Color::CompareHex.new([user_colors(actor)[:bg], user_colors(actor)[:text]]).brightness(0.88) %>; border-top: var(--su-7) solid var(--card-color);" data-testid="profile-preview-card" data-repositioning-dropdown="true">
     <div class="gap-4 grid">
         <%= render "shared/profile_card_content", context: "preview-card", actor: actor %>
     </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It was suggested that preview cards would be more user-friendly if they "dropped up" when they would otherwise be positioned partly out of the viewport at the bottom of the page (most prevalent with comment threads). 

This PR adds a new helper to `dropdownUtils` which can be used as a scroll listener anywhere we have dropdowns we want to switch position (detected by a data attribute on the dropdown content). Currently, this is only used for preview cards, but it should be generic enough we could pop the data attribute on other crayons dropdowns and get the same effects.

The listener's callback is debounced because scroll events fire _a lot_ at the same time and we don't need to fire the callback every time. 

## Related Tickets & Documents

https://github.com/forem/rfcs/pull/222

## QA Instructions, Screenshots, Recordings

This change affects comment and article byline preview card dropdowns. You can find them on:

- The article page (author name in byline and comment author names)
- The article comments index page 
- The podcast episode page (comments at the bottom)

On each page, try:

- Scrolling until one of the dropdown triggers is close to the bottom of the page
- Hovering the trigger and checking the card appears _above_ the button
- Clicking the trigger and checking the same
- Scroll the dropdown trigger button back into the middle/top of the page and check that the default is still to drop downwards

NB: The callback is only fired on scroll. So if you resize your browser window, then hover the item without scrolling, you might not see the effects. But if you scroll after resizing, then you should 🙂 


https://user-images.githubusercontent.com/20773163/129044626-ffd26a50-f571-477b-8045-19259e465bce.mp4


### UI accessibility concerns?

Not really, but there is a usability benefit in having the dropdown fully visible as much as possible. You'll notice in the code that we have to temporarily remove `display: none` from the dropdown content to detect the position. Although technically this means it will appear in the accessibility tree, the property is almost immediately removed and therefore shouldn't have any impact on users.

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: The existing tests continue to cover functionality, as this is only a visual consideration
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![a cute dog moves it's head from an upright to an upside down position](https://media.giphy.com/media/FnsbzAybylCs8/giphy.gif)
