### PR TITLE
Ensure first argument is interpreted as a string, even when absent

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -30,7 +30,7 @@ printf "Starting the test runner...\n\n"
 
 bundle exec rails assets:precompile;
 
-if [ $1 = "--creator-onboarding-seed" ]; then
+if [ "$1" = "--creator-onboarding-seed" ]; then
    echo "Running E2E tests with creator onboarding seed data"
    CYPRESS_RAILS_CYPRESS_OPTS="--config-file cypress.dev.json" RAILS_ENV=test E2E=true CREATOR_ONBOARDING_SEED_DATA=1 E2E_FOLDER=creatorOnboardingFlows bundle exec rake cypress:open
 else


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I saw a warning when bin/e2e was passed no arguments, pointing to line
33

When we get no value for $1, the original version would become

    if [ = "--creator-onboarding-seed" ]

The new change ensures we're comparing a string to a string, and
becomes

    if [ "" = "--creator-onboarding-seed" ]

This squelches the error without removing the original functionality.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

run `bin/e2e` with no arguments, after the assets precompile and before we start loading the seeds, no warning should be shown about `bin/e2e: line 33: [: =: unary operator expected`

run `bin/e2e --creator-onboarding-seed` and confirm this also still works as well.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: test tooling change only
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: bugfix for local tooling

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
