### PR TITLE
Make sure open preview cards don't collapse on scroll

### DIFF
--- a/app/javascript/utilities/dropdownUtils.js
+++ b/app/javascript/utilities/dropdownUtils.js
@@ -29,18 +29,23 @@ const handleDropdownRepositions = () => {
     // Default to dropping downwards
     element.classList.remove('reverse');
 
-    // We can't determine position on an element with display:none, so we "show" the dropdown with 0 opacity very temporarily
-    element.style.opacity = 0;
-    element.style.display = 'block';
-    const isWithinViewport = isInViewport({ element });
+    const isDropdownCurrentlyOpen = element.style.display === 'block';
 
-    // Revert the temporary changes to determine position
-    element.style.removeProperty('display');
-    element.style.removeProperty('opacity');
+    if (!isDropdownCurrentlyOpen) {
+      // We can't determine position on an element with display:none, so we "show" the dropdown with 0 opacity very temporarily
+      element.style.opacity = 0;
+      element.style.display = 'block';
+    }
 
-    if (!isWithinViewport) {
+    if (!isInViewport({ element })) {
       // If the element isn't fully visible when dropping down, reverse the direction
       element.classList.add('reverse');
+    }
+
+    if (!isDropdownCurrentlyOpen) {
+      // Revert the temporary changes to determine position
+      element.style.removeProperty('display');
+      element.style.removeProperty('opacity');
     }
   }
 };

--- a/app/views/comments/_comment_header.html.erb
+++ b/app/views/comments/_comment_header.html.erb
@@ -13,7 +13,7 @@
     </button>
     <%= render "/shared/profile_preview_card", actor: comment.user, id: "comment-profile-preview-content-#{comment.id}" %>
     <% if commentable_author_is_op?(commentable, comment) %>
-      <span class="crayons-tooltip inline-block spec-op-author -mr-2" data-tooltip="<%= get_ama_or_op_banner(commentable) %>">
+      <span class="crayons-tooltip inline-block spec-op-author -ml-2" data-tooltip="<%= get_ama_or_op_banner(commentable) %>">
         <%= inline_svg_tag("small-medal.svg", aria: true, class: "crayons-icon", title: get_ama_or_op_banner(commentable)) %>
       </span>
     <% end %>

--- a/cypress/integration/seededFlows/articleFlows/viewArticleDiscussion.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/viewArticleDiscussion.spec.js
@@ -10,7 +10,7 @@ describe('View article discussion', () => {
     });
   });
 
-  it.skip('follows and unfollows a user from a comment preview card', () => {
+  it('follows and unfollows a user from a comment preview card', () => {
     // Make sure the preview card is ready to be interacted with
     cy.get('[data-initialized]');
     cy.findByRole('button', { name: 'Admin McAdmin profile details' }).click();


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The test flake we saw in https://github.com/forem/forem/pull/14477 was due to a genuine bug in [the PR I merged yesterday](https://github.com/forem/forem/pull/14473) to reposition dropdowns when partially obscured by the viewport. The code didn't properly account for dropdowns which are already opened and require repositioning. I've added a guard now to make sure we don't close them unintentionally 🙂 

I've also thrown in a very minor tweak to the UI for an author's own comment on a post, because while running the test I noticed this was a little off.

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/14478

## QA Instructions, Screenshots, Recordings

- Visit an article with comments, and open a preview card by clicking on an author name
- Scroll up and down to trigger the preview card reposition and make sure the dropdown doesn't unexpectedly close
- Check a comment made by the article's author, and verify the alignment of the author name + the "author" medal icon looks correct, e.g.:

![screenshot of an author's comment, with their name next to a medal icon](https://user-images.githubusercontent.com/20773163/129158784-02764f7d-1c4b-4faf-bd44-71d3c88e21e9.png)



### UI accessibility concerns?

This bug was a general usability issue, affecting all users

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


