### PR TITLE
Only print BUILDKITE environment variables when they were present

### DIFF
--- a/scripts/build_containers.sh
+++ b/scripts/build_containers.sh
@@ -161,10 +161,10 @@ function prune_containers {
 
 trap prune_containers ERR INT EXIT
 
-echo "Branch: $BUILDKITE_BRANCH"
-echo "PR    : $BUILDKITE_PULL_REQUEST"
-echo "Commit: $BUILDKITE_COMMIT"
-echo "Tag   : $BUILDKITE_TAG"
+if [ -v BUILDKITE_BRANCH ]; then echo "Branch: $BUILDKITE_BRANCH"; fi
+if [ -v BUILDKITE_PULL_REQUEST ]; then echo "PR    : $BUILDKITE_PULL_REQUEST"; fi
+if [ -v BUILDKITE_COMMIT ]; then echo "Commit: $BUILDKITE_COMMIT"; fi
+if [ -v BUILDKITE_TAG ]; then echo "Tag   : $BUILDKITE_TAG"; fi
 
 if [ ! -v BUILDKITE_BRANCH ]; then
 

--- a/scripts/build_containers.sh
+++ b/scripts/build_containers.sh
@@ -161,10 +161,13 @@ function prune_containers {
 
 trap prune_containers ERR INT EXIT
 
-if [ -v BUILDKITE_BRANCH ]; then echo "Branch: $BUILDKITE_BRANCH"; fi
-if [ -v BUILDKITE_PULL_REQUEST ]; then echo "PR    : $BUILDKITE_PULL_REQUEST"; fi
-if [ -v BUILDKITE_COMMIT ]; then echo "Commit: $BUILDKITE_COMMIT"; fi
-if [ -v BUILDKITE_TAG ]; then echo "Tag   : $BUILDKITE_TAG"; fi
+if [ -v BUILDKITE ]
+then
+    echo "Branch: $BUILDKITE_BRANCH"
+    echo "PR    : $BUILDKITE_PULL_REQUEST"
+    echo "Commit: $BUILDKITE_COMMIT"
+    echo "Tag   : $BUILDKITE_TAG"
+fi
 
 if [ ! -v BUILDKITE_BRANCH ]; then
 


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Only print environment variables if they have been defined.

This was causing errors running the build_containers.sh script
locally, since only buildkite was passing these (and errors stop the
script, so nothing was built).


## Related Tickets & Documents

Follows the work in #13750 where the print statements were introduced.

## QA Instructions, Screenshots, Recordings

Run scripts/build_containers.sh, no  error should occur, script should echo "Not running in Buildkite." and start building production images locally. 


### UI accessibility concerns?
None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: build tooling only
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: minor developer side bugfix (no end user impact).

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
