### PR TITLE
Remove discussion lock prior to deleting an article

### DIFF
--- a/app/services/users/delete_articles.rb
+++ b/app/services/users/delete_articles.rb
@@ -14,6 +14,7 @@ module Users
           EdgeCache::BustUser.call(comment.user)
           comment.delete
         end
+        article.discussion_lock&.delete
         article.delete
         article.purge
       end

--- a/spec/services/users/delete_articles_spec.rb
+++ b/spec/services/users/delete_articles_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe Users::DeleteArticles, type: :service do
     expect(Article.find(article3.id)).to be_present
   end
 
+  it "deletes the articles' discussion locks before deleting the article" do
+    create(:discussion_lock, article: article, locking_user: user)
+    expect do
+      described_class.call(user)
+    end.to change(DiscussionLock, :count).from(1).to(0)
+  end
+
   context "with comments" do
     before do
       allow(EdgeCache::BustComment).to receive(:call)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This removes any existing discussion lock on an article before trying to delete the article. 

## Related Tickets & Documents
https://app.honeybadger.io/fault/66984/f36076a8740179b74a5a4b5474521d2d

## QA Instructions, Screenshots, Recordings
1. Make a discussion lock for some user's article
2. Banish the author
3. See that it banishes successfully

### UI accessibility concerns?
Nope

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] will tell the community success team

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![An animated in black-and-white dog on a skateboard with a helmet pushes itself with its front paws](https://media.giphy.com/media/3oI9JX4AM4Pz8BMZ44/giphy.gif)