### PR TITLE
Fixes #13601 - Storybook redirects off page

### DIFF
--- a/app/javascript/crayons/navigation/NavigationTabs/__stories__/navigationTab.html.stories.jsx
+++ b/app/javascript/crayons/navigation/NavigationTabs/__stories__/navigationTab.html.stories.jsx
@@ -1,5 +1,6 @@
 import { h } from 'preact';
 import '../../../storybook-utilities/designSystem.scss';
+import { useState } from 'preact/hooks';
 import notes from './navigation-tab.md';
 
 export default {
@@ -7,32 +8,67 @@ export default {
   parameters: { notes },
 };
 
-export const Default = () => (
-  <nav className="crayons-tabs" aria-label="View feed options">
-    <ul className="crayons-tabs__list">
-      <li>
-        <a
-          data-text="Feed"
-          href="/"
-          className="crayons-tabs__item crayons-tabs__item--current"
-          aria-current="page"
-        >
-          Feed
-        </a>
-      </li>
-      <li>
-        <a data-text="Popular" href="/" className="crayons-tabs__item">
-          Popular
-        </a>
-      </li>
-      <li>
-        <a data-text="Latest" href="/" className="crayons-tabs__item">
-          Latest
-        </a>
-      </li>
-    </ul>
-  </nav>
-);
+const tabs = {
+  feed: 'Feed',
+  popular: 'Popular',
+  latest: 'Latest',
+};
+
+export const Default = () => {
+  const [currentTab, setCurrentTab] = useState(
+    window.location.hash.substr(1) || tabs.feed,
+  );
+
+  const tabOnClick = (tabId) => {
+    setCurrentTab(tabId);
+  };
+
+  return (
+    <nav className="crayons-tabs" aria-label="View feed options">
+      <ul className="crayons-tabs__list">
+        <li>
+          <a
+            data-text={tabs.feed}
+            className={`crayons-tabs__item ${
+              currentTab === tabs.feed ? 'crayons-tabs__item--current' : ''
+            }`}
+            aria-current={currentTab === tabs.feed ? 'page' : null}
+            onClick={() => tabOnClick(tabs.feed)}
+            href={`#${tabs.feed}`}
+          >
+            {tabs.feed}
+          </a>
+        </li>
+        <li>
+          <a
+            data-text={tabs.popular}
+            className={`crayons-tabs__item ${
+              currentTab === tabs.popular ? 'crayons-tabs__item--current' : ''
+            }`}
+            aria-current={currentTab === tabs.popular ? 'page' : null}
+            onClick={() => tabOnClick(tabs.popular)}
+            href={`#${tabs.popular}`}
+          >
+            {tabs.popular}
+          </a>
+        </li>
+        <li>
+          <a
+            data-text={tabs.latest}
+            className={`crayons-tabs__item ${
+              currentTab === tabs.latest ? 'crayons-tabs__item--current' : ''
+            }`}
+            aria-current={currentTab === tabs.latest ? 'page' : null}
+            onClick={() => tabOnClick(tabs.latest)}
+            href={`#${tabs.latest}`}
+          >
+            {tabs.latest}
+          </a>
+        </li>
+      </ul>
+    </nav>
+  );
+};
 
 Default.story = {
   name: 'default',


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- #13601 - Fixed the anchor tags with hash routes to prevent navigating to different page.
- Since the stories are inside iFrame, I couldn't keep it in the same story navigatable view, instead it will open the story on fullscreen and the corresponding selected tab is highlighed.
- Took reference from implemented Tab component for className toggles - [Tabs.tsx](https://github.com/forem/forem/blob/main/app/javascript/article-form/components/Tabs.jsx#L28)
- Used state to highlight the current tab.
- Used location.hash to set the initial state.

## Related Tickets & Documents

Closes #13601 

## QA Instructions, Screenshots, Recordings

The fix is shown in the GIF below

![13601](https://user-images.githubusercontent.com/7134153/129250051-580211cd-9a40-4de5-8a6b-43f1a46b2c84.gif)


### UI accessibility concerns?

There are no UI changes.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is a bugfix in storybook story
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: This is a bugfix in storybook story

## What gif best describes this PR or how it makes you feel?

![I think my work here is done](https://media.giphy.com/media/mVq3s3OU4s0abtzpOI/giphy.gif)
