### PR TITLE
Streamline hover delay for preview card

### DIFF
--- a/app/assets/stylesheets/profile-preview-card.scss
+++ b/app/assets/stylesheets/profile-preview-card.scss
@@ -11,7 +11,7 @@
 
   &__content.crayons-dropdown:hover {
     display: block;
-    animation: hoverAppear 500ms;
+    animation: hoverAppear 1s;
 
     &.showing {
       animation: none;
@@ -20,7 +20,7 @@
 
   &__trigger:hover + .profile-preview-card__content.crayons-dropdown {
     display: block;
-    animation: hoverAppear 500ms;
+    animation: hoverAppear 1s;
 
     &.showing {
       animation: none;
@@ -30,14 +30,17 @@
   @keyframes hoverAppear {
     0% {
       opacity: var(--opacity-0);
+      pointer-events: none;
     }
 
     99% {
       opacity: var(--opacity-0);
+      pointer-events: none;
     }
 
     100% {
       opacity: var(--opacity-100);
+      pointer-events: unset;
     }
   }
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

@citizen428 noticed that sometimes the hover delay for the preview card didn't seem to be working as expected, with the result being that users were occasionally blocked from completing the action they wanted to (e.g. clicking a link above or below the preview trigger).

A little bit of investigation and the problem was:

- Hover on the preview trigger immediately started the 'delay appear' animation
- Hover on the (invisible) dropdown card continued the animation

The upshot is that hovering on the _invisible_ preview card was causing the preview card to appear 🙈  e.g.:

https://user-images.githubusercontent.com/20773163/129328030-2ed727ab-1404-437b-8a9a-1f2580ca2592.mp4

In this PR I've added `pointer-events: none` to the dropdown content while it's invisibly animating in. This means that click events in the region will pass through to any elements below it, and a hover in this general area won't trigger the preview card appearance.

NB: pointer events are only blocked on the dropdown content, and not the trigger button. So it's possible for a user to still pop the preview card open/closed without delay.

I've also increased the hover delay time to 1s as I think it was still possible to accidentally trigger them.

## Related Tickets & Documents

https://github.com/forem/rfcs/pull/222

## QA Instructions, Screenshots, Recordings

- Start hovering over an author name with preview card (e.g. author byline on article page)
- Move your mouse downwards around where the card would eventually appear
- Check that the card doesn't unexpectedly pop open
- Hover the trigger for a second so the preview _does_ open, and check you can interact with the elements inside (profile link, follow button)
- Check you can still click to open and close the dropdown without any delays

https://user-images.githubusercontent.com/20773163/129329583-ba04f76f-026f-4ae6-b2cf-37a1383e6c9d.mp4


### UI accessibility concerns?

Not really, this is a general usability concern affecting all users

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: unfortunately Cypress doesn't have a hover command to test this functionality
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: minor UI concern

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![woman salutes](https://media.giphy.com/media/3og0ILzGlzG26yNINq/giphy.gif)
