### PR TITLE
Encapsulate initializer methods in modules

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Style/TopLevelMethodDefinition
 require "mini_magick"
 
 # Carrierwave uses MiniMagick for image processing. To prevent server timeouts
@@ -7,57 +6,62 @@ MiniMagick.configure do |config|
   config.timeout = 10
 end
 
-def local_storage_config
-  CarrierWave.configure do |config|
-    config.storage = :file
-    config.enable_processing = !Rails.env.test? # disabled for test
-    config.asset_host = if Rails.env.production?
-                          "https://#{ApplicationConfig['APP_DOMAIN']}"
-                        end
+module CarrierWaveInitializer
+  def self.local_storage_config
+    CarrierWave.configure do |config|
+      config.storage = :file
+      config.enable_processing = !Rails.env.test? # disabled for test
+      config.asset_host = if Rails.env.production?
+                            "https://#{ApplicationConfig['APP_DOMAIN']}"
+                          end
+    end
   end
-end
 
-def standard_production_config
-  CarrierWave.configure do |config|
-    config.storage = :fog
-    config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]
-    config.fog_provider = "fog/aws"
-    config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" }
-    config.fog_credentials = {
-      provider: "AWS",
-      aws_access_key_id: ApplicationConfig["AWS_ID"],
-      aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
-      region: ApplicationConfig["AWS_UPLOAD_REGION"].presence || ApplicationConfig["AWS_DEFAULT_REGION"]
-    }
+  def self.standard_production_config
+    CarrierWave.configure do |config|
+      config.storage = :fog
+      config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]
+      config.fog_provider = "fog/aws"
+      config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" }
+      config.fog_credentials = {
+        provider: "AWS",
+        aws_access_key_id: ApplicationConfig["AWS_ID"],
+        aws_secret_access_key: ApplicationConfig["AWS_SECRET"],
+        region: ApplicationConfig["AWS_UPLOAD_REGION"].presence || ApplicationConfig["AWS_DEFAULT_REGION"]
+      }
+    end
   end
-end
 
-def forem_cloud_config
-  CarrierWave.configure do |config|
-    config.storage = :fog
-    config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]
-    config.fog_provider = "fog/aws"
-    config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/remoteimages"
-    config.fog_public = false
-    config.fog_credentials = {
-      provider: "AWS",
-      use_iam_profile: true,
-      region: "us-east-2"
-    }
+  def self.forem_cloud_config
+    CarrierWave.configure do |config|
+      config.storage = :fog
+      config.fog_directory = ApplicationConfig["AWS_BUCKET_NAME"]
+      config.fog_provider = "fog/aws"
+      config.asset_host = "https://#{ApplicationConfig['APP_DOMAIN']}/remoteimages"
+      config.fog_public = false
+      config.fog_credentials = {
+        provider: "AWS",
+        use_iam_profile: true,
+        region: "us-east-2"
+      }
+    end
+  end
+
+  def self.initialize!
+    if Rails.env.production? && ENV["FILE_STORAGE_LOCATION"] != "file"
+      if ENV["FOREM_CONTEXT"] == "forem_cloud"
+        forem_cloud_config
+      elsif ApplicationConfig["AWS_ID"].present?
+        standard_production_config
+      else
+        local_storage_config
+      end
+    else
+      local_storage_config
+    end
   end
 end
 
 Rails.application.reloader.to_prepare do
-  if Rails.env.production? && ENV["FILE_STORAGE_LOCATION"] != "file"
-    if ENV["FOREM_CONTEXT"] == "forem_cloud"
-      forem_cloud_config
-    elsif ApplicationConfig["AWS_ID"].present?
-      standard_production_config
-    else
-      local_storage_config
-    end
-  else
-    local_storage_config
-  end
+  CarrierWaveInitializer.initialize!
 end
-# rubocop:enable Style/TopLevelMethodDefinition


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Two of the initializers had an ignored rubocop rule about top level method definitions. It's unclear we needed to do this (I don't see us wanting to have defined global methods), and this change moves them to modules to reduce namespace pollution.

The methods were being added to the main object and available as private methods on every object in the app. This didn't make much sense.

I believe the capybara [`wait_for_javascript`](https://github.com/forem/forem/blob/main/spec/support/initializers/capybara.rb#L30-L32) global method is in fact expected to be available everywhere in test, and it's defined in spec/support/initializers so not part of the app in prod or development, and only called from system tests, so I haven't changed anything there. 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

I did check that (1) the app boots, I can open a console, and (2) the storage was configured (CarrierWave::Uploader::Base answers the appropriate methods with the correct response, suggesting local_storage_config was called) and SlackClient constant was defined. 

Otherwise "nothing breaks" is the only expectation.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: refactor
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: refactor

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
