### PR TITLE
Fix erblint failures

### DIFF
--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -136,12 +136,13 @@
 
     <div id="set-experience-options" class="set-experience-options dropdown-options hidden">
       <% rating_hash = { "Expert" => [10, 5], "Advanced" => [8, 4], "Mid-level" => [5, 3], "Beginner" => [3, 2], "Novice" => [1, 1] } %>
+      <% current_rating_value = @rating_vote.rating.round(0) if @rating_vote %>
       <% rating_hash.each do |rating_name, rating_level| %>
       <button
         value="<%= rating_level[0] %>"
         name="rating_vote_<%= rating_level[0] %>"
         id="js__rating__vote__<%= rating_level[0] %>"
-        class="level-rating-button <%= " selected" if @rating_vote&.rating&.to_i == rating_level[0] %>"
+        class="level-rating-button <%= " selected" if current_rating_value == rating_level[0] %>"
         data-user-id="<%= current_user.id %>"
         data-article-id="<%= @moderatable.id %>"
         data-group="experience_level">

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -1,4 +1,4 @@
-<% title "Moderating " + @moderatable.title %>
+<% title "Moderating #{@moderatable.title}" %>
 
 <% cache(release_adjusted_cache_key("mod-styling")) do %>
   <style>
@@ -78,7 +78,7 @@
         </div>
       </button>
 
-      <div id="adjust-tags-options"  class="adjust-tags-options dropdown-options hidden">
+      <div id="adjust-tags-options" class="adjust-tags-options dropdown-options hidden">
         <% if current_user.any_admin? %>
           <% if @moderatable.tag_list.size < 4 %>
             <div class="add-tag-container">
@@ -119,7 +119,7 @@
     <% end %>
 
     <% @rating_vote = RatingVote.where(article_id: @moderatable.id, user_id: current_user.id).first %>
-    <button aria-haspopup="true aria-expanded="false" aria-controls="set-experience-options" class="other-things-btn set-experience" type="button" data-other-things-type="set-experience" aria-label="Open experience level section">
+    <button aria-haspopup="true" aria-expanded="false" aria-controls="set-experience-options" class="other-things-btn set-experience" type="button" data-other-things-type="set-experience" aria-label="Open experience level section">
       <div class="label-wrapper">
         <div class="icon circle centered-icon">
           <%= inline_svg_tag("book.svg", aria: true, title: "Book") %>
@@ -141,7 +141,7 @@
         value="<%= rating_level[0] %>"
         name="rating_vote_<%= rating_level[0] %>"
         id="js__rating__vote__<%= rating_level[0] %>"
-        class="level-rating-button <%= " selected" if @rating_vote&.rating == rating_level[0].to_f %>"
+        class="level-rating-button <%= " selected" if @rating_vote&.rating&.to_i == rating_level[0] %>"
         data-user-id="<%= current_user.id %>"
         data-article-id="<%= @moderatable.id %>"
         data-group="experience_level">
@@ -166,8 +166,7 @@
           id="unpublish-article-btn"
           data-article-id="<%= @moderatable.id %>"
           data-article-author="<%= @moderatable.username %>"
-          data-article-slug="<%= @moderatable.slug %>"
-        >
+          data-article-slug="<%= @moderatable.slug %>">
           Unpublish Article
         </button>
       </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- a closing quote on the `aria-haspopup="true ` caused some issues when
running erblint (lots of keywords were assumed to be strings, and vice versa)

- a warning about Lint/FloatComparison raised about casting the
rating_level value to_f, I chose to convert the float to integer and
compare to the value instead.

I suspect the lint rule (from git hooks) didn't run in the most recent changes to this file.


## Related Tickets & Documents

https://github.com/ludwiczakpawel/dev.to/commit/38214380ddb3445a2cca0ce04d222a8138dac2ce the missing closing quote was introduced a few months ago.

The float cast (which may be a new lint rule triggering?) was added in https://github.com/forem/forem/pull/7777 so has been there for over a year (and seems like it wasn't as unreliable for comparisons as the lint rule suggested).

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://docs.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
