### PR TITLE
Adjust images used for moderation

### DIFF
--- a/app/views/moderations/_reactions.html.erb
+++ b/app/views/moderations/_reactions.html.erb
@@ -6,5 +6,5 @@
   <%= image_tag("twemoji/thumb-down.svg", alt: "Thumbs down emoji") %>
 </button>
 <button class="reaction-button <%= Reaction.cached_any_reactions_for?(moderatable, current_user, "vomit") ? "reacted" : "" %>" data-reactable-id="<%= moderatable.id %>" data-category="vomit" data-reactable-type="Article">
-  <%= image_tag("twemoji/thumb-up.svg", alt: "Nausea face emoji") %>
+  <%= image_tag("twemoji/suspicious.svg", alt: "Suspicious face emoji") %>
 </button>

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -34,7 +34,7 @@
               data-category="thumbsdown"
               data-reactable-type="<%= @moderatable.class.name %>">
         <div class="reaction-button-circle">
-          <%= inline_svg_tag("twemoji/thumb-up.svg", aria: true, class: "crayons-icon crayons-icon--default", width: 32, height: 32, title: "Thumb up") %>
+          <%= inline_svg_tag("twemoji/thumb-down.svg", aria: true, class: "crayons-icon crayons-icon--default", width: 32, height: 32, title: "Thumb down") %>
           <%= inline_svg_tag("checkmark.svg", aria: true, class: "crayons-icon reaction-checkmark", title: "Checkmark") %>
         </div>
         <span class="vote-text">Low Quality</span>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Migrating to the twemoji icons, a few images were selected incorrectly. This fixes that.

- when moderating a post, the downvote button should use the
thumb-down image

- when showing the nausea reaction, use the suspicous face emoji

## Related Tickets & Documents
https://github.com/forem/forem/pull/14517 - I actually viewed and attached a screenshot showing the wrong behavior on the actions panel. Sorry! 

## QA Instructions, Screenshots, Recordings

When moderating an article, the downvote should show a thumb down, not a thumb up, icon. 
1. Visit /mod (as a moderator)
2. select an article and look in the moderator actions

![moderator actions](https://user-images.githubusercontent.com/1237369/129795956-8a3c135b-29d8-4caa-a6f0-6ac39bd65291.png)


### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: changing the image (feels like testing for a constant).
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: bugfix

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
