### PR TITLE
Mark hero banner html_safe

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -97,7 +97,7 @@
       <div id="hero-html-wrapper" class="overflow-x-hidden" data-name="<%= @hero_area.name %>">
         <script>
           // Make sure html variant element has id hero-html-wrapper and data-name as its name
-          if (localStorage.getItem('exited_hero') === '<%= @hero_area.name %>') {
+          if (localStorage.getItem('exited_hero') === '<%= @hero_area.name.html_safe %>') {
             document.getElementById('hero-html-wrapper').style.display = 'none';
           }
         </script>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Currently you can't close the hero banner for CodeLand and have it stay closed. This happens because we perform, the following check in `app/views/layouts/application.html.erb`:

```erb
if (localStorage.getItem('exited_hero') === '<%= @hero_area.name.html_safe %>') {
```

Unfortunately the `&` gets escaped, so we end up with the following comparison:

```js
if (localStorage.getItem('exited_hero') === 'CodeLand Registration &amp; Speaker Announcement') {
```

Since `localStorage` is set from `app/assets/javascripts/initializers/initializeHeroBannerClose.js` no escaping happens and the strings don't match.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

None

## Added/updated tests?

- [X] No, and this is why: Trying to get the fix out
