### PR TITLE
Add bio to onboarding

### DIFF
--- a/app/javascript/onboarding/components/ProfileForm.jsx
+++ b/app/javascript/onboarding/components/ProfileForm.jsx
@@ -96,7 +96,7 @@ export class ProfileForm extends Component {
     const field = e.target;
     const { name, value } = field;
 
-    let sibling = field.nextElementSibling
+    const sibling = field.nextElementSibling
       ? field.nextElementSibling
       : field.previousElementSibling;
     sibling.value = value;
@@ -152,12 +152,8 @@ export class ProfileForm extends Component {
   }
 
   render() {
-    const {
-      prev,
-      slidesCount,
-      currentSlideIndex,
-      communityConfig,
-    } = this.props;
+    const { prev, slidesCount, currentSlideIndex, communityConfig } =
+      this.props;
     const { profile_image_90, username, name } = this.user;
     const { canSkip, groups = [], error, errorMessage } = this.state;
 
@@ -236,6 +232,18 @@ export class ProfileForm extends Component {
                 onFieldChange={this.handleFieldChange}
               />
             </div>
+            <div className="onboarding-profile-sub-section">
+              <TextArea
+                field={{
+                  attribute_name: 'summary',
+                  label: 'Bio',
+                  placeholder_text: 'Tell us a little about yourself',
+                  required: false,
+                }}
+                onFieldChange={this.handleFieldChange}
+              />
+            </div>
+
             {sections}
           </div>
         </div>

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -70,10 +70,10 @@
       <label class="crayons-field__label" for="profile[summary]">
         Bio
       </label>
-      <%= f.text_field "profile[summary]",
-                       value: profile.summary,
-                       placeholder: "A short bio...",
-                       class: "crayons-textfield js-color-field" %>
+      <%= f.text_area "profile[summary]",
+                      value: profile.summary,
+                      placeholder: "A short bio...",
+                      class: "crayons-textfield js-color-field" %>
     </div>
   </div>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

After the recent profile field changes the onboarding page looked a bit empty.

![2021-08-19 10_27_59-Welcome to DEV and 7 more pages - Personal - Microsoft​ Edge Beta](https://user-images.githubusercontent.com/47985/130004438-cd8c1747-3ff5-4584-91a6-d2980b5406f6.png)

This wasn't really a regression, more of an oversight in terms of thinking through all areas of the product that will be influenced by the recent changes. In a Slack conversation with @benhalpern we decided to add the bio (the `summary` profile attribute) to this modal since it's an actual column of the `profiles` table and therefore will be present on all Forem instances.

## Related Tickets & Documents

Profile generalization

## QA Instructions, Screenshots, Recordings

Updated modal:
![2021-08-19 10_26_46-Welcome to DEV and 7 more pages - Personal - Microsoft​ Edge Beta](https://user-images.githubusercontent.com/47985/130004569-141aeea0-b031-474a-b0eb-4720957511fb.png)

Since I found it weird that we use a `textarea` in the modal but an `input` in the profile page I changed the latter to be a text area too:

![2021-08-19 10_30_17-Settings - DEV 🌱 and 7 more pages - Personal - Microsoft​ Edge Beta](https://user-images.githubusercontent.com/47985/130004617-50de3e86-151a-49ce-ba68-38d1c7601ae7.png)


### UI accessibility concerns?

None

## Added/updated tests?

- [X] No, and this is why: I couldn't find existing ones and this change seemed minor enough

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
