### PR TITLE
Revise editor publish logic

### DIFF
--- a/app/javascript/article-form/actions.js
+++ b/app/javascript/article-form/actions.js
@@ -44,7 +44,7 @@ function processPayload(payload) {
   return neededPayload;
 }
 
-export function submitArticle(payload, clearStorage, errorCb, failureCb) {
+export function submitArticle(payload, clearStorage, successCb, errorCb) {
   const method = payload.id ? 'PUT' : 'POST';
   const url = payload.id ? `/articles/${payload.id}` : '/articles';
   fetch(url, {
@@ -63,13 +63,13 @@ export function submitArticle(payload, clearStorage, errorCb, failureCb) {
     .then((response) => {
       if (response.current_state_path) {
         clearStorage();
+        successCb();
         window.location.replace(response.current_state_path);
       } else {
-        // If there is an error and the method is POST, we know they are trying to publish.
-        errorCb(response, method === 'POST');
+        errorCb(response);
       }
     })
-    .catch(failureCb);
+    .catch(errorCb);
 }
 
 function generateUploadFormdata(payload) {

--- a/app/javascript/article-form/actions.js
+++ b/app/javascript/article-form/actions.js
@@ -44,7 +44,7 @@ function processPayload(payload) {
   return neededPayload;
 }
 
-export function submitArticle(payload, clearStorage, successCb, errorCb) {
+export function submitArticle({ payload, onSuccess, onError }) {
   const method = payload.id ? 'PUT' : 'POST';
   const url = payload.id ? `/articles/${payload.id}` : '/articles';
   fetch(url, {
@@ -62,14 +62,13 @@ export function submitArticle(payload, clearStorage, successCb, errorCb) {
     .then((response) => response.json())
     .then((response) => {
       if (response.current_state_path) {
-        clearStorage();
-        successCb();
+        onSuccess();
         window.location.replace(response.current_state_path);
       } else {
-        errorCb(response);
+        onError(response);
       }
     })
-    .catch(errorCb);
+    .catch(onError);
 }
 
 function generateUploadFormdata(payload) {

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -268,12 +268,14 @@ export class ArticleForm extends Component {
       published: true,
     };
 
-    submitArticle(
+    submitArticle({
       payload,
-      this.removeLocalStorage,
-      () => this.setState({ published: true, submitting: false }),
-      this.handleArticleError,
-    );
+      onSuccess: () => {
+        this.removeLocalStorage();
+        this.setState({ published: true, submitting: false });
+      },
+      onError: this.handleArticleError,
+    });
   };
 
   onSaveDraft = (e) => {
@@ -284,12 +286,14 @@ export class ArticleForm extends Component {
       published: false,
     };
 
-    submitArticle(
+    submitArticle({
       payload,
-      this.removeLocalStorage,
-      () => this.setState({ published: false, submitting: false }),
-      this.handleArticleError,
-    );
+      onSuccess: () => {
+        this.removeLocalStorage();
+        this.setState({ published: false, submitting: false });
+      },
+      onError: this.handleArticleError,
+    });
   };
 
   onClearChanges = (e) => {

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -262,18 +262,34 @@ export class ArticleForm extends Component {
 
   onPublish = (e) => {
     e.preventDefault();
-    this.setState({ submitting: true, published: true });
-    const { state } = this;
-    state.published = true;
-    submitArticle(state, this.removeLocalStorage, this.handleArticleError);
+    this.setState({ submitting: true });
+    const payload = {
+      ...this.state,
+      published: true,
+    };
+
+    submitArticle(
+      payload,
+      this.removeLocalStorage,
+      () => this.setState({ published: true, submitting: false }),
+      this.handleArticleError,
+    );
   };
 
   onSaveDraft = (e) => {
     e.preventDefault();
-    this.setState({ submitting: true, published: false });
-    const { state } = this;
-    state.published = false;
-    submitArticle(state, this.removeLocalStorage, this.handleArticleError);
+    this.setState({ submitting: true });
+    const payload = {
+      ...this.state,
+      published: false,
+    };
+
+    submitArticle(
+      payload,
+      this.removeLocalStorage,
+      () => this.setState({ published: false, submitting: false }),
+      this.handleArticleError,
+    );
   };
 
   onClearChanges = (e) => {
@@ -310,14 +326,11 @@ export class ArticleForm extends Component {
     });
   };
 
-  handleArticleError = (response, publishFailed = false) => {
+  handleArticleError = (response) => {
     window.scrollTo(0, 0);
-    const { published } = this.state;
     this.setState({
       errors: response,
       submitting: false,
-      // Even if it's an update that failed, published will still be set to true
-      published: published && !publishFailed,
     });
   };
 

--- a/cypress/integration/seededFlows/publishingFlows/publishOrSavePost.spec.js
+++ b/cypress/integration/seededFlows/publishingFlows/publishOrSavePost.spec.js
@@ -1,0 +1,258 @@
+describe('Publish or save a post', () => {
+  describe('v1 Editor', () => {
+    const validPublishedArticleContent =
+      '---\ntitle: Test title\npublished: true\ndescription:\ntags:\n---\nSome content';
+
+    const invalidPublishedArticleContent =
+      '---\ntitle: Test title\npublished: true\ndescription:\ntags:\n---\nSome content {%tag %}';
+
+    const validDraftArticleContent =
+      '---\ntitle: Test title\npublished: false\ndescription:\ntags:\n---\nSome content';
+
+    beforeEach(() => {
+      cy.testSetup();
+      cy.fixture('users/articleEditorV1User.json').as('user');
+
+      cy.get('@user').then((user) => {
+        cy.loginAndVisit(user, '/new');
+      });
+    });
+
+    it('Publishes a post without errors', () => {
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Content')
+          .clear()
+          .type(validPublishedArticleContent);
+        cy.findByRole('button', { name: 'Save changes' }).click();
+      });
+      //   The post should now be published
+      cy.findByRole('heading', { name: 'Test title' });
+      cy.findByRole('heading', { name: 'Discussion (0)' });
+      cy.findByRole('link', { name: 'Edit' });
+      cy.findByRole('link', { name: 'Manage' });
+      cy.findByRole('link', { name: 'Stats' });
+    });
+
+    it('Saves a draft without errors', () => {
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Content')
+          .clear()
+          .type(validDraftArticleContent);
+        cy.findByRole('button', { name: 'Save changes' }).click();
+      });
+
+      // The Draft view should be shown
+      cy.findByText(/Unpublished Post/);
+      cy.findByRole('heading', { name: 'Test title' });
+      cy.findByRole('link', { name: 'Click to edit' });
+    });
+
+    it('Shows an error message when markdown is incorrect', () => {
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Content')
+          .clear()
+          .type(invalidPublishedArticleContent, {
+            parseSpecialCharSequences: false,
+          });
+        cy.findByRole('button', { name: 'Save changes' }).click();
+      });
+
+      cy.findByRole('heading', { name: 'Whoops, something went wrong:' });
+      // We should still be on the form page
+      cy.findByRole('form', { name: /^Edit post$/i });
+    });
+
+    it('Shows an error message when network request fails', () => {
+      cy.intercept('POST', '/articles', { statusCode: 500 });
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Content')
+          .clear()
+          .type(validPublishedArticleContent);
+        cy.findByRole('button', { name: 'Save changes' }).click();
+      });
+      cy.findByRole('heading', { name: 'Whoops, something went wrong:' });
+      // We should still be on the form page
+      cy.findByRole('form', { name: /^Edit post$/i });
+    });
+  });
+
+  describe('v2 Editor', () => {
+    beforeEach(() => {
+      cy.testSetup();
+      cy.fixture('users/articleEditorV2User.json').as('user');
+
+      cy.get('@user').then((user) => {
+        cy.loginAndVisit(user, '/new');
+      });
+    });
+
+    it('Publishes a post without errors', () => {
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Title').clear().type('Test title');
+        cy.findByLabelText('Post Content').clear().type('something');
+        cy.findByRole('button', { name: 'Publish' }).click();
+      });
+      //   The post should now be published
+      cy.findByRole('heading', { name: 'Test title' });
+      cy.findByRole('heading', { name: 'Discussion (0)' });
+      cy.findByRole('link', { name: 'Edit' });
+      cy.findByRole('link', { name: 'Manage' });
+      cy.findByRole('link', { name: 'Stats' });
+    });
+
+    it('Saves a draft without errors', () => {
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Title').clear().type('Test title');
+        cy.findByLabelText('Post Content').clear().type('something');
+        cy.findByRole('button', { name: 'Save draft' }).click();
+      });
+
+      // The Draft view should be shown
+      cy.findByText(/Unpublished Post/);
+      cy.findByRole('heading', { name: 'Test title' });
+      cy.findByRole('link', { name: 'Click to edit' });
+    });
+
+    it('Shows an error message when publishing with incorrect markdown', () => {
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Title').clear().type('Test title');
+
+        cy.findByLabelText('Post Content').clear().type('{% tag %}', {
+          parseSpecialCharSequences: false,
+        });
+        cy.findByRole('button', { name: 'Publish' }).click();
+      });
+
+      cy.findByRole('heading', { name: 'Whoops, something went wrong:' });
+      // We should still be on the form page
+      cy.findByRole('form', { name: /^Edit post$/i });
+      cy.findByRole('button', { name: 'Publish' });
+      cy.findByRole('button', { name: 'Save draft' });
+    });
+
+    it('Shows an error message when saving draft with incorrect markdown', () => {
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Title').clear().type('Test title');
+
+        cy.findByLabelText('Post Content').clear().type('{% tag %}', {
+          parseSpecialCharSequences: false,
+        });
+        cy.findByRole('button', { name: 'Save draft' }).click();
+      });
+
+      cy.findByRole('heading', { name: 'Whoops, something went wrong:' });
+      // We should still be on the form page
+      cy.findByRole('form', { name: /^Edit post$/i });
+      cy.findByRole('button', { name: 'Publish' });
+      cy.findByRole('button', { name: 'Save draft' });
+    });
+
+    it('Shows an error message when publishing and network request fails', () => {
+      cy.intercept('POST', '/articles', { statusCode: 500 });
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Title').clear().type('Test title');
+        cy.findByLabelText('Post Content').clear().type('something');
+        cy.findByRole('button', { name: 'Publish' }).click();
+      });
+      cy.findByRole('heading', { name: 'Whoops, something went wrong:' });
+      // We should still be on the form page
+      cy.findByRole('form', { name: /^Edit post$/i });
+      cy.findByRole('button', { name: 'Publish' });
+      cy.findByRole('button', { name: 'Save draft' });
+    });
+
+    it('Shows an error message when saving draft and network request fails', () => {
+      cy.intercept('POST', '/articles', { statusCode: 500 });
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Title').clear().type('Test title');
+        cy.findByLabelText('Post Content').clear().type('something');
+        cy.findByRole('button', { name: 'Save draft' }).click();
+      });
+      cy.findByRole('heading', { name: 'Whoops, something went wrong:' });
+      // We should still be on the form page
+      cy.findByRole('form', { name: /^Edit post$/i });
+      cy.findByRole('button', { name: 'Publish' });
+      cy.findByRole('button', { name: 'Save draft' });
+    });
+
+    it('Maintains draft status when editing a draft fails', () => {
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Title').clear().type('Test title');
+        cy.findByLabelText('Post Content').clear().type('something');
+        cy.findByRole('button', { name: 'Save draft' }).click();
+      });
+
+      // Check we are on the draft post page, and choose to edit
+      cy.findByText(/Unpublished Post/);
+      cy.findByRole('link', { name: 'Click to edit' }).click();
+
+      cy.findByLabelText('Post Content').clear().type('something else');
+      cy.intercept('PUT', '/articles/*', { statusCode: 500 });
+      cy.findByRole('button', { name: 'Save draft' }).click();
+
+      // We should still be on the form page and see the draft publish/save options
+      cy.findByRole('form', { name: /^Edit post$/i });
+      cy.findByRole('button', { name: 'Publish' });
+      cy.findByRole('button', { name: 'Save draft' });
+
+      // Check post is still draft in dashboard
+      cy.visitAndWaitForUserSideEffects('/dashboard');
+      cy.findByRole('heading', { name: 'Dashboard' });
+      cy.findByRole('link', { name: 'Draft' });
+    });
+
+    it('Maintains draft status when publishing a draft fails', () => {
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Title').clear().type('Test title');
+        cy.findByLabelText('Post Content').clear().type('something');
+        cy.findByRole('button', { name: 'Save draft' }).click();
+      });
+
+      // Check we are on the draft post page, and choose to edit and publish
+      cy.findByText(/Unpublished Post/);
+      cy.findByRole('link', { name: 'Click to edit' }).click();
+
+      cy.findByLabelText('Post Content').clear().type('something else');
+      cy.intercept('PUT', '/articles/*', { statusCode: 500 });
+      cy.findByRole('button', { name: 'Publish' }).click();
+
+      // We should still be on the form page and see the draft publish/save options
+      cy.findByRole('form', { name: /^Edit post$/i });
+      cy.findByRole('button', { name: 'Publish' });
+      cy.findByRole('button', { name: 'Save draft' });
+
+      // Check post is still draft in dashboard
+      cy.visitAndWaitForUserSideEffects('/dashboard');
+      cy.findByRole('heading', { name: 'Dashboard' });
+      cy.findByRole('link', { name: 'Draft' });
+    });
+
+    it('Maintains published status when editing a published post fails', () => {
+      cy.findByRole('form', { name: /^Edit post$/i }).within(() => {
+        cy.findByLabelText('Post Title').clear().type('Test title');
+        cy.findByLabelText('Post Content').clear().type('something');
+        cy.findByRole('button', { name: 'Publish' }).click();
+      });
+
+      // Wait for published post page, and choose to edit
+      cy.findByRole('heading', { name: 'Test title' });
+      cy.findByRole('heading', { name: 'Discussion (0)' });
+      cy.findByRole('link', { name: 'Edit' }).click();
+
+      cy.findByLabelText('Post Content').clear().type('something else');
+      cy.intercept('PUT', '/articles/*', { statusCode: 500 });
+      cy.findByRole('button', { name: 'Save changes' }).click();
+
+      // We should still be on the form page and see the draft publish/save options
+      cy.findByRole('form', { name: /^Edit post$/i });
+      cy.findByRole('button', { name: 'Save changes' });
+      cy.findByRole('button', { name: 'Publish' }).should('not.exist');
+      cy.findByRole('button', { name: 'Save draft' }).should('not.exist');
+
+      // Check post is still published in dashboard
+      cy.visitAndWaitForUserSideEffects('/dashboard');
+      cy.findByRole('heading', { name: 'Dashboard' });
+      cy.findByRole('link', { name: 'Draft' }).should('not.exist');
+    });
+  });
+});


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This code was working, but as noted in #12349 it was a bit _funky_ and difficult to understand why it was doing certain things.

I've refactored this area so that:

- We don't touch the 'published' state until the outcome of the network request is known 
- If the network request fails, no change needs to be made to the 'published' state (since we didn't optimistically update it in the first place)
- I removed a 'failure callback' that was never passed in to the `submitArticle` function. Instead, I've replaced it with the general error callback which can be used for the same purpose.

I've added Cypress tests to cover the scenarios of draft/publish for new/existing posts with a variety of success/error situations.

## Related Tickets & Documents

Closes #12349

## QA Instructions, Screenshots, Recordings

For the most part this should be captured by the new Cypress tests, but generally we want to make sure that for **both versions** of the editor:

- Publishing a post works
- Saving a draft works
- Errors on publishing a post or saving a draft are handled (e.g. trigger a parsing error by entering an invalid liquid tag like `{% tag %}` in the content

The V2 editor has a slightly different set of submit options for editing a previously saved draft vs published post. Check that:

- when I edit a published post and I trigger an error (as above, or blocking the `/articles` network request in devtools), the button at the bottom of the page is still "Save changes" and not "Publish"
- when I do the same for a previously saved draft and either click "Publish" or "Save draft" (test both), when the request fails, I still see "Publish" / "Save draft" buttons and not "Save changes" 

In all cases we can double check that the user's dashboard shows that a post hasn't been accidentally changed to draft/published when it shouldn't have been

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: no change to functionality

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Marge Simpson says "I redecorated!"](https://media.giphy.com/media/3orif6ZAGbISohmD28/giphy.gif?cid=ecf05e47v5pg4g18rfq3a51y9qkwhd2r99donzxed321amut&rid=giphy.gif&ct=g)
