### PR TITLE
Look for <html> tags instead of <body> for email viewing

### DIFF
--- a/app/models/email_message.rb
+++ b/app/models/email_message.rb
@@ -1,13 +1,10 @@
 class EmailMessage < Ahoy::Message
   belongs_to :feedback_message, optional: true
 
-  # So far this is mostly used to be compatible with administrate gem,
-  # which doesn't seem to play nicely with namespaces. But there could be other
-  # reasons to define behavior here, similar to how we use the Tag model.
-  def body_html_content
-    doctype_index = content.index("<!DOCTYPE")
-    closing_body_index = content.index("</body>") + 6
-    content[doctype_index..closing_body_index]
+  def html_content
+    html_index = content.index("<html")
+    closing_html_index = content.index("</html>") + 7
+    content[html_index..closing_html_index]
   end
 
   def self.find_for_reports(feedback_message_ids)

--- a/app/views/admin/email_messages/show.html.erb
+++ b/app/views/admin/email_messages/show.html.erb
@@ -40,7 +40,7 @@
     <h2>Email content</h2>
     <p><em>The content is previewed below without formatting</em></p>
     <div class="crayons-card my-5 p-5">
-      <%= @email.body_html_content.html_safe %>
+      <%= @email.html_content.html_safe %>
     </div>
   </div>
 </div>

--- a/app/views/admin/feedback_messages/_feedback_message.html.erb
+++ b/app/views/admin/feedback_messages/_feedback_message.html.erb
@@ -93,7 +93,7 @@
                   <p class="to__subject">Type: <%= email.utm_campaign&.capitalize %></p>
                   <p class="to__subject">To: <%= email.to %></p>
                   <p class="to__subject">Subject: <%= email.subject %></p>
-                  <%= email.body_html_content.html_safe %>
+                  <%= email.html_content.html_safe %>
                 </div>
               <% end %>
             <% else %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When looking for the closing `</body>` tag for rendering email messages within the app, it sometimes fails, specifically for the Devise-generated confirmation email. This should fix that, since it grabs the entire `<html>` of the email.

## Related Tickets & Documents
https://app.honeybadger.io/fault/66984/0032f7edebb6170a8eb849a0abb390a1

## QA Instructions, Screenshots, Recordings
1. Go into `rails console`
2. `EmailMessage.last.html_content` should render something

### UI accessibility concerns?
Nope

## Added/updated tests?
- [x] No, and this is why: Not sure how to test this view -- unfortunately testing in production 😬 

## [Forem core team only] How will this change be communicated?
- [x] Will communicate with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

!["Probably!"](https://media.giphy.com/media/xThtagzLmmuXDTRBIs/giphy-downsized.gif?cid=ecf05e477xlyb9h0gfuymwzkk6dxp4b34ezztwbohe29k2p1&rid=giphy-downsized.gif&ct=g)
