### PR TITLE
Avoid blank screen in Deep Links Edge cases

### DIFF
--- a/app/javascript/runtimeBanner/RuntimeBanner.jsx
+++ b/app/javascript/runtimeBanner/RuntimeBanner.jsx
@@ -82,16 +82,13 @@ export const RuntimeBanner = () => {
   }
 
   const targetPath = `https://${window.location.host}/r/mobile?deep_link=${window.location.pathname}`;
-  const targetURL = `https://udl.forem.com/?r=${encodeURIComponent(
-    targetPath,
-  )}`;
+  const targetURL = `https://udl.forem.com/${encodeURIComponent(targetPath)}`;
 
   return (
     <div class="runtime-banner">
       <a
         href={targetURL}
         class="flex items-center flex-1"
-        target="_blank"
         rel="noopener noreferrer"
       >
         <svg


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

Some situations (non-Safari browser + embedded WebView in 3rd party apps) leave a blank page behind after a Deep Link. This PR fixes that.

## Related Tickets & Documents

https://github.com/forem/forem-ios/issues/88
https://github.com/forem/forem-ios/pull/90

## QA Instructions, Screenshots, Recordings

If possible and you have an iOS device running the current Testflight release version `1.0.4 (67)` (or greater) you can
1. Open [this Tweet's link](https://twitter.com/noope91/status/1430178695973687311)
   - Use the Twitter mobile app or any browser that's **not Safari**
   - This self hosted Forem is currently running this PR
2. Open the Runtime banner and deep link into the app
3. Go back to Twitter and a blank page shouldn't be there

If you try this same process ^ but using a Tweet from DEV ([like this one](https://twitter.com/ThePracticalDev/status/1430233699610677251)) you would arrive (in step 3) at a blank page, this is what we want to fix.

### UI accessibility concerns?

None - No changes were made to the DOM elements other than removing `target="_blank"`

## Added/updated tests?

- [x] No, and this is why: Current tests cover the runtime banner feature, this only removes the `target="_blank"` attribute

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Small refactor that will enhance the UX with no major changes involved

## [optional] What gif best describes this PR or how it makes you feel?

![mobile tabs](https://media.giphy.com/media/3oGRFLswfKzceq5kLm/giphy.gif?cid=ecf05e47k8rgi3grwnsrsr12b4kpsvklrydut3frivq44ajz&rid=giphy.gif&ct=g)
