### PR TITLE
[15 min fix] Stop skip content link flashing on mobile

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -138,6 +138,7 @@
   height: var(--header-height);
   transform: translate(-50%, -200%);
   transition: transform var(--transition-props);
+  opacity: var(--opacity-0);
 }
 
 .js-focus-visible .skip-content-link:focus:not(.focus-visible) {
@@ -149,6 +150,7 @@
   transform: translate(-50%, 0);
   outline: none;
   border: 2px solid var(--header-button-focus-color);
+  opacity: var(--opacity-1);
 }
 
 .pwa-nav-buttons {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On mobile devices (particularly iOS - I wasn't able to reproduce on my android Pixel), the skip to content link was intermittently flashing up as visible inside the header bar when a page was loading. For example:

https://user-images.githubusercontent.com/20773163/130227916-32a5011e-c4d2-4bd0-89a8-09515c99b27e.mp4

This PR sets the opacity of the link to 0 when it's not intended to be visible, instead of only relying on it being tucked under the header bar.

NB: Using opacity 0 instead of `hidden` means that assistive tech users will still find the "Skip to content" link in the list of interactive controls, even if it's not visually presented on the screen

## Related Tickets & Documents

Fixes #14492

## QA Instructions, Screenshots, Recordings

On a mobile device (ideally iOS, and ideally we also test this from within the mobile app too):

- Navigate to and from the home page, visiting different new pages
- Make sure the skip to content link isn't visible

I've tested this on a simulator, but it would be great if someone is able to test on a real device.

We can test that the 'normal' skip to content functionality is continuing to work by testing on desktop that the Tab key on a fresh page load takes us to the visible skip link.

### UI accessibility concerns?

As noted in the description, the change doesn't affect the "visibility" of the control to assistive technologies, and the existing skip link behaviour should continue to work as normal

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: this is really a visual bug, and I think it need a manual test to verify
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


