### PR TITLE
[15 min fix] Swap position of profile dropdown for users

### DIFF
--- a/app/assets/stylesheets/views/profile.scss
+++ b/app/assets/stylesheets/views/profile.scss
@@ -43,7 +43,6 @@
 
   &__details {
     padding: var(--padding);
-    padding-top: 0;
   }
 
   &__meta {

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -28,7 +28,13 @@
           </span>
 
           <div class="profile-header__actions">
-            <div class="profile-dropdown mr-2 relative hidden" data-username="<%= @user.username %>">
+            <% if user_signed_in? %>
+              <a href="/connect/@<%= @user.username %>" class="hidden mr-2" id="user-connect-redirect">
+                <button class="chat-action-button crayons-btn crayons-btn--outlined hidden" id="modal-opener">Chat</button>
+              </a>
+            <% end %>
+            <button id="user-follow-butt" class="crayons-btn whitespace-nowrap follow-action-button user-profile-follow-button follow-user" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>"}'>Follow</button>
+            <div class="profile-dropdown ml-2 relative hidden" data-username="<%= @user.username %>">
               <button id="user-profile-dropdown" aria-expanded="false" aria-controls="user-profile-dropdownmenu" aria-haspopup="true" class="crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon">
                 <%= inline_svg_tag("overflow-horizontal.svg", class: "dropdown-icon crayons-icon", aria: true, title: "User actions") %>
               </button>
@@ -50,12 +56,6 @@
                 <span class="report-abuse-link-wrapper" data-path="/report-abuse?url=<%= user_url(@user) %>"></span>
               </div>
             </div>
-            <% if user_signed_in? %>
-              <a href="/connect/@<%= @user.username %>" class="hidden mr-2" id="user-connect-redirect">
-                <button class="chat-action-button crayons-btn crayons-btn--outlined hidden" id="modal-opener">Chat</button>
-              </a>
-            <% end %>
-            <button id="user-follow-butt" class="crayons-btn whitespace-nowrap follow-action-button user-profile-follow-button follow-user" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>"}'>Follow</button>
           </div>
         </div>
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On small screens (portrait mobile), the dropdown position on a user's profile page led to the dropdown content being partially off-screen - e.g.:

![screenshot of a mobile viewport with the dropdown open and partially out of view at the left side of the screen](https://user-images.githubusercontent.com/20773163/130259573-acf6b0dd-7353-49ff-8d1d-68a6c70fe579.png)

The simplest fix for this is to reliably place the dropdown to the right of screen, so it will always be visible when it opens. The right-side of a group is also a fairly standard place to have an overflow menu, so I just went ahead and swapped this round. 

## Related Tickets & Documents

Fixes #13968

## QA Instructions, Screenshots, Recordings

- Check a user's profile in desktop and mobile viewports, making sure you can see the full content of the dropdown menu
- Test it out with a user you follow, a user that also follows you back, and in the logged out state, so you can see the full combination of buttons that appear on this page

Desktop:
![Cscreenshot of desktop view with menu at the right](https://user-images.githubusercontent.com/20773163/130259952-dc980c0b-70e2-487a-ab1f-370e7e3f616e.png)


Mobile:

![screenshot of mobile viewport with menu open at the right](https://user-images.githubusercontent.com/20773163/130260023-91fb7b75-e8ea-42d0-8fe0-02236c078a5e.png)


### UI accessibility concerns?

N/A - no change to functionality

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: Existing tests continue to test the functionality
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://docs.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

