### PR TITLE
Added the Forem creator role.

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -40,6 +40,7 @@ class RegistrationsController < Devise::RegistrationsController
   def update_first_user_permissions(resource)
     return unless Settings::General.waiting_on_first_user
 
+    resource.add_role(:forem_creator)
     resource.add_role(:super_admin)
     resource.add_role(:trusted)
     resource.skip_confirmation!

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -16,6 +16,7 @@ class Role < ApplicationRecord
     trusted
     warned
     workshop_pass
+    forem_creator # The account that created the Forem instance
   ].freeze
 
   has_and_belongs_to_many :users, join_table: :users_roles # rubocop:disable Rails/HasAndBelongsToMany


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a new `forem_creator` role. This role will be used for the admin onboarding work currently being worked on. I discussed this with @Ridhwana, and a role seemed to make the most sense.

This will allow us to send the appropriate onboarding email for a Forem creator as well as use the appropriate onboarding for a Forem creator (work in progress). There could be other uses for it in the future, but these are the immediate needs.

I purposely did not add it to the special roles constants as we do not want to be able to change a form creator. Mind you, if ever in the future, someone wants to transfer ownership of a Forem, it might be useful. We can always address that later as it may be a rare occurrence.

https://github.com/forem/forem/blob/d34db0b2e1c37be6e2750338b2809ae60f2dc445/app/lib/constants/role.rb#L11-L29

## Related Tickets & Documents

Prework for #14376

## QA Instructions, Screenshots, Recordings

These E2E tests cover the change https://github.com/forem/forem/blob/d34db0b2e1c37be6e2750338b2809ae60f2dc445/cypress/integration/creatorOnboardingFlows/creatorSignup.spec.js cover this change.

### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why:Existing tests in https://github.com/forem/forem/blob/d34db0b2e1c37be6e2750338b2809ae60f2dc445/cypress/integration/creatorOnboardingFlows/creatorSignup.spec.js cover this change.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
