### PR TITLE
ignore dump.rdb redis backup file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ postcss_error.log
 # ripgrep ignore file
 .rgignore
 config/definitions.rb
+
+# ignore redis backup
+dump.rdb


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When using gitpod - the redis backup file dump.rdb shows in the working tree.

Add it to the gitignore file so it's not mistakenly staged or committed.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Hmm... edit a file in the forem directory named dump.rdb (doesn't matter what it contains).
Git status should not show it in unstaged/untracked files

### UI accessibility concerns?
None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: DX config
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: the absence of this rule was surprising, the presence avoids surprises

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![degausser destroying backup tapes](https://user-images.githubusercontent.com/1237369/130683828-d2d3f6ad-333e-4a0a-982d-cbcb3eeca976.png)
