### PR TITLE
Fix documentation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,4 @@ We are all humans trying to work together to improve the community. Always be
 kind and appreciate the need for trade-offs. ❤️
 
 Before making your first pull request or issue, give our full
-[Contributor's Guide](https://developers.forem.com/contributing/forem/) a read.
+[Contributor's Guide](https://developers.forem.com/contributing-guide/forem/) a read.


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

The location of the contributors guide appears to have changed urls during the gitdocs -> docosaurus migration.

https://developers.forem.com/contributing/forem gave a 404

Update to https://developers.forem.com/contributing-guide/forem which is the new location for the full contributor's guide.

## Related Tickets & Documents

https://github.com/forem/forem-docs/issues/6 sort of - same issue (broken links from forem markdown files to developer documentation site) - different approach to addressing it.


## QA Instructions, Screenshots, Recordings

Follow link. Observe you get content and not a 404 page

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: documentation only
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [x] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

I'm not even sure we should do this here (rather than fixing the documentation to preserve the public url or add a redirect).

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
