### PR TITLE
[15-minute fix] Fix `Users::SuggestRecent#established_user_comment_count`

### DIFF
--- a/app/services/users/suggest_recent.rb
+++ b/app/services/users/suggest_recent.rb
@@ -58,13 +58,13 @@ module Users
 
     def established_user_article_count
       Rails.cache.fetch("established_user_article_count", expires_in: 1.day) do
-        User.where("articles_count > 0").average(:articles_count) || User.average(:articles_count)
+        User.where(articles_count: 1..).average(:articles_count) || User.average(:articles_count)
       end
     end
 
     def established_user_comment_count
       Rails.cache.fetch("established_user_comment_count", expires_in: 1.day) do
-        User.where(comments_count: 1).average(:comments_count) || User.average(:comments_count)
+        User.where(comments_count: 1..).average(:comments_count) || User.average(:comments_count)
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Once upon a time, there was a refactoring. During this refactoring our noble hero (yours truly) changed some code to use newer `ActiveRecord` syntax. However, in one such case `> 0` got refactored to `1` instead of `1..`.  On a more recent adventure, our hero noticed his previous mistake and after hanging his head in shame slew this dragon of his own making. And everyone lived happily until the next bug got introduced.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Nothing specific.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] No, and this is why: this happened in a private method and we generally don't test those. Also the change seems harmless enough (there be dragons at the end other end of this sentence).

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
