### PR TITLE
Unify padding of code blocks

### DIFF
--- a/app/assets/stylesheets/components/syntax.scss
+++ b/app/assets/stylesheets/components/syntax.scss
@@ -23,6 +23,11 @@ blockquote pre.highlight {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   overflow-wrap: initial;
+  padding: var(--su-2);
+
+  @media (min-width: $breakpoint-m) {
+    padding: var(--su-6);
+  }
 
   code {
     font-size: 100%;
@@ -36,12 +41,6 @@ div.highlight {
   // this a way to separate scroll of long code & icons in panel
   .highlight {
     overflow: auto;
-
-    padding: var(--su-2);
-
-    @media (min-width: $breakpoint-m) {
-      padding: var(--su-6);
-    }
   }
 }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Different padding was being applied to code blocks depending on their location in a document - e.g. as a list item, vs in the main document. See the screenshots on #14563 for the "before" version 🙂 

This PR moves the padding CSS to the 'catch-all' for codeblocks so that the same applies to all.

One thing I noticed while working on this issue is that in all cases other than the "code block on its own" example, the "full screen mode" icon in the top-right corner is not rendered. This seems to be a separate bug  and is already logged here - #11059

## Related Tickets & Documents

Fixes #14563

## QA Instructions, Screenshots, Recordings

Create a new post locally using the different types of code block locations targeted by this CSS. I used:

````md
## Code block on its own:

```
code
```

## Code block in a list item:

1. Something
    ```
    code
    ```
2. Something else

## Pre on its own:

<pre>
something
</pre>

## Code block in a blockquote:

> ```
>code
>```
````

Check the padding looks consistent in both the preview and the published view:

![screenshot of the markdown above saved as a post](https://user-images.githubusercontent.com/20773163/130753370-c49b7a9a-474d-4a55-b2ca-2804be4f2061.png)

Check the layout in mobile also as the padding is slightly smaller

![the same post rendered in a mobile size screen (portrait)](https://user-images.githubusercontent.com/20773163/130753510-06556a7c-7cf3-45dc-80cf-8fdc4627dea2.png)


### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: This is purely a CSS change, and there isn't a useful test we could write for this
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

