### PR TITLE
#12643 Add eslint rule for formatting redundant curly braces in jsx

### DIFF
--- a/app/javascript/.eslintrc.js
+++ b/app/javascript/.eslintrc.js
@@ -56,6 +56,10 @@ module.exports = {
     'jsx-a11y/no-onchange': 'off',
     'prefer-const': ['error'],
     'prefer-destructuring': ['warn', { object: true, array: false }],
+    'react/jsx-curly-brace-presence': [
+      'error',
+      { props: 'never', children: 'never' },
+    ],
   },
   overrides: [
     {

--- a/app/javascript/chat/message.jsx
+++ b/app/javascript/chat/message.jsx
@@ -109,7 +109,7 @@ export const Message = ({
 
       <div
         id={dropdownContentId}
-        className={`messagebody__dropdownmenu report__abuse__button hidden`}
+        className="messagebody__dropdownmenu report__abuse__button hidden"
       >
         <Button
           variant="ghost-danger"

--- a/app/javascript/utilities/codeFullscreenModeSwitcher.js
+++ b/app/javascript/utilities/codeFullscreenModeSwitcher.js
@@ -1,9 +1,8 @@
 let isFullScreenModeCodeOn = false;
 let screenScroll = 0;
-const fullScreenWindow = document.getElementsByClassName(
-  'js-fullscreen-code',
-)[0];
-const body = document.body;
+const fullScreenWindow =
+  document.getElementsByClassName('js-fullscreen-code')[0];
+const { body } = document;
 
 function setAfterFullScreenScrollPosition() {
   window.scrollTo(0, screenScroll);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Initially I thought I would have to build and publish my very own eslint plugin to solve this issue but later on I found out that such linting rule already exists. After merging this PR you can expect to see this linting check in action fixing where
```jsx
<MyComponent type={ 'exampleType' }>{ 'Hello world' }</MyComponent>
```
Would be corrected to:
```jsx
<MyComponent type="exampleType">Hello world</MyComponent>
```
As, you can see below, I ran the linter on all JavaScript files and it found and fixed 1 issue here -> https://github.com/itsnikhil/forem/commit/17508f12970621a323711cc5f08e0a67b7a7977b#diff-55437c4c12bdc7f18b73ceb37af6c27f95e647ef5ada26083c7fa53bd3730832R112

## Related Tickets & Documents
This PR fixes https://github.com/forem/forem/issues/12643

## QA Instructions, Screenshots, Recordings
You can run the following command and such linting violations will be marked as errors
```bash
 yarn run lint:frontend
```
![image](https://user-images.githubusercontent.com/20350674/130853092-6f40e1a7-7aa9-4e22-b561-eef4fa7d2bc8.png)
And with `--fix`, it will try to automatically fix such errors
```bash
 yarn run lint:frontend --fix
```

### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [x] No, there are no unit tests for linting violations.. I have done manual testing but if there is some way please let me know.

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## What gif best describes this PR or how it makes you feel?
![check](https://media.giphy.com/media/JGUMPPTMRCVPbSncVF/giphy.gif?cid=ecf05e47jwaid5x2wiyfwcbujd2nz6krpcq6kmdod08r9vqp&rid=giphy.gif&ct=g)
