### PR TITLE
Add exclusion to AASA supported paths

### DIFF
--- a/app/controllers/deep_links_controller.rb
+++ b/app/controllers/deep_links_controller.rb
@@ -1,4 +1,6 @@
 class DeepLinksController < ApplicationController
+  AASA_PATHS = ["/*", "NOT /users/auth/*"].freeze
+
   def mobile; end
 
   # Apple Application Site Association - based on Apple docs guidelines
@@ -15,12 +17,11 @@ class DeepLinksController < ApplicationController
     # Now restructure the array of arrays into valid AASA App ID's
     # Example: ['TEAM1.app.bundle.one', 'TEAM2.app.bundle.two']
     supported_apps = consumer_apps.map { |result| result.join(".") }
-    aasa_paths = ["/*", "NOT /users/auth/*"]
 
     render json: {
       applinks: {
         apps: [],
-        details: supported_apps.map { |app_id| { appID: app_id, paths: aasa_paths } }
+        details: supported_apps.map { |app_id| { appID: app_id, paths: AASA_PATHS } }
       },
       activitycontinuation: {
         apps: supported_apps

--- a/spec/requests/universal_links_spec.rb
+++ b/spec/requests/universal_links_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Universal Links (Apple)", type: :request do
   let(:aasa_route) { "/.well-known/apple-app-site-association" }
   let(:forem_app_id) { "R9SWHSQNV8.com.forem.app" }
+  let(:expected_paths) { ["/*", "NOT /users/auth/*"] }
 
   describe "returns a valid Apple App Site Association file" do
     context "with multiple ConsumerApps" do
@@ -20,7 +21,7 @@ RSpec.describe "Universal Links (Apple)", type: :request do
         expect(json_response.dig("applinks", "apps")).to be_empty
         json_response.dig("applinks", "details").each do |hash|
           expect(both_app_ids).to include(hash["appID"])
-          expect(hash["paths"]).to match_array(["/*"])
+          expect(hash["paths"]).to match_array(expected_paths)
         end
       end
     end
@@ -34,7 +35,7 @@ RSpec.describe "Universal Links (Apple)", type: :request do
         expect(json_response.dig("applinks", "apps")).to be_empty
         json_response.dig("applinks", "details").each do |hash|
           expect(hash["appID"]).to eq(forem_app_id)
-          expect(hash["paths"]).to match_array(["/*"])
+          expect(hash["paths"]).to match_array(expected_paths)
         end
       end
     end
@@ -49,7 +50,7 @@ RSpec.describe "Universal Links (Apple)", type: :request do
         expect(json_response.dig("applinks", "apps")).to be_empty
         json_response.dig("applinks", "details").each do |hash|
           expect(hash["appID"]).to eq(forem_app_id)
-          expect(hash["paths"]).to match_array(["/*"])
+          expect(hash["paths"]).to match_array(expected_paths)
         end
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [x] Optimization

## Description

This PR adds authentication routes as excluded from Apple App Site Association (AASA) file.

The exclusion rules are [documented here](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html)

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

1. Boot local server
2. Go to `localhost:3000/.well-known/apple-app-site-association`
3. You should see the default Forem iOS app supported with this new exclusion rule

### UI accessibility concerns?

None - Backend change

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: It's an optimization/fix on an edge case. It's a small enhancement on how Universal Links are managed on iOS when users also have the Forem iOS app installed.

## [optional] What gif best describes this PR or how it makes you feel?

![surprise smile](https://media.giphy.com/media/26tkl5TDu9MlvxFeM/giphy.gif?cid=ecf05e47eye1k7tbzjvfv9841ff68xsbzcv792yc00xi6hoc&rid=giphy.gif&ct=g)
