### PR TITLE
Remove redundant freeze calls

### DIFF
--- a/app/controllers/liquid_tags_controller.rb
+++ b/app/controllers/liquid_tags_controller.rb
@@ -1,7 +1,7 @@
 class LiquidTagsController < ApplicationController
   before_action :authenticate_user!
 
-  FILTER_REGEX = /^(?:NullTag|Liquid::)/.freeze
+  FILTER_REGEX = /^(?:NullTag|Liquid::)/
 
   def index
     custom_tags = Liquid::Template.tags.filter_map do |name, tag|

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,7 +1,7 @@
 class SitemapsController < ApplicationController
   before_action :set_cache_control_headers, only: %i[show]
 
-  SITEMAP_REGEX = /\Asitemap-(?<date_string>[A-Z][a-z][a-z]-\d{4})\.xml\z/.freeze
+  SITEMAP_REGEX = /\Asitemap-(?<date_string>[A-Z][a-z][a-z]-\d{4})\.xml\z/
 
   def show
     match = params[:sitemap].match(SITEMAP_REGEX)

--- a/app/liquid_tags/asciinema_tag.rb
+++ b/app/liquid_tags/asciinema_tag.rb
@@ -1,6 +1,6 @@
 class AsciinemaTag < LiquidTagBase
   PARTIAL = "liquids/asciinema".freeze
-  ASCIINEMA_URL_REGEX = %r{https://asciinema.org/a/(?<id>\d+)}.freeze
+  ASCIINEMA_URL_REGEX = %r{https://asciinema.org/a/(?<id>\d+)}
 
   def initialize(_tag_name, id, _parse_context)
     super

--- a/app/liquid_tags/codepen_tag.rb
+++ b/app/liquid_tags/codepen_tag.rb
@@ -2,7 +2,6 @@ class CodepenTag < LiquidTagBase
   PARTIAL = "liquids/codepen".freeze
   URL_REGEXP =
     %r{\A(http|https)://(codepen\.io|codepen\.io/team)/[a-zA-Z0-9_\-]{1,30}/pen/([a-zA-Z0-9]{5,32})/{0,1}\z}
-      .freeze
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/codesandbox_tag.rb
+++ b/app/liquid_tags/codesandbox_tag.rb
@@ -5,7 +5,6 @@ class CodesandboxTag < LiquidTagBase
       \A(module=([a-zA-Z0-9\-_/.@%])+)\Z|
       \A(runonclick=((0|1){1}))\Z|
       \Aview=(editor|split|preview)\Z}x
-      .freeze
 
   def initialize(_tag_name, id, _parse_context)
     super

--- a/app/liquid_tags/dotnet_fiddle_tag.rb
+++ b/app/liquid_tags/dotnet_fiddle_tag.rb
@@ -2,7 +2,7 @@ require "uri"
 
 class DotnetFiddleTag < LiquidTagBase
   PARTIAL = "liquids/dotnetfiddle".freeze
-  LINK_REGEXP = %r{\A(https)://(dotnetfiddle\.net)/(Widget)/[a-zA-Z0-9\-/]*\z}.freeze
+  LINK_REGEXP = %r{\A(https)://(dotnetfiddle\.net)/(Widget)/[a-zA-Z0-9\-/]*\z}
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/gist_tag.rb
+++ b/app/liquid_tags/gist_tag.rb
@@ -2,7 +2,6 @@ class GistTag < LiquidTagBase
   PARTIAL = "liquids/gist".freeze
   VALID_LINK_REGEXP =
     %r{\Ahttps://gist\.github\.com/([a-zA-Z0-9](-?[a-zA-Z0-9]){0,38})/([a-zA-Z0-9]){1,32}(/[a-zA-Z0-9]+)?\Z}
-      .freeze
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/git_pitch_tag.rb
+++ b/app/liquid_tags/git_pitch_tag.rb
@@ -1,6 +1,6 @@
 class GitPitchTag < LiquidTagBase
   PARTIAL = "liquids/gitpitch".freeze
-  URL_REGEXP = %r{(http|https)://gitpitch.com/[a-zA-Z0-9\-/]*}.freeze
+  URL_REGEXP = %r{(http|https)://gitpitch.com/[a-zA-Z0-9\-/]*}
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -1,7 +1,7 @@
 class GithubTag
   class GithubReadmeTag
     PARTIAL = "liquids/github_readme".freeze
-    GITHUB_DOMAIN_REGEXP = %r{.*github.com/}.freeze
+    GITHUB_DOMAIN_REGEXP = %r{.*github.com/}
     OPTION_NO_README = "no-readme".freeze
     VALID_OPTIONS = [OPTION_NO_README].freeze
 

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -2,9 +2,9 @@ class GlitchTag < LiquidTagBase
   attr_accessor :uri
 
   PARTIAL = "liquids/glitch".freeze
-  ID_REGEXP = /\A[a-zA-Z0-9\-]{1,110}\z/.freeze
-  TILDE_PREFIX_REGEXP = /\A~/.freeze
-  OPTION_REGEXP = /(app|code|no-files|preview-first|no-attribution|file=\w(\.\w)?)/.freeze
+  ID_REGEXP = /\A[a-zA-Z0-9\-]{1,110}\z/
+  TILDE_PREFIX_REGEXP = /\A~/
+  OPTION_REGEXP = /(app|code|no-files|preview-first|no-attribution|file=\w(\.\w)?)/
   OPTIONS_TO_QUERY_PAIR = {
     "app" => %w[previewSize 100],
     "code" => %w[previewSize 0],

--- a/app/liquid_tags/js_fiddle_tag.rb
+++ b/app/liquid_tags/js_fiddle_tag.rb
@@ -1,7 +1,7 @@
 class JsFiddleTag < LiquidTagBase
   PARTIAL = "liquids/jsfiddle".freeze
-  OPTION_REGEXP = /\A(js|html|css|result|,)*\z/.freeze
-  LINK_REGEXP = %r{\A(http|https)://(jsfiddle\.net)/[a-zA-Z0-9\-/]*\z}.freeze
+  OPTION_REGEXP = /\A(js|html|css|result|,)*\z/
+  LINK_REGEXP = %r{\A(http|https)://(jsfiddle\.net)/[a-zA-Z0-9\-/]*\z}
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/jsitor_tag.rb
+++ b/app/liquid_tags/jsitor_tag.rb
@@ -1,7 +1,7 @@
 class JsitorTag < LiquidTagBase
   PARTIAL = "liquids/jsitor".freeze
-  URL_REGEXP = %r{\A(https|http)://jsitor\.com/embed/\w+[-?a-zA-Z&]*\Z}.freeze
-  ID_REGEXP = /\A[\w&?-]+\Z/.freeze
+  URL_REGEXP = %r{\A(https|http)://jsitor\.com/embed/\w+[-?a-zA-Z&]*\Z}
+  ID_REGEXP = /\A[\w&?-]+\Z/
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/kotlin_tag.rb
+++ b/app/liquid_tags/kotlin_tag.rb
@@ -1,6 +1,6 @@
 class KotlinTag < LiquidTagBase
   PARTIAL = "liquids/kotlin".freeze
-  PARAM_REGEXP = /\A[a-zA-Z0-9]+\z/.freeze
+  PARAM_REGEXP = /\A[a-zA-Z0-9]+\z/
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/reddit_tag.rb
+++ b/app/liquid_tags/reddit_tag.rb
@@ -2,7 +2,7 @@ class RedditTag < LiquidTagBase
   include ActionView::Helpers::SanitizeHelper
 
   PARTIAL = "liquids/reddit".freeze
-  URL_REGEXP = %r{\Ahttps://(www.)?reddit.com}.freeze
+  URL_REGEXP = %r{\Ahttps://(www.)?reddit.com}
 
   def initialize(_tag_name, url, _parse_context)
     super

--- a/app/liquid_tags/spotify_tag.rb
+++ b/app/liquid_tags/spotify_tag.rb
@@ -1,7 +1,7 @@
 class SpotifyTag < LiquidTagBase
   PARTIAL = "liquids/spotify".freeze
-  URI_REGEXP = /spotify:(track|artist|playlist|album|episode|show):\w{22}/.freeze
-  URI_PLAYLIST_REGEXP = /spotify:(user):([a-zA-Z0-9]+):playlist:\w{22}/.freeze # legacy support
+  URI_REGEXP = /spotify:(track|artist|playlist|album|episode|show):\w{22}/
+  URI_PLAYLIST_REGEXP = /spotify:(user):([a-zA-Z0-9]+):playlist:\w{22}/ # legacy support
   TYPE_HEIGHT = {
     track: 80,
     user: 380,

--- a/app/liquid_tags/stackblitz_tag.rb
+++ b/app/liquid_tags/stackblitz_tag.rb
@@ -1,8 +1,8 @@
 class StackblitzTag < LiquidTagBase
   PARTIAL = "liquids/stackblitz".freeze
-  ID_REGEXP = /\A[a-zA-Z0-9\-]{0,60}\z/.freeze
-  VIEW_OPTION_REGEXP = /\Aview=(preview|editor|both)\z/.freeze
-  FILE_OPTION_REGEXP = /\Afile=(.*)\z/.freeze
+  ID_REGEXP = /\A[a-zA-Z0-9\-]{0,60}\z/
+  VIEW_OPTION_REGEXP = /\Aview=(preview|editor|both)\z/
+  FILE_OPTION_REGEXP = /\Afile=(.*)\z/
 
   def initialize(_tag_name, id, _parse_context)
     super

--- a/app/liquid_tags/stackexchange_tag.rb
+++ b/app/liquid_tags/stackexchange_tag.rb
@@ -9,7 +9,7 @@ class StackexchangeTag < LiquidTagBase
     "question" => "!*1SgQGDOL9bPBHULz9sKS.y6qv7V9fYNszvdhDuv5",
     "site" => "!mWxO_PNa4i"
   }.freeze
-  ID_REGEXP = /\A\d{1,20}\z/.freeze
+  ID_REGEXP = /\A\d{1,20}\z/
 
   attr_reader :site, :post_type
 

--- a/app/liquid_tags/tweet_tag.rb
+++ b/app/liquid_tags/tweet_tag.rb
@@ -1,7 +1,7 @@
 class TweetTag < LiquidTagBase
   include ActionView::Helpers::AssetTagHelper
   PARTIAL = "liquids/tweet".freeze
-  ID_REGEXP = /\A\d{10,20}\z/.freeze # id must be all numbers between 10 and 20 chars
+  ID_REGEXP = /\A\d{10,20}\z/ # id must be all numbers between 10 and 20 chars
 
   SCRIPT = <<~JAVASCRIPT.freeze
     var videoPreviews = document.getElementsByClassName("ltag__twitter-tweet__media__video-wrapper");

--- a/app/liquid_tags/twitter_timeline_tag.rb
+++ b/app/liquid_tags/twitter_timeline_tag.rb
@@ -2,7 +2,7 @@ class TwitterTimelineTag < LiquidTagBase
   include ActionView::Helpers::AssetTagHelper
   PARTIAL = "liquids/twitter_timeline".freeze
 
-  URL_REGEXP = %r{\Ahttps://twitter\.com/[a-zA-Z0-9]+/timelines/\d+\Z}.freeze
+  URL_REGEXP = %r{\Ahttps://twitter\.com/[a-zA-Z0-9]+/timelines/\d+\Z}
 
   SCRIPT = <<~JAVASCRIPT.freeze
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/app/liquid_tags/wikipedia_tag.rb
+++ b/app/liquid_tags/wikipedia_tag.rb
@@ -1,6 +1,6 @@
 class WikipediaTag < LiquidTagBase
   PARTIAL = "liquids/wikipedia".freeze
-  WIKI_REGEXP = %r{\Ahttps?://([a-z-]+)\.wikipedia.org/wiki/(\S+)\z}.freeze
+  WIKI_REGEXP = %r{\Ahttps?://([a-z-]+)\.wikipedia.org/wiki/(\S+)\z}
   TEXT_CLEANUP_XPATH = "//div[contains(@class, 'noprint') or contains(@class, 'hatnote')] | " \
                        "//span[@class='mw-ref'] | //figure | //sup".freeze
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,7 +5,7 @@ class Comment < ApplicationRecord
   include PgSearch::Model
   include Reactable
 
-  BODY_MARKDOWN_SIZE_RANGE = (1..25_000).freeze
+  BODY_MARKDOWN_SIZE_RANGE = (1..25_000)
 
   COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze
 
@@ -18,7 +18,7 @@ class Comment < ApplicationRecord
     .+?             # host
     (?::\d+)?       # optional port
     \z
-  }x.freeze
+  }x
 
   # The date that we began limiting the number of user mentions in a comment.
   MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 3, 12).freeze

--- a/app/models/github_issue.rb
+++ b/app/models/github_issue.rb
@@ -1,11 +1,11 @@
 # NOTE: we are using `GithubIssue` to store issues, pull requests and comments
 class GithubIssue < ApplicationRecord
   CATEGORIES = %w[issue issue_comment].freeze
-  API_URL_REGEXP = %r{\Ahttps://api.github.com/repos/.*\z}.freeze
-  PATH_COMMENT_REGEXP = %r{/issues/comments/}.freeze
-  PATH_ISSUE_REGEXP = %r{/issues/}.freeze
-  PATH_PULL_REQUEST_REGEXP = %r{/pulls/}.freeze
-  PATH_REPO_REGEXP = %r{.*github.com/repos/}.freeze
+  API_URL_REGEXP = %r{\Ahttps://api.github.com/repos/.*\z}
+  PATH_COMMENT_REGEXP = %r{/issues/comments/}
+  PATH_ISSUE_REGEXP = %r{/issues/}
+  PATH_PULL_REQUEST_REGEXP = %r{/pulls/}
+  PATH_REPO_REGEXP = %r{.*github.com/repos/}
 
   serialize :issue_serialized, Hash
 

--- a/app/models/navigation_link.rb
+++ b/app/models/navigation_link.rb
@@ -1,5 +1,5 @@
 class NavigationLink < ApplicationRecord
-  SVG_REGEXP = /<svg .*>/im.freeze
+  SVG_REGEXP = /<svg .*>/im
 
   before_validation :allow_relative_url, if: :url?
   before_save :strip_local_hostname, if: :url?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,9 +1,9 @@
 class Organization < ApplicationRecord
   include CloudinaryHelper
 
-  COLOR_HEX_REGEXP = /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/.freeze
-  INTEGER_REGEXP = /\A\d+\z/.freeze
-  SLUG_REGEXP = /\A[a-zA-Z0-9\-_]+\z/.freeze
+  COLOR_HEX_REGEXP = /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/
+  INTEGER_REGEXP = /\A\d+\z/
+  SLUG_REGEXP = /\A[a-zA-Z0-9\-_]+\z/
   MESSAGES = {
     integer_only: "Integer only. No sign allowed.",
     reserved_word: "%<value>s is a reserved word. Contact site admins for help registering your organization."

--- a/app/models/settings/general.rb
+++ b/app/models/settings/general.rb
@@ -8,7 +8,7 @@ module Settings
     # the cache, or call Settings::General.clear_cache
     cache_prefix { "v1" }
 
-    HEX_COLOR_REGEX = /\A#(\h{6}|\h{3})\z/.freeze
+    HEX_COLOR_REGEX = /\A#(\h{6}|\h{3})\z/
     LIGHTNING_ICON = File.read(Rails.root.join("app/assets/images/lightning.svg")).freeze
     STACK_ICON = File.read(Rails.root.join("app/assets/images/stack.svg")).freeze
 

--- a/app/models/settings/user_experience.rb
+++ b/app/models/settings/user_experience.rb
@@ -3,7 +3,7 @@ module Settings
   class UserExperience < RailsSettings::Base
     self.table_name = :settings_user_experiences
 
-    HEX_COLOR_REGEX = /\A#(\h{6}|\h{3})\z/.freeze
+    HEX_COLOR_REGEX = /\A#(\h{6}|\h{3})\z/
 
     # The configuration is cached, change this if you want to force update
     # the cache, or call Settings::UserExperience.clear_cache

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -9,7 +9,7 @@ class Tag < ActsAsTaggableOn::Tag
   include PgSearch::Model
 
   ALLOWED_CATEGORIES = %w[uncategorized language library tool site_mechanic location subcommunity].freeze
-  HEX_COLOR_REGEXP = /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/.freeze
+  HEX_COLOR_REGEXP = /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/
 
   belongs_to :badge, optional: true
   belongs_to :mod_chat_channel, class_name: "ChatChannel", optional: true

--- a/app/models/users/setting.rb
+++ b/app/models/users/setting.rb
@@ -2,7 +2,7 @@ module Users
   class Setting < ApplicationRecord
     self.table_name_prefix = "users_"
 
-    HEX_COLOR_REGEXP = /\A#?(?:\h{6}|\h{3})\z/.freeze
+    HEX_COLOR_REGEXP = /\A#?(?:\h{6}|\h{3})\z/
 
     belongs_to :user, touch: true
     scope :with_feed, -> { where.not(feed_url: [nil, ""]) }

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -1,5 +1,5 @@
 class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
-  LIQUID_TAG_SYNTAX_REGEX = /\{%|%\}/.freeze
+  LIQUID_TAG_SYNTAX_REGEX = /\{%|%\}/
   def initialize
     super
 

--- a/app/services/color/compare_hex.rb
+++ b/app/services/color/compare_hex.rb
@@ -3,7 +3,7 @@ module Color
     ACCENT_MODIFIERS = [1.14, 1.08, 1.06, 0.96, 0.9, 0.8, 0.7, 0.6].freeze
     BRIGHTNESS_FORMAT = "#%<r>02x%<g>02x%<b>02x".freeze
     OPACITY_FORMAT = "rgba(%<r>d, %<g>d, %<b>d, %<a>.2f)".freeze
-    RGB_REGEX = /^#?(?<r>..)(?<g>..)(?<b>..)$/.freeze
+    RGB_REGEX = /^#?(?<r>..)(?<g>..)(?<b>..)$/
 
     def initialize(hexes)
       @hexes = hexes.sort

--- a/app/services/error_messages/clean.rb
+++ b/app/services/error_messages/clean.rb
@@ -1,6 +1,6 @@
 module ErrorMessages
   class Clean
-    FRONTMATTER_ERROR = /expected key while parsing a block mapping at line/.freeze
+    FRONTMATTER_ERROR = /expected key while parsing a block mapping at line/
 
     REPLACEMENT_ERROR = "There was a problem parsing the front-matter YAML. " \
                         "Perhaps you need to escape a quote or a colon or something. " \

--- a/app/services/markdown_processor/fixer/base.rb
+++ b/app/services/markdown_processor/fixer/base.rb
@@ -8,7 +8,7 @@ module MarkdownProcessor
     # For example
     # METHODS = %i[add_quotes_to_tile add_quotes_to_description]
     class Base
-      FRONT_MATTER_DETECTOR = /-{3}.*?-{3}/m.freeze
+      FRONT_MATTER_DETECTOR = /-{3}.*?-{3}/m
 
       def self.call(markdown)
         return unless markdown
@@ -62,7 +62,7 @@ module MarkdownProcessor
       end
 
       # Match @_username_ that is not preceded by backtick
-      USERNAME_WITH_UNDERSCORE_REGEXP = /(?<!`)@_\w+_/.freeze
+      USERNAME_WITH_UNDERSCORE_REGEXP = /(?<!`)@_\w+_/
 
       # Escapes underscored username that is not in code
       def self.escape_underscored_username_in_line!(line)

--- a/app/validators/valid_domain_csv_validator.rb
+++ b/app/validators/valid_domain_csv_validator.rb
@@ -1,6 +1,6 @@
 class ValidDomainCsvValidator < ActiveModel::EachValidator
   DEFAULT_MESSAGE = "must be a comma-separated list of valid domains".freeze
-  VALID_DOMAIN = /^[a-zA-Z0-9]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/.freeze
+  VALID_DOMAIN = /^[a-zA-Z0-9]{1,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/
 
   def validate_each(record, attribute, value)
     return unless value

--- a/config/initializers/0_application_config.rb
+++ b/config/initializers/0_application_config.rb
@@ -1,5 +1,5 @@
 class ApplicationConfig
-  URI_REGEXP = %r{(?<scheme>https?://)?(?<host>.+?)(?<port>:\d+)?$}.freeze
+  URI_REGEXP = %r{(?<scheme>https?://)?(?<host>.+?)(?<port>:\d+)?$}
 
   def self.[](key)
     if ENV.key?(key)

--- a/lib/liquid/raw.rb
+++ b/lib/liquid/raw.rb
@@ -4,7 +4,7 @@
 module Liquid
   class Raw < Block
     remove_const(:FullTokenPossiblyInvalid) if defined?(FullTokenPossiblyInvalid)
-    FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*#{TagEnd}\z/om.freeze # rubocop:disable Naming/ConstantName
+    FullTokenPossiblyInvalid = /\A(.*)#{TagStart}\s*(\w+)\s*#{TagEnd}\z/om # rubocop:disable Naming/ConstantName
   end
 
   Template.register_tag("raw", Raw)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

A recent Rubocop upgrade seems to have added a new cop:

> Style/RedundantFreeze: Do not freeze immutable objects, as freezing them has no effect.

It seems like we didn't run this yet against `main` so in one of my PRs I ended up with a big diff due to the commit hook automatically fixing things.

## Related Tickets & Documents

m/a

## QA Instructions, Screenshots, Recordings

Nothing

### UI accessibility concerns?

n/a

## Added/updated tests?

- [X] No, and this is why: automated updated, no functionality change

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: automated updated, no functionality change