### PR TITLE
Install foreman for procfile and setup appdomain in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,8 +18,12 @@ tasks:
     init: >
       cp .env_sample .env &&
       gem install solargraph &&
+      gem install foreman &&
       bin/setup
     command: >
+      APP_DOMAIN=$(gp url 3000 | cut -f 3 -d / )
+      echo "APP_DOMAIN=\"$(gp url 3000 | cut -f 3 -d /)\"" >> .env
+      echo 'APP_PROTOCOL="https://"' >> .env
       bin/startup
   - command: >
       gp await-port 3000 &&

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -17,12 +17,12 @@ tasks:
       redis-server &
     init: >
       cp .env_sample .env &&
+      echo "APP_DOMAIN=\"$(gp url 3000 | cut -f 3 -d /)\"" >> .env &&
+      echo 'APP_PROTOCOL="https://"' >> .env &&
       gem install solargraph &&
       gem install foreman &&
       bin/setup
     command: >
-      echo "APP_DOMAIN=\"$(gp url 3000 | cut -f 3 -d /)\"" >> .env &&
-      echo 'APP_PROTOCOL="https://"' >> .env &&
       bin/startup
   - command: >
       gp await-port 3000 &&

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,9 +21,8 @@ tasks:
       gem install foreman &&
       bin/setup
     command: >
-      APP_DOMAIN=$(gp url 3000 | cut -f 3 -d / )
-      echo "APP_DOMAIN=\"$(gp url 3000 | cut -f 3 -d /)\"" >> .env
-      echo 'APP_PROTOCOL="https://"' >> .env
+      echo "APP_DOMAIN=\"$(gp url 3000 | cut -f 3 -d /)\"" >> .env &&
+      echo 'APP_PROTOCOL="https://"' >> .env &&
       bin/startup
   - command: >
       gp await-port 3000 &&


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Foreman was not installed in gitpod, so bin/startup would fail fast and the system would be stuck at "waiting for port 3000" indefinitely.

Additionally, the APP_DOMAIN can be fetched from the `gp` utility to
get the url for port 3000, so I've added that to the .env file after copying it. 

Since the .env file is read top down - it's easier to implement
appending the corrected value than to replace it at the beginning, but
I'm completely open to redoing this via a sed command or similar, to
change the variable at the top (this would be less confusing for
anyone else dealing with the file I guess - I'm not sure how much anyone will be hand-editing the .env, and if they do change the app domain in gitpod at the top it's unlikely to break anything accidentally. I'm on the fence here).


## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Notes on tested gitpod config PR's (there might be a better way. this was the one that initially occurred to me).

It looks like gitpod has an "open" syntax that sets the environment up according to the base branch (trunk/main/master) - given a repo url you can setup a workspace for it - and the .gitpod.yml file in the repo will be read - I didn't see a note on how to set it up using a branch.

You can (in the in-browser vs-code) switch branches, but I really wanted to test the boot up (from "open" to "browse" and login as admin) - so I merged this PR into my remote's main - gitpod accessible via https://gitpod.io/#https://github.com/djuber/forem to test 

This step had been failing because foreman was not installed:
![success](https://user-images.githubusercontent.com/1237369/131181622-16668942-35e9-440a-9b02-59aae9490aee.png)

And logging in was failing because app domain was not set (CSRF protection requires the APP_DOMAIN to equal the request domain, this doesn't work with the default "localhost:3000" setting).

![logged-in](https://user-images.githubusercontent.com/1237369/131182560-19c0085c-6350-4772-b7b4-76bb4793b9ed.png)


### UI accessibility concerns?

None, not used outside of gitpod environments.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: config change, test performed manually in a fork
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?


- [ ] I'll update the [Developer Docs](https://developers.forem.com) and/or
- [x] I will share this change in a [forem.dev](http://forem.dev) post

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![vscode](https://user-images.githubusercontent.com/1237369/131182143-6d464c8c-fcf3-4ceb-ad6f-aec351edbdca.png)
