### PR TITLE
Fixed "Pin to profile" button styling

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -231,7 +231,6 @@
     form {
       padding: 10px 0px;
       font-size: 15px;
-      font-family: $helvetica-condensed;
       font-stretch: condensed;
 
       select {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The "Pin to profile" button was out of font-styling evenness. This was happening because it was a `<form>` button unlike others which were custom styled anchor links. Therefore, this form button styling overwrote the custom style and made it look different.

### Proposed Solution
Made sure the form button inherits the same font styling as other buttons residing inside that div.

## Related Tickets & Documents
This is a fix related to issue https://github.com/forem/forem/issues/14503

## QA Instructions, Screenshots, Recordings

* To verify this fix, need to make sure all the action buttons of a post follow same font-styling.
* Testing location - `Manage` section of any post.
* Here are the screenshots of before/after fix.

* Before fix 

![before](https://user-images.githubusercontent.com/22269104/131288746-eecbd6c8-1b0d-458a-af9a-914f9d2ba4b9.png)

* After fix

![after](https://user-images.githubusercontent.com/22269104/131288759-957d9686-683e-4511-8b61-25a6c2f38963.png)

### UI accessibility concerns?

* The responsiveness of the app remains intact after the fix.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is a css style edit and need no tests to validate.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
