### PR TITLE
Only tech admins can manage page feature flags

### DIFF
--- a/app/views/admin/pages/_form.html.erb
+++ b/app/views/admin/pages/_form.html.erb
@@ -74,23 +74,25 @@
       <%= render partial: "landing_page_modal", locals: { page: @landing_page } %>
     <% end %>
 
-    <div class="form-group">
-      <p>
-        <b><%= link_to "Feature Flag", "/admin/feature_flags" %></b>
-        <span class="badge badge-<%= FeatureFlag.exist?(@page.feature_flag_name) ? "success" : "warning" %>">
-          <%= FeatureFlag.exist?(@page.feature_flag_name) ? "Present" : "Not Present" %>
-        </span>
-        <br>
-        <% if FeatureFlag.exist?(@page.feature_flag_name) %>
-          Access to this page is being guarded by the feature flag <code><%= @page.feature_flag_name %></code>.
-          <%= link_to "Modify flag here", "/admin/feature_flags/features/#{@page.feature_flag_name}" %>
-        <% else %>
-          Everyone has access. Optionally guard access to this page by creating feature <code><%= @page.feature_flag_name %></code>
-          <%= link_to "here", "/admin/feature_flags/features" %>
-        <% end %>
-        <br>
-      </p>
-    </div>
+    <% if current_user.has_role?(:tech_admin) %>
+      <div class="form-group">
+        <p>
+          <b><%= link_to "Feature Flag", "/admin/feature_flags" %></b>
+          <span class="badge badge-<%= FeatureFlag.exist?(@page.feature_flag_name) ? "success" : "warning" %>">
+            <%= FeatureFlag.exist?(@page.feature_flag_name) ? "Present" : "Not Present" %>
+          </span>
+          <br>
+          <% if FeatureFlag.exist?(@page.feature_flag_name) %>
+            Access to this page is being guarded by the feature flag <code><%= @page.feature_flag_name %></code>.
+            <%= link_to "Modify flag here", "/admin/feature_flags/features/#{@page.feature_flag_name}" %>
+          <% else %>
+            Everyone has access. Optionally guard access to this page by creating feature <code><%= @page.feature_flag_name %></code>
+            <%= link_to "here", "/admin/feature_flags/features" %>
+          <% end %>
+          <br>
+        </p>
+      </div>
+    <% end %>
     <%= form.submit class: "crayons-btn" %>
   <% end %>
 

--- a/spec/requests/admin/pages_spec.rb
+++ b/spec/requests/admin/pages_spec.rb
@@ -5,4 +5,19 @@ RSpec.describe "/admin/customization/pages", type: :request do
   it_behaves_like "an InternalPolicy dependant request", Page do
     let(:request) { get admin_pages_path }
   end
+
+  describe "when managing feature flags" do
+    it "allows tech admins to manage the feature flag for a page" do
+      user = create(:user, :admin, :tech_admin)
+      sign_in user
+      get new_admin_page_path
+      expect(response.body).to include("Feature Flag")
+    end
+
+    it "does not allow non tech admins to manage the feature flag for a page" do
+      sign_in create(:user, :admin)
+      get new_admin_page_path
+      expect(response.body).not_to include("Feature Flag")
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

When creating a new page as an admin who doesn't also have the role "tech admin" one would see the following:

![image](https://user-images.githubusercontent.com/47985/131303484-3e786e56-c4c5-4a0e-b464-c07eb6b02c88.png)

However, feature flag management is only available to tech admins, so this whole section is now hidden for regular admins.

Note: the issue mentioned two possible solutions, I went for the first but am happy to go with the other one ("how the message, but disable the link and provide a message explaining the `tech_admin `role is required") if people prefer that.

## Related Tickets & Documents

Closes #9737

## QA Instructions, Screenshots, Recordings

1. Go to `/admin/customization/pages` as a user who has both "admin" and "tech admin" roles. You should see the message from the screenshot above.
2. Go to `/admin/customization/pages` as a user who has only the "admin" role, you should not see this message.

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
