### PR TITLE
Make sure input can scroll into view on mobile

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -30,13 +30,13 @@
   box-sizing: border-box;
   padding: var(--su-4);
   width: 100%;
-  height: 800px;
-  max-height: 90vh;
+  min-height: 100%;
   overflow: auto;
 
   @media screen and (min-width: $breakpoint-s) {
     justify-content: center;
     padding: var(--su-7) var(--su-8);
+    height: 800px;
   }
 }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It was noticed on android mobile (not sure if this was affecting iOS also) that when you tapped into an input field during onboarding, the soft keyboard was blocking the input content. Scrolling inputs into view when the keyboard appears is default mobile behaviour, but it seems our fixed height in the CSS was breaking this.

I've made a small change that keeps modal heights consistent on desktop, but allows the mobile browser to "do its thing" and make sure the input stays in view.

## Related Tickets & Documents

Fixes https://github.com/forem/forem/issues/13811

## QA Instructions, Screenshots, Recordings

- Onboard as a new user, visiting `/onboarding`
- On a desktop/non-mobile device, check that the modal sizing all looks as before
- On a mobile device, check that when you enter your bio, the keyboard doesn't obscure the input


https://user-images.githubusercontent.com/20773163/131341233-47c21416-ab12-4405-a5da-31ff3ac4741d.mp4

([Check out our docs for advice on how to run local code on your mobile device](https://developers.forem.com/tests/manuel-tests))

### UI accessibility concerns?

Fixes a general usability issue

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: This is really specific to mobile devices, and UI-based. I don't think there's a useful test we can write for this.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![popping up from the long grass](https://media.giphy.com/media/dxbDsOKgq5IlcjzTC7/giphy-downsized-large.gif?cid=ecf05e47gji6e8bwoadatklylckgc65aehlgahltjxnz2etl&rid=giphy-downsized-large.gif&ct=g)
