### PR TITLE
Cache tables which are known to exist

### DIFF
--- a/app/lib/database.rb
+++ b/app/lib/database.rb
@@ -1,13 +1,19 @@
-# Database related utility functions
-module Database
+# Database related utility functionsc
+class Database
   # Checks if the database is ready and the specified table exists. This can be
   # useful during bin/setup and similar tasks. It also works if the connection
   # hasn't been established yet.
   #
   # @param table [String] the name of the table to check for
   def self.table_available?(table)
-    ActiveRecord::Base.connection.table_exists?(table)
+    available_tables[table] ||=
+      ActiveRecord::Base.connection.table_exists?(table)
   rescue ActiveRecord::NoDatabaseError, ActiveRecord::ConnectionNotEstablished
     false
   end
+
+  def self.available_tables
+    @available_tables ||= {}
+  end
+  private_class_method :available_tables
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Only check again for negative results.

The ActiveRecord `table_exists?` method this is calling does no caching (it executes a schema query on every call). 

Since we're more likely _waiting_ for a table or connection that might not exist yet, than guarding against a known table being removed during execution, if the table was ever found to exist, assume it continues to until the process stops (next deploy, for example).

## Related Tickets & Documents

Internal discussion https://forem-team.slack.com/archives/C7GE84DEJ/p1630424291037000 about a sudden large increase in the number of calls to [`data_source_sql`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/connection_adapters/postgresql/schema_statements.rb#L758-L768) showing in datadog after a recent change to the settings module base class in #14138 


## QA Instructions, Screenshots, Recordings

I tested this in console by calling `Database.table_available?` twice each with "users" (which is a positive result, should only execute query once) and "notfound" (a negative result will continue to check for presence, will execute multiple postgres queries).

I have query logging enabled and was able to check this in /var/log/postgresql's main log (file name depends on server setup, read permissions may require root/postgres user)

### UI accessibility concerns?
None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: should not change tested behavior
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
