### PR TITLE
Remove extra script tag from embedded gists to prevent them from mixing up

### DIFF
--- a/app/javascript/utilities/gist.js
+++ b/app/javascript/utilities/gist.js
@@ -30,11 +30,13 @@ function getGistTags(nodes) {
 
 function loadEmbeddedGists(postscribe, gistTags) {
   for (const gistTag of gistTags) {
-    postscribe(gistTag, gistTag.firstElementChild.outerHTML, {
-      beforeWrite(text) {
-        return gistTag.childElementCount > 3 ? '' : text;
-      },
-    });
+    setTimeout(() => {
+      postscribe(gistTag, gistTag.firstElementChild.outerHTML, {
+        beforeWrite(text) {
+          return gistTag.childElementCount > 3 ? '' : text;
+        },
+      });
+    }, 500);
   }
 }
 

--- a/app/javascript/utilities/gist.js
+++ b/app/javascript/utilities/gist.js
@@ -30,13 +30,13 @@ function getGistTags(nodes) {
 
 function loadEmbeddedGists(postscribe, gistTags) {
   for (const gistTag of gistTags) {
-    setTimeout(() => {
-      postscribe(gistTag, gistTag.firstElementChild.outerHTML, {
-        beforeWrite(text) {
-          return gistTag.childElementCount > 3 ? '' : text;
-        },
-      });
-    }, 500);
+    const gistWrapper = gistTag.firstElementChild;
+    postscribe(gistTag, gistWrapper.outerHTML, {
+      beforeWrite(text) {
+        return gistTag.childElementCount > 3 ? '' : text;
+      },
+    });
+    gistWrapper.remove();
   }
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Solves issue #14428. Added a timeout which gives consistent order of gists.

## Related Tickets & Documents
https://github.com/krux/postscribe#how-to-use-postscribe-to-render-an-ad-after-load

## QA Instructions, Screenshots, Recordings
To recreate the issue, make sure you restart your browser or empty the cache. 
- Head to a (post page )[https://dev.to/luvejo/how-to-build-a-carousel-from-scratch-using-vue-js-4ki0]
- Select the author on the right
- Now select the same post from the author page
- Gists should now be mixed up 
(Able to produce behaviour in all browsers.)

To test in your local you can create a post which has multiple gists. And can follow the same steps as above. 
Moving to given branch in PR, issue should be resolved.

### UI accessibility concerns?

None

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
