### PR TITLE
Change mobile new comment notification text and add sound

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -38,7 +38,7 @@ class Device < ApplicationRecord
         alert: {
           title: Settings::Community.community_name,
           subtitle: title,
-          body: body
+          body: body.truncate(512)
         },
         "thread-id": Settings::Community.community_name,
         sound: "default"

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -40,7 +40,8 @@ class Device < ApplicationRecord
           subtitle: title,
           body: body
         },
-        "thread-id": Settings::Community.community_name
+        "thread-id": Settings::Community.community_name,
+        sound: "default"
       },
       data: payload
     }

--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -3,6 +3,8 @@
 module Notifications
   module NewComment
     class Send
+      include ActionView::Helpers::TextHelper
+
       def initialize(comment)
         @comment = comment
       end
@@ -42,7 +44,8 @@ module Notifications
           user_ids: targets,
           title: "💬 New Comment",
           body: "#{comment.user.username} commented on " \
-                "#{comment.commentable.title.strip}:\n#{comment.body_markdown.strip}",
+                "#{comment.commentable.title.strip}:\n" \
+                "#{strip_tags(comment.processed_html).strip}",
           payload: {
             url: URL.url(comment.path),
             type: "new comment"

--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -40,8 +40,9 @@ module Notifications
 
         PushNotifications::Send.call(
           user_ids: targets,
-          title: "@#{comment.user.username}",
-          body: "Re: #{comment.parent_or_root_article.title.strip}",
+          title: "💬 New Comment",
+          body: "#{comment.user.username} commented on " \
+                "#{comment.commentable.title.strip}:\n#{comment.body_markdown.strip}",
           payload: {
             url: URL.url(comment.path),
             type: "new comment"

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Device, type: :model do
   let(:device) { create(:device) }
+  let(:user) { create(:user) }
 
   describe "validations" do
     subject { device }
@@ -12,6 +13,27 @@ RSpec.describe Device, type: :model do
 
       it { is_expected.to validate_presence_of(:token) }
       it { is_expected.to validate_uniqueness_of(:token).scoped_to(%i[user_id platform consumer_app_id]) }
+    end
+  end
+
+  describe "#create_notification" do
+    let(:data_hash) { { "alert" => "Hello World" } }
+
+    context "when iOS device" do
+      let(:consumer_app_ios) { create(:consumer_app, platform: :ios) }
+
+      it "creates an Apns2 notification" do
+        mocked_objects = mock_rpush(consumer_app_ios)
+
+        device = create(:device, user: user, platform: "iOS")
+        device.create_notification("Subtitle", "Body", data_hash)
+        expect(mocked_objects[:rpush_notification].data[:aps][:alert][:title]).to eq(Settings::Community.community_name)
+        expect(mocked_objects[:rpush_notification].data[:aps][:alert][:subtitle]).to eq("Subtitle")
+        expect(mocked_objects[:rpush_notification].data[:aps][:alert][:body]).to eq("Body")
+        expect(mocked_objects[:rpush_notification].data[:aps][:"thread-id"]).to eq(Settings::Community.community_name)
+        expect(mocked_objects[:rpush_notification].data[:aps][:sound]).to eq("default")
+        expect(mocked_objects[:rpush_notification].data[:data]).to eq(data_hash)
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

As outlined in https://github.com/forem/forem-ios/issues/105, this PR changes the text of mobile notification for new comments to be more informative and useful. The subtitle of the notification now includes and emoji for easy glanceability and explains what this notification is related to. The text of the notification now spells out which user made a comment, which post it was on, and the beginning of the comment text.

**Bonus**: we weren't sending a sound property, which is required for iOS to play a sound or vibrate. It won't assume we want the default: absence of the property tells the OS not to play any sound or vibration!

## Screens

iOS Before
![ios-before](https://user-images.githubusercontent.com/37842/132415936-4c89b8b3-f13c-46d9-94bf-824b23c915d5.jpeg)

iOS After
![ios-after](https://user-images.githubusercontent.com/37842/132415960-c38ddfe2-d33d-447a-b438-bfd04c3b562b.jpeg)

WatchOS short glance before
![watch-short-glace-before](https://user-images.githubusercontent.com/37842/132416301-1d921203-6cde-4e8e-a881-a46c836f1b4c.jpeg)

WatchOS short glance after
![watch-short-glance-after](https://user-images.githubusercontent.com/37842/132416314-01dfe04e-3692-49b9-abc6-471a8ac7d502.jpeg)

WatchOS long glance before
![watch-long-glance-before](https://user-images.githubusercontent.com/37842/132416354-2ef2a51e-4ce0-432a-9ded-856d1cdfaaf4.jpeg)

WatchOS long glance after
![watch-short-glance-after](https://user-images.githubusercontent.com/37842/132416404-ea934580-c2b7-4e30-a9f7-5cf2febb9380.jpeg)


## Related Tickets & Documents

Related to https://github.com/forem/forem-ios/issues/105


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

No: this change is compatible with both versions 1.0.3 and 1.0.4 of the Forem iOS app

## [optional] What gif best describes this PR or how it makes you feel?

![New Notification GIF](https://media.giphy.com/media/AMcAQXdWpCbrm8OLbE/giphy.gif?cid=ecf05e471g7r8qupc1vhjhf0gxwodvae2d8jvsb4evrkqa49&rid=giphy.gif&ct=g)
