### PR TITLE
When calling Faker::Markdown, avoid "sandwich" method

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -512,7 +512,7 @@ seeder.create_if_none(Listing) do
       Listing.create!(
         user: user,
         title: Faker::Lorem.sentence,
-        body_markdown: Faker::Markdown.random,
+        body_markdown: Faker::Markdown.random(:sandwich, :random),
         location: Faker::Address.city,
         organization_id: user.organizations.first&.id,
         listing_category_id: category_id,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -512,7 +512,7 @@ seeder.create_if_none(Listing) do
       Listing.create!(
         user: user,
         title: Faker::Lorem.sentence,
-        body_markdown: Faker::Markdown.random(:sandwich, :random),
+        body_markdown: Faker::Markdown.random.lines.take(10).join,
         location: Faker::Address.city,
         organization_id: user.organizations.first&.id,
         listing_category_id: category_id,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

[Faker::Markdown.random](https://github.com/faker-ruby/faker/blob/master/lib/faker/default/markdown.rb#L119-L137) accepts an excluded method list, use this to exclude `:sandwich`.

Since `random` can also be selected by `random` (it is one of the `available_methods` sampled), and it's then called without the exclude list,  we exclude it as well (so that it won't call sandwich after calling random without an exclude list).

This avoids generating body_markdown exceeding 12 newlines (which is validated in Listing and prevents save, breaking the seeds process).

A totally reasonable and probably more readable approach would be to use [citizen428's suggested](https://github.com/forem/forem/issues/14683#issuecomment-914891139) method - take the first 10 lines and join the body back together.

## Related Tickets & Documents

fixes #14683 

## QA Instructions, Screenshots, Recordings

Since this relies on the random results from faker - I took repeated sampling to determine this was okay
- results here https://gist.github.com/djuber/44850f0d1beaee54cd34961a93c5e941

### UI accessibility concerns?

None 

## Added/updated tests?

- [x] No, and this is why: bugfix to developer seed data

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: trivial

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![markov-chain](https://user-images.githubusercontent.com/1237369/132544461-f0d92cf1-c9c1-4a16-8d3d-64578eb8bf64.png)
