### PR TITLE
Accessible names for follow buttons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -144,7 +144,7 @@ module ApplicationHelper
         }
       },
       class: "crayons-btn follow-action-button whitespace-nowrap #{classes} #{user_follow}",
-      aria: { label: "Follow #{followable_type}: #{followable_name}" },
+      aria: { label: "Follow #{followable_type}: #{followable_name}", pressed: "false" },
     )
   end
 

--- a/app/javascript/packs/followButtons.js
+++ b/app/javascript/packs/followButtons.js
@@ -59,7 +59,7 @@ function addAriaLabelToButton({ button, followType, followName, style = '' }) {
       break;
     case 'follow-back':
       label = `Follow ${followType.toLowerCase()} back: ${followName}`;
-      pressed = 'true';
+      pressed = 'false';
       break;
     case 'following':
       label = `Unfollow ${followType.toLowerCase()}: ${followName}`;
@@ -67,14 +67,15 @@ function addAriaLabelToButton({ button, followType, followName, style = '' }) {
       break;
     case 'self':
       label = `Edit profile`;
-      pressed = 'false';
       break;
     default:
       label = `Follow ${followType.toLowerCase()}: ${followName}`;
       pressed = 'false';
   }
   button.setAttribute('aria-label', label);
-  button.setAttribute('aria-pressed', pressed);
+  pressed.length === 0
+    ? button.removeAttribute('aria-pressed')
+    : button.setAttribute('aria-pressed', pressed);
 }
 
 /**

--- a/app/javascript/packs/followButtons.js
+++ b/app/javascript/packs/followButtons.js
@@ -62,7 +62,6 @@ function addAriaLabelToButton({ button, followType, followName, style = '' }) {
       pressed = 'false';
       break;
     case 'following':
-      label = `Unfollow ${followType.toLowerCase()}: ${followName}`;
       pressed = 'true';
       break;
     case 'self':

--- a/app/javascript/packs/followButtons.js
+++ b/app/javascript/packs/followButtons.js
@@ -42,7 +42,7 @@ function addButtonFollowText(button, style) {
 }
 
 /**
- * Sets the aria-label of the button
+ * Sets the aria-label and aria-pressed value of the button
  *
  * @param {HTMLElement} button The Follow button to update.
  * @param {string} followType The followableType of the button.
@@ -51,23 +51,30 @@ function addButtonFollowText(button, style) {
  */
 function addAriaLabelToButton({ button, followType, followName, style = '' }) {
   let label = '';
+  let pressed = '';
   switch (style) {
     case 'follow':
       label = `Follow ${followType.toLowerCase()}: ${followName}`;
+      pressed = 'false';
       break;
     case 'follow-back':
       label = `Follow ${followType.toLowerCase()} back: ${followName}`;
+      pressed = 'true';
       break;
     case 'following':
       label = `Unfollow ${followType.toLowerCase()}: ${followName}`;
+      pressed = 'true';
       break;
     case 'self':
       label = `Edit profile`;
+      pressed = 'false';
       break;
     default:
       label = `Follow ${followType.toLowerCase()}: ${followName}`;
+      pressed = 'false';
   }
   button.setAttribute('aria-label', label);
+  button.setAttribute('aria-pressed', pressed);
 }
 
 /**

--- a/app/javascript/packs/followButtons.js
+++ b/app/javascript/packs/followButtons.js
@@ -62,6 +62,7 @@ function addAriaLabelToButton({ button, followType, followName, style = '' }) {
       pressed = 'false';
       break;
     case 'following':
+      label = `Follow ${followType.toLowerCase()}: ${followName}`;
       pressed = 'true';
       break;
     case 'self':

--- a/cypress/integration/seededFlows/articleFlows/followAuthor.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/followAuthor.spec.js
@@ -22,10 +22,12 @@ describe('Follow author from article sidebar', () => {
       cy.get('@followButton').click();
 
       cy.get('@followButton').should('have.text', 'Following');
+      cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
 
       cy.get('@followButton').click();
       cy.wait('@followRequest');
       cy.get('@followButton').should('have.text', 'Follow');
+      cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
     });
   });
 });

--- a/cypress/integration/seededFlows/articleFlows/followFromArticleLiquidTag.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/followFromArticleLiquidTag.spec.js
@@ -31,10 +31,27 @@ describe('Follow from article liquid tag', () => {
             'followUserButton',
           );
           cy.get('@followUserButton').should('have.text', 'Follow');
+          cy.get('@followUserButton').should(
+            'have.attr',
+            'aria-pressed',
+            'false',
+          );
+
           cy.get('@followUserButton').click();
           cy.get('@followUserButton').should('have.text', 'Following');
+          cy.get('@followUserButton').should(
+            'have.attr',
+            'aria-pressed',
+            'true',
+          );
+
           cy.get('@followUserButton').click();
           cy.get('@followUserButton').should('have.text', 'Follow');
+          cy.get('@followUserButton').should(
+            'have.attr',
+            'aria-pressed',
+            'false',
+          );
         });
       });
     });

--- a/cypress/integration/seededFlows/articleFlows/previewProfile.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/previewProfile.spec.js
@@ -89,15 +89,7 @@ describe('Preview user profile from article page', () => {
           );
           cy.get('@followUserButton').click();
 
-          // Wait for Follow button to disappear and Following button to be initialized
-          cy.findByRole('button', {
-            name: 'Follow user: Admin McAdmin',
-          }).should('not.exist');
-
-          cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' }).as(
-            'unfollowUserButton',
-          );
-          cy.get('@unfollowUserButton').should(
+          cy.get('@followUserButton').should(
             'have.attr',
             'aria-pressed',
             'true',
@@ -138,13 +130,14 @@ describe('Preview user profile from article page', () => {
 
           cy.findByRole('button', {
             name: 'Follow user: Admin McAdmin',
-          }).click();
+          }).as('userFollowButton');
 
-          // Wait for Follow button to disappear and Following button to be initialized
-          cy.findByRole('button', {
-            name: 'Follow user: Admin McAdmin',
-          }).should('not.exist');
-          cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' });
+          cy.get('@userFollowButton').click();
+          cy.get('@userFollowButton').should(
+            'have.attr',
+            'aria-pressed',
+            'true',
+          );
         });
       });
     });
@@ -162,12 +155,14 @@ describe('Preview user profile from article page', () => {
         .within(() => {
           cy.findByRole('button', {
             name: 'Follow user: Admin McAdmin',
-          }).click();
-          // Confirm the follow button has been updated
-          cy.findByRole('button', {
-            name: 'Follow user: Admin McAdmin',
-          }).should('not.exist');
-          cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' });
+          }).as('userFollowButton');
+
+          cy.get('@userFollowButton').click();
+          cy.get('@userFollowButton').should(
+            'have.attr',
+            'aria-pressed',
+            'true',
+          );
         });
 
       // Close the preview card so the next preview button can be clicked
@@ -180,7 +175,8 @@ describe('Preview user profile from article page', () => {
 
       cy.findAllByTestId('profile-preview-card')
         .last()
-        .findByRole('button', { name: 'Unfollow user: Admin McAdmin' });
+        .findByRole('button', { name: 'Follow user: Admin McAdmin' })
+        .should('have.attr', 'aria-pressed', 'true');
     });
 
     it('should detach listeners on preview card close', () => {

--- a/cypress/integration/seededFlows/articleFlows/previewProfile.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/previewProfile.spec.js
@@ -90,7 +90,10 @@ describe('Preview user profile from article page', () => {
           cy.get('@followUserButton').click();
 
           // Wait for Follow button to disappear and Following button to be initialized
-          cy.get('@followUserButton').should('not.exist');
+          cy.findByRole('button', {
+            name: 'Follow user: Admin McAdmin',
+          }).should('not.exist');
+
           cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' }).as(
             'unfollowUserButton',
           );

--- a/cypress/integration/seededFlows/articleFlows/previewProfile.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/previewProfile.spec.js
@@ -78,15 +78,27 @@ describe('Preview user profile from article page', () => {
           cy.findByText('Edinburgh');
           cy.findByText('University of Life');
 
-          cy.findByRole('button', {
-            name: 'Follow user: Admin McAdmin',
-          }).click();
+          cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).as(
+            'followUserButton',
+          );
+
+          cy.get('@followUserButton').should(
+            'have.attr',
+            'aria-pressed',
+            'false',
+          );
+          cy.get('@followUserButton').click();
 
           // Wait for Follow button to disappear and Following button to be initialized
-          cy.findByRole('button', {
-            name: 'Follow user: Admin McAdmin',
-          }).should('not.exist');
-          cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' });
+          cy.get('@followUserButton').should('not.exist');
+          cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' }).as(
+            'unfollowUserButton',
+          );
+          cy.get('@unfollowUserButton').should(
+            'have.attr',
+            'aria-pressed',
+            'true',
+          );
         });
 
       // Check we can close the preview dropdown

--- a/cypress/integration/seededFlows/articleFlows/seriesFlows/previewProfileFromSeries.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/seriesFlows/previewProfileFromSeries.spec.js
@@ -32,13 +32,26 @@ describe('Preview profile from series', () => {
       cy.findByText('Edinburgh');
       cy.findByText('University of Life');
 
-      cy.findByRole('button', { name: 'Follow user: Series User' }).click();
+      cy.findByRole('button', { name: 'Follow user: Series User' }).as(
+        'userFollowButton',
+      );
+      cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'false');
+      cy.get('@userFollowButton').click();
 
       // Check that the follow button has updated as expected
-      cy.findByRole('button', { name: 'Follow user: Series User' }).should(
-        'not.exist',
+      cy.get('@userFollowButton').should('have.text', 'Following');
+      cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
+      cy.get('@userFollowButton').should('not.exist');
+
+      cy.findByRole('button', { name: 'Unfollow user: Series User' }).as(
+        'userUnfollowButton',
       );
-      cy.findByRole('button', { name: 'Unfollow user: Series User' });
+      cy.get('@userUnfollowButton').should('have.text', 'Follow');
+      cy.get('@userUnfollowButton').should(
+        'have.attr',
+        'aria-pressed',
+        'false',
+      );
     });
   });
 });

--- a/cypress/integration/seededFlows/articleFlows/seriesFlows/previewProfileFromSeries.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/seriesFlows/previewProfileFromSeries.spec.js
@@ -38,16 +38,8 @@ describe('Preview profile from series', () => {
       cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'false');
       cy.get('@userFollowButton').click();
 
-      // Check that the follow button has updated as expected
-      cy.findByRole('button', { name: 'Follow user: Series User' }).should(
-        'not.exist',
-      );
-
-      cy.findByRole('button', { name: 'Unfollow user: Series User' }).as(
-        'userUnfollowButton',
-      );
-      cy.get('@userUnfollowButton').should('have.text', 'Following');
-      cy.get('@userUnfollowButton').should('have.attr', 'aria-pressed', 'true');
+      cy.get('@userFollowButton').should('have.text', 'Following');
+      cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
     });
   });
 });

--- a/cypress/integration/seededFlows/articleFlows/seriesFlows/previewProfileFromSeries.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/seriesFlows/previewProfileFromSeries.spec.js
@@ -39,19 +39,15 @@ describe('Preview profile from series', () => {
       cy.get('@userFollowButton').click();
 
       // Check that the follow button has updated as expected
-      cy.get('@userFollowButton').should('have.text', 'Following');
-      cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
-      cy.get('@userFollowButton').should('not.exist');
+      cy.findByRole('button', { name: 'Follow user: Series User' }).should(
+        'not.exist',
+      );
 
       cy.findByRole('button', { name: 'Unfollow user: Series User' }).as(
         'userUnfollowButton',
       );
-      cy.get('@userUnfollowButton').should('have.text', 'Follow');
-      cy.get('@userUnfollowButton').should(
-        'have.attr',
-        'aria-pressed',
-        'false',
-      );
+      cy.get('@userUnfollowButton').should('have.text', 'Following');
+      cy.get('@userUnfollowButton').should('have.attr', 'aria-pressed', 'true');
     });
   });
 });

--- a/cypress/integration/seededFlows/articleFlows/viewArticleDiscussion.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/viewArticleDiscussion.spec.js
@@ -23,10 +23,12 @@ describe('View article discussion', () => {
 
       // Confirm the follow button has been updated
       cy.get('@userFollowButton').should('have.text', 'Following');
+      cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
 
       // Repeat and check the button changes back to 'Follow'
       cy.get('@userFollowButton').click();
       cy.get('@userFollowButton').should('have.text', 'Follow');
+      cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'false');
     });
   });
 

--- a/cypress/integration/seededFlows/homeFeedFlows/profilePreviewCards.spec.js
+++ b/cypress/integration/seededFlows/homeFeedFlows/profilePreviewCards.spec.js
@@ -27,13 +27,18 @@ describe('Home feed profile preview cards', () => {
         cy.findByText('Edinburgh');
         cy.findByText('University of Life');
 
-        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).click();
-
-        // Check that following status has been updated
-        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).should(
-          'not.exist',
+        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).as(
+          'userFollowButton',
         );
-        cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' });
+        cy.get('@userFollowButton').should(
+          'have.attr',
+          'aria-pressed',
+          'false',
+        );
+        cy.get('@userFollowButton').click();
+
+        cy.get('@userFollowButton').should('have.text', 'Following');
+        cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
       });
   });
 });

--- a/cypress/integration/seededFlows/loggedOutFlows/homeFeed.spec.js
+++ b/cypress/integration/seededFlows/loggedOutFlows/homeFeed.spec.js
@@ -30,11 +30,6 @@ describe('Logged out Home feed', () => {
         cy.get('@userFollowButton').click();
 
         // Confirm the follow button has been updated
-        cy.get('@userFollowButton').should('have.text', 'Following');
-        cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
-
-        // Repeat and check the button changes back to 'Follow'
-        cy.get('@userFollowButton').click();
         cy.get('@userFollowButton').should('have.text', 'Follow');
         cy.get('@userFollowButton').should(
           'have.attr',

--- a/cypress/integration/seededFlows/loggedOutFlows/homeFeed.spec.js
+++ b/cypress/integration/seededFlows/loggedOutFlows/homeFeed.spec.js
@@ -24,7 +24,23 @@ describe('Logged out Home feed', () => {
         cy.findByText('Edinburgh');
         cy.findByText('University of Life');
 
-        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).click();
+        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).as(
+          'userFollowButton',
+        );
+        cy.get('@userFollowButton').click();
+
+        // Confirm the follow button has been updated
+        cy.get('@userFollowButton').should('have.text', 'Following');
+        cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
+
+        // Repeat and check the button changes back to 'Follow'
+        cy.get('@userFollowButton').click();
+        cy.get('@userFollowButton').should('have.text', 'Follow');
+        cy.get('@userFollowButton').should(
+          'have.attr',
+          'aria-pressed',
+          'false',
+        );
       });
 
     // Clicking a follow button while logged out should always trigger the log in to continue modal

--- a/cypress/integration/seededFlows/loggedOutFlows/tagIndex.spec.js
+++ b/cypress/integration/seededFlows/loggedOutFlows/tagIndex.spec.js
@@ -31,11 +31,6 @@ describe('Logged out - tag index page', () => {
         cy.get('@userFollowButton').click();
 
         // Confirm the follow button has been updated
-        cy.get('@userFollowButton').should('have.text', 'Following');
-        cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
-
-        // Repeat and check the button changes back to 'Follow'
-        cy.get('@userFollowButton').click();
         cy.get('@userFollowButton').should('have.text', 'Follow');
         cy.get('@userFollowButton').should(
           'have.attr',

--- a/cypress/integration/seededFlows/loggedOutFlows/tagIndex.spec.js
+++ b/cypress/integration/seededFlows/loggedOutFlows/tagIndex.spec.js
@@ -25,7 +25,23 @@ describe('Logged out - tag index page', () => {
         cy.findByText('Edinburgh');
         cy.findByText('University of Life');
 
-        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).click();
+        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).as(
+          'userFollowButton',
+        );
+        cy.get('@userFollowButton').click();
+
+        // Confirm the follow button has been updated
+        cy.get('@userFollowButton').should('have.text', 'Following');
+        cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
+
+        // Repeat and check the button changes back to 'Follow'
+        cy.get('@userFollowButton').click();
+        cy.get('@userFollowButton').should('have.text', 'Follow');
+        cy.get('@userFollowButton').should(
+          'have.attr',
+          'aria-pressed',
+          'false',
+        );
       });
 
     // Clicking a follow button while logged out should always trigger the log in to continue modal

--- a/cypress/integration/seededFlows/notificationsFlows/followUserFromNotifications.spec.js
+++ b/cypress/integration/seededFlows/notificationsFlows/followUserFromNotifications.spec.js
@@ -14,11 +14,14 @@ describe('Follow user from notifications', () => {
     cy.findByRole('button', { name: 'Follow user back: User' }).as(
       'followButton',
     );
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
     cy.get('@followButton').click();
 
     cy.get('@followButton').should('have.text', 'Following');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
 
     cy.get('@followButton').click();
     cy.get('@followButton').should('have.text', 'Follow back');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
   });
 });

--- a/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
+++ b/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
@@ -10,9 +10,6 @@ describe('Follow podcast', () => {
   it('Follows and unfollows a podcast', () => {
     cy.get('[data-follow-clicks-initialized]');
 
-    cy.findByRole('heading', {
-      name: 'Developer on Fire Developer on Fire Follow',
-    });
     cy.findByRole('button', { name: 'Follow podcast: Developer on Fire' }).as(
       'followButton',
     );

--- a/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
+++ b/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
@@ -20,6 +20,7 @@ describe('Follow podcast', () => {
     cy.get('@followButton').click();
     // Inner text should now be following
     cy.get('@followButton').should('have.text', 'Following');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
 
     // Check that state is persisted on refresh
     cy.visitAndWaitForUserSideEffects('/developeronfire');
@@ -30,6 +31,7 @@ describe('Follow podcast', () => {
     // Check it reverts back to Follow on click
     cy.get('@followButton').click();
     cy.get('@followButton').should('have.text', 'Follow');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
 
     // Check that state is persisted on refresh
     cy.visitAndWaitForUserSideEffects('/developeronfire');

--- a/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
+++ b/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
@@ -24,9 +24,6 @@ describe('Follow podcast', () => {
 
     // Check that state is persisted on refresh
     cy.visitAndWaitForUserSideEffects('/developeronfire');
-    cy.findByRole('button', { name: 'Unfollow podcast: Developer on Fire' }).as(
-      'followButton',
-    );
 
     // Check it reverts back to Follow on click
     cy.get('@followButton').click();

--- a/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
+++ b/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
@@ -25,6 +25,9 @@ describe('Follow podcast', () => {
 
     // Check that state is persisted on refresh
     cy.visitAndWaitForUserSideEffects('/developeronfire');
+    cy.findByRole('button', { name: 'Follow podcast: Developer on Fire' }).as(
+      'followButton',
+    );
     cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
 
     // Check it reverts back to Follow on click

--- a/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
+++ b/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
@@ -10,6 +10,10 @@ describe('Follow podcast', () => {
   it('Follows and unfollows a podcast', () => {
     cy.get('[data-follow-clicks-initialized]');
 
+    cy.findByRole('heading', {
+      name: 'Developer on Fire Developer on Fire Follow',
+    });
+
     cy.findByRole('button', { name: 'Follow podcast: Developer on Fire' }).as(
       'followButton',
     );
@@ -21,6 +25,7 @@ describe('Follow podcast', () => {
 
     // Check that state is persisted on refresh
     cy.visitAndWaitForUserSideEffects('/developeronfire');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
 
     // Check it reverts back to Follow on click
     cy.get('@followButton').click();

--- a/cypress/integration/seededFlows/profileFlows/followOrganisation.spec.js
+++ b/cypress/integration/seededFlows/profileFlows/followOrganisation.spec.js
@@ -16,6 +16,8 @@ describe('Follow user from profile page', () => {
       'followButton',
     );
 
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
+
     cy.get('@followButton').click();
     // Inner text should now be following
     cy.get('@followButton').should('have.text', 'Following');
@@ -23,10 +25,15 @@ describe('Follow user from profile page', () => {
 
     // Check that state is persisted on refresh
     cy.visitAndWaitForUserSideEffects('/bachmanity');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
 
     // Check it reverts back to Follow on click
     cy.get('@followButton').click();
     cy.get('@followButton').should('have.text', 'Follow');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
+
+    // Check that the update persists after reload
+    cy.visitAndWaitForUserSideEffects('/bachmanity');
     cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
   });
 });

--- a/cypress/integration/seededFlows/profileFlows/followOrganisation.spec.js
+++ b/cypress/integration/seededFlows/profileFlows/followOrganisation.spec.js
@@ -12,24 +12,21 @@ describe('Follow user from profile page', () => {
   it('follows and unfollows an organisation', () => {
     cy.intercept('/follows').as('followsRequest');
 
-    cy.findByRole('button', {
-      name: 'Follow organization: Bachmanity',
-    }).click();
-    cy.wait('@followsRequest');
-    cy.findByRole('button', { name: 'Unfollow organization: Bachmanity' });
+    cy.findByRole('button', { name: 'Follow organization: Bachmanity' }).as(
+      'followButton',
+    );
 
-    // Check that the update persists after reload
+    cy.get('@followButton').click();
+    // Inner text should now be following
+    cy.get('@followButton').should('have.text', 'Following');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
+
+    // Check that state is persisted on refresh
     cy.visitAndWaitForUserSideEffects('/bachmanity');
 
-    cy.findByRole('button', {
-      name: 'Unfollow organization: Bachmanity',
-    }).click();
-    cy.wait('@followsRequest');
-
-    cy.findByRole('button', { name: 'Follow organization: Bachmanity' });
-
-    // Check that the update persists after reload
-    cy.visitAndWaitForUserSideEffects('/bachmanity');
-    cy.findByRole('button', { name: 'Follow organization: Bachmanity' });
+    // Check it reverts back to Follow on click
+    cy.get('@followButton').click();
+    cy.get('@followButton').should('have.text', 'Follow');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
   });
 });

--- a/cypress/integration/seededFlows/profileFlows/followUser.spec.js
+++ b/cypress/integration/seededFlows/profileFlows/followUser.spec.js
@@ -14,26 +14,19 @@ describe('Follow user from profile page', () => {
 
     cy.findByRole('button', {
       name: 'Follow user: Article Editor v1 User',
-    }).click();
+    }).as('followButton');
+    cy.get('@followButton').click();
     cy.wait('@followsRequest');
-    cy.findByRole('button', {
-      name: 'Unfollow user: Article Editor v1 User',
-    }).as('unFollowButton');
 
-    cy.get('@unFollowButton').should('have.text', 'Following');
-    cy.get('@unFollowButton').should('have.attr', 'aria-pressed', 'true');
+    cy.get('@followButton').should('have.text', 'Following');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
 
     // Check that the update persists after reload
     cy.visitAndWaitForUserSideEffects('/article_editor_v1_user');
 
-    cy.get('@unFollowButton').click();
+    cy.get('@followButton').click();
 
     cy.wait('@followsRequest');
-    cy.get('@unFollowButton').should('not.exist');
-
-    cy.findByRole('button', { name: 'Follow user: Article Editor v1 User' }).as(
-      'followButton',
-    );
 
     cy.get('@followButton').should('have.text', 'Follow');
     cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');

--- a/cypress/integration/seededFlows/profileFlows/followUser.spec.js
+++ b/cypress/integration/seededFlows/profileFlows/followUser.spec.js
@@ -23,6 +23,7 @@ describe('Follow user from profile page', () => {
 
     // Check that the update persists after reload
     cy.visitAndWaitForUserSideEffects('/article_editor_v1_user');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
 
     cy.get('@followButton').click();
 

--- a/cypress/integration/seededFlows/profileFlows/followUser.spec.js
+++ b/cypress/integration/seededFlows/profileFlows/followUser.spec.js
@@ -16,20 +16,31 @@ describe('Follow user from profile page', () => {
       name: 'Follow user: Article Editor v1 User',
     }).click();
     cy.wait('@followsRequest');
-    cy.findByRole('button', { name: 'Unfollow user: Article Editor v1 User' });
-
-    // Check that the update persists after reload
-    cy.visitAndWaitForUserSideEffects('/article_editor_v1_user');
-
     cy.findByRole('button', {
       name: 'Unfollow user: Article Editor v1 User',
-    }).click();
-    cy.wait('@followsRequest');
+    }).as('unFollowButton');
 
-    cy.findByRole('button', { name: 'Follow user: Article Editor v1 User' });
+    cy.get('@unFollowButton').should('have.text', 'Following');
+    cy.get('@unFollowButton').should('have.attr', 'aria-pressed', 'true');
 
     // Check that the update persists after reload
     cy.visitAndWaitForUserSideEffects('/article_editor_v1_user');
-    cy.findByRole('button', { name: 'Follow user: Article Editor v1 User' });
+
+    cy.get('@unFollowButton').click();
+
+    cy.wait('@followsRequest');
+    cy.get('@unFollowButton').should('not.exist');
+
+    cy.findByRole('button', { name: 'Follow user: Article Editor v1 User' }).as(
+      'followButton',
+    );
+
+    cy.get('@followButton').should('have.text', 'Follow');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
+
+    // Check that the update persists after reload
+    cy.visitAndWaitForUserSideEffects('/article_editor_v1_user');
+    cy.get('@followButton').should('have.text', 'Follow');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
   });
 });

--- a/cypress/integration/seededFlows/searchFlows/followUser.spec.js
+++ b/cypress/integration/seededFlows/searchFlows/followUser.spec.js
@@ -31,9 +31,11 @@ describe('Follow user from search results', () => {
 
     cy.wait('@followsRequest');
     cy.get('@followButton').should('have.text', 'Following');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
 
     cy.get('@followButton').click();
     cy.wait('@followsRequest');
     cy.get('@followButton').should('have.text', 'Follow');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
   });
 });

--- a/cypress/integration/seededFlows/searchFlows/previewProfileFromPostSearchResults.spec.js
+++ b/cypress/integration/seededFlows/searchFlows/previewProfileFromPostSearchResults.spec.js
@@ -28,13 +28,27 @@ describe('Preview profile from post search results', () => {
         cy.findByText('Edinburgh');
         cy.findByText('University of Life');
 
-        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).click();
-
-        // Check that following status has been updated
-        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).should(
-          'not.exist',
+        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).as(
+          'followUserButton',
         );
-        cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' });
+
+        cy.get('@followUserButton').should(
+          'have.attr',
+          'aria-pressed',
+          'false',
+        );
+        cy.get('@followUserButton').click();
+
+        // Wait for Follow button to disappear and Following button to be initialized
+        cy.get('@followUserButton').should('not.exist');
+        cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' }).as(
+          'unfollowUserButton',
+        );
+        cy.get('@unfollowUserButton').should(
+          'have.attr',
+          'aria-pressed',
+          'true',
+        );
       });
   });
 });

--- a/cypress/integration/seededFlows/searchFlows/previewProfileFromPostSearchResults.spec.js
+++ b/cypress/integration/seededFlows/searchFlows/previewProfileFromPostSearchResults.spec.js
@@ -39,16 +39,7 @@ describe('Preview profile from post search results', () => {
         );
         cy.get('@followUserButton').click();
 
-        // Wait for Follow button to disappear and Following button to be initialized
-        cy.get('@followUserButton').should('not.exist');
-        cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' }).as(
-          'unfollowUserButton',
-        );
-        cy.get('@unfollowUserButton').should(
-          'have.attr',
-          'aria-pressed',
-          'true',
-        );
+        cy.get('@followUserButton').should('have.attr', 'aria-pressed', 'true');
       });
   });
 });

--- a/cypress/integration/seededFlows/tagsFlows/followTag.spec.js
+++ b/cypress/integration/seededFlows/tagsFlows/followTag.spec.js
@@ -20,11 +20,13 @@ describe('Follow tag', () => {
       cy.wait('@followsRequest');
 
       cy.get('@followButton').should('have.text', 'Following');
+      cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
 
       cy.get('@followButton').click();
       cy.wait('@followsRequest');
 
       cy.get('@followButton').should('have.text', 'Follow');
+      cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
     });
   });
 

--- a/cypress/integration/seededFlows/tagsFlows/previewProfileFromTagIndex.spec.js
+++ b/cypress/integration/seededFlows/tagsFlows/previewProfileFromTagIndex.spec.js
@@ -38,20 +38,8 @@ describe('Preview profile from the tag index page', () => {
         );
         cy.get('@userFollowButton').click();
 
-        // Check that the follow button has updated as expected
         cy.get('@userFollowButton').should('have.text', 'Following');
         cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
-        cy.get('@userFollowButton').should('not.exist');
-
-        cy.findByRole('button', { name: 'Unfollow user: Series User' }).as(
-          'userUnfollowButton',
-        );
-        cy.get('@userUnfollowButton').should('have.text', 'Follow');
-        cy.get('@userUnfollowButton').should(
-          'have.attr',
-          'aria-pressed',
-          'false',
-        );
       });
   });
 });

--- a/cypress/integration/seededFlows/tagsFlows/previewProfileFromTagIndex.spec.js
+++ b/cypress/integration/seededFlows/tagsFlows/previewProfileFromTagIndex.spec.js
@@ -28,7 +28,7 @@ describe('Preview profile from the tag index page', () => {
         cy.findByText('Edinburgh');
         cy.findByText('University of Life');
 
-        cy.findByRole('button', { name: 'Follow user: Series User' }).as(
+        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).as(
           'userFollowButton',
         );
         cy.get('@userFollowButton').should(

--- a/cypress/integration/seededFlows/tagsFlows/previewProfileFromTagIndex.spec.js
+++ b/cypress/integration/seededFlows/tagsFlows/previewProfileFromTagIndex.spec.js
@@ -28,13 +28,30 @@ describe('Preview profile from the tag index page', () => {
         cy.findByText('Edinburgh');
         cy.findByText('University of Life');
 
-        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).click();
-
-        // Check that following status has been updated
-        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).should(
-          'not.exist',
+        cy.findByRole('button', { name: 'Follow user: Series User' }).as(
+          'userFollowButton',
         );
-        cy.findByRole('button', { name: 'Unfollow user: Admin McAdmin' });
+        cy.get('@userFollowButton').should(
+          'have.attr',
+          'aria-pressed',
+          'false',
+        );
+        cy.get('@userFollowButton').click();
+
+        // Check that the follow button has updated as expected
+        cy.get('@userFollowButton').should('have.text', 'Following');
+        cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
+        cy.get('@userFollowButton').should('not.exist');
+
+        cy.findByRole('button', { name: 'Unfollow user: Series User' }).as(
+          'userUnfollowButton',
+        );
+        cy.get('@userUnfollowButton').should('have.text', 'Follow');
+        cy.get('@userUnfollowButton').should(
+          'have.attr',
+          'aria-pressed',
+          'false',
+        );
       });
   });
 });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
 - This PR changes the already existing follow buttons to [toggle buttons](https://inclusive-components.design/toggle-button/)
 - Added `aria-pressed` value to all follow buttons, set to true when followed.

## Related Tickets & Documents
 - This PR addresses the second part of Follow button enhancements #14356 
## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

![alt_text](https://media.giphy.com/media/WU0J9RYTNjKa6XrqB3/giphy.gif)
