### PR TITLE
Handle GibbonError when Mailchimp api key was not set

### DIFF
--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -41,7 +41,7 @@ module Mailchimp
         )
 
         success = true
-      rescue Gibbon::MailChimpError => e
+      rescue Gibbon::MailChimpError, Gibbon::GibbonError => e
         # If user was previously subscribed, set their status to "pending"
         return resubscribe_to_newsletter if previously_subcribed?(e)
 

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -41,7 +41,9 @@ module Mailchimp
         )
 
         success = true
-      rescue Gibbon::MailChimpError, Gibbon::GibbonError => e
+      rescue Gibbon::GibbonError => e
+        report_error(e)
+      rescue Gibbon::MailChimpError => e
         # If user was previously subscribed, set their status to "pending"
         return resubscribe_to_newsletter if previously_subcribed?(e)
 

--- a/spec/services/mailchimp/bot_spec.rb
+++ b/spec/services/mailchimp/bot_spec.rb
@@ -90,6 +90,17 @@ RSpec.describe Mailchimp::Bot, type: :service do
 
       expect(mailchimp_bot).to have_received(:resubscribe_to_newsletter)
     end
+
+    it "does not try to resubscribe on other errors" do
+      mailchimp_bot = described_class.new(user)
+      gibbon_error =
+        Gibbon::GibbonError.new("You must set an api_key prior to making a call")
+      allow(mailchimp_bot.gibbon).to receive(:upsert).and_raise(gibbon_error)
+      allow(mailchimp_bot).to receive(:resubscribe_to_newsletter)
+      mailchimp_bot.upsert_to_newsletter
+
+      expect(mailchimp_bot).not_to have_received(:resubscribe_to_newsletter)
+    end
   end
 
   describe "manage community moderator list" do

--- a/spec/services/mailchimp/bot_spec.rb
+++ b/spec/services/mailchimp/bot_spec.rb
@@ -91,15 +91,13 @@ RSpec.describe Mailchimp::Bot, type: :service do
       expect(mailchimp_bot).to have_received(:resubscribe_to_newsletter)
     end
 
-    it "does not try to resubscribe on other errors" do
+    it "handles GibbonError" do
       mailchimp_bot = described_class.new(user)
       gibbon_error =
         Gibbon::GibbonError.new("You must set an api_key prior to making a call")
       allow(mailchimp_bot.gibbon).to receive(:upsert).and_raise(gibbon_error)
-      allow(mailchimp_bot).to receive(:resubscribe_to_newsletter)
-      mailchimp_bot.upsert_to_newsletter
 
-      expect(mailchimp_bot).not_to have_received(:resubscribe_to_newsletter)
+      expect { mailchimp_bot.upsert_to_newsletter }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Gibbon raises an [unhandled error](https://app.honeybadger.io/projects/72638/faults/73753178
) when an api key is missing. 
 
Internal discussion with Ben about whether this was a managed api key (part of the hosting product) or an admin managed item:
> I believe they would be on their own to set that up. If it's not present it probably shouldn't result in an error. 

Since this check happens in a background worker, there's no great way to forward this alert to a responsible party - log the error and move on.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

I added a test case for this. It might have been smarter to set an empty api key and then check it doesn't raise than to stub the gibbon request - it's easy enough to replicate locally in console:

```ruby
[2] pry(main)> Settings::General.mailchimp_api_key
=> "Optional-valid"                               
[3] pry(main)> ApplicationConfig["MAILCHIMP_API_KEY"]
=> "Optional-valid"                                  
[4] pry(main)> Settings::General.mailchimp_api_key=""
=> ""
[5] pry(main)> Settings::General.mailchimp_api_key  
=> ""
[6] pry(main)> mcb = Mailchimp::Bot.new(User.find(11))
[7] pry(main)> mcb.gibbon.lists.upsert()
Gibbon::GibbonError: You must set an api_key prior to making a call
```

### UI accessibility concerns?

None, background worker

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: bugfix

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![gibbons](https://user-images.githubusercontent.com/1237369/132754776-3272886a-e9c5-4c2c-a75f-60abc3aec91c.png)
