### PR TITLE
Fixed awaiting web server command in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -27,7 +27,7 @@ tasks:
   - command: >
       gp await-port 3000 &&
       printf "Waiting for Forem server ..." &&
-      until $(curl -sNL $(gp url 3000) | grep -q "DEV"); do printf '.'; sleep 5; done && echo "" &&
+      until $(curl -sNL $(gp url 3000) | grep -q "Forem"); do printf '.'; sleep 5; done && echo "" &&
       gp preview $(gp url 3000)
 
 github:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes the awaiting web server command in Gitpod. It was previously checking the curl command for `DEV`. Now it checks for `Forem`.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

- Launch Gitpod. The gp terminal session in Gitpod should complete successfully if the webserver is running.
- 
![image](https://user-images.githubusercontent.com/833231/132792529-231e51fd-3951-4919-9ba7-a14a5ac8599d.png)

Note that there is another issue with Gitpod at the moment with the init command (#14698). That will be addressed in another PR. For the time being, run the following to start the web server in the Forem Server terminal session.

```
cp .env_sample .env &&
echo "APP_DOMAIN=\"$(gp url 3000 | cut -f 3 -d /)\"" >> .env &&
echo 'APP_PROTOCOL="https://"' >> .env &&
gem install solargraph &&
gem install foreman &&
bin/setup &&
bin/startup
```

![image](https://user-images.githubusercontent.com/833231/132792744-0acf5733-5cc9-4025-9391-897f41df0a69.png)

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is a container prebuild script.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) and/or
      [Admin Guide](https://admin.forem.com/), or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/jnmsc0Z910FW6nawKM/giphy.gif?cid=ecf05e47jz5rfq6sr30jxr2ri8hyswh3jyiof9xvms9qntcj&rid=giphy.gif&ct=g)
