### PR TITLE
[15-minute fix] Don't try to create invalid RatingVote

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -142,11 +142,14 @@ class ReactionsController < ApplicationController
   end
 
   def rate_article(reaction)
+    user_experience_level = current_user.setting.experience_level
+    return unless user_experience_level
+
     RatingVote.create(article_id: reaction.reactable_id,
                       group: "experience_level",
                       user_id: current_user.id,
                       context: "readinglist_reaction",
-                      rating: current_user.setting.experience_level)
+                      rating: user_experience_level)
   end
 
   def clear_moderator_reactions(id, type, mod, category)

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -211,20 +211,41 @@ RSpec.describe "Reactions", type: :request do
       before do
         user.setting.update_column(:experience_level, 8)
         sign_in user
+      end
+
+      it "creates reaction" do
         post "/reactions", params: {
           reactable_id: article.id,
           reactable_type: "Article",
           category: "readinglist"
         }
-      end
 
-      it "creates reaction" do
         expect(Reaction.last.reactable_id).to eq(article.id)
       end
 
       it "creates rating vote" do
-        expect(RatingVote.last.context).to eq("readinglist_reaction")
-        expect(RatingVote.last.rating).to be(8.0)
+        post "/reactions", params: {
+          reactable_id: article.id,
+          reactable_type: "Article",
+          category: "readinglist"
+        }
+
+        rating_vote = RatingVote.last
+        expect(rating_vote.context).to eq("readinglist_reaction")
+        expect(rating_vote.rating).to be(8.0)
+      end
+
+      it "does not attempt to create a rating vote when the user's experience level is unset" do
+        user.setting.update_column(:experience_level, nil)
+        allow(RatingVote).to receive(:create)
+
+        post "/reactions", params: {
+          reactable_id: article.id,
+          reactable_type: "Article",
+          category: "readinglist"
+        }
+
+        expect(RatingVote).not_to have_received(:create)
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

When a user adds an article to their reading list we use their self-set experience level to influence the article's experience level. When confirming a question in a discussion with the product team, I noticed that we don't actually check if a user has an experience level set before trying to create the rating. This PR adds a guard clause to avoid that.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Nothing specific

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: minor backend fix
