### PR TITLE
Fix bug where OAuth signups were not pulling in OAuth provider's profile image

### DIFF
--- a/app/services/users/safe_remote_profile_image_url.rb
+++ b/app/services/users/safe_remote_profile_image_url.rb
@@ -2,9 +2,12 @@ module Users
   module SafeRemoteProfileImageUrl
     # Basic check for nil and blank URLs, alongside likely incomplete URLs, such as just "image.jpg".
     def self.call(url)
-      url.gsub!("http://", "https://") if url.match?(%r{https?://})
-
-      url.presence || Users::ProfileImageGenerator.call
+      if url&.start_with?("http")
+        url.sub!("http://", "https://")
+        url
+      else
+        Users::ProfileImageGenerator.call
+      end
     end
   end
 end

--- a/app/services/users/safe_remote_profile_image_url.rb
+++ b/app/services/users/safe_remote_profile_image_url.rb
@@ -2,11 +2,9 @@ module Users
   module SafeRemoteProfileImageUrl
     # Basic check for nil and blank URLs, alongside likely incomplete URLs, such as just "image.jpg".
     def self.call(url)
-      if url.match?(%r{https?://})
-        url[0..6].gsub("http://", "https://") + url[7..]
-      else
-        Users::ProfileImageGenerator.call
-      end
+      url.gsub!("http://", "https://") if url.match?(%r{https?://})
+
+      url.presence || Users::ProfileImageGenerator.call
     end
   end
 end

--- a/app/services/users/safe_remote_profile_image_url.rb
+++ b/app/services/users/safe_remote_profile_image_url.rb
@@ -2,9 +2,11 @@ module Users
   module SafeRemoteProfileImageUrl
     # Basic check for nil and blank URLs, alongside likely incomplete URLs, such as just "image.jpg".
     def self.call(url)
-      return url if url.to_s.start_with?("https")
-
-      Users::ProfileImageGenerator.call
+      if url.match?(%r{https?://})
+        url[0..6].gsub("http://", "https://") + url[7..]
+      else
+        Users::ProfileImageGenerator.call
+      end
     end
   end
 end

--- a/spec/services/users/safe_remote_profile_image_url_spec.rb
+++ b/spec/services/users/safe_remote_profile_image_url_spec.rb
@@ -17,4 +17,9 @@ RSpec.describe Users::SafeRemoteProfileImageUrl, type: :service do
   it "returns fallback image if passed non-URL" do
     expect(described_class.call("image")).to start_with("https://emojipedia-us.s3")
   end
+
+  it "returns a secure HTTPS image link if pass a regular HTTP link" do
+    url = "http://image.com/image.jpg"
+    expect(described_class.call(url)).to eq "https://image.com/image.jpg"
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a bug where we weren't pulling in the OAuth provider's (Twitter/GitHub/Facebook/etc) profile image, and instead were always auto generating one. The problem is partly because we take a conservative approach of when a URL is not `https`, we default to auto-generating one.

This PR makes it so it always fills in `http` profile image URLs with `https`, and if the URL is still blank, we auto generate the profile image.

## Related Tickets & Documents
Resolves #14432 

## QA Instructions, Screenshots, Recordings
1. Log in via Twitter
2. See that your profile image persisted
3. Log in via GitHub
4. See that your profile image persisted
5. (optional) Log in via Facebook (this is kind of a pain -- Forem team members feel free to DM me for instructions and necessary auth tokens)
6. See that your profile image persisted

### UI accessibility concerns?
Nope

## Added tests?

- [x] No, and this is why: I tried writing tests for this but it seemed too verbose to try to mock it, since we don't persist profile image files in the test database.
- [x] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![Homer Simpsons pumps his fist victoriously, and says "All right, we're back in business."](https://media.giphy.com/media/26tk134Ku0nTdKmuA/giphy.gif?cid=ecf05e47s63mw4oon91ya14i55px8z5j47zka38jh0bhqij3&rid=giphy.gif&ct=g)