### PR TITLE
Remove ApplicationHelper#sanitize_and_decode

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -269,11 +269,6 @@ module ApplicationHelper
     URL.organization(organization)
   end
 
-  def sanitize_and_decode(str)
-    # using to_str instead of to_s to prevent removal of html entity code
-    HTMLEntities.new.decode(sanitize(str).to_str)
-  end
-
   def estimated_user_count
     User.registered.estimated_count
   end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -98,7 +98,7 @@
             <%= render "articles/video_player", meta_tags: true, article: @article %>
           <% elsif @article.main_image.present? %>
             <div class="crayons-article__cover">
-              <img src="<%= cloud_cover_url(@article.main_image) %>" width="1000" height="420" style="background-color:<%= @article.main_image_background_hex_color %>;" class="crayons-article__cover__image" alt="Cover image for <%= sanitize_and_decode @article.title %>">
+              <img src="<%= cloud_cover_url(@article.main_image) %>" width="1000" height="420" style="background-color:<%= @article.main_image_background_hex_color %>;" class="crayons-article__cover__image" alt="Cover image for <%= @article.title %>">
             </div>
           <% end %>
 
@@ -115,7 +115,7 @@
               <% if @article.search_optimized_title_preamble.present? && !user_signed_in? %>
                 <span class="fs-xl color-base-70 block"><%= @article.search_optimized_title_preamble %></span>
               <% end %>
-              <%= sanitize_and_decode @article.title %>
+              <%= @article.title %>
             </h1>
 
             <% cache("main-article-tags-#{@article.cached_tag_list}", expires_in: 30.hours) do %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -55,7 +55,7 @@
       <header class="crayons-article__header">
         <% if @commentable.respond_to?(:main_image) && @commentable.main_image.present? %>
           <div class="crayons-article__cover">
-            <img src="<%= cloud_cover_url(@commentable.main_image) %>" width="1000" height="420" style="background-color:<%= @commentable.main_image_background_hex_color %>;" class="crayons-article__cover__image" alt="Cover image for <%= sanitize_and_decode @commentable.title %>">
+            <img src="<%= cloud_cover_url(@commentable.main_image) %>" width="1000" height="420" style="background-color:<%= @commentable.main_image_background_hex_color %>;" class="crayons-article__cover__image" alt="Cover image for <%= @commentable.title %>">
           </div>
         <% end %>
 

--- a/app/views/dashboards/_dashboard_article.html.erb
+++ b/app/views/dashboards/_dashboard_article.html.erb
@@ -24,7 +24,7 @@
     </div>
   </div>
 
-  <a href="<%= article.current_state_path %>"><h2><%= "[Archived] " if article.archived %><%= sanitize_and_decode article.title %></h2></a>
+  <a href="<%= article.current_state_path %>"><h2><%= "[Archived] " if article.archived %><%= article.title %></h2></a>
   <div class="dashboard-meta-details">
     <% if article.published %>
       <span>

--- a/app/views/dashboards/_dashboard_article_row.html.erb
+++ b/app/views/dashboards/_dashboard_article_row.html.erb
@@ -10,7 +10,7 @@
             <img class="crayons-logo__image align-top" src="<%= article.organization&.profile_image_90 %>" alt="<%= article.organization&.name %>" width="24" height="24" loading="lazy" />
           </span>
         <% end %>
-        <%= sanitize_and_decode article.title %>
+        <%= article.title %>
       </a>
     </h3>
     <% if article.published %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -199,13 +199,6 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#sanitize_and_decode" do
-    it "sanitize and decode string" do
-      expect(helper.sanitize_and_decode("<script>alert('alert')</script>")).to eq("alert('alert')")
-      expect(helper.sanitize_and_decode("&lt; hello")).to eq("< hello")
-    end
-  end
-
   describe "#cloudinary", cloudinary: true do
     it "returns cloudinary-manipulated link" do
       image = helper.optimized_image_url(Faker::Placeholdit.image)

--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -98,11 +98,14 @@ RSpec.describe "Using the editor", type: :system do
   describe "using v2 editor", js: true do
     it "fill out form with rich content and click publish" do
       visit "/new"
-      fill_in "article-form-title", with: "This is a test"
+      fill_in "article-form-title", with: "This is a <span> test"
       fill_in "tag-input", with: "What, Yo"
       fill_in "article_body_markdown", with: "Hello"
       find("button", text: /\APublish\z/).click
+
+      expect(page).to have_xpath("//div[@class='crayons-article__header__meta']//h1")
       expect(page).to have_text("Hello")
+      expect(page).not_to have_text("</span>")
       expect(page).to have_link("#what", href: "/t/what")
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] BUG

## Description
Remove the feature originally implemented in https://github.com/forem/forem/pull/7593. Rails' ERB template is already sufficient at rendering given text as is, ie. no processing and already escaped. 

## Related Tickets & Documents
Supersedes https://github.com/forem/forem/pull/12789
Resolves https://github.com/forem/forem/issues/2204, https://github.com/forem/forem/issues/8705
## QA Instructions, Screenshots, Recordings
I wrote a test to accompany this so it should be sufficient.

but if you would like to try it.
1. Create an article with title similar to `Hello <span> there`
2. When saved, it should be exactly the same. There shouldn't be a `</span>` appearing out of nowhere.

## Added tests?
- [x] updated existing spec

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a