### PR TITLE
Ensure ActiveRecord::Base has descendants before checking triggers

### DIFF
--- a/spec/models/hair_trigger_spec.rb
+++ b/spec/models/hair_trigger_spec.rb
@@ -5,6 +5,12 @@ require "rails_helper"
 RSpec.describe HairTrigger, type: :model do
   describe ".migrations_current?" do
     it "is always true" do
+      # work-around empty AR::Base descendants array caused by with_model cleanup
+      # HairTrigger uses AR::Base to get database triggers (and compare against the schema)
+      if ActiveRecord::Base.descendants.blank?
+        ActiveSupport::DescendantsTracker.store_inherited(ActiveRecord::Base, ApplicationRecord)
+      end
+
       expect(described_class.migrations_current?).to be(true)
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

HairTrigger uses the ActiveRecord::Base.descendants to find triggers
in the db (from `models`). WithModel (used in the Settings::Base spec)
clears this during its descendants cleanup, causing this test to
ocassionally fail.

Before checking hairtrigger, if AR::Base descendents is empty, add
ApplicationRecord back to the list - there's an assumption here that all of our
application models inherit from application record - this may or may
not be true if we use engine generated models that do not follow this
convention and need to validate triggers there.

### Backstory (why this is needed)

`WithModel::Model#cleanup_descendants_tracking` is clearing the descendants list by deleting it from tracking: 
https://github.com/Casecommons/with_model/blob/master/lib/with_model/model.rb#L56-L62 

hair trigger's `models` method uses the AR::Base descendants to find models - so we can check current triggers 
https://github.com/jenseng/hair_trigger/blob/master/lib/hair_trigger.rb#L38

When the Settings::Base spec runs on the same node as the HairTrigger spec, and runs before it - the hairtrigger spec has been failing to validate the triggers.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

The failing situation is as follows:

```
bundle exec rspec spec/models/settings/base_spec.rb spec/models/hairtrigger_spec.rb
```

This should pass in the branch (and it's observed to fail in main)

### UI accessibility concerns?

none. test only change.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: flaky test fix

