### PR TITLE
Remove Connect from listings

### DIFF
--- a/app/javascript/listings/components/BodyMarkdown.jsx
+++ b/app/javascript/listings/components/BodyMarkdown.jsx
@@ -17,7 +17,7 @@ export const BodyMarkdown = ({ onChange, defaultValue }) => (
     />
     <p className="crayons-field__description">
       400 characters max, 12 line break max, no images allowed, *markdown is
-      encouraged*
+      encouraged*. Please include a contact method if necessary.
     </p>
   </div>
 );

--- a/app/javascript/listings/listingForm.jsx
+++ b/app/javascript/listings/listingForm.jsx
@@ -7,7 +7,6 @@ import { DEFAULT_TAG_FORMAT } from '../article-form/components/TagsField';
 import { Title } from './components/Title';
 import { BodyMarkdown } from './components/BodyMarkdown';
 import { Categories } from './components/Categories';
-import { ContactViaConnect } from './components/ContactViaConnect';
 import { ExpireDate } from './components/ExpireDate';
 
 export class ListingForm extends Component {
@@ -37,7 +36,6 @@ export class ListingForm extends Component {
       categoriesForDetails: this.categoriesForDetails,
       organizations,
       organizationId: null, // change this for /edit later
-      contactViaConnect: this.listing.contact_via_connect || 'checked',
       expireDate: this.listing.expires_at || '',
     };
   }
@@ -58,7 +56,6 @@ export class ListingForm extends Component {
       categoriesForSelect,
       organizations,
       organizationId,
-      contactViaConnect,
       expireDate,
     } = this.state;
 
@@ -115,10 +112,6 @@ export class ListingForm extends Component {
             onChange={linkState(this, 'expireDate')}
           />
           {selectOrg}
-          <ContactViaConnect
-            checked={contactViaConnect}
-            onChange={linkState(this, 'contactViaConnect')}
-          />
         </div>
       );
     }
@@ -132,10 +125,6 @@ export class ListingForm extends Component {
         />
         <Tags defaultValue={tagList} onInput={linkState(this, 'tagList')} />
         {selectOrg}
-        <ContactViaConnect
-          checked={contactViaConnect}
-          onChange={linkState(this, 'contactViaConnect')}
-        />
       </div>
     );
   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

We'll eventually remove Connect from Forem. In the meantime, let's no longer add new listings with the "Contact via Connect" option. This PR removes the option for new listings. As a side-effect, one can also no longer disable it for existing listings but I think that's ok, there are only 15 of them in the DB (well 16, but one is our test listing).

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Click around the listings area and make sure everything still works as expected.

### UI accessibility concerns?

n/a

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] Changelog post on forem.dev
