### PR TITLE
Add internal top tags API

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -8,7 +8,16 @@ class TagsController < ApplicationController
   def index
     skip_authorization
     @tags_index = true
-    @tags = Tag.includes(:sponsorship).order(hotness_score: :desc).limit(100)
+    tags = Tag.order(hotness_score: :desc).limit(100)
+
+    respond_to do |format|
+      format.html do
+        @tags = tags.includes(:sponsorship)
+        render "index"
+      end
+
+      format.json { render json: tags.pluck(:name) }
+    end
   end
 
   def edit

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -9,18 +9,7 @@ class TagsController < ApplicationController
   def index
     skip_authorization
     @tags_index = true
-    tags = Tag.order(hotness_score: :desc).limit(100)
-
-    respond_to do |format|
-      format.html do
-        @tags = tags.includes(:sponsorship)
-        render "index"
-      end
-
-      format.json do
-        render json: tags.select(INDEX_API_ATTRIBUTES).as_json(only: INDEX_API_ATTRIBUTES)
-      end
-    end
+    @tags = Tag.includes(:sponsorship).order(hotness_score: :desc).limit(100)
   end
 
   def edit
@@ -53,6 +42,12 @@ class TagsController < ApplicationController
       .select(ATTRIBUTES_FOR_SERIALIZATION)
 
     set_surrogate_key_header Tag.table_key, @tags.map(&:record_key)
+  end
+
+  def autocomplete
+    skip_authorization
+    tags = Tag.order(hotness_score: :desc).limit(100).select(INDEX_API_ATTRIBUTES)
+    render json: tags.as_json(only: INDEX_API_ATTRIBUTES)
   end
 
   private

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -44,7 +44,7 @@ class TagsController < ApplicationController
     set_surrogate_key_header Tag.table_key, @tags.map(&:record_key)
   end
 
-  def autocomplete
+  def suggest
     skip_authorization
     tags = Tag.order(hotness_score: :desc).limit(100).select(INDEX_API_ATTRIBUTES)
     render json: tags.as_json(only: INDEX_API_ATTRIBUTES)

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,6 +4,7 @@ class TagsController < ApplicationController
   after_action :verify_authorized
 
   ATTRIBUTES_FOR_SERIALIZATION = %i[id name bg_color_hex text_color_hex].freeze
+  INDEX_API_ATTRIBUTES = %i[name rules_html].freeze
 
   def index
     skip_authorization
@@ -16,7 +17,9 @@ class TagsController < ApplicationController
         render "index"
       end
 
-      format.json { render json: tags.pluck(:name) }
+      format.json do
+        render json: tags.select(INDEX_API_ATTRIBUTES).as_json(only: INDEX_API_ATTRIBUTES)
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,8 +157,8 @@ Rails.application.routes.draw do
     resources :notifications, only: [:index]
     resources :tags, only: [:index] do
       collection do
-        get "/autocomplete", to: "tags#autocomplete", defaults: { format: :json }
         get "/onboarding", to: "tags#onboarding"
+        get "/suggest", to: "tags#suggest", defaults: { format: :json }
       end
     end
     resources :stripe_active_cards, only: %i[create update destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Rails.application.routes.draw do
     resources :notifications, only: [:index]
     resources :tags, only: [:index] do
       collection do
+        get "/autocomplete", to: "tags#autocomplete", defaults: { format: :json }
         get "/onboarding", to: "tags#onboarding"
       end
     end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe "Tags", type: :request, proper_status: true do
       get tags_path
       expect(response.body).to include("Top tags")
     end
+  end
 
+  describe "GET /tags/autocomplete" do
     it "returns a JSON representation of the top tags if requested", :aggregate_failures do
       tag = create(:tag)
 
-      get tags_path, headers: { "ACCEPT" => "application/json" }
+      get autocomplete_tags_path, headers: { "ACCEPT" => "application/json" }
 
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to match(%r{application/json; charset=utf-8}i)

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "Tags", type: :request, proper_status: true do
     end
   end
 
-  describe "GET /tags/autocomplete" do
+  describe "GET /tags/suggest" do
     it "returns a JSON representation of the top tags", :aggregate_failures do
       tag = create(:tag)
 
-      get autocomplete_tags_path
+      get suggest_tags_path
 
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to match(%r{application/json; charset=utf-8}i)

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "Tags", type: :request, proper_status: true do
   end
 
   describe "GET /tags/autocomplete" do
-    it "returns a JSON representation of the top tags if requested", :aggregate_failures do
+    it "returns a JSON representation of the top tags", :aggregate_failures do
       tag = create(:tag)
 
-      get autocomplete_tags_path, headers: { "ACCEPT" => "application/json" }
+      get autocomplete_tags_path
 
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to match(%r{application/json; charset=utf-8}i)

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -3,8 +3,19 @@ require "rails_helper"
 RSpec.describe "Tags", type: :request, proper_status: true do
   describe "GET /tags" do
     it "returns proper page" do
-      get "/tags"
+      get tags_path
       expect(response.body).to include("Top tags")
+    end
+
+    it "returns a JSON representation of the top tags if requested", :aggregate_failures do
+      tag = create(:tag)
+
+      get tags_path, headers: { "ACCEPT" => "application/json" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to match(%r{application/json; charset=utf-8}i)
+      tags = JSON.parse(response.body)
+      expect(tags.first).to eq(tag.name)
     end
   end
 

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe "Tags", type: :request, proper_status: true do
 
       expect(response).to have_http_status(:ok)
       expect(response.content_type).to match(%r{application/json; charset=utf-8}i)
-      tags = JSON.parse(response.body)
-      expect(tags.first).to eq(tag.name)
+      response_tag = JSON.parse(response.body).first
+      expect(response_tag["name"]).to eq(tag.name)
+      expect(response_tag).to have_key("rules_html")
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

This PR adds an *internal* top tags API for suggestion purposes at `/tags/suggest`. I decided to not go with the one available at `/api/tags` for the following reasons:

1. The public API is still unstable which is why we versioned it as v0.
2. The public API returns attributes we won't need, like colors.
3. The public API sorts tags only by `taggings_count`. On the other hand, the Top Tags page (`/tags`) sorts them by "hotness score" which uses recently tagged articles and their comments, etc. During our call, we talked about "easy", "medium", and "hard" approaches to this topic, and reusing the logic from the internal controller gives us "medium" for free.
4. We may want to further tweak the logic in the future in ways that don't necessarily make sense for the public API.

Note: so far this endpoint only returns the tag names as an ordered array (index 0 is the "hottest" tag), if you'd like to have any other attributes available please let me know and I'll add them. For now, 100 tags will be returned, let me know if we should increase this number.

## Related Tickets & Documents

#14751 

## QA Instructions, Screenshots, Recordings

Nothing specific, the test should cover this quite well. Here's a request and the response:

![API request example](https://user-images.githubusercontent.com/47985/134132525-d7ff5974-4b4d-4f24-a3ab-95069bb44989.png)

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: without a frontend, this PR is quite meaningless by itself. We should write a changelog post once the whole user story is finished.