### PR TITLE
Fix organization's admin unable to view an article's stats

### DIFF
--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -36,7 +36,7 @@ class ArticlePolicy < ApplicationPolicy
   end
 
   def stats?
-    user_author? || user_admin?
+    user_author? || user_admin? || user_org_admin?
   end
 
   def permitted_attributes

--- a/spec/policies/article_policy_spec.rb
+++ b/spec/policies/article_policy_spec.rb
@@ -51,4 +51,15 @@ RSpec.describe ArticlePolicy do
     it { is_expected.to permit_actions(%i[update new edit manage create delete_confirm destroy preview]) }
     it { is_expected.to permit_actions(%i[admin_unpublish]) }
   end
+
+  context "when user is an article's org_admin" do
+    let(:user) { create(:user, :org_admin) }
+    let(:org) { user.organizations.first }
+    let(:user2) { create(:user) }
+    let(:article) { build_stubbed(:article, organization_id: org.id, user: user2) }
+
+    before { create(:organization_membership, user: user2, organization: org) }
+
+    it { is_expected.to permit_actions(%i[update new edit stats create delete_confirm destroy preview]) }
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This is a bug fix to allow an organization's admin to view any of the organization's article's stats.
## Related Tickets & Documents
Fixes #14669


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

