### PR TITLE
Add mutable flag to APNS notifcation payload

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -41,7 +41,8 @@ class Device < ApplicationRecord
           body: body.truncate(512)
         },
         "thread-id": Settings::Community.community_name,
-        sound: "default"
+        sound: "default",
+        "mutable-content": 1
       },
       data: payload
     }

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -42,6 +42,7 @@ class Device < ApplicationRecord
         },
         "thread-id": Settings::Community.community_name,
         sound: "default",
+        # This key is required to modify the notifiaction in the iOS app: https://developer.apple.com/documentation/usernotifications/modifying_content_in_newly_delivered_notifications#2942066
         "mutable-content": 1
       },
       data: payload

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Device, type: :model do
         expect(mocked_objects[:rpush_notification].data[:aps][:alert][:body]).to eq("Body")
         expect(mocked_objects[:rpush_notification].data[:aps][:"thread-id"]).to eq(Settings::Community.community_name)
         expect(mocked_objects[:rpush_notification].data[:aps][:sound]).to eq("default")
+        expect(mocked_objects[:rpush_notification].data[:aps][:"mutable-content"]).to eq(1)
         expect(mocked_objects[:rpush_notification].data[:data]).to eq(data_hash)
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR adds a required field and value to the Apple Push Notification Service payload send from Forem to allow the Forem iOS application to add image attachments to said notifications. We want to do this so the Forem iOS app can attach a Forem's logo image to incoming notifications (this image data can not be sent with push notifications).

Per Apple's [docs](https://developer.apple.com/documentation/usernotifications/modifying_content_in_newly_delivered_notifications#2942066), for an iOS application to modify the content of an incoming push notification the field `mutable-content` must be present in the notification payload with a value of 1. This PR adds that value and an associated test.

## Related Tickets & Documents

Draft pull request for iOS: https://github.com/forem/forem-ios/pull/108
Originating issue for iOS: https://github.com/forem/forem-ios/issues/105

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

No: this change is backwards compatible with existing versions of the Forem iOS application.

## [optional] What gif best describes this PR or how it makes you feel?

![Mutable in sign language](https://media.giphy.com/media/9JzymOaePKIwdxTSsz/giphy.gif?cid=790b7611b34dfde6b0a8f86fa8cb67a9b105a5e03f98857c&rid=giphy.gif&ct=g)
