### PR TITLE
Don't include "anti-followed" tags in email digest

### DIFF
--- a/app/javascript/leftSidebar/TagsFollowed.jsx
+++ b/app/javascript/leftSidebar/TagsFollowed.jsx
@@ -23,6 +23,14 @@ export const TagsFollowed = ({ tags = [] }) => {
             href={`/t/${tag.name}`}
           >
             {`#${tag.name}`}
+            {tag.points < 1 && (
+              <span
+                class="crayons-indicator crayons-indicator--critical crayons-indicator--outlined"
+                title="This tag has negative follow weight"
+              >
+                Anti-follow
+              </span>
+            )}
           </a>
         </div>
       ))}

--- a/app/javascript/leftSidebar/TagsFollowed.jsx
+++ b/app/javascript/leftSidebar/TagsFollowed.jsx
@@ -10,30 +10,24 @@ export const TagsFollowed = ({ tags = [] }) => {
 
   return (
     <Fragment>
-      {tags.map((tag) => (
-        <div
-          key={tag.id}
-          className="sidebar-nav-element"
-          id={`sidebar-element-${tag.name}`}
-        >
-          <a
-            title={`${tag.name} tag`}
-            onClick={trackSidebarTagClick}
-            className="crayons-link crayons-link--block"
-            href={`/t/${tag.name}`}
+      {tags.map((tag) =>
+        tag.points >= 1 ? (
+          <div
+            key={tag.id}
+            className="sidebar-nav-element"
+            id={`sidebar-element-${tag.name}`}
           >
-            {`#${tag.name}`}
-            {tag.points < 1 && (
-              <span
-                class="crayons-indicator crayons-indicator--critical crayons-indicator--outlined"
-                title="This tag has negative follow weight"
-              >
-                Anti-follow
-              </span>
-            )}
-          </a>
-        </div>
-      ))}
+            <a
+              title={`${tag.name} tag`}
+              onClick={trackSidebarTagClick}
+              className="crayons-link crayons-link--block"
+              href={`/t/${tag.name}`}
+            >
+              {`#${tag.name}`}
+            </a>
+          </div>
+        ) : null,
+      )}
     </Fragment>
   );
 };

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -230,7 +230,7 @@ class Article < ApplicationRecord
   # NOTE: @citizen428
   # I'd usually avoid using Arel directly like this. However, none of the more
   # straight-forward ways of negating the above scope worked:
-  # 1. A subquery doesn't really work either because we're not dealing with a simple NOT IN scenario.
+  # 1. A subquery doesn't work because we're not dealing with a simple NOT IN scenario.
   # 2. where.not(cached_tagged_with_any(tags).where_values_hash) doesn't work because where_values_hash
   #    only works for simple conditions and returns an empty hash in this case.
   scope :not_cached_tagged_with_any, lambda { |tags|

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -227,6 +227,12 @@ class Article < ApplicationRecord
     end
   }
 
+  # NOTE: @citizen428
+  # I'd usually avoid using Arel directly like this. However, none of the more
+  # straight-forward ways of negating the above scope worked:
+  # 1. A subquery doesn't really work either because we're not dealing with a simple NOT IN scenario.
+  # 2. where.not(cached_tagged_with_any(tags).where_values_hash) doesn't work because where_values_hash
+  #    only works for simple conditions and returns an empty hash in this case.
   scope :not_cached_tagged_with_any, lambda { |tags|
     where(cached_tagged_with_any(tags).arel.constraints.reduce(:or).not)
   }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -227,6 +227,10 @@ class Article < ApplicationRecord
     end
   }
 
+  scope :not_cached_tagged_with_any, lambda { |tags|
+    where(cached_tagged_with_any(tags).arel.constraints.reduce(:or).not)
+  }
+
   scope :active_help, lambda {
     stories = published.cached_tagged_with("help").order(created_at: :desc)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -259,7 +259,9 @@ class User < ApplicationRecord
 
   def followed_articles
     Article
-      .cached_tagged_with_any(cached_followed_tag_names).unscope(:select)
+      .cached_tagged_with_any(cached_followed_tag_names)
+      .not_cached_tagged_with_any(cached_antifollowed_tag_names)
+      .unscope(:select)
       .union(Article.where(user_id: cached_following_users_ids))
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -320,7 +320,7 @@ class User < ApplicationRecord
         id: Follow.where(
           follower_id: id,
           followable_type: "ActsAsTaggableOn::Tag",
-          points: ..0,
+          points: ...1,
         ).select(:followable_id),
       ).pluck(:name)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -258,9 +258,13 @@ class User < ApplicationRecord
   end
 
   def followed_articles
-    Article
+    relation = Article
+    if cached_antifollowed_tag_names.any?
+      relation = relation.not_cached_tagged_with_any(cached_antifollowed_tag_names)
+    end
+
+    relation
       .cached_tagged_with_any(cached_followed_tag_names)
-      .not_cached_tagged_with_any(cached_antifollowed_tag_names)
       .unscope(:select)
       .union(Article.where(user_id: cached_following_users_ids))
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -307,6 +307,20 @@ class User < ApplicationRecord
         id: Follow.where(
           follower_id: id,
           followable_type: "ActsAsTaggableOn::Tag",
+          points: 1..,
+        ).select(:followable_id),
+      ).pluck(:name)
+    end
+  end
+
+  def cached_antifollowed_tag_names
+    cache_name = "user-#{id}-#{following_tags_count}-#{last_followed_at&.rfc3339}/antifollowed_tag_names"
+    Rails.cache.fetch(cache_name, expires_in: 24.hours) do
+      Tag.where(
+        id: Follow.where(
+          follower_id: id,
+          followable_type: "ActsAsTaggableOn::Tag",
+          points: ..0,
         ).select(:followable_id),
       ).pluck(:name)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -257,6 +257,9 @@ class User < ApplicationRecord
     "/#{username}"
   end
 
+  # NOTE: This method is only used in the EmailDigestArticleCollector and does
+  # not perform particularly well. It should most likely not be used in other
+  # parts of the app.
   def followed_articles
     relation = Article
     if cached_antifollowed_tag_names.any?

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -99,7 +99,7 @@ module Broadcasts
       end
 
       def user_following_tags?
-        user.cached_followed_tag_names > 1
+        user.cached_followed_tag_names.count > 1
       end
 
       def welcome_broadcast

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -99,7 +99,7 @@ module Broadcasts
       end
 
       def user_following_tags?
-        user.cached_followed_tag_names.count > 1
+        user.cached_followed_tag_names.any?
       end
 
       def welcome_broadcast

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -99,7 +99,7 @@ module Broadcasts
       end
 
       def user_following_tags?
-        user.cached_followed_tag_names.any?
+        user.cached_followed_tag_names > 1
       end
 
       def welcome_broadcast

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -65,7 +65,9 @@ class EmailDigestArticleCollector
   end
 
   def user_has_followings?
-    @user.following_users_count.positive? || @user.cached_followed_tag_names.any?
+    @user.following_users_count.positive? ||
+      @user.cached_followed_tag_names.any? ||
+      @user.cached_antifollowed_tag_names.any?
   end
 
   def last_user_emails

--- a/app/workers/follows/update_points_worker.rb
+++ b/app/workers/follows/update_points_worker.rb
@@ -9,7 +9,8 @@ module Follows
       return unless article && user
 
       adjust_other_tag_follows_of_user(user.id)
-      followed_tag_names = user.cached_followed_tag_names
+      followed_tag_names =
+        user.cached_followed_tag_names + user.cached_antifollowed_tag_names
       article.decorate.cached_tag_list_array.each do |tag_name|
         if followed_tag_names.include?(tag_name)
           recalculate_tag_follow_points(tag_name, user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,7 +146,6 @@ Rails.application.routes.draw do
     resources :response_templates, only: %i[index create edit update destroy]
     resources :feedback_messages, only: %i[index create]
     resources :organizations, only: %i[update create destroy]
-    resources :followed_articles, only: [:index]
     resources :follows, only: %i[show create] do
       collection do
         get "/bulk_show", to: "follows#bulk_show"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -942,6 +942,22 @@ RSpec.describe Article, type: :model do
     end
   end
 
+  describe ".not_cached_tagged_with_any" do
+    it "can exclude multiple tags when given an array of strings" do
+      included = create(:article, tags: "includeme")
+      excluded1 = create(:article, tags: "includeme, lol")
+      excluded2 = create(:article, tags: "includeme, omg")
+
+      articles = described_class
+        .cached_tagged_with_any("includeme")
+        .not_cached_tagged_with_any(%w[lol omg])
+
+      expect(articles).to include included
+      expect(articles).not_to include excluded1
+      expect(articles).not_to include excluded2
+    end
+  end
+
   context "when callbacks are triggered before save" do
     it "assigns path on save" do
       expect(article.path).to eq("/#{article.username}/#{article.slug}")

--- a/spec/services/email_digest_article_collector_spec.rb
+++ b/spec/services/email_digest_article_collector_spec.rb
@@ -62,13 +62,19 @@ RSpec.describe EmailDigestArticleCollector, type: :service do
     end
 
     context "when using tags" do
-      it "takes 'antifollowed' tags into account" do
+      it "takes 'antifollowed' tags into account", :aggregate_failures do
         articles = create_list(:article, 3, public_reactions_count: 40, score: 40)
         tag = articles.first.tags.first
-        create(:follow, followable: tag, follower: user, explicit_points: -999)
+        user.follow(tag)
 
-        digest = described_class.new(user).articles_to_send
-        expect(digest).to be_empty
+        digest1 = described_class.new(user).articles_to_send
+        expect(digest1.size).to eq 3
+
+        tag_follow = user.follows.first
+        tag_follow.update(explicit_points: -999)
+
+        digest2 = described_class.new(user).articles_to_send
+        expect(digest2.size).to eq 0
       end
     end
   end

--- a/spec/services/email_digest_article_collector_spec.rb
+++ b/spec/services/email_digest_article_collector_spec.rb
@@ -62,14 +62,13 @@ RSpec.describe EmailDigestArticleCollector, type: :service do
     end
 
     context "when using tags" do
-      it "takes antifollowed tags into account", :aggregate_failures do
+      it "takes 'antifollowed' tags into account" do
         articles = create_list(:article, 3, public_reactions_count: 40, score: 40)
         tag = articles.first.tags.first
         create(:follow, followable: tag, follower: user, explicit_points: -999)
 
         digest = described_class.new(user).articles_to_send
         expect(digest).to be_empty
-        expect(digest.size).to eq 0
       end
     end
   end

--- a/spec/services/email_digest_article_collector_spec.rb
+++ b/spec/services/email_digest_article_collector_spec.rb
@@ -60,5 +60,17 @@ RSpec.describe EmailDigestArticleCollector, type: :service do
         end
       end
     end
+
+    context "when using tags" do
+      it "takes antifollowed tags into account", :aggregate_failures do
+        articles = create_list(:article, 3, public_reactions_count: 40, score: 40)
+        tag = articles.first.tags.first
+        create(:follow, followable: tag, follower: user, explicit_points: -999)
+
+        digest = described_class.new(user).articles_to_send
+        expect(digest).to be_empty
+        expect(digest.size).to eq 0
+      end
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Bug Fix

## Description

The digest emails could include articles for the tags the user "anti-followed". In case you aren't aware of this feature, "anti-following is done somewhat counter-intuitively by following a tag first and then assigning it a negative score.

![image](https://user-images.githubusercontent.com/47985/134124268-8702f45b-d24d-4a24-a1ef-73f9d1d48896.png)

In the case of the digest email, this led to a problem because `EmailDigestArticleCollector` only checked if `User#cached_followed_tag_names` contains any tags, without also checking if any of them are anti-follows. I suspect that the same mechanism is creating problems in other areas too, e.g. I saw the same method being used in `Users::SuggestRecent` but again we don't seem to differential between follows and anti-follows.

This PR does the following:

* Change `User#cached_followed_tag_names` to only include tags with a score >= 1.
* Introduce `User#cached_antifollowed_tag_names` that includes tags with a score < 1.
* Update `EmailDigestArticleCollector` to take both into account for the purposes of the `user_has_followings?` helper because otherwise there'd be a corner-case where we fall back to all articles if a user has only anti-followed tags. Since this class uses `@user.followed_articles` which in turn relies on `cached_followed_tag_names` this class should no longer return articles the user is actively trying to avoid.
* Since I was dealing with tags already, I thought it might be a good idea to also excluded anti-followed tags from the tag list in the left sidebar.

## Related Tickets & Documents

Closes #13915

## QA Instructions, Screenshots, Recordings

* The unit tests hopefully have this covered quite well.

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
