### PR TITLE
Ensure seeded listings are valid for e2e tests

### DIFF
--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -465,7 +465,7 @@ seeder.create_if_none(Listing) do
   Listing.create!(
     user: admin_user,
     title: "Listing title",
-    body_markdown: Faker::Markdown.random,
+    body_markdown: Faker::Markdown.random.lines.take(10).join,
     location: Faker::Address.city,
     organization_id: admin_user.organizations.first&.id,
     listing_category_id: ListingCategory.first.id,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Ensure Listing created when seeding e2e tests pass validation.

This matches the same change made to the db/seeds.rb file at
https://github.com/forem/forem/blob/main/db/seeds.rb#L515

Since there's a validation that Listings are only 12 lines or
shorter, and no technical limit on the length of
`Faker::Markdown.random`'s output, take the first 10 lines only.


## Related Tickets & Documents

#14685 fixed this in the db/seeds.rb file

https://app.travis-ci.com/github/forem/forem/jobs/538669620 observed failure

## QA Instructions, Screenshots, Recordings

Well, I guess you could call db:seed:e2e a lot and hope for the best, or run it just once and confirm nothing broke (i.e. passing the e2e seeded flow is sufficient to demonstrate this fixed).

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: seed data update - test setup only

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: tiny change to seed data for cypress tests

## [optional] What gif best describes this PR or how it makes you feel?

![seed guy](https://user-images.githubusercontent.com/1237369/134195751-f35c4907-8aa9-4720-b7c1-22b95bd2a140.gif)