### PR TITLE
Fix inconsistencies with DisplayAd

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
+++ b/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
@@ -136,15 +136,14 @@ function trackCustomImpressions() {
     }
 
     // display add
-    var rotatingDisplayUnits = document.querySelectorAll('[data-rotating-display-unit]');
+    var displayAds = document.querySelectorAll('[data-display-unit]');
     if (rotatingDisplayUnits.length > 0
       && tokenMeta
       && !isBot
       && windowBigEnough
       && checkUserLoggedIn()) {
         var csrfToken = tokenMeta.getAttribute('content');
-        [].forEach.call(rotatingDisplayUnits, function(unit) {
-          // do whatever
+        [].forEach.call(displayAds, function(unit) {
           trackAdImpression(csrfToken, unit);
           unit.removeEventListener('click', trackAdClick, false );
           unit.addEventListener('click', function(e) { trackAdClick(csrfToken, e) });

--- a/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
+++ b/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
@@ -223,7 +223,6 @@ function trackAdImpression(token, adBox) {
 }
 
 function trackAdClick(token, adBox) {
-  console.log(adBox);
   if (!adClicked) {
     var dataBody = {
       display_ad_event: {

--- a/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
+++ b/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
@@ -137,7 +137,7 @@ function trackCustomImpressions() {
 
     // display add
     var displayAds = document.querySelectorAll('[data-display-unit]');
-    if (rotatingDisplayUnits.length > 0
+    if (displayAds.length > 0
       && tokenMeta
       && !isBot
       && windowBigEnough

--- a/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
+++ b/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
@@ -72,7 +72,7 @@ function trackCustomImpressions() {
     var ArticleElement = document.getElementById('article-body') || document.getElementById('comment-article-indicator');
     var tokenMeta = document.querySelector("meta[name='csrf-token']")
     var isBot = /bot|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex/i.test(navigator.userAgent) // is crawler
-    var windowBigEnough =  window.innerWidth > 1250
+    var windowBigEnough =  window.innerWidth > 1023
 
     // Sidebar HTML variant tracking
     var stickyNav = document.getElementById('article-show-primary-sticky-nav');
@@ -136,16 +136,19 @@ function trackCustomImpressions() {
     }
 
     // display add
-    var adBox = document.getElementById('sponsorship-arbitrary-display-widget')
-    if (adBox
+    var rotatingDisplayUnits = document.querySelectorAll('[data-rotating-display-unit]');
+    if (rotatingDisplayUnits.length > 0
       && tokenMeta
       && !isBot
       && windowBigEnough
       && checkUserLoggedIn()) {
         var csrfToken = tokenMeta.getAttribute('content');
-        trackAdImpression(csrfToken, adBox)
-        adBox.removeEventListener('click', trackAdClick, false );
-        adBox.addEventListener('click', function() { trackAdClick(csrfToken, adBox) });
+        [].forEach.call(rotatingDisplayUnits, function(unit) {
+          // do whatever
+          trackAdImpression(csrfToken, unit);
+          unit.removeEventListener('click', trackAdClick, false );
+          unit.addEventListener('click', function(e) { trackAdClick(csrfToken, e) });
+        });
       }
   }, 1800)
 }
@@ -220,6 +223,7 @@ function trackAdImpression(token, adBox) {
 }
 
 function trackAdClick(token, adBox) {
+  console.log(adBox);
   if (!adClicked) {
     var dataBody = {
       display_ad_event: {

--- a/app/assets/stylesheets/widgets.scss
+++ b/app/assets/stylesheets/widgets.scss
@@ -360,5 +360,6 @@
     border-radius: var(--radius);
     display: inline-block;
     vertical-align: middle;
+    margin: 10px auto;
   }
 }

--- a/app/helpers/display_ad_helper.rb
+++ b/app/helpers/display_ad_helper.rb
@@ -1,6 +1,5 @@
 module DisplayAdHelper
   def display_ads_placement_area_options_array
-    DisplayAd::ALLOWED_PLACEMENT_AREAS.map
-      .with_index { |area, index| [DisplayAd::ALLOWED_PLACEMENT_AREAS_HUMAN_READABLE[index], area] }
+    DisplayAd::ALLOWED_PLACEMENT_AREAS_HUMAN_READABLE.zip(DisplayAd::ALLOWED_PLACEMENT_AREAS)      
   end
 end

--- a/app/helpers/display_ad_helper.rb
+++ b/app/helpers/display_ad_helper.rb
@@ -1,0 +1,6 @@
+module DisplayAdHelper
+  def display_ads_placement_area_options_array
+    DisplayAd::ALLOWED_PLACEMENT_AREAS.map
+      .with_index { |area, index| [DisplayAd::ALLOWED_PLACEMENT_AREAS_HUMAN_READABLE[index], area] }
+  end
+end

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -1,16 +1,24 @@
 class DisplayAd < ApplicationRecord
   resourcify
 
+  ALLOWED_PLACEMENT_AREAS = %w[sidebar_left sidebar_left_2 sidebar_right].freeze
+
   belongs_to :organization
   has_many :display_ad_events, dependent: :destroy
 
   validates :organization_id, presence: true
   validates :placement_area, presence: true,
-                             inclusion: { in: %w[sidebar_left sidebar_right] }
+                             inclusion: { in: ALLOWED_PLACEMENT_AREAS }
   validates :body_markdown, presence: true
   before_save :process_markdown
 
   scope :approved_and_published, -> { where(approved: true, published: true) }
+
+  ALLOWED_TAGS = %w[
+    a abbr add b blockquote br center cite code col colgroup dd del dl dt em figcaption
+    h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
+    tbody td tfoot th thead time tr u ul video].freeze
+  ALLOWED_ATTRIBUTES = %w[href src alt height width].freeze
 
   def self.for_display(area)
     relation = approved_and_published.where(placement_area: area).order(success_rate: :desc)
@@ -28,14 +36,10 @@ class DisplayAd < ApplicationRecord
     renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
     markdown = Redcarpet::Markdown.new(renderer)
     initial_html = markdown.render(body_markdown)
-    # Temporarily disable the sanitisation in order to launch the SheCoded Campaign.
-    # TODO: find an alternate solution.
-
-    # stripped_html = ActionController::Base.helpers.sanitize initial_html,
-    #                                                         tags: %w[a em i b u br img h1 h2 h3 h4 div style],
-    #                                                         attributes: %w[href target src height width style]
-    stripped_html = initial_html.html_safe # rubocop:disable Rails/OutputSafety
+    stripped_html = ActionController::Base.helpers.sanitize initial_html,
+                                                            tags: ALLOWED_TAGS,
+                                                            attributes: ALLOWED_ATTRIBUTES
     html = stripped_html.delete("\n")
-    self.processed_html = Html::Parser.new(html).prefix_all_images(350).html
+    self.processed_html = Html::Parser.new(html).prefix_all_images(350, synchronous_detail_detection: true).html
   end
 end

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -2,6 +2,9 @@ class DisplayAd < ApplicationRecord
   resourcify
 
   ALLOWED_PLACEMENT_AREAS = %w[sidebar_left sidebar_left_2 sidebar_right].freeze
+  ALLOWED_PLACEMENT_AREAS_HUMAN_READABLE = ["Sidebar Left (First Position)",
+                                            "Sidebar Left (Second Position)",
+                                            "Sidebar Right"].freeze
 
   belongs_to :organization
   has_many :display_ad_events, dependent: :destroy
@@ -28,6 +31,10 @@ class DisplayAd < ApplicationRecord
     else
       relation.limit(rand(1..15)).sample
     end
+  end
+
+  def human_readable_placement_area
+    ALLOWED_PLACEMENT_AREAS_HUMAN_READABLE[ALLOWED_PLACEMENT_AREAS.find_index(placement_area)]
   end
 
   private

--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -16,6 +16,7 @@ module Html
     RAW_TAG_DELIMITERS = ["{", "}", "raw", "endraw", "----"].freeze
     RAW_TAG = "{----% raw %----}".freeze
     END_RAW_TAG = "{----% endraw %----}".freeze
+    TIMEOUT = 10
 
     attr_accessor :html
     private :html=
@@ -32,7 +33,7 @@ module Html
       self
     end
 
-    def prefix_all_images(width = 880)
+    def prefix_all_images(width = 880, synchronous_detail_detection: false)
       # wrap with Cloudinary or allow if from giphy or githubusercontent.com
       doc = Nokogiri::HTML.fragment(@html)
 
@@ -41,6 +42,12 @@ module Html
         next unless src
         # allow image to render as-is
         next if allowed_image_host?(src)
+
+        if synchronous_detail_detection
+          height_width = image_height_width(img)
+          img["height"] = height_width[0]
+          img["width"] = height_width[1]
+        end
 
         img["loading"] = "lazy"
         img["src"] = if Giphy::Image.valid_url?(src)
@@ -53,6 +60,13 @@ module Html
       @html = doc.to_html
 
       self
+    end
+
+    def image_height_width(img)
+      src = img.attr("src")
+      return unless src
+
+      FastImage.size(src, timeout: TIMEOUT)
     end
 
     def wrap_all_images_in_links

--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -43,7 +43,7 @@ module Html
         # allow image to render as-is
         next if allowed_image_host?(src)
 
-        if synchronous_detail_detection
+        if synchronous_detail_detection && img
           width, height = image_width_height(img)
           img["width"] = width
           img["height"] = height

--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -45,8 +45,8 @@ module Html
 
         if synchronous_detail_detection
           height_width = image_height_width(img)
-          img["height"] = height_width[0]
-          img["width"] = height_width[1]
+          img["width"] = height_width[0]
+          img["height"] = height_width[1]
         end
 
         img["loading"] = "lazy"
@@ -66,7 +66,7 @@ module Html
       src = img.attr("src")
       return unless src
 
-      FastImage.size(src, timeout: TIMEOUT)
+      FastImage.size(src, timeout: TIMEOUT) # outputs as [width, height]
     end
 
     def wrap_all_images_in_links

--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -44,9 +44,9 @@ module Html
         next if allowed_image_host?(src)
 
         if synchronous_detail_detection
-          height_width = image_height_width(img)
-          img["width"] = height_width[0]
-          img["height"] = height_width[1]
+          width, height = image_height_width(img)
+          img["width"] = width
+          img["height"] = height
         end
 
         img["loading"] = "lazy"

--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -44,7 +44,7 @@ module Html
         next if allowed_image_host?(src)
 
         if synchronous_detail_detection
-          width, height = image_height_width(img)
+          width, height = image_width_height(img)
           img["width"] = width
           img["height"] = height
         end
@@ -62,11 +62,11 @@ module Html
       self
     end
 
-    def image_height_width(img)
+    def image_width_height(img)
       src = img.attr("src")
       return unless src
 
-      FastImage.size(src, timeout: TIMEOUT) # outputs as [width, height]
+      FastImage.size(src, timeout: TIMEOUT)
     end
 
     def wrap_all_images_in_links

--- a/app/views/admin/display_ads/_form.html.erb
+++ b/app/views/admin/display_ads/_form.html.erb
@@ -10,7 +10,7 @@
 
 <div class="form-group">
   <%= label_tag :placement_area, "Placement Area:" %>
-  <%= select_tag :placement_area, options_for_select(%w[sidebar_left sidebar_right], selected: @display_ad.placement_area), include_blank: true %>
+  <%= select_tag :placement_area, options_for_select(DisplayAd::ALLOWED_PLACEMENT_AREAS, selected: @display_ad.placement_area), include_blank: true %>
 </div>
 
 <div class="form-group">

--- a/app/views/admin/display_ads/_form.html.erb
+++ b/app/views/admin/display_ads/_form.html.erb
@@ -10,7 +10,7 @@
 
 <div class="form-group">
   <%= label_tag :placement_area, "Placement Area:" %>
-  <%= select_tag :placement_area, options_for_select(DisplayAd::ALLOWED_PLACEMENT_AREAS, selected: @display_ad.placement_area), include_blank: true %>
+  <%= select_tag :placement_area, options_for_select(display_ads_placement_area_options_array, selected: @display_ad.placement_area), include_blank: true %>
 </div>
 
 <div class="form-group">

--- a/app/views/admin/display_ads/index.html.erb
+++ b/app/views/admin/display_ads/index.html.erb
@@ -17,7 +17,6 @@
       <th scope="col">ID</th>
       <th scope="col">Organization</th>
       <th scope="col">Placement Area</th>
-      <th scope="col">Body Markdown</th>
       <th scope="col">Published</th>
       <th scope="col">Approved</th>
       <th scope="col">Success Rate</th>
@@ -28,8 +27,7 @@
         <tr>
           <td><%= link_to display_ad.id, edit_admin_display_ad_path(display_ad) %></td>
           <td><%= link_to display_ad.organization.name, admin_organization_path(display_ad.organization) %></td>
-          <td><%= display_ad.placement_area %></td>
-          <td><%= display_ad.body_markdown.truncate(30) %></td>
+          <td><%= display_ad.human_readable_placement_area %></td>
           <td><%= display_ad.published %></td>
           <td><%= display_ad.approved %></td>
           <td><%= display_ad.success_rate %></td>

--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -22,7 +22,7 @@
     <% cache("display-area-left-#{rand(5)}", expires_in: 5.minutes) do %>
       <% @left_sidebar_ad = DisplayAd.for_display("sidebar_left") %>
       <% if @left_sidebar_ad %>
-        <div class="crayons-card crayons-card--secondary p-3 crayons-sponsorship-widget" data-rotating-display-unit data-id="<%= @left_sidebar_ad.id %>">
+        <div class="crayons-card crayons-card--secondary p-3 crayons-sponsorship-widget" data-display-unit data-id="<%= @left_sidebar_ad.id %>">
           <%= @left_sidebar_ad.processed_html.html_safe %>
         </div>
       <% end %>
@@ -30,7 +30,7 @@
     <% cache("display-area-left-2-#{rand(5)}", expires_in: 5.minutes) do %>
       <% @second_left_sidebar_ad = DisplayAd.for_display("sidebar_left_2") %>
       <% if @second_left_sidebar_ad %>
-        <div class="mt-4 crayons-card crayons-card--secondary p-3 crayons-sponsorship-widget" data-rotating-display-unit data-id="<%= @second_left_sidebar_ad.id %>">
+        <div class="mt-4 crayons-card crayons-card--secondary p-3 crayons-sponsorship-widget" data-display-unit data-id="<%= @second_left_sidebar_ad.id %>">
           <%= @second_left_sidebar_ad.processed_html.html_safe %>
         </div>
       <% end %>

--- a/app/views/articles/_sidebar.html.erb
+++ b/app/views/articles/_sidebar.html.erb
@@ -22,8 +22,16 @@
     <% cache("display-area-left-#{rand(5)}", expires_in: 5.minutes) do %>
       <% @left_sidebar_ad = DisplayAd.for_display("sidebar_left") %>
       <% if @left_sidebar_ad %>
-        <div class="crayons-sponsorship-widget" id="sponsorship-arbitrary-display-widget" data-id="<%= @left_sidebar_ad.id %>">
+        <div class="crayons-card crayons-card--secondary p-3 crayons-sponsorship-widget" data-rotating-display-unit data-id="<%= @left_sidebar_ad.id %>">
           <%= @left_sidebar_ad.processed_html.html_safe %>
+        </div>
+      <% end %>
+    <% end %>
+    <% cache("display-area-left-2-#{rand(5)}", expires_in: 5.minutes) do %>
+      <% @second_left_sidebar_ad = DisplayAd.for_display("sidebar_left_2") %>
+      <% if @second_left_sidebar_ad %>
+        <div class="mt-4 crayons-card crayons-card--secondary p-3 crayons-sponsorship-widget" data-rotating-display-unit data-id="<%= @second_left_sidebar_ad.id %>">
+          <%= @second_left_sidebar_ad.processed_html.html_safe %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/sidebars/_homepage_content.html.erb
+++ b/app/views/sidebars/_homepage_content.html.erb
@@ -2,7 +2,7 @@
   <% cache(release_adjusted_cache_key("main-article-right-sidebar-discussions-#{params[:timeframe]}"), expires_in: (params[:timeframe].blank? ? 120 : 360).seconds) do %>
     <% @sidebar_ad = DisplayAd.for_display("sidebar_right") %>
     <% if @sidebar_ad %>
-      <div class="crayons-card crayons-card--secondary p-4 crayons-sponsorship-widget">
+      <div class="crayons-card crayons-card--secondary p-4 crayons-sponsorship-widget" data-rotating-display-unit data-id="<%= @sidebar_ad.id %>">
         <%= @sidebar_ad.processed_html.html_safe %>
       </div>
     <% end %>

--- a/app/views/sidebars/_homepage_content.html.erb
+++ b/app/views/sidebars/_homepage_content.html.erb
@@ -2,7 +2,7 @@
   <% cache(release_adjusted_cache_key("main-article-right-sidebar-discussions-#{params[:timeframe]}"), expires_in: (params[:timeframe].blank? ? 120 : 360).seconds) do %>
     <% @sidebar_ad = DisplayAd.for_display("sidebar_right") %>
     <% if @sidebar_ad %>
-      <div class="crayons-card crayons-card--secondary p-4 crayons-sponsorship-widget" data-rotating-display-unit data-id="<%= @sidebar_ad.id %>">
+      <div class="crayons-card crayons-card--secondary p-4 crayons-sponsorship-widget" data-display-unit data-id="<%= @sidebar_ad.id %>">
         <%= @sidebar_ad.processed_html.html_safe %>
       </div>
     <% end %>

--- a/spec/factories/display_ads.rb
+++ b/spec/factories/display_ads.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :display_ad do
     placement_area { "sidebar_left" }
-    body_markdown { "Hello _hey_ Hey hey #{rand(1000000000)}" }
+    sequence(:body_markdown) { |n| "Hello _hey_ Hey hey #{n}" }
     organization
   end
 end

--- a/spec/factories/display_ads.rb
+++ b/spec/factories/display_ads.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :display_ad do
     placement_area { "sidebar_left" }
-    body_markdown { "Hello _hey_ Hey hey" }
+    body_markdown { "Hello _hey_ Hey hey #{rand(1000000000)}" }
     organization
   end
 end

--- a/spec/helpers/display_ad_helper_spec.rb
+++ b/spec/helpers/display_ad_helper_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+describe DisplayAdHelper, type: :helper do
+  describe ".display_ads_placement_area_options_array" do
+    it "returns proper human value" do
+      expect(helper.display_ads_placement_area_options_array[1]).to eq ["Sidebar Left (Second Position)", "sidebar_left_2"]
+    end
+  end
+end

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe DisplayAd, type: :model do
 
   context "when callbacks are triggered before save" do
     it "generates #processed_html from #body_markdown" do
-      expect(display_ad.processed_html).to eq("<p>Hello <em>hey</em> Hey hey</p>")
+      expect(display_ad.processed_html).to start_with("<p>Hello <em>hey</em> Hey hey")
     end
 
     it "does not render disallowed tags" do
@@ -44,7 +44,7 @@ RSpec.describe DisplayAd, type: :model do
 
     it "does not render disallowed attributes" do
       display_ad.update(body_markdown: "<p style='margin-top:100px'>Hello <em>hey</em> Hey hey</p>")
-      expect(display_ad.processed_html).to eq("<p>Hello <em>hey</em> Hey hey</p>")
+      expect(display_ad.processed_html).to start_with("<p>Hello <em>hey</em> Hey hey</p>")
     end
   end
 

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe DisplayAd, type: :model do
     it "generates #processed_html from #body_markdown" do
       expect(display_ad.processed_html).to eq("<p>Hello <em>hey</em> Hey hey</p>")
     end
+
+    it "does not render disallowed tags" do
+      display_ad.update(body_markdown: "<style>body { color: black}</style> Hey hey")
+      expect(display_ad.processed_html).to eq("<p>body { color: black} Hey hey</p>")
+    end
+
+    it "does not render disallowed attributes" do
+      display_ad.update(body_markdown: "<p style='margin-top:100px'>Hello <em>hey</em> Hey hey</p>")
+      expect(display_ad.processed_html).to eq("<p>Hello <em>hey</em> Hey hey</p>")
+    end
   end
 
   describe ".for_display" do

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe DisplayAd, type: :model do
       display_ad.placement_area = "tsdsdsdds"
       expect(display_ad).not_to be_valid
     end
+
+    it "returns human readable name" do
+      display_ad.placement_area = "sidebar_left_2"
+      expect(display_ad.human_readable_placement_area).to eq("Sidebar Left (Second Position)")
+    end
   end
 
   context "when callbacks are triggered before save" do

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -59,14 +59,16 @@ RSpec.describe "StoriesIndex", type: :request do
       expect(response.body).to include("This is a landing page!")
     end
 
-    it "renders all display_ads when published and approved" do
+    it "renders all display_ads of different placements when published and approved" do
       org = create(:organization)
-      ad = create(:display_ad, published: true, approved: true, organization: org)
+      ad = create(:display_ad, published: true, approved: true, organization: org, placement_area: "sidebar_left")
+      second_left_ad = create(:display_ad, published: true, approved: true, organization: org, placement_area: "sidebar_left_2")
       right_ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_right",
                                      organization: org)
 
       get "/"
       expect(response.body).to include(ad.processed_html)
+      expect(response.body).to include(second_left_ad.processed_html)
       expect(response.body).to include(right_ad.processed_html)
     end
 
@@ -79,6 +81,18 @@ RSpec.describe "StoriesIndex", type: :request do
       get "/"
       expect(response.body).not_to include(ad.processed_html)
       expect(response.body).not_to include(right_ad.processed_html)
+    end
+
+    it "renders only one display ad of placement" do
+      org = create(:organization)
+      left_ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_left",
+                       organization: org)
+      second_left_ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_left",
+                              organization: org)
+
+      get "/"
+      expect(response.body).to include(left_ad.processed_html)
+      expect(response.body).not_to include(second_left_ad.processed_html)
     end
 
     it "displays correct sponsors", :aggregate_failures do

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -85,14 +85,12 @@ RSpec.describe "StoriesIndex", type: :request do
 
     it "renders only one display ad of placement" do
       org = create(:organization)
-      left_ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_left",
-                       organization: org)
-      second_left_ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_left",
-                              organization: org)
+      left_ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_left", organization: org)
+      second_left_ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_left", organization: org)
 
       get "/"
-      expect(response.body).to include(left_ad.processed_html)
-      expect(response.body).not_to include(second_left_ad.processed_html)
+      expect(response.body).to include(left_ad.processed_html).or(include(second_left_ad.processed_html))
+      expect(response.body).to include("crayons-sponsorship-widget").once
     end
 
     it "displays correct sponsors", :aggregate_failures do

--- a/spec/services/html/parser_spec.rb
+++ b/spec/services/html/parser_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Html::Parser, type: :service do
 
       it "detects height and width" do
         html = "<img src='https://image.com/image.jpg'>"
-        parsed_html = described_class.new(html).prefix_all_images.html
+        parsed_html = described_class.new(html).prefix_all_images(350, synchronous_detail_detection: true).html
         expect(parsed_html).to include("height=")
       end
     end

--- a/spec/services/html/parser_spec.rb
+++ b/spec/services/html/parser_spec.rb
@@ -72,9 +72,10 @@ RSpec.describe Html::Parser, type: :service do
       end
 
       it "detects height and width" do
+        allow(FastImage).to receive(:size).and_return([100,200])
         html = "<img src='https://image.com/image.jpg'>"
         parsed_html = described_class.new(html).prefix_all_images(350, synchronous_detail_detection: true).html
-        expect(parsed_html).to include("height=")
+        expect(parsed_html).to include("height=\"200\"")
       end
     end
   end

--- a/spec/services/html/parser_spec.rb
+++ b/spec/services/html/parser_spec.rb
@@ -70,6 +70,12 @@ RSpec.describe Html::Parser, type: :service do
         parsed_html = described_class.new(html).prefix_all_images.html
         expect(parsed_html).to include("https://res.cloudinary.com")
       end
+
+      it "detects height and width" do
+        html = "<img src='https://image.com/image.jpg'>"
+        parsed_html = described_class.new(html).prefix_all_images.html
+        expect(parsed_html).to include("height=")
+      end
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

At the core of this PR, is adding back in sanitation so that we allow for a consistent, safe interface for creating `DisplayAd` content. It's currently awkward and fairly unsafe to use this functionality for many creators. This fixes things.

Therefore removes this code:

>    \# Temporarily disable the sanitisation in order to launch the SheCoded Campaign.
>    \# TODO: find an alternate solution.

I think the core purpose of this is well in the rearview for Forem and DEV needs.

This does remove the capacity for inline styles (not immediately breaking existing stuff, but will on re-save of anything), but adds the same wrapping class to the left-hand ads as the right. This should be a big win for visual consistency while still providing a lot of flexibility as far as how admins might choose to use this functionality.

<img width="261" alt="Screen Shot 2021-09-21 at 1 25 55 PM" src="https://user-images.githubusercontent.com/3102842/134362591-c7d4150e-e0cd-4c83-8846-619a559e5846.png">

This also fixes the issue of `DisplayAdEvent` tracking only working for the left ad and not the right ad. This now works across the board, meaning we track impressions and clicks.

We already use a functionality called `for_display` to determine which ad to display in order to reward top performing display units on average, but without consistent and complete implementation of the click tracking, it is hard for admins to understand how to use this functionality and we can't really document it properly.

I also added one new location: `left_sidebar_2` which will now allow admins to set two units on the left if they choose to, and they all work with the same consistency.

This also uses `FastImage` to detect image aspect ratios so they display without the page jumping when rendered without being cached. E.g. like this:

https://user-images.githubusercontent.com/3102842/134372470-ff602677-60b2-4fea-97e5-fbea214c4953.mov

All in all this should provide clarity and stability to allow admins to make more use of these features. We sure will be able to take advantage of this on DEV.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

This will provide an opportunity to add more clear and detailed docs of how this functionality works.

- [x] I plan to make a PR into to the admin docs myself when this is merged.
