### PR TITLE
[15 minute fix] Podcast fixes/clean up

### DIFF
--- a/app/assets/stylesheets/ltags/PodcastTag.scss
+++ b/app/assets/stylesheets/ltags/PodcastTag.scss
@@ -29,6 +29,7 @@
 
     a {
       color: white;
+      text-decoration: none;
 
       .tinyimage {
         width: 22px;

--- a/app/assets/stylesheets/user-profile-header.scss
+++ b/app/assets/stylesheets/user-profile-header.scss
@@ -79,6 +79,9 @@
     a {
       color: rgb(97, 97, 97);
     }
+    .crayons-btn--outlined {
+      background: white;
+    }
     .profile-pic-wrapper {
       float: left;
       width: calc(14.5vw + 60px);
@@ -253,77 +256,5 @@
     z-index: 5;
     display: inline-block;
     margin-left: 5px;
-  }
-  .user-profile-follow-button {
-    background: $green;
-    border: 0;
-    font-size: 17px;
-    border-radius: 3px;
-    vertical-align: 3px;
-    padding: 2px 6px;
-    cursor: pointer;
-    min-width: 120px;
-    opacity: 0.7;
-    &.showing {
-      opacity: 1;
-    }
-    @media screen and (min-width: 430px) {
-      font-size: 18px;
-      padding: 3px 8px;
-      vertical-align: 7px;
-      border-radius: 5px;
-      min-width: 140px;
-    }
-    @media screen and (min-width: 950px) {
-      font-size: 22px;
-      padding: 4px 8px;
-      vertical-align: 12px;
-      border-radius: 5px;
-      min-width: 140px;
-    }
-  }
-
-  // same as above, just add class to above style
-  .user-profile-chat-button-wrapper {
-    position: relative;
-    z-index: 5;
-    display: inline-block;
-    margin-left: 5px;
-  }
-
-  .user-profile-chat-button {
-    background: $green;
-    color: white;
-    border: 0;
-    font-size: 17px;
-    border-radius: 3px;
-    vertical-align: 3px;
-    padding: 2px 6px;
-    cursor: pointer;
-    min-width: 60px;
-    font-family: 'HelveticaNeue-CondensedBold', 'HelveticaNeueBoldCondensed',
-      'HelveticaNeue-Bold-Condensed', 'Helvetica Neue Bold Condensed',
-      'HelveticaNeueBold', 'HelveticaNeue-Bold', 'Helvetica Neue Bold',
-      'HelveticaNeue', 'Helvetica Neue', 'TeXGyreHerosCnBold', 'Helvetica',
-      'Tahoma', 'Geneva', 'Arial Narrow', 'Arial', sans-serif;
-    -webkit-appearance: none;
-    font-stretch: condensed;
-    &.showing {
-      opacity: 1;
-    }
-    @media screen and (min-width: 430px) {
-      font-size: 18px;
-      padding: 3px 8px;
-      vertical-align: 7px;
-      border-radius: 5px;
-      min-width: 80px;
-    }
-    @media screen and (min-width: 950px) {
-      font-size: 22px;
-      padding: 4px 8px;
-      vertical-align: 12px;
-      border-radius: 5px;
-      min-width: 80px;
-    }
   }
 }

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -19,7 +19,7 @@
         <div class="profile-header__actions">
           <button
             id="user-follow-butt"
-            class="crayons-btn whitespace-nowrap follow-action-button user-profile-follow-button"
+            class="crayons-btn whitespace-nowrap follow-action-button"
             data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>", "name": "<%= @user.name %>"}'>
             Follow
           </button>

--- a/app/views/podcast_episodes/_liquid.html.erb
+++ b/app/views/podcast_episodes/_liquid.html.erb
@@ -1,14 +1,13 @@
 <% image_url = Images::Optimizer.call(podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png", crop: nil, fetch_format: "jpg") %>
 
-<div class="podcastliquidtag" style="background: #<%= podcast.main_color_hex %> url(<%= image_url %>)" data-meta="<%= episode.decorate.mobile_player_metadata.to_json %>">
+<div class="podcastliquidtag" style="background: #<%= podcast.main_color_hex %>" data-meta="<%= episode.decorate.mobile_player_metadata.to_json %>">
   <div class="podcastliquidtag__info">
     <a href="/<%= podcast.slug %>/<%= episode.slug %>">
       <h1 class="podcastliquidtag__info__episodetitle"><%= episode.title %></h1>
     </a>
     <a href="/<%= podcast.slug %>" style="display:block">
       <h2 class="podcastliquidtag__info__podcasttitle">
-        <%= podcast.title %> <button class="crayons-btn follow-action-button" data-info='{"id":<%= podcast.id %>,"className":"<%= podcast.class.name %>", "name": <%= podcast.name %>}'>&nbsp;</button>
-
+        <%= podcast.title %>
       </h2>
     </a>
   </div>

--- a/app/views/podcast_episodes/_liquid.html.erb
+++ b/app/views/podcast_episodes/_liquid.html.erb
@@ -1,5 +1,3 @@
-<% image_url = Images::Optimizer.call(podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png", crop: nil, fetch_format: "jpg") %>
-
 <div class="podcastliquidtag" style="background: #<%= podcast.main_color_hex %>" data-meta="<%= episode.decorate.mobile_player_metadata.to_json %>">
   <div class="podcastliquidtag__info">
     <a href="/<%= podcast.slug %>/<%= episode.slug %>">

--- a/app/views/podcast_episodes/index.html.erb
+++ b/app/views/podcast_episodes/index.html.erb
@@ -2,18 +2,20 @@
   <%= render "podcast_episodes/meta" %>
 <% end %>
 <% if @podcast %>
-  <% image = Images::Optimizer.call(@podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png", fetch_format: "jpg", crop: nil) %>
-  <div class="user-profile-header podcast-header" style="background:#<%= @podcast.main_color_hex %> url(<%= image %>);">
+  <div class="user-profile-header podcast-header" style="background:#<%= @podcast.main_color_hex %>;">
     <div class="tag-or-query-header-container">
       <h1><img class="record main-image" src="<%= Images::Optimizer.call(@podcast.image_url, crop: "fill", width: 420, height: 420) %>"
                alt="<%= @podcast.title %>" /> <%= @podcast.title %>
-               <button
-                id="user-follow-butt"
-                class="crayons-btn follow-action-button user-profile-follow-button"
-                data-info='{"id":<%= @podcast.id %>,"className":"<%= @podcast.class.name %>", "name": "<%= @podcast.name %>"}'>
-                  &nbsp;
-              </button>
-</h1>
+      </h1>
+      <h2>
+        <button
+          id="user-follow-butt"
+          class="crayons-btn follow-action-button"
+          style="min-width: 100px;"
+          data-info='{"id":<%= @podcast.id %>,"className":"<%= @podcast.class.name %>", "name": "<%= @podcast.name %>"}'>
+            &nbsp;
+        </button>
+      </h2>
     </div>
   </div>
 <% end %>

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -30,8 +30,7 @@
 
 <main id="main-content" class="podcast-episode-container" data-meta="<%= @episode.decorate.mobile_player_metadata.to_json %>">
   <div class="hero">
-    <% image_url = Images::Optimizer.call(@podcast.pattern_image_url || "https://i.imgur.com/fKYKgo4.png", fetch_format: "jpg", crop: nil) %>
-    <div class="title" style="background:#<%= @podcast.main_color_hex %> url(<%= image_url %>)">
+    <div class="title" style="background:#<%= @podcast.main_color_hex %>">
       <h2>
         <a href="/<%= @podcast.slug %>">
           <img aria-hidden="true" alt="<%= @podcast.title %>" src="<%= optimized_image_url(@podcast.image_url, width: 60, quality: 80) %>" /><%= @podcast.title %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,7 +35,7 @@
                 </a>
               <% end %>
             <% end %>
-            <button id="user-follow-butt" class="crayons-btn whitespace-nowrap follow-action-button user-profile-follow-button follow-user" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>", "name": "<%= @user.name %>"}'>Follow</button>
+            <button id="user-follow-butt" class="crayons-btn whitespace-nowrap follow-action-button follow-user" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>", "name": "<%= @user.name %>"}'>Follow</button>
             <div class="profile-dropdown ml-2 s:relative hidden" data-username="<%= @user.username %>">
               <button id="user-profile-dropdown" aria-expanded="false" aria-controls="user-profile-dropdownmenu" aria-haspopup="true" class="crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon">
                 <%= inline_svg_tag("overflow-horizontal.svg", class: "dropdown-icon crayons-icon", aria: true, title: "User actions") %>

--- a/cypress/integration/seededFlows/loggedOutFlows/showLoginModal.spec.js
+++ b/cypress/integration/seededFlows/loggedOutFlows/showLoginModal.spec.js
@@ -98,7 +98,7 @@ describe('Show log in modal', () => {
     cy.get('[data-follow-clicks-initialized]');
 
     cy.findByRole('heading', {
-      name: 'Developer on Fire Developer on Fire Follow',
+      name: 'Developer on Fire Developer on Fire',
     });
 
     verifyLoginModalBehavior(() =>

--- a/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
+++ b/cypress/integration/seededFlows/podcastFlows/followPodcast.spec.js
@@ -11,7 +11,7 @@ describe('Follow podcast', () => {
     cy.get('[data-follow-clicks-initialized]');
 
     cy.findByRole('heading', {
-      name: 'Developer on Fire Developer on Fire Follow',
+      name: 'Developer on Fire Developer on Fire',
     });
 
     cy.findByRole('button', { name: 'Follow podcast: Developer on Fire' }).as(


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is the clean up of some broken and mangled functionality in podcast land. It doesn't go nearly far enough to bring podcasts up to date with proper styling and being bug-free in general, but it's a small start.

I figured given the bugginess instability in podcast land anything to clean up and fix things is a pretty easy "yes".

- The podcast liquid tag follow button is currently broken. This just removes that button.
- I removed "pattern image" from the view, and I'll remove this from the backend later. This functionality takes way too much upkeep and we don't need it.

## Related Tickets & Documents

Fixes https://github.com/forem/forem/issues/13667

## QA Instructions, Screenshots, Recordings

This is what podcasts currently look like: Basically unusable if not properly set up (and it seems really hard for admins to properly set them up).

Yikes.

<img width="1291" alt="Screen Shot 2021-09-22 at 12 38 32 PM" src="https://user-images.githubusercontent.com/3102842/134385766-c34ac249-16d3-4a22-8c82-a04f5a1a35f1.png">
<img width="731" alt="Screen Shot 2021-09-22 at 12 38 24 PM" src="https://user-images.githubusercontent.com/3102842/134385789-432511e7-d57b-40e3-b051-610bb356d681.png">
<img width="871" alt="Screen Shot 2021-09-22 at 12 55 54 PM" src="https://user-images.githubusercontent.com/3102842/134387946-c805f351-47ac-4040-89c5-e58a550558be.png">


Now:

<img width="1174" alt="Screen Shot 2021-09-22 at 8 19 49 PM" src="https://user-images.githubusercontent.com/3102842/134438675-730e394f-df69-4c1a-ae63-c4e22d2082c0.png">

Not a huge fix, but a little less broken.

### UI accessibility concerns?

This clean up definitely has a positive impact on UI accessibility overall in a good way. It does not entirely fix all a11y concerns related to podcasts, but it cleans things up for future improvements.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Regression tests should handle this.
- [ ] I need help with writing tests