### PR TITLE
Check Connect feature flag in more places

### DIFF
--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -31,6 +31,8 @@ class OrganizationMembership < ApplicationRecord
   end
 
   def add_chat_channel_membership(user, channel, role)
+    return unless FeatureFlag.enabled?(:connect)
+
     membership = ChatChannelMembership.find_or_initialize_by(user_id: user.id, chat_channel_id: channel.id)
     membership.role = role
     membership.save

--- a/app/services/tag_moderators/add.rb
+++ b/app/services/tag_moderators/add.rb
@@ -15,7 +15,7 @@ module TagModerators
         tag = Tag.find(tag_ids[index])
         add_tag_mod_role(user, tag)
         ::TagModerators::AddTrustedRole.call(user)
-        add_to_chat_channels(user, tag)
+        add_to_chat_channels(user, tag) if FeatureFlag.enabled?(:connect)
         tag.update(supported: true) unless tag.supported?
 
         NotifyMailer


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

When we deployed the feature flag for Connect we overlooked a few more places where it could have been used, this PR remedies that. This was flagged because newly assigned tag moderators still received channel invitation emails despite Connect being disabled.

* In the tag moderators case, emails should only have been sent if the tag didn't have a chat channel yet, as we then end up in `ChatChannels::CreateWithUsers` which ends up calling `ChatChannels#invite_users` which eventually calls `NotifyMailer.channel_invite_email`.
* In the organization case we may not actually send an email at all but the feature flag of course still makes sense.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Nothing specific.

### UI accessibility concerns?

n/a

## Added/updated tests?

- [X] No

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
