### PR TITLE
Remove unneeded checks for code tags when filtering articles from search indexing

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -13,7 +13,8 @@ class SitemapsController < ApplicationController
     end
 
     @articles = Article.published
-      .where("published_at > ? AND published_at < ? AND score > ?", date, date.end_of_month, 3)
+      .where("published_at > ? AND published_at < ? AND score > ?",
+             date, date.end_of_month, Settings::UserExperience.index_minimum_score)
       .pluck(:path, :last_comment_at)
 
     set_surrogate_controls(date)

--- a/app/lib/constants/settings/user_experience.rb
+++ b/app/lib/constants/settings/user_experience.rb
@@ -18,6 +18,10 @@ module Constants
           description: "Minimum score needed for a post to show up on the unauthenticated home page.",
           placeholder: "0"
         },
+        index_minimum_score: {
+          description: "Minimum score needed for a post to be indexed by search engines.",
+          placeholder: "0"
+        },
         primary_brand_color_hex: {
           description: "Determines background/border of buttons etc. Must be dark enough to contrast with white text.",
           placeholder: "#0a0a0a"

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -490,6 +490,17 @@ class Article < ApplicationRecord
     followers.uniq.compact
   end
 
+  def skip_indexing?
+    # should the article be indexed by crawlers?
+    !published ||
+      (score < 5 &&
+       user.comments_count < 1 &&
+       !featured &&
+       processed_html.exclude?("<code>")) ||
+      featured_number.to_i < 1_500_000_000 ||
+      score < -1
+  end
+
   private
 
   def search_score

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -495,7 +495,7 @@ class Article < ApplicationRecord
     # true if unpublished, or spammy,
     # or low score, not featured, and from a user with no comments
     !published ||
-      (score < Settings::UserExperience.home_feed_minimum_score &&
+      (score < Settings::UserExperience.index_minimum_score &&
        user.comments_count < 1 &&
        !featured) ||
       featured_number.to_i < 1_500_000_000 ||

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -497,8 +497,7 @@ class Article < ApplicationRecord
     !published ||
       (score < Settings::UserExperience.home_feed_minimum_score &&
        user.comments_count < 1 &&
-       !featured &&
-       processed_html.exclude?("<code>")) ||
+       !featured) ||
       featured_number.to_i < 1_500_000_000 ||
       score < -1
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -491,9 +491,11 @@ class Article < ApplicationRecord
   end
 
   def skip_indexing?
-    # should the article be indexed by crawlers?
+    # should the article be skipped indexed by crawlers?
+    # true if unpublished, or spammy,
+    # or low score, not featured, and from a user with no comments
     !published ||
-      (score < 5 &&
+      (score < Settings::UserExperience.home_feed_minimum_score &&
        user.comments_count < 1 &&
        !featured &&
        processed_html.exclude?("<code>")) ||

--- a/app/models/settings/user_experience.rb
+++ b/app/models/settings/user_experience.rb
@@ -11,6 +11,7 @@ module Settings
     # basic (current default), rich (cover image on all posts), compact (more minimal)
     setting :feed_style, type: :string, default: "basic"
     setting :home_feed_minimum_score, type: :integer, default: 0
+    setting :index_minimum_score, type: :integer, default: 0
     setting :primary_brand_color_hex, type: :string, default: "#3b49df", validates: {
       format: {
         with: HEX_COLOR_REGEX,

--- a/app/views/admin/settings/forms/_user_experience.html.erb
+++ b/app/views/admin/settings/forms/_user_experience.html.erb
@@ -44,6 +44,14 @@
                              placeholder: Constants::Settings::UserExperience::DETAILS[:home_feed_minimum_score][:placeholder] %>
         </div>
         <div class="crayons-field">
+          <%= admin_config_label :index_minimum_score, model: Settings::UserExperience %>
+          <%= admin_config_description Constants::Settings::UserExperience::DETAILS[:index_minimum_score][:description] %>
+          <%= f.number_field :index_minimum_score,
+                             class: "crayons-textfield",
+                             value: Settings::UserExperience.index_minimum_score,
+                             placeholder: Constants::Settings::UserExperience::DETAILS[:index_minimum_score][:placeholder] %>
+        </div>
+        <div class="crayons-field">
           <%= admin_config_label :default_font, model: Settings::UserExperience %>
           <%= admin_config_description Constants::Settings::UserExperience::DETAILS[:default_font][:description] %>
           <%= select_tag "settings_user_experience[default_font]",

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -51,13 +51,7 @@
       <meta property="og:image" content="<%= article_social_image_url(@article) %>" />
       <meta name="twitter:image:src" content="<%= article_social_image_url(@article) %>">
     <% end %>
-    <% if !@article.published ||
-      (@article.score < 5 &&
-        @article.user.comments_count < 1 &&
-        !@article.featured &&
-        @article.processed_html.exclude?("<code>")) ||
-      @article.featured_number.to_i < 1500000000 ||
-      @article.score < -1 %>
+    <% if @article.skip_indexing? %>
       <meta name="robots" content="noindex">
       <meta name="robots" content="nofollow">
     <% end %>

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -201,27 +201,13 @@ RSpec.describe "StoriesShow", type: :request do
       expect(response.body).to include("noindex")
     end
 
-    it "has noindex if article has low score even with <code>" do
-      article = create(:article, score: -5)
-      article.update_column(:processed_html, "<code>hello</code>")
-      get article.path
-      expect(response.body).to include("noindex")
-    end
-
     it "does not have noindex if article has high score" do
       article = create(:article, score: 6)
       get article.path
       expect(response.body).not_to include("noindex")
     end
 
-    it "does not have noindex if article intermediate score and <code>" do
-      article = create(:article, score: 3)
-      article.update_column(:processed_html, "<code>hello</code>")
-      get article.path
-      expect(response.body).not_to include("noindex")
-    end
-
-    it "does not have noindex if article w/ intermediate score w/ 1 comment " do
+    it "does not have noindex if article w/ intermediate score w/ 1 comment" do
       article = create(:article, score: 3)
       article.user.update_column(:comments_count, 1)
       get article.path


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Remove the check for `<code>` tags (there are a few test cases that exercise this that can be removed still). 
Simplify the presence of two "magic" numbers 3 and 5 in the sitemap generation and article show pages, if an article is going to be included in the sitemap, it should be indexed.


## Related Tickets & Documents

Andy's [forem.team post](https://forem.team/andy/hidden-feature-preventing-articles-without-a-code-tag-to-be-crawled-5eod)

Ben's suggestion from the comment was the guidance here.

## QA Instructions, Screenshots, Recordings

Behavior covered by the spec/requests/stories_show_spec.rb cases.

Confirmed new setting shows and can be updated in the admin/customization page:

![Admin view](https://user-images.githubusercontent.com/1237369/134728075-14dfa9ef-5ae2-43ed-8a92-b30fb5c64cdc.png)

 
### UI accessibility concerns?

None.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: refactor
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams
- [x] I will add a Forem.dev changelog post
- [x] [Updated the admin guide](https://github.com/forem/admin-docs/pull/16)

## [optional] Are there any post deployment tasks we need to perform?

DEV and possibly other communities should have the created setting set to non-zero. 