### PR TITLE
Move featured story to separate service

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -148,7 +148,7 @@ class StoriesController < ApplicationController
   end
 
   def featured_story
-    @featured_story ||= Articles::Feeds::LargeForemExperimental.find_featured_story(@stories)
+    @featured_story ||= Articles::Feeds::FindFeaturedStory.call(@stories)
   end
 
   def handle_podcast_index

--- a/app/services/articles/feeds/find_featured_story.rb
+++ b/app/services/articles/feeds/find_featured_story.rb
@@ -1,0 +1,16 @@
+module Articles
+  module Feeds
+    module FindFeaturedStory
+      def self.call(stories)
+        featured_story =
+          if stories.is_a?(ActiveRecord::Relation)
+            stories.where.not(main_image: nil).first
+          else
+            stories.detect { |story| story.main_image.present? }
+          end
+
+        featured_story || Article.new
+      end
+    end
+  end
+end

--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -11,19 +11,6 @@ module Articles
         @experience_level_weight = 1 # default weight for user experience level
       end
 
-      def self.find_featured_story(stories)
-        featured_story =  if stories.is_a?(ActiveRecord::Relation)
-                            stories.where.not(main_image: nil).first
-                          else
-                            stories.detect { |story| story.main_image.present? }
-                          end
-        featured_story || Article.new
-      end
-
-      def find_featured_story(stories)
-        self.class.find_featured_story(stories)
-      end
-
       def default_home_feed(user_signed_in: false)
         _featured_story, stories = default_home_feed_and_featured_story(user_signed_in: user_signed_in, ranking: true)
         stories

--- a/spec/services/articles/feeds/find_featured_story_spec.rb
+++ b/spec/services/articles/feeds/find_featured_story_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Articles::Feeds::FindFeaturedStory, type: :service do
+  before { create(:article) }
+
+  context "when passed an ActiveRecord collection" do
+    it "returns first article with a main image" do
+      featured_story = described_class.call(Article.all)
+      expect(featured_story.main_image).not_to be_nil
+    end
+  end
+
+  context "when passed an array" do
+    it "returns first article with a main image" do
+      featured_story = described_class.call(Article.all.to_a)
+      expect(featured_story.main_image).to be_present
+    end
+  end
+
+  context "when passed collection without any articles" do
+    it "returns an new, empty Article object" do
+      expect(described_class.call([])).not_to be_persisted
+    end
+  end
+end

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
     context "when user logged in" do
       let(:stories) { feed.default_home_feed(user_signed_in: true) }
 
-      it "includes stories " do
+      it "includes stories" do
         expect(stories).to include(old_story)
         expect(stories).to include(new_story)
       end
@@ -252,7 +252,7 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
         expect(feed.score_experience_level(article)).to eq(-3)
       end
 
-      it "returns  proper negative when fractional" do
+      it "returns proper negative when fractional" do
         article.experience_level_rating = 8
         expect(feed.score_experience_level(article)).to eq(-3.5)
       end
@@ -387,43 +387,6 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
       it "still returns articles" do
         expect(globally_hot_articles).not_to be_empty
       end
-    end
-  end
-
-  describe ".find_featured_story" do
-    let(:featured_story) { described_class.find_featured_story(stories) }
-
-    context "when passed an ActiveRecord collection" do
-      let(:stories) { Article.all }
-
-      it "returns first article with a main image" do
-        expect(featured_story.main_image).not_to be_nil
-      end
-    end
-
-    context "when passed an array" do
-      let(:stories) { Article.all.to_a }
-
-      it "returns first article with a main image" do
-        expect(featured_story.main_image).not_to be_nil
-      end
-    end
-
-    context "when passed collection without any articles" do
-      let(:stories) { [] }
-
-      it "returns an new, empty Article object" do
-        expect(featured_story.main_image).to be_nil
-        expect(featured_story.id).to be_nil
-      end
-    end
-  end
-
-  describe "#find_featured_story" do
-    it "calls the class method" do
-      allow(described_class).to receive(:find_featured_story)
-      feed.find_featured_story([])
-      expect(described_class).to have_received(:find_featured_story)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

I recently refactored some feed code ([PR](https://github.com/forem/forem/pull/14707)). However, there's one more thing that could have been extracted into an independent object, the finding of the featured story. This PR extracts this so we don't make it part of a feed strategy when it's actually a pretty generic process.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Nothing specific, specs should be green.

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: internal refactoring