### PR TITLE
Suggest top tags when tag search is empty

### DIFF
--- a/app/assets/stylesheets/views/article-form.scss
+++ b/app/assets/stylesheets/views/article-form.scss
@@ -257,6 +257,12 @@
     }
   }
 
+  &__tagsoptionsheading {
+    padding: var(--su-3);
+    font-size: var(--fs-l);
+    border-bottom: 1px solid var(--base-20);
+  }
+
   &__tagname {
     color: var(--base-90);
     font-weight: var(--fw-medium);

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -46,7 +46,7 @@ class TagsController < ApplicationController
 
   def suggest
     skip_authorization
-    tags = Tag.where(supported: true).order(hotness_score: :desc).limit(100).select(INDEX_API_ATTRIBUTES)
+    tags = Tag.supported.order(hotness_score: :desc).limit(100).select(INDEX_API_ATTRIBUTES)
     render json: tags.as_json(only: INDEX_API_ATTRIBUTES)
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -46,7 +46,7 @@ class TagsController < ApplicationController
 
   def suggest
     skip_authorization
-    tags = Tag.order(hotness_score: :desc).limit(100).select(INDEX_API_ATTRIBUTES)
+    tags = Tag.where(supported: true).order(hotness_score: :desc).limit(100).select(INDEX_API_ATTRIBUTES)
     render json: tags.as_json(only: INDEX_API_ATTRIBUTES)
   end
 

--- a/app/javascript/shared/components/__tests__/tags.test.jsx
+++ b/app/javascript/shared/components/__tests__/tags.test.jsx
@@ -1,3 +1,4 @@
+import fetch from 'jest-fetch-mock';
 import { h } from 'preact';
 import { render, fireEvent } from '@testing-library/preact';
 import { axe } from 'jest-axe';
@@ -8,6 +9,7 @@ describe('<Tags />', () => {
     const environment = document.createElement('meta');
     environment.setAttribute('name', 'environment');
     document.body.appendChild(environment);
+    window.fetch = fetch;
   });
 
   it('should have no a11y violations', async () => {

--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -74,6 +74,7 @@ export class Tags extends Component {
       cursorIdx: 0,
       prevLen: 0,
       showingRulesForTag: null,
+      showingTopTags: false,
       ...listingState,
     };
   }
@@ -160,6 +161,7 @@ export class Tags extends Component {
 
   handleKeyDown = (e) => {
     const component = this;
+    const { searchResults } = this.state;
     const { maxTags } = this.props;
     if (component.selected.length === maxTags && e.key === KEYS.COMMA) {
       e.preventDefault();
@@ -169,7 +171,7 @@ export class Tags extends Component {
     if (
       (e.key === KEYS.DOWN || e.key === KEYS.TAB) &&
       !this.isBottomOfSearchResults &&
-      component.props.defaultValue !== ''
+      searchResults.length > 0
     ) {
       e.preventDefault();
       this.moveDownInSearchResults();
@@ -305,6 +307,7 @@ export class Tags extends Component {
   }
 
   fetchTopTagSuggestions() {
+    this.setState({ showingTopTags: true });
     const { topTags = [] } = this.state;
     if (topTags.length > 0) {
       return Promise.resolve().then(() =>
@@ -328,6 +331,8 @@ export class Tags extends Component {
     if (query === '') {
       return this.fetchTopTagSuggestions();
     }
+    this.setState({ showingTopTags: false });
+
     const { listing } = this.props;
 
     const dataHash = { name: query };
@@ -377,7 +382,8 @@ export class Tags extends Component {
 
   render() {
     let searchResultsHTML = '';
-    const { searchResults, selectedIndex, showingRulesForTag } = this.state;
+    const { searchResults, selectedIndex, showingRulesForTag, showingTopTags } =
+      this.state;
     const {
       classPrefix,
       defaultValue,
@@ -432,6 +438,9 @@ export class Tags extends Component {
     ) {
       searchResultsHTML = (
         <div className={`${classPrefix}__tagsoptions`}>
+          {showingTopTags ? (
+            <h2 className={`${classPrefix}__tagsoptionsheading`}>Top tags</h2>
+          ) : null}
           {searchResultsRows}
           <div className={`${classPrefix}__tagsoptionsbottomrow`}>
             Some tags have rules and guidelines determined by community

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -41,6 +41,7 @@ class Tag < ActsAsTaggableOn::Tag
                   using: { tsearch: { prefix: true } }
 
   scope :eager_load_serialized_data, -> {}
+  scope :supported, -> { where(supported: true) }
 
   # possible social previews templates for articles with a particular tag
   def self.social_preview_templates

--- a/app/services/search/tag.rb
+++ b/app/services/search/tag.rb
@@ -3,7 +3,7 @@ module Search
     ATTRIBUTES = %i[id name hotness_score rules_html supported short_summary].freeze
 
     def self.search_documents(term)
-      results = ::Tag.search_by_name(term).where(supported: true).reorder(hotness_score: :desc).select(*ATTRIBUTES)
+      results = ::Tag.search_by_name(term).supported.reorder(hotness_score: :desc).select(*ATTRIBUTES)
       serialize(results)
     end
 

--- a/app/views/layouts/_sidebar_tags.html.erb
+++ b/app/views/layouts/_sidebar_tags.html.erb
@@ -10,7 +10,7 @@
   <% else %>
     <h3 class="crayons-subtitle-3 p-2">Popular Tags</h3>
     <div id="sidebar-nav-default-tags" class="overflow-y-auto" style="max-height: 42vh">
-      <% Tag.where(supported: true).order(hotness_score: :desc).limit(30).pluck(:id, :name).each do |tag_array| %>
+      <% Tag.supported.order(hotness_score: :desc).limit(30).pluck(:id, :name).each do |tag_array| %>
         <div class="sidebar-nav-element" id="default-sidebar-element-<%= tag_array.second %>">
           <a class="crayons-link crayons-link--block py-2 px-2" href="<%= tag_path(tag_array.second) %>">
             #<%= tag_array.second %>

--- a/app/workers/tags/resave_supported_tags_worker.rb
+++ b/app/workers/tags/resave_supported_tags_worker.rb
@@ -5,7 +5,7 @@ module Tags
     sidekiq_options queue: :low_priority, retry: 5
 
     def perform
-      Tag.where(supported: true).find_each(&:save)
+      Tag.supported.find_each(&:save)
     end
   end
 end

--- a/cypress/integration/seededFlows/publishingFlows/addTagsToArticle.spec.js
+++ b/cypress/integration/seededFlows/publishingFlows/addTagsToArticle.spec.js
@@ -1,0 +1,58 @@
+describe('Add tags to article', () => {
+  const exampleTopTags = [
+    { name: 'tagone' },
+    {
+      name: 'tagtwo',
+      rules_html:
+        '<p>Here are some rules <a href="//www.test.com">link here</a></p>\n',
+    },
+  ];
+
+  beforeEach(() => {
+    cy.testSetup();
+    cy.fixture('users/articleEditorV2User.json').as('user');
+
+    cy.get('@user').then((user) => {
+      cy.loginAndVisit(user, '/new');
+    });
+  });
+
+  it('automatically suggests top tags when field is focused', () => {
+    cy.intercept('/tags/suggest', exampleTopTags);
+    cy.findByRole('textbox', { name: 'Post Tags' }).focus();
+
+    cy.findByRole('button', { name: 'tagone' }).should('exist');
+    cy.findByRole('button', {
+      name: 'tagtwo Here are some rules link here',
+    }).should('exist');
+  });
+
+  it('automatically suggests top tags again after tag insertion', () => {
+    cy.intercept('/tags/suggest', exampleTopTags);
+    cy.findByRole('textbox', { name: 'Post Tags' }).clear().type('something');
+
+    // Search is in progress, top tags which don't match shouldn't be shown
+    cy.findByRole('button', { name: 'tagone' }).should('not.exist');
+    cy.findByRole('button', {
+      name: 'tagtwo Here are some rules link here',
+    }).should('not.exist');
+
+    // Users initiates fresh search by typing comma
+    cy.findByRole('textbox', { name: 'Post Tags' }).type(',');
+    cy.findByRole('button', { name: 'tagone' }).should('exist');
+    cy.findByRole('button', {
+      name: 'tagtwo Here are some rules link here',
+    }).should('exist');
+  });
+
+  it("doesn't suggest top tags already added", () => {
+    cy.intercept('/tags/suggest', exampleTopTags);
+    cy.findByRole('textbox', { name: 'Post Tags' }).focus();
+    cy.findByRole('button', { name: 'tagone' }).click();
+
+    cy.findByRole('button', { name: 'tagone' }).should('not.exist');
+    cy.findByRole('button', {
+      name: 'tagtwo Here are some rules link here',
+    }).should('exist');
+  });
+});

--- a/cypress/integration/seededFlows/publishingFlows/addTagsToArticle.spec.js
+++ b/cypress/integration/seededFlows/publishingFlows/addTagsToArticle.spec.js
@@ -29,7 +29,7 @@ describe('Add tags to article', () => {
 
   it('automatically suggests top tags again after tag insertion', () => {
     cy.intercept('/tags/suggest', exampleTopTags);
-    cy.findByRole('textbox', { name: 'Post Tags' }).clear().type('something');
+    cy.findByRole('textbox', { name: 'Post Tags' }).clear().type('something,');
 
     // Search is in progress, top tags which don't match shouldn't be shown
     cy.findByRole('button', { name: 'tagone' }).should('not.exist');
@@ -37,8 +37,8 @@ describe('Add tags to article', () => {
       name: 'tagtwo Here are some rules link here',
     }).should('not.exist');
 
-    // Users initiates fresh search by typing comma
-    cy.findByRole('textbox', { name: 'Post Tags' }).type(',');
+    // Users initiating fresh search after comma
+    cy.findByRole('textbox', { name: 'Post Tags' }).focus();
     cy.findByRole('button', { name: 'tagone' }).should('exist');
     cy.findByRole('button', {
       name: 'tagtwo Here are some rules link here',

--- a/spec/system/homepage/user_visits_homepage_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "User visits a homepage", type: :system do
     it "shows the tags block" do
       visit "/"
       within("#sidebar-nav-default-tags") do
-        Tag.where(supported: true).limit(30).each do |tag|
+        Tag.supported.limit(30).each do |tag|
           expect(page).to have_link("##{tag.name}", href: "/t/#{tag.name}")
         end
       end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a user hasn't typed in any search term for tags in the v2 article editor, we now suggest the 'top tags' for the community.

An "empty search" includes:

- When the user initially focuses the tags input
- When a user selects a tag from the dropdown, and we immediately move on to a 'fresh search' 

**Some limitations to this PR:**

- There are known accessibility and usability issues with this widget, and this PR does not address them. These issues are captured and are being looked at by the Content Experience pod

Known issues include:

- A bug where if you fully type a search term it disappears (https://github.com/forem/forem/issues/14812)
- Minimal feedback to user on tag selection
- Search occasionally feeling 'slow' / being a character behind
- Appropriate accessible names/roles/announcements missing
- Allowing user to add more than 4 tags when the limit is 4

This PR only handles populating search results with the top tags when the search term is empty.

## Related Tickets & Documents

Top tags API was introduced in https://github.com/forem/forem/pull/14752
https://github.com/forem/forem/issues/14751

## QA Instructions, Screenshots, Recordings

- Make sure your user preferences are for the V2 editor
- Visit `/new`
- Focus the tags input, check that "top tags" appear
- Start typing a tag and check that searching for a tag works as before
- Select a tag from the dropdown, and verify the "top tags" appear for your next selection
- Select one of the top tags, and check it no longer appears as a suggestion
- Type a tag manually, adding a comma afterwards, and check the top tags show up again
- Type a tag manually, but then delete it all and check the top tags show up again
- Edit an existing post with tags and check no issues have been introduced there


https://user-images.githubusercontent.com/20773163/134924607-07a56b4a-f455-4232-a7b8-b9eb18ed5b08.mp4


### UI accessibility concerns?

As mentioned in the description there are several accessibility issues with this widget, but this PR does not introduce any new ones. We will be addressing the accessibility issues soon.

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

N/A

## [optional] What gif best describes this PR or how it makes you feel?

![tag, you're it](https://media.giphy.com/media/3o6Ei0fWOw1iQ79d0A/giphy.gif?cid=ecf05e47jt8pgqd9hv4hrfn0hwq07w54h0aaz7muzxlfas1d&rid=giphy.gif&ct=g)
