### PR TITLE
Fix admin menu when Connect feature flag is disabled

### DIFF
--- a/app/views/admin/shared/_nested_sidebar.html.erb
+++ b/app/views/admin/shared/_nested_sidebar.html.erb
@@ -21,10 +21,11 @@
         <%= inline_svg_tag(group[:svg], aria_hidden: true, class: "dropdown-icon crayons-icon") %>
         <%= display_name(group_name) %>
       </button>
+      <% first_child = group[:children].detect { |child| child[:visible] } %>
       <ul id="<%= group_name %>"
           data-sidebar-target="submenu"
           class="js-menu-activator <%= deduced_scope(request) == group_name.to_s ? "collapse show" : "collapse" %>"
-          data-target-href="/admin/<%= group_name %>/<%= group[:children][0][:controller] %>">
+          data-target-href="/admin/<%= group_name %>/<%= first_child[:controller] %>">
         <% group[:children].each do |item| %>
           <% if item[:visible] %>
             <li>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

When we added the Connect feature flag we introduced a little bug in the admin navigation: usually, when you open a group the first element will automatically be activated. This doesn't work if the first subitem is invisible, as is the case for  "Chat channels" when the feature flag is disabled. This PR changes the logic to activate the first visible child instead. 

## Related Tickets & Documents

Reported by @ludwiczakpawel via Slack.

## QA Instructions, Screenshots, Recordings

1. Enable the Connect feature flag: `FeatureFlag.enable(:connect)`
2. When you go to `/admin` and click on "Apps", "Chat Channels" should be active.
3. Disable the Connect feature flag:  `FeatureFlag.disble(:connect)`
4. When you go to `/admin` and click on "Apps", "Consumer Apps" should be active.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] No, and this is why: I'm not quite sure how to test this without too much setup effort and the change seems minimal enough. This whole edge-case only happens when we have a feature flag that affects the first child of an admin menu group, so I didn't feel like spending too much time on this.

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: minor refactoring/bug fix