### PR TITLE
[Tiny fix] Fix a couple small bugs from DisplayAd clean up

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
+++ b/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
@@ -143,10 +143,10 @@ function trackCustomImpressions() {
       && windowBigEnough
       && checkUserLoggedIn()) {
         var csrfToken = tokenMeta.getAttribute('content');
-        [].forEach.call(displayAds, function(unit) {
+        displayAds.forEach(unit => {
           trackAdImpression(csrfToken, unit);
           unit.removeEventListener('click', trackAdClick, false );
-          unit.addEventListener('click', function(e) { trackAdClick(csrfToken, e) });
+          unit.addEventListener('click', function(e) { trackAdClick(csrfToken, e.target) });
         });
       }
   }, 1800)
@@ -221,7 +221,8 @@ function trackAdImpression(token, adBox) {
   })
 }
 
-function trackAdClick(token, adBox) {
+function trackAdClick(token, clickedElement) {
+  var adBox = clickedElement.closest('[data-display-unit]');
   if (!adClicked) {
     var dataBody = {
       display_ad_event: {

--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -44,9 +44,9 @@ module Html
         next if allowed_image_host?(src)
 
         if synchronous_detail_detection && img
-          width, height = image_width_height(img)
-          img["width"] = width
-          img["height"] = height
+          attribute_width, attribute_height = image_width_height(img)
+          img["width"] = attribute_width
+          img["height"] = attribute_height
         end
 
         img["loading"] = "lazy"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a quick fix to follow up on #14789

**JS:**

Changing the JS to use modern approach as opposed to hack, and fixing a problem with fetching the right element all the time.

**Ruby:** We accidentally re-used the `width` variable, which didn't cause a visible problem, but caused the width we pass into the image proxy to be one we retrieve from the original image instead of the one we pass.