### PR TITLE
Modify capitalization of default navigation link

### DIFF
--- a/lib/tasks/add_navigation_links.rake
+++ b/lib/tasks/add_navigation_links.rake
@@ -57,7 +57,7 @@ namespace :navigation_links do
       section: :other,
     )
     NavigationLink.where(url: "/terms").first_or_create(
-      name: "Terms of use",
+      name: "Terms of Use",
       url: URL.url("terms"),
       icon: look_icon,
       display_only_when_signed_in: false,
@@ -150,7 +150,7 @@ namespace :navigation_links do
       section: :other,
     )
     NavigationLink.where(url: "#{base_url}/terms").first_or_create(
-      name: "Terms of use",
+      name: "Terms of Use",
       icon: look_icon,
       display_only_when_signed_in: false,
       position: 2,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Updating a few characters

## Description
Changing `Terms of use` to `Terms of Use`

This has been bothering for me a while, and it's now consistent with `Code of Conduct` (which is not `Code of conduct` ) capitalization-wise

## Related Tickets & Documents
N/A

## QA Instructions, Screenshots, Recordings
N/A

### UI accessibility concerns?
N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: not necessary
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: I doubt anyone will notice or mind