### PR TITLE
Allow search endpoint to be used without q param

### DIFF
--- a/app/views/stories/articles_search/index.html.erb
+++ b/app/views/stories/articles_search/index.html.erb
@@ -20,7 +20,7 @@
 
     <div class="block s:flex items-center justify-between">
       <h1 class="crayons-title hidden s:block pl-2">
-        Search results <%= "for #{params[:q]}" unless params[:q].empty? %>
+        Search results <%= "for #{params[:q]}" unless params[:q].blank? %>
       </h1>
 
       <nav id="sorting-option-tabs" aria-label="Search result sort options" class="-mx-3 m:mx-0">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If you didn't specify `q=`, this template would raise an error. HTTP params are basically the only thing `blank?` and `present?` are good for since there is no distinction between an empty string and a missing value.

[Search requests have been failing since last night](https://app.datadoghq.com/apm/resource/practical_developer/rack.request/18301539a1a8bcc8?query=env%3Aproduction%20service%3Apractical_developer%20operation_name%3Arack.request%20resource_name%3A%22Stories%3A%3AArticlesSearchController%23index%22%20status%3Aerror&env=production&index=apm-search&spanID=4314481071243849254&topGraphs=latency%3Alatency%2CbreakdownAs%3Apercentage%2Cerrors%3Aversion_count%2Chits%3Acount&start=1632831153636&end=1632922790000&paused=true).

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Just changing to a more permissive method
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: