### PR TITLE
Add recent resource sitemap endpoint for posts

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -2,8 +2,28 @@ class SitemapsController < ApplicationController
   before_action :set_cache_control_headers, only: %i[show]
 
   SITEMAP_REGEX = /\Asitemap-(?<date_string>[A-Z][a-z][a-z]-\d{4})\.xml\z/
+  RESULTS_LIMIT = Rails.env.production? ? 10_000 : 5
 
   def show
+    if params[:sitemap].start_with? "sitemap-posts"
+      posts_sitemap
+    else
+      monthly_sitemap
+    end
+    set_cache_control_headers(@max_age,
+                              stale_while_revalidate: @stale_while_revalidate,
+                              stale_if_error: @stale_if_error)
+    render layout: false
+  end
+
+  private
+
+  def posts_sitemap
+    @articles = Article.published.order("published_at DESC").limit(RESULTS_LIMIT).offset(offset).pluck(:path, :last_comment_at)
+    set_surrogate_controls(Time.now)
+  end
+
+  def monthly_sitemap
     match = params[:sitemap].match(SITEMAP_REGEX)
     not_found unless match && match[:date_string]
     begin
@@ -18,13 +38,7 @@ class SitemapsController < ApplicationController
       .pluck(:path, :last_comment_at)
 
     set_surrogate_controls(date)
-    set_cache_control_headers(@max_age,
-                              stale_while_revalidate: @stale_while_revalidate,
-                              stale_if_error: @stale_if_error)
-    render layout: false
   end
-
-  private
 
   def set_surrogate_controls(date)
     @stale_if_error = "86400"
@@ -35,5 +49,9 @@ class SitemapsController < ApplicationController
       @max_age = "259200" # three days
       @stale_while_revalidate = "432000" # five days
     end
+  end
+
+  def offset
+    params[:sitemap].split("-")[2].to_i * RESULTS_LIMIT # elvaluates to 0 if not present or not a number
   end
 end

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -40,5 +40,39 @@ RSpec.describe "Sitemaps", type: :request do
       expect(response.body).not_to include(articles.last.path)
       expect(response.media_type).to eq("application/xml")
     end
+
+    it "renders most recent posts if /sitemap-posts" do
+      create_list(:article, 8)
+      get "/sitemap-posts.xml"
+      expect(response.body).to include(Article.order("published_at DESC").first.path)
+      expect(response.body).not_to include(Article.order("published_at DESC").last.path)
+    end
+
+    it "renders second page if /sitemap-posts-1" do
+      create_list(:article, 8)
+      get "/sitemap-posts-1.xml"
+      expect(response.body).not_to include(Article.order("published_at DESC").first.path)
+      expect(response.body).to include(Article.order("published_at DESC").last.path)
+    end
+
+    it "renders first page if /sitemap-posts-randomn0tnumber" do
+      create_list(:article, 8)
+      get "/sitemap-posts-randomn0tnumber.xml"
+      expect(response.body).to include(Article.order("published_at DESC").first.path)
+      expect(response.body).not_to include(Article.order("published_at DESC").last.path)
+    end
+
+    it "renders empty if /sitemap-posts-2" do
+      # no posts this far down.
+      create_list(:article, 8)
+      get "/sitemap-posts-2.xml"
+      expect(response.body).not_to include(Article.order("published_at DESC").first.path)
+      expect(response.body).not_to include(Article.order("published_at DESC").last.path)
+    end
+
+    it "renders 'recent' version of surrogate control" do
+      get "/sitemap-posts-2.xml"
+      expect(response.header["Surrogate-Control"]).to include("8640")
+    end
   end
 end

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Sitemaps", type: :request do
       expect(response.body).to include(Article.order("published_at DESC").last.path)
     end
 
-    it "renders first page if /sitemap-posts-randomn0tnumber" do
+    it "renders first page if /sitemap-posts-randomn0tnumber", :aggregate_failures do
       create_list(:article, 8)
       get "/sitemap-posts-randomn0tnumber.xml"
       expect(response.body).to include(Article.order("published_at DESC").first.path)

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Sitemaps", type: :request do
       expect(response.media_type).to eq("application/xml")
     end
 
-    it "renders most recent posts if /sitemap-posts" do
+    it "renders most recent posts if /sitemap-posts", :aggregate_failures do
       create_list(:article, 8)
       get "/sitemap-posts.xml"
       expect(response.body).to include(Article.order("published_at DESC").first.path)

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Sitemaps", type: :request do
       expect(response.body).not_to include(Article.order("published_at DESC").last.path)
     end
 
-    it "renders empty if /sitemap-posts-2" do
+    it "renders empty if /sitemap-posts-2", :aggregate_failures do
       # no posts this far down.
       create_list(:article, 8)
       get "/sitemap-posts-2.xml"

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Sitemaps", type: :request do
       expect(response.body).not_to include(Article.order("published_at DESC").last.path)
     end
 
-    it "renders second page if /sitemap-posts-1" do
+    it "renders second page if /sitemap-posts-1", :aggregate_failures do
       create_list(:article, 8)
       get "/sitemap-posts-1.xml"
       expect(response.body).not_to include(Article.order("published_at DESC").first.path)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds an endpoint to our sitemap route called `/sitemap-posts.xml`, with an optional number called `/sitemap-posts-2.xml` etc.

Sitemaps need to be at the root of the domain, which is why the logic like this exists in the first place.

Currently we _only_ have "monthly" sitemaps... `/sitemap-Sep-2021.xml`, which forces an admin to go into Google Search Console at the beginning of every month to add a new sitemap.

This allows an admin to provide encapsulated sitemaps and glean information about what Google is searching when, but is not an ideal _default_ sitemap to provide. This is the "default" sitemap for posts on Forem.

There is optionally a zero-indexed value to append here if a Forem has more than 10k published posts, but generally a Forem can get by for a while with just submitting `/sitemap-posts` to Google Search Console.

This naming convention opens us up to adding `/sitemap-pages` and `/sitemap-users`, `/sitemap-organizations`, etc.... But I thought starting here was good, as those would require additional functionality.

<img width="864" alt="Screen Shot 2021-09-29 at 11 13 16 AM" src="https://user-images.githubusercontent.com/3102842/135297791-555ca4f9-9360-46df-a1be-40b80291ffd3.png">

This simplifies SEO and allows us to give clear instructions to creators:

1. Submit `/sitemap-posts` to Google Search Console to help your crawl rate. This will include the most recent 10k indexable posts on the platform.
2. Optionally submit monthly sitemaps if you want to see a breakdown of crawl based on month.

I have chosen to use "posts" as opposed to "articles" which I think of more of a "private term" if we can help it.

## Related Tickets & Documents

There are a couple forem.dev posts about sitemap confusion and this should be a step in helping us provide a good answer.

https://forem.dev/lee/sitemaps-submission-frequency-5ep2
https://forem.dev/akhil/unable-to-submit-sitemap-5g

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [x] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_