### PR TITLE
Add real release version into the running code

### DIFF
--- a/app/controllers/api/v0/instances_controller.rb
+++ b/app/controllers/api/v0/instances_controller.rb
@@ -13,7 +13,7 @@ module Api
           name: Settings::Community.community_name,
           registered_users_count: User.registered.estimated_count,
           tagline: Settings::Community.tagline,
-          version: "edge.#{Time.now.utc.strftime('%Y%m%d')}.0",
+          version: release_version,
           visibility: visibility
         }, status: :ok
       end
@@ -24,6 +24,24 @@ module Api
         return "pending" if Settings::General.waiting_on_first_user
 
         Settings::UserExperience.public ? "public" : "private"
+      end
+
+      def release_version
+        File.read("#{Rails.root}/.release-version")
+
+      # Accommodate the .release-version file not existing in the case where
+      # this deployment is deployed from a checkout/snapshot of the code.
+      rescue => e
+        # Get the latest modified file in the app. We don't use git in case it's
+        # being run from a snapshot of the code outside a git repo (for example:
+        # https://github.com/forem/forem/archive/refs/heads/main.zip), but
+        # instead we use the latest modified time ("mtime") from application
+        # code.
+        latest_mtime = Dir["#{Rails.root}/{app,config,db,lib}/**/*"]
+          .max_by { |filename| File.mtime(filename) }
+          .then { |filename| File.mtime(filename) }
+
+        "edge.#{latest_mtime.strftime('%Y%m%d')}.0"
       end
     end
   end

--- a/app/controllers/api/v0/instances_controller.rb
+++ b/app/controllers/api/v0/instances_controller.rb
@@ -27,17 +27,17 @@ module Api
       end
 
       def release_version
-        File.read("#{Rails.root}/.release-version")
+        File.read(Rails.root.join(".release-version"))
 
       # Accommodate the .release-version file not existing in the case where
       # this deployment is deployed from a checkout/snapshot of the code.
-      rescue => e
+      rescue StandardError
         # Get the latest modified file in the app. We don't use git in case it's
         # being run from a snapshot of the code outside a git repo (for example:
         # https://github.com/forem/forem/archive/refs/heads/main.zip), but
         # instead we use the latest modified time ("mtime") from application
         # code.
-        latest_mtime = Dir["#{Rails.root}/{app,config,db,lib}/**/*"]
+        latest_mtime = Dir[Rails.root.join("{app,config,db,lib}/**/*")]
           .max_by { |filename| File.mtime(filename) }
           .then { |filename| File.mtime(filename) }
 

--- a/scripts/release
+++ b/scripts/release
@@ -69,6 +69,9 @@ begin
   puts "Merged #{source} into #{channel}"
 
   begin
+    run "echo '#{tag}' > .release-version"
+    run "git add .release-version"
+    run "git commit --message 'Version #{tag}'"
     run "git tag #{tag}"
     puts "Tagged #{tag}"
   rescue StandardError


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds the actual released version (via the release script) into the code. The idea is:

- Run `scripts/release` to cut a new release, which automatically adds and commits a `.release-version` file with the tag generated for the release
- Buildkite builds new containers with that file in it
- When you deploy from `stable`, it will have that file in it
- When you hit the `/api/instance` endpoint, the `version` property of the JSON response contains that release tag

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: I don't know if this _can_ be tested using RSpec since it relies on global state that we're expecting not to change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

- `curl -s https://demo.forem.com/api/instance | jq '.version'` should return `stable.RELEASEDATE.0`