### PR TITLE
dont show rules for top tags

### DIFF
--- a/app/javascript/shared/components/tags.jsx
+++ b/app/javascript/shared/components/tags.jsx
@@ -419,13 +419,15 @@ export class Tags extends Component {
         ) : (
           ''
         )}
-        <div
-          className={`${classPrefix}__tagrules--${
-            showingRulesForTag === tag.name ? 'active' : 'inactive'
-          }`}
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: tag.rules_html }}
-        />
+        {!showingTopTags && (
+          <div
+            className={`${classPrefix}__tagrules--${
+              showingRulesForTag === tag.name ? 'active' : 'inactive'
+            }`}
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: tag.rules_html }}
+          />
+        )}
       </div>
     ));
     if (

--- a/cypress/integration/seededFlows/publishingFlows/addTagsToArticle.spec.js
+++ b/cypress/integration/seededFlows/publishingFlows/addTagsToArticle.spec.js
@@ -23,7 +23,7 @@ describe('Add tags to article', () => {
 
     cy.findByRole('button', { name: 'tagone' }).should('exist');
     cy.findByRole('button', {
-      name: 'tagtwo Here are some rules link here',
+      name: 'tagtwo',
     }).should('exist');
   });
 
@@ -34,14 +34,14 @@ describe('Add tags to article', () => {
     // Search is in progress, top tags which don't match shouldn't be shown
     cy.findByRole('button', { name: 'tagone' }).should('not.exist');
     cy.findByRole('button', {
-      name: 'tagtwo Here are some rules link here',
+      name: 'tagtwo',
     }).should('not.exist');
 
     // Users initiating fresh search after comma
     cy.findByRole('textbox', { name: 'Post Tags' }).focus();
     cy.findByRole('button', { name: 'tagone' }).should('exist');
     cy.findByRole('button', {
-      name: 'tagtwo Here are some rules link here',
+      name: 'tagtwo',
     }).should('exist');
   });
 
@@ -52,7 +52,7 @@ describe('Add tags to article', () => {
 
     cy.findByRole('button', { name: 'tagone' }).should('not.exist');
     cy.findByRole('button', {
-      name: 'tagtwo Here are some rules link here',
+      name: 'tagtwo',
     }).should('exist');
   });
 });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Now that we show all top tags as soon as the tags input is focused, the UI is pretty overwhelming on DEV in particular, due to the large chunks of HTML for the 'rules'. As a stop-gap while we rethink the tags autocomplete as a whole, this PR removes the rules from the 'top tags' suggestions. Rules are still shown once a user starts searching.

## Related Tickets & Documents

https://github.com/forem/forem/pull/14817


## QA Instructions, Screenshots, Recordings

- Make sure you have some rules set for some of your tags locally. You can do this in Admin > Content manager > Tags
- Draft a new post in the V2 editor
- Click on the tags field and check rules are not shown, only the tag names
- Start typing one of the tags with rules
- Check that the rules are shown, as before

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


