### PR TITLE
Add Rails cache instrumentation to Honeycomb

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -8,6 +8,7 @@ else
 
   # Honeycomb automatic Rails integration
   notification_events = %w[
+    cache_read.active_support
     sql.active_record
     render_template.action_view
     render_partial.action_view


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We are instrumenting the Rails cache's underlying Redis queries, but not the cache operation itself, so we have no instrumentation telling us whether any of the cache queries are hits vs misses, meaning we don't have any information at all on the _effectiveness_ of the Redis cache. For example, we can see the raw Redis query here, but notice there is nothing showing the cause of the Redis query:

<img width="1169" alt="Screenshot of a Honeycomb trace showing the cache's raw Redis query" src="https://user-images.githubusercontent.com/108205/135635682-6384e6d2-bc3a-435a-a67e-9d8925cc0030.png">

It doesn't contain the full story, it just looks like the Redis query was fired off during a template render. Technically, that _is_ what it's doing, but there's no useful information to query on, aggregate, or group by, including cache hit vs miss. The duration of the Redis query is useful, but we need cache-specific context.

The Honeycomb Beeline instrumentation appears to use `ActiveSupport::Instrumentation` (basing this hypothesis purely on the names of the events in the list), so I pulled the name of the notification event from [this page](https://guides.rubyonrails.org/active_support_instrumentation.html#active-support).

The Datadog cache integration [doesn't report cache hit vs miss](https://app.datadoghq.com/apm/resource/practical_developer-cache/rails.cache/a509a3c69ad1028d?query=env%3Aproduction%20service%3Apractical_developer-cache%20operation_name%3Arails.cache%20resource_name%3AGET&env=production&event=AQAAAXw8JwM_zDT2kQAAAABBWHc4SnhoYUFBQVFiSTd3bzRVX2dxWXo&index=apm-search&spanID=2648969811800351488&timeHint=1633093200000&topGraphs=latency%3Alatency%2CbreakdownAs%3Apercentage%2Cerrors%3Aversion_count%2Chits%3Aversion_count&traceID=3721861417863818048&start=1633094279637&end=1633097879637&paused=true), either, so I'm trying to get _some_ instrumentation around it.

![Screenshot from Datadog's Rails cache integration](https://user-images.githubusercontent.com/108205/135635499-76a17c52-f19f-42a5-9fc3-e6e9a3891b64.png)


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Config change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![image](https://c.tenor.com/cLnzRPB0jEAAAAAC/ally-sheedy-short-circuit.gif)
