### PR TITLE
Eager-load comment user data

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -94,7 +94,7 @@ class Comment < ApplicationRecord
     commentable.comments
       .includes(user: %i[setting profile])
       .arrange(order: "score DESC")
-      .to_a[0...limit]
+      .to_a[0..limit - 1]
       .to_h
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -91,7 +91,11 @@ class Comment < ApplicationRecord
   alias touch_by_reaction save
 
   def self.tree_for(commentable, limit = 0)
-    commentable.comments.includes(:user).arrange(order: "score DESC").to_a[0..limit - 1].to_h
+    commentable.comments
+      .includes(user: %i[setting profile])
+      .arrange(order: "score DESC")
+      .to_a[0...limit]
+      .to_h
   end
 
   def search_id

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -124,7 +124,7 @@
     <div class="comments" id="comment-trees-container">
       <% if @root_comment.present? %>
         <% cache ["comment_root-view-root_#{user_signed_in?}", @root_comment] do %>
-          <%= tree_for(@root_comment, @root_comment.subtree.includes(:user).arrange[@root_comment], @commentable) %>
+          <%= tree_for(@root_comment, @root_comment.subtree.includes(user: %i[setting profile]).arrange[@root_comment], @commentable) %>
         <% end %>
       <% else %>
         <% Comment.tree_for(@commentable).each do |comment, sub_comments| %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Profiles and user settings are loaded for on each comment author. On posts with many comments (such as [this one](https://ui.honeycomb.io/thepracticaldev/datasets/rails/result/tejvNGu5MkN/trace/duNeN3TnCTi)), this invokes a *lot* of DB queries. Each of these partials is a comment:

![Screenshot showing the several queries per comment render](https://user-images.githubusercontent.com/108205/135733365-2dfa43aa-59ae-4c09-822e-0a51cddfc0fb.png)

Every single one that isn't cached invokes 3 queries:

1. `user.settings`
2. `user.profile`
3. `ProfileField.header`

The first two are fetched from the database for every comment. This PR replaces the first 2 per comment with 2 queries for all comments.

The third is short-circuited by the ActiveRecord query cache, so while it will return a new instance of that profile field and ActiveRecord reports it as a query, it doesn't actually reach out to the database. I don't know how to avoid that allocation, tbh, but if it's not hitting the database it's probably fine for now — according to that trace it only takes 80-122µs for each one after the first (not counting GC, just the allocation, see screenshot below). The latency between the app and DB on DEV is 1.0-1.5ms, so the two queries took over 20x more time than that.

<img width="591" alt="Screenshot showing the profile field query is short-circuited after only 87 microseconds" src="https://user-images.githubusercontent.com/108205/135733598-ec479261-9684-4154-9c4b-88d1836e5fb5.png">


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: No observable behavior has changed, existing tests are sufficient
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_