### PR TITLE
Remove organization dependency and improve display ad UX

### DIFF
--- a/app/controllers/admin/display_ads_controller.rb
+++ b/app/controllers/admin/display_ads_controller.rb
@@ -6,13 +6,13 @@ module Admin
 
     def index
       @display_ads = DisplayAd.order(id: :desc)
-        .joins(:organization)
-        .includes([:organization])
         .page(params[:page]).per(50)
 
       return if params[:search].blank?
 
-      @display_ads = @display_ads.where("organizations.name ILIKE :search", search: "%#{params[:search]}%")
+      @display_ads = @display_ads.
+        where("processed_html ILIKE :search OR placement_area ILIKE :search OR organizations.name ILIKE :search",
+              search: "%#{params[:search]}%")
     end
 
     def new
@@ -28,7 +28,7 @@ module Admin
 
       if @display_ad.save
         flash[:success] = "Display Ad has been created!"
-        redirect_to admin_display_ads_path
+        redirect_to edit_admin_display_ad_path(@display_ad.id)
       else
         flash[:danger] = @display_ad.errors_as_sentence
         render :new
@@ -40,7 +40,7 @@ module Admin
 
       if @display_ad.update(display_ad_params)
         flash[:success] = "Display Ad has been updated!"
-        redirect_to admin_display_ads_path
+        redirect_to edit_admin_display_ad_path(params[:id])
       else
         flash[:danger] = @display_ad.errors_as_sentence
         render :edit

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -6,10 +6,9 @@ class DisplayAd < ApplicationRecord
                                             "Sidebar Left (Second Position)",
                                             "Sidebar Right"].freeze
 
-  belongs_to :organization
+  belongs_to :organization, optional: true
   has_many :display_ad_events, dependent: :destroy
 
-  validates :organization_id, presence: true
   validates :placement_area, presence: true,
                              inclusion: { in: ALLOWED_PLACEMENT_AREAS }
   validates :body_markdown, presence: true

--- a/app/views/admin/display_ads/_form.html.erb
+++ b/app/views/admin/display_ads/_form.html.erb
@@ -1,24 +1,45 @@
-<div class="form-group">
-  <%= label_tag :organization_id, "Organization ID:" %>
-  <%= text_field_tag :organization_id, @display_ad.organization_id, class: "form-control" %>
-</div>
+<div class="grid l:grid-cols-2">
+  <div class="p-2">
+    <div class="form-group">
+      <%= label_tag :organization_id, "Organization ID:" %>
+      <%= text_field_tag :organization_id, @display_ad.organization_id, class: "form-control" %>
+    </div>
 
-<div class="form-group">
-  <%= label_tag :body_markdown, "Body Markdown:" %>
-  <%= text_area_tag :body_markdown, @display_ad.body_markdown, size: "100x10", class: "form-control" %>
-</div>
+    <div class="form-group">
+      <%= label_tag :body_markdown, "Body Markdown:" %>
+      <%= text_area_tag :body_markdown, @display_ad.body_markdown, size: "100x10", class: "form-control" %>
+    </div>
 
-<div class="form-group">
-  <%= label_tag :placement_area, "Placement Area:" %>
-  <%= select_tag :placement_area, options_for_select(display_ads_placement_area_options_array, selected: @display_ad.placement_area), include_blank: true %>
-</div>
+    <div class="form-group">
+      <%= label_tag :placement_area, "Placement Area:" %>
+      <%= select_tag :placement_area, options_for_select(display_ads_placement_area_options_array, selected: @display_ad.placement_area), include_blank: true %>
+    </div>
 
-<div class="form-group">
-  <%= label_tag :published, "Published:" %>
-  <%= select_tag :published, options_for_select([false, true], selected: @display_ad.published) %>
-</div>
+    <div class="form-group">
+      <%= label_tag :published, "Published:" %>
+      <%= select_tag :published, options_for_select([false, true], selected: @display_ad.published) %>
+    </div>
 
-<div class="form-group">
-  <%= label_tag :approved, "Approved:" %>
-  <%= select_tag :approved, options_for_select([false, true], selected: @display_ad.approved) %>
+    <div class="form-group">
+      <%= label_tag :approved, "Approved:" %>
+      <%= select_tag :approved, options_for_select([false, true], selected: @display_ad.approved) %>
+    </div>
+  </div>
+  <div class="p-2">
+    <div class="crayons-card crayons-card--secondary p-4 crayons-sponsorship-widget">
+      <% if @display_ad.persisted? %>
+        <%= @display_ad.processed_html.html_safe %>
+      <% else %>
+        <p>
+          Display ads will show up in the designated placement area <strong>once published and approved</strong>. You can safely preview them here before publishing.
+        </p>
+        <p class="mt-3">
+          Multiple ads that share the same placement area will be swapped every few minutes. <strong>The units with the most engagement will show up the most often</strong>.
+        </p>
+        <p class="mt-3">
+          Organization ID is optional. Use it if you want to attribute an ad to a specific organization.
+        </p>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/admin/display_ads/edit.html.erb
+++ b/app/views/admin/display_ads/edit.html.erb
@@ -1,3 +1,4 @@
+<%= stylesheet_link_tag "minimal", media: "all"%>
 <h2 class="crayons-title mb-6">Edit Display Ad:</h2>
 <div class="crayons-card p-6">
   <%= form_for([:admin, @display_ad], method: :patch) do %>

--- a/app/views/admin/display_ads/index.html.erb
+++ b/app/views/admin/display_ads/index.html.erb
@@ -1,6 +1,6 @@
 <nav class="flex mb-4" aria-label="Display Ads navigation">
   <%= form_tag(admin_display_ads_path, method: "get") do %>
-    <%= text_field_tag(:search, params[:search], aria: { label: "Search" }, class: "crayons-header--search-input crayons-textfield", placeholder: "Search by Org name") %>
+    <%= text_field_tag(:search, params[:search], aria: { label: "Search" }, class: "crayons-header--search-input crayons-textfield", placeholder: "Search") %>
   <% end %>
   <div class="ml-auto">
     <div class="justify-content-end">
@@ -15,7 +15,6 @@
   <thead>
     <tr>
       <th scope="col">ID</th>
-      <th scope="col">Organization</th>
       <th scope="col">Placement Area</th>
       <th scope="col">Published</th>
       <th scope="col">Approved</th>
@@ -26,7 +25,6 @@
     <% @display_ads.each do |display_ad| %>
         <tr>
           <td><%= link_to display_ad.id, edit_admin_display_ad_path(display_ad) %></td>
-          <td><%= link_to display_ad.organization.name, admin_organization_path(display_ad.organization) %></td>
           <td><%= display_ad.human_readable_placement_area %></td>
           <td><%= display_ad.published %></td>
           <td><%= display_ad.approved %></td>

--- a/app/views/admin/display_ads/new.html.erb
+++ b/app/views/admin/display_ads/new.html.erb
@@ -2,6 +2,6 @@
 <div class="crayons-card p-6">
   <%= form_for([:admin, @display_ad], method: :post) do %>
     <%= render "form" %>
-    <%= submit_tag "Create Display Ad", class: "btn btn-primary" %>
+    <%= submit_tag "Save Display Ad", class: "btn btn-primary" %>
   <% end %>
 </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -96,7 +96,7 @@
       <% end %>
 
       <%= yield %>
-      <% if @help_url %>
+      <% if false #@help_url HELP BUTTON NOT CURRENTLY LINKING TO PROPER PAGES %>
         <a class="admin-help-button crayons-btn crayons-btn--icon-rounded crayons-btn--s" href="<%= @help_url %>" target="_blank" rel="noopener noreferer">
           <%= inline_svg_tag("circle-question.svg", aria: true, title: "Forem Admin Guide") %>
         </a>

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -8,10 +8,9 @@ RSpec.describe DisplayAd, type: :model do
     describe "builtin validations" do
       subject { display_ad }
 
-      it { is_expected.to belong_to(:organization) }
+      it { is_expected.to belong_to(:organization).optional }
       it { is_expected.to have_many(:display_ad_events).dependent(:destroy) }
 
-      it { is_expected.to validate_presence_of(:organization_id) }
       it { is_expected.to validate_presence_of(:placement_area) }
       it { is_expected.to validate_presence_of(:body_markdown) }
     end

--- a/spec/requests/admin/display_ads_spec.rb
+++ b/spec/requests/admin/display_ads_spec.rb
@@ -68,6 +68,11 @@ RSpec.describe "/admin/customization/display_ads", type: :request do
           end.to change { display_ad.reload.approved }.from(false).to(true)
         end
       end
+
+      it "redirects back to edit path" do
+        put admin_display_ad_path(display_ad.id), params: params
+        expect(response.body).to redirect_to edit_admin_display_ad_path(display_ad.id)
+      end
     end
 
     describe "DELETE /admin/display_ads/:id" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR removes the organization dependency for display ads which was confusing admins due to the fact that organization attribution was never fully implemented.

In the future we may implement further features that make use of this, or we could remove it altogether, but this should remove confusion.

In implementation I wanted to fix some other UX issues with display ads and ad clarity. So now we have more instructions, and we also have a preview of the display ad right there in the admin section.

I also changed the "search" UX to include multiple columns instead of just searching by organization name.

**Creating new ad:**

<img width="814" alt="Screen Shot 2021-10-04 at 10 08 02 AM" src="https://user-images.githubusercontent.com/3102842/135868709-93a28f72-3efe-460e-9bfc-e79206a695e3.png">

**Displaying saved ad:**

<img width="1021" alt="Screen Shot 2021-10-04 at 10 12 36 AM" src="https://user-images.githubusercontent.com/3102842/135868708-fea3e15e-f71d-4a32-bf24-d5a0a497c8c4.png">


Along the way I noticed that we still have the "help link", but it generally links to the wrong places. I'm not sure what the intentions of this are, but I commented it out for now.

## Related Tickets & Documents

https://github.com/forem/rfcs/issues/287

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
