### PR TITLE
Optimize `Article` query in `EdgeCache::BustArticle`

### DIFF
--- a/app/services/edge_cache/bust_article.rb
+++ b/app/services/edge_cache/bust_article.rb
@@ -85,7 +85,7 @@ module EdgeCache
         end
 
         TIMEFRAMES.each do |timestamp, interval|
-          next unless Article.published.where("published_at > ?", timestamp.call).tagged_with(tag)
+          next unless Article.published.where("published_at > ?", timestamp.call).cached_tagged_with_any(tag)
             .order(public_reactions_count: :desc).limit(3).ids.include?(article.id)
 
           cache_bust.call("/top/#{interval}")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This query is our number 5-6 query (depending on the time frame you look at) and has a _median_ execution time of 200ms, which is kinda wild for a query we run this frequently — especially multiple times in a single Sidekiq job. Comparing the two query scopes in a production Rails console on DEV:

```
irb(main):050:0> Benchmark.ms { Article.cached_tagged_with('ruby').published.where('published_at > ?', 1.day.ago).order(public_reactions_count: :desc).limit(3).ids.count }
=> 5.241397011559457
irb(main):051:0> Benchmark.ms { Article.cached_tagged_with('ruby').published.where('published_at > ?', 1.day.ago).order(public_reactions_count: :desc).limit(3).ids.count }
=> 5.306847975589335
irb(main):052:0> Benchmark.ms { Article.tagged_with('ruby').published.where('published_at > ?', 1.day.ago).order(public_reactions_count: :desc).limit(3).ids.count }
=> 41.070447012316436
irb(main):053:0> Benchmark.ms { Article.tagged_with('ruby').published.where('published_at > ?', 1.day.ago).order(public_reactions_count: :desc).limit(3).ids.count }
=> 40.60379695147276
```

This change speeds up the query by a factor of 8x. I don't know if we'll see this kind of speedup in production (I checked against a Rails console that is otherwise idle, but production servers are not).

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: existing tests should be sufficient, the scopes I'm using have been tested to match the slower ones provided by `acts-as-taggable-on`
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: enough people know about the `cached_tagged_with_*` scopes