### PR TITLE
Safari CSS gradient bug #14311

### DIFF
--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -51,8 +51,8 @@
       left: 0;
       top: 0;
       background: linear-gradient(
-        rgba(255, 255, 255, 0) 250px,
-        var(--story-comments-bg)
+        var(--story-comments-bg-top) 250px,
+        var(--story-comments-bg-bottom)
       );
     }
   }

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -224,7 +224,9 @@
   --tag-color-hover: var(--base-100);
 
   // Story
-  --story-comments-bg: var(--base-0);
+  --story-comments-bg: 249, 249, 249;
+  --story-comments-bg-top: rgba(var(--story-comments-bg), 0);
+  --story-comments-bg-bottom: rgba(var(--story-comments-bg), 1);
 
   // Select icon
   --select-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDE2TDYgMTBIMThMMTIgMTZaIiBmaWxsPSIjMDgwOTBBIi8+Cjwvc3ZnPg==);

--- a/app/assets/stylesheets/themes/hacker.scss
+++ b/app/assets/stylesheets/themes/hacker.scss
@@ -217,7 +217,9 @@
   --tag-color-hover: var(--base-100);
 
   // Story
-  --story-comments-bg: #0d0d0d;
+  --story-comments-bg: 13, 13, 13;
+  --story-comments-bg-top: rgba(var(--story-comments-bg), 0);
+  --story-comments-bg-bottom: rgba(var(--story-comments-bg), 1);
 
   // Select icon
   --select-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDE2TDYgMTBIMThMMTIgMTZaIiBmaWxsPSIjMkVGRjdCIi8+Cjwvc3ZnPg==);

--- a/app/assets/stylesheets/themes/minimal.scss
+++ b/app/assets/stylesheets/themes/minimal.scss
@@ -204,7 +204,9 @@
   --tag-color-hover: var(--base-100);
 
   // Story
-  --story-comments-bg: #fafafa; //hotfix
+  --story-comments-bg: 250, 250, 250;
+  --story-comments-bg-top: rgba(var(--story-comments-bg), 0);
+  --story-comments-bg-bottom: rgba(var(--story-comments-bg), 1);
 
   // Select icon
   --select-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDE2TDYgMTBIMThMMTIgMTZaIiBmaWxsPSIjN2E3YTdhIi8+Cjwvc3ZnPg==);

--- a/app/assets/stylesheets/themes/night.scss
+++ b/app/assets/stylesheets/themes/night.scss
@@ -215,7 +215,9 @@
   --tag-color-hover: var(--base-100);
 
   // Story
-  --story-comments-bg: #151e2a; //hotfix
+  --story-comments-bg: 21, 30, 42;
+  --story-comments-bg-top: rgba(var(--story-comments-bg), 0);
+  --story-comments-bg-bottom: rgba(var(--story-comments-bg), 1);
 
   // Select icon
   --select-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDE2TDYgMTBIMThMMTIgMTZaIiBmaWxsPSIjYzJjNmNhIi8+Cjwvc3ZnPg==);

--- a/app/assets/stylesheets/themes/pink.scss
+++ b/app/assets/stylesheets/themes/pink.scss
@@ -204,7 +204,9 @@
   --tag-color-hover: var(--base-100);
 
   // Story
-  --story-comments-bg: rgba(255, 255, 255, 0.05);
+  --story-comments-bg: 255, 255, 255;
+  --story-comments-bg-top: rgba(var(--story-comments-bg), 0);
+  --story-comments-bg-bottom: rgba(var(--story-comments-bg), 1);
 
   // Select icon
   --select-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEyIDE2TDYgMTBIMThMMTIgMTZaIiBmaWxsPSIjNTcxOTJkIi8+Cjwvc3ZnPg==);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Transition to a transparent version of the same background color with
no opacity so that safari transitions through correctly.

Switch all --story-comments-bg themes to hexadecimal, fixes no fade bug
in "Pink" theme.

## Related Tickets & Documents

Closes #14311 

## QA Instructions, Screenshots, Recordings

Please see the linked issue for screenshots of the issue and how it should look with this fix.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: I don't think this CSS change needs tests.
- [ ] I need help with writing tests