### PR TITLE
Delete old retained emails after certain period

### DIFF
--- a/app/models/email_message.rb
+++ b/app/models/email_message.rb
@@ -11,4 +11,23 @@ class EmailMessage < Ahoy::Message
     select(:to, :subject, :content, :utm_campaign, :feedback_message_id)
       .where(feedback_message_id: feedback_message_ids)
   end
+
+  def self.fast_destroy_old_retained_email_deliveries(destroy_before_timestamp = 3.months.ago)
+    # We remove email delivery records periodically, except some we retain long term.
+    # We generally want to retain emails directly sent by human admins.
+    # The only email currently sent manually are those that are tied directly to a feedback message.
+    sql = <<-SQL.squish
+      DELETE FROM ahoy_messages
+      WHERE ahoy_messages.id IN (
+        SELECT ahoy_messages.id
+        FROM ahoy_messages
+        WHERE created_at < ? AND feedback_message_id = null
+        LIMIT 50000
+      )
+    SQL
+
+    email_sql = EmailMessage.sanitize_sql([sql, destroy_before_timestamp])
+
+    BulkSqlDelete.delete_in_batches(email_sql)
+  end
 end

--- a/app/workers/emails/remove_old_emails_worker.rb
+++ b/app/workers/emails/remove_old_emails_worker.rb
@@ -1,0 +1,11 @@
+module Emails
+  class RemoveOldEmailsWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform
+      EmailMessage.fast_destroy_old_retained_email_deliveries
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -124,6 +124,10 @@ remove_old_notifications:
   description: "Deletes old notifications from the database (runs daily at 05:00 UTC)"
   cron: "0 5 * * *"
   class: "Notifications::RemoveOldNotificationsWorker"
+remove_old_emails:
+  description: "Deletes old emails we don't need to retain from the database (runs daily at 06:00 UTC)"
+  cron: "0 6 * * *"
+  class: "Emails::RemoveOldEmailsWorker"
 sync_credits_counter_cache:
   description: "Sychronizes counter caches for credits (runs daily at 16:00 UTC)"
   cron: "0 16 * * *"

--- a/spec/models/email_message_spec.rb
+++ b/spec/models/email_message_spec.rb
@@ -6,4 +6,12 @@ RSpec.describe EmailMessage, type: :model do
 
     it { is_expected.to belong_to(:feedback_message).optional }
   end
+
+  describe "#fast_destroy_old_notifications" do
+    it "bulk deletes emails older than given timestamp" do
+      allow(BulkSqlDelete).to receive(:delete_in_batches)
+      described_class.fast_destroy_old_retained_email_deliveries("a_time")
+      expect(BulkSqlDelete).to have_received(:delete_in_batches).with(a_string_including("< 'a_time'"))
+    end
+  end
 end

--- a/spec/workers/emails/remove_old_emails_worker_spec.rb
+++ b/spec/workers/emails/remove_old_emails_worker_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Emails::RemoveOldEmailsWorker, type: :woker do
+  include_examples "#enqueues_on_correct_queue", "low_priority"
+
+  describe "#perform" do
+    let(:worker) { subject }
+
+    it "fast destroys notifications" do
+      allow(EmailMessage).to receive(:fast_destroy_old_retained_email_deliveries)
+      worker.perform
+      expect(EmailMessage).to have_received(:fast_destroy_old_retained_email_deliveries)
+    end
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This is a draft PR proof of concept. We have discussed the technical need to not retain old emails (they are large records).

But we do want to retain emails that admins directly send as humans, and the specific request is the replies to feedback messages (aka reports).

I think this approach would accomplish all of this in the same pattern we use to delete old notifications, which would also pile up in the same way if not trimmed.

This would be a big win for our overall scalability.

I have left this as a draft as a proposed approach. May need more eyes to assure it is what we want to do.

## Related Tickets & Documents

https://github.com/forem/rfcs/issues/180

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

TBD