### PR TITLE
Consolidate and internationalize various 'contact us' prompts

### DIFF
--- a/app/views/devise/shared/_authorization_error.html.erb
+++ b/app/views/devise/shared/_authorization_error.html.erb
@@ -20,6 +20,6 @@
     <% end %>
     If you haven't received your confirmation email yet, <a href="<%= confirm_email_path %>">click here</a> to resend it.
     <br>
-    Contact <%= email_link %> if you continue having trouble.
+    <%= t("contact_prompts.if_continued_trouble_html") %>
   </div>
 <% end %>

--- a/app/views/feedback_messages/index.html.erb
+++ b/app/views/feedback_messages/index.html.erb
@@ -9,7 +9,7 @@
     <h2>Thank you for your report.</h2>
     <h3><a href="/">Return to home page</a></h3>
     <p>
-      Questions? Send an email to <%= email_link %>
+      <%= t("contact_prompts.if_any_questions_html") %>
     </p>
   </div>
 </div>

--- a/app/views/mailers/notify_mailer/account_deleted_email.html.erb
+++ b/app/views/mailers/notify_mailer/account_deleted_email.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Contact us at <%= email_link %> if there is anything more we can help with. 😊
+  <%= t("contact_prompts.if_we_can_help_html") %> 😊
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/account_deletion_requested_email.html.erb
+++ b/app/views/mailers/notify_mailer/account_deletion_requested_email.html.erb
@@ -8,7 +8,7 @@
 </p>
 
 <p>
-  Contact us at <%= email_link %> if there is anything more we can help with. 😊
+  <%= t("contact_prompts.if_we_can_help_html") %> 😊
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/account_deletion_requested_email.text.erb
+++ b/app/views/mailers/notify_mailer/account_deletion_requested_email.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @name %>,
 Your account deletion was requested. Please, visit this page: <%= user_confirm_destroy_url(@token) %> to destroy your account. The link will expire in 12 hours.
-Contact us at <%= email_link %> if there is anything more we can help with.
+<%= t("contact_prompts.if_we_can_help_html") %>
 
 Thanks,
 The <%= community_name %> Team

--- a/app/views/mailers/notify_mailer/organization_deleted_email.html.erb
+++ b/app/views/mailers/notify_mailer/organization_deleted_email.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Contact us at <%= email_link %> if there is anything more we can help with. 😊
+  <%= t("contact_prompts.if_we_can_help_html") %> 😊
 </p>
 
 <p>

--- a/app/views/mailers/notify_mailer/organization_deleted_email.text.erb
+++ b/app/views/mailers/notify_mailer/organization_deleted_email.text.erb
@@ -2,7 +2,7 @@ Hi <%= @name %>.
 
 Your organization <%= @org_name %> on <%= community_name %> has been successfully deleted.
 
-Contact us at <%= email_link %> if there is anything more we can help with.
+<%= t("contact_prompts.if_we_can_help_html") %>
 
 Thanks,
 The <%= community_name %> Team

--- a/app/views/notifications/_notifications_list.html.erb
+++ b/app/views/notifications/_notifications_list.html.erb
@@ -10,7 +10,7 @@
 
   <div class="align-center p-9 py-10 color-base-80 crayons-card mb-2">
     <h2 class="fw-bold fs-l">An error occurred!</h2>
-    <p class="color-base-60 pt-2">This has been logged and we're tracking it. If you see too many of these, please report it to <%= email_link %>!</p>
+    <p class="color-base-60 pt-2">This has been logged and we're tracking it.</p>
   </div>
 <% end %>
 

--- a/app/views/notifications/_tagadjustment.html.erb
+++ b/app/views/notifications/_tagadjustment.html.erb
@@ -24,8 +24,7 @@
         <p class="mb-2">Check out <a href="/tags">other popular tags</a> which may be more appropriate</p>
       <% end %>
       <p>
-        Thanks for being part of <%= community_name %>! If you feel like this mod action was a mistake, feel free to contact
-        <%= email_link %>. 🤗
+        Thanks for being part of <%= community_name %>! <%= t("contact_prompts.if_any_questions_html") %> 🤗
       </p>
   </div>
 </div>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -130,6 +130,8 @@
   </div>
 
   <div>
-    <p>Feel free to contact <%= email_link %> with any questions.</p>
+    <p>
+      <%= t("contact_prompts.if_any_questions_html") %>
+    </p>
   </div>
 </div>

--- a/app/views/users/_publishing_from_rss.html.erb
+++ b/app/views/users/_publishing_from_rss.html.erb
@@ -23,8 +23,8 @@
       <a href="<%= publishing_from_rss_guide_path %>">guide</a>.
     </p>
     <p>
-      Your feed will be fetched every time you submit this form and updates will be automatically fetched periodically thereafter. Contact
-      <%= email_link %> if you encounter issues.
+      Your feed will be fetched every time you submit this form and updates will be automatically fetched periodically thereafter.
+      <%= t("contact_prompts.if_any_questions_html") %>
     </p>
     <p>FYI: Medium RSS feed URLs are <em>https://medium.com/feed/@your_username</em></p>
     <p><em>By submitting your RSS Feed URL, you agree that you own and/or have permission to syndicate the associated content.</em></p>

--- a/app/views/users/confirm_destroy.html.erb
+++ b/app/views/users/confirm_destroy.html.erb
@@ -50,7 +50,7 @@
       </p>
 
       <p>
-        Feel free to contact <%= email_link %> with any questions.
+        <%= t("contact_prompts.if_any_questions_html") %>
       </p>
     </div>
   </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -15,8 +15,8 @@
 
   <% if params[:state] == "previous-registration" %>
     <div class="crayons-banner crayons-banner--error" role="alert">
-      There is an existing account authorized with that social account. Contact
-      <%= email_link %> if this is a mistake.
+      There is an existing account authorized with that social account.
+      <%= t("contact_prompts.if_any_questions_html") %>
     </div>
   <% end %>
 

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -33,7 +33,7 @@
   <% end %>
   <div style="margin:50px auto;max-width:80%;font-size:0.86em;">
     <p>
-      <strong>Video is beta:</strong> Email <%= email_link %> if you have any problems.
+      <strong>Video is beta:</strong> <%= t("contact_prompts.if_any_questions_html") %>
     </p>
   </div>
 </center>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,10 @@ en:
     view: View
     week: Week
     year: Year
+  contact_prompts:
+    if_continued_trouble_html: <a href="/contact">Contact us</a> if you continue having trouble.
+    if_we_can_help_html: <a href="/contact">Contact us</a> if there is anything we can help with.
+    if_any_questions_html: <a href="/contact">Contact us</a> if you have any questions.
   dashboard:
     following_users: Following users
     loading: loading...

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -34,6 +34,10 @@ fr:
     view: Vue
     week: Semaine
     year: Année
+  contact_prompts:
+    if_continued_trouble_html: <a href="/contact">Contactez-nous</a> si vous continuez à avoir des problèmes.
+    if_we_can_help_html: <a href="/contact">Contactez-nous</a> si nous pouvons vous aider.
+    if_any_questions_html: <a href="/contact">Contactez-nous</a> si vous avez des questions.
   dashboard:
     following_users: Utilisateurs suivis
     loading: Chargement en cours...

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -88,6 +88,11 @@ RSpec.describe "UserSettings", type: :request do
         expect(response.body).to include(*titles)
       end
 
+      it "includes contact us on RSS page properly" do
+        get user_settings_path(:extensions)
+        expect(response.body).to include('<a href="/contact">')
+      end
+
       it "renders heads up dupe account message with proper param" do
         get "/settings?state=previous-registration"
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We currently have a logical inconsistency with how we use the "email link" on the site. We certainly do not want people contacting "noreply" as it is in a few places...

<img width="516" alt="Screen Shot 2021-10-05 at 10 40 28 AM" src="https://user-images.githubusercontent.com/3102842/136045458-802f6889-ebc7-4eed-aa59-1d001ebc5f01.png">

This does not entirely fix our issues of logical inconsistencies, but does generally replace this type of prompt with a link to `/contact` which admins can configure to whatever they want (and generally do seem to configure properly). This should simplify the source of truth for admins on how they want to be contacted... All roads lead to the contact page and they can make their decisions from there.

By way of killing two birds with one stone, I consolidated several different prompts with slight variation into a library of three we can reach from. We could expand this over time, but I think consistency here is good. We may occasionally lose some charm in a super specific way of asking for contact, but generally I think we need to make that trade off for a highly usable consistent experience.

Here is this HTML in full display on the RSS fetch page:

<img width="712" alt="Screen Shot 2021-10-05 at 10 44 59 AM" src="https://user-images.githubusercontent.com/3102842/136046016-20543f0f-18cd-452e-85a5-db1b004daabb.png">

## Related Tickets & Documents

https://github.com/forem/forem/issues/14888

## QA Instructions, Screenshots, Recordings

Double check that it shows up as expected.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

This should not change functionality in any major way.