### PR TITLE
fix: accessibility issue with feeds comment section

### DIFF
--- a/app/javascript/articles/Article.jsx
+++ b/app/javascript/articles/Article.jsx
@@ -120,6 +120,7 @@ export const Article = ({
                   <CommentsCount
                     count={article.comments_count}
                     articlePath={article.path}
+                    articleTitle={article.title}
                   />
                 </div>
               )}

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -201,6 +201,7 @@ Object {
                   class="crayons-story__details"
                 >
                   <a
+                    aria-label="Comments for article Unbranded Home Loan Account. 0 comment(s) so far"
                     class="crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon-left"
                     data-testid="add-a-comment"
                     href="/some-post/path#comments"
@@ -449,6 +450,7 @@ Object {
                 class="crayons-story__details"
               >
                 <a
+                  aria-label="Comments for article Unbranded Home Loan Account. 0 comment(s) so far"
                   class="crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon-left"
                   data-testid="add-a-comment"
                   href="/some-post/path#comments"

--- a/app/javascript/articles/components/CommentsCount.jsx
+++ b/app/javascript/articles/components/CommentsCount.jsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types';
 import { Button } from '../../crayons/Button';
 import { locale } from '../../utilities/locale';
 
-
-export const CommentsCount = ({ count, articlePath }) => {
+export const CommentsCount = ({ count, articlePath, articleTitle }) => {
   const commentsSVG = () => (
     <svg
       className="crayons-icon"
@@ -15,6 +14,7 @@ export const CommentsCount = ({ count, articlePath }) => {
       <path d="M10.5 5h3a6 6 0 110 12v2.625c-3.75-1.5-9-3.75-9-8.625a6 6 0 016-6zM12 15.5h1.5a4.501 4.501 0 001.722-8.657A4.5 4.5 0 0013.5 6.5h-3A4.5 4.5 0 006 11c0 2.707 1.846 4.475 6 6.36V15.5z" />
     </svg>
   );
+  const commentsAriaLabelText = `Comments for article ${articleTitle}. ${count} comment(s) so far`;
 
   if (count > 0) {
     return (
@@ -25,12 +25,15 @@ export const CommentsCount = ({ count, articlePath }) => {
         url={`${articlePath}#comments`}
         icon={commentsSVG}
         tagName="a"
+        aria-label={commentsAriaLabelText}
       >
         <span title="Number of comments">
           {count}
           <span className="hidden s:inline">
             &nbsp;
-            {`${count > 1 ? `${locale('core.comment')}s` : locale('core.comment') }`}
+            {`${
+              count > 1 ? `${locale('core.comment')}s` : locale('core.comment')
+            }`}
           </span>
         </span>
       </Button>
@@ -46,6 +49,7 @@ export const CommentsCount = ({ count, articlePath }) => {
         icon={commentsSVG}
         tagName="a"
         data-testid="add-a-comment"
+        aria-label={commentsAriaLabelText}
       >
         <span className="inline s:hidden">0</span>
         <span className="hidden s:inline">{locale('core.add_comment')}</span>
@@ -63,6 +67,7 @@ CommentsCount.defaultProps = {
 CommentsCount.propTypes = {
   count: PropTypes.number,
   articlePath: PropTypes.string.isRequired,
+  articleTitle: PropTypes.string.isRequired,
 };
 
 CommentsCount.displayName = 'CommentsCount';


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Improved the accessibility of the feeds comment section by adding a more meaningful name to the comment button element.

**Comments section name before the fix :** 

On mobile the accessible name for this link is either:

Completely blank (if no comments exist)
Just the number (e.g. a link with name '1')
On desktop the accessible names are:

Add comment (if no comments exist)
"1 comment" / "X comments" (if comments do exist)

**Comments section name after the fix :**

Both on mobile and the desktop:

for both cases (if no comments exist)(if no comments exist) below will be the name for the comments section on a feed:
`Comments for article ${articleTitle}. ${count} comment(s) so far`


## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

With this fix accessibility of the site has been improved in the comments section on a feed. now the name of the comment section is more meaningful and conveys a unique message based on the article title and number of comments on the article so far. attached are the screenshots below for mobile and desktop versions:

**For Mobile:**
<img width="1440" alt="Screenshot 2021-10-05 at 10 58 47 PM" src="https://user-images.githubusercontent.com/9020200/136073274-6eedbe7e-f580-4996-95b9-cdb0c27a95b8.png">
<img width="1440" alt="Screenshot 2021-10-05 at 10 58 53 PM" src="https://user-images.githubusercontent.com/9020200/136073291-aeb48078-884b-4258-8cb8-8807417af57a.png">


**For Desktop:**
<img width="1440" alt="Screenshot 2021-10-05 at 10 58 31 PM" src="https://user-images.githubusercontent.com/9020200/136073321-de938d22-8163-45ce-b56b-138680e50b99.png">
<img width="1440" alt="Screenshot 2021-10-05 at 10 58 39 PM" src="https://user-images.githubusercontent.com/9020200/136073331-6471cb72-c976-4161-bffa-591932f8c735.png">

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/6xE1FNcorRInS/giphy.gif)
