### PR TITLE
Auto register Forems on Discover

### DIFF
--- a/app/controllers/api/v0/instances_controller.rb
+++ b/app/controllers/api/v0/instances_controller.rb
@@ -9,6 +9,7 @@ module Api
           cover_image_url: Settings::General.main_social_image,
           description: Settings::Community.community_description,
           display_in_directory: Settings::UserExperience.display_in_directory,
+          domain: Settings::General.app_domain,
           logo_image_url: Settings::General.logo_png,
           name: Settings::Community.community_name,
           registered_users_count: User.registered.estimated_count,

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -46,6 +46,7 @@ class RegistrationsController < Devise::RegistrationsController
     resource.skip_confirmation!
     Settings::General.waiting_on_first_user = false
     Users::CreateMascotAccount.call
+    Discover::RegisterWorker.perform_async # Register Forem instance on https://discover.forem.com
   end
 
   def recaptcha_verified?

--- a/spec/requests/api/v0/instances_spec.rb
+++ b/spec/requests/api/v0/instances_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe "Api::V0::Instances", type: :request do
       expect(response.parsed_body["cover_image_url"]).to eq Settings::General.main_social_image
       expect(response.parsed_body["description"]).to eq Settings::Community.community_description
       expect(response.parsed_body["display_in_directory"]).to eq Settings::UserExperience.display_in_directory
+      expect(response.parsed_body["domain"]).to eq Settings::General.app_domain
       expect(response.parsed_body["logo_image_url"]).to eq Settings::General.logo_png
       expect(response.parsed_body["name"]).to eq Settings::Community.community_name
       expect(response.parsed_body["registered_users_count"]).to eq User.registered.estimated_count

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -407,6 +407,18 @@ RSpec.describe "Registrations", type: :request do
           expect(User.first).to be nil
         end.to raise_error Pundit::NotAuthorizedError
       end
+
+      it "enqueues Discover::RegisterWorker" do
+        sidekiq_assert_enqueued_with(job: Discover::RegisterWorker) do
+          post "/users", params:
+            { user: { name: "test #{rand(10)}",
+                      username: "haha_#{rand(10)}",
+                      email: "yoooo#{rand(100)}@yo.co",
+                      password: "PaSSw0rd_yo000",
+                      forem_owner_secret: "test",
+                      password_confirmation: "PaSSw0rd_yo000" } }
+        end
+      end
     end
 
     context "with the creator_onboarding feature flag" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Following up on the conversation from https://github.com/forem/forem/pull/14865#discussion_r719663741, this PR adds logic for a Forem to register itself on Forem Discover.

This original implementation was removed in the previous PR, this one brings it back. The primary concern was that by registering the Forem right after the creation of the first user, the value of the Forem's domain would be something like `forem-3232dsdsd.forem.cloud` instead of the actual domain. In other words, we may be registering "too early" in the onboarding process.

As it turns out, the flip of the `app_domain` is done manually and internally by the systems team so we don't have a great, programmatic way to know when it's "okay" to register on Discover. I've explored callbacks in the past on Rails settings, and there's not a clean solution there AFAIK.

Instead, the original `forem-3232dsdsd.forem.cloud` URL will work even after the `app_domain` is updated. So we can still have the Forem register on Discover under that domain. Then, we added the `domain` value to the `instance` API so that when Discover pings the Forem later on, it'll update the `domain` value according 🎉 .

This approach will also help us stay up-to-date if/when a Forem changes their domain in the future.

## Related Tickets & Documents

https://github.com/forem/forem/pull/14865#discussion_r719663741

## QA Instructions, Screenshots, Recordings

N/A

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

No

## [optional] What gif best describes this PR or how it makes you feel?

![register_now_gif](https://media.giphy.com/media/Ltz1ZA728qKw4mEY94/giphy.gif)
