### PR TITLE
Change preview card hover delay

### DIFF
--- a/app/assets/stylesheets/profile-preview-card.scss
+++ b/app/assets/stylesheets/profile-preview-card.scss
@@ -1,7 +1,10 @@
+$dropdownhoverdelay: 590ms;
+$dropdowntransition: 300ms;
+
 .profile-preview-card {
   &__content.crayons-dropdown {
     transition: border, border-top;
-    transition-duration: 300ms;
+    transition-duration: $dropdowntransition;
     color: var(--base-100);
     padding-top: 0;
     top: 100%;
@@ -12,7 +15,7 @@
 
   &__content.crayons-dropdown:hover {
     display: block;
-    animation: hoverAppear 1s;
+    animation: hoverAppear $dropdownhoverdelay;
 
     &.showing {
       animation: none;
@@ -21,7 +24,7 @@
 
   &__trigger:hover + .profile-preview-card__content.crayons-dropdown {
     display: block;
-    animation: hoverAppear 1s;
+    animation: hoverAppear $dropdownhoverdelay;
 
     &.showing {
       animation: none;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After some use of `1s` I think this is _too long_ of a wait to show the card. We had previously deemed `500ms` as possibly too short, but I think we went a little too far.

There is no way to prove who is right, and maybe we could do this in a more sophisticated way in the future, but for now I _feel_ that this proposed duration is better than `1s`.

I did move a couple time values in this file into scss variables in case we want to continue changing this up. Just seemed a little cleaner way to store this kind of thing in the file.

![bugs vs daffy](https://media1.giphy.com/media/YaXcVXGvBQlEI/200w.webp?cid=ecf05e470x3py8qnanxlw8fa65mpy4xdb4lzk3rlfw296xap&rid=200w.webp&ct=g)