### PR TITLE
Remove tag categories from admin UI and remove aliased tags from /tags page

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -5,7 +5,7 @@ module Admin
     ALLOWED_PARAMS = %i[
       id supported rules_markdown short_summary pretty_name bg_color_hex
       text_color_hex user_id alias_for badge_id requires_approval
-      category social_preview_template wiki_body_markdown submission_template
+      social_preview_template wiki_body_markdown submission_template
       name
     ].freeze
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -17,7 +17,7 @@ class TagsController < ApplicationController
   def index
     skip_authorization
     @tags_index = true
-    @tags = Tag.includes(:sponsorship).order(hotness_score: :desc).limit(100)
+    @tags = Tag.where(alias_for: nil).includes(:sponsorship).order(hotness_score: :desc).limit(100)
   end
 
   def edit

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -17,10 +17,6 @@
     <%= f.select(:badge_id, options_for_select(badges_for_options, tag.badge_id), { include_blank: true }, { class: "crayons-select" }) %>
   </div>
   <div class="crayons-field mt-3">
-    <%= f.label :category, class: "crayons-field__label" %>
-    <%= f.select(:category, options_for_select(Tag.valid_categories, tag.category), {}, { class: "crayons-select" }) %>
-  </div>
-  <div class="crayons-field mt-3">
     <%= f.label :social_preview_template, class: "crayons-field__label" %>
     <%= f.select(:social_preview_template, Tag.social_preview_templates, {}, { class: "crayons-select" }) %>
   </div>

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -28,9 +28,9 @@
     <%= f.label :pretty_name, class: "crayons-field__label" %>
     <%= f.text_field :pretty_name, value: tag.pretty_name, class: "crayons-textfield" %>
   </div>
-  <div class="crayons-field mt-3">
+  <div class="crayons-field crayons-field--checkbox mt-3">
+    <%= f.check_box :requires_approval, class: "crayons-checkbox" %>
     <%= f.label :requires_approval, class: "crayons-field__label" %>
-    <%= f.check_box :requires_approval %>
   </div>
   <div class="crayons-field mt-3">
     <%= f.label :short_summary, class: "crayons-field__label" %>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,13 +1,13 @@
 <div class="flex items-center mb-6">
   <div class="crayons-tabs">
     <div class="nav-item">
-      <%= link_to "All", admin_tags_path("q[supported_not_null]": "true"), class: "crayons-tabs__item #{'crayons-tabs__item--current' if params.dig(:q, :supported_not_null)}", "aria-label": "All Tags", data: {text: "All"} %>
+      <%= link_to "All", admin_tags_path("q[supported_not_null]": "true"), class: "crayons-tabs__item #{'crayons-tabs__item--current' if params.dig(:q, :supported_not_null)}", "aria-label": "All Tags", data: { text: "All" } %>
     </div>
     <div class="nav-item">
-      <%= link_to "Supported", admin_tags_path("q[supported_eq": "true"), class: "crayons-tabs__item #{'crayons-tabs__item--current' if params.dig(:q, :supported_eq) == 'true'}", "aria-label": "Supported Tags", data: {text: "Supported"} %>
+      <%= link_to "Supported", admin_tags_path("q[supported_eq": "true"), class: "crayons-tabs__item #{'crayons-tabs__item--current' if params.dig(:q, :supported_eq) == 'true'}", "aria-label": "Supported Tags", data: { text: "Supported" } %>
     </div>
     <div class="nav-item">
-      <%= link_to "Unsupported", admin_tags_path("q[supported_eq": "false"), class: "crayons-tabs__item #{'crayons-tabs__item--current' if params.dig(:q, :supported_eq) == 'false'}", "aria-label": "Unsupported Tags", data: {text: "Unsupported"} %>
+      <%= link_to "Unsupported", admin_tags_path("q[supported_eq": "false"), class: "crayons-tabs__item #{'crayons-tabs__item--current' if params.dig(:q, :supported_eq) == 'false'}", "aria-label": "Unsupported Tags", data: { text: "Unsupported" } %>
     </div>
   </div>
 
@@ -37,7 +37,6 @@
       <th scope="col"><%= sort_link(@q, :id, {}, { aria: { label: "Sort by ID" } }) %></th>
       <th scope="col"><%= sort_link(@q, :alias_for, {}, { aria: { label: "Sort by Alias For" } }) %></th>
       <th scope="col"><%= sort_link(@q, :taggings_count, {}, { aria: { label: "Sort by Taggings Count" } }) %></th>
-      <th scope="col"><%= sort_link(@q, :category, {}, { aria: { label: "Sort by Category" } }) %></th>
       <th scope="col">Is Moderated?</th>
     </tr>
   </thead>
@@ -48,7 +47,6 @@
         <td><%= tag.id %></td>
         <td><%= tag.alias_for %></td>
         <td><%= tag.taggings_count %></td>
-        <td><%= tag.category %></td>
         <td><%= tag.tag_moderator_ids.any? %></td>
       </tr>
     <% end %>

--- a/spec/requests/admin/tags_spec.rb
+++ b/spec/requests/admin/tags_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "/admin/content_manager/tags", type: :request do
       short_summary: "Everything WWW related ", rules_markdown: "## NO SPAM",
       submission_template: "# <TITLE>\n\n<ARTICLE_BODY>",
       pretty_name: "dubdubdub", bg_color_hex: "#333333",
-      text_color_hex: "#ffffff", badge_id: badge.id, category: "site_mechanic",
+      text_color_hex: "#ffffff", badge_id: badge.id,
       social_preview_template: "article"
     }
   end

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe "Tags", type: :request, proper_status: true do
       get tags_path
       expect(response.body).to include("Top tags")
     end
+
+    it "does not include tags with alias" do
+      create(:tag, name: "ruby")
+      create(:tag, name: "aliastag", alias_for: "ruby")
+
+      get tags_path
+      expect(response.body).not_to include("aliastag")
+    end
   end
 
   describe "GET /tags/suggest" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This PR does two things:
1. Removes the tag category field from the admin tags pages
2. Remove aliased tags from the /tags index page

Note that it doesn't remove tag category feature, in case we want to use it in the future. We _could_ remove it entirely (DEV only has 5 tags that have a category), but some internal team discussion showed that we might want to keep it.

## Related Tickets & Documents
https://github.com/forem/forem/issues/14914
https://github.com/forem/rfcs/issues/294

## QA Instructions, Screenshots, Recordings
1. Visit localhost:3000/admin/content_manager/tags
2. See that the categories sort column is gone
3. Click on any tag there
4. See that the categories dropdown is gone

### UI accessibility concerns?
Nope

## Added tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![The Tootsie Roll owl licks a Tootsie Roll lollipop.](https://media.giphy.com/media/YSk7b2efrNwhbDKSep/source.mov)