### PR TITLE
Add a notification on password reset

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -10,6 +10,7 @@ class PasswordsController < Devise::PasswordsController
   protected
 
   def after_sending_reset_password_instructions_path_for(_resource_name)
+    flash[:global_notice] = "Your password reset instructions have been sent."
     session[:referrer]
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Changes made:

1. Adds a notice on clicking the "Send me password reset instructions" button

## Related Tickets & Documents

Resolves #10130 

## QA Instructions, Screenshots, Recordings

1. Visit /users/password/new
2. Enter email ID and click submit
3. A notice should appear on the /enter page that the app is redirected to

### UI accessibility concerns?

No

## Added/updated tests?

- [ x] No, and this is why: Existing tests should suffice since only one line has been added

## [optional] What gif best describes this PR or how it makes you feel?

![First time!](https://media2.giphy.com/media/26DN0TFE3TXYJq70A/giphy.gif)
