### PR TITLE
Fix notifications not deleting because mentions already destroyed

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -122,11 +122,7 @@ class Notification < ApplicationRecord
     def remove_all(notifiable_ids:, notifiable_type:)
       return unless %w[Article Comment Mention].include?(notifiable_type) && notifiable_ids.present?
 
-      if Rails.env.production?
-        Notifications::RemoveAllWorker.perform_async(notifiable_ids, notifiable_type)
-      else
-        Notifications::RemoveAllWorker.new.perform(notifiable_ids, notifiable_type)
-      end
+      Notifications::RemoveAllWorker.perform_async(notifiable_ids, notifiable_type)
     end
 
     def remove_all_without_delay(notifiable_ids:, notifiable_type:)

--- a/spec/services/mentions/create_all_spec.rb
+++ b/spec/services/mentions/create_all_spec.rb
@@ -47,6 +47,7 @@ RSpec.shared_examples "valid notifiable and has mentions" do
     expect do
       set_markdown_and_save(notifiable, "Hello, you are cool.")
       described_class.call(notifiable)
+      Sidekiq::Worker.drain_all
     end
       .to change { Mention.all.size }.by(-1)
       .and change { Notification.all.size }.by(-1)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- Fix: This feature was already implemented (Remove notifications when mentions are deleted)
  - Small change to make removing of notifications testable
  - Use `notifiable_type` and `notifiable_ids` instead of trying to fetch collection that has already been destroyed

## Related Tickets & Documents
Closes #13735

## QA Instructions, Screenshots, Recordings

- Comment on an article, mentioning a user
- Observe notification in mentioned user's notifications
- Edit comment, removing mention
- Observe notification removed in user's notifications

### UI accessibility concerns?

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

