### PR TITLE
Coloring tags

### DIFF
--- a/app/assets/javascripts/initializers/initScrolling.js
+++ b/app/assets/javascripts/initializers/initScrolling.js
@@ -111,7 +111,7 @@ function buildTagsHTML(tag) {
   return `<div class="crayons-card p-4 m:p-6 flex flex-col single-article" id="follows-${tag.id}" style="border: 1px solid ${tag.color}; box-shadow: 3px 3px 0 ${tag.color}">
     <h3 class="s:mb-1 p-0 fw-medium">
       <a href="/t/${tag.name}" class="crayons-tag crayons-tag--l">
-        <span class="crayons-tag__prefix">#</span>${tag.name}
+        ${tag.name}
       </a>
       ${antifollow}
     </h3>

--- a/app/assets/javascripts/initializers/initScrolling.js
+++ b/app/assets/javascripts/initializers/initScrolling.js
@@ -110,7 +110,7 @@ function buildTagsHTML(tag) {
 
   return `<div class="crayons-card p-4 m:p-6 flex flex-col single-article" id="follows-${tag.id}" style="border: 1px solid ${tag.color}; box-shadow: 3px 3px 0 ${tag.color}">
     <h3 class="s:mb-1 p-0 fw-medium">
-      <a href="/t/${tag.name}" class="crayons-tag crayons-tag--l">
+      <a href="/t/${tag.name}" class="crayons-tag">
         ${tag.name}
       </a>
       ${antifollow}

--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -35,7 +35,7 @@ function buildArticleHTML(article) {
       flareTag =
         "<a href='/t/" +
         article.flare_tag.name +
-        "' class='crayons-tag' style='background:" +
+        "' class='crayons-tag crayons-tag--flare' style='background:" +
         article.flare_tag.bg_color_hex +
         ';color:' +
         article.flare_tag.text_color_hex +

--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -39,7 +39,7 @@ function buildArticleHTML(article) {
         article.flare_tag.bg_color_hex +
         ';color:' +
         article.flare_tag.text_color_hex +
-        "'><span className='crayons-tag__prefix'>#</span>" +
+        "'>" +
         article.flare_tag.name +
         '</a>';
     }
@@ -68,7 +68,7 @@ function buildArticleHTML(article) {
           tagString +
           '<a href="/t/' +
           t +
-          '" class="crayons-tag"><span class="crayons-tag__prefix">#</span>' +
+          '" class="crayons-tag">' +
           t +
           '</a>\n';
       });

--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -139,6 +139,8 @@
   &__tags {
     margin-bottom: var(--su-2);
     margin-left: calc(var(--su-1) * -1);
+    font-size: var(--fs-s);
+    color: var(--base-80);
   }
 
   &__title {
@@ -147,10 +149,9 @@
     font-size: var(--title-font-size);
     overflow-wrap: anywhere;
     word-break: break-word;
-    margin-bottom: var(--su-1);
 
     @media (min-width: $breakpoint-m) {
-      margin-bottom: var(--su-2);
+      margin-bottom: var(--su-1);
     }
 
     a {

--- a/app/assets/stylesheets/components/tags.scss
+++ b/app/assets/stylesheets/components/tags.scss
@@ -16,6 +16,10 @@
     color: var(--tag-color);
   }
 
+  &--flare::before {
+    color: revert;
+  }
+
   &--filled {
     background: var(--tag-color-faded);
   }

--- a/app/assets/stylesheets/components/tags.scss
+++ b/app/assets/stylesheets/components/tags.scss
@@ -1,32 +1,32 @@
 @import '../config/import';
 
 .crayons-tag {
-  font-size: var(--fs-s);
-  color: var(--tag-color);
-  line-height: 1.3;
+  --tag-color: var(--base-a60);
+  --tag-color-faded: var(--base-a5);
+
   border-radius: var(--radius);
-  padding: var(--su-1);
-  display: inline-block;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  background: transparent;
+  transition: all var(--transition-props);
 
-  &__prefix {
-    opacity: 0.4;
-    font-weight: normal;
+  &::before {
+    content: '#';
+    color: var(--tag-color);
   }
 
-  &[href]:hover {
-    color: var(--tag-color-hover);
+  &--filled {
+    background: var(--tag-color-faded);
   }
 
-  &--l {
-    font-size: var(--fs-l);
-  }
+  &[href] {
+    padding: clamp(var(--su-1), 0.25em, 0.5em) 0.5em;
 
-  &--xl {
-    font-size: var(--fs-xl);
-  }
-
-  &--2xl {
-    font-size: var(--fs-2xl);
-    padding: var(--su-1) var(--su-2);
+    &:hover,
+    &:focus {
+      background: var(--tag-color-faded);
+      color: var(--base-100);
+    }
   }
 }

--- a/app/assets/stylesheets/views/listings.scss
+++ b/app/assets/stylesheets/views/listings.scss
@@ -31,6 +31,7 @@
 
   &__tags {
     min-height: var(--su-4);
+    font-size: var(--fs-s);
   }
 
   &__date {

--- a/app/javascript/actionsPanel/actionsPanel.js
+++ b/app/javascript/actionsPanel/actionsPanel.js
@@ -194,10 +194,10 @@ function renderTagOnArticle(tagName, colors) {
     getArticleContainer().getElementsByClassName('spec__tags')[0];
 
   const newTag = document.createElement('a');
-  newTag.innerText = `#${tagName}`;
-  newTag.setAttribute('class', 'crayons-tag mr-1');
+  newTag.innerText = `${tagName}`;
+  newTag.setAttribute('class', 'crayons-tag');
   newTag.setAttribute('href', `/t/${tagName}`);
-  newTag.style = `background-color: ${colors.bg}; color: ${colors.text};`;
+  newTag.style = `--tag-color: ${colors.text};`;
 
   articleTagsContainer.appendChild(newTag);
 }

--- a/app/javascript/article-form/components/Preview.jsx
+++ b/app/javascript/article-form/components/Preview.jsx
@@ -14,14 +14,7 @@ function titleArea({
   let tags = '';
   if (tagArray.length > 0 && tagArray[0].length > 0) {
     tags = tagArray.map((tag) => {
-      return (
-        tag.length > 0 && (
-          <span className="crayons-tag">
-            <span className="crayons-tag__prefix">#</span>
-            {tag}
-          </span>
-        )
-      );
+      return tag.length > 0 && <span className="crayons-tag mr-2">{tag}</span>;
     });
   }
 

--- a/app/javascript/articles/Article.jsx
+++ b/app/javascript/articles/Article.jsx
@@ -106,7 +106,7 @@ export const Article = ({
 
           <div className="crayons-story__indention">
             <ContentTitle article={article} />
-            <TagList tags={article.tag_list} />
+            <TagList tags={article.tag_list} flare_tag={article.flare_tag} />
 
             {article.class_name === 'Article' && (
               // eslint-disable-next-line no-underscore-dangle

--- a/app/javascript/articles/Article.jsx
+++ b/app/javascript/articles/Article.jsx
@@ -106,7 +106,7 @@ export const Article = ({
 
           <div className="crayons-story__indention">
             <ContentTitle article={article} />
-            <TagList tags={article.tag_list} flare_tag={article.flare_tag} />
+            <TagList tags={article.tag_list} />
 
             {article.class_name === 'Article' && (
               // eslint-disable-next-line no-underscore-dangle

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -162,6 +162,7 @@ Object {
                 <a
                   class="crayons-tag"
                   href="/t/javascript"
+                  style="background: rgb(0, 0, 0); color: rgb(255, 255, 255);"
                 >
                   javascript
                 </a>
@@ -395,6 +396,7 @@ Object {
               <a
                 class="crayons-tag"
                 href="/t/javascript"
+                style="background: rgb(0, 0, 0); color: rgb(255, 255, 255);"
               >
                 javascript
               </a>

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -162,35 +162,19 @@ Object {
                 <a
                   class="crayons-tag"
                   href="/t/javascript"
-                  style="background: rgb(0, 0, 0); color: rgb(255, 255, 255);"
                 >
-                  <span
-                    class="crayons-tag__prefix"
-                  >
-                    #
-                  </span>
                   javascript
                 </a>
                 <a
                   class="crayons-tag"
                   href="/t/ruby"
                 >
-                  <span
-                    class="crayons-tag__prefix"
-                  >
-                    #
-                  </span>
                   ruby
                 </a>
                 <a
                   class="crayons-tag"
                   href="/t/go"
                 >
-                  <span
-                    class="crayons-tag__prefix"
-                  >
-                    #
-                  </span>
                   go
                 </a>
               </div>
@@ -411,35 +395,19 @@ Object {
               <a
                 class="crayons-tag"
                 href="/t/javascript"
-                style="background: rgb(0, 0, 0); color: rgb(255, 255, 255);"
               >
-                <span
-                  class="crayons-tag__prefix"
-                >
-                  #
-                </span>
                 javascript
               </a>
               <a
                 class="crayons-tag"
                 href="/t/ruby"
               >
-                <span
-                  class="crayons-tag__prefix"
-                >
-                  #
-                </span>
                 ruby
               </a>
               <a
                 class="crayons-tag"
                 href="/t/go"
               >
-                <span
-                  class="crayons-tag__prefix"
-                >
-                  #
-                </span>
                 go
               </a>
             </div>

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -160,7 +160,7 @@ Object {
                 class="crayons-story__tags"
               >
                 <a
-                  class="crayons-tag"
+                  class="crayons-tag crayons-tag--flare"
                   href="/t/javascript"
                   style="background: rgb(0, 0, 0); color: rgb(255, 255, 255);"
                 >
@@ -394,7 +394,7 @@ Object {
               class="crayons-story__tags"
             >
               <a
-                class="crayons-tag"
+                class="crayons-tag crayons-tag--flare"
                 href="/t/javascript"
                 style="background: rgb(0, 0, 0); color: rgb(255, 255, 255);"
               >

--- a/app/javascript/articles/components/TagList.jsx
+++ b/app/javascript/articles/components/TagList.jsx
@@ -1,32 +1,16 @@
 import { h } from 'preact';
 import PropTypes from 'prop-types';
 
-export const TagList = ({ tags = [], flare_tag }) => {
-  let tagsToDisplay = tags;
-  if (flare_tag) {
-    tagsToDisplay = tagsToDisplay.filter((tag) => tag !== flare_tag.name);
-  }
+export const TagList = ({ tags = [] }) => {
   return (
     <div className="crayons-story__tags">
-      {flare_tag && (
-        <a
-          className="crayons-tag"
-          href={`/t/${flare_tag.name}`}
-          style={{
-            background: flare_tag.bg_color_hex,
-            color: flare_tag.text_color_hex,
-          }}
-        >
-          <span className="crayons-tag__prefix">#</span>
-          {flare_tag.name}
-        </a>
-      )}
-      {tagsToDisplay.map((tag) => (
-        <a key={`tag-${tag}`} className="crayons-tag" href={`/t/${tag}`}>
-          <span className="crayons-tag__prefix">#</span>
-          {tag}
-        </a>
-      ))}
+      {tags.map((tag) => {
+        return (
+          <a key={`tag-${tag}`} className="crayons-tag" href={`/t/${tag}`}>
+            {tag}
+          </a>
+        );
+      })}
     </div>
   );
 };

--- a/app/javascript/articles/components/TagList.jsx
+++ b/app/javascript/articles/components/TagList.jsx
@@ -1,16 +1,30 @@
 import { h } from 'preact';
 import PropTypes from 'prop-types';
 
-export const TagList = ({ tags = [] }) => {
+export const TagList = ({ tags = [], flare_tag }) => {
+  let tagsToDisplay = tags;
+  if (flare_tag) {
+    tagsToDisplay = tagsToDisplay.filter((tag) => tag !== flare_tag.name);
+  }
   return (
     <div className="crayons-story__tags">
-      {tags.map((tag) => {
-        return (
-          <a key={`tag-${tag}`} className="crayons-tag" href={`/t/${tag}`}>
-            {tag}
-          </a>
-        );
-      })}
+      {flare_tag && (
+        <a
+          className="crayons-tag"
+          href={`/t/${flare_tag.name}`}
+          style={{
+            background: flare_tag.bg_color_hex,
+            color: flare_tag.text_color_hex,
+          }}
+        >
+          {flare_tag.name}
+        </a>
+      )}
+      {tagsToDisplay.map((tag) => (
+        <a key={`tag-${tag}`} className="crayons-tag" href={`/t/${tag}`}>
+          {tag}
+        </a>
+      ))}
     </div>
   );
 };

--- a/app/javascript/articles/components/TagList.jsx
+++ b/app/javascript/articles/components/TagList.jsx
@@ -10,7 +10,7 @@ export const TagList = ({ tags = [], flare_tag }) => {
     <div className="crayons-story__tags">
       {flare_tag && (
         <a
-          className="crayons-tag"
+          className="crayons-tag crayons-tag--flare"
           href={`/t/${flare_tag.name}`}
           style={{
             background: flare_tag.bg_color_hex,

--- a/app/javascript/listings/components/SelectedTags.jsx
+++ b/app/javascript/listings/components/SelectedTags.jsx
@@ -15,7 +15,6 @@ export const SelectedTags = ({ tags, onRemoveTag, onKeyPress }) => {
             className="tag-name crayons-tag"
             data-no-instant
           >
-            <span className="crayons-tag__prefix">#</span>
             <span role="button" tabIndex="0">
               {tag}
             </span>

--- a/app/javascript/listings/singleListing/TagLinks.jsx
+++ b/app/javascript/listings/singleListing/TagLinks.jsx
@@ -7,12 +7,12 @@ export const TagLinks = ({ tags, onClick }) => (
       ? tags.map((tag) => {
           return (
             <a
+              key={tag}
               href={`/listings?t=${tag}`}
               onClick={(e) => onClick(e, tag)}
               className="crayons-tag"
               data-no-instant
             >
-              <span className="crayons-tag__prefix">#</span>
               {tag}
             </a>
           );

--- a/app/javascript/modCenter/singleArticle/index.jsx
+++ b/app/javascript/modCenter/singleArticle/index.jsx
@@ -15,7 +15,6 @@ export class SingleArticle extends Component {
     if (tag) {
       return (
         <span className="crayons-tag" key={key}>
-          <span className="crayons-tag__prefix">#</span>
           {tag}
         </span>
       );

--- a/app/javascript/readingList/components/ItemListItem.jsx
+++ b/app/javascript/readingList/components/ItemListItem.jsx
@@ -53,8 +53,12 @@ export const ItemListItem = ({ item, children }) => {
             <span datatestid="item-tags">
               <span class="color-base-30"> • </span>
               {adaptedItem.tags.map((tag) => (
-                <a className="crayons-tag" href={`/t/${tag.name}`}>
-                  {`#${tag.name}`}
+                <a
+                  key={`tag-${tag}`}
+                  className="crayons-tag"
+                  href={`/t/${tag.name}`}
+                >
+                  {tag.name}
                 </a>
               ))}
             </span>

--- a/app/javascript/readingList/components/TagList.jsx
+++ b/app/javascript/readingList/components/TagList.jsx
@@ -18,7 +18,7 @@ function LargeScreenTagList({ availableTags, selectedTag, onSelectTag }) {
           </a>
         </li>
         {availableTags.map((tag) => (
-          <li>
+          <li key={`tag-${tag}`}>
             <a
               className={`crayons-link crayons-link--block${
                 selectedTag === tag ? ' crayons-link--current' : ''
@@ -61,6 +61,7 @@ export function TagList({
       <option>all tags</option>
       {availableTags.map((tag) => (
         <option
+          key={`tag-${tag}`}
           selected={tag === selectedTag}
           className={`crayons-link crayons-link--block ${
             tag === selectedTag ? 'crayons-link--current' : ''

--- a/app/javascript/readingList/components/__tests__/ItemListItem.test.jsx
+++ b/app/javascript/readingList/components/__tests__/ItemListItem.test.jsx
@@ -98,9 +98,9 @@ describe('<ItemListItem />', () => {
 
     const { getByText } = render(<ItemListItem item={item} />);
 
-    getByText('#discuss');
+    getByText('discuss');
 
-    expect(getByText('#discuss').closest('a').getAttribute('href')).toBe(
+    expect(getByText('discuss').closest('a').getAttribute('href')).toBe(
       '/t/discuss',
     );
   });

--- a/app/views/admin/tags/edit.html.erb
+++ b/app/views/admin/tags/edit.html.erb
@@ -1,6 +1,9 @@
 <header class="flex mb-6 items-center">
   <div>
-    <h2 class="crayons-title"><span class="crayons-tag" style="background:<%= @tag.bg_color_hex %>;color:<%= @tag.text_color_hex %>;"><%= @tag.name %></span></h2>
+    <% tag_color = Color::CompareHex.new([@tag.bg_color_hex || "#000000", @tag.text_color_hex || "#ffffff"]).brightness(0.8) %>
+    <% tag_color_faded = Color::CompareHex.new([tag_color]).opacity(0.1) %>
+
+    <h2 class="crayons-title"><span class="crayons-tag" style="--tag-color: <%= tag_color %>; --tag-color-faded: <%= tag_color_faded %>;"><%= @tag.name %></span></h2>
     <p>Tagged <%= @tag.taggings_count %> times</p>
   </div>
 

--- a/app/views/admin/tags/edit.html.erb
+++ b/app/views/admin/tags/edit.html.erb
@@ -1,6 +1,6 @@
 <header class="flex mb-6 items-center">
   <div>
-    <h2 class="crayons-title"><span class="crayons-tag crayons-tag--2xl" style="background:<%= @tag.bg_color_hex %>;color:<%= @tag.text_color_hex %>;">#<%= @tag.name %></span></h2>
+    <h2 class="crayons-title"><span class="crayons-tag" style="background:<%= @tag.bg_color_hex %>;color:<%= @tag.text_color_hex %>;"><%= @tag.name %></span></h2>
     <p>Tagged <%= @tag.taggings_count %> times</p>
   </div>
 

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -101,17 +101,12 @@
           <%= story.title %>
         </a>
       </h2>
-      <div class="crayons-story__tags">
-        <% flare_tag = FlareTag.new(story, @tag).tag %>
-        <% if flare_tag %>
-          <a href="<%= URL.tag flare_tag %>" class="crayons-tag" style="background:<%= flare_tag.bg_color_hex %>;color:<%= flare_tag.text_color_hex %>"><span class="crayons-tag__prefix">#</span><%= flare_tag.name %></a>
-        <% end %>
-        <% tags_to_display = story.cached_tag_list_array
-           if flare_tag
-             tags_to_display = tags_to_display.reject { |tag| tag == flare_tag.name }
-           end %>
-        <% tags_to_display.each do |tag| %>
-        <a href="/t/<%= tag %>" class="crayons-tag"><span class="crayons-tag__prefix">#</span><%= tag %></a>
+      <div class="crayons-story__tags flex">
+        <% story.cached_tag_list_array.each do |tag| %>
+          <% tag_hash = tag_colors(tag) %>
+          <% tag_color = Color::CompareHex.new([tag_hash[:background] || "#000000", tag_hash[:color] || "#ffffff"]).brightness(0.8) %>
+          <% tag_color_faded = Color::CompareHex.new([tag_color || "#000000"]).opacity(0.1) %>
+          <a class="crayons-tag" <% if tag_hash[:background] || tag_hash[:color] %> style="--tag-color: <%= tag_color %>; --tag-color-faded: <%= tag_color_faded %>;"<% end %> href="/t/<%= tag %>"><%= tag %></a>
         <% end %>
       </div>
       <div class="crayons-story__bottom">

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -16,9 +16,9 @@
           <% user_stickies.each_with_index do |article, index| %>
             <a class="crayons-link crayons-link--contentful" href="<%= article.path %>">
               <%= article.title %>
-              <div class="crayons-link__secondary -ml-1">
+              <div class="crayons-link__secondary">
                 <% article.decorate.cached_tag_list_array.each do |tag| %>
-                  <span class="crayons-tag"><span class="crayons-tag__prefix">#</span><%= tag %></span>
+                  <span class="crayons-tag"><%= tag %></span>
                 <% end %>
               </div>
             </a>
@@ -41,9 +41,9 @@
               </span>
               <div>
                 <%= article.title %>
-                <div class="crayons-link__secondary -ml-1">
+                <div class="crayons-link__secondary">
                   <% article.decorate.cached_tag_list_array.each do |tag| %>
-                    <span class="crayons-tag"><span class="crayons-tag__prefix">#</span><%= tag %></span>
+                    <span class="crayons-tag"><%= tag %></span>
                   <% end %>
                 </div>
               </div>

--- a/app/views/articles/_tag_identifier.html.erb
+++ b/app/views/articles/_tag_identifier.html.erb
@@ -1,4 +1,7 @@
 <% flare_tag = FlareTag.new(story, @tag).tag %>
 <% if flare_tag %>
-  <span class="crayons-story__flare-tag" style="background:<%= flare_tag.bg_color_hex %>;color:<%= flare_tag.text_color_hex %>">
-    #<%= flare_tag.name %></span><% end %><%= story.title %>
+  <% tag_color = Color::CompareHex.new([flare_tag.bg_color_hex || "#000000", flare_tag.text_color_hex || "#ffffff"]).brightness(0.8) %>
+  <% tag_color_faded = Color::CompareHex.new([tag_color]).opacity(0.1) %>
+
+  <span class="crayons-story__flare-tag crayons-tag crayons-tag--flare" <% if flare_tag.bg_color_hex || flare_tag.text_color_hex %> style="--tag-color: <%= tag_color %>; --tag-color-faded: <%= tag_color_faded %>;"<% end %>>
+    <%= flare_tag.name %></span><% end %><%= story.title %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -149,9 +149,12 @@
             </h1>
 
             <% cache("main-article-tags-#{@article.cached_tag_list}", expires_in: 30.hours) do %>
-              <div class="spec__tags">
+              <div class="spec__tags flex color-base-80">
                 <% @article.cached_tag_list_array.each do |tag| %>
-                  <a class="crayons-tag" href="/t/<%= tag %>"><span class="crayons-tag__prefix">#</span><%= tag %></a>
+                  <% tag_hash = tag_colors(tag) %>
+                  <% tag_color = Color::CompareHex.new([tag_hash[:background] || "#000000", tag_hash[:color] || "#ffffff"]).brightness(0.8) %>
+                  <% tag_color_faded = Color::CompareHex.new([tag_color]).opacity(0.1) %>
+                  <a class="crayons-tag" <% if tag_hash[:background] || tag_hash[:color] %> style="--tag-color: <%= tag_color %>; --tag-color-faded: <%= tag_color_faded %>;"<% end %> href="/t/<%= tag %>"><%= tag %></a>
                 <% end %>
               </div>
             <% end %>

--- a/app/views/dashboards/following_tags.html.erb
+++ b/app/views/dashboards/following_tags.html.erb
@@ -26,12 +26,11 @@
             <% @followed_tags.each do |follow| %>
               <% tag = follow.followable %>
               <% if tag %>
-                <% color = Color::CompareHex.new([tag.bg_color_hex || "#0000000", tag.text_color_hex || "#ffffff"]).brightness(0.8) %>
-                <div class="crayons-card branded-2 p-4 m:p-6 m:pt-4 flex flex-col single-article break-word content-center <% if follow.explicit_points < 0 %>opacity-75<% end %>" style="border-top-color: <%= color %>;" id="follows-<%= follow.id %>">
+                <% tag_color = Color::CompareHex.new([tag.bg_color_hex || "#000000", tag.text_color_hex || "#ffffff"]).brightness(0.8) %>
+                <% tag_color_faded = Color::CompareHex.new([tag_color || "#000000"]).opacity(0.1) %>
+                <div class="crayons-card branded-2 p-4 m:p-6 m:pt-4 flex flex-col single-article break-word content-center <% if follow.explicit_points < 0 %>opacity-75<% end %>" style="border-top-color: <%= tag_color %>;" id="follows-<%= follow.id %>">
                   <h3 class="s:mb-1 -ml-1 p-0 fw-medium">
-                    <a href="<%= URL.tag tag %>" class="crayons-tag crayons-tag--l">
-                      <span class="crayons-tag__prefix">#</span><%= tag.name %>
-                    </a>
+                    <a class="crayons-tag" <% if tag.bg_color_hex || tag.text_color_hex %> style="--tag-color: <%= tag_color %>; --tag-color-faded: <%= tag_color_faded %>;"<% end %> href="/t/<%= tag %>"><%= tag %></a>
                     <% if follow.explicit_points < 0 %>
                       <span class="crayons-indicator crayons-indicator--critical crayons-indicator--outlined" title="This tag has negative follow weight">Anti-follow</span>
                     <% end %>

--- a/app/views/notifications/shared/_article_preview.html.erb
+++ b/app/views/notifications/shared/_article_preview.html.erb
@@ -3,7 +3,7 @@
     <h3 class="notification__preview__title"><%= h(json_data["article"]["title"]) %></h3>
     <div class="-ml-1">
       <% json_data["article"]["cached_tag_list_array"].each do |tag| %>
-        <span class="crayons-tag"><span class="crayons-tag__prefix">#</span><%= tag %></span>
+        <span class="crayons-tag"><%= tag %></span>
       <% end %>
     </div>
   </a>

--- a/app/views/stories/tagged_articles/index.html.erb
+++ b/app/views/stories/tagged_articles/index.html.erb
@@ -5,7 +5,7 @@
 <% flag = true %>
 <% cache("tag-stories-index-#{params}-#{flag}-#{@tag_model.updated_at}-#{user_signed_in?}", expires_in: expiry_minutes.minutes) do %>
   <div class="crayons-layout">
-    <header class="tag-header crayons-card branded-4" style="border-top-color: <%= Color::CompareHex.new([@tag_model.bg_color_hex || "#0000000", @tag_model.text_color_hex || "#ffffff"]).brightness(0.88) %>">
+    <header class="tag-header crayons-card branded-4" style="border-top-color: <%= Color::CompareHex.new([@tag_model.bg_color_hex || "#000000", @tag_model.text_color_hex || "#ffffff"]).brightness(0.88) %>">
       <div class="flex">
         <% if @tag_model.badge_id && @tag_model.badge %>
             <img src="<%= optimized_image_url(@tag_model.badge.badge_image_url, width: 64) %>" alt="" class="mr-4" style="transform: rotate(<%= -25 + (@tag_model.id.digits.first * 5) %>deg); width: 64px; height: 64px;" />
@@ -16,8 +16,9 @@
               <% if @tag_model && @tag_model.pretty_name.present? %>
                 <%= @tag_model.pretty_name %>
               <% else %>
-                <span class="opacity-50">#</span>
-                <%= @tag %>
+                <span class="crayons-tag" style="--tag-color: <%= Color::CompareHex.new([@tag_model.bg_color_hex || "#000000", @tag_model.text_color_hex || "#ffffff"]).brightness(0.88) %>">
+                  <%= @tag %>
+                </span>
               <% end %>
             </h1>
             <% if @tag_model %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -27,12 +27,12 @@
 
   <div class="grid gap-2 m:gap-4 l:gap-6 m:grid-cols-2 l:grid-cols-3 px-2 m:px-0" data-follow-button-container="true">
     <% @tags.each do |tag| %>
-      <% color = Color::CompareHex.new([tag.bg_color_hex || "#0000000", tag.text_color_hex || "#ffffff"]).brightness(0.8) %>
-      <div class="tag-card crayons-card branded-4 p-4 m:p-6 m:pt-4 flex flex-col relative" style="border-top-color: <%= color %>; ">
-        <h3 class="crayons-tag crayons-tag--l mb-2">
-          <a href="<%= URL.tag tag %>" class="crayons-link">
-            <span class="crayons-tag__prefix">#</span><%= tag.name %>
-          </a>
+      <% tag_color = Color::CompareHex.new([tag.bg_color_hex || "#000000", tag.text_color_hex || "#ffffff"]).brightness(0.8) %>
+      <% tag_color_faded = Color::CompareHex.new([tag_color]).opacity(0.1) %>
+
+      <div class="tag-card crayons-card branded-4 p-4 m:p-6 m:pt-4 flex flex-col relative" style="border-top-color: <%= tag_color %>; ">
+        <h3 class="mb-2 -ml-2">
+          <a class="crayons-tag" <% if tag.bg_color_hex || tag.text_color_hex %> style="--tag-color: <%= tag_color %>; --tag-color-faded: <%= tag_color_faded %>;"<% end %> href="<%= URL.tag tag %>"><%= tag.name %></a>
         </h3>
         <% if tag.short_summary.present? %>
           <p class="mb-2 color-base-70 truncate-at-3"><%= sanitize tag.short_summary %></p>

--- a/cypress/integration/seededFlows/loggedOutFlows/showLoginModal.spec.js
+++ b/cypress/integration/seededFlows/loggedOutFlows/showLoginModal.spec.js
@@ -76,7 +76,7 @@ describe('Show log in modal', () => {
     );
 
     cy.visit('/t/tag1');
-    cy.findByRole('heading', { name: '# tag1' });
+    cy.findByRole('heading', { name: 'tag1' });
 
     verifyLoginModalBehavior(() =>
       cy.findByRole('button', { name: 'Follow tag: tag1' }),

--- a/cypress/integration/seededFlows/moderationFlows/adjustPostTags.spec.js
+++ b/cypress/integration/seededFlows/moderationFlows/adjustPostTags.spec.js
@@ -12,7 +12,7 @@ describe('Adjust post tags', () => {
     it('should add a tag to a post', () => {
       cy.findByRole('heading', { name: 'Tag test article' }).click();
       cy.getIframeBody('.article-iframe')
-        .findByRole('link', { name: '#tag2' })
+        .findByRole('link', { name: 'tag2' })
         .should('not.exist');
 
       cy.getIframeBody('.actions-panel-iframe').within(() => {
@@ -24,13 +24,13 @@ describe('Adjust post tags', () => {
 
       cy.getIframeBody('.article-iframe').within(() => {
         cy.findByText('The #tag2 tag was added.');
-        cy.findByRole('link', { name: '#tag2' });
+        cy.findByRole('link', { name: 'tag2' });
       });
     });
 
     it('should remove a tag from a post', () => {
       cy.findByRole('heading', { name: 'Tag test article' }).click();
-      cy.getIframeBody('.article-iframe').findByRole('link', { name: '#tag1' });
+      cy.getIframeBody('.article-iframe').findByRole('link', { name: 'tag1' });
 
       cy.getIframeBody('.actions-panel-iframe').within(() => {
         cy.findByRole('button', { name: 'Open adjust tags section' }).click();
@@ -42,7 +42,7 @@ describe('Adjust post tags', () => {
 
       cy.getIframeBody('.article-iframe').within(() => {
         cy.findByText('The #tag1 tag was removed.');
-        cy.findByRole('link', { name: '#tag1' }).should('not.exist');
+        cy.findByRole('link', { name: 'tag1' }).should('not.exist');
       });
     });
   });
@@ -60,7 +60,7 @@ describe('Adjust post tags', () => {
     it('should add a tag to a post', () => {
       cy.findByRole('heading', { name: 'Tag test article' }).click();
       cy.getIframeBody('.article-iframe')
-        .findByRole('link', { name: '#tag2' })
+        .findByRole('link', { name: 'tag2' })
         .should('not.exist');
 
       cy.getIframeBody('.actions-panel-iframe').within(() => {
@@ -72,13 +72,13 @@ describe('Adjust post tags', () => {
 
       cy.getIframeBody('.article-iframe').within(() => {
         cy.findByText('The #tag2 tag was added.');
-        cy.findByRole('link', { name: '#tag2' });
+        cy.findByRole('link', { name: 'tag2' });
       });
     });
 
     it('should remove a tag from a post', () => {
       cy.findByRole('heading', { name: 'Tag test article' }).click();
-      cy.getIframeBody('.article-iframe').findByRole('link', { name: '#tag1' });
+      cy.getIframeBody('.article-iframe').findByRole('link', { name: 'tag1' });
 
       cy.getIframeBody('.actions-panel-iframe').within(() => {
         cy.findByRole('button', { name: 'Open adjust tags section' }).click();
@@ -90,7 +90,7 @@ describe('Adjust post tags', () => {
 
       cy.getIframeBody('.article-iframe').within(() => {
         cy.findByText('The #tag1 tag was removed.');
-        cy.findByRole('link', { name: '#tag1' }).should('not.exist');
+        cy.findByRole('link', { name: 'tag1' }).should('not.exist');
       });
     });
   });
@@ -109,7 +109,7 @@ describe('Adjust post tags', () => {
       cy.findByRole('heading', { name: 'Tag test article' });
       cy.findByRole('main').as('main');
 
-      cy.findByRole('link', { name: '#tag2' }).should('not.exist');
+      cy.findByRole('link', { name: 'tag2' }).should('not.exist');
 
       cy.findByRole('button', { name: 'Moderation' }).click();
       cy.getIframeBody('#mod-container').within(() => {
@@ -120,7 +120,7 @@ describe('Adjust post tags', () => {
       });
 
       cy.get('@main').within(() => {
-        cy.findByRole('link', { name: '#tag2' });
+        cy.findByRole('link', { name: 'tag2' });
       });
     });
 
@@ -128,7 +128,7 @@ describe('Adjust post tags', () => {
       cy.findByRole('heading', { name: 'Tag test article' });
       cy.findByRole('main').as('main');
 
-      cy.findByRole('link', { name: '#tag1' }).should('exist');
+      cy.findByRole('link', { name: 'tag1' }).should('exist');
       cy.findByRole('button', { name: 'Moderation' }).click();
 
       cy.getIframeBody('#mod-container').within(() => {
@@ -140,7 +140,7 @@ describe('Adjust post tags', () => {
       });
 
       cy.get('@main').within(() => {
-        cy.findByRole('link', { name: '#tag1' }).should('not.exist');
+        cy.findByRole('link', { name: 'tag1' }).should('not.exist');
       });
     });
   });

--- a/cypress/integration/seededFlows/tagsFlows/followTag.spec.js
+++ b/cypress/integration/seededFlows/tagsFlows/followTag.spec.js
@@ -37,7 +37,7 @@ describe('Follow tag', () => {
 
       cy.get('@user').then((user) => {
         cy.loginAndVisit(user, '/t/tag1').then(() => {
-          cy.findByRole('heading', { name: '# tag1' });
+          cy.findByRole('heading', { name: 'tag1' });
           cy.get('[data-follow-clicks-initialized]');
         });
       });

--- a/spec/system/search/display_articles_search_spec.rb
+++ b/spec/system/search/display_articles_search_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Display articles search spec", type: :system, js: true do
     expect(find("#article-link-#{found_article_one.id}")["href"]).to include(found_article_one.path)
     expect(page).to have_selector("button[data-reactable-id=\"#{found_article_one.id}\"]")
     expect(page).to have_content("5 min read")
-    expect(find_link("#ruby")["href"]).to include("/t/ruby")
+    expect(find_link("ruby")["href"]).to include("/t/ruby")
     expect(page).to have_content("3 reactions")
     expect(page).to have_content("2 comments")
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR brings back coloring to tags on Article page but in slightly less intrusive and overwhelming way.
It now follows the concept we've been exploring for Tags visual in general (as well as Tags autocompletion field) and lays the CSS foundation for this. Under the hood this PR also drops extra markup for `#` character as it's now just `::before` element - having this markup was kinda redundant and pointless anyway.

This also increases the contrast on Feed cards tags but other than that it does NOT bring the coloring to Feed as there are some technical implications that I'll likely handle separately.

## QA Instructions, Screenshots, Recordings

`javascript` tag is being hovered:

**Before:**
![image](https://user-images.githubusercontent.com/108287/136770284-1b09bd81-c729-4160-a065-5184207eaecc.png)

**After:**
![image](https://user-images.githubusercontent.com/108287/136769942-bdd9e48f-b7c2-4a00-9c85-b030db7adde0.png)


### UI accessibility concerns?

Hopefully not. If anything, we increased the contrast for tags so should be good?

## Added/updated tests?

- [ ] Yes
- [x] No, as I hope I don't need to...
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_