### PR TITLE
Do not display skip link on mobile search page

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -128,7 +128,8 @@ var instantClick
 
     if (newUrl) {
       const skipLink = document.querySelector('.skip-content-link');
-        if (skipLink) {
+      const noSkipLink = newUrl.includes('/search?') && ['iOS', 'Android'].includes(Runtime.currentOS());
+        if (skipLink && !noSkipLink) {
           skipLink.focus();
         }
       document.getElementById('page-route-change').textContent = title;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Currently the skip link is showing up in mobile contexts when it is not usable.

I made this PR check for iOS or Android in the specific context of `/search?` in order to avoid displaying it in this very narrow context. While it is possible that someone could have an external keyboard, I felt like this is generally a context where the skip link is less likely to be requested.

If anyone has a better idea for logic that will more precisely detect this scenario, I very much welcome it! It's a two line PR, so an alternate approach shouldn't be too difficult to come by if there are ideas. 

## Related Tickets & Documents
https://github.com/forem/forem/issues/14998

## QA Instructions, Screenshots, Recordings

<img width="396" alt="Screen Shot 2021-10-09 at 3 44 37 PM" src="https://user-images.githubusercontent.com/3102842/136672249-f14cc541-a0ae-47d8-bffa-1f6a68fb0a8d.png">

### UI accessibility concerns?

Yes, this should be evaluated for accessibility concerns.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This seems isolated and difficult to test
- [ ] I need help with writing tests

