### PR TITLE
cleanup: replace reaction.reactable with reactable, since it's a local variable

### DIFF
--- a/app/workers/reactions/update_relevant_scores_worker.rb
+++ b/app/workers/reactions/update_relevant_scores_worker.rb
@@ -10,7 +10,7 @@ module Reactions
       return unless reactable
 
       reactable.touch_by_reaction if reactable.respond_to?(:touch_by_reaction)
-      if reaction.reactable.respond_to?(:sync_reactions_count)
+      if reactable.respond_to?(:sync_reactions_count)
         ThrottledCall.perform(:sync_reactions_count, throttle_for: 15.minutes) do
           reactable.sync_reactions_count
         end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We assigned reactable earlier in the method, and won't reach this line
unless reactable exists, no need to ask the reaction for this object again.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Nothing should change.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: refactor
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._
- [x] This change does not need to be communicated, and this is why not: tiny cleanup
