### PR TITLE
[15 min fix] Prevent scroll jumps when using mention autocomplete

### DIFF
--- a/app/javascript/crayons/MentionAutocompleteTextArea/MentionAutocompleteTextArea.jsx
+++ b/app/javascript/crayons/MentionAutocompleteTextArea/MentionAutocompleteTextArea.jsx
@@ -218,7 +218,7 @@ export const MentionAutocompleteTextArea = forwardRef(
         // inputs. This check is necessary to prevent an issue in iOS browsers only.
         // An additional check to see if the component can be focusable
         // covers the use case for clicking on elements in the mention autocomplete list.
-        activeInput.focus();
+        activeInput.focus({ preventScroll: true });
         activeInput.setSelectionRange(cursorPosition, cursorPosition - 1);
         setFocusable(true);
       }
@@ -325,7 +325,7 @@ export const MentionAutocompleteTextArea = forwardRef(
           plainTextArea,
           comboboxTextArea,
         });
-        plainTextArea.focus();
+        plainTextArea.focus({ preventScroll: true });
       }
 
       // Initialize the new text areas in the "non-autosuggest" state, hiding the combobox until a search begins


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On a long scrolling post, sometimes the mention autocomplete can make the text area jump/change scroll position unexpectedly, particularly if you try to insert a mention at the far top or bottom of the scroll region.

This PR adds a small tweak so that when we manipulate focus to handle mentions, we don't trigger any 'normal' focus scroll behaviour. This feels more appropriate, since in this case, users haven't triggered the focus event and shouldn't even be aware of it happening.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

**Before:**

https://user-images.githubusercontent.com/20773163/136944022-0f0bda7b-d239-4651-b49b-164834963001.mp4

**After:**

https://user-images.githubusercontent.com/20773163/136944032-57b6e28c-31a2-4bbf-8732-a22b4fa89f96.mp4


### UI accessibility concerns?

N/A - general UX bug fix

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: minor UI tweak - I'm not sure there's a meaningful test we can write for this
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


