### PR TITLE
Make e2e seed safe to run twice

### DIFF
--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -160,7 +160,7 @@ end
 
 ##############################################################################
 
-seeder.create_if_doesnt_exist(User, "email", "article-editor-v2-user@forem.com") do
+seeder.create_if_doesnt_exist(User, "email", "article-editor-v2-user@forem.local") do
   user = User.create!(
     name: "Article Editor v2 User",
     email: "article-editor-v2-user@forem.local",
@@ -237,7 +237,7 @@ chat_user_2 = seeder.create_if_doesnt_exist(User, "email", "chat-user-2@forem.lo
 end
 
 ##############################################################################
-seeder.create_if_doesnt_exist(User, "email", "notifications-user@forem.com") do
+seeder.create_if_doesnt_exist(User, "email", "notifications-user@forem.local") do
   user = User.create!(
     name: "Notifications User",
     email: "notifications-user@forem.local",
@@ -265,7 +265,7 @@ end
 
 ##############################################################################
 
-seeder.create_if_doesnt_exist(User, "email", "liquid-tags-user@forem.com") do
+seeder.create_if_doesnt_exist(User, "email", "liquid-tags-user@forem.local") do
   liquid_tags_user = User.create!(
     name: "Liquid tags User",
     email: "liquid-tags-user@forem.local",
@@ -344,7 +344,7 @@ end
 
 ##############################################################################
 
-seeder.create_if_doesnt_exist(Article, "title", "Test article") do
+seeder.create_if_doesnt_exist(Article, "slug", "test-article-slug") do
   markdown = <<~MARKDOWN
     ---
     title:  Test article
@@ -355,7 +355,7 @@ seeder.create_if_doesnt_exist(Article, "title", "Test article") do
     #{Faker::Markdown.random}
     #{Faker::Hipster.paragraph(sentence_count: 2)}
   MARKDOWN
-  article = Article.create(
+  article = Article.create!(
     body_markdown: markdown,
     featured: true,
     show_comments: true,
@@ -397,7 +397,7 @@ end
 
 ##############################################################################
 
-seeder.create_if_doesnt_exist(User, "email", "series-user@forem.com") do
+seeder.create_if_doesnt_exist(User, "email", "series-user@forem.local") do
   series_user = User.create!(
     name: "Series User",
     email: "series-user@forem.local",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We're creating a podcast with title "Developer on Fire" but checking
if a podcast with title "Test podcast" exists. This creates a problem
if the db is not cleared between script runs, since the seed will
raise a validation error creating the podcast since the slug and feed
url have been taken.

Adjust the guard condition to prevent recreating the data if it's present.


## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
on main:

Run the e2e seed task twice. Should not raise errors.

```
RAILS_ENV=test rails db:drop db:create db:schema:load
E2E=true RAILS_ENV=test rake db:seed:e2e
E2E=true RAILS_ENV=test rake db:seed:e2e
```

### UI accessibility concerns?

None, test setup only.

## Added/updated tests?

- [x] No, and this is why: cleanup of test setup

Really - the only rational test for this would be to have the e2e-ci script call the seed _twice_ - that seems like it might be overkill for something that doesn't matter to the test setup. However, we could do it - the seeds are pretty fast (the second time, because of the guard conditions, it's a handful of selects and not inserts). 

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: housekeeping

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![doitagain](https://user-images.githubusercontent.com/1237369/136977880-258f6241-ada5-48ac-bb57-37d3c0f5011d.gif)
