### PR TITLE
Make default alt text in editor 'image description'

### DIFF
--- a/app/javascript/article-form/components/ClipboardButton.jsx
+++ b/app/javascript/article-form/components/ClipboardButton.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { Button } from '@crayons';
 
 function linksToMarkdownForm(imageLinks) {
-  return imageLinks.map((imageLink) => `![Alt Text](${imageLink})`).join('\n');
+  return imageLinks
+    .map((imageLink) => `![Image description](${imageLink})`)
+    .join('\n');
 }
 
 const CopyIcon = () => (

--- a/app/javascript/article-form/components/EditorBody.jsx
+++ b/app/javascript/article-form/components/EditorBody.jsx
@@ -19,11 +19,9 @@ function handleImageSuccess(textAreaRef) {
     // Function is within the component to be able to access
     // textarea ref.
     const editableBodyElement = textAreaRef.current;
-    const { links, image } = response;
-    const altText = image[0]
-      ? image[0].name.replace(/\.[^.]+$/, '')
-      : 'alt text';
-    const markdownImageLink = `![${altText}](${links[0]})\n`;
+    const { links } = response;
+
+    const markdownImageLink = `![Image description](${links[0]})\n`;
     const { selectionStart, selectionEnd, value } = editableBodyElement;
     const before = value.substring(0, selectionStart);
     const after = value.substring(selectionEnd, value.length);

--- a/app/javascript/utilities/markdown/markdownLintCustomRules.js
+++ b/app/javascript/utilities/markdown/markdownLintCustomRules.js
@@ -37,12 +37,12 @@ export const noDefaultAltTextRule = {
         children.forEach((contentChild) => {
           if (
             contentChild.type === 'image' &&
-            contentChild.line.toLowerCase().includes('![alt text]')
+            contentChild.line.toLowerCase().includes('![image description]')
           ) {
             onError({
               lineNumber: contentChild.lineNumber,
               detail: '/p/editor_guide#alt-text-for-images',
-              context: `Consider replacing the 'alt text' in square brackets at ${getImageTextString(
+              context: `Consider replacing the 'Image description' in square brackets at ${getImageTextString(
                 contentChild.line,
               )} with a description of the image`,
             });

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -74,7 +74,7 @@
       When adding GIFs to posts and comments, please note that there is a limit of 200 megapixels per frame/page.
       <img src="https://res.cloudinary.com/practicaldev/image/fetch/s--OsLaFSo9--/c_fill,f_auto,fl_progressive,h_220,q_auto,w_220/https://thepracticaldev.s3.amazonaws.com/uploads/user/profile_image/31047/af153cd6-9994-4a68-83f4-8ddf3e13f0bf.jpg" alt="example image, with sloan" loading="lazy" />
     </p>
-    <pre>![Alt text of image](put-link-to-image-here)</pre>
+    <pre>![Image description](put-link-to-image-here)</pre>
     <figure>
         <img src="https://res.cloudinary.com/practicaldev/image/fetch/s--OsLaFSo9--/c_fill,f_auto,fl_progressive,h_50,q_auto,w_50/https://thepracticaldev.s3.amazonaws.com/uploads/user/profile_image/31047/af153cd6-9994-4a68-83f4-8ddf3e13f0bf.jpg" alt="example image, with sloan" loading="lazy" />
         <figcaption>You can even add a caption using the HTML <code>figcaption</code> tag!</figcaption>
@@ -97,8 +97,8 @@
     <%= render partial: "editor_guide_h3", locals: { id: "alt-text-for-images", title: "Providing alternative descriptions for images" } %>
     <p>Some users might not be able to see or easily process images that you use in your posts. Providing an alternative description for an image helps make sure that everyone can understand your post, whether they can see the image or not.</p>
     <p>When you upload an image in the editor, you will see the following text to copy and paste into your post:</p>
-    <pre>![Alt Text](/file-path/my-image.png)</pre>
-    <p>Replace the "Alt Text" in square brackets with a description of your image - for example:</p>
+    <pre>![Image description](/file-path/my-image.png)</pre>
+    <p>Replace the "Image description" in square brackets with a description of your image - for example:</p>
     <pre>![A pie chart showing 40% responded "Yes", 50% responded "No" and 10% responded "Not sure"](/file-path/my-image.png)</pre>
     <p>By doing this, if someone reads your post using an assistive device like a screen reader (which turns written content into spoken audio) they will hear the description you entered.</p>
 

--- a/app/views/pages/_editor_markdown_help.html.erb
+++ b/app/views/pages/_editor_markdown_help.html.erb
@@ -24,7 +24,7 @@
       When adding GIFs to posts and comments, please note that there is a limit of 200 megapixels per frame/page.
       <img src="https://res.cloudinary.com/practicaldev/image/fetch/s--OsLaFSo9--/c_fill,f_auto,fl_progressive,h_220,q_auto,w_220/https://thepracticaldev.s3.amazonaws.com/uploads/user/profile_image/31047/af153cd6-9994-4a68-83f4-8ddf3e13f0bf.jpg" alt="example image, with sloan" loading="lazy" />
     </p>
-    <pre>![Alt text of image](put-link-to-image-here)</pre>
+    <pre>![Image description](put-link-to-image-here)</pre>
     <figcaption> You can even add a caption using the HTML <code>figcaption</code> tag!</figcaption>
 
     <h3>Headers</h3>

--- a/app/views/pages/markdown_basics.html.erb
+++ b/app/views/pages/markdown_basics.html.erb
@@ -24,7 +24,7 @@
     <h3><strong>Inline Images</strong></h3>
     <p>
       <img src="https://res.cloudinary.com/practicaldev/image/fetch/s--OsLaFSo9--/c_fill,f_auto,fl_progressive,h_220,q_auto,w_220/https://thepracticaldev.s3.amazonaws.com/uploads/user/profile_image/31047/af153cd6-9994-4a68-83f4-8ddf3e13f0bf.jpg" alt="example image, with sloan" loading="lazy" />
-      <code>![Alt text of image](put-link-to-image-here)</code>
+      <code>![Image description](put-link-to-image-here)</code>
     </p>
 
     <h3><strong>Headers</strong></h3>

--- a/cypress/integration/seededFlows/publishingFlows/previewPost.spec.js
+++ b/cypress/integration/seededFlows/publishingFlows/previewPost.spec.js
@@ -220,7 +220,7 @@ describe('Post Editor', () => {
 
     it('should show a maximum of 3 accessibility suggestions', () => {
       const postTextWithFourErrors =
-        '# Heading level 1\n![](http://imagewithoutalt.png)\n![alt text](http://imagewithdefaultalt.png)\n#### Heading level 4';
+        '# Heading level 1\n![](http://imagewithoutalt.png)\n![Image description](http://imagewithdefaultalt.png)\n#### Heading level 4';
       cy.findByRole('form', { name: /^Edit post$/i }).as('articleForm');
 
       cy.get('@articleForm')
@@ -239,7 +239,7 @@ describe('Post Editor', () => {
 
       // Check each expected description has appeared
       cy.findByText(
-        "Consider replacing the 'alt text' in square brackets at ![alt text](http://imagewithdefaultalt.png) with a description of the image",
+        "Consider replacing the 'Image description' in square brackets at ![Image description](http://imagewithdefaultalt.png) with a description of the image",
       );
       cy.findByText(
         'Consider adding an image description in the square brackets at ![](http://imagewithoutalt.png)',
@@ -259,7 +259,7 @@ describe('Post Editor', () => {
 
     it('should display image suggestions over heading suggestions', () => {
       const textWithThreeImageErrors =
-        '![](http://imageerror1.png)\n![Alt Text](http://imageerror2.png)\n![Alt Text](http://imageerror3.png)';
+        '![](http://imageerror1.png)\n![Image description](http://imageerror2.png)\n![Image description](http://imageerror3.png)';
       const textWithHeadingErrors = '# Heading level 1\n #### Heading level 4';
 
       cy.findByRole('form', { name: /^Edit post$/i }).as('articleForm');
@@ -351,18 +351,20 @@ describe('Post Editor', () => {
       cy.get('@articleForm')
         .findByLabelText('Post Content')
         .clear()
-        .type('![alt text](http://image1.png)\n![Alt Text](http://image2.png)');
+        .type(
+          '![Image description](http://image1.png)\n![Image description](http://image2.png)',
+        );
 
       cy.get('@articleForm')
         .findByRole('button', { name: /^Preview$/i })
         .click();
 
       cy.findByText(
-        "Consider replacing the 'alt text' in square brackets at ![alt text](http://image1.png) with a description of the image",
+        "Consider replacing the 'Image description' in square brackets at ![Image description](http://image1.png) with a description of the image",
       );
 
       cy.findByText(
-        "Consider replacing the 'alt text' in square brackets at ![Alt Text](http://image2.png) with a description of the image",
+        "Consider replacing the 'Image description' in square brackets at ![Image description](http://image2.png) with a description of the image",
       );
 
       cy.findAllByRole('link', {
@@ -381,14 +383,16 @@ describe('Post Editor', () => {
       cy.get('@articleForm')
         .findByLabelText('Post Content')
         .clear()
-        .type('Some text ![alt text](http://image1.png) Some more text');
+        .type(
+          'Some text ![Image description](http://image1.png) Some more text',
+        );
 
       cy.get('@articleForm')
         .findByRole('button', { name: /^Preview$/i })
         .click();
 
       cy.findByText(
-        "Consider replacing the 'alt text' in square brackets at ![alt text](http://image1.png) with a description of the image",
+        "Consider replacing the 'Image description' in square brackets at ![Image description](http://image1.png) with a description of the image",
       );
     });
   });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently when we upload an image in the editor (either via the upload image button or via drag & drop / copy/paste), we display the markdown with the placeholder "alt text", e.g. `[Alt Text](/my-image.png)`.

This PR changes this default alt text to "Image description", i.e. `[Image description](/my-image.png)`. This lays some groundwork for the upcoming changes to image upload as part of the editor markdown toolbar, but also generally makes the placeholder text a bit more user-friendly and informative for less technical audiences.

I've updated the accessibility suggestions linter to match the new default text as well as the editor help.

## Related Tickets & Documents

Groundwork for https://github.com/forem/forem/issues/14808

## QA Instructions, Screenshots, Recordings

- Add a new image in the V1 & V2 editors using the image upload button, check the default alt text is "Image description"
- Repeat using drag & drop of an image into the editor, and check the default alt text
- Repeat again with image copy/paste into the editor
- In the V2 editor, leave the default alt text of 'Image description' and click on the Preview tab - make sure the accessibility suggestions banner is shown with the correct content

### UI accessibility concerns?

Hopefully changing this default alt text might make the purpose of the text in `[]` for images a bit more obvious to less technical audiences. Even if not, the accessibility suggestions linter will still continue to draw attention to it.

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: it's just a very minor terminology change

