### PR TITLE
cleanup: replace outer scope "user" with block scoped "model"

### DIFF
--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -130,8 +130,8 @@ module Authentication
 
     def update_user(user)
       user.tap do |model|
-        user.unlock_access! if user.access_locked?
-        user.assign_attributes(provider.existing_user_data)
+        model.unlock_access! if model.access_locked?
+        model.assign_attributes(provider.existing_model_data)
 
         update_profile_updated_at(model)
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

It's confusing why we set model as the block binding, but still access
user from the method argument (reaching outside the `tap` block).

Within this block, use model consistently to name the user.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

I expect no changes since this is a variable renaming. If the tests pass that's fine.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: refactor
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: refactor

