### PR TITLE
Change fixed organization id to fixed organization slug

### DIFF
--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -88,7 +88,7 @@ end
 
 ##############################################################################
 
-seeder.create_if_none(Organization) do
+seeder.create_if_doesnt_exist(Organization, "slug", "bachmanity") do
   organization = Organization.create!(
     name: "Bachmanity",
     summary: Faker::Company.bs,


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Since we create an organization with a known slug, use
find_by here to set the organization_id on the seeded DisplayAd.

Ensure this slug is present by guarding for that, rather than "any organization exists".

This solves a situation that never occurs in CI, where we create exactly one Organization on a new database, and the id is in fact 1, but can occur if the table is cleared but the db is not dropped (the sequence does not reset) - especially if mixing e2e/cypress specs and rspec specs which use different seeds - the unit tests could leave an organization in the db (with a different id and different slug).  

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Running `rake db:seed:e2e` should not raise any error. 



### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: refactor of test setup

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: seed value refactor
