### PR TITLE
Load any translation files in subdirectories

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -55,6 +55,8 @@ module PracticalDeveloper
 
     config.middleware.use Rack::Deflater
 
+    config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]
+
     config.i18n.fallbacks = [:en]
 
     # Globally handle Pundit::NotAuthorizedError by serving 404

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,1 +1,0 @@
-I18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We need to add the same path patterns that we check in the I18n tasks to the app so translation works in views.

This ensures files in config/locales/views/ are loaded, for example.

Very open to feedback if this is the right idea and the wrong implementation.

## Related Tickets & Documents

Issue discovered due to missing translations in tests in https://github.com/forem/forem/pull/15022 

## QA Instructions, Screenshots, Recordings

I18n.load_path should include config/locales/views/ right now that's `misc/en.yml` and `misc/fr.yml`.

There's a secondary issue where the two files there do not match  the pattern in i18n-tasks.yml because there is nothing before the locale (does this need to be misc/misc.en.yml or views/misc.en.yml or is the dotted-file path pattern in the i18n-tasks different from what we anticipate wanting?)

```yaml
    ## More files:
    - config/locales/**/*.%{locale}.yml
```

This looks like it only affects testing the validity/consistency of the additional files - but we either want to change that match pattern or change the load path to match that pattern (so we're validating all of the translation files we're using).


My local testing was as follows

Before

```ruby
 I18n.config.load_path.reject {|p| p =~ /vendor/ }
=> ["/home/djuber/src/forem/config/locales/devise.en.yml",
 "/home/djuber/src/forem/config/locales/devise_invitable.en.yml",
 "/home/djuber/src/forem/config/locales/devise_invitable.fr.yml",
 "/home/djuber/src/forem/config/locales/doorkeeper.en.yml",
 "/home/djuber/src/forem/config/locales/en.yml",
 "/home/djuber/src/forem/config/locales/fr.yml",
 "/home/djuber/src/forem/config/locales/kaminari.fr.yml"]
```

After we can see the last two files were added to views/misc/en.yml and views/misc/fr.yml

```ruby
I18n.config.load_path.reject {|p| p =~ /vendor/ }
=> ["/home/djuber/src/forem/config/locales/devise.en.yml",      
 "/home/djuber/src/forem/config/locales/devise_invitable.en.yml",
 "/home/djuber/src/forem/config/locales/devise_invitable.fr.yml",
 "/home/djuber/src/forem/config/locales/doorkeeper.en.yml",
 "/home/djuber/src/forem/config/locales/en.yml",
 "/home/djuber/src/forem/config/locales/fr.yml",
 "/home/djuber/src/forem/config/locales/kaminari.fr.yml",
 "/home/djuber/src/forem/config/locales/views/misc/en.yml",
 "/home/djuber/src/forem/config/locales/views/misc/fr.yml"]
```

I then tested this change against the spec/requests/videos_spec.rb in the branch for #15022 and confirmed this resolved the failures there.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: will be covered by existing tests for spec/requests/videos_spec.rb once this unblocks the linked PR 
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: bugfix

