### PR TITLE
Remove txn from `with_statement_timeout` block

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -60,28 +60,14 @@ class ApplicationRecord < ActiveRecord::Base
       .seconds / 1000
   end
 
-  def self.with_statement_timeout(duration)
-    # Using SET LOCAL only works inside a transaction.
-    transaction do
-      original_timeout = statement_timeout
-      milliseconds = (duration.to_f * 1000).to_i
-      connection.execute "SET LOCAL statement_timeout = #{milliseconds}"
-      yield
-    ensure
-      # Typically this value is reset after a transaction is completed (whether
-      # successfully or unsuccessfully), but a nested transaction will not reset
-      # this value after the inner transaction is complete because they are not
-      # isolated from the outer transaction the way the outer transaction is
-      # from transactions on other connections. Nested transactions are
-      # implemented simply as savepoints inside the top-level transaction. For
-      # this reason, we need to explicitly reset the statement timeout so that
-      # when the block completes the statement timeout is reset to its previous
-      # value.
-      #
-      # See: https://www.postgresql.org/docs/11/sql-savepoint.html
-      milliseconds = original_timeout.to_i * 1000
-      connection.execute "SET LOCAL statement_timeout = #{milliseconds}"
-    end
+  def self.with_statement_timeout(duration, connection: self.connection)
+    original_timeout = statement_timeout
+    milliseconds = (duration.to_f * 1000).to_i
+    connection.execute "SET statement_timeout = #{milliseconds}"
+    yield
+  ensure
+    milliseconds = original_timeout.to_i * 1000
+    connection.execute "SET statement_timeout = #{milliseconds}"
   end
 
   def errors_as_sentence

--- a/app/workers/emails/remove_old_emails_worker.rb
+++ b/app/workers/emails/remove_old_emails_worker.rb
@@ -4,12 +4,8 @@ module Emails
 
     sidekiq_options queue: :low_priority, retry: 10
 
-    STATEMENT_TIMEOUT = ENV.fetch("STATEMENT_TIMEOUT_REMOVE_OLD_EMAILS", 10_000).to_i.seconds / 1_000.to_f
-
     def perform
-      ApplicationRecord.with_statement_timeout STATEMENT_TIMEOUT do
-        EmailMessage.fast_destroy_old_retained_email_deliveries
-      end
+      EmailMessage.fast_destroy_old_retained_email_deliveries
     end
   end
 end


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Turns out #15085 caused a *different* problem. It would work for the first delete batch in `BulkSqlDelete`, but subsequent `DELETE` queries would then get their `statement_timeout`s reset to the global setting. The issue was that `BulkSqlDelete` uses methods that don't respect nested transactions, and we were already resetting the value of the setting to its previous value anyway, so there was really no reason to run it inside a transaction.

There was never any indication of the issue in testing because `BulkSqlDelete` explicitly does not run that method in the `test` environment. It never occurred to me that it's because it hard-commits the transaction rather than unnesting a layer of nested transactions.

The only failure mode I know of here is that the `ensure` block breaks because `connection` is severed. In that case, the value is reset anyway when the connection pool replaces the connection so the failure does not propagate.

## Related Tickets & Documents

- #15085

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: The tests written in #15085 are still valid
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_