### PR TITLE
Added callbacks to purge cache

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -101,7 +101,12 @@ class Article < ApplicationRecord
   before_save :fetch_video_duration
   before_save :set_caches
   before_create :create_password
+  # Purging article edge-cache
+  after_create :purge_all
   before_destroy :before_destroy_actions, prepend: true
+
+  after_destroy :purge, :purge_all
+  after_save :purge
 
   after_save :create_conditional_autovomits
   after_save :bust_cache

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1373,4 +1373,32 @@ RSpec.describe Article, type: :model do
       expect(another_article.errors.messages[:feed_source_url]).to include(error_message)
     end
   end
+
+  describe "Validating edge-cache purging calls" do
+    let(:article) { create(:article) }
+
+    before do
+      allow(article).to receive(:purge)
+      allow(article).to receive(:purge_all)
+    end
+
+    it "invokes :purge_all when a new article is created" do
+      article.run_callbacks(:create)
+
+      expect(article).to have_received(:purge_all).once
+    end
+
+    it "invokes :purge when an article is saved" do
+      article.run_callbacks(:save)
+
+      expect(article).to have_received(:purge).once
+    end
+
+    it "invokes :purge and :purge_all when an article is destroyed" do
+      article.run_callbacks(:destroy)
+
+      expect(article).to have_received(:purge).once
+      expect(article).to have_received(:purge_all).once
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When a new article was created, then the existing `articles` cache was not getting flushed. Because of which, newly created article was not showing up in the response until that stale cache was purged by some other action.

### Proposed Solution
Added different callbacks which performs under various stages of `article` lifecycle to purge cache data and maintain consistency.
* `after_create` - it invokes `:purge_all` and clears existing cache collection. So that, next request would hit server and stores fresh copy of data as cache.
* `after_save` - It invokes `:purge` and purges only itself from cache collection. (like, when an article gets updated)
* `after_destroy` - It invokes both `:purge` and `:purge_all` clearing record and also the collection holding that record.

Article creation, updation and destruction happens at different parts of application. In order to stay consistent, attached these purge actions to activerecord callbacks.

## Related Tickets & Documents

This PR is related to issue https://github.com/forem/forem/issues/6417

## QA Instructions, Screenshots, Recordings

`NOTE` - It is not possible to test the functionality in local environment. We need to deploy to live server to verify the changes.

Steps to validate:
* After an article is created/updated/destroyed, next request involving article(s) retrieval will have `x-cache:  MISS` in its response headers.
  - This is because, the stale cache was purged and response was fetched from server.
* Next consecutive requests will now have `x-cache: HIT` as it is served from cache.
* Not all endpoints will show this behaviour. Those endpoints which set `surrogate_key` inside response headers will respond to cache miss/hit. Rest all endpoints related to articles will always contain `x-cache: MISS`.
* Endpoints which set `surrogate_key` in response headers are...
  - `https://dev.to/api/articles`
  - `https://dev.to/api/articles/:id`
  - `https://dev.to/api/articles/:slug`

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## Are there any post deployment tasks we need to perform?
Yup, validating this fix. Making sure data is purged after creation/updation/destruction of an article by monitoring `x-cache` key of the request(s) made to those endpoints which set and deliver `surrogate_key` inside response headers.
