### PR TITLE
Bug Fix: Following an organization from article's sidebar creates an incorrect `follow` record

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -53,16 +53,14 @@ class FollowsController < ApplicationController
   def create
     authorize Follow
 
-    followable = case params[:followable_type].downcase
-                 when "organization"
-                   Organization.find(params[:followable_id])
-                 when "tag"
-                   Tag.find(params[:followable_id])
-                 when "podcast"
-                   Podcast.find(params[:followable_id])
-                 else
-                   User.find(params[:followable_id])
-                 end
+    followable_klass = case params[:followable_type]
+                       when "Organization", "Tag", "Podcast"
+                         params[:followable_type].constantize
+                       else
+                         User
+                       end
+
+    followable = followable_klass.find(params[:followable_id])
 
     need_notification = Follow.need_new_follower_notification_for?(followable.class.name)
 

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -53,7 +53,7 @@ class FollowsController < ApplicationController
   def create
     authorize Follow
 
-    followable_klass = case params[:followable_type]
+    followable_klass = case params[:followable_type].capitalize
                        when "Organization", "Tag", "Podcast"
                          params[:followable_type].constantize
                        else

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -102,7 +102,6 @@ class FollowsController < ApplicationController
 
   def follow(followable, need_notification: false)
     user_follow = current_user.follow(followable)
-    puts
     Notification.send_new_follower_notification(user_follow) if need_notification
     "followed"
   rescue ActiveRecord::RecordInvalid

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -55,7 +55,7 @@ class FollowsController < ApplicationController
 
     followable_klass = case params[:followable_type].capitalize
                        when "Organization", "Tag", "Podcast"
-                         params[:followable_type].constantize
+                         params[:followable_type].capitalize.constantize
                        else
                          User
                        end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -53,12 +53,12 @@ class FollowsController < ApplicationController
   def create
     authorize Follow
 
-    followable = case params[:followable_type]
-                 when "Organization"
+    followable = case params[:followable_type].downcase
+                 when "organization"
                    Organization.find(params[:followable_id])
-                 when "Tag"
+                 when "tag"
                    Tag.find(params[:followable_id])
-                 when "Podcast"
+                 when "podcast"
                    Podcast.find(params[:followable_id])
                  else
                    User.find(params[:followable_id])
@@ -102,6 +102,7 @@ class FollowsController < ApplicationController
 
   def follow(followable, need_notification: false)
     user_follow = current_user.follow(followable)
+    puts
     Notification.send_new_follower_notification(user_follow) if need_notification
     "followed"
   rescue ActiveRecord::RecordInvalid

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -124,7 +124,7 @@ module ApplicationHelper
 
     user_follow = followable.instance_of?(User) ? "follow-user" : ""
     followable_type = if followable.respond_to?(:decorated?) && followable.decorated?
-                        followable.object.class.name.downcase
+                        followable.object.class.name
                       else
                         followable.class.name
                       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,7 +126,7 @@ module ApplicationHelper
     followable_type = if followable.respond_to?(:decorated?) && followable.decorated?
                         followable.object.class.name.downcase
                       else
-                        followable.class.name.downcase
+                        followable.class.name
                       end
 
     followable_name = followable.name

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -17,12 +17,7 @@
         </span>
 
         <div class="profile-header__actions">
-          <button
-            id="user-follow-butt"
-            class="crayons-btn whitespace-nowrap follow-action-button"
-            data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>", "name": "<%= @user.name %>"}'>
-            <%= t("core.follow") %>
-          </button>
+          <%= follow_button(@user) %>
         </div>
       </div>
 

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -17,7 +17,12 @@
         </span>
 
         <div class="profile-header__actions">
-          <%= follow_button(@user) %>
+          <button
+            id="user-follow-butt"
+            class="crayons-btn whitespace-nowrap follow-action-button"
+            data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>", "name": "<%= @user.name %>"}'>
+            <%= t("core.follow") %>
+          </button>
         </div>
       </div>
 

--- a/cypress/integration/seededFlows/articleFlows/followFromArticleLiquidTag.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/followFromArticleLiquidTag.spec.js
@@ -83,10 +83,10 @@ describe('Follow from article liquid tag', () => {
 
       it('Follows a user from an article liquid tag', () => {
         cy.findByRole('main').within(() => {
-          cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).as(
+          cy.findByRole('button', { name: 'Follow user back: Admin McAdmin'}).as(
             'followUserButton',
           );
-          cy.get('@followUserButton').should('have.text', 'Follow');
+          cy.get('@followUserButton').should('have.text', 'Follow back');
           cy.get('@followUserButton').click();
           cy.get('@followUserButton').should('have.text', 'Following');
           cy.get('@followUserButton').click();

--- a/cypress/integration/seededFlows/articleFlows/followOrganization.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/followOrganization.spec.js
@@ -34,6 +34,12 @@ describe('Follow an organization from article sidebar', () => {
       '/admin_mcadmin/test-organization-article-slug',
     );
     cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
+
+    // Go to dashboard and check under 'Following Organizations'
+    cy.visitAndWaitForUserSideEffects('/dashboard/following_organizations');
+    cy.findByRole('main')
+      .findByRole('link', { name: 'Bachmanity' })
+      .should('exist');
   });
 
   it('Unfollows an organization from the sidebar', () => {
@@ -58,5 +64,11 @@ describe('Follow an organization from article sidebar', () => {
       '/admin_mcadmin/test-organization-article-slug',
     );
     cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
+
+    // Go to dashboard and check under 'Following Organizations'
+    cy.visitAndWaitForUserSideEffects('/dashboard/following_organizations');
+    cy.findByRole('main')
+      .findByRole('link', { name: 'Bachmanity' })
+      .should('not.exist');
   });
 });

--- a/cypress/integration/seededFlows/articleFlows/followOrganization.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/followOrganization.spec.js
@@ -1,0 +1,49 @@
+describe('Follow organization from article sidebar', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.viewport('macbook-16');
+    cy.fixture('users/articleEditorV1User.json').as('user');
+
+    cy.get('@user').then((user) => {
+      cy.loginAndVisit(
+        user,
+        '/admin_mcadmin/test-organization-article-slug',
+      ).then(() => {
+        cy.get('[data-follow-clicks-initialized]');
+        cy.findByRole('heading', { name: 'Organization test article' });
+      });
+    });
+  });
+
+  it('Follows and unfollows an organization from the sidebar', () => {
+    cy.intercept('/follows').as('followRequest');
+
+    cy.findByRole('complementary', { name: 'Author details' }).within(() => {
+      cy.findByRole('button', { name: 'Follow organization: Bachmanity' }).as(
+        'followButton',
+      );
+    });
+
+    // Follow
+    cy.get('@followButton').click();
+    cy.get('@followButton').should('have.text', 'Following');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
+
+    // Check that the state persists after refresh
+    cy.visitAndWaitForUserSideEffects(
+      '/admin_mcadmin/test-organization-article-slug',
+    );
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
+
+    // Unfollow
+    cy.get('@followButton').click();
+    cy.get('@followButton').should('have.text', 'Follow');
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
+
+    // Check that the state persists after refresh
+    cy.visitAndWaitForUserSideEffects(
+      '/admin_mcadmin/test-organization-article-slug',
+    );
+    cy.get('@followButton').should('have.attr', 'aria-pressed', 'false');
+  });
+});

--- a/cypress/integration/seededFlows/articleFlows/followOrganization.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/followOrganization.spec.js
@@ -1,4 +1,4 @@
-describe('Follow organization from article sidebar', () => {
+describe('Follow an organization from article sidebar', () => {
   beforeEach(() => {
     cy.testSetup();
     cy.viewport('macbook-16');
@@ -15,7 +15,7 @@ describe('Follow organization from article sidebar', () => {
     });
   });
 
-  it('Follows and unfollows an organization from the sidebar', () => {
+  it('Follows an organization from the sidebar', () => {
     cy.intercept('/follows').as('followRequest');
 
     cy.findByRole('complementary', { name: 'Author details' }).within(() => {
@@ -34,6 +34,19 @@ describe('Follow organization from article sidebar', () => {
       '/admin_mcadmin/test-organization-article-slug',
     );
     cy.get('@followButton').should('have.attr', 'aria-pressed', 'true');
+  });
+
+  it('Unfollows an organization from the sidebar', () => {
+    cy.intercept('/follows').as('followRequest');
+
+    cy.findByRole('complementary', { name: 'Author details' }).within(() => {
+      cy.findByRole('button', { name: 'Follow organization: Bachmanity' }).as(
+        'followButton',
+      );
+    });
+
+    // Follow
+    cy.get('@followButton').click();
 
     // Unfollow
     cy.get('@followButton').click();

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -392,6 +392,7 @@ seeder.create_if_doesnt_exist(Article, "title", "Organization test article") do
     show_comments: true,
     user_id: admin_user.id,
     organization_id: Organization.first.id,
+    slug: "test-organization-article-slug",
   )
 end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Following an organization from an article show page doesn't work as expected.
Clicking the "Follow" button makes a POST request to FollowsController#create with the following params
```
{
  followable_type: "organization",
  followable_id: 4094,
  verb: "follow"
}
```
Notice the character casing of `followable_type`. 
In the `create` action, as per the current logic, the switch case incorrectly returns from the last else block a `User` object instead of `Organization`. Hence for the above example, a `follow` record is created with `followable_id` as `4094` and `followable_type` as `User` instead of `Organization`. 

This issue only occurs when following from the article show page. It appears to work properly when you try to follow the organization from it's profile.

## Related Tickets & Documents
Fixes #15001

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

