### PR TITLE
Don't notify authors about own org posts

### DIFF
--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -33,6 +33,9 @@ module Notifications
         article_followers = notifiable.followers.reject do |follower|
           user_ids_with_article_mentions.include?(follower.id)
         end
+        # We don't want to notify authors about their own articles, e.g. when
+        # they post under an organization.
+        article_followers -= [notifiable.user]
 
         article_followers.sort_by(&:updated_at).last(10_000).reverse_each do |follower|
           now = Time.current

--- a/spec/services/notifications/notifiable_action/send_spec.rb
+++ b/spec/services/notifications/notifiable_action/send_spec.rb
@@ -75,4 +75,17 @@ RSpec.describe Notifications::NotifiableAction::Send, type: :service do
       expect(Notification.count).to eq(0)
     end
   end
+
+  context "when publishing an article under an organization" do
+    it "doesn't create a notification for the article author" do
+      user = create(:user)
+      organization = create(:organization)
+      user.follow(organization)
+      article = create(:article, user: user, organization: organization)
+
+      expect do
+        described_class.call(article, "Published")
+      end.not_to change(Notification, :count)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

Up until now when a user published an article under an organization we sent them a notification about that. This PR fixes that.

## Related Tickets & Documents

Closes #14663

## QA Instructions, Screenshots, Recordings

This is well covered by the spec but if you want to test this do the following:

* Add your user to an organization
* Publish an article under the organization
* Ensure no notification has been created 

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
