### PR TITLE
Fix the Creator Signup Spec

### DIFF
--- a/cypress/integration/creatorOnboardingFlows/creatorSignup.spec.js
+++ b/cypress/integration/creatorOnboardingFlows/creatorSignup.spec.js
@@ -1,7 +1,10 @@
 describe('Creator Signup Page', () => {
   beforeEach(() => {
     cy.testSetup();
-    // NOTE: The "New Forem Owner" field is displayed based on a rails env variable which is set on Travis already. It cannot be dynamically updated for the Cypress tests, hence we have chosen the route of passing the forem_owner_secret as a param. This sends us down the path with least resistance.
+    // NOTE: The "New Forem Owner" field is displayed based on a rails env variable
+    // which is set on Travis already. It cannot be dynamically updated for the
+    // Cypress tests, hence we have chosen the route of passing the forem_owner_secret
+    // as a param. This sends us down the path with least resistance.
     cy.visit('/enter?state=new-user&forem_owner_secret=secret');
   });
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Previously, if you did not have `FOREM_OWNER_SECRET="secret"` set in your local env, and ran the Cypress tests, it would pass locally but fail on Travis. 
The reason for this is because our Travis setup has `FOREM_OWNER_SECRET="secret"` set which then sends the code down the path of the first `else` statement below where it requires the field to be filled out in our Cypress test:.
```
      <% if ForemInstance.needs_owner_secret? %>
        <% if params[:forem_owner_secret].present? %>
          <%= f.hidden_field :forem_owner_secret, value: params[:forem_owner_secret] %>
        <% else %>
          <div class="crayons-field mt-6">
            <%= f.label :forem_owner_secret, "New Forem Secret", class: "crayons-field__label" %>
            <%= f.password_field :forem_owner_secret, class: "crayons-textfield", required: ForemInstance.needs_owner_secret?, placeholder: "As provided by your Forem host" %>
          </div>
        <% end %>
      <% end %>
```


So, initially after brainstorming with @aitchiss we thought the best way forward is to just assume that that the ENV variable is set, thus mimicking what Travis is doing. However, we knew that not everyone has `FOREM_OWNER_SECRET="secret"` setup. We then thought of maybe having a custom error for those who do not have the ENV variable set up. 

It's useful to note here that it was not possible to update the rails environment variables in Cypress, since Cypress and Rails runs in two separate processes so there’s not an easy way for one to know what the other is doing.

**TLDR;**
After loads of more thought I found a different path of least resistance, which is simply setting the forem_owner_secret through the params which is already an existing code path. This allows the us to test both locally and on Travis without conflicts based on whether the ENV var is set or not.

```
      <% if ForemInstance.needs_owner_secret? %>
        <% if params[:forem_owner_secret].present? %>
          <%= f.hidden_field :forem_owner_secret, value: params[:forem_owner_secret] %>
        <% else %>
```

## Related Tickets & Documents
https://github.com/forem/forem/issues/14655

## QA Instructions, Screenshots, Recordings
1. Removing `export FOREM_OWNER_SECRET="secret"` in the `.env` file. 
2. Run `yarn e2e:creator-onboarding-seed`
The tests in `CreatorSignup.spec.js` should pass

3. Kill the Cypress server
4. Add `export FOREM_OWNER_SECRET="secret"` in the `.env` file. 
5. Run `yarn e2e:creator-onboarding-seed`
The tests in `CreatorSignup.spec.js` should pass


### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/RKZ25EH1junlFIUjza/giphy.gif)
