### PR TITLE
Replace spread syntax with Object.assign in untranspiled JS file

### DIFF
--- a/app/assets/javascripts/initializers/initScrolling.js
+++ b/app/assets/javascripts/initializers/initScrolling.js
@@ -289,10 +289,10 @@ function insertArticles(articles) {
 }
 
 function paginate(tag, params, requiresApproval) {
-  const searchHash = {
-    ...{ per_page: 15, page: nextPage },
-    ...JSON.parse(params),
-  };
+  const searchHash = Object.assign(
+    { per_page: 15, page: nextPage },
+    JSON.parse(params),
+  );
 
   if (tag && tag.length > 0) {
     searchHash.tag_names = searchHash.tag_names || [];


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Files in `app/javascripts/initializers` aren't transpiled, so some "newer" JavaScript operators aren't supported by older browsers. Even though technically we don't support the browser versions the used that has filed the issue has, I deemed it as a low effort fix to use `Object.assign()` which accomplish the same thing and it supposed by older versions of the same engine.

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/15137

## QA Instructions, Screenshots, Recordings

Scroll on a page with infinite scrolling

