### PR TITLE
Ensure shown vomit reactions have reactable

### DIFF
--- a/app/controllers/admin/feedback_messages_controller.rb
+++ b/app/controllers/admin/feedback_messages_controller.rb
@@ -78,16 +78,21 @@ module Admin
     private
 
     def get_vomits
+      status, limit = case params[:status]
+                      when "Open", ->(s) { s.blank? }
+                        ["valid", nil]
+                      when "Resolved"
+                        ["confirmed", 10]
+                      else
+                        ["invalid", 10]
+                      end
       q = Reaction.includes(:user, :reactable)
+        .where(category: "vomit", status: status)
         .select(:id, :user_id, :reactable_type, :reactable_id)
         .order(updated_at: :desc)
-      if params[:status] == "Open" || params[:status].blank?
-        q.where(category: "vomit", status: "valid")
-      elsif params[:status] == "Resolved"
-        q.where(category: "vomit", status: "confirmed").limit(10)
-      else
-        q.where(category: "vomit", status: "invalid").limit(10)
-      end
+        .limit(limit)
+      # don't show reactions where the reactable was not found
+      q.select(&:reactable)
     end
 
     def send_slack_message(params)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is the counter-argument to #15152 - filter in the controller
rather than adding lots of conditional logic to the view to handle the
case where there was a vomit reaction left for a deleted user causing
the moderation reports page to fail to load.

This was determined to be a safer route after finding additional places we try to reach into reactable (like the published time for articles) and a realization that there's no need to act on a vomit when the reacted item (article, user, comment) is no longer present.

The underlying issue is more than likely a user deletion failure (if the process fails to cleanup dependencies the data is left in an inconsistent state). 

I cleaned up (you might disagree!) the conditions around the status parameter by extracting the choices early and having a single query.

## Related Tickets & Documents

#15152 
https://app.honeybadger.io/projects/66984/faults/76463803

## QA Instructions, Screenshots, Recordings

Same as 15152 - visit the moderation/reports page, find a vomited item, delete it - reload the page. Vomit reaction to deleted object should no longer be shown - no error should be raised.

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: bugfix
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not:  bugfix, only facing moderators

