### PR TITLE
Fix Tooltips 

### DIFF
--- a/app/assets/stylesheets/components/tooltips.scss
+++ b/app/assets/stylesheets/components/tooltips.scss
@@ -37,7 +37,10 @@
     @extend .crayons-tooltip__content;
     content: attr(data-tooltip);
     left: 0;
+    bottom: 100%;
+    top: unset;
     transform: translateY(var(--su-1));
+    pointer-events: none;
   }
 
   &:hover {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When working on an update to a feature, I tried adding a tooltip and realized that they weren't working properly. I did some more debugging and realized that the `.crayons-hover-tooltip` class is being used in two places, namely:
- On the comments page when the condition `commentable_author_is_op` is true 
- when invite-only-mode enabled and we have no enabled registration options

Hence I first tested if the tooltiips are working correctly in these places and they weren't as per the screenshots below: 

<img width="970" alt="Screenshot 2021-10-22 at 12 01 48" src="https://user-images.githubusercontent.com/2786819/138437069-871ecf27-ae14-4657-ab3d-dd6e92553a00.png">
<img width="483" alt="Screenshot 2021-10-22 at 12 03 52" src="https://user-images.githubusercontent.com/2786819/138437082-d07616c6-189c-4a3f-b124-7cf82cf8788e.png">


I then did some debugging and realized that the `bottom: 100%` was causing the issue.
On removal i tested again and the tooltips were visible again:

<img width="1131" alt="Screenshot 2021-10-22 at 12 06 45" src="https://user-images.githubusercontent.com/2786819/138437265-88de5eec-2a7e-46ba-910d-2007a6e5a7a2.png">
  
<img width="428" alt="Screenshot 2021-10-22 at 12 06 28" src="https://user-images.githubusercontent.com/2786819/138437257-115f6514-f8a9-4f99-ac44-b0b5c8e08500.png">

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
- Go to the /config page 
- Click on "invite-only-mode" and refresh.
In this section you should be able to test the tooltips.

If you want to test the comment tooltips, you can [set this method to return true](https://github.com/forem/forem/blob/main/app/helpers/comments_helper.rb#L18) and craete a comment on a post to see the author tooltip. 

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
