### PR TITLE
Use proper Node version for Storybook

### DIFF
--- a/app/javascript/netlify.toml
+++ b/app/javascript/netlify.toml
@@ -5,7 +5,6 @@
   ignore = "git diff --quiet HEAD^ HEAD ./ && git diff --quiet HEAD^ HEAD ../assets/stylesheets/config/"
 [build.environment]
   NODE_VERSION = "14"
-  YARN_VERSION = "1.21"
 
 # See <https://docs.netlify.com/routing/redirects/redirect-options/> for more options
 [[redirects]]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes an issue where Storybook builds weren't working because we had a package that needed a higher Node version than our Netlify build specified. I've updated to match our `.nvmrc`. 