### PR TITLE
Add back reaction translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,14 @@ en:
     popular_tags: Popular Tags
     post: Post
     posts: Posts
+    reaction: Reaction
+    reaction_pluralized:
+      one: reaction
+      other: reactions
+    reactions:
+      heart: Heart
+      save: Save
+      unicorn: Unicorn
     read_next: Read next
     reading_list: Reading list
     reply: Reply

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -41,6 +41,14 @@ fr:
     popular_tags: Sujets populaires
     post: Publication
     posts: Publications
+    reaction: Réaction
+    reaction_pluralized:
+      one: réaction
+      other: réactions
+    reactions:
+      heart: Coeur
+      save: Sauver
+      unicorn: Licorne
     read_next: Lire ensuite
     reading_list: Liste de lecture
     reply: Répondre


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This adds translations that were removed in https://github.com/forem/forem/pull/15058 and not added back in by accident 😅 

**This is a quick fix.** I'm not 100% sure how to solve what #15058 was trying to do, which was to extract reaction translations out into its own file. I couldn't figure out how to convert the JS properly to use it in the new file pattern (`config/locales/views/reactions/en.yml` for ex.) -- to be fixed later.

## Related Tickets & Documents
#15058 

## QA Instructions, Screenshots, Recordings
1. Leave reactions on an article
2. Go to home page
3. Click Top filter, sort by infinity
4. See that there aren't translation errors

### UI accessibility concerns?
Nope

## Added tests?
- no, quick fix

## [optional] Are there any post deployment tasks we need to perform?
No