### PR TITLE
Grab IP address for Nginx Forem instances

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -163,7 +163,7 @@ class ApplicationController < ActionController::Base
   end
 
   def anonymous_user
-    User.new(ip_address: request.env["HTTP_FASTLY_CLIENT_IP"])
+    User.new(ip_address: request.env["HTTP_FASTLY_CLIENT_IP"] || request.env["HTTP_X_FORWARDED_FOR"])
   end
 
   def api_action?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a bug where we weren't able to capture IP addresses of users without accounts for Forem Cloud/Forems not using Fastly. This was specifically an issue for submitting abuse reports as an anonymous user for non-Fastly Forems.

With this change, we'll be able to rate limit anonymous users properly by their IP address.

## Related Tickets & Documents
Slack thread: https://forem-team.slack.com/archives/C0134R988P9/p1635260036003400

## QA Instructions, Screenshots, Recordings
Try to submit an abuse report locally while logged out: http://localhost:3000/report-abuse

Note that you'll need Google ReCAPTCHA enabled locally.

### UI accessibility concerns?
Nope

## Added tests?

- [x] No, and this is why: Not too sure how to write one, but we did test in production! 🙃

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![A person claps their hands and says triumphantly, "Easy."](https://media.giphy.com/media/aNbGyHcDYphNbhe4EE/giphy.gif)