### PR TITLE
Cleanup single reaction template

### DIFF
--- a/app/views/notifications/_single_reaction.html.erb
+++ b/app/views/notifications/_single_reaction.html.erb
@@ -23,7 +23,6 @@
           actors: link_to(notification.json_data["user"]["name"], notification.json_data["user"]["path"], class: "crayons-link fw-bold"),
           # title is blank when it's a comment with only an image, for example
           title: title_link,
-          class: "crayons-link fw-bold",
           end: "",
           reactions: tag.span(inline_svg_tag(reaction_image(category), class: "crayons-icon reaction-image mx-1 reaction-icon--#{category}", title: t("views.reactions.category.#{category}")))) %>
   </div>


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

An error was reported on the notifications index page for some comments (this logs to honeybadger but has internal handling on the notification list to show "An error occurred!" in the tile instead of the reaction comment).

This is related to a recent localization change to the erb template in #15058 that slipped through (I'm still not sure how to create those notifications in app and don't know what the cause is in the app)

## Related Tickets & Documents

fixes #15205 

## QA Instructions, Screenshots, Recordings

Load the last notification for a reaction.
Update the json_data to cause `json_data["reaction"]["aggregated_siblings"]` to be empty (`[]`) or contain only stale info (older than 24 hours).
View the notified user's /notifications index page 

Confirm no tile contains "An Error Occurred!" and the reaction is present in the list.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Bugfix
- [x] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![paren-bug](https://user-images.githubusercontent.com/1237369/138958941-c5601c14-2ca9-4d64-acaa-10c7011b1f06.jpeg)
