### PR TITLE
Media Cards - CSS fix for border radius

### DIFF
--- a/app/assets/stylesheets/components/media-cards.scss
+++ b/app/assets/stylesheets/components/media-cards.scss
@@ -11,7 +11,9 @@
     position: relative;
 
     img {
-      border-radius: var(--radius-auto) var(--radius-auto) 0 0;
+      border-radius: var(--radius-auto);
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
     }
 
     &__badge {

--- a/app/assets/stylesheets/components/media-cards.scss
+++ b/app/assets/stylesheets/components/media-cards.scss
@@ -2,7 +2,6 @@
 
 .media-card {
   background: var(--card-bg);
-  border-radius: var(--radius);
   display: flex;
   flex-direction: column;
   color: var(--card-color);
@@ -12,7 +11,7 @@
     position: relative;
 
     img {
-      border-radius: var(--radius) var(--radius) 0 0;
+      border-radius: var(--radius-auto) var(--radius-auto) 0 0;
     }
 
     &__badge {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

As title says: it's a tiny CSS fix for making border-radius on media cards (videos primarily) automatic as we have on other cards... 

## QA Instructions, Screenshots, Recordings

When viewing /videos, each individual card should have rounded corners on desktop and NOT rounded corners on mobile.

## Added/updated tests?

- [x] No

## [Forem core team only] How will this change be communicated?

- [x] No