### PR TITLE
Escape the backslash in the regex string so the backslash is preserved

### DIFF
--- a/app/views/admin/navigation_links/_form.html.erb
+++ b/app/views/admin/navigation_links/_form.html.erb
@@ -5,7 +5,7 @@
 </div>
 <div class="form-group">
   <%= form.label :url %>
-  <%= form.text_field :url, class: "form-control", pattern: "^(https?:\/\/|\/)\w+\.[^\s]+$|^\/[^\s]*$", title: "The URL can be absolute by beginning with http/s or it can be relative beginning with a /", required: true %>
+  <%= form.text_field :url, class: "form-control", pattern: "^(https?:\/\/|\/)\\w+\.[^\s]+$|^\/[^\s]*$", title: "The URL can be absolute by beginning with http/s or it can be relative beginning with a /", required: true %>
   <div class="alert alert-info">A full (external) or relative (internal) URL for the link</div>
 </div>
 <div class="form-group" data-controller="svg-icon-upload">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This ensures it's rendered in the pattern regex field in the browser.

Without `"\\w"` -> `"\w"` we get `"\w"` -> `"w"` and only urls starting with
w (www, for example) are accepted by the matcher.


## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Visit http://localhost:3000/admin/customization/navigation_links and add a new link or edit an existing one.

Set the url to https://forem.dev 

On main:

![pattern-rejected](https://user-images.githubusercontent.com/1237369/139509152-f863f37b-6825-4fd2-99c7-010194f91b3e.png)

this branch (hard to take an image of a warning _not_ being shown, but it's successfully posting the update):

![Screenshot from 2021-10-29 17-47-20](https://user-images.githubusercontent.com/1237369/139509180-abca3824-c733-4c88-bef9-031e2bb78f15.png)


### UI accessibility concerns?

none

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: we have cypress tests in place that expect the form to show, and tests that exercise the controller (spec/requests/admin/navigation_link_spec), should we move the logic from the request test to the e2e tests to validate the input pattern works as expected?  
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

