### PR TITLE
Compare the utc offset from the timestamp, not now

### DIFF
--- a/spec/views/articles_spec.rb
+++ b/spec/views/articles_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "articles/show", type: :view do
     render
 
     # Jan 1, 1970 or Dec 31, 1969, depending on time zone
-    expected_date = Time.zone.utc_offset.negative? ? "Dec 31, 1969" : "Jan 1, 1970"
+    expected_date = Time.zone.at(0).utc_offset.negative? ? "Dec 31, 1969" : "Jan 1, 1970"
     expect(rendered).to have_text(expected_date)
     expect(rendered).not_to have_text("</time>")
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Time Zones are political things, and move. The timezone database knows
this, and correctly interprets times as they would have been at the
time.

For example, when the Time zone is Africa/Monrovia, the offset now is
0, but the offset in 1970 was [-44.5 minutes](https://en.wikipedia.org/wiki/UTC%E2%88%9200:44#History ), so Time.zone.at(0) is Dec 31st, 1969, 23:15:30 and not Jan 1st, 1970 00:00:00. 

Prevent this spec from randomly failing based on Zonebie's selected
timezone by comparing the offset _then_ against UTC, and predicting
whether the 60's have ended yet.


## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

```
ZONEBIE_TZ="Africa/Monrovia" bundle exec rspec spec/views/articles_spec.rb
```

### UI accessibility concerns?
None

## Added/updated tests?

- [x] Yes (fixing a test)

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: flaky test update

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
