### PR TITLE
Disable all providers when `providers_to_enable` param is blank

### DIFF
--- a/app/services/settings/authentication/upsert.rb
+++ b/app/services/settings/authentication/upsert.rb
@@ -11,7 +11,7 @@ module Settings
       end
 
       def self.update_enabled_providers(value)
-        enabled_providers = value.split(",").filter_map do |entry|
+        enabled_providers = value.to_s.split(",").filter_map do |entry|
           entry unless invalid_provider_entry(entry)
         end
         return if email_login_disabled_with_one_or_less_auth_providers(enabled_providers)

--- a/app/services/settings/authentication/upsert.rb
+++ b/app/services/settings/authentication/upsert.rb
@@ -11,7 +11,10 @@ module Settings
       end
 
       def self.update_enabled_providers(value)
-        return if value.blank?
+        if value.blank?
+          Settings::Authentication.providers = []
+          return
+        end
 
         enabled_providers = value.split(",").filter_map do |entry|
           entry unless invalid_provider_entry(entry)

--- a/app/services/settings/authentication/upsert.rb
+++ b/app/services/settings/authentication/upsert.rb
@@ -11,11 +11,6 @@ module Settings
       end
 
       def self.update_enabled_providers(value)
-        if value.blank?
-          Settings::Authentication.providers = []
-          return
-        end
-
         enabled_providers = value.split(",").filter_map do |entry|
           entry unless invalid_provider_entry(entry)
         end

--- a/spec/services/settings/authentication/upsert_spec.rb
+++ b/spec/services/settings/authentication/upsert_spec.rb
@@ -35,6 +35,38 @@ RSpec.describe Settings::Authentication::Upsert, type: :service do
     }.from(%w[github]).to(%w[twitter])
   end
 
+  it "does not save 1 or fewer providers when email_password login is not allowed" do
+    expect do
+      Settings::Authentication.allow_email_password_login = false
+      described_class.call(
+        {
+          "auth_providers_to_enable" => "twitter",
+          "twitter_key" => "asdf",
+          "twitter_secret" => "asdf_secret"
+        },
+      )
+    end.not_to change {
+      Settings::Authentication.providers
+    }
+  end
+
+  it "will save with 1 or providers providers when email_password login is not allowed" do
+    expect do
+      Settings::Authentication.allow_email_password_login = false
+      described_class.call(
+        {
+          "auth_providers_to_enable" => "twitter,github",
+          "twitter_key" => "asdf",
+          "twitter_secret" => "asdf_secret",
+          "github_key" => "asdf",
+          "github_secret" => "asdf_secret"
+        },
+      )
+    end.to change {
+      Settings::Authentication.providers
+    }.from(%w[github]).to(%w[twitter github])
+  end
+
   it "disables providers even when provider parameter is blank" do
     expect do
       described_class.call({ "auth_providers_to_enable" => "" })

--- a/spec/services/settings/authentication/upsert_spec.rb
+++ b/spec/services/settings/authentication/upsert_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Settings::Authentication::Upsert, type: :service do
+  before { Settings::Authentication.providers = %w[github] }
+
+  it "assigns enabled providers from parameters" do
+    expect do
+      described_class.call(
+        {
+          "auth_providers_to_enable" => "github,facebook,twitter",
+          "github_key" => "asdf",
+          "github_secret" => "asdf_secret",
+          "twitter_key" => "asdf",
+          "twitter_secret" => "asdf_secret",
+          "facebook_key" => "asdf",
+          "facebook_secret" => "asdf_secret"
+        },
+      )
+    end.to change {
+      Settings::Authentication.providers
+    }.from(%w[github]).to(%w[github facebook twitter])
+  end
+
+  it "disables providers that are not present" do
+    expect do
+      described_class.call(
+        {
+          "auth_providers_to_enable" => "twitter",
+          "twitter_key" => "asdf",
+          "twitter_secret" => "asdf_secret"
+        },
+      )
+    end.to change {
+      Settings::Authentication.providers
+    }.from(%w[github]).to(%w[twitter])
+  end
+
+  it "disables providers even when provider parameter is blank" do
+    expect do
+      described_class.call({ "auth_providers_to_enable" => "" })
+    end.to change {
+      Settings::Authentication.providers
+    }.from(%w[github]).to([])
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Assign empty array to `Settings::Authentication.providers` if the providers string is blank (all of them are disabled)

Also add new spec for example cases of the `Settings::Authentication::Upsert` helper

## Related Tickets & Documents
#14975 

## QA Instructions, Screenshots, Recordings

- Login as Admin
- Go to Admin -> Customization -> Authentication Settings
- Make sure a provider is enabled
- Disable all providers
- refresh
- all providers should still be disabled

# Screenshots
<img width="983" alt="image" src="https://user-images.githubusercontent.com/1904364/139777965-aff7536e-ec83-4055-be13-64480819a675.png">

- _click_ `disable`
- _click_ `Update Settings`
- _refresh_

<img width="939" alt="image" src="https://user-images.githubusercontent.com/1904364/139778060-5d38f0f9-f2b0-41c6-9ac6-1e008b408642.png">

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
