### PR TITLE
treat cmd and ctrl key shortcuts separately on macOS

### DIFF
--- a/app/assets/javascripts/initializers/runtime.js
+++ b/app/assets/javascripts/initializers/runtime.js
@@ -156,4 +156,14 @@ class Runtime {
       return event.ctrlKey;
     }
   }
+
+  /**
+   * Returns a string representation of the expected modifier key for the current OS.
+   * This allows us to display correct shortcut key hints to users in the UI, and set up correct shortcut key bindings.
+   *
+   * @returns {string} either 'cmd' if on macOS, or 'ctrl' otherwise
+   */
+  static getOSKeyboardModifierKeyString() {
+    return Runtime.currentOS() === 'macOS' ? 'cmd' : 'ctrl';
+  }
 }

--- a/app/javascript/.storybook/preview-head.html
+++ b/app/javascript/.storybook/preview-head.html
@@ -1,7 +1,7 @@
 <script>
   var Runtime = {
-    currentOS: function () {
-      return 'macOS';
+    getOSKeyboardModifierKeyString: function () {
+      return 'cmd';
     },
   };
 </script>

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -477,7 +477,7 @@ export class ArticleForm extends Component {
 
         <KeyboardShortcuts
           shortcuts={{
-            [`${Runtime.currentOS() === 'macOS' ? 'cmd' : 'ctrl'}+shift+KeyP`]:
+            [`${Runtime.getOSKeyboardModifierKeyString()}+shift+KeyP`]:
               this.fetchPreview,
           }}
         />

--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -1,3 +1,4 @@
+/* global Runtime */
 import { h, Component } from 'preact';
 import PropTypes from 'prop-types';
 import linkState from 'linkstate';
@@ -476,7 +477,8 @@ export class ArticleForm extends Component {
 
         <KeyboardShortcuts
           shortcuts={{
-            'ctrl+shift+KeyP': this.fetchPreview,
+            [`${Runtime.currentOS() === 'macOS' ? 'cmd' : 'ctrl'}+shift+KeyP`]:
+              this.fetchPreview,
           }}
         />
       </form>

--- a/app/javascript/crayons/MarkdownToolbar/MarkdownToolbar.jsx
+++ b/app/javascript/crayons/MarkdownToolbar/MarkdownToolbar.jsx
@@ -1,4 +1,3 @@
-/* global Runtime */
 import { h } from 'preact';
 import { useState, useLayoutEffect } from 'preact/hooks';
 import {
@@ -16,9 +15,6 @@ export const MarkdownToolbar = ({ textAreaId }) => {
   const [overflowMenuOpen, setOverflowMenuOpen] = useState(false);
   const smallScreen = useMediaQuery(`(max-width: ${BREAKPOINTS.Medium - 1}px)`);
 
-  const keyboardShortcutModifierText =
-    Runtime.currentOS() === 'macOS' ? 'CMD' : 'CTRL';
-
   const markdownSyntaxFormatters = {
     ...coreSyntaxFormatters,
     ...secondarySyntaxFormatters,
@@ -27,11 +23,13 @@ export const MarkdownToolbar = ({ textAreaId }) => {
   const keyboardShortcuts = Object.fromEntries(
     Object.keys(markdownSyntaxFormatters)
       .filter(
-        (syntaxName) => !!markdownSyntaxFormatters[syntaxName].keyboardShortcut,
+        (syntaxName) =>
+          !!markdownSyntaxFormatters[syntaxName].getKeyboardShortcut,
       )
       .map((syntaxName) => {
-        const { keyboardShortcut } = markdownSyntaxFormatters[syntaxName];
-        return [keyboardShortcut, () => insertSyntax(syntaxName)];
+        const { command } =
+          markdownSyntaxFormatters[syntaxName].getKeyboardShortcut?.();
+        return [command, () => insertSyntax(syntaxName)];
       }),
   );
 
@@ -189,8 +187,9 @@ export const MarkdownToolbar = ({ textAreaId }) => {
 
   const getSecondaryFormatterButtons = (isOverflow) =>
     Object.keys(secondarySyntaxFormatters).map((controlName, index) => {
-      const { icon, label, keyboardShortcutKeys } =
+      const { icon, label, getKeyboardShortcut } =
         secondarySyntaxFormatters[controlName];
+
       return (
         <Button
           key={`${controlName}-btn`}
@@ -216,9 +215,9 @@ export const MarkdownToolbar = ({ textAreaId }) => {
             smallScreen ? null : (
               <span aria-hidden="true">
                 {label}
-                {keyboardShortcutKeys ? (
+                {getKeyboardShortcut ? (
                   <span className="opacity-75">
-                    {` ${keyboardShortcutModifierText} + ${keyboardShortcutKeys}`}
+                    {` ${getKeyboardShortcut().tooltipHint}`}
                   </span>
                 ) : null}
               </span>
@@ -236,7 +235,7 @@ export const MarkdownToolbar = ({ textAreaId }) => {
       aria-controls={textAreaId}
     >
       {Object.keys(coreSyntaxFormatters).map((controlName, index) => {
-        const { icon, label, keyboardShortcutKeys } =
+        const { icon, label, getKeyboardShortcut } =
           coreSyntaxFormatters[controlName];
         return (
           <Button
@@ -253,9 +252,9 @@ export const MarkdownToolbar = ({ textAreaId }) => {
               smallScreen ? null : (
                 <span aria-hidden="true">
                   {label}
-                  {keyboardShortcutKeys ? (
+                  {getKeyboardShortcut ? (
                     <span className="opacity-75">
-                      {` ${keyboardShortcutModifierText} + ${keyboardShortcutKeys}`}
+                      {` ${getKeyboardShortcut().tooltipHint}`}
                     </span>
                   ) : null}
                 </span>

--- a/app/javascript/crayons/MarkdownToolbar/__tests__/MarkdownToolbar.test.jsx
+++ b/app/javascript/crayons/MarkdownToolbar/__tests__/MarkdownToolbar.test.jsx
@@ -7,7 +7,7 @@ import { MarkdownToolbar } from '../MarkdownToolbar';
 describe('<MarkdownToolbar />', () => {
   beforeEach(() => {
     global.Runtime = {
-      currentOS: jest.fn(() => 'macOS'),
+      getOSKeyboardModifierKeyString: jest.fn(() => 'cmd'),
     };
 
     global.window.matchMedia = jest.fn((query) => {

--- a/app/javascript/crayons/MarkdownToolbar/markdownSyntaxFormatters.js
+++ b/app/javascript/crayons/MarkdownToolbar/markdownSyntaxFormatters.js
@@ -1,3 +1,4 @@
+/* global Runtime */
 import {
   Bold,
   Italic,
@@ -13,6 +14,9 @@ import {
   Divider,
 } from './icons';
 
+const keyboardShortcutModifier = () =>
+  Runtime.currentOS() === 'macOS' ? 'cmd' : 'ctrl';
+
 const isStringStartAUrl = (string) => {
   const startingText = string.substring(0, 8);
   return startingText === 'https://' || startingText.startsWith('http://');
@@ -22,8 +26,13 @@ export const coreSyntaxFormatters = {
   bold: {
     icon: Bold,
     label: 'Bold',
-    keyboardShortcut: 'ctrl+b',
-    keyboardShortcutKeys: `B`,
+    getKeyboardShortcut: () => {
+      const modifier = keyboardShortcutModifier();
+      return {
+        command: `${modifier}+b`,
+        tooltipHint: `${modifier.toUpperCase()} + B`,
+      };
+    },
     getFormatting: (selection) => ({
       formattedText: `**${selection}**`,
       cursorOffsetStart: 2,
@@ -33,8 +42,13 @@ export const coreSyntaxFormatters = {
   italic: {
     icon: Italic,
     label: 'Italic',
-    keyboardShortcut: 'ctrl+i',
-    keyboardShortcutKeys: `I`,
+    getKeyboardShortcut: () => {
+      const modifier = keyboardShortcutModifier();
+      return {
+        command: `${modifier}+i`,
+        tooltipHint: `${modifier.toUpperCase()} + I`,
+      };
+    },
     getFormatting: (selection) => ({
       formattedText: `_${selection}_`,
       cursorOffsetStart: 1,
@@ -44,8 +58,13 @@ export const coreSyntaxFormatters = {
   link: {
     icon: Link,
     label: 'Link',
-    keyboardShortcut: 'ctrl+k',
-    keyboardShortcutKeys: `K`,
+    getKeyboardShortcut: () => {
+      const modifier = keyboardShortcutModifier();
+      return {
+        command: `${modifier}+k`,
+        tooltipHint: `${modifier.toUpperCase()} + K`,
+      };
+    },
     getFormatting: (selection) => {
       const isUrl = isStringStartAUrl(selection);
       const selectionLength = selection.length;
@@ -170,8 +189,13 @@ export const secondarySyntaxFormatters = {
   underline: {
     icon: Underline,
     label: 'Underline',
-    keyboardShortcut: 'ctrl+u',
-    keyboardShortcutKeys: `U`,
+    getKeyboardShortcut: () => {
+      const modifier = keyboardShortcutModifier();
+      return {
+        command: `${modifier}+u`,
+        tooltipHint: `${modifier.toUpperCase()} + U`,
+      };
+    },
     getFormatting: (selection) => ({
       formattedText: `<u>${selection}</u>`,
       cursorOffsetStart: 3,
@@ -181,8 +205,13 @@ export const secondarySyntaxFormatters = {
   strikethrough: {
     icon: Strikethrough,
     label: 'Strikethrough',
-    keyboardShortcut: 'ctrl+shift+x',
-    keyboardShortcutKeys: `SHIFT + X`,
+    getKeyboardShortcut: () => {
+      const modifier = keyboardShortcutModifier();
+      return {
+        command: `${modifier}+shift+x`,
+        tooltipHint: `${modifier.toUpperCase()} + SHIFT + X`,
+      };
+    },
     getFormatting: (selection) => ({
       formattedText: `~~${selection}~~`,
       cursorOffsetStart: 2,

--- a/app/javascript/crayons/MarkdownToolbar/markdownSyntaxFormatters.js
+++ b/app/javascript/crayons/MarkdownToolbar/markdownSyntaxFormatters.js
@@ -14,9 +14,6 @@ import {
   Divider,
 } from './icons';
 
-const keyboardShortcutModifier = () =>
-  Runtime.currentOS() === 'macOS' ? 'cmd' : 'ctrl';
-
 const isStringStartAUrl = (string) => {
   const startingText = string.substring(0, 8);
   return startingText === 'https://' || startingText.startsWith('http://');
@@ -27,7 +24,7 @@ export const coreSyntaxFormatters = {
     icon: Bold,
     label: 'Bold',
     getKeyboardShortcut: () => {
-      const modifier = keyboardShortcutModifier();
+      const modifier = Runtime.getOSKeyboardModifierKeyString();
       return {
         command: `${modifier}+b`,
         tooltipHint: `${modifier.toUpperCase()} + B`,
@@ -43,7 +40,7 @@ export const coreSyntaxFormatters = {
     icon: Italic,
     label: 'Italic',
     getKeyboardShortcut: () => {
-      const modifier = keyboardShortcutModifier();
+      const modifier = Runtime.getOSKeyboardModifierKeyString();
       return {
         command: `${modifier}+i`,
         tooltipHint: `${modifier.toUpperCase()} + I`,
@@ -59,7 +56,7 @@ export const coreSyntaxFormatters = {
     icon: Link,
     label: 'Link',
     getKeyboardShortcut: () => {
-      const modifier = keyboardShortcutModifier();
+      const modifier = Runtime.getOSKeyboardModifierKeyString();
       return {
         command: `${modifier}+k`,
         tooltipHint: `${modifier.toUpperCase()} + K`,
@@ -190,7 +187,7 @@ export const secondarySyntaxFormatters = {
     icon: Underline,
     label: 'Underline',
     getKeyboardShortcut: () => {
-      const modifier = keyboardShortcutModifier();
+      const modifier = Runtime.getOSKeyboardModifierKeyString();
       return {
         command: `${modifier}+u`,
         tooltipHint: `${modifier.toUpperCase()} + U`,
@@ -206,7 +203,7 @@ export const secondarySyntaxFormatters = {
     icon: Strikethrough,
     label: 'Strikethrough',
     getKeyboardShortcut: () => {
-      const modifier = keyboardShortcutModifier();
+      const modifier = Runtime.getOSKeyboardModifierKeyString();
       return {
         command: `${modifier}+shift+x`,
         tooltipHint: `${modifier.toUpperCase()} + SHIFT + X`,

--- a/app/javascript/shared/components/useKeyboardShortcuts.js
+++ b/app/javascript/shared/components/useKeyboardShortcuts.js
@@ -126,10 +126,13 @@ export function useKeyboardShortcuts(
     const keyEvent = (e) => {
       if (e.defaultPrevented) return;
 
-      // Get special keys
-      const keys = `${e.ctrlKey || e.metaKey ? 'ctrl+' : ''}${
-        e.altKey ? 'alt+' : ''
-      }${(e.ctrlKey || e.metaKey || e.altKey) && e.shiftKey ? 'shift+' : ''}`;
+      const ctrlKeyEntry = e.ctrlKey ? 'ctrl+' : '';
+      const cmdKeyEntry = e.metaKey ? 'cmd+' : '';
+      const altKeyEntry = e.altKey ? 'alt+' : '';
+      const shiftKeyEntry = e.shiftKey ? 'shift+' : '';
+
+      // We build the special keys string in an opinionated order to ensure consistency
+      const keys = `${ctrlKeyEntry}${cmdKeyEntry}${altKeyEntry}${shiftKeyEntry}`;
 
       // If no special keys, except shift, are pressed and focus is inside a field return
       if (e.target instanceof Node && isFormField(e.target) && !keys) return;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Our current `KeyboardShortcuts` helper component conflates `ctrl` and `cmd` as the same thing, which causes a problem on macOS where `ctrl` keys have separate readline shortcut bindings, which we shouldn't unintentionally override.

This currently mostly impacts the `MarkdownToolbar` in storybook, where e.g. `ctrl+b` is triggering the same action as `cmd+b`.  It also impacts the editor preview shortcut which is `cmd+shift+p` on macOS, but is also triggered by `ctrl+shift+p`.

The change in this PR updates the `KeyboardShortcuts` to regard `ctrl` and `cmd` separately. It's therefore the responsibility of the caller to decide if `ctrl` and `cmd` should execute the same action, and only listen for the correct modifier key if not.

## Related Tickets & Documents

Fixes https://github.com/forem/forem/issues/15263

## QA Instructions, Screenshots, Recordings

- Run `yarn storybook` locally, and select the `MarkdownToolbar` from the left side navigation
- If you are using a mac, check that `cmd` shortcuts continue to work as expected (shortcuts, where available, are noted in the tooltips if you hover or focus a toolbar button)
- If you are using a mac, check that substituting `ctrl` for `cmd` for these shortcuts does not trigger the formatters
- If you are not using a mac, check that `ctrl` shortcuts continue to work as expected (NB: you will still see "CMD" noted in the tooltip in the toolbar - this is a shortcoming of Storybook, where we stub the currentOS)
- Run the main app
- Go to create a new post at `/new`
- If you are on mac, check that `cmd+shift+p` opens the preview
- If you are on mac, check that `ctrl+shift+p` doesn't open the preview
- If you're not using a mac, check that `ctrl+shift+p` opens the preview as before 

### UI accessibility concerns?

This does partly address an accessibility concern, in that a lot of assistive technologies come with their own keyboard shortcuts, and this will help us (to some extent) make sure we are not overriding commands unnecessarily.

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why:  I think this will be well tested when we start adding integration tests for the markdown toolbar
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


