### PR TITLE
Caching sum privileged reaction scores

### DIFF
--- a/db/migrate/20211104161101_add_privileged_users_reaction_sum.rb
+++ b/db/migrate/20211104161101_add_privileged_users_reaction_sum.rb
@@ -1,0 +1,5 @@
+class AddPrivilegedUsersReactionSum < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :privileged_users_reaction_points_sum, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_19_151431) do
+ActiveRecord::Schema.define(version: 2021_11_04_161101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2021_10_19_151431) do
     t.integer "positive_reactions_count", default: 0, null: false
     t.integer "previous_positive_reactions_count", default: 0
     t.integer "previous_public_reactions_count", default: 0, null: false
+    t.integer "privileged_users_reaction_points_sum", default: 0
     t.text "processed_html"
     t.integer "public_reactions_count", default: 0, null: false
     t.boolean "published", default: false


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

Adding caching column for reaction sums

In a future commit, I'll introduce the logic to handle the caching of the sum.

Related to  #15240

## Related Tickets & Documents

PR #15240 

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] This change does not need to be communicated, and this is why not: this change introduces a new cached column
