### PR TITLE
[Quick Fix] Fix Layout Of Field Description and Character Count

### DIFF
--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -157,13 +157,17 @@
                               aria: { describedby: "#{field.attribute_name}-description" },
                               data: { character_span_id: "#{field.attribute_name}-characters" },
                               class: "crayons-textfield") %>
-            <div id="<%= field.attribute_name %>-description" class="self-end fs-s">
-              <span class="screen-reader-only">Available characters used: </span>
-              <span id="<%= field.attribute_name %>-characters"></span>/<%= character_count_denominator(field["input_type"]) %>
+            <div style="display: grid; grid-template-columns: 85% 15%;">
+              <div>
+                <% if field.description.present? %>
+                  <p class="crayons-field__description"><%= field.description %></p>
+                <% end %>
+              </div>
+               <div id="<%= field.attribute_name %>-description" class="fs-s" style="justify-self: end;">
+                <span class="screen-reader-only">Available characters used: </span>
+                <span id="<%= field.attribute_name %>-characters"></span>/<%= character_count_denominator(field["input_type"]) %>
+              </div>
             </div>
-          <% end %>
-          <% if field.description.present? %>
-            <p class="crayons-field__description"><%= field.description %></p>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Quick fix for the wonky layout of profile descriptions and their character count (from [this PR](https://github.com/forem/forem/pull/15255)).

## QA Instructions, Screenshots, Recordings
Navigate to localhost:3000/settings/profile and ensure that, for fields that have a description, the description and the character counter are on the same line and spaced adequately from each other

### UI accessibility concerns?
None, this is purely layout, not content-related.

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: _unnecessary; layout fix_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] I will share this change internally with the appropriate teams

