### PR TITLE
Caching sum privileged reaction scores

### DIFF
--- a/app/controllers/admin/privileged_reactions_controller.rb
+++ b/app/controllers/admin/privileged_reactions_controller.rb
@@ -2,12 +2,10 @@ module Admin
   class PrivilegedReactionsController < Admin::ApplicationController
     layout "admin"
 
-    PRIVILEGED_REACTION_CATEGORIES = %i[thumbsup thumbsdown vomit].freeze
-
     def index
       @q = Reaction
         .includes(:user, :reactable)
-        .where(category: PRIVILEGED_REACTION_CATEGORIES)
+        .privileged_category
         .order(created_at: :desc)
         .ransack(params[:q])
       @privileged_reactions = @q.result.page(params[:page] || 1).per(25)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -460,6 +460,7 @@ class Article < ApplicationRecord
   def update_score
     self.score = reactions.sum(:points) + Reaction.where(reactable_id: user_id, reactable_type: "User").sum(:points)
     update_columns(score: score,
+                   privileged_users_reaction_points_sum: reactions.privileged_category.sum(:points),
                    comment_score: comments.sum(:score),
                    hotness_score: BlackBox.article_hotness_score(self),
                    spaminess_rating: BlackBox.calculate_spaminess(self))

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -5,8 +5,14 @@ class Reaction < ApplicationRecord
     "thumbsdown" => -10.0
   }.freeze
 
+  # The union of public and privileged categories
   CATEGORIES = %w[like readinglist unicorn thinking hands thumbsup thumbsdown vomit].freeze
+
+  # These are the general category of reactions that anyone can choose
   PUBLIC_CATEGORIES = %w[like readinglist unicorn thinking hands].freeze
+
+  # These are categories of reactions that administrators can select
+  PRIVILEGED_CATEGORIES = %w[thumbsup thumbsdown vomit].freeze
   REACTABLE_TYPES = %w[Comment Article User].freeze
   STATUSES = %w[valid invalid confirmed archived].freeze
 
@@ -31,6 +37,7 @@ class Reaction < ApplicationRecord
       .or(comment_vomits.where(reactable_id: user.comment_ids))
       .or(user_vomits.where(user_id: user.id))
   }
+  scope :privileged_category, -> { where(category: PRIVILEGED_CATEGORIES) }
 
   validates :category, inclusion: { in: CATEGORIES }
   validates :reactable_type, inclusion: { in: REACTABLE_TYPES }

--- a/lib/data_update_scripts/20211104200856_update_each_articles_privileged_user_point_count.rb
+++ b/lib/data_update_scripts/20211104200856_update_each_articles_privileged_user_point_count.rb
@@ -1,0 +1,17 @@
+module DataUpdateScripts
+  class UpdateEachArticlesPrivilegedUserPointCount
+    def run
+      # This code is "idempotent" in that it's calculating and caching a value stored elsewhere.
+      Article.find_in_batches do |articles|
+        articles.each do |article|
+          # Given that we have a default of 0, don't update if we
+          # don't have any reactions.
+          next unless article.reactions.privileged_category.exist?
+
+          article.update_column(:privileged_users_reaction_points_sum,
+                                article.reactions.privileged_category.sum(:points))
+        end
+      end
+    end
+  end
+end

--- a/lib/data_update_scripts/20211104200856_update_each_articles_privileged_user_point_count.rb
+++ b/lib/data_update_scripts/20211104200856_update_each_articles_privileged_user_point_count.rb
@@ -6,7 +6,7 @@ module DataUpdateScripts
         articles.each do |article|
           # Given that we have a default of 0, don't update if we
           # don't have any reactions.
-          next unless article.reactions.privileged_category.exist?
+          next unless article.reactions.privileged_category.exists?
 
           article.update_column(:privileged_users_reaction_points_sum,
                                 article.reactions.privileged_category.sum(:points))

--- a/spec/lib/data_update_scripts/update_each_articles_privileged_user_point_count_spec.rb
+++ b/spec/lib/data_update_scripts/update_each_articles_privileged_user_point_count_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20211104200856_update_each_articles_privileged_user_point_count.rb",
+)
+
+describe DataUpdateScripts::UpdateEachArticlesPrivilegedUserPointCount do
+  it "updates articles scores" do
+    article = create(:article)
+    user = create(:user, :trusted)
+    reaction = create(:thumbsdown_reaction, user: user, reactable: article)
+
+    # Short-circuiting callbacks
+    reaction.update_column(:points, 1_000_000)
+
+    expect { described_class.new.run }.to change { article.reload.privileged_users_reaction_points_sum }.to(1_000_000)
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1331,6 +1331,14 @@ RSpec.describe Article, type: :model do
       article.update_score
       expect { article.update_score }.not_to change { article.reload.hotness_score }
     end
+
+    it "caches the privileged score values" do
+      user = create(:user, :trusted)
+
+      create(:thumbsdown_reaction, reactable: article, user: user)
+
+      expect { article.update_score }.to change { article.reload.privileged_users_reaction_points_sum }
+    end
   end
 
   describe "#feed_source_url and canonical_url must be unique for published articles" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This relates to work on improving the feed.  Namely that in the current
proposal in PR #15240 I'm not accounting for how privileged users have
given feedback on an article.

With this change, I will now have a cached value on the articles table
that can be a proxy for how the privileged users have reacted.

In addition there's a small refactor that moves a constant to the
correct scoping object.

## Related Tickets & Documents

Dependent on #15283.  Related to but independent of #15240.

## QA Instructions, Screenshots, Recordings

Given that we require the `articles.privileged_users_reaction_points_sum` should we have a check that says "Don't do this calculation if the column doesn't exist?"

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: this change is updating a cached column

## [optional] Are there any post deployment tasks we need to perform?

No.
