### PR TITLE
Extracting container for allowed tags & attrs

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -35,8 +35,8 @@ class ArticlesController < ApplicationController
       articles: @articles,
       user: @user,
       tag: @tag,
-      allowed_tags: HtmlRendering::AllowedTags::FEED,
-      allowed_attributes: HtmlRendering::AllowedAttributes::FEED
+      allowed_tags: MarkdownProcessor::AllowedTags::FEED,
+      allowed_attributes: MarkdownProcessor::AllowedAttributes::FEED
     }
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -7,17 +7,6 @@ class ArticlesController < ApplicationController
   before_action :set_cache_control_headers, only: %i[feed]
   after_action :verify_authorized
 
-  FEED_ALLOWED_TAGS = %w[
-    a b blockquote br center cite code col colgroup dd del div dl dt em em h1 h2
-    h3 h4 h5 h6 i iframe img li ol p pre q small span strong sup table tbody td
-    tfoot th thead time tr u ul
-  ].freeze
-
-  FEED_ALLOWED_ATTRIBUTES = %w[
-    alt class colspan data-conversation data-lang em height href id ref rel
-    rowspan size span src start strong title value width
-  ].freeze
-
   def feed
     skip_authorization
 
@@ -46,8 +35,8 @@ class ArticlesController < ApplicationController
       articles: @articles,
       user: @user,
       tag: @tag,
-      allowed_tags: FEED_ALLOWED_TAGS,
-      allowed_attributes: FEED_ALLOWED_ATTRIBUTES
+      allowed_tags: HtmlRendering::AllowedTags::FEED,
+      allowed_attributes: HtmlRendering::AllowedAttributes::FEED
     }
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -116,7 +116,7 @@ module ApplicationHelper
 
   def sanitized_sidebar(text)
     ActionController::Base.helpers.sanitize simple_format(text),
-                                            tags: %w[p b i em strike strong u br]
+                                            HtmlRendering::AllowedTags::SIDEBAR
   end
 
   def follow_button(followable, style = "full", classes = "")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -116,7 +116,7 @@ module ApplicationHelper
 
   def sanitized_sidebar(text)
     ActionController::Base.helpers.sanitize simple_format(text),
-                                            HtmlRendering::AllowedTags::SIDEBAR
+                                            tags: HtmlRendering::AllowedTags::SIDEBAR
   end
 
   def follow_button(followable, style = "full", classes = "")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -116,7 +116,7 @@ module ApplicationHelper
 
   def sanitized_sidebar(text)
     ActionController::Base.helpers.sanitize simple_format(text),
-                                            tags: HtmlRendering::AllowedTags::SIDEBAR
+                                            tags: MarkdownProcessor::AllowedTags::SIDEBAR
   end
 
   def follow_button(followable, style = "full", classes = "")

--- a/app/models/badge_achievement.rb
+++ b/app/models/badge_achievement.rb
@@ -1,6 +1,4 @@
 class BadgeAchievement < ApplicationRecord
-  CONTEXT_MESSAGE_ALLOWED_TAGS = %w[strong em i b u a code].freeze
-  CONTEXT_MESSAGE_ALLOWED_ATTRIBUTES = %w[href name].freeze
   resourcify
 
   belongs_to :user
@@ -29,8 +27,8 @@ class BadgeAchievement < ApplicationRecord
     html = parsed_markdown.finalize
     final_html = ActionController::Base.helpers.sanitize(
       html,
-      tags: CONTEXT_MESSAGE_ALLOWED_TAGS,
-      attributes: CONTEXT_MESSAGE_ALLOWED_ATTRIBUTES,
+      tags: HtmlRendering::AllowedTags::BADGE_ACHIEVEMENT_CONTEXT_MESSAGE,
+      attributes: HtmlRendering::AllowedAttributes::BADGE_ACHIEVEMENT_CONTEXT_MESSAGE,
     )
 
     self.rewarding_context_message = final_html

--- a/app/models/badge_achievement.rb
+++ b/app/models/badge_achievement.rb
@@ -27,8 +27,8 @@ class BadgeAchievement < ApplicationRecord
     html = parsed_markdown.finalize
     final_html = ActionController::Base.helpers.sanitize(
       html,
-      tags: HtmlRendering::AllowedTags::BADGE_ACHIEVEMENT_CONTEXT_MESSAGE,
-      attributes: HtmlRendering::AllowedAttributes::BADGE_ACHIEVEMENT_CONTEXT_MESSAGE,
+      tags: MarkdownProcessor::AllowedTags::BADGE_ACHIEVEMENT_CONTEXT_MESSAGE,
+      attributes: MarkdownProcessor::AllowedAttributes::BADGE_ACHIEVEMENT_CONTEXT_MESSAGE,
     )
 
     self.rewarding_context_message = final_html

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -37,8 +37,8 @@ class DisplayAd < ApplicationRecord
     markdown = Redcarpet::Markdown.new(renderer)
     initial_html = markdown.render(body_markdown)
     stripped_html = ActionController::Base.helpers.sanitize initial_html,
-                                                            tags: HtmlRendering::AllowedTags::DISPLAY_ADD,
-                                                            attributes: HtmlRendering::AllowedAttributes::DISPLAY_ADD
+                                                            tags: HtmlRendering::AllowedTags::DISPLAY_AD,
+                                                            attributes: HtmlRendering::AllowedAttributes::DISPLAY_AD
     html = stripped_html.delete("\n")
     self.processed_html = Html::Parser.new(html).prefix_all_images(350, synchronous_detail_detection: true).html
   end

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -16,13 +16,6 @@ class DisplayAd < ApplicationRecord
 
   scope :approved_and_published, -> { where(approved: true, published: true) }
 
-  ALLOWED_TAGS = %w[
-    a abbr add b blockquote br center cite code col colgroup dd del dl dt em figcaption
-    h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
-    tbody td tfoot th thead time tr u ul video
-  ].freeze
-  ALLOWED_ATTRIBUTES = %w[href src alt height width].freeze
-
   def self.for_display(area)
     relation = approved_and_published.where(placement_area: area).order(success_rate: :desc)
 
@@ -44,8 +37,8 @@ class DisplayAd < ApplicationRecord
     markdown = Redcarpet::Markdown.new(renderer)
     initial_html = markdown.render(body_markdown)
     stripped_html = ActionController::Base.helpers.sanitize initial_html,
-                                                            tags: ALLOWED_TAGS,
-                                                            attributes: ALLOWED_ATTRIBUTES
+                                                            tags: HtmlRendering::AllowedTags::DISPLAY_ADD,
+                                                            attributes: HtmlRendering::AllowedAttributes::DISPLAY_ADD
     html = stripped_html.delete("\n")
     self.processed_html = Html::Parser.new(html).prefix_all_images(350, synchronous_detail_detection: true).html
   end

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -37,8 +37,8 @@ class DisplayAd < ApplicationRecord
     markdown = Redcarpet::Markdown.new(renderer)
     initial_html = markdown.render(body_markdown)
     stripped_html = ActionController::Base.helpers.sanitize initial_html,
-                                                            tags: HtmlRendering::AllowedTags::DISPLAY_AD,
-                                                            attributes: HtmlRendering::AllowedAttributes::DISPLAY_AD
+                                                            tags: MarkdownProcessor::AllowedTags::DISPLAY_AD,
+                                                            attributes: MarkdownProcessor::AllowedAttributes::DISPLAY_AD
     html = stripped_html.delete("\n")
     self.processed_html = Html::Parser.new(html).prefix_all_images(350, synchronous_detail_detection: true).html
   end

--- a/app/models/html_rendering.rb
+++ b/app/models/html_rendering.rb
@@ -44,6 +44,10 @@ module HtmlRendering
 
     MARKDOWN_PROCESSOR_LISTINGS = %w[a abbr aside b blockquote br code em h4 h5 h6 hr i
                                      kbd li ol p pre small span strong sub sup u ul].freeze
+
+    SIDEBAR = %w[b br em i p strike strong u].freeze
+
+    BADGE_ACHIEVEMENT_CONTEXT_MESSAGE = %w[a b code em i strong u].freeze
   end
 
   # A container module for the allowed attributes in various rendering
@@ -62,5 +66,7 @@ module HtmlRendering
                                     rowspan span src start title type value].freeze
 
     MARKDOWN_PROCESSOR = %w[alt href src].freeze
+
+    BADGE_ACHIEVEMENT_CONTEXT_MESSAGE = %w[href name].freeze
   end
 end

--- a/app/models/html_rendering.rb
+++ b/app/models/html_rendering.rb
@@ -1,0 +1,66 @@
+# The purpose of this module is to provide a common place for
+# answering the question:
+#
+# What HTML tags and attributes are allowed for what contexts?
+#
+# In performing some analysis, I found that we had at least 5 places
+# in our code base that specified AllowedTags and AllowedAttributes.
+#
+# There should be parity between the name of constants in both
+# AllowedTags and AllowedAttributes.  That is to say if one of those
+# modules has FEED then the other should have FEED as well.
+module HtmlRendering
+  # A container module for the allowed tags in various rendering
+  # contexts.
+  module AllowedTags
+    FEED = %w[a b blockquote br center cite code col colgroup dd del div dl dt em em h1 h2
+              h3 h4 h5 h6 i iframe img li ol p pre q small span strong sup table tbody td
+              tfoot th thead time tr u ul].freeze
+
+    PODCAST_SHOW = %w[
+      a b blockquote br center cite code col colgroup dd del div dl dt em
+      h1 h2 h3 h4 h5 h6 i img li ol p pre q small span strong sup table
+      tbody td tfoot th thead time tr u ul
+    ].freeze
+
+    DISPLAY_AD = %w[a abbr add b blockquote br center cite code col colgroup dd del dl dt
+                    em figcaption h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt
+                    ruby small source span strong sub sup table tbody td tfoot th thead
+                    time tr u ul video].freeze
+
+    RENDERED_MARKDOWN_SCRUBBER = %w[a abbr add b blockquote br center cite code col
+                                    colgroup dd del dl dt em figcaption h1 h2 h3 h4 h5
+                                    h6 hr img kbd li mark ol p pre q rp rt ruby small
+                                    source span strong sub sup table tbody td tfoot th
+                                    thead time tr u ul video].freeze
+
+    MARKDOWN_PROCESSOR_DEFAULT = %w[a abbr aside b blockquote br code em h1 h2 h3 h4 h5
+                                    h6 hr i img kbd li ol p pre small span strong sub
+                                    sup u ul].freeze
+
+    MARKDOWN_PROCESSOR_LIMITED = %w[b br code em i p strong u].freeze
+
+    MARKDOWN_PROCESSOR_INLINE_LIMITED = %w[b code em i strong u].freeze
+
+    MARKDOWN_PROCESSOR_LISTINGS = %w[a abbr aside b blockquote br code em h4 h5 h6 hr i
+                                     kbd li ol p pre small span strong sub sup u ul].freeze
+  end
+
+  # A container module for the allowed attributes in various rendering
+  # contexts.
+  module AllowedAttributes
+    FEED = %w[alt class colspan data-conversation data-lang em height href id ref rel
+              rowspan size span src start strong title value width].freeze
+
+    PODCAST_SHOW = %w[alt class colspan data-conversation data-lang em height href id ref
+                      rel rowspan size span src start strong title value width].freeze
+
+    DISPLAY_AD = %w[alt height href src width].freeze
+
+    RENDERED_MARKDOWN_SCRUBBER = %w[alt colspan controls data-conversation data-lang
+                                    data-no-instant data-url href id loop name ref rel
+                                    rowspan span src start title type value].freeze
+
+    MARKDOWN_PROCESSOR = %w[alt href src].freeze
+  end
+end

--- a/app/models/html_rendering.rb
+++ b/app/models/html_rendering.rb
@@ -13,21 +13,27 @@ module HtmlRendering
   # A container module for the allowed tags in various rendering
   # contexts.
   module AllowedTags
-    FEED = %w[a b blockquote br center cite code col colgroup dd del div dl dt em em h1 h2
+    FEED = %w[a b blockquote br center cite code col colgroup dd del div dl dt em h1 h2
               h3 h4 h5 h6 i iframe img li ol p pre q small span strong sup table tbody td
               tfoot th thead time tr u ul].freeze
 
+    # In FEED but not PODCAST_SHOW: [iframe]
+    # In PODCAST_SHOW but not FEED: []
     PODCAST_SHOW = %w[
       a b blockquote br center cite code col colgroup dd del div dl dt em
       h1 h2 h3 h4 h5 h6 i img li ol p pre q small span strong sup table
       tbody td tfoot th thead time tr u ul
     ].freeze
 
+    # In FEED but not DISPLAY_AD: [div i iframe]
+    # In DISPLAY_AD but not FEED: [abbr add figcaption hr kbd mark rp rt ruby source sub video]
     DISPLAY_AD = %w[a abbr add b blockquote br center cite code col colgroup dd del dl dt
                     em figcaption h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt
                     ruby small source span strong sub sup table tbody td tfoot th thead
                     time tr u ul video].freeze
 
+    # In FEED but not RENDERED_MARKDOWN_SCRUBBER: [div i iframe]
+    # In RENDERED_MARKDOWN_SCRUBBER but not FEED: [abbr add figcaption hr kbd mark rp rt ruby source sub video]
     RENDERED_MARKDOWN_SCRUBBER = %w[a abbr add b blockquote br center cite code col
                                     colgroup dd del dl dt em figcaption h1 h2 h3 h4 h5
                                     h6 hr img kbd li mark ol p pre q rp rt ruby small

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -3,9 +3,9 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
   def initialize
     super
 
-    self.tags = HtmlRendering::AllowedTags::RENDERED_MARKDOWN_SCRUBBER
+    self.tags = MarkdownProcessor::AllowedTags::RENDERED_MARKDOWN_SCRUBBER
 
-    self.attributes = HtmlRendering::AllowedAttributes::RENDERED_MARKDOWN_SCRUBBER
+    self.attributes = MarkdownProcessor::AllowedAttributes::RENDERED_MARKDOWN_SCRUBBER
   end
 
   def allowed_node?(node)

--- a/app/sanitizers/rendered_markdown_scrubber.rb
+++ b/app/sanitizers/rendered_markdown_scrubber.rb
@@ -3,16 +3,9 @@ class RenderedMarkdownScrubber < Rails::Html::PermitScrubber
   def initialize
     super
 
-    self.tags = %w[
-      a abbr add b blockquote br center cite code col colgroup dd del dl dt em figcaption
-      h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt ruby small source span strong sub sup table
-      tbody td tfoot th thead time tr u ul video
-    ]
+    self.tags = HtmlRendering::AllowedTags::RENDERED_MARKDOWN_SCRUBBER
 
-    self.attributes = %w[
-      alt colspan data-conversation data-lang data-no-instant data-url href id loop
-      name ref rel rowspan span src start title type value controls
-    ]
+    self.attributes = HtmlRendering::AllowedAttributes::RENDERED_MARKDOWN_SCRUBBER
   end
 
   def allowed_node?(node)

--- a/app/services/markdown_processor.rb
+++ b/app/services/markdown_processor.rb
@@ -1,7 +1,9 @@
-# The purpose of this module is to provide a common place for
-# answering the question:
+# The purpose of this module is provide a common place for logic
+# around Markdown processing.
 #
-# What HTML tags and attributes are allowed for what contexts?
+# The submodules AllowedTags and AllowedAttributes answer the
+# question: What HTML tags and attributes are allowed for what
+# contexts?
 #
 # In performing some analysis, I found that we had at least 5 places
 # in our code base that specified AllowedTags and AllowedAttributes.
@@ -9,7 +11,7 @@
 # There should be parity between the name of constants in both
 # AllowedTags and AllowedAttributes.  That is to say if one of those
 # modules has FEED then the other should have FEED as well.
-module HtmlRendering
+module MarkdownProcessor
   # A container module for the allowed tags in various rendering
   # contexts.
   module AllowedTags

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -8,7 +8,6 @@ module MarkdownProcessor
     ].freeze
 
     WORDS_READ_PER_MINUTE = 275.0
-    ALLOWED_ATTRIBUTES = %w[href src alt].freeze
 
     def initialize(content, source: nil, user: nil)
       @content = content
@@ -46,50 +45,26 @@ module MarkdownProcessor
       (word_count / WORDS_READ_PER_MINUTE).ceil
     end
 
-    def evaluate_markdown
+    def evaluate_markdown(allowed_tags: HtmlRendering::AllowedTags::MARKDOWN_PROCESSOR_DEFAULT)
       return if @content.blank?
 
       renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
-      allowed_tags = %w[strong abbr aside em p h1 h2 h3 h4 h5 h6 i u b code pre
-                        br ul ol li small sup sub img a span hr blockquote kbd]
       ActionController::Base.helpers.sanitize(markdown.render(@content),
                                               tags: allowed_tags,
-                                              attributes: ALLOWED_ATTRIBUTES)
+                                              attributes: HtmlRendering::AllowedAttributes::MARKDOWN_PROCESSOR)
     end
 
-    def evaluate_limited_markdown
-      return if @content.blank?
-
-      renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
-      markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
-      allowed_tags = %w[strong i u b em p br code]
-      ActionController::Base.helpers.sanitize(markdown.render(@content),
-                                              tags: allowed_tags,
-                                              attributes: ALLOWED_ATTRIBUTES)
+    def evaluate_limited_markdown(allowed_tags: HtmlRendering::AllowedTags::MARKDOWN_PROCESSOR_LIMITED)
+      evaluate_markdown(allowed_tags: allowed_tags)
     end
 
-    def evaluate_inline_limited_markdown
-      return if @content.blank?
-
-      renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
-      markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
-      allowed_tags = %w[strong i u b em code]
-      ActionController::Base.helpers.sanitize(markdown.render(@content),
-                                              tags: allowed_tags,
-                                              attributes: ALLOWED_ATTRIBUTES)
+    def evaluate_inline_limited_markdown(allowed_tags: HtmlRendering::AllowedTags::MARKDOWN_PROCESSOR_INLINE_LIMITED)
+      evaluate_markdown(allowed_tags: allowed_tags)
     end
 
-    def evaluate_listings_markdown
-      return if @content.blank?
-
-      renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
-      markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
-      allowed_tags = %w[strong abbr aside em p h4 h5 h6 i u b code pre
-                        br ul ol li small sup sub a span hr blockquote kbd]
-      ActionController::Base.helpers.sanitize(markdown.render(@content),
-                                              tags: allowed_tags,
-                                              attributes: ALLOWED_ATTRIBUTES)
+    def evaluate_listings_markdown(allowed_tags: HtmlRendering::AllowedTags::MARKDOWN_PROCESSOR_LISTINGS)
+      evaluate_markdown(allowed_tags: allowed_tags)
     end
 
     def tags_used

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -45,25 +45,27 @@ module MarkdownProcessor
       (word_count / WORDS_READ_PER_MINUTE).ceil
     end
 
-    def evaluate_markdown(allowed_tags: HtmlRendering::AllowedTags::MARKDOWN_PROCESSOR_DEFAULT)
+    def evaluate_markdown(allowed_tags: MarkdownProcessor::AllowedTags::MARKDOWN_PROCESSOR_DEFAULT)
       return if @content.blank?
 
       renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)
       markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
       ActionController::Base.helpers.sanitize(markdown.render(@content),
                                               tags: allowed_tags,
-                                              attributes: HtmlRendering::AllowedAttributes::MARKDOWN_PROCESSOR)
+                                              attributes: MarkdownProcessor::AllowedAttributes::MARKDOWN_PROCESSOR)
     end
 
-    def evaluate_limited_markdown(allowed_tags: HtmlRendering::AllowedTags::MARKDOWN_PROCESSOR_LIMITED)
+    def evaluate_limited_markdown(allowed_tags: MarkdownProcessor::AllowedTags::MARKDOWN_PROCESSOR_LIMITED)
       evaluate_markdown(allowed_tags: allowed_tags)
     end
 
-    def evaluate_inline_limited_markdown(allowed_tags: HtmlRendering::AllowedTags::MARKDOWN_PROCESSOR_INLINE_LIMITED)
+    # rubocop:disable Layout/LineLength
+    def evaluate_inline_limited_markdown(allowed_tags: MarkdownProcessor::AllowedTags::MARKDOWN_PROCESSOR_INLINE_LIMITED)
       evaluate_markdown(allowed_tags: allowed_tags)
     end
+    # rubocop:enable Layout/LineLength
 
-    def evaluate_listings_markdown(allowed_tags: HtmlRendering::AllowedTags::MARKDOWN_PROCESSOR_LISTINGS)
+    def evaluate_listings_markdown(allowed_tags: MarkdownProcessor::AllowedTags::MARKDOWN_PROCESSOR_LISTINGS)
       evaluate_markdown(allowed_tags: allowed_tags)
     end
 

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -85,8 +85,8 @@
           <%= simple_format((@episode.processed_html || @episode.body), sanitize: true) %>
         <% else %>
           <%= sanitize (@episode.processed_html || ""),
-                       tags: %w[strong br em a table tbody thead tfoot th tr td col colgroup del p h1 h2 h3 h4 h5 h6 blockquote time div span i em u b ul ol li dd dl dt q code pre img sup cite center small],
-                       attributes: %w[href strong em class ref rel src title alt colspan height width size rowspan span value start data-conversation data-lang id] %>
+                       tags: HtmlRendering::AllowedTags::PODCAST_EPISODE,
+                       attributes: HtmlRendering::AllowedAttributes::PODCAST_EPISODE %>
         <% end %>
 
         <p><a href="<%= @episode.website_url %>"><%= t("views.podcasts.source") %></a></p>

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -85,8 +85,8 @@
           <%= simple_format((@episode.processed_html || @episode.body), sanitize: true) %>
         <% else %>
           <%= sanitize (@episode.processed_html || ""),
-                       tags: HtmlRendering::AllowedTags::PODCAST_EPISODE,
-                       attributes: HtmlRendering::AllowedAttributes::PODCAST_EPISODE %>
+                       tags: HtmlRendering::AllowedTags::PODCAST_SHOW,
+                       attributes: HtmlRendering::AllowedAttributes::PODCAST_SHOW %>
         <% end %>
 
         <p><a href="<%= @episode.website_url %>"><%= t("views.podcasts.source") %></a></p>

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -85,8 +85,8 @@
           <%= simple_format((@episode.processed_html || @episode.body), sanitize: true) %>
         <% else %>
           <%= sanitize (@episode.processed_html || ""),
-                       tags: HtmlRendering::AllowedTags::PODCAST_SHOW,
-                       attributes: HtmlRendering::AllowedAttributes::PODCAST_SHOW %>
+                       tags: MarkdownProcessor::AllowedTags::PODCAST_SHOW,
+                       attributes: MarkdownProcessor::AllowedAttributes::PODCAST_SHOW %>
         <% end %>
 
         <p><a href="<%= @episode.website_url %>"><%= t("views.podcasts.source") %></a></p>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

_**Note:** I'm proposing changing where we store knowledge regarding tags.  The goal is to begin assessing what patterns we have and why. For example, why does DisplayAd have the set of tags that it does?  Are we missing any?_


Prior to this commit, we had several different locations in which we
specified ALLOWED_TAGS and ALLOWED_ATTRIBUTES for HTML rendering and
sanitization.

Curious to see how these either intersected or didn't, I opted to
create a container module that allows for us to more readily normalize
these allowed tags and attributes.  It's possible that we won't do any
normalization, but this work helps make that easier.

Ideally, I'd love us to contextualize "why did we choose the
tags/attributes we chose?"  But for now, I think consolidating these
tags and attributes will help make adding a `details` and `summary` tag
easier.

This relates to forem/rfcs#296

See [Google Sheet][1] for analysis of what tags/attributes are used, the
intersection and union.

[1]:https://docs.google.com/spreadsheets/d/1yj-a1qus1o0o4cj-_gOMP5yteeg-_f3s5z7kvK0Y7RM/edit#gid=0

## Related Tickets & Documents

- forem/rfcs#296

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: a non-changing refactor

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: This is a refactor of the code-base.
