### PR TITLE
Issue #9077 has already been resolved, added specs

### DIFF
--- a/app/services/mentions/create_all.rb
+++ b/app/services/mentions/create_all.rb
@@ -41,9 +41,11 @@ module Mentions
       # The "mentioned-user" css is added by Html::Parser#user_link_if_exists
       doc = Nokogiri::HTML(notifiable.processed_html)
 
-      # Remove any mentions that are embedded within a comment liquid tag
+      # Remove any mentions that are embedded within any liquid tags
       non_liquid_tag_mentions = doc.css(".mentioned-user").reject do |tag|
-        tag.ancestors(".liquid-comment").any?
+        tag.ancestors(".liquid-comment").any? ||
+          tag.ancestors("[class^=ltag]").any? ||
+          tag.ancestors("[class*=' ltag']").any?
       end
 
       non_liquid_tag_mentions.map { |link| link.text.delete("@").downcase }

--- a/spec/services/mentions/create_all_spec.rb
+++ b/spec/services/mentions/create_all_spec.rb
@@ -16,6 +16,18 @@ RSpec.shared_examples "valid notifiable and no mentions" do
     described_class.call(notifiable)
     expect(Mention.all.size).to eq(1)
   end
+
+  it "does not create a mention if notifiable is updated with mention inside code block", :aggregate_failures do
+    set_markdown_and_save(notifiable, mention_code_markdown)
+    described_class.call(notifiable)
+    expect(Mention.all.size).to eq(0)
+  end
+
+  it "does not create a mention if notifiable is updated with mention inside code snippet", :aggregate_failures do
+    set_markdown_and_save(notifiable, mention_snippet_markdown)
+    described_class.call(notifiable)
+    expect(Mention.all.size).to eq(0)
+  end
 end
 
 RSpec.shared_examples "valid notifiable and has mentions" do
@@ -115,7 +127,9 @@ RSpec.describe Mentions::CreateAll, type: :service do
   let(:user2)              { create(:user) }
   let(:article)            { create(:article, user_id: user.id) }
   let(:markdown)           { "Hello, you are cool." }
-  let(:mention_markdown)   { "Hello @#{user.username}, you are cool." }
+  let(:mention_markdown) { "Hello @#{user.username}, you are cool." }
+  let(:mention_snippet_markdown) { "This is how I would mention `@#{user.username}` without a notification" }
+  let(:mention_code_markdown) { " ... ``` mention a user @#{user.username} in a code block``` ..." }
 
   def set_markdown_and_save(notifiable, markdown)
     notifiable.update(body_markdown: markdown)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
I looked into the issue and tested it locally. I also added a couple new specs that show my findings. This issue seems to have already been resolved. 

## Related Tickets & Documents
#9077

## QA Instructions, Screenshots, Recordings

- Mention a user on an article inside a code block or inside a snippet
- That use should not  have any new notifications and no new Mentions should be created

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

