### PR TITLE
Markdown toolbar - update new line logic for block syntaxes

### DIFF
--- a/app/javascript/crayons/MarkdownToolbar/__tests__/markdownSyntaxFormatters.test.js
+++ b/app/javascript/crayons/MarkdownToolbar/__tests__/markdownSyntaxFormatters.test.js
@@ -914,7 +914,7 @@ describe('markdownSyntaxFormatters', () => {
 
       it('formats multiple lines of text as an ordered list', () => {
         const textAreaValue = 'one\ntwo\nthree';
-        const expectedNewTextAreaValue = '\n\n1. one\n2. two\n3. three\n';
+        const expectedNewTextAreaValue = '1. one\n2. two\n3. three\n';
 
         const { newTextAreaValue, newCursorStart, newCursorEnd } =
           coreSyntaxFormatters['orderedList'].getFormatting({
@@ -998,7 +998,7 @@ describe('markdownSyntaxFormatters', () => {
 
       it("formats as an ordered list if at least one line of selection doesn't match ordered list format", () => {
         const textAreaValue = '1. one\ntwo\n3. three';
-        const expectedNewTextAreaValue = '\n\n1. 1. one\n2. two\n3. 3. three\n';
+        const expectedNewTextAreaValue = '1. 1. one\n2. two\n3. 3. three\n';
 
         const { newTextAreaValue, newCursorStart, newCursorEnd } =
           coreSyntaxFormatters['orderedList'].getFormatting({
@@ -1011,6 +1011,91 @@ describe('markdownSyntaxFormatters', () => {
         expect(
           newTextAreaValue.substring(newCursorStart, newCursorEnd),
         ).toEqual('1. 1. one\n2. two\n3. 3. three');
+      });
+
+      it("doesn't add new lines before list, if at the beginning of text area", () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '1. one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['orderedList'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('1. one');
+      });
+
+      it('adds one new line before list, if directly preceded by a single new line', () => {
+        const textAreaValue = '\none';
+        const expectedNewTextAreaValue = '\n\n1. one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['orderedList'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 1,
+            selectionEnd: 4,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('1. one');
+      });
+
+      it('adds two new lines before list, if no new lines already exist before it', () => {
+        const textAreaValue = 'one two';
+        const expectedNewTextAreaValue = 'one \n\n1. two\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['orderedList'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 4,
+            selectionEnd: 7,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('1. two');
+      });
+
+      it("doesn't add a new line after list if one already exists", () => {
+        const textAreaValue = 'one\n';
+        const expectedNewTextAreaValue = '1. one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['orderedList'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('1. one');
+      });
+
+      it('adds a new line after list if none exists', () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '1. one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['orderedList'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('1. one');
       });
     });
 
@@ -1034,7 +1119,7 @@ describe('markdownSyntaxFormatters', () => {
 
       it('formats multiple lines of text as an unordered list', () => {
         const textAreaValue = 'one\ntwo\nthree';
-        const expectedNewTextAreaValue = '\n\n- one\n- two\n- three\n';
+        const expectedNewTextAreaValue = '- one\n- two\n- three\n';
 
         const { newTextAreaValue, newCursorStart, newCursorEnd } =
           coreSyntaxFormatters['unorderedList'].getFormatting({
@@ -1118,7 +1203,7 @@ describe('markdownSyntaxFormatters', () => {
 
       it("formats as an unordered list if at least one line of selection doesn't match unordered list format", () => {
         const textAreaValue = '- one\ntwo\n- three';
-        const expectedNewTextAreaValue = '\n\n- - one\n- two\n- - three\n';
+        const expectedNewTextAreaValue = '- - one\n- two\n- - three\n';
 
         const { newTextAreaValue, newCursorStart, newCursorEnd } =
           coreSyntaxFormatters['unorderedList'].getFormatting({
@@ -1131,6 +1216,91 @@ describe('markdownSyntaxFormatters', () => {
         expect(
           newTextAreaValue.substring(newCursorStart, newCursorEnd),
         ).toEqual('- - one\n- two\n- - three');
+      });
+
+      it("doesn't add new lines before list, if at the beginning of text area", () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '- one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['unorderedList'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('- one');
+      });
+
+      it('adds one new line before list, if directly preceded by a single new line', () => {
+        const textAreaValue = '\none';
+        const expectedNewTextAreaValue = '\n\n- one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['unorderedList'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 1,
+            selectionEnd: 4,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('- one');
+      });
+
+      it('adds two new lines before list, if no new lines already exist before it', () => {
+        const textAreaValue = 'one two';
+        const expectedNewTextAreaValue = 'one \n\n- two\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['unorderedList'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 4,
+            selectionEnd: 7,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('- two');
+      });
+
+      it("doesn't add a new line after list if one already exists", () => {
+        const textAreaValue = 'one\n';
+        const expectedNewTextAreaValue = '- one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['unorderedList'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('- one');
+      });
+
+      it('adds a new line after list if none exists', () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '- one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['unorderedList'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('- one');
       });
     });
 
@@ -1262,6 +1432,91 @@ describe('markdownSyntaxFormatters', () => {
         expect(newCursorStart).toEqual(5);
         expect(newCursorEnd).toEqual(8);
       });
+
+      it("doesn't add new lines before heading, if at the beginning of text area", () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '## one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['heading'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
+      });
+
+      it('adds one new line before heading, if directly preceded by a single new line', () => {
+        const textAreaValue = '\none';
+        const expectedNewTextAreaValue = '\n\n## one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['heading'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 1,
+            selectionEnd: 4,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
+      });
+
+      it('adds two new lines before heading, if no new lines already exist before it', () => {
+        const textAreaValue = 'one two';
+        const expectedNewTextAreaValue = 'one \n\n## two\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['heading'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 4,
+            selectionEnd: 7,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('two');
+      });
+
+      it("doesn't add a new line after heading if one already exists", () => {
+        const textAreaValue = 'one\n';
+        const expectedNewTextAreaValue = '## one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['heading'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
+      });
+
+      it('adds a new line after heading if none exists', () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '## one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['heading'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
+      });
     });
 
     describe('quote', () => {
@@ -1284,7 +1539,7 @@ describe('markdownSyntaxFormatters', () => {
 
       it('formats multiple lines of text as a quote', () => {
         const textAreaValue = 'one\ntwo\nthree';
-        const expectedNewTextAreaValue = '\n\n> one\n> two\n> three\n';
+        const expectedNewTextAreaValue = '> one\n> two\n> three\n';
 
         const { newTextAreaValue, newCursorStart, newCursorEnd } =
           coreSyntaxFormatters['quote'].getFormatting({
@@ -1368,7 +1623,7 @@ describe('markdownSyntaxFormatters', () => {
 
       it("formats as a quote if at least one line of selection doesn't match quote format", () => {
         const textAreaValue = '> one\ntwo\n> three';
-        const expectedNewTextAreaValue = '\n\n> > one\n> two\n> > three\n';
+        const expectedNewTextAreaValue = '> > one\n> two\n> > three\n';
 
         const { newTextAreaValue, newCursorStart, newCursorEnd } =
           coreSyntaxFormatters['quote'].getFormatting({
@@ -1381,6 +1636,91 @@ describe('markdownSyntaxFormatters', () => {
         expect(
           newTextAreaValue.substring(newCursorStart, newCursorEnd),
         ).toEqual('> > one\n> two\n> > three');
+      });
+
+      it("doesn't add new lines before quote, if at the beginning of text area", () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '> one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['quote'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('> one');
+      });
+
+      it('adds one new line before quote, if directly preceded by a single new line', () => {
+        const textAreaValue = '\none';
+        const expectedNewTextAreaValue = '\n\n> one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['quote'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 1,
+            selectionEnd: 4,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('> one');
+      });
+
+      it('adds two new lines before quote, if no new lines already exist before it', () => {
+        const textAreaValue = 'one two';
+        const expectedNewTextAreaValue = 'one \n\n> two\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['quote'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 4,
+            selectionEnd: 7,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('> two');
+      });
+
+      it("doesn't add a new line after quote if one already exists", () => {
+        const textAreaValue = 'one\n';
+        const expectedNewTextAreaValue = '> one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['quote'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('> one');
+      });
+
+      it('adds a new line after quote if none exists', () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '> one\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['quote'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('> one');
       });
     });
 
@@ -1404,7 +1744,7 @@ describe('markdownSyntaxFormatters', () => {
 
       it('formats multiple lines of text as a code block', () => {
         const textAreaValue = 'one\ntwo\nthree';
-        const expectedNewTextAreaValue = '\n\n```\none\ntwo\nthree\n```\n';
+        const expectedNewTextAreaValue = '```\none\ntwo\nthree\n```\n';
 
         const { newTextAreaValue, newCursorStart, newCursorEnd } =
           coreSyntaxFormatters['codeBlock'].getFormatting({
@@ -1503,6 +1843,91 @@ describe('markdownSyntaxFormatters', () => {
           newTextAreaValue.substring(newCursorStart, newCursorEnd),
         ).toEqual('two');
       });
+
+      it("doesn't add new lines before code block, if at the beginning of text area", () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '```\none\n```\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['codeBlock'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
+      });
+
+      it('adds one new line before code block, if directly preceded by a single new line', () => {
+        const textAreaValue = '\none';
+        const expectedNewTextAreaValue = '\n\n```\none\n```\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['codeBlock'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 1,
+            selectionEnd: 4,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
+      });
+
+      it('adds two new lines before code block, if no new lines already exist before it', () => {
+        const textAreaValue = 'one two';
+        const expectedNewTextAreaValue = 'one \n\n```\ntwo\n```\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['codeBlock'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 4,
+            selectionEnd: 7,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('two');
+      });
+
+      it("doesn't add a new line after code block if one already exists", () => {
+        const textAreaValue = 'one\n';
+        const expectedNewTextAreaValue = '```\none\n```\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['codeBlock'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
+      });
+
+      it('adds a new line after code block if none exists', () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '```\none\n```\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          coreSyntaxFormatters['codeBlock'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
+      });
     });
 
     describe('divider', () => {
@@ -1570,6 +1995,74 @@ describe('markdownSyntaxFormatters', () => {
         expect(
           newTextAreaValue.substring(newCursorStart, newCursorEnd),
         ).toEqual('two');
+      });
+
+      it("doesn't add new lines before divider, if at the beginning of text area", () => {
+        const textAreaValue = 'one';
+        const expectedNewTextAreaValue = '---\none\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          secondarySyntaxFormatters['divider'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
+      });
+
+      it('adds one new line before divider, if directly preceded by a single new line', () => {
+        const textAreaValue = '\none';
+        const expectedNewTextAreaValue = '\n\n---\none\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          secondarySyntaxFormatters['divider'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 1,
+            selectionEnd: 4,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
+      });
+
+      it('adds two new lines before divider, if no new lines already exist before it', () => {
+        const textAreaValue = 'one two';
+        const expectedNewTextAreaValue = 'one \n\n---\ntwo\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          secondarySyntaxFormatters['divider'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 4,
+            selectionEnd: 7,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('two');
+      });
+
+      it("doesn't add a new line after divider if one already exists", () => {
+        const textAreaValue = 'one\n';
+        const expectedNewTextAreaValue = '---\none\n';
+
+        const { newTextAreaValue, newCursorStart, newCursorEnd } =
+          secondarySyntaxFormatters['divider'].getFormatting({
+            value: textAreaValue,
+            selectionStart: 0,
+            selectionEnd: 3,
+          });
+
+        expect(newTextAreaValue).toEqual(expectedNewTextAreaValue);
+        expect(
+          newTextAreaValue.substring(newCursorStart, newCursorEnd),
+        ).toEqual('one');
       });
     });
   });

--- a/app/javascript/crayons/MarkdownToolbar/markdownSyntaxFormatters.js
+++ b/app/javascript/crayons/MarkdownToolbar/markdownSyntaxFormatters.js
@@ -2,6 +2,8 @@
 import {
   getLastIndexOfCharacter,
   getNextIndexOfCharacter,
+  getNumberOfNewLinesFollowingSelection,
+  getNumberOfNewLinesPrecedingSelection,
   getSelectionData,
 } from '../../utilities/textAreaUtils';
 import {
@@ -23,6 +25,40 @@ const ORDERED_LIST_ITEM_REGEX = /^\d+\.\s+.*/;
 const MARKDOWN_LINK_REGEX =
   /^\[([\w\s\d]*)\]\((url|(https?:\/\/[\w\d./?=#]+))\)$/;
 const URL_PLACEHOLDER_TEXT = 'url';
+
+const NUMBER_OF_NEW_LINES_BEFORE_BLOCK_SYNTAX = 2;
+const NUMBER_OF_NEW_LINES_BEFORE_AFTER_SYNTAX = 1;
+
+const getNewLinePrefixSuffixes = ({ selectionStart, selectionEnd, value }) => {
+  const numberOfNewLinesBeforeSelection = getNumberOfNewLinesPrecedingSelection(
+    { selectionStart, value },
+  );
+  const numberOfNewLinesFollowingSelection =
+    getNumberOfNewLinesFollowingSelection({ selectionEnd, value });
+
+  // We only add new lines if we're not at the beginning of the text area
+  const numberOfNewLinesNeededAtStart =
+    selectionStart === 0
+      ? 0
+      : NUMBER_OF_NEW_LINES_BEFORE_BLOCK_SYNTAX -
+        numberOfNewLinesBeforeSelection;
+
+  let newLinesPrefix = '';
+  // only add new lines if we're not at the beginning of the text area
+  if (numberOfNewLinesNeededAtStart > 0) {
+    for (let i = 0; i < numberOfNewLinesNeededAtStart; i++) {
+      newLinesPrefix = `${newLinesPrefix}\n`;
+    }
+  }
+
+  const newLinesSuffix =
+    numberOfNewLinesFollowingSelection >=
+    NUMBER_OF_NEW_LINES_BEFORE_AFTER_SYNTAX
+      ? ''
+      : '\n';
+
+  return { newLinesPrefix, newLinesSuffix };
+};
 
 const handleLinkFormattingForEmptyTextSelection = ({
   textBeforeSelection,
@@ -316,18 +352,18 @@ const undoOrAddFormattingForMultilineSyntax = ({
   }
 
   // Add the formatting
-  const numberOfNewLinesBeforeSelection = (
-    textBeforeSelection.slice(-2).match(/\n/g) || []
-  ).length;
+
+  const { newLinesPrefix, newLinesSuffix } = getNewLinePrefixSuffixes({
+    selectionStart,
+    selectionEnd,
+    value,
+  });
+  const { length: newLinePrefixLength } = newLinesPrefix;
 
   // Multiline insertions should occur after two new lines (whether added already by user or inserted automatically)
-  const newLinesToAddBeforeSelection = 2 - numberOfNewLinesBeforeSelection;
-  let newtextBeforeSelection = textBeforeSelection;
-  Array.from({ length: newLinesToAddBeforeSelection }, () => {
-    newtextBeforeSelection += '\n';
-  });
+  const newtextBeforeSelection = `${textBeforeSelection}${newLinesPrefix}`;
 
-  const cursorStartBaseline = selectionStart + newLinesToAddBeforeSelection;
+  const cursorStartBaseline = selectionStart + newLinePrefixLength;
   const cursorStartBlockPrefixOffset = blockPrefix ? blockPrefix.length : 0;
   const cursorStartLinePrefixOffset =
     selectedText === '' && linePrefix ? linePrefix.length : 0;
@@ -335,7 +371,9 @@ const undoOrAddFormattingForMultilineSyntax = ({
   return {
     newTextAreaValue: `${newtextBeforeSelection}${
       blockPrefix ? blockPrefix : ''
-    }${formattedText}${blockSuffix ? blockSuffix : ''}\n${textAfterSelection}`,
+    }${formattedText}${
+      blockSuffix ? blockSuffix : ''
+    }${newLinesSuffix}${textAfterSelection}`,
     newCursorStart:
       cursorStartBaseline +
       cursorStartBlockPrefixOffset +
@@ -344,7 +382,7 @@ const undoOrAddFormattingForMultilineSyntax = ({
       selectionEnd +
       formattedText.length -
       selectedText.length +
-      newLinesToAddBeforeSelection +
+      newLinePrefixLength +
       (blockPrefix?.length || 0),
   };
 };
@@ -453,6 +491,14 @@ export const coreSyntaxFormatters = {
       const { selectedText, textBeforeSelection, textAfterSelection } =
         getSelectionData({ selectionStart, selectionEnd, value });
 
+      const { newLinesPrefix, newLinesSuffix } = getNewLinePrefixSuffixes({
+        selectionStart,
+        selectionEnd,
+        value,
+      });
+      const { length: newLinePrefixLength } = newLinesPrefix;
+      const { length: newLineSuffixLength } = newLinesSuffix;
+
       if (selectedText === '' && textBeforeSelection !== '') {
         // Check start of line for whether we're in an empty ordered list
         const lastNewLine = getLastIndexOfCharacter({
@@ -479,9 +525,9 @@ export const coreSyntaxFormatters = {
       if (selectedText === '') {
         // Otherwise insert an empty list for an empty selection
         return {
-          newTextAreaValue: `${textBeforeSelection}\n\n1. \n${textAfterSelection}`,
-          newCursorStart: selectionStart + 5,
-          newCursorEnd: selectionEnd + 5,
+          newTextAreaValue: `${textBeforeSelection}${newLinesPrefix}1. ${newLinesSuffix}${textAfterSelection}`,
+          newCursorStart: selectionStart + 3 + newLinePrefixLength,
+          newCursorEnd: selectionEnd + 3 + newLinePrefixLength,
         };
       }
 
@@ -508,15 +554,18 @@ export const coreSyntaxFormatters = {
         };
       }
       // Otherwise convert to an ordered list
-      const formattedList = `\n\n${splitByNewLine
+      const formattedList = `${newLinesPrefix}${splitByNewLine
         .map((textChunk, index) => `${index + 1}. ${textChunk}`)
-        .join('\n')}\n`;
+        .join('\n')}${newLinesSuffix}`;
+
+      const cursorOffsetStart =
+        selectedText.length === 0 ? 4 : newLinePrefixLength;
 
       return {
         newTextAreaValue: `${textBeforeSelection}${formattedList}${textAfterSelection}`,
-        newCursorStart: selectionStart + (selectedText.length === 0 ? 4 : 2),
+        newCursorStart: selectionStart + cursorOffsetStart,
         newCursorEnd:
-          selectionEnd + formattedList.length - selectedText.length - 1,
+          selectionStart + formattedList.length - newLineSuffixLength,
       };
     },
   },
@@ -578,13 +627,20 @@ export const coreSyntaxFormatters = {
         };
       }
 
+      const { newLinesPrefix, newLinesSuffix } = getNewLinePrefixSuffixes({
+        selectionStart,
+        selectionEnd,
+        value,
+      });
+      const { length: newLinePrefixLength } = newLinesPrefix;
+
       const adjustingHeading = currentHeadingIndex > 0;
-      const cursorOffset = adjustingHeading ? 1 : 5;
+      const cursorOffset = adjustingHeading ? 1 : 3 + newLinePrefixLength;
 
       return {
         newTextAreaValue: adjustingHeading
           ? `${textBeforeSelection}#${selectedText}${textAfterSelection}`
-          : `${textBeforeSelection}\n\n## ${selectedText}\n${textAfterSelection}`,
+          : `${textBeforeSelection}${newLinesPrefix}## ${selectedText}${newLinesSuffix}${textAfterSelection}`,
         newCursorStart: selectionStart + cursorOffset,
         newCursorEnd: selectionEnd + cursorOffset,
       };

--- a/app/javascript/crayons/MarkdownToolbar/markdownSyntaxFormatters.js
+++ b/app/javascript/crayons/MarkdownToolbar/markdownSyntaxFormatters.js
@@ -43,13 +43,10 @@ const getNewLinePrefixSuffixes = ({ selectionStart, selectionEnd, value }) => {
       : NUMBER_OF_NEW_LINES_BEFORE_BLOCK_SYNTAX -
         numberOfNewLinesBeforeSelection;
 
-  let newLinesPrefix = '';
-  // only add new lines if we're not at the beginning of the text area
-  if (numberOfNewLinesNeededAtStart > 0) {
-    for (let i = 0; i < numberOfNewLinesNeededAtStart; i++) {
-      newLinesPrefix = `${newLinesPrefix}\n`;
-    }
-  }
+  const newLinesPrefix = String.prototype.padStart(
+    numberOfNewLinesNeededAtStart,
+    '\n',
+  );
 
   const newLinesSuffix =
     numberOfNewLinesFollowingSelection >=

--- a/app/javascript/utilities/__tests__/textAreaUtils.test.js
+++ b/app/javascript/utilities/__tests__/textAreaUtils.test.js
@@ -3,6 +3,8 @@ import {
   getLastIndexOfCharacter,
   getNextIndexOfCharacter,
   getSelectionData,
+  getNumberOfNewLinesPrecedingSelection,
+  getNumberOfNewLinesFollowingSelection,
 } from '../textAreaUtils';
 
 describe('getMentionWordData', () => {
@@ -186,5 +188,99 @@ describe('getSelectionData', () => {
       textAfterSelection: ' three four',
       selectedText: 'two',
     });
+  });
+});
+
+describe('getNumberOfNewLinesPrecedingSelection', () => {
+  it('returns 0 when selection start is 0', () => {
+    expect(
+      getNumberOfNewLinesPrecedingSelection({
+        selectionStart: 0,
+        value: 'some text',
+      }),
+    ).toEqual(0);
+  });
+
+  it('returns 0 if no new lines exist before selection', () => {
+    expect(
+      getNumberOfNewLinesPrecedingSelection({
+        selectionStart: 9,
+        value: 'some text',
+      }),
+    ).toEqual(0);
+  });
+
+  it('returns count of new lines before selection', () => {
+    expect(
+      getNumberOfNewLinesPrecedingSelection({
+        selectionStart: 6,
+        value: 'some\n\ntext',
+      }),
+    ).toEqual(2);
+  });
+
+  it('only returns count of new lines immediately before selection', () => {
+    expect(
+      getNumberOfNewLinesPrecedingSelection({
+        selectionStart: 7,
+        value: 'some\n\ntext',
+      }),
+    ).toEqual(0);
+  });
+
+  it('stops counting new lines as soon as any other character occurs', () => {
+    expect(
+      getNumberOfNewLinesPrecedingSelection({
+        selectionStart: 9,
+        value: '\n\n\nsome\n\ntext',
+      }),
+    ).toEqual(2);
+  });
+});
+
+describe('getNumberOfNewLinesFollowingSelection', () => {
+  it('returns 0 when selection end is end of text area value', () => {
+    expect(
+      getNumberOfNewLinesFollowingSelection({
+        selectionEnd: 9,
+        value: 'some text',
+      }),
+    ).toEqual(0);
+  });
+
+  it('returns 0 if no new lines exist after selection', () => {
+    expect(
+      getNumberOfNewLinesFollowingSelection({
+        selectionEnd: 1,
+        value: 'some text',
+      }),
+    ).toEqual(0);
+  });
+
+  it('returns count of new lines after selection', () => {
+    expect(
+      getNumberOfNewLinesFollowingSelection({
+        selectionEnd: 4,
+        value: 'some\n\ntext',
+      }),
+    ).toEqual(2);
+  });
+
+  it('only returns count of new lines immediately after selection', () => {
+    expect(
+      getNumberOfNewLinesFollowingSelection({
+        selectionEnd: 1,
+        value: 'some\n\ntext',
+      }),
+    ).toEqual(0);
+  });
+
+  it('stops counting new lines as soon as any other character occurs', () => {
+    expect(
+      getNumberOfNewLinesFollowingSelection({
+        selectionEnd: 0,
+        value: '\n\n\nsome\n\ntext',
+      }),
+    ).toEqual(3);
   });
 });

--- a/app/javascript/utilities/textAreaUtils.js
+++ b/app/javascript/utilities/textAreaUtils.js
@@ -176,6 +176,61 @@ export const getNextIndexOfCharacter = ({
 };
 
 /**
+ * Counts how many new lines come immediately before the user's current selection start
+ * @param {object} args
+ * @param {number} args.selectionStart The index of user's current selection start
+ * @param {string} args.value The value of the textarea
+ *
+ * @returns {number} Number of new lines directly before selection start
+ */
+export const getNumberOfNewLinesPrecedingSelection = ({
+  selectionStart,
+  value,
+}) => {
+  if (selectionStart === 0) {
+    return 0;
+  }
+
+  let count = 0;
+  let searchIndex = selectionStart - 1;
+
+  while (searchIndex >= 0 && value.charAt(searchIndex) === '\n') {
+    count++;
+    searchIndex--;
+  }
+
+  return count;
+};
+
+/**
+ * Counts how many new lines come immediately after the user's current selection end
+ *
+ * @param {object} args
+ * @param {number} args.selectionEnd The index of user's current selection end
+ * @param {string} args.value The value of the textarea
+ *
+ * @returns {number} the count of new line characters immediately following selection
+ */
+export const getNumberOfNewLinesFollowingSelection = ({
+  selectionEnd,
+  value,
+}) => {
+  if (selectionEnd === value.length) {
+    return 0;
+  }
+
+  let count = 0;
+  let searchIndex = selectionEnd;
+
+  while (searchIndex < value.length && value.charAt(searchIndex) === '\n') {
+    count++;
+    searchIndex++;
+  }
+
+  return count;
+};
+
+/**
  * Retrieve data about the user's current text selection
  *
  * @param {Object} params


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds another small enhancement to the markdown toolbar in Storybook (not currently live in the app yet).

For block level elements, the formatters currently always insert two new lines before, and one new line after.

This PR tweaks that behaviour so that we only insert those new lines if they don't already exist i.e:

- if the selection is the first text in the textarea (not previous characters/lines), don't add any new lines
- if the selection is immediately preceded by 2 new lines, don't add any before the formatted block
- if the selection is immediately preceded by 1 new line, only add one new line before the formatted block
- if the selection is immediately followed by a new line, don't add any after the formatted block
- in all other cases, continue to add 2 new lines before, and one new line after

## Related Tickets & Documents

Overarching epic: https://github.com/forem/forem/issues/14808
Closes https://github.com/forem/forem/issues/15294

## QA Instructions, Screenshots, Recordings

Run `yarn storybook` locally, and navigate to the MarkdownToolbar component. Experiment with block syntaxes, checking for the rules mentioned in the description above.

The block syntaxes are:

- Heading
- Ordered list
- Unordered list
- Quote
- Code block
- Line divider

### UI accessibility concerns?

Nothing new here

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: part of a larger epic which will have a communication strategy / no user-facing changes

