### PR TITLE
WIP: handle comments page for deleted article

### DIFF
--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -2,7 +2,11 @@
 <% if @root_comment.present? %>
   <% title(@root_comment.title.to_s) %>
 <% else %>
+    <% if @commentable %>
   <% title(t("views.comments.meta.title_root", title: @commentable.title)) %>
+    <% else %>
+  <% title(t("views.comments.orphan.deleted")) %>
+    <% end %>
 <% end %>
 
 <% if @commentable %>
@@ -61,6 +65,7 @@
           </div>
         <% end %>
 
+  <% if @commentable %>
         <div class="crayons-article__header__meta">
           <h1 class="fs-2xl s:fs-3xl l:fs-4xl fw-bold s:fw-heavy lh-tight mb-1">
             <%= @commentable.title %>
@@ -71,9 +76,10 @@
                   on: tag.span(@commentable.published_at ? t("views.comments.parent.date", date: @commentable.published_at.strftime(t("time.formats.comment"))) : "", class: %w[published-at])) %>
           </p>
         </div>
+  <% end %>
       </header>
 
-      <% if @commentable.processed_html.present? %>
+      <% if @commentable && @commentable.processed_html.present? %>
         <div class="crayons-article__main">
           <div class="crayons-article__body text-styles -mt-1 m:-mt-2">
             <% if @commentable.processed_html.size < 350 %>
@@ -139,7 +145,7 @@
         <% cache ["comment_root-view-root_#{user_signed_in?}", @root_comment] do %>
           <%= tree_for(@root_comment, @root_comment.subtree.includes(user: %i[setting profile]).arrange[@root_comment], @commentable) %>
         <% end %>
-      <% else %>
+      <% elsif @commentable %>
         <% Comment.tree_for(@commentable).each do |comment, sub_comments| %>
           <% cache ["comment_root_#{user_signed_in?}", comment] do %>
             <%= tree_for(comment, sub_comments, @commentable) %>

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -172,7 +172,18 @@ RSpec.describe "Comments", type: :request do
     end
 
     context "when the article is deleted" do
-      it "index action renders deleted_commentable_comment view" do
+      it "index action shows comment from a deleted post" do
+        article = create(:article)
+        create(:comment, commentable: article)
+        article_path = article.path
+
+        article.destroy
+
+        get "#{article_path}/comments"
+        expect(response.body).to include("Comment from a deleted post")
+      end
+
+      it "show action shows comment from a deleted post" do
         article = create(:article)
         comment = create(:comment, commentable: article)
 

--- a/spec/views/comments/index.html.erb_spec.rb
+++ b/spec/views/comments/index.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "comments/index", type: :view do
+  context "when the article is deleted" do
+    before do
+      assign(:on_comments_page, true)
+      assign(:comment, Comment.new)
+      assign(:podcast, nil)
+      assign(:root_comment, nil)
+      assign(:user, create(:user))
+      assign(:commentable, nil)
+      assign(:article, nil)
+    end
+
+    it "renders without error" do
+      expect { render }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
There are two possible paths to a deleted posts comments - either via /username/comment/:id (@comment.path) or via the original post slug (/user/:article-slug/comments) - which is marked "legacy" in [routes.rb](https://github.com/forem/forem/blob/main/config/routes.rb#L419-L420) but appears to be crawled occassionally by bots.

```ruby
    # Legacy comment format (might still be floating around app, and external links)
    get "/:username/:slug/comments", to: "comments#index"
```

After https://github.com/forem/forem/pull/15052 removed the (also
broken) deleted commentable template and the redirect, requests for
comments from deleted articles raise no method errors (initially
trying to set the page title to "Comments for commentable.title" but
the assumption that `@commentable` is non-nil is present in several
other places.

Added tests currently fail (by design). Either we want to update the
controller so that comments from deleted articles are no longer
viewable (returning not found, as we did prior to
https://github.com/forem/forem/pull/5199 - in which case the test is not needed),
 or by making the view safe for the case where `@commentable` is nil and no 
`@root_comment` is present.

These requests are happening quite frequently (@maestromac and I
suspect the sitemap may contain these pages and crawlers are visiting
the site from a published link), as evidenced by
https://app.honeybadger.io/projects/66984/faults/81994265

However, checking the sitemap-index, sitemap-posts, sitemap-users

I suspect we want to go back to "not found unless commentable" since the comments all have their commentable set to nil here during `Article#destroy` callbacks, rather than trying to handle arbitrary slugs and show the orphaned comment, since no comments will be found when looking up by slug anyway - I'll undo this approach and add notfound handling in the controller instead. 

```
  Comment Update All (1.0ms)  UPDATE "comments" SET "commentable_id" = $1, "commentable_type" = $2 WHERE "comments"."commentable_id" = $3 AND "comments"."commentable_type" = $4  [["commentable_id", nil], ["commentable_type", nil], ["commentable_id", 7], ["commentable_type", "Article"]]
```

Otherwise, the tests pass as of bb37b842f but the view renders nothing (and doesn't distinguish between deleted article slugs and slugs which never were valid - you always get no comment tree, just a comment creation input (which can't be submitted because of validation errors: "Commentable can't be blank")

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Initially tested comment index via `@comment.path`

![comment-from-a-deleted-post](https://user-images.githubusercontent.com/1237369/141333074-8f2730f7-488a-4d70-9b6a-ed242b82ab85.png)

But the legacy path from the deleted comment is meaningless:

![comments-of-a-deleted-post](https://user-images.githubusercontent.com/1237369/141333179-714caebd-94ae-4260-bb28-319c5bbff6b3.png)

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
