### PR TITLE
DRAFT - Consolidating duplicate code

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -47,38 +47,9 @@ class Message < ApplicationRecord
     html = MarkdownProcessor::Parser.new(message_markdown).evaluate_markdown
     html = target_blank_links(html)
     html = append_rich_links(html)
-    html = wrap_mentions_with_links(html)
+    html = Html::Parser::WrapMentionWithLinks.call(html, mention_handler: method(:user_link_if_exists))
     html = handle_slash_command(html)
     self.message_html = html
-  end
-
-  def wrap_mentions_with_links(html)
-    return unless html
-
-    html_doc = Nokogiri::HTML(html)
-
-    # looks for nodes that isn't <code>, <a>, and contains "@"
-    targets = html_doc.xpath('//html/body/*[not (self::code) and not(self::a) and contains(., "@")]').to_a
-
-    # A Queue system to look for and replace possible usernames
-    until targets.empty?
-      node = targets.shift
-
-      # only focus on portion of text with "@"
-      node.xpath("text()[contains(.,'@')]").each do |el|
-        el.replace(el.text.gsub(/\B@[a-z0-9_-]+/i) { |text| user_link_if_exists(text) })
-      end
-
-      # enqueue children that has @ in it's text
-      children = node.xpath('*[not(self::code) and not(self::a) and contains(., "@")]').to_a
-      targets.concat(children)
-    end
-
-    if html_doc.at_css("body")
-      html_doc.at_css("body").inner_html
-    else
-      html_doc.to_html
-    end
   end
 
   def user_link_if_exists(mention)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Using the `flay` gem, I found some duplicate code:

```
24) IDENTICAL code found in :until (mass*2 = 124)
  app/models/message.rb:64
  app/services/html/parser.rb:227
```

This change consolidates the very specific duplication, but it
highlights that there's likely some additional locations that would
benefit from review.

The rules for parsing a message are perhaps generally applicable
elsewhere.

## Related Tickets & Documents

None.

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [X] No, and this is why: it's consolidating duplicate methods

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: because it's a refactor with no external impact.
