### PR TITLE
Nullify invalid tag colors

### DIFF
--- a/lib/data_update_scripts/20211112173720_nullify_empty_tag_colors.rb
+++ b/lib/data_update_scripts/20211112173720_nullify_empty_tag_colors.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class NullifyEmptyTagColors
+    def run
+      # idempotent since the value restriction will answer no rows a second time
+      Tag.where(bg_color_hex: "").update(bg_color_hex: nil)
+      Tag.where(text_color_hex: "").update(text_color_hex: nil)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/nullify_empty_tag_colors_spec.rb
+++ b/spec/lib/data_update_scripts/nullify_empty_tag_colors_spec.rb
@@ -13,18 +13,14 @@ describe DataUpdateScripts::NullifyEmptyTagColors do
   end
 
   it "sets empty string in background color to nil" do
-    expect(empty_bg_tag.bg_color_hex).to eq("")
-
-    described_class.new.run
-
-    expect(empty_bg_tag.reload.bg_color_hex).to be_nil
+    expect { described_class.new.run }
+      .to change { empty_bg_tag.reload.bg_color_hex }
+      .from("").to(nil)
   end
 
   it "sets empty string in foreground text color to nil" do
-    expect(empty_fg_tag.text_color_hex).to eq("")
-
-    described_class.new.run
-
-    expect(empty_fg_tag.reload.text_color_hex).to be_nil
+    expect { described_class.new.run }
+      .to change { empty_fg_tag.reload.text_color_hex }
+      .from("").to(nil)
   end
 end

--- a/spec/lib/data_update_scripts/nullify_empty_tag_colors_spec.rb
+++ b/spec/lib/data_update_scripts/nullify_empty_tag_colors_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20211112173720_nullify_empty_tag_colors.rb",
+)
+
+describe DataUpdateScripts::NullifyEmptyTagColors do
+  let(:empty_bg_tag) { create(:tag) }
+  let(:empty_fg_tag) { create(:tag) }
+
+  before do
+    empty_bg_tag.update_columns(bg_color_hex: "")
+    empty_fg_tag.update_columns(text_color_hex: "")
+  end
+
+  it "sets empty string in background color to nil" do
+    expect(empty_bg_tag.bg_color_hex).to eq("")
+
+    described_class.new.run
+
+    expect(empty_bg_tag.reload.bg_color_hex).to be_nil
+  end
+
+  it "sets empty string in foreground text color to nil" do
+    expect(empty_fg_tag.text_color_hex).to eq("")
+
+    described_class.new.run
+
+    expect(empty_fg_tag.reload.text_color_hex).to be_nil
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Set bg_color_hex and text_color_hex to nil when they were an empty
string.

This is a cleanup of legacy data (from form submissions, when the
field was unset and another attribute was updated, the value could be
saved as '' rather than set nil). This is no longer possible due to
validations added in #10495 so only needs to be handled once.

## Related Tickets & Documents

Noticed after #15266 was merged, and these values caused page failures on the stories controller, see [Jamie's explanation](https://forem.team/engineering/2021-11-11-changing-tag-colors-brings-down-the-site-apparently-2olp)

Mitigated by checking for presence rather than truthiness in #15356 

Expected update size is limited to ~544 rows in DEV's db, probably fewer than 10 in most other forem instances.

## QA Instructions, Screenshots, Recordings

You could replicate the before actions in the spec (update_column to set the color to '' rather than a valid value) and run the script. Running the script twice should be a noop (since there will be no matching rows once they've been updated).

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: behavior neutral cleanup.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![blank pages](https://user-images.githubusercontent.com/1237369/141513101-0d5ff6a3-4f43-4514-8db5-0a3ac630db7c.gif)
