### PR TITLE
Now labels with the CSS class crayons-btn that wrap inputs of type file have focus states

### DIFF
--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -132,7 +132,9 @@
 }
 
 .js-focus-visible .crayons-btn.focus-visible:focus,
-.js-focus-visible .crayons-btn.focus-visible:focus-within {
+.js-focus-visible .crayons-btn.focus-visible:focus-within,
+label[class*='crayons-btn']:focus-within // label for input[type="file"] made to look like a button as the browse... button can't be styled.
+{
   background-color: var(--bg-hover);
   border-color: var(--border-hover);
   box-shadow: var(--shadow-hover);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

`<input type="file" />`s cannot have their buttons styled. The way we currently handle the styling of this is by wrapping `<input type="file" />` with a `<label class="crayons-btn ..." />` and hide the input visually. This looks good and is accessible. However our implementation currently does not provide a focus state for that button like label.

This PR adds a focus state for these kinds of labels via [:focus-within](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within).

## Related Tickets & Documents

Closes #15234 
Fixes upload button styling in #15363 

## QA Instructions, Screenshots, Recordings

1. Create a new post by navigating to http:/:localhost:300/new
2. Click in the content area of the new post to give it focus.
3. Press <kbd></kbd> and <kbd></kbd> to tab backwards.
4. Notice that the upload button now has a focus state.

### Light Theme

![Nov-15-2021 10-16-05](https://user-images.githubusercontent.com/833231/141806506-3ddf344c-9455-4d17-b36b-4c0d26c69126.gif)

### Dark Theme

![Nov-15-2021 10-17-33](https://user-images.githubusercontent.com/833231/141806781-05489385-2c63-4e98-86ee-31fa639bd9b4.gif)

### UI accessibility concerns?

This makes any file uploads we've styled as button like with a label more accessible as it gives a visual cue that it has focus now.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is a small change to CSS only. It doesn't merit a test.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![The Rock doing seated rows saying "Focus!"](https://media.giphy.com/media/14afmHqKZ3ctsk/giphy.gif)
