### PR TITLE
Guarding against spam from OAuth Sources

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -95,7 +95,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       flash[:alert] = user_errors
       redirect_to new_user_registration_url
     end
-  rescue ::Authentication::Errors::PreviouslySuspended => e
+  rescue ::Authentication::Errors::PreviouslySuspended, ::Authentication::Errors::SpammyEmailDomain => e
     flash[:global_notice] = e.message
     redirect_to root_path
   rescue StandardError => e

--- a/app/errors/authentication/errors.rb
+++ b/app/errors/authentication/errors.rb
@@ -22,5 +22,8 @@ module Authentication
                community_email: ForemInstance.email)
       end
     end
+
+    class SpammyEmailDomain < Error
+    end
   end
 end

--- a/app/errors/authentication/errors.rb
+++ b/app/errors/authentication/errors.rb
@@ -23,6 +23,7 @@ module Authentication
       end
     end
 
+    # Raised when we find an email that's from a spammy domain.
     class SpammyEmailDomain < Error
     end
   end

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -88,7 +88,7 @@ module Authentication
       return unless domain
       return if Settings::Authentication.acceptable_domain?(domain: domain)
 
-      message = "Marking as spam email #{identity.email} from provider #{identity.provider}."
+      message = "This #{identity.provider} email address #{identity.email} has been marked as spam"
 
       raise Authentication::Errors::SpammyEmailDomain, message
     end

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -20,12 +20,22 @@ module Authentication
       @cta_variant = cta_variant
     end
 
+    # @api public
+    #
+    # @see #initialize method for parameters
+    #
+    # @return user [User] when the given provider is valid
+    #
+    # @raises [Authentication::Errors::PreviouslySuspended] when the user was already suspended
+    # @raises [Authentication::Errors::SpammyEmailDomain] when the associated email is spammy
     def self.call(...)
       new(...).call
     end
 
+    # @api private
     def call
       identity = Identity.build_from_omniauth(provider)
+      guard_against_spam_from!(identity: identity)
       return current_user if current_user_identity_exists?
 
       # These variables need to be set outside of the scope of the
@@ -72,6 +82,16 @@ module Authentication
     end
 
     private
+
+    def guard_against_spam_from!(identity:)
+      domain = identity.email.split("@")[-1]
+      return unless domain
+      return if Settings::Authentication.acceptable_domain?(domain: domain)
+
+      message = "Marking as spam email #{identity.email} from provider #{identity.provider}."
+
+      raise Authentication::Errors::SpammyEmailDomain, message
+    end
 
     attr_reader :provider, :current_user, :cta_variant
 

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -6,6 +6,19 @@ RSpec.describe Authentication::Authenticator, type: :service do
     allow(Settings::Authentication).to receive(:providers).and_return(Authentication::Providers.available)
   end
 
+  # A shared context is somewhat like a module mixin.  You define
+  # the specs to share and then later you can `include_context` for
+  # that shared context.
+  shared_examples "spam handling" do
+    context "when email is spammy" do
+      it "raises an Identity::SpamDomainForIdentityError" do
+        allow(Settings::Authentication).to receive(:acceptable_domain?).and_return(false)
+
+        expect { service.call }.to raise_error(Authentication::Errors::SpammyEmailDomain)
+      end
+    end
+  end
+
   context "when authenticating through an unknown provider" do
     it "raises ProviderNotFound" do
       auth_payload = OmniAuth.config.mock_auth[:github].merge(provider: "okta")
@@ -18,6 +31,8 @@ RSpec.describe Authentication::Authenticator, type: :service do
   context "when authenticating through Apple", vcr: { cassette_name: "fastly_sloan" } do
     let!(:auth_payload) { OmniAuth.config.mock_auth[:apple] }
     let!(:service) { described_class.new(auth_payload) }
+
+    include_context "spam handling"
 
     describe "new user" do
       it "creates a new user" do
@@ -212,6 +227,8 @@ RSpec.describe Authentication::Authenticator, type: :service do
   context "when authenticating through Github" do
     let!(:auth_payload) { OmniAuth.config.mock_auth[:github] }
     let!(:service) { described_class.new(auth_payload) }
+
+    include_context "spam handling"
 
     describe "new user" do
       it "creates a new user" do
@@ -414,6 +431,8 @@ RSpec.describe Authentication::Authenticator, type: :service do
     let!(:auth_payload) { OmniAuth.config.mock_auth[:facebook] }
     let!(:service) { described_class.new(auth_payload) }
 
+    include_context "spam handling"
+
     describe "new user" do
       it "creates a new user" do
         expect do
@@ -502,6 +521,8 @@ RSpec.describe Authentication::Authenticator, type: :service do
   context "when authenticating through Twitter" do
     let!(:auth_payload) { OmniAuth.config.mock_auth[:twitter] }
     let!(:service) { described_class.new(auth_payload) }
+
+    include_context "spam handling"
 
     describe "new user" do
       it "creates a new user" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Prior to this commit, when an administrator had indicated blocked email
domains, those blocks were not applied to identities created via the
OAuth sources (e.g., Twitter, Facebook, etc).  With this change, we're
hooking into the similar logic flow as suspended email accounts.

## Related Tickets & Documents

Related to #15403, #15397, and forem/rfcs#281

## QA Instructions, Screenshots, Recordings

To QA this locally requires several things:

- First you'll need to configure your instance to allow for OAuth from one of the providers
- Then you'll need to update the blocked domain
  - Goto `/admin/customization/config` and open the Authentication setting.
  - Assuming you're using your OAuth account, add you email accounts domain to the Block email domains section
- In an incongito browser tab, create an account by connecting to the OAuth account

You should receive a flash message about a spammy email address.  And you won't have created an account.

_Note: I have not tested this in the browser as I have not yet configured my application to handle the OAuth providers.  However, I've spliced in this behavior in the same area in which we check for suspended accounts, so I have a high degree of confidence that this will work as intended._

### UI accessibility concerns?

I do have a question regarding the flash message, if the text is the correct text.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I'm not sure how best to communicate this change and need help

