### PR TITLE
Update Youtube Liquid Tag to accept seconds in timestamp query

### DIFF
--- a/app/liquid_tags/youtube_tag.rb
+++ b/app/liquid_tags/youtube_tag.rb
@@ -1,5 +1,10 @@
 class YoutubeTag < LiquidTagBase
   PARTIAL = "liquids/youtube".freeze
+  MARKER_TO_SECONDS_MAP = {
+    "h" => 60 * 60,
+    "m" => 60,
+    "s" => 1
+  }.freeze
 
   def initialize(_tag_name, id, _parse_context)
     super
@@ -29,19 +34,23 @@ class YoutubeTag < LiquidTagBase
     input_no_space
   end
 
-  def translate_start_time(id)
-    time = id.split("?t=")[-1]
-    time_hash = {
-      h: time.scan(/\d+h/)[0]&.delete("h").to_i,
-      m: time.scan(/\d+m/)[0]&.delete("m").to_i,
-      s: time.scan(/\d+s/)[0]&.delete("s").to_i
-    }
-    time_in_seconds = (time_hash[:h] * 3600) + (time_hash[:m] * 60) + time_hash[:s]
-    "#{id.split('?t=')[0]}?start=#{time_in_seconds}"
+  def valid_id?(id)
+    id.match?(/\A[a-zA-Z0-9_-]{11}((\?t=)?(\d{1,}h?)?(\d{1,2}m)?(\d{1,2}s)?){5,11}?\Z/)
   end
 
-  def valid_id?(id)
-    id =~ /\A[a-zA-Z0-9_-]{11}((\?t=)?(\d{1}h)?(\d{1,2}m)?(\d{1,2}s)?){5,11}?\Z/
+  def translate_start_time(id)
+    time = id.split("?t=")[-1]
+    return "#{id.split('?t=')[0]}?start=#{time}" if time.match?(/\A\d+\Z/)
+
+    time_elements = time.split(/[a-z]/)
+    time_markers = time.split(/\d+/)[1..]
+
+    seconds = 0
+    time_markers.each_with_index do |m, i|
+      seconds += MARKER_TO_SECONDS_MAP.fetch(m, 0) * time_elements[i].to_i
+    end
+
+    "#{id.split('?t=')[0]}?start=#{seconds}"
   end
 end
 

--- a/spec/liquid_tags/youtube_tag_spec.rb
+++ b/spec/liquid_tags/youtube_tag_spec.rb
@@ -3,21 +3,8 @@ require "rails_helper"
 RSpec.describe YoutubeTag, type: :liquid_tag do
   describe "#id" do
     let(:valid_id_no_time) { "dQw4w9WgXcQ" }
-    let(:valid_ids_with_time) { "QASbw8_0meM?t=8h12m26s" }
+    let(:valid_id_with_time) { "QASbw8_0meM?t=8h12m26s" }
     let(:invalid_id) { Faker::Lorem.characters(number: rand(12..100)) }
-
-    def parsed_id(id)
-      return id unless id.include?("?t=")
-
-      id_array = id.split("?t=")
-      time_hash = {
-        h: id_array[1].scan(/\d+h/)[0]&.delete("h").to_i,
-        m: id_array[1].scan(/\d+m/)[0]&.delete("m").to_i,
-        s: id_array[1].scan(/\d+s/)[0]&.delete("s").to_i
-      }
-      time_string = ((time_hash[:h] * 3600) + (time_hash[:m] * 60) + time_hash[:s]).to_s
-      "#{id_array[0]}?start=#{time_string}"
-    end
 
     def generate_new_liquid(id)
       Liquid::Template.register_tag("youtube", YoutubeTag)
@@ -33,7 +20,7 @@ RSpec.describe YoutubeTag, type: :liquid_tag do
     end
 
     it "accepts valid YouTube ID with starting times" do
-      liquid = generate_new_liquid(valid_ids_with_time).render
+      liquid = generate_new_liquid(valid_id_with_time).render
 
       expect(liquid).to include('<iframe')
       expect(liquid).to include('src="https://www.youtube.com/embed/QASbw8_0meM?start=29546"')
@@ -47,7 +34,7 @@ RSpec.describe YoutubeTag, type: :liquid_tag do
     end
 
     it "accepts YouTube ID with start times and one empty space" do
-      liquid = generate_new_liquid("#{valid_ids_with_time} ").render
+      liquid = generate_new_liquid("#{valid_id_with_time} ").render
 
       expect(liquid).to include('<iframe')
       expect(liquid).to include('src="https://www.youtube.com/embed/QASbw8_0meM?start=29546"')


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In production, the Youtube Liquid Tag works when you pass in a video ID with a timestamp query in the following format: `fhH5xX_yW6U?t=1h1m1s` (1hour, 1 minute, 1 second).

Youtube does not appear to format the timestamp query like above anymore. Timestamp queries are now in the format: `fhH5xX_yW6U?t=120` (120 seconds).

However, our current Youtube Liquid Tag does not accept the `?t=120` format. This PR fixes that.

## Related Tickets & Documents
This bug fix is necessary for my ongoing work on [unifying how we generate Liquid Tags](https://github.com/forem/forem/issues/15099#issuecomment-973058737
) in Forem. Specifically, this PR allows my work on the Youtube Liquid Tag to proceed.

## QA Instructions, Screenshots, Recordings
- In the app, create a new post. In the body, create a Youtube Liquid Tag with a valid ID, and append a timestamp query in the two formats discussed above (e.g. `?t=1h1m1s` and `?t=120`).
- Click on the Preview tab; check that the video renders properly. Play the video and ensure playback starts from the timestamp point.

### UI accessibility concerns?
No concerns; all changes are backend.

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] I will share this change internally with the appropriate teams


## [optional] What gif best describes this PR or how it makes you feel?

![Woman spraying bug spray towards the camera](https://media.giphy.com/media/3o6gE2LfcxozwGwTbq/giphy-downsized.gif)
