### PR TITLE
Gitpod: wait for postgresql to be listening before startup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,11 +13,11 @@ ports:
 
 tasks:
   - name: Forem Server
-    before: redis-server &
+    before: >
+      redis-server &
+      gp await-port 5432
     init: ./gitpod-init.sh
-    command: >
-      gp await-port 5432 &&
-      bin/startup
+    command: bin/startup
   - name: Open Site
     command: >
       gp await-port 3000 &&

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,7 +15,8 @@ tasks:
   - name: Forem Server
     before: >
       redis-server &
-      gp await-port 5432
+      gp await-port 5432 &&
+      sleep 1
     init: ./gitpod-init.sh
     command: bin/startup
   - name: Open Site

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,7 +15,9 @@ tasks:
   - name: Forem Server
     before: redis-server &
     init: ./gitpod-init.sh
-    command: bin/startup
+    command: >
+      gp await-port 5432 &&
+      bin/startup
   - name: Open Site
     command: >
       gp await-port 3000 &&

--- a/gitpod-init.sh
+++ b/gitpod-init.sh
@@ -5,4 +5,5 @@ echo "APP_DOMAIN=\"$(gp url 3000 | cut -f 3 -d /)\"" >> .env
 echo 'APP_PROTOCOL="https://"' >> .env
 gem install solargraph
 gem install foreman
+gp await-port 5432
 bin/setup

--- a/gitpod-init.sh
+++ b/gitpod-init.sh
@@ -5,5 +5,4 @@ echo "APP_DOMAIN=\"$(gp url 3000 | cut -f 3 -d /)\"" >> .env
 echo 'APP_PROTOCOL="https://"' >> .env
 gem install solargraph
 gem install foreman
-gp await-port 5432
 bin/setup


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

 https://github.com/forem/forem/issues/15428 points out an issue where
 the command sequence runs (foreman starts the Procfile.dev)
 but rails exits early because the database is not up.

Await the db port before proceeding.

Initially I thought to put this in the gitpod-init.sh (called as init) but I believe the initializer may not be run for pre-built containers? The failure in the main branch happened very early (while it took 10+ minutes in a branch build).

## Related Tickets & Documents

fixes #15428 

## QA Instructions, Screenshots, Recordings

The behavior in question was happening reliably for me when connecting to a prebuilt environment (where bin/setup had already been run and did not need to re-run) or after stopping and reconnecting to a workspace.

I suppose connecting via the [gitpod link](https://gitpod.io/#https://github.com/forem/forem/pull/15429) to this branch, and ensuring the foreman process doesn't error early because web/rails stopped, disconnecting (Stop Workspace), waiting for it to stop, and reconnecting/opening the workspace "warm" and confirming rails starts successfully the second time covers the desired behavior change.

On main (or before adding the sleep) I got the error described in the linked issue 

```
20:26:42 web.1       | Exiting
20:26:43 web.1       | /workspace/.rvm/ruby-3.0.2/gems/activerecord-6.1.4.1/lib/active_record/connection_adapters/postgresql_adapter.rb:83:in `rescue in new_client': FATAL:  the database system is starting up (ActiveRecord::ConnectionNotEstablished)
20:26:43 web.1       |  from /workspace/.rvm/ruby-3.0.2/gems/activerecord-6.1.4.1/lib/active_record/connection_adapters/postgresql_adapter.rb:77:in `new_client'
```

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: development environment setup
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: closing the issue is sufficient.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
