### PR TITLE
Reflect search query in page title

### DIFF
--- a/app/views/stories/articles_search/_meta.html.erb
+++ b/app/views/stories/articles_search/_meta.html.erb
@@ -1,4 +1,5 @@
-<% title t("views.search.meta.title") %>
+<% title t("views.search.meta.title", for: (params[:q].present? ? t("views.search.meta.for", query: params[:q]) : "")) %>
+
 <link rel="canonical" href="<%= app_url(search_path) %>" />
 <meta name="description" content="<%= Settings::Community.community_description %>">
 <%= meta_keywords_default %>

--- a/config/locales/views/misc/en.yml
+++ b/config/locales/views/misc/en.yml
@@ -85,7 +85,8 @@ en:
         newest: Newest
         oldest: Oldest
       meta:
-        title: Search Results
+        title: Search Results%{for}
+        for: " for %{query}"
         description: "%{site} => Search Results"
     series:
       meta:

--- a/config/locales/views/misc/fr.yml
+++ b/config/locales/views/misc/fr.yml
@@ -85,7 +85,8 @@ fr:
         newest: Newest
         oldest: Oldest
       meta:
-        title: Search Results
+        title: Search Results%{for}
+        for: " for %{query}"
         description: "%{site} => Search Results"
     series:
       meta:

--- a/spec/system/search/search_title_spec.rb
+++ b/spec/system/search/search_title_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Search page title", type: :system do
+  let!(:current_user) { create(:user) }
+
+  before do
+    sign_in current_user
+  end
+
+  context "when search query param exists" do
+    it "includes the search term in title and heading" do
+      visit "/search?q=helloworld"
+
+      expect(page).to have_title("Search Results for helloworld - DEV(local)")
+      expect(page.find("h1")).to have_content("Search results for helloworld")
+    end
+  end
+
+  context "when search query param doesn't exist" do
+    it "does not include search term in title and heading" do
+      visit "/search"
+
+      expect(page).to have_title("Search Results - DEV(local)")
+      expect(page.find("h1")).to have_content("Search results")
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Best practice for accessible search page titles is to include the search query as part of the title, as well as reflecting it in the `h1` of the page. We have already made the change to show the search term in the `h1`. This PR updates the title to use the search param too.

NB: We previously had concerns about caching issues when we started using the query param in the `h1`: https://github.com/forem/forem/pull/14848. As this PR uses that same query param, I believe there's no negative impact with this change, but I'd appreciate a concept check on that!

## Related Tickets & Documents

Closes #14735

## QA Instructions, Screenshots, Recordings

- Visit the search page _without_ an active search - i.e.: `/search`. Check that the page title (on your browser tab) is "Search Results - { community name }"
- Search for a phrase or word. Check that the page title is "Search Results for { whatever you searched for } - { community name }"

### UI accessibility concerns?

This represents an accessibility enhancement

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

