### PR TITLE
Favoring delete_all on user relationships

### DIFF
--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -1,4 +1,7 @@
 module Ahoy
+  #  @note When we destroy the related user, it's using dependent:
+  #        :delete for the relationship.  That means no before/after
+  #        destroy callbacks will be called on this object.
   class Event < ApplicationRecord
     include Ahoy::QueryMethods
 

--- a/app/models/ahoy/visit.rb
+++ b/app/models/ahoy/visit.rb
@@ -1,4 +1,7 @@
 module Ahoy
+  #  @note When we destroy the related user, it's using dependent:
+  #        :delete for the relationship.  That means no before/after
+  #        destroy callbacks will be called on this object.
   class Visit < ApplicationRecord
     self.table_name = "ahoy_visits"
 

--- a/app/models/api_secret.rb
+++ b/app/models/api_secret.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class ApiSecret < ApplicationRecord
   has_secure_token :secret
 

--- a/app/models/badge_achievement.rb
+++ b/app/models/badge_achievement.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class BadgeAchievement < ApplicationRecord
   CONTEXT_MESSAGE_ALLOWED_TAGS = %w[strong em i b u a code].freeze
   CONTEXT_MESSAGE_ALLOWED_ATTRIBUTES = %w[href name].freeze

--- a/app/models/discussion_lock.rb
+++ b/app/models/discussion_lock.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class DiscussionLock < ApplicationRecord
   belongs_to :article
   belongs_to :locking_user, class_name: "User"

--- a/app/models/display_ad_event.rb
+++ b/app/models/display_ad_event.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class DisplayAdEvent < ApplicationRecord
   belongs_to :display_ad
   belongs_to :user

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class Identity < ApplicationRecord
   NO_EMAIL_MSG = "No email found. Please relink your %<provider>s " \
                  "account to avoid errors.".freeze

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class Mention < ApplicationRecord
   belongs_to :user
   belongs_to :mentionable, polymorphic: true

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class Note < ApplicationRecord
   belongs_to :author, class_name: "User", optional: true
   belongs_to :noteable, polymorphic: true, touch: true

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class Notification < ApplicationRecord
   belongs_to :notifiable, polymorphic: true
   belongs_to :user, optional: true

--- a/app/models/notification_subscription.rb
+++ b/app/models/notification_subscription.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class NotificationSubscription < ApplicationRecord
   belongs_to :notifiable, polymorphic: true
   belongs_to :user

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -11,6 +11,9 @@ class OrganizationMembership < ApplicationRecord
   after_create  :update_user_organization_info_updated_at
   after_destroy :update_user_organization_info_updated_at
 
+  # @note In the case where we delete the user, we don't need to worry
+  #       about updating the user.  Hence the the `user has_many
+  #       :organization_memberships dependent: :delete_all`
   def update_user_organization_info_updated_at
     user.touch(:organization_info_updated_at)
   end

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class OrganizationMembership < ApplicationRecord
   belongs_to :user
   belongs_to :organization

--- a/app/models/podcast_episode_appearance.rb
+++ b/app/models/podcast_episode_appearance.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class PodcastEpisodeAppearance < ApplicationRecord
   belongs_to :user, class_name: "User", inverse_of: :podcast_episode_appearances
   belongs_to :podcast_episode

--- a/app/models/podcast_ownership.rb
+++ b/app/models/podcast_ownership.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class PodcastOwnership < ApplicationRecord
   belongs_to :owner, class_name: "User", foreign_key: :user_id, inverse_of: :podcasts_owned
   belongs_to :podcast

--- a/app/models/poll_skip.rb
+++ b/app/models/poll_skip.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class PollSkip < ApplicationRecord
   belongs_to :poll
   belongs_to :user

--- a/app/models/poll_vote.rb
+++ b/app/models/poll_vote.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class PollVote < ApplicationRecord
   belongs_to :user
   belongs_to :poll_option

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class Profile < ApplicationRecord
   belongs_to :user
 

--- a/app/models/response_template.rb
+++ b/app/models/response_template.rb
@@ -1,3 +1,6 @@
+#  @note When we destroy the related user, it's using dependent:
+#        :delete for the relationship.  That means no before/after
+#        destroy callbacks will be called on this object.
 class ResponseTemplate < ApplicationRecord
   resourcify
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   # NOTE: we are using an inline module to keep profile related things together.
   concerning :Profiles do
     included do
-      has_one :profile, dependent: :destroy
+      has_one :profile, dependent: :delete
 
       # NOTE: There are rare cases were we want to skip this callback, primarily
       # in tests. `skip_callback` modifies global state, which is not thread-safe
@@ -43,8 +43,8 @@ class User < ApplicationRecord
   acts_as_followable
   acts_as_follower
 
-  has_one :notification_setting, class_name: "Users::NotificationSetting", dependent: :destroy
-  has_one :setting, class_name: "Users::Setting", dependent: :destroy
+  has_one :notification_setting, class_name: "Users::NotificationSetting", dependent: :delete
+  has_one :setting, class_name: "Users::Setting", dependent: :delete
 
   has_many :access_grants, class_name: "Doorkeeper::AccessGrant", foreign_key: :resource_owner_id,
                            inverse_of: :resource_owner, dependent: :delete_all
@@ -52,13 +52,13 @@ class User < ApplicationRecord
                            inverse_of: :resource_owner, dependent: :delete_all
   has_many :affected_feedback_messages, class_name: "FeedbackMessage",
                                         inverse_of: :affected, foreign_key: :affected_id, dependent: :nullify
-  has_many :ahoy_events, class_name: "Ahoy::Event", dependent: :destroy
-  has_many :ahoy_visits, class_name: "Ahoy::Visit", dependent: :destroy
-  has_many :api_secrets, dependent: :destroy
+  has_many :ahoy_events, class_name: "Ahoy::Event", dependent: :delete_all
+  has_many :ahoy_visits, class_name: "Ahoy::Visit", dependent: :delete_all
+  has_many :api_secrets, dependent: :delete_all
   has_many :articles, dependent: :destroy
   has_many :audit_logs, dependent: :nullify
   has_many :authored_notes, inverse_of: :author, class_name: "Note", foreign_key: :author_id, dependent: :delete_all
-  has_many :badge_achievements, dependent: :destroy
+  has_many :badge_achievements, dependent: :delete_all
   has_many :badge_achievements_rewarded, class_name: "BadgeAchievement", foreign_key: :rewarder_id,
                                          inverse_of: :rewarder, dependent: :nullify
   has_many :badges, through: :badge_achievements
@@ -72,32 +72,33 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :created_podcasts, class_name: "Podcast", foreign_key: :creator_id, inverse_of: :creator, dependent: :nullify
   has_many :credits, dependent: :destroy
-  has_many :discussion_locks, dependent: :destroy, inverse_of: :locking_user, foreign_key: :locking_user_id
-  has_many :display_ad_events, dependent: :destroy
+  has_many :discussion_locks, dependent: :delete_all, inverse_of: :locking_user, foreign_key: :locking_user_id
+  has_many :display_ad_events, dependent: :delete_all
   has_many :email_authorizations, dependent: :delete_all
   has_many :email_messages, class_name: "Ahoy::Message", dependent: :destroy
   has_many :field_test_memberships, class_name: "FieldTest::Membership", as: :participant, dependent: :destroy
+  # Consider that we might be able to use dependent: :delete_all as the GithubRepo busts the user cache
   has_many :github_repos, dependent: :destroy
   has_many :html_variants, dependent: :destroy
-  has_many :identities, dependent: :destroy
+  has_many :identities, dependent: :delete_all
   has_many :identities_enabled, -> { enabled }, class_name: "Identity", inverse_of: false
   has_many :listings, dependent: :destroy
-  has_many :mentions, dependent: :destroy
-  has_many :notes, as: :noteable, inverse_of: :noteable, dependent: :destroy
-  has_many :notification_subscriptions, dependent: :destroy
-  has_many :notifications, dependent: :destroy
+  has_many :mentions, dependent: :delete_all
+  has_many :notes, as: :noteable, inverse_of: :noteable, dependent: :delete_all
+  has_many :notification_subscriptions, dependent: :delete_all
+  has_many :notifications, dependent: :delete_all
   has_many :offender_feedback_messages, class_name: "FeedbackMessage",
                                         inverse_of: :offender, foreign_key: :offender_id, dependent: :nullify
-  has_many :organization_memberships, dependent: :destroy
+  has_many :organization_memberships, dependent: :delete_all
   has_many :organizations, through: :organization_memberships
   # we keep page views as they belong to the article, not to the user who viewed it
   has_many :page_views, dependent: :nullify
-  has_many :podcast_episode_appearances, dependent: :destroy, inverse_of: :user
+  has_many :podcast_episode_appearances, dependent: :delete_all, inverse_of: :user
   has_many :podcast_episodes, through: :podcast_episode_appearances, source: :podcast_episode
-  has_many :podcast_ownerships, dependent: :destroy, inverse_of: :owner
+  has_many :podcast_ownerships, dependent: :delete_all, inverse_of: :owner
   has_many :podcasts_owned, through: :podcast_ownerships, source: :podcast
-  has_many :poll_skips, dependent: :destroy
-  has_many :poll_votes, dependent: :destroy
+  has_many :poll_skips, dependent: :delete_all
+  has_many :poll_votes, dependent: :delete_all
   has_many :profile_pins, as: :profile, inverse_of: :profile, dependent: :delete_all
 
   # we keep rating votes as they belong to the article, not to the user who viewed it
@@ -106,7 +107,7 @@ class User < ApplicationRecord
   has_many :reactions, dependent: :destroy
   has_many :reporter_feedback_messages, class_name: "FeedbackMessage",
                                         inverse_of: :reporter, foreign_key: :reporter_id, dependent: :nullify
-  has_many :response_templates, inverse_of: :user, dependent: :destroy
+  has_many :response_templates, inverse_of: :user, dependent: :delete_all
   has_many :source_authored_user_subscriptions, class_name: "UserSubscription",
                                                 foreign_key: :author_id, inverse_of: :author, dependent: :destroy
   has_many :subscribed_to_user_subscriptions, class_name: "UserSubscription",
@@ -115,7 +116,7 @@ class User < ApplicationRecord
   has_many :tweets, dependent: :nullify
   has_many :webhook_endpoints, class_name: "Webhook::Endpoint", inverse_of: :user, dependent: :delete_all
   has_many :devices, dependent: :delete_all
-  has_many :sponsorships, dependent: :destroy
+  has_many :sponsorships, dependent: :delete_all
 
   mount_uploader :profile_image, ProfileImageUploader
 

--- a/app/models/users/notification_setting.rb
+++ b/app/models/users/notification_setting.rb
@@ -1,4 +1,7 @@
 module Users
+  #  @note When we destroy the related user, it's using dependent:
+  #        :delete for the relationship.  That means no before/after
+  #        destroy callbacks will be called on this object.
   class NotificationSetting < ApplicationRecord
     self.table_name_prefix = "users_"
     self.ignored_columns = %w[email_connect_messages]

--- a/app/models/users/setting.rb
+++ b/app/models/users/setting.rb
@@ -1,4 +1,7 @@
 module Users
+  #  @note When we destroy the related user, it's using dependent:
+  #        :delete for the relationship.  That means no before/after
+  #        destroy callbacks will be called on this object.
   class Setting < ApplicationRecord
     self.table_name_prefix = "users_"
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,49 +40,49 @@ RSpec.describe User, type: :model do
     describe "builtin validations" do
       subject { user }
 
-      it { is_expected.to have_one(:profile).dependent(:destroy) }
-      it { is_expected.to have_one(:notification_setting).dependent(:destroy) }
-      it { is_expected.to have_one(:setting).dependent(:destroy) }
+      it { is_expected.to have_one(:profile).dependent(:delete) }
+      it { is_expected.to have_one(:notification_setting).dependent(:delete) }
+      it { is_expected.to have_one(:setting).dependent(:delete) }
 
       it { is_expected.to have_many(:access_grants).class_name("Doorkeeper::AccessGrant").dependent(:delete_all) }
       it { is_expected.to have_many(:access_tokens).class_name("Doorkeeper::AccessToken").dependent(:delete_all) }
-      it { is_expected.to have_many(:ahoy_events).class_name("Ahoy::Event").dependent(:destroy) }
-      it { is_expected.to have_many(:ahoy_visits).class_name("Ahoy::Visit").dependent(:destroy) }
-      it { is_expected.to have_many(:api_secrets).dependent(:destroy) }
+      it { is_expected.to have_many(:ahoy_events).class_name("Ahoy::Event").dependent(:delete_all) }
+      it { is_expected.to have_many(:ahoy_visits).class_name("Ahoy::Visit").dependent(:delete_all) }
+      it { is_expected.to have_many(:api_secrets).dependent(:delete_all) }
       it { is_expected.to have_many(:articles).dependent(:destroy) }
       it { is_expected.to have_many(:audit_logs).dependent(:nullify) }
-      it { is_expected.to have_many(:badge_achievements).dependent(:destroy) }
+      it { is_expected.to have_many(:badge_achievements).dependent(:delete_all) }
       it { is_expected.to have_many(:badges).through(:badge_achievements) }
       it { is_expected.to have_many(:collections).dependent(:destroy) }
       it { is_expected.to have_many(:comments).dependent(:destroy) }
       it { is_expected.to have_many(:credits).dependent(:destroy) }
-      it { is_expected.to have_many(:discussion_locks).dependent(:destroy) }
-      it { is_expected.to have_many(:display_ad_events).dependent(:destroy) }
+      it { is_expected.to have_many(:discussion_locks).dependent(:delete_all) }
+      it { is_expected.to have_many(:display_ad_events).dependent(:delete_all) }
       it { is_expected.to have_many(:email_authorizations).dependent(:delete_all) }
       it { is_expected.to have_many(:email_messages).class_name("Ahoy::Message").dependent(:destroy) }
       it { is_expected.to have_many(:field_test_memberships).class_name("FieldTest::Membership").dependent(:destroy) }
       it { is_expected.to have_many(:github_repos).dependent(:destroy) }
       it { is_expected.to have_many(:html_variants).dependent(:destroy) }
-      it { is_expected.to have_many(:identities).dependent(:destroy) }
+      it { is_expected.to have_many(:identities).dependent(:delete_all) }
       it { is_expected.to have_many(:identities_enabled) }
       it { is_expected.to have_many(:listings).dependent(:destroy) }
-      it { is_expected.to have_many(:mentions).dependent(:destroy) }
-      it { is_expected.to have_many(:notes).dependent(:destroy) }
-      it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
-      it { is_expected.to have_many(:notifications).dependent(:destroy) }
-      it { is_expected.to have_many(:organization_memberships).dependent(:destroy) }
+      it { is_expected.to have_many(:mentions).dependent(:delete_all) }
+      it { is_expected.to have_many(:notes).dependent(:delete_all) }
+      it { is_expected.to have_many(:notification_subscriptions).dependent(:delete_all) }
+      it { is_expected.to have_many(:notifications).dependent(:delete_all) }
+      it { is_expected.to have_many(:organization_memberships).dependent(:delete_all) }
       it { is_expected.to have_many(:organizations).through(:organization_memberships) }
       it { is_expected.to have_many(:page_views).dependent(:nullify) }
-      it { is_expected.to have_many(:podcast_episode_appearances).dependent(:destroy) }
+      it { is_expected.to have_many(:podcast_episode_appearances).dependent(:delete_all) }
       it { is_expected.to have_many(:podcast_episodes).through(:podcast_episode_appearances).source(:podcast_episode) }
-      it { is_expected.to have_many(:podcast_ownerships).dependent(:destroy) }
+      it { is_expected.to have_many(:podcast_ownerships).dependent(:delete_all) }
       it { is_expected.to have_many(:podcasts_owned).through(:podcast_ownerships).source(:podcast) }
-      it { is_expected.to have_many(:poll_skips).dependent(:destroy) }
-      it { is_expected.to have_many(:poll_votes).dependent(:destroy) }
+      it { is_expected.to have_many(:poll_skips).dependent(:delete_all) }
+      it { is_expected.to have_many(:poll_votes).dependent(:delete_all) }
       it { is_expected.to have_many(:profile_pins).dependent(:delete_all) }
       it { is_expected.to have_many(:rating_votes).dependent(:nullify) }
       it { is_expected.to have_many(:reactions).dependent(:destroy) }
-      it { is_expected.to have_many(:response_templates).dependent(:destroy) }
+      it { is_expected.to have_many(:response_templates).dependent(:delete_all) }
       it { is_expected.to have_many(:source_authored_user_subscriptions).dependent(:destroy) }
       it { is_expected.to have_many(:subscribed_to_user_subscriptions).dependent(:destroy) }
       it { is_expected.to have_many(:subscribers).dependent(:destroy) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

Prior to this commit, several of the user's "has_many" were marked as
`depenedent: :destroy`.
    
In the case of :destroy, ActiveRecord instantiates each object and then
runs destroy. Whereas in the case of :delete, ActiveRecord issues a SQL
command to delete the related files.
    
It is often "safer" to use :destroy, as it guarantees that you'll
instantiate the record and run it's callbacks. But sometimes you have
to go with the speed of SQL.
    
And while not directly related to #15424 it is representative of our
callback ecosystem creating some unexpected computational loads.
    
## Related Tickets & Documents

Related to #15442 and #15424

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: this is an optimization to some inner workings, and thus doesn't warrant communication.
