### PR TITLE
Accessibility improvements for hide comments modal

### DIFF
--- a/app/javascript/contentDisplayPolicy/initHiddenComments.js
+++ b/app/javascript/contentDisplayPolicy/initHiddenComments.js
@@ -16,9 +16,19 @@ export function initHiddenComments() {
       });
   }
 
-  function showHideCommentsModal(commentId) {
+  function showHideCommentsModal(commentId, commentUrl) {
     const form = document.getElementById('hide-comments-modal__form');
     form.action = `/comments/${commentId}/hide`;
+
+    const report_link = document.getElementById(
+      'hide-comments-modal__report-link',
+    );
+    report_link.href = `/report-abuse?url=${commentUrl}`;
+
+    const comment_permalink = document.getElementById(
+      'hide-comments-modal__comment-permalink',
+    );
+    comment_permalink.href = commentUrl;
 
     window.Forem.showModal({
       title: 'Confirm hiding the comment',
@@ -38,10 +48,10 @@ export function initHiddenComments() {
   );
 
   hideButtons.forEach((butt) => {
-    const { commentId } = butt.dataset;
+    const { commentId, commentUrl } = butt.dataset;
     butt.addEventListener('click', (e) => {
       e.preventDefault();
-      showHideCommentsModal(commentId);
+      showHideCommentsModal(commentId, commentUrl);
     });
   });
 

--- a/app/views/comments/_comment_header.html.erb
+++ b/app/views/comments/_comment_header.html.erb
@@ -42,6 +42,7 @@
               class="flex justify-between crayons-link crayons-link--block w-100 bg-transparent border-0 hide-comment"
               data-hide-type="hide"
               data-comment-id="<%= comment.id %>"
+              data-comment-url="<%= URL.url(comment.path) %>"
               aria-label="<%= t("views.comments.menu.action.aria_label", action: t("views.comments.menu.action.hide"), user: comment.user.name) %>">
               <%= t("views.comments.menu.action.hide_text") %>
             </button>

--- a/app/views/comments/_hide_comments_modal.html.erb
+++ b/app/views/comments/_hide_comments_modal.html.erb
@@ -2,7 +2,7 @@
   <%= form_with url: "/comments/hide", class: "hide-comments-modal__form", id: "hide-comments-modal__form", method: :patch, remote: true, html: { "data-type": "json" } do |f| %>
     <div class="hide-comments-modal__content">
       <p class="pb-2">
-        Are you sure you want to hide this comment? It will become hidden in your post, but will still be visible via the comment's permalink.
+        Are you sure you want to hide this comment? It will become hidden in your post, but will still be visible via the comment's <%= link_to "permalink", "#", id: "hide-comments-modal__comment-permalink" %>.
       </p>
       <label class="crayons-field crayons-field--checkbox my-2">
         <%= f.check_box :hide_children, class: "hide_children crayons-checkbox" %>
@@ -15,5 +15,5 @@
       </p>
     </div>
   <% end %>
-  <p class="fs-s color-base-60">For further actions, you may consider blocking this person and/or reporting abuse</p>
+  <p class="fs-s color-base-60">For further actions, you may consider blocking this person and/or <%= link_to "reporting abuse", "/report-abuse", id: "hide-comments-modal__report-link" %></p>
 </div>

--- a/cypress/integration/seededFlows/articleFlows/hideArticleComments.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/hideArticleComments.spec.js
@@ -24,5 +24,14 @@ describe('Hiding/unhiding comments on an article', () => {
       }).click();
       cy.findByRole('img', { name: 'Expand' }).should('not.exist');
     });
+
+    it('has report-abuse link  when showing hiding comment modal', () => {
+      cy.findByRole('button', { name: 'Toggle dropdown menu' }).click();
+      cy.findByRole('button', { name: "Hide Admin McAdmin's comment" }).click();
+
+      cy.findByRole('link', { name: 'reporting abuse' })
+        .should('have.attr', 'href')
+        .and('contains', `/admin_mcadmin/comment/`);
+    });
   });
 });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Optimization

## Description
Implemented accessibility improvements suggested by @aitchiss in #15178 
On hide comment modal:
- added a link to report a comment url
- added a comment permalink

## Related Tickets & Documents
#15178 

## QA Instructions, Screenshots, Recordings
### UI accessibility concerns?

![изображение](https://user-images.githubusercontent.com/30115/142986283-46f25f72-6482-466c-831c-1a8c154065d2.png)

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: a small improvement doesn't add any new behavior. 


