### PR TITLE
Allow Forem admin to turn off feature image req

### DIFF
--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -16,7 +16,7 @@ class ArticleDecorator < ApplicationDecorator
   #
   # @see ./app/views/stories/feeds/show.json.jbuilder for an example
   #      of usage
-  def can_be_featured_in_feed
+  def can_be_featured_in_feed?
     return false unless featured
     return true if main_image.present?
     return true unless FeatureFlag.accessible?(:featured_story_must_have_main_image)
@@ -27,7 +27,7 @@ class ArticleDecorator < ApplicationDecorator
   # Why the alias?  Because an associated JSON builder uses the
   # can_be_featured_in_feed, but having the can_be_featured_in_feed?
   # method helps create conditions of least surprise.
-  alias can_be_featured_in_feed? can_be_featured_in_feed
+  alias can_be_featured_in_feed can_be_featured_in_feed?
 
   def current_state_path
     published ? "/#{username}/#{slug}" : "/#{username}/#{slug}?preview=#{password}"

--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -13,6 +13,9 @@ class ArticleDecorator < ApplicationDecorator
   # @return [TrueClass] if this article can be "featured" in the feed
   # @return [FalseClass] if this article should not be "featured" in
   #         the feed
+  #
+  # @see ./app/views/stories/feeds/show.json.jbuilder for an example
+  #      of usage
   def can_be_featured_in_feed
     return false unless featured
     return true if main_image.present?

--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -1,6 +1,31 @@
 class ArticleDecorator < ApplicationDecorator
   LONG_MARKDOWN_THRESHOLD = 900
 
+  # This method answers whethor or not this decorated article can be
+  # featured in the feed.
+  #
+  # @note From #15292 we want to no longer require the featured
+  #       article to have an image.  However, there are some
+  #       assumptions made in the view about featured articles having
+  #       images.  Furthermore, by enabling a feature flag, if the
+  #       code breaks we can toggle the requirement back on.
+  #
+  # @return [TrueClass] if this article can be "featured" in the feed
+  # @return [FalseClass] if this article should not be "featured" in
+  #         the feed
+  def can_be_featured_in_feed
+    return false unless featured
+    return true if main_image.present?
+    return true unless FeatureFlag.accessible?(:featured_story_must_have_main_image)
+
+    false
+  end
+
+  # Why the alias?  Because an associated JSON builder uses the
+  # can_be_featured_in_feed, but having the can_be_featured_in_feed?
+  # method helps create conditions of least surprise.
+  alias can_be_featured_in_feed? can_be_featured_in_feed
+
   def current_state_path
     published ? "/#{username}/#{slug}" : "/#{username}/#{slug}?preview=#{password}"
   end

--- a/app/javascript/articles/Article.jsx
+++ b/app/javascript/articles/Article.jsx
@@ -38,8 +38,11 @@ export const Article = ({
     'crayons-story__tertiary',
   ];
 
+  // In https://github.com/forem/forem/issues/15292 we no longer
+  // require that a featured article have an image.
   let showCover =
-    (isFeatured || (feedStyle === 'rich' && article.main_image)) &&
+    article.main_image &&
+    (isFeatured || feedStyle === 'rich') &&
     !article.cloudinary_video_url;
 
   // pinned article can have a cover image

--- a/app/javascript/articles/Feed.jsx
+++ b/app/javascript/articles/Feed.jsx
@@ -31,12 +31,13 @@ export const Feed = ({ timeFrame, renderFeed }) => {
 
         const pinnedArticle = feedItems.find((story) => story.pinned === true);
 
-        // Ensure first article is one with a main_image
-        // This is important because the featuredStory will
-        // appear at the top of the feed, with a larger
-        // main_image than any of the stories or feed elements.
+        // In https://github.com/forem/forem/issues/15292 we
+        // introduced the idea that the featured story did not require
+        // an image.  So instead of encoding that it has an image, I'm
+        // falling back to the server to state if this is an article
+        // that can be featured.
         const featuredStory = feedItems.find(
-          (story) => story.main_image !== null,
+          (story) => story.can_be_featured_in_feed === true,
         );
 
         // If pinned and featured article aren't the same,

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -255,7 +255,7 @@ class Article < ApplicationRecord
            :video_thumbnail_url, :video_closed_caption_track_url,
            :experience_level_rating, :experience_level_rating_distribution, :cached_user, :cached_organization,
            :published_at, :crossposted_at, :description, :reading_time, :video_duration_in_seconds,
-           :last_comment_at)
+           :last_comment_at, :featured)
   }
 
   scope :limited_columns_internal_select, lambda {

--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -11,7 +11,7 @@ module Articles
         # Per #15292 we want to move towards not requiring feature's
         # to have a main image.  This allows us to inch our way
         # towards that configuration.
-        @must_have_main_image = false # FeatureFlag.accessible?(:featured_story_must_have_main_image)
+        @must_have_main_image = FeatureFlag.accessible?(:featured_story_must_have_main_image)
       end
 
       def must_have_main_image?

--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -8,7 +8,7 @@ module Articles
         @tag = tag
         @article_score_applicator = Articles::Feeds::ArticleScoreCalculatorForUser.new(user: user)
 
-        # Per #15292 we want to move towards not requiring feature's
+        # Per #15292 we want to move towards not requiring features
         # to have a main image.  This allows us to inch our way
         # towards that configuration.
         @must_have_main_image = FeatureFlag.accessible?(:featured_story_must_have_main_image)

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -3,7 +3,8 @@
   <% if featured == true %>
     <div id="featured-story-marker" data-featured-article="articles-<%= story.id %>"></div>
   <% end %>
-  <% if featured == true || (feed_style_preference == "rich" && story.main_image.present?) %>
+  <%# In https://github.com/forem/forem/issues/15292 we no longer require that a featured article have an image. %>
+  <% if story.main_image.present? && (featured == true || feed_style_preference == "rich") %>
     <a href="<%= story.path %>" title="<%= story.title %>" aria-label="article"
       style="background-color: <%= story.main_image_background_hex_color %>; background-image: url(<%= cloud_cover_url(story.main_image) %>);"
       class="crayons-story__cover crayons-story__cover__image">

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -6,7 +6,7 @@ article_attributes_to_include = %i[
 article_methods_to_include = %i[
   readable_publish_date flare_tag class_name
   cloudinary_video_url video_duration_in_minutes published_at_int
-  published_timestamp
+  published_timestamp can_be_featured_in_feed
 ]
 
 json.array!(@stories) do |article|

--- a/lib/data_update_scripts/20211121235419_add_feature_flag_featured_story_must_have_admin_page.rb
+++ b/lib/data_update_scripts/20211121235419_add_feature_flag_featured_story_must_have_admin_page.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class AddFeatureFlagFeaturedStoryMustHaveAdminPage
+    def run
+      FeatureFlag.add(:featured_story_must_have_main_image)
+    end
+  end
+end

--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -6,9 +6,14 @@ RSpec.describe ArticleDecorator, type: :decorator do
     article.decorate
   end
 
+  subject(:decorated_article) { build(:article).decorate }
+
   let(:article) { build(:article) }
   let(:published_article) { create_article(published: true) }
   let(:organization) { build(:organization) }
+
+  it { is_expected.to respond_to(:can_be_featured_in_feed) }
+  it { is_expected.to respond_to(:can_be_featured_in_feed?) }
 
   context "with serialization" do
     it "serializes both the decorated object IDs and decorated methods" do

--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe ArticleDecorator, type: :decorator do
   it { is_expected.to respond_to(:can_be_featured_in_feed) }
   it { is_expected.to respond_to(:can_be_featured_in_feed?) }
 
+  describe "#can_be_featured_in_feed" do
+    it "is an alias of #can_be_featured_in_feed?" do
+      decorated_article = build(:article).decorate
+      expect(decorated_article.method(:can_be_featured_in_feed))
+        .to eq(decorated_article.method(:can_be_featured_in_feed?))
+    end
+  end
+
   context "with serialization" do
     it "serializes both the decorated object IDs and decorated methods" do
       article = published_article

--- a/spec/lib/data_update_scripts/add_feature_flag_featured_story_must_have_admin_page_spec.rb
+++ b/spec/lib/data_update_scripts/add_feature_flag_featured_story_must_have_admin_page_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20211121235419_add_feature_flag_featured_story_must_have_admin_page.rb",
+)
+
+describe DataUpdateScripts::AddFeatureFlagFeaturedStoryMustHaveAdminPage do
+  after do
+    FeatureFlag.remove(:featured_story_must_have_main_image)
+  end
+
+  it "adds the :featured_story_must_have_main_image flag" do
+    expect do
+      described_class.new.run
+    end.to change { FeatureFlag.exist?(:featured_story_must_have_main_image) }.from(false).to(true)
+  end
+
+  it "works if the flag is already available" do
+    FeatureFlag.add(:featured_story_must_have_main_image)
+
+    expect do
+      described_class.new.run
+    end.not_to change { FeatureFlag.exist?(:featured_story_must_have_main_image) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,6 +80,11 @@ RSpec.configure do |config|
 
   config.extend WithModel
 
+  config.before(:each, :system) do
+    # Test that our tests handle the "future state" of the application code.
+    allow(FeatureFlag).to receive(:accessible?).with(:featured_story_must_have_main_image).and_return(false)
+  end
+
   config.after(:each, type: :system) do
     Warden::Manager._on_request.clear
   end

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -11,6 +11,26 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
   let!(:old_story) { create(:article, published_at: 3.days.ago) }
   let!(:low_scoring_article) { create(:article, score: -1000) }
 
+  describe "#must_have_main_image?" do
+    subject { feed.must_have_main_image? }
+
+    context "when FeatureFlag.accessible?(:featured_story_must_have_main_image) is true" do
+      before do
+        allow(FeatureFlag).to receive(:accessible?).with(:featured_story_must_have_main_image).and_return(true)
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when FeatureFlag.accessible?(:featured_story_must_have_main_image) is false" do
+      before do
+        allow(FeatureFlag).to receive(:accessible?).with(:featured_story_must_have_main_image).and_return(false)
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe "#featured_story_and_default_home_feed" do
     let(:default_feed) { feed.featured_story_and_default_home_feed }
     let(:featured_story) { default_feed.first }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Prior to this commit, all featured articles required a main image.  With
this commit, I'm doing a few things:

1) Structuring the view logic to no longer assume that features have images.
2) Delegating the "should I feature this" from javascript into the
   article decorator.
3) Exposing a feature flag which should allow for easing the rollout.

Caveat: There are two `.jsx` and I'm trying to track down both of their
use cases but due to caching uncertainty, I don't know if I've done
that.

I'll definitely need some "understands the inter-play of the different
jsx files and when they are rendered."


## Related Tickets & Documents

Closes #15292

## QA Instructions, Screenshots, Recordings

First, I went with a feature flag so we could more quickly "revert" the change.

This one I'm going to need help with.  I'm trying to track down where
we use the two changed `.jsx` files, but am uncertain if I'm finding
those places.

### UI accessibility concerns?

From an accessibility perspective, I'm not concerned with removing the image.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] PENDING: This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [X] I will share this change internally with the appropriate teams
