### PR TITLE
Adjust "Public" Radio Buttons on the Creator Settings Form

### DIFF
--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -76,7 +76,7 @@
       </div>
       <div>
         <%= radio_button_tag :public, "0", false, class: "crayons-radio" %>
-        <label for="public_1">Members Only</label>
+        <label for="public_1">Members only</label>
       </div>
     </div>
   </fieldset>

--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -71,12 +71,12 @@
     <legend class="crayons-field__label mb-2">Who can view content in this community?</legend>
     <div>
       <div class="mb-2">
-        <%= radio_button_tag :public, "0", false, class: "crayons-radio" %>
+        <%= radio_button_tag :public, "1", true, class: "crayons-radio" %>
         <label for="public_0">Everyone</label>
       </div>
       <div>
-        <%= radio_button_tag :public, "1", true, class: "crayons-radio" %>
-        <label for="public_1">Members only</label>
+        <%= radio_button_tag :public, "0", false, class: "crayons-radio" %>
+        <label for="public_1">Members Only</label>
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adjusts the booleans that tie back to the labels for the "Who can view content in this community?" section of the Creator Settings form. As it currently stands, when a Creator selects "Everyone," the form does not update in the backend or the Config as expected since "Everyone" is currently set to `public` = `false` when it really should equate to `public` = `true`. There are two ways that we could address this issue and I am happy to implement either of the two fixes, but to keep the text on the form consistent, I opted to go with the first of the two approaches:
- **Approach 1 (Current Implementation)**: Keep the labels as-is and adjust the booleans associated with the labels instead. To accomplish this, I set the "Everyone" radio button to `true` rather than `false`. By doing this, the labels will remain the same, but the radio buttons will default to "Everyone" being `true` and selected, rather than "Members only" being true and selected (please see the "Before" and "After" screenshots as outlined in the "QA Instructions" section of this PR for more context!).
- **Approach 2**: Alternatively, we can adjust the labels and keep the booleans associated with the labels instead. To accomplish this, we would need to switch the "Everyone" label with "Members Only" and vice-versa.

## Related Tickets & Documents
Relates to #14645 

## QA Instructions, Screenshots, Recordings
#### Please note that you will need to essentially clear out your database to take this feature for a spin. 🏎️  

To do so, you can either drop your entire database via `rails:db drop` 

_**or**_

You can open a rails console via `rails c` and do the following:
 ```
# Enable the feature flag
FeatureFlag.enable(:creator_onboarding)

# Delete all users 
User.destroy_all

# Set `waiting_on_first_user` to be true
Settings::General.waiting_on_first_user = true

# If you've logged in before set the mascot id to nil
 Settings::General.mascot_user_id = nil
```

Now, run your server and navigate to `http://localhost:3000/` and complete the "Create Account" form. After completing the "Create Account" form, you should be brought to the new Creator Setup page, `${baseUrl}/admin/creator_settings/new?referrer=${baseUrl}`.

Once on the Creator Settings page, you will want to test the changes outlined below:
#### Before:
<img width="568" alt="Screen Shot 2021-11-23 at 10 44 18 AM" src="https://user-images.githubusercontent.com/32834804/143076840-169d148c-81c1-42cd-bfa0-f30c6a631a30.png">

#### After:
<img width="645" alt="Screen Shot 2021-11-23 at 10 41 40 AM" src="https://user-images.githubusercontent.com/32834804/143076724-73dc58fc-ce83-472b-8994-993972a88bf7.png">

To test that the changes work, please ensure that you upon selecting a "Who can view content in this community?" radio button and submitting the Creator Settings form, the backend and Config update as expected. **The "Everyone" radio button should evaluate to `true` and the "Members only" label should evaluate to `false`.**

To further test this, navigate to "/admin/customization/config" after successfully submitting the form and ensure that the "Public" checkbox located beneath "User Experience and Brand" reflects your selection from the Creator Settings form:
<img width="820" alt="Screen Shot 2021-11-23 at 10 46 28 AM" src="https://user-images.githubusercontent.com/32834804/143077137-b10ca5f0-4ee7-42df-9814-83e2b7b63e40.png">

----------------------------------

#### Alternative Implementation:
Rather than adjusting the booleans associated with the "Who can view content in this community?" radio buttons, we could alternatively adjust the labels, as outlined in the PR description above. If we decided to go with this implementation rather than the one implemented in this PR, the form's appearance would change to look like this:

#### After:
<img width="648" alt="Screen Shot 2021-11-23 at 10 45 20 AM" src="https://user-images.githubusercontent.com/32834804/143076979-4b667d9d-2720-4534-a510-f27d12c98446.png">

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility concerns?
N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: there are already E2E tests for these radio buttons
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Jetsons pushing a button](https://media.giphy.com/media/fo1YqvMOtZJYRuO6lM/giphy.gif)
