### PR TITLE
Preventing author profile from going transparent

### DIFF
--- a/app/assets/stylesheets/components/dropdowns.scss
+++ b/app/assets/stylesheets/components/dropdowns.scss
@@ -2,9 +2,11 @@
 
 .crayons-dropdown {
   position: absolute;
+  top: 100%;
   display: none; // initially hidden
   padding: var(--su-2);
   min-width: 250px;
+  margin-top: var(--su-1);
   z-index: var(--z-dropdown);
   background: var(--card-bg);
   color: var(--card-color);
@@ -21,5 +23,7 @@
     // Flips the dropdown to drop-upwards when set
     bottom: 100%;
     top: unset;
+    margin-top: unset;
+    margin-bottom: var(--su-1);
   }
 }

--- a/app/assets/stylesheets/components/profile-preview-card.scss
+++ b/app/assets/stylesheets/components/profile-preview-card.scss
@@ -14,7 +14,7 @@
   }
 
   &__content.crayons-dropdown:hover {
-    display: table;
+    display: block;
     animation: hoverAppear var(--dropdown-hover-delay);
 
     &.showing {
@@ -23,8 +23,8 @@
   }
 
   &__trigger:hover + .profile-preview-card__content.crayons-dropdown {
-    display: table;
-    animation: hoverAppear vaR(--dropdown-hover-delay);
+    display: block;
+    animation: hoverAppear var(--dropdown-hover-delay);
 
     &.showing {
       animation: none;

--- a/app/assets/stylesheets/components/profile-preview-card.scss
+++ b/app/assets/stylesheets/components/profile-preview-card.scss
@@ -14,7 +14,7 @@
   }
 
   &__content.crayons-dropdown:hover {
-    display: block;
+    display: table;
     animation: hoverAppear var(--dropdown-hover-delay);
 
     &.showing {
@@ -23,7 +23,7 @@
   }
 
   &__trigger:hover + .profile-preview-card__content.crayons-dropdown {
-    display: block;
+    display: table;
     animation: hoverAppear vaR(--dropdown-hover-delay);
 
     &.showing {

--- a/app/assets/stylesheets/components/profile-preview-card.scss
+++ b/app/assets/stylesheets/components/profile-preview-card.scss
@@ -7,7 +7,6 @@
     transition-duration: var(--dropdown-transition);
     color: var(--base-100);
     padding-top: 0;
-    top: 100%;
     left: 0;
     font-size: var(--fs-base);
     font-weight: var(--fw-normal);

--- a/app/assets/stylesheets/views/article-form.scss
+++ b/app/assets/stylesheets/views/article-form.scss
@@ -102,6 +102,7 @@
     height: var(--article-form-actions-height);
     display: flex;
     align-items: center;
+    position: relative;
     padding: 0 var(--su-2);
 
     @media (min-width: $breakpoint-m) {

--- a/app/javascript/CommentSubscription/CommentSubscription.jsx
+++ b/app/javascript/CommentSubscription/CommentSubscription.jsx
@@ -38,39 +38,6 @@ export class CommentSubscription extends Component {
     this.state = initialState;
   }
 
-  componentDidUpdate() {
-    const { showOptions } = this.state;
-
-    if (showOptions) {
-      window.addEventListener('scroll', this.dropdownPlacementHandler);
-      this.dropdownPlacementHandler();
-    } else {
-      window.removeEventListener('scroll', this.dropdownPlacementHandler);
-    }
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('scroll', this.dropdownPlacementHandler);
-  }
-
-  dropdownPlacementHandler = () => {
-    const { base: element } = this.dropdownElement;
-
-    // Reset the top before doing any calculations
-    element.style.bottom = '';
-
-    const { bottom: dropDownBottom } = element.getBoundingClientRect();
-    const { height } = this.buttonGroupElement.base.getBoundingClientRect();
-
-    if (
-      Math.sign(dropDownBottom) === -1 ||
-      dropDownBottom > window.innerHeight
-    ) {
-      // The 4 pixels is the box shadow from the drop down.
-      element.style.bottom = `${height + 4}px`;
-    }
-  };
-
   commentSubscriptionClick = (event) => {
     this.setState({
       subscriptionType: event.target.value,
@@ -143,8 +110,9 @@ export class CommentSubscription extends Component {
             triggerButtonId="subscription-settings-btn"
             dropdownContentId="subscription-settings-dropdown"
             dropdownContentCloseButtonId="subscription-settings-done-btn"
+            data-repositioning-dropdown="true"
             data-testid="subscriptions-panel"
-            className={`right-4 left-4 s:right-0 p-4 s:left-auto${
+            className={`right-0 p-4 s:left-auto${
               positionType === 'relative' ? ' w-full' : ''
             }`}
             ref={(element) => {

--- a/app/javascript/article-form/components/Options.jsx
+++ b/app/javascript/article-form/components/Options.jsx
@@ -93,7 +93,7 @@ export const Options = ({
         triggerButtonId="post-options-btn"
         dropdownContentId="post-options-dropdown"
         dropdownContentCloseButtonId="post-options-done-btn"
-        className="bottom-2 s:bottom-100 left-2 s:left-0 right-2 s:left-auto p-4"
+        className="reverse left-2 s:left-0 right-2 s:left-auto p-4"
       >
         <h3 className="mb-6">Post options</h3>
         <div className="crayons-field mb-6">

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -33,7 +33,7 @@
         <%= inline_svg_tag("overflow-horizontal.svg", aria_hidden: true, class: "dropdown-icon crayons-icon", title: t("views.actions.more.title")) %>
       </button>
 
-      <div id="article-show-more-dropdown" class="crayons-dropdown side-bar left-2 right-2 m:right-auto m:left-100 s:left-auto bottom-100 m:bottom-auto m:top-0 mb-1 m:mb-0 top-unset m:top-100">
+      <div id="article-show-more-dropdown" class="crayons-dropdown side-bar left-2 right-2 m:right-auto m:left-100 s:left-auto mb-1 m:mb-0 top-unset bottom-100 m:top-0 m:bottom-unset">
         <div>
           <button
             id="copy-post-url-button"

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -33,7 +33,7 @@
         <%= inline_svg_tag("overflow-horizontal.svg", aria_hidden: true, class: "dropdown-icon crayons-icon", title: t("views.actions.more.title")) %>
       </button>
 
-      <div id="article-show-more-dropdown" class="crayons-dropdown side-bar left-2 right-2 m:right-auto m:left-100 s:left-auto bottom-100 m:bottom-auto m:top-0 mb-1 m:mb-0">
+      <div id="article-show-more-dropdown" class="crayons-dropdown side-bar left-2 right-2 m:right-auto m:left-100 s:left-auto bottom-100 m:bottom-auto m:top-0 mb-1 m:mb-0 top-unset m:top-100">
         <div>
           <button
             id="copy-post-url-button"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this change, when you would hover over an author profile that
was "close to" the bottom of the page, the card would be transparent
instead of the expected opaque.

With this change, when you hover over an author profile that is "close"
to the bottom of the page, the card renders as an opaque card.

Now why does this work?  I don't really know, except to say that a
`display: table` imperative is a more "chunky" display element than a
block.  I would love for someone to explain why this works.

Tested against on MacOS Safari, Firefox, and Chrome.

https://developer.mozilla.org/en-US/docs/Web/CSS/display

## Related Tickets & Documents

Fixes #15290

## QA Instructions, Screenshots, Recordings

Open to the homepage, and scroll so that the bottom-most visible article card is position just above the browser window.  Hover over the author.  With this fix, the card should be opaque and rendered past the bottom of the view frame.

Without this commit, the card will be transparent-ish and the text from the article card will "bleed" through.

### UI accessibility concerns?

Uncertain.

## Added/updated tests?

- [x] No, and this is why: I don't believe it's necessary.

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: it is a small bug fix for a UI edge case (albeit not an extreme edge case but a somewhat common one).
