### PR TITLE
Enabling scrolling for onboarding

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -36,7 +36,6 @@
   @media screen and (min-width: $breakpoint-s) {
     justify-content: center;
     padding: var(--su-7) var(--su-8);
-    height: auto;
   }
 }
 

--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -36,7 +36,7 @@
   @media screen and (min-width: $breakpoint-s) {
     justify-content: center;
     padding: var(--su-7) var(--su-8);
-    height: 800px;
+    height: auto;
   }
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

When I am in Safari and as part of the onboarding
get to the form to build my profile, I go to Actual
Size (<kbd>Cmd</kbd>+<kbd>0</kbd>) then Zoom In
twice (<kbd>Cmd</kbd>+<kbd>+</kbd> then <kbd>Cmd</kbd>+<kbd>+</kbd>).
This zooms in enough (for my viewing configuration) to ensure that the
rendered "panel" extends beyond the view port.

Prior to this commit, I was stuck as there were no scroll options for
the rendered "panel".

With this commit, and Dan's help, I have a scrollable panel and can
complete my task.

## Related Tickets & Documents

Fixes #15279

## QA Instructions, Screenshots, Recordings

See the above description.

### UI accessibility concerns?

I think this improves accessibility by restoring a scrollable region.

## Added/updated tests?

- [x] No, and this is why: I verified in the UI

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
