### PR TITLE
Validating community does not include < nor >

### DIFF
--- a/app/models/settings/community.rb
+++ b/app/models/settings/community.rb
@@ -7,7 +7,17 @@ module Settings
             default: ApplicationConfig["COMMUNITY_COPYRIGHT_START_YEAR"] || Time.zone.today.year
     setting :community_description, type: :string
     setting :community_emoji, type: :string, default: "🌱", validates: { emoji_only: true }
-    setting :community_name, type: :string, default: ApplicationConfig["COMMUNITY_NAME"] || "New Forem"
+    setting(
+      :community_name,
+      type: :string,
+      default: ApplicationConfig["COMMUNITY_NAME"] || "New Forem",
+      validates: {
+        format: {
+          with: /\A[^[<|>]]+\Z/,
+          message: "may not include the \"<\" nor \">\" character"
+        }
+      },
+    )
     setting :member_label, type: :string, default: "user"
     setting :staff_user_id, type: :integer, default: 1
     setting :tagline, type: :string

--- a/spec/models/settings/community_spec.rb
+++ b/spec/models/settings/community_spec.rb
@@ -1,6 +1,22 @@
 require "rails_helper"
 
 RSpec.describe Settings::Community do
+  describe "validating community name" do
+    it "does not allow '<' nor '>' character" do
+      expect do
+        described_class.community_name = "<Hiya"
+      end.to raise_error(/may not include the "<" nor ">"/)
+
+      expect do
+        described_class.community_name = "Bya>"
+      end.to raise_error(/may not include the "<" nor ">"/)
+
+      expect do
+        described_class.community_name = "Hello Folks"
+      end.not_to raise_error
+    end
+  end
+
   describe "validating emojis strings" do
     it "allows emoji-only strings" do
       expect do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

If a community name has a < or > it may cause havoc when the community
attempts to send an email.

## Related Tickets & Documents

Closes #15274

## QA Instructions, Screenshots, Recordings

None.

Here's the UI when I attempt to update:


<img width="671" alt="Screen Shot 2021-11-23 at 4 11 18 PM" src="https://user-images.githubusercontent.com/2130/143129874-6c9614a4-c6d9-40b3-b0cf-1adefe2cadee.png">
### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
