### PR TITLE
Automatically run DataUpdateScripts in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -135,9 +135,9 @@ Rails.application.configure do
 
     # Check if there are any data update scripts to run during startup
     if %w[Console Server DBConsole].any? { |const| Rails.const_defined?(const) } && DataUpdateScript.scripts_to_run?
-      message = "Data update scripts need to be run before you can start the application. " \
-                "Please run 'rails data_updates:run'"
-      raise message
+      Rails.application.load_tasks
+      puts "Running data updates..." # rubocop:disable Rails/Output
+      Rake::Task["data_updates:run"].invoke
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

How many times have you pulled down the latest code only to be told "Nope! Run `rails data_updates:run` first"? What if the robots could do that for us?

Honestly I can't believe it took me this long to get fed up with this error :joy: 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

- Delete the record of a random DUS having been executed so that it will be required to run again `psql Forem_development -c 'delete from data_update_scripts where id in (select id from data_update_scripts order by random() limit 1);'`
- Open up a rails console with `rails c`
  - Note the "Running data updates..."
- Exit and `rails c` again
  - No "Running data updates" message because none were pending

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Even if we wrote tests for it, this code runs before tests execute so we'd have no control case
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
