### PR TITLE
prevent default on keyboard shortcut presses

### DIFF
--- a/app/javascript/crayons/MarkdownToolbar/MarkdownToolbar.jsx
+++ b/app/javascript/crayons/MarkdownToolbar/MarkdownToolbar.jsx
@@ -75,7 +75,13 @@ export const MarkdownToolbar = ({ textAreaId }) => {
       .map((syntaxName) => {
         const { command } =
           markdownSyntaxFormatters[syntaxName].getKeyboardShortcut?.();
-        return [command, () => insertSyntax(syntaxName)];
+        return [
+          command,
+          (e) => {
+            e.preventDefault();
+            insertSyntax(syntaxName);
+          },
+        ];
       }),
   );
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The markdown toolbar shortcuts were not preventing any default browser action, as they should. For example, if you open Firefox on a mac and execute `cmd + U` in the editor, the underline would be inserted, but view source would also open in a new tab.

This PR adds in a `preventDefault()` to make sure only our shortcut runs.

## Related Tickets & Documents

Related to toolbar work - https://github.com/forem/forem/pull/15347
Fixes https://github.com/forem/forem/issues/15507

## QA Instructions, Screenshots, Recordings

Try running the app on multiple browsers, start a new post, and execute the toolbar shortcuts while in the text area:

- cmd/ctrl + b
- cmd/ctrl + i
- cmd/ctrl + k
- cmd/ctr + u
- cmd/ctrl + shift + x

In each case you should see a markdown syntax appear in the editor, but no other browser-specific actions should be apparent

### UI accessibility concerns?

N/A - a general usability issue

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: I'm not sure there's a meaningful test to write for this, given it's so browser specific / outside of our app code
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [X] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


