### PR TITLE
Adding ugc role to untrusted profile URLs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -381,6 +381,8 @@ class User < ApplicationRecord
     end
   end
 
+  alias trusted? trusted
+
   def moderator_for_tags
     Rails.cache.fetch("user-#{id}/tag_moderators_list", expires_in: 200.hours) do
       tag_ids = roles.where(name: "tag_moderator").pluck(:resource_id)

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -83,7 +83,7 @@
             <% end %>
 
             <% if @user.profile.website_url.present? %>
-              <a href="<%= @user.profile.website_url %>" target="_blank" rel="noopener me" class="profile-header__meta__item">
+              <a href="<%= @user.profile.website_url %>" target="_blank" rel="noopener me <%= "ugc" unless @user.trusted? %>" class="profile-header__meta__item">
                 <%= inline_svg_tag("external-link.svg", class: "crayons-icon mr-2 shrink-0", aria: true, title: t("views.users.website")) %>
                 <%= @user.profile.website_url %>
               </a>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

Prior to this commit, we trusted all user profiles.  There are folks
using DEV.to profiles to help with their spam efforts.

With this commit, we're trying to thwart their efforts.


## Related Tickets & Documents

Closes forem/rfcs#334

## QA Instructions, Screenshots, Recordings

In the user's profile (`/:username`) inspect their profile URL.  If they are not a trusted person, then there should be a `rel="ugc"` attribute on the link.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: Small change that is logically evident

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
