### PR TITLE
Update the COC and TOS Description on the Creator Settings Form

### DIFF
--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -83,9 +83,10 @@
 </div>
 
 <div class="crayons-field mt-6 align-left">
-  <fieldset aria-describedby="section-description">
+  <fieldset aria-describedby="terms-description">
     <legend class="crayons-field__label mb-2">Finally, please agree to the following:</legend>
     <div>
+    <p id="terms-subtitle" class="crayons-field__description">You will have the opportunity to establish the Code of Conduct and Terms and Conditions for the users of your Forem during the setup process.</p>
       <div class="mb-2">
         <%= hidden_field_tag :checked_code_of_conduct, "0" %>
         <%= check_box_tag :checked_code_of_conduct, "1", false, class: "crayons-checkbox", required: true %>
@@ -97,6 +98,5 @@
         <label for="checked_terms_and_conditions">I agree to our <a href="/terms">Terms and Conditions</a>.</label>
       </div>
     </div>
-    <p class="crayons-field__description fs-italic p-2">You will have the opportunity to establish the Code of Conduct and Terms and Conditions for the users of your Forem during the setup process.</p>
   </fieldset>
 </div>

--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -83,10 +83,10 @@
 </div>
 
 <div class="crayons-field mt-6 align-left">
-  <fieldset aria-describedby="terms-description">
-    <legend class="crayons-field__label mb-2">Finally, please agree to the following:</legend>
+  <fieldset aria-describedby="section-description">
+    <legend class="crayons-field__label">Finally, please agree to the following:</legend>
     <div>
-    <p id="terms-subtitle" class="crayons-field__description">You will have the opportunity to establish the Code of Conduct and Terms and Conditions for the users of your Forem during the setup process.</p>
+      <p class="crayons-field__description">You will have the opportunity to establish the Code of Conduct and Terms and Conditions for the users of your Forem during the setup process.</p>
       <div class="mb-2">
         <%= hidden_field_tag :checked_code_of_conduct, "0" %>
         <%= check_box_tag :checked_code_of_conduct, "1", false, class: "crayons-checkbox", required: true %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR refactors the COC and TOS description on the Creator Settings form (per @anujbhavsar96's design feedback) by doing the following:
- [x] Moving the COC and TOS description text below the checkbox legend
- [x] Un-italicizing the text and instead styling the text with the `crayons-field__description` class

## Related Tickets & Documents
Relates to issue #15524 

## QA Instructions, Screenshots, Recordings
#### Please note that you will need to essentially clear out your database to take this feature for a spin. 🏎️  

To do so, you can either drop your entire database via `rails:db drop` 

_**or**_

You can open a rails console via `rails c` and do the following:
 ```
# Enable the feature flag
FeatureFlag.enable(:creator_onboarding)

# Delete all users 
User.destroy_all

# Set `waiting_on_first_user` to be true
Settings::General.waiting_on_first_user = true

# If you've logged in before set the mascot id to nil
 Settings::General.mascot_user_id = nil
```

Now, run your server and navigate to `http://localhost:3000/` and complete the "Create Account" form. After completing the "Create Account" form, you should be brought to the new Creator Setup page, `${baseUrl}/admin/creator_settings/new?referrer=${baseUrl}`.

#### Once on the Creator Settings page, you will want to observe the changes outlined above in the PR description and ensure that the there aren't any typos and that the refactored text is accessible:
#### Before:
![Screen Shot 2021-11-19 at 9 44 21 AM](https://user-images.githubusercontent.com/32834804/142659840-361f9b54-d296-4a91-919d-97554167972e.png)

#### After:
![Screen Shot 2021-11-29 at 2 07 28 PM](https://user-images.githubusercontent.com/32834804/143943189-e793fb86-b0b7-4301-9f67-8b39ef309391.png)

### UI accessibility concerns?
I should have addressed any UI accessibility concerns in this PR!

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: there is already an E2E test that tests this.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Sandy Cheeks adjusting tubes attached to SpongeBob](https://media.giphy.com/media/3ohzAydU1n35b8k1nG/giphy.gif)
