### PR TITLE
Fix Rpush app when creating Android notification

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -52,7 +52,10 @@ class Device < ApplicationRecord
 
   def android_notification(title, body, payload)
     n = Rpush::Gcm::Notification.new
-    n.app = ConsumerApp.rpush_app(app_bundle: app_bundle, platform: platform)
+    n.app = ConsumerApps::RpushAppQuery.call(
+      app_bundle: consumer_app.app_bundle,
+      platform: platform,
+    )
     n.registration_ids = [token]
     n.priority = "high"
     n.content_available = true

--- a/spec/services/push_notifications/send_spec.rb
+++ b/spec/services/push_notifications/send_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe PushNotifications::Send, type: :service do
 
   before do
     allow(ApplicationConfig).to receive(:[]).with("RPUSH_IOS_PEM").and_return("dGVzdGluZw==")
+    allow(ApplicationConfig).to receive(:[]).with("RPUSH_FCM_KEY").and_return("dGVzdGluZw==")
     allow(ApplicationConfig).to receive(:[]).and_return("stub")
   end
 
@@ -59,31 +60,33 @@ RSpec.describe PushNotifications::Send, type: :service do
   end
 
   context "with devices for multiple users" do
-    let(:consumer_app) { create(:consumer_app) }
+    let(:consumer_app_ios) { create(:consumer_app, platform: Device::IOS) }
+    let(:consumer_app_android) { create(:consumer_app, platform: Device::ANDROID) }
 
     before do
-      create(:device, user: user, consumer_app: consumer_app)
-      create(:device, user: user2, consumer_app: consumer_app)
+      create(:device, user: user, consumer_app: consumer_app_ios)
+      create(:device, user: user2, consumer_app: consumer_app_ios)
+      create(:device, user: user2, consumer_app: consumer_app_android, platform: Device::ANDROID)
     end
 
     it "creates a notification and enqueues it" do
-      mocked_objects = mock_rpush(consumer_app)
+      mocked_objects = mock_rpush(consumer_app_ios)
 
-      described_class.call(**many_targets_params)
+      described_class.call(**params)
 
-      expect(mocked_objects[:rpush_notification]).to have_received(:save!).exactly(2).times
+      expect(mocked_objects[:rpush_notification]).to have_received(:save!).exactly(1).times
 
       sidekiq_assert_enqueued_jobs(1, only: PushNotifications::DeliverWorker)
     end
 
     it "creates a single notification for each of the user's devices when they have multiple" do
-      create(:device, user: user)
-
-      mocked_objects = mock_rpush(consumer_app)
+      ios_mocked_objects = mock_rpush(consumer_app_ios)
+      android_mocked_objects = mock_rpush(consumer_app_android)
 
       described_class.call(**many_targets_params)
 
-      expect(mocked_objects[:rpush_notification]).to have_received(:save!).exactly(3).times
+      expect(ios_mocked_objects[:rpush_notification]).to have_received(:save!).exactly(2).times
+      expect(android_mocked_objects[:rpush_notification]).to have_received(:save!).exactly(1).times
 
       sidekiq_assert_enqueued_jobs(1, only: PushNotifications::DeliverWorker)
     end

--- a/spec/services/push_notifications/send_spec.rb
+++ b/spec/services/push_notifications/send_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe PushNotifications::Send, type: :service do
 
       described_class.call(**params)
 
-      expect(mocked_objects[:rpush_notification]).to have_received(:save!).exactly(1).times
+      expect(mocked_objects[:rpush_notification]).to have_received(:save!).once
 
       sidekiq_assert_enqueued_jobs(1, only: PushNotifications::DeliverWorker)
     end
@@ -85,8 +85,8 @@ RSpec.describe PushNotifications::Send, type: :service do
 
       described_class.call(**many_targets_params)
 
-      expect(ios_mocked_objects[:rpush_notification]).to have_received(:save!).exactly(2).times
-      expect(android_mocked_objects[:rpush_notification]).to have_received(:save!).exactly(1).times
+      expect(ios_mocked_objects[:rpush_notification]).to have_received(:save!).twice
+      expect(android_mocked_objects[:rpush_notification]).to have_received(:save!).once
 
       sidekiq_assert_enqueued_jobs(1, only: PushNotifications::DeliverWorker)
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

#15212 fixed some of the ConsumerApp issues we had with Android notifications but this was a detailed I missed. The Rpush app should be assigned by what the `ConsumerApps::RpushAppQuery` query returns. This was causing a server error when trying to queue a comment for PN delivery.

Leaving a comment in [this thread](https://community.benhalpern.com/rt4914/test-post-22m1) displays this error:

<img width="1086" alt="Screen Shot 2021-11-29 at 20 11 38" src="https://user-images.githubusercontent.com/6045239/143973455-90a1cdc7-9409-4c55-80b6-3f46420f7e65.png">

## Related Tickets & Documents

#15212

## QA Instructions, Screenshots, Recordings

If you create an Android Device (model in DB) associated to a ConsumerApp and run this it should work:

```ruby
device.create_notification("Test title", "Test body", { url: URL.url })
```

It's a bit tricky to set this up. Since this is code not currently "under load" in production I'd say it's okay to merge without trying it out locally, unless anyone really wants to 🙂  It's doing the same as the iOS counterpart ([visible here](https://github.com/forem/forem/blob/main/app/models/device.rb#L32-L35)).

### UI accessibility concerns?

None - Backend changes only

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Communicated in the future as the Android project as a whole goes public

## [optional] What gif best describes this PR or how it makes you feel?

**That someone was me:**

![bart cleaning the sink plumbing](https://media.giphy.com/media/xT5LMsVTNO9b1wHKDe/giphy.gif)
