### PR TITLE
Add single view count translation

### DIFF
--- a/config/locales/views/dashboard/en.yml
+++ b/config/locales/views/dashboard/en.yml
@@ -62,6 +62,7 @@ en:
           icon: Views
           lt_25: "< 25"
           text_html:
+            one: "%{scale} view"
             other: "%{scale} views"
           u_25: under 25
         subscriptions:

--- a/config/locales/views/dashboard/fr.yml
+++ b/config/locales/views/dashboard/fr.yml
@@ -62,6 +62,7 @@ fr:
           icon: Views
           lt_25: "< 25"
           text_html:
+            one: "%{scale} view"
             other: "%{scale} views"
           u_25: under 25
         subscriptions:


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes an error shown when the article has one view


```
I18n::InvalidPluralizationData: translation data {:other=>"%{scale} views"} can not be used with :count => 1. key 'one' is missing.
```

Add key 'one' to both translation files for this key.



## Related Tickets & Documents
https://app.honeybadger.io/projects/66984/faults/82770707
#15069 

## QA Instructions, Screenshots, Recordings

View the articles dashboard. If necessary set article view counter to 1. Confirm no error is raised.


### UI accessibility concerns?

None.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: bugfix
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![loneliest number](https://user-images.githubusercontent.com/1237369/144079354-0a9fa185-9aa0-458c-9cbb-fcc9c3c5dfed.png)
