### PR TITLE
Add translations for one credit

### DIFF
--- a/config/locales/views/credits/en.yml
+++ b/config/locales/views/credits/en.yml
@@ -48,6 +48,8 @@ en:
       tag: 'Tag: %{name}'
       status:
         user:
-          other: You have %{count} personal credits to spend
+          one: "You have %{count} personal credit to spend"
+          other: "You have %{count} personal credits to spend"
         org_html:
+          one: "%{name} has %{num} credit to spend"
           other: "%{name} has %{num} credits to spend"

--- a/config/locales/views/credits/fr.yml
+++ b/config/locales/views/credits/fr.yml
@@ -48,6 +48,8 @@ fr:
       tag: 'Tag: %{name}'
       status:
         user:
-          other: You have %{count} personal credits to spend
+          one: "You have %{count} personal credit to spend"
+          other: "You have %{count} personal credits to spend"
         org_html:
+          one: "%{name} has %{num} credit to spend"
           other: "%{name} has %{num} credits to spend"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It's possible an organization or user will have just one credit.
When this happens, the translation will fail to render in the view
 (and an error will be raised).

Add key "one:" for personal and organizational credits.

## Related Tickets & Documents

Follow on to #15544 (checking other locale files for missing translation keys turned up these two cases). 

## QA Instructions, Screenshots, Recordings

Set user available credits to 1, I had 16 to spend so set to 1 by "spending" the others, removing them would also work:

```ruby
user.credits.drop(1).map {|c| c.update(spent: true) }
```

~View dashboard page (http://localhost:3000/dashboard) (this always says credits available, not localized)~
View credits page http://localhost:3000/credits/

No error raised.
 
![1-credit](https://user-images.githubusercontent.com/1237369/144084001-644736ed-e8dc-434e-85a1-716ef0104558.png)



On main branch this does cause an error:

![Screenshot from 2021-11-30 10-07-59](https://user-images.githubusercontent.com/1237369/144083786-4c526260-c1e8-4895-bf1e-4ffc7d739d3c.png)

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: bugfix
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [x] This change does not need to be communicated, and this is why not: discussed internally after #15544 -  same message

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
