### PR TITLE
Fixing broken logic

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -82,7 +82,7 @@ class Reaction < ApplicationRecord
     # @return [TrueClass] yup, they're spamming the system.
     # @return [FalseClass] they're not (yet) spamming the system
     def user_has_been_given_too_many_spammy_article_reactions?(user:, threshold: 2)
-      article_vomits.where(reactable_type: "Article", reactable_id: user.articles.ids).size > threshold
+      article_vomits.where(reactable_id: user.articles.ids).size > threshold
     end
 
     # @param user [User] the user who might be spamming the system
@@ -90,7 +90,7 @@ class Reaction < ApplicationRecord
     # @return [TrueClass] yup, they're spamming the system.
     # @return [FalseClass] they're not (yet) spamming the system
     def user_has_been_given_too_many_spammy_comment_reactions?(user:, threshold: 2)
-      article_vomits.where(reactable_type: "Comment", reactable_id: user.comments.ids).size > threshold
+      comment_vomits.where(reactable_id: user.comments.ids).size > threshold
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

In #15412 I introduced faulty logic, and didn't reuse existing scopes.

For comparison, the original code for comment threshold checks was here:
https://github.com/forem/forem/blob/5d5dbaca95d1fa944a687e07709c530ed7cfbd62/app/models/comment.rb#L303

```ruby
Reaction.comment_vomits.where(reactable_id: user.comments.pluck(:id)).size > 2
```

This change restores that and tightens up the scope usage.

## Related Tickets & Documents

PR #15412

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: the test would be verifying ActiveRecord behavior.

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
