### PR TITLE
Now radio buttons in creator settings are on the same line in fieldsets

### DIFF
--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -53,7 +53,7 @@
 <div class="crayons-field mt-6 align-left">
   <fieldset aria-describedby="section-description">
     <legend class="crayons-field__label mb-2">Who can join this community?</legend>
-    <div class="flex gap-1">
+    <div class="flex gap-3">
       <%= radio_button_tag :invite_only_mode, "0", false, class: "crayons-radio" %>
       <label for="invite_only_mode_0">Everyone</label>
       <%= radio_button_tag :invite_only_mode, "1", true, class: "crayons-radio" %>

--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -54,10 +54,14 @@
   <fieldset aria-describedby="section-description">
     <legend class="crayons-field__label mb-2">Who can join this community?</legend>
     <div class="flex gap-3">
-      <%= radio_button_tag :invite_only_mode, "0", false, class: "crayons-radio" %>
-      <label for="invite_only_mode_0">Everyone</label>
-      <%= radio_button_tag :invite_only_mode, "1", true, class: "crayons-radio" %>
-      <label for="invite_only_mode_1">Invite only</label>
+      <div>
+        <%= radio_button_tag :invite_only_mode, "0", false, class: "crayons-radio" %>
+        <label for="invite_only_mode_0">Everyone</label>
+      </div>
+      <div>
+        <%= radio_button_tag :invite_only_mode, "1", true, class: "crayons-radio" %>
+        <label for="invite_only_mode_1">Invite only</label>
+      </div>
     </div>
   </fieldset>
 </div>
@@ -65,11 +69,15 @@
 <div class="crayons-field mt-6 align-left">
   <fieldset aria-describedby="section-description">
     <legend class="crayons-field__label mb-2">Who can view content in this community?</legend>
-    <div class="flex gap-1">
-      <%= radio_button_tag :public, "1", true, class: "crayons-radio" %>
-      <label for="public_0">Everyone</label>
-      <%= radio_button_tag :public, "0", false, class: "crayons-radio" %>
-      <label for="public_1">Members only</label>
+    <div class="flex gap-3">
+      <div>
+        <%= radio_button_tag :public, "1", true, class: "crayons-radio" %>
+        <label for="public_0">Everyone</label>
+      </div>
+      <div>
+        <%= radio_button_tag :public, "0", false, class: "crayons-radio" %>
+        <label for="public_1">Members only</label>
+      </div>
     </div>
   </fieldset>
 </div>

--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -53,15 +53,11 @@
 <div class="crayons-field mt-6 align-left">
   <fieldset aria-describedby="section-description">
     <legend class="crayons-field__label mb-2">Who can join this community?</legend>
-    <div>
-      <div class="mb-2">
-        <%= radio_button_tag :invite_only_mode, "0", false, class: "crayons-radio" %>
-        <label for="invite_only_mode_0">Everyone</label>
-      </div>
-      <div>
-        <%= radio_button_tag :invite_only_mode, "1", true, class: "crayons-radio" %>
-        <label for="invite_only_mode_1">Only people who are invited</label>
-      </div>
+    <div class="flex gap-1">
+      <%= radio_button_tag :invite_only_mode, "0", false, class: "crayons-radio" %>
+      <label for="invite_only_mode_0">Everyone</label>
+      <%= radio_button_tag :invite_only_mode, "1", true, class: "crayons-radio" %>
+      <label for="invite_only_mode_1">Invite only</label>
     </div>
   </fieldset>
 </div>
@@ -69,15 +65,11 @@
 <div class="crayons-field mt-6 align-left">
   <fieldset aria-describedby="section-description">
     <legend class="crayons-field__label mb-2">Who can view content in this community?</legend>
-    <div>
-      <div class="mb-2">
-        <%= radio_button_tag :public, "1", true, class: "crayons-radio" %>
-        <label for="public_0">Everyone</label>
-      </div>
-      <div>
-        <%= radio_button_tag :public, "0", false, class: "crayons-radio" %>
-        <label for="public_1">Members only</label>
-      </div>
+    <div class="flex gap-1">
+      <%= radio_button_tag :public, "1", true, class: "crayons-radio" %>
+      <label for="public_0">Everyone</label>
+      <%= radio_button_tag :public, "0", false, class: "crayons-radio" %>
+      <label for="public_1">Members only</label>
     </div>
   </fieldset>
 </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Gives the form more real estate. Previously radio button options were on separate lines. This came about while working on #15499 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

1. Ensure you're logged out from the Forem instance.
2. Set up the database to be in a state where you are about to create the Forem creator role

```ruby
# Enable the feature flag
FeatureFlag.enable(:creator_onboarding)

# Delete all users 
User.destroy_all

# Set `waiting_on_first_user` to be true
Settings::General.waiting_on_first_user = true

# If you've logged in before set the mascot id to nil
Settings::General.mascot_user_id = nil

# If you've logged in before set the logo SVG to nil
Settings::General.logo_svg = nil
```
3. Click on the login link. Since the feature flag is enabled, you'll be redirected to Creator Signup Form.
4. Fill in the necessary information and submit the form.
5. On the next page ensure that the radio buttons for the sections "Who can join this community?" and "Who can view content in this community?" are on the same line.

### Before

![image](https://user-images.githubusercontent.com/833231/144111196-732968a8-2017-4ee7-8aba-06ca580d3054.png)

### After

![image](https://user-images.githubusercontent.com/833231/144113287-0417ab9c-08e5-4713-b1bc-0090eaab9bd3.png)

### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Tests already cover this. It's only CSS/markup changes
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
