### PR TITLE
Remove z-index from liquid tags

### DIFF
--- a/app/assets/stylesheets/ltags/GithubReadmeTag.scss
+++ b/app/assets/stylesheets/ltags/GithubReadmeTag.scss
@@ -1,6 +1,5 @@
 @import '../variables';
 .ltag-github-readme-tag {
-  z-index: 1;
   position: relative;
   border: 1px solid $light-medium-gray;
   border-radius: 3px;

--- a/app/assets/stylesheets/ltags/GithubTag.scss
+++ b/app/assets/stylesheets/ltags/GithubTag.scss
@@ -5,7 +5,6 @@
   margin: 1.1em auto 1.3em;
   max-width: 580px;
   position: relative;
-  z-index: 1;
 
   h1 {
     font-size: var(--fs-xl) !important;

--- a/app/assets/stylesheets/ltags/TwitterTimelineTag.scss
+++ b/app/assets/stylesheets/ltags/TwitterTimelineTag.scss
@@ -3,7 +3,6 @@
 .ltag_twitter-timeline-liquid-tag {
   margin: 1.1em auto 1.3em;
   max-width: 580px;
-  z-index: 1;
   position: relative;
 }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Removed the z-index:1 from liquid tags present in 'GithubReadmeTag.scss', 'GithubTag.scss' and 'TwitterTimelineTag.scss'.
The removal of this eliminates the weird visibility issue when the article-show-more-dropdown overlaps the pretty embeds on the page.

## Related Tickets & Documents
Closes #15500 

## QA Instructions, Screenshots, Recordings

Steps to test the changes:
1. Add a post with a pretty embed.
2. Click the 3-dots on the side to open the Show More drop-down.
3. Hover near the pretty embed.
4. No weird overlap happens between the drop-down and the pretty embed.

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![happy](https://user-images.githubusercontent.com/49329642/144120845-892c264c-c18c-4417-8c91-5767424026d8.gif)

