### PR TITLE
Avoid email reassignment when connecting OAuth provider

### DIFF
--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -150,6 +150,24 @@ RSpec.describe Authentication::Authenticator, type: :service do
         end.to change { user.reload.apple_username }.to("newname")
       end
 
+      # rubocop:disable RSpec/AnyInstance
+      it "avoids overriding the email when a provider has a different one" do
+        existing_email = user.email
+
+        # The following mocks the behavior of `current_user` being available
+        # which means we're connecting an existing account with the new identity
+        allow_any_instance_of(described_class).to receive(:proper_user).and_return(user)
+        forem_auth_payload = OmniAuth.config.mock_auth[:forem].merge(email: "different+email@example.com")
+
+        described_class.call(forem_auth_payload)
+
+        # We want to keep the previous email the user had instead of overriding
+        # with the new (different) email given by the OAuth provider
+        expect(user.reload.email).to eq(existing_email)
+        expect(user.reload.unconfirmed_email).to be_nil
+      end
+      # rubocop:enable RSpec/AnyInstance
+
       it "sets remember_me for the existing user" do
         user.update_columns(remember_token: nil, remember_created_at: nil)
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Closes https://github.com/forem/forem-passport/issues/44

When someone connects a new OAuth provider to an existing account we don't want to change their primary email. We also trust OAuth service providers to confirm their users' email accounts (prove ownership), so new account that come authenticated by an OAuth service provider should be trusted (no need to send an email to verify for ourselves).

## Related Tickets & Documents

https://github.com/forem/forem-passport/issues/44

## QA Instructions, Screenshots, Recordings

1. Enable Email auth on your local environment
2. Enable Forem Passport auth on your local environment
3. Sign up to the local environment using an email address `whatever@email.com`
4. Connect the new account with a Forem passport account that uses a different email `whatever+test@email.com`
   - The old adding a `+something` to the end of your username (but before the "@") [trick](https://www.google.com/search?q=adding+%2B+to+email+address+trick&sxsrf=AOaemvIOJuX8r2-emBXlu3QLNVyFxqfWrw%3A1638309577988&ei=yZ6mYb_oO7KTseMP6pKQkAw&ved=0ahUKEwj_8LXjisH0AhWySWwGHWoJBMIQ4dUDCA4&uact=5&oq=adding+%2B+to+email+address+trick&gs_lcp=Cgdnd3Mtd2l6EAMyCAghEBYQHRAeMggIIRAWEB0QHjIICCEQFhAdEB4yCAghEBYQHRAeOgcIABBHELADOgUIABCABDoGCAAQFhAeSgQIQRgAULQCWLoGYIgIaAFwAngAgAGQAYgBjwaSAQMwLjaYAQCgAQHIAQjAAQE&sclient=gws-wiz)
5. The OAuth provider should now be associated with the existing account and the "request for email confirmation" **shouldn't come up** (see screenshot below)

<img width="1164" alt="Screen Shot 2021-11-30 at 16 02 42" src="https://user-images.githubusercontent.com/6045239/144135271-83a37c1b-d566-498d-b05c-e541467ea908.png">

### UI accessibility concerns?

None - Backend update

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Bug fix that doesn't require broader communication

## [optional] Are there any post deployment tasks we need to perform?

Forem Fleet deploy in order to have this update take effect

## [optional] What gif best describes this PR or how it makes you feel?

![wait a minute. hold up. wait a minute](https://media.giphy.com/media/xULW8MYvpNOfMXfDH2/giphy.gif)
