### PR TITLE
Extracting Article.featured scope

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -112,7 +112,7 @@ module Admin
 
     def articles_featured
       Article.published.or(Article.where(published_from_feed: true))
-        .where(featured: true)
+        .featured
         .where("featured_number > ?", Time.current.to_i)
         .includes(:user)
         .limited_columns_internal_select

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -32,7 +32,7 @@ class ArticlesController < ApplicationController
                     .includes(:user)
                 else
                   @articles
-                    .where(featured: true)
+                    .featured
                     .or(@articles.where(score: Settings::UserExperience.home_feed_minimum_score..))
                     .includes(:user)
                 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -292,6 +292,8 @@ class Article < ApplicationRecord
     order(column => dir.to_sym)
   }
 
+  scope :featured, -> { where(featured: true) }
+
   scope :feed, lambda {
                  published.includes(:taggings)
                    .select(

--- a/app/services/article_api_index_service.rb
+++ b/app/services/article_api_index_service.rb
@@ -139,7 +139,7 @@ class ArticleApiIndexService
 
   def base_articles
     published_articles_with_users_and_organizations
-      .where(featured: true)
+      .featured
       .order(hotness_score: :desc)
       .page(page)
       .per(per_page || DEFAULT_PER_PAGE)

--- a/app/services/articles/feeds/find_featured_story.rb
+++ b/app/services/articles/feeds/find_featured_story.rb
@@ -8,6 +8,12 @@ module Articles
       # @return [Article]
       #
       # @note the must_have_main_image parameter name matches PR #15240
+      #
+      # @note One might assume that this would query on the
+      #       `Articles.where(featured: true)` but in my sleuthing,
+      #       the origin of this method's inner logic never included a
+      #       consideration for `featured == true`.  Perhaps that
+      #       should change?
       def self.call(stories, must_have_main_image: true)
         featured_story =
           if must_have_main_image

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -32,7 +32,8 @@ class EmailDigestArticleCollector
                    Article.select(:title, :description, :path)
                      .published
                      .where("published_at > ?", cutoff_date)
-                     .where(featured: true, email_digest_eligible: true)
+                     .featured
+                     .where(email_digest_eligible: true)
                      .where.not(user_id: @user.id)
                      .where("score > ?", 25)
                      .order(score: :desc)

--- a/app/workers/reactions/bust_homepage_cache_worker.rb
+++ b/app/workers/reactions/bust_homepage_cache_worker.rb
@@ -8,7 +8,7 @@ module Reactions
       reaction = Reaction.find_by(id: reaction_id, reactable_type: "Article")
       return unless reaction&.reactable
 
-      featured_articles_ids = Article.where(featured: true).order(hotness_score: :desc).limit(3).ids
+      featured_articles_ids = Article.featured.order(hotness_score: :desc).limit(3).ids
       return unless featured_articles_ids.include?(reaction.reactable_id)
 
       reaction.reactable.touch


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

In addition adding commentary on the oddly named
`Articles::Feeds::FindFeaturedStory` class given that it never filters
on "featured".

## Related Tickets & Documents

Related to #15292 and #15475

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: added a scope method that is the equivalent of past functionality

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: added a scope method that is the equivalent of past functionality
