### PR TITLE
Remove some README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,41 +5,15 @@
 </div>
 <br>
 <p align="center">
-  <a href="https://www.ruby-lang.org/en/">
-    <img src="https://img.shields.io/badge/Ruby-v3.0.2-green.svg" alt="ruby version">
-  </a>
-  <a href="http://rubyonrails.org/">
-    <img src="https://img.shields.io/badge/Rails-v6.0.3-brightgreen.svg" alt="rails version">
-  </a>
   <a href="https://travis-ci.com/forem/forem">
     <img src="https://travis-ci.com/forem/forem.svg?branch=main" alt="Travis Status for forem/forem">
   </a>
-  <a href="https://codeclimate.com/github/forem/forem/maintainability">
-    <img src="https://api.codeclimate.com/v1/badges/ce45bf63293073364bcb/maintainability" alt="Code Climate maintainability">
-  </a>
-  <a href="https://codeclimate.com/github/forem/forem/trends/technical_debt">
-    <img src="https://img.shields.io/codeclimate/tech-debt/forem/forem" alt="Code Climate technical debt">
-  </a>
-  <a href="https://www.codetriage.com/forem/forem">
-    <img src="https://www.codetriage.com/forem/forem/badges/users.svg" alt="CodeTriage badge">
-  </a>
-  <img src="https://badgen.net/dependabot/forem/forem?icon=dependabot" alt="Dependabot Badge">
-  <a href="https://gitpod.io/from-referrer/">
-    <img src="https://img.shields.io/badge/setup-automated-blue?logo=gitpod" alt="GitPod badge">
-  </a>
-  <a href="https://app.netlify.com/sites/docsdevto/deploys">
-    <img src="https://api.netlify.com/api/v1/badges/e5dbe779-7bca-4390-80b9-6e678b4806a3/deploy-status" alt="Netlify badge">
-  </a>
-  <img src="https://img.shields.io/github/languages/code-size/forem/forem" alt="GitHub code size in bytes">
   <img src="https://img.shields.io/github/commit-activity/w/forem/forem" alt="GitHub commit activity">
   <a href="https://github.com/forem/forem/issues?q=is%3Aissue+is%3Aopen+label%3A%22ready+for+dev%22">
     <img src="https://img.shields.io/github/issues/forem/forem/ready for dev" alt="GitHub issues ready for dev">
   </a>
-  <a href="https://app.honeybadger.io/project/Pl5JzZB5ax">
-    <img src="https://img.shields.io/badge/honeybadger-active-informational" alt="Honeybadger badge">
-  </a>
-  <a href="https://knapsackpro.com/dashboard/organizations/1142/projects/1022/test_suites/1434/builds">
-    <img src="https://img.shields.io/badge/Knapsack%20Pro-Parallel%20%2F%20dev.to-%230074ff" alt="Knapsack Pro Parallel CI builds for dev.to" style="max-width:100%;">
+  <a href="https://gitpod.io/from-referrer/">
+    <img src="https://img.shields.io/badge/setup-automated-blue?logo=gitpod" alt="GitPod badge">
   </a>
 </p>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Documentation Update

## Description

As discussed internally, this PR removes several badges from the top of our README, especially the ones that needed manual updates and tended to be out of date.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Here's the rich diff of the before and after:

![Screen Shot 2021-12-01 at 12 09 07](https://user-images.githubusercontent.com/47985/144175595-c2a736b3-0e0a-42ce-8c29-7338dea48c55.png)

### UI accessibility concerns?

None

## Added/updated tests?

- [X] No, and this is why: nothing to test here

## [Forem core team only] How will this change be communicated?

- [X] I've updated the README or added inline documentation
