### PR TITLE
Increase scrollable area on toolbar

### DIFF
--- a/app/assets/stylesheets/components/editor-toolbar.scss
+++ b/app/assets/stylesheets/components/editor-toolbar.scss
@@ -1,6 +1,5 @@
 .editor-toolbar {
   display: flex;
-  // background: var(--base-0);
 
   .toolbar-btn .spinner-or-cancel {
     .cancel {

--- a/app/assets/stylesheets/components/editor-toolbar.scss
+++ b/app/assets/stylesheets/components/editor-toolbar.scss
@@ -1,11 +1,6 @@
 .editor-toolbar {
   display: flex;
-  background: var(--base-0);
-
-  &::-webkit-scrollbar {
-    background: transparent;
-    height: 0;
-  }
+  // background: var(--base-0);
 
   .toolbar-btn .spinner-or-cancel {
     .cancel {

--- a/app/assets/stylesheets/views/article-form.scss
+++ b/app/assets/stylesheets/views/article-form.scss
@@ -167,8 +167,15 @@
     position: sticky;
     top: 0;
     background: var(--base-0);
-    padding: var(--su-2) var(--content-padding-x);
+    padding: 0 var(--content-padding-x);
     padding-right: var(--toolbar-padding-right, 0);
+    overflow-x: auto;
+    flex-shrink: 0;
+
+    &::-webkit-scrollbar {
+      background: transparent;
+      height: 0;
+    }
 
     margin: calc(var(--content-padding-y) * -1)
       calc(var(--content-padding-x) * -1) var(--su-6)
@@ -180,6 +187,7 @@
 
     @media (min-width: $breakpoint-m) {
       --toolbar-padding-right: var(--content-padding-x);
+      overflow: visible;
     }
   }
 

--- a/app/javascript/article-form/components/Toolbar.jsx
+++ b/app/javascript/article-form/components/Toolbar.jsx
@@ -10,11 +10,13 @@ export const Toolbar = ({ version, textAreaId }) => {
         version === 'v1' ? 'border-t-0' : ''
       }`}
     >
-      {version === 'v1' ? (
-        <ImageUploader editorVersion={version} />
-      ) : (
-        <MarkdownToolbar textAreaId={textAreaId} />
-      )}
+      <div className="my-1 s:my-2">
+        {version === 'v1' ? (
+          <ImageUploader editorVersion={version} />
+        ) : (
+          <MarkdownToolbar textAreaId={textAreaId} />
+        )}
+      </div>
     </div>
   );
 };

--- a/app/javascript/article-form/components/Toolbar.jsx
+++ b/app/javascript/article-form/components/Toolbar.jsx
@@ -10,7 +10,7 @@ export const Toolbar = ({ version, textAreaId }) => {
         version === 'v1' ? 'border-t-0' : ''
       }`}
     >
-      <div className="my-1 s:my-2">
+      <div className="my-2">
         {version === 'v1' ? (
           <ImageUploader editorVersion={version} />
         ) : (

--- a/app/javascript/crayons/MarkdownToolbar/MarkdownToolbar.jsx
+++ b/app/javascript/crayons/MarkdownToolbar/MarkdownToolbar.jsx
@@ -321,7 +321,7 @@ export const MarkdownToolbar = ({ textAreaId }) => {
 
   return (
     <div
-      className="editor-toolbar relative overflow-x-auto m:overflow-visible"
+      className="editor-toolbar relative"
       aria-label="Markdown formatting toolbar"
       role="toolbar"
       aria-controls={textAreaId}
@@ -335,7 +335,7 @@ export const MarkdownToolbar = ({ textAreaId }) => {
             variant="ghost"
             contentType="icon"
             icon={icon}
-            className="toolbar-btn mr-2"
+            className="toolbar-btn mr-1 s:mr-2"
             tabindex={index === 0 ? '0' : '-1'}
             onClick={() => insertSyntax(controlName)}
             onKeyUp={(e) => handleToolbarButtonKeyPress(e, 'toolbar-btn')}

--- a/app/javascript/crayons/MarkdownToolbar/MarkdownToolbar.jsx
+++ b/app/javascript/crayons/MarkdownToolbar/MarkdownToolbar.jsx
@@ -335,7 +335,7 @@ export const MarkdownToolbar = ({ textAreaId }) => {
             variant="ghost"
             contentType="icon"
             icon={icon}
-            className="toolbar-btn mr-1 s:mr-2"
+            className="toolbar-btn mr-1"
             tabindex={index === 0 ? '0' : '-1'}
             onClick={() => insertSyntax(controlName)}
             onKeyUp={(e) => handleToolbarButtonKeyPress(e, 'toolbar-btn')}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

This PR does two things:

1. Increases the scrollable area on the article editor toolbar so it should be slightly easier to scroll through it on touch devices.
2. Reduces the spacing between toolbar buttons because it doesn't have to be that big.

## QA Instructions, Screenshots, Recordings

You can spin up local env and, if you know how, run it on your mobile device, otherwise try chrome dev tools or ios emulator. Anyway, the toolbar should scroll just fine.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: not needed