### PR TITLE
Remove Italics from Community Name Field on Creator Settings Form

### DIFF
--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -4,7 +4,7 @@
     <span class="crayons-field__required crayons-tooltip" data-tooltip="This will set the primary name for your Forem" aria-describedby="community-name-subtitle"></span>
     <p id="community-name-subtitle" class="crayons-field__description">Used as the primary name for your Forem.</p>
   <% end %>
-  <%= text_field_tag :community_name, "", placeholder: "Climbing Life", class: "crayons-textfield fs-italic", required: true %>
+  <%= text_field_tag :community_name, "", placeholder: "Climbing Life", class: "crayons-textfield", required: true %>
 </div>
 
 <div class="crayons-field mt-6 align-left">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR removes the italics from the Community Name field per some feedback from @anujbhavsar96 and @ludwiczakpawel.

## Related Tickets & Documents
Relates to issue #15524 

## QA Instructions, Screenshots, Recordings
#### Please note that you will need to essentially clear out your database to take this feature for a spin. 🏎️  

To do so, you can either drop your entire database via `rails:db drop` 

_**or**_

You can open a rails console via `rails c` and do the following:
 ```
# Enable the feature flag
FeatureFlag.enable(:creator_onboarding)

# Delete all users 
User.destroy_all

# Set `waiting_on_first_user` to be true
Settings::General.waiting_on_first_user = true

# If you've logged in before set the mascot id to nil
 Settings::General.mascot_user_id = nil
```

Now, run your server and navigate to `http://localhost:3000/` and complete the "Create Account" form. After completing the "Create Account" form, you should be brought to the new Creator Setup page, `${baseUrl}/admin/creator_settings/new?referrer=${baseUrl}`.

Once on the Creator Settings page, you will want to test the changes outlined below:
#### Before:
<img width="757" alt="Screen Shot 2021-12-01 at 6 57 48 AM" src="https://user-images.githubusercontent.com/32834804/144248079-9c2fa645-3c06-43c6-bf96-e04ad9cdd3a6.png">

#### After:
<img width="788" alt="Screen Shot 2021-12-01 at 6 57 38 AM" src="https://user-images.githubusercontent.com/32834804/144248099-e392078d-8833-419e-8ca7-676a324bae3a.png">

### UI accessibility concerns?
N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: there are already tests for Creator Settings page and this change merely changes some styling.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Command + Z buttons](https://media.giphy.com/media/KDz938kEyh1UfJJGAp/giphy.gif)
