### PR TITLE
quote localized strings in credits/purchase embedded script

### DIFF
--- a/app/views/credits/new.html.erb
+++ b/app/views/credits/new.html.erb
@@ -152,7 +152,7 @@
 
     var form = document.getElementById('new_credit');
     form.onsubmit = function(_event) {
-      changeSubmitButton({ text: <%= t("views.credits.new.form.submitting") %>, active: false })
+      changeSubmitButton({ text: '<%= t("views.credits.new.form.submitting") %>', active: false })
     }
 
     var stripe = Stripe('<%= Settings::General.stripe_publishable_key %>');
@@ -217,7 +217,7 @@
           stripe.createToken(card).then(function(result) {
             if (result.error) {
               // Inform the user if there was an error.
-              changeSubmitButton({ text: <%= t("views.credits.new.form.submit") %>, active: true });
+              changeSubmitButton({ text: '<%= t("views.credits.new.form.submit") %>', active: true });
               var errorElement = document.getElementById('card-errors');
               errorElement.textContent = result.error.message;
             } else {

--- a/spec/views/credits/new.html.erb_spec.rb
+++ b/spec/views/credits/new.html.erb_spec.rb
@@ -24,4 +24,11 @@ RSpec.describe "credits/new", type: :view do
 
     expect(rendered).to have_content("color: 'white'")
   end
+
+  it "renders localized submitting message in js correctly" do
+    render
+
+    expect(rendered).to have_content("changeSubmitButton({ text: 'Submitting...', active: false })")
+    expect(rendered).to have_content("changeSubmitButton({ text: 'Complete Purchase', active: true })")
+  end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The internationalized string inside a javascript snippet in the view was not quoted, causing a parse error, and consequently causing the script (which controls the behavior of the two buttons on the form, enabling credit card management with stripe) not to function.

Quote the string, ensuring the script runs.

## Related Tickets & Documents

fixes #15454 

#15134 added the call to translation t() 
https://app.honeybadger.io/projects/66984/faults/65884099 

## QA Instructions, Screenshots, Recordings

As a user, visit /credits/purchase.

If you don't have stripe configured (default) you can see this error in the console:

```
Uncaught IntegrationError: Please call Stripe() with your publishable key. You used an empty string.
```

If you see instead a parse error:

```
Uncaught SyntaxError: missing } after property list
```

Then this is not fixed.


### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams


## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
