### PR TITLE
Block more bots

### DIFF
--- a/config/fastly/snippets/bad_bot_detection.vcl
+++ b/config/fastly/snippets/bad_bot_detection.vcl
@@ -36,6 +36,12 @@ sub vcl_recv {
     || req.http.user-agent ~ "Microsoft URL Control"
     || req.http.user-agent ~ "Indy Library"
     || req.http.user-agent ~ "Fuzz Faster"
+    # Spoofed user agent, Firefox 62 was released in Sep 2018, this line added
+    # in Dec 2021.
+    || (req.http.user-agent ~ "Firefox/62.0" && req.http.user-agent ~ "Win64")
+    # DEV gets an order of magnitude more traffic from AhrefsBot than any other
+    # search crawler.
+    || req.http.user-agent ~ "AhrefsBot"
     || req.http.user-agent == "8484 Boston Project v 1.0"
     || req.http.user-agent == "Atomic_Email_Hunter/4.0"
     || req.http.user-agent == "atSpider/1.0"
@@ -107,6 +113,8 @@ sub vcl_recv {
     || req.http.user-agent == "RSurf15a 41"
     || req.http.user-agent == "RSurf15a 51"
     || req.http.user-agent == "RSurf15a 81"
+    # Block Ruby bots unless they're interacting with the API
+    || (req.http.user-agent == "Ruby" && !(req.http.url ~ "^/api"))
     || req.http.user-agent == "searchbot admin@google.com"
     || req.http.user-agent == "ShablastBot 1.0"
     || req.http.user-agent == "snap.com beta crawler v0"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

I noticed a dramatic uptick in traffic to the `StoriesController#index` route on DEV at 40 minutes past the hour every single hour of the day like clockwork. Since preventing scraping is also something I've been working on with the community team (they get a _lot_ of complaints about plagiarism), I began investigating.

Turns out the vast majority of those requests are supplying a `User-Agent` header that is simply `Ruby`. So this PR blocks requests with that user agent, but since this is the default user agent string for `Net::HTTP` in the Ruby standard library, this PR only blocks them if they're not using the API (AFAIK, the only blessed path prefix for API clients). We couldn't block it by IP address because it was using a new IP (owned by Amazon) every time, as if a Lambda spins up once per hour, makes exactly 1000 requests, and shuts down again.

After some more digging, I noticed two other things about user agents:

- One user agent was claiming it was `Firefox/62.0`, which was released 3 years ago, so I'm calling shenanigans on it
- Another was AhrefsBot which, according to their own documentation, is "used by thousands of digital marketers around the world to plan, execute, and monitor their online marketing campaigns", so it seems useful but it also hits DEV (or at least, gets past the Fastly cache) _an order of magnitude more_ than any other search crawler, including Google

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is effectively an infrastructure config change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

No, these snippets are added to Fastly [on every deployment](https://github.com/forem/forem/blob/cca3bed04373706ae0be52b5bc008ecf3702097f/release-tasks.sh#L19)