### PR TITLE
Validate payment info present before attempting to process

### DIFF
--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -45,12 +45,15 @@ class CreditsController < ApplicationController
   end
 
   def validate_input(number_to_purchase)
-    # these set flash[:error] as a side-effect before returning false.
+    # these both set flash[:error] as a side-effect before returning false.
     ensure_payment_option! && ensure_nonzero_amount!(number_to_purchase)
   end
 
   def ensure_payment_option!
-    return true if params[:selected_card].present? || params[:stripe_token].present?
+    # we need either a credit card, a stripe token, or an organization (with billing setup)
+    # to complete the payment
+    purchase_options = params.slice(:selected_card, :stripe_token, :organization_id).compact_blank
+    return true if purchase_options.present?
 
     flash[:error] = "Please add a credit card before purchasing"
     false

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -25,44 +25,18 @@ class CreditsController < ApplicationController
 
     number_to_purchase = params[:credit][:number_to_purchase].to_i
 
-    if validate_input(number_to_purchase)
-      payment = Payments::ProcessCreditPurchase.call(
-        current_user,
-        number_to_purchase,
-        purchase_options: params.slice(:stripe_token, :selected_card, :organization_id),
-      )
+    payment = Payments::ProcessCreditPurchase.call(
+      current_user,
+      number_to_purchase,
+      purchase_options: params.slice(:stripe_token, :selected_card, :organization_id),
+    )
 
-      if payment.success?
-        @purchaser = payment.purchaser
-        redirect_to credits_path, notice: "#{number_to_purchase} new credits purchased!"
-      else
-        flash[:error] = payment.error
-        redirect_to purchase_credits_path
-      end
+    if payment.success?
+      @purchaser = payment.purchaser
+      redirect_to credits_path, notice: "#{number_to_purchase} new credits purchased!"
     else
+      flash[:error] = payment.error
       redirect_to purchase_credits_path
     end
-  end
-
-  def validate_input(number_to_purchase)
-    # these both set flash[:error] as a side-effect before returning false.
-    ensure_payment_option! && ensure_nonzero_amount!(number_to_purchase)
-  end
-
-  def ensure_payment_option!
-    # we need either a credit card, a stripe token, or an organization (with billing setup)
-    # to complete the payment
-    purchase_options = params.slice(:selected_card, :stripe_token, :organization_id).compact_blank
-    return true if purchase_options.present?
-
-    flash[:error] = "Please add a credit card before purchasing"
-    false
-  end
-
-  def ensure_nonzero_amount!(number_to_purchase)
-    return true if number_to_purchase.positive?
-
-    flash[:error] = "At least one credit must be purchased"
-    false
   end
 end

--- a/app/controllers/credits_controller.rb
+++ b/app/controllers/credits_controller.rb
@@ -25,6 +25,9 @@ class CreditsController < ApplicationController
 
     number_to_purchase = params[:credit][:number_to_purchase].to_i
 
+    ensure_selected_card!
+    ensure_nonzero_amount!(number_to_purchase)
+
     payment = Payments::ProcessCreditPurchase.call(
       current_user,
       number_to_purchase,
@@ -38,5 +41,19 @@ class CreditsController < ApplicationController
       flash[:error] = payment.error
       redirect_to purchase_credits_path
     end
+  end
+
+  def ensure_selected_card!
+    return if params[:selected_card].present?
+
+    flash[:error] = "Please add a credit card before purchasing"
+    redirect_to purchase_credits_path
+  end
+
+  def ensure_nonzero_amount!(number_to_purchase)
+    return if number_to_purchase.positive?
+
+    flash[:error] = "At least one credit must be purchased"
+    redirect_to purchase_credits_path
   end
 end

--- a/app/services/payments/process_credit_purchase.rb
+++ b/app/services/payments/process_credit_purchase.rb
@@ -29,7 +29,7 @@ module Payments
         process_purchase
         create_credits if success?
       else
-        self.error = "Please select a payment method"
+        self.error = I18n.t("services.payments.errors.select_payment_method")
       end
 
       self

--- a/app/services/payments/process_credit_purchase.rb
+++ b/app/services/payments/process_credit_purchase.rb
@@ -25,8 +25,7 @@ module Payments
     end
 
     def call
-      # we expect at least one of :stripe_token, :organization_id, or :selected_card to process
-      if purchase_options.compact_blank.present?
+      if payment_method_provided?
         process_purchase
         create_credits if success?
       else
@@ -44,6 +43,11 @@ module Payments
 
     attr_accessor :user, :credits_count, :success, :purchase_options
     attr_writer :purchaser, :error
+
+    def payment_method_provided?
+      # we expect at least one of :stripe_token or :selected_card to process
+      purchase_options.slice(:stripe_token, :selected_card).compact_blank.present?
+    end
 
     def process_purchase
       customer = find_or_create_customer

--- a/app/services/payments/process_credit_purchase.rb
+++ b/app/services/payments/process_credit_purchase.rb
@@ -25,8 +25,14 @@ module Payments
     end
 
     def call
-      process_purchase
-      create_credits if success?
+      # we expect at least one of :stripe_token, :organization_id, or :selected_card to process
+      if purchase_options.compact_blank.present?
+        process_purchase
+        create_credits if success?
+      else
+        self.error = "Please select a payment method"
+      end
+
       self
     end
 

--- a/config/locales/services/payments/en.yml
+++ b/config/locales/services/payments/en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  services:
+    payments:
+      errors:
+        select_payment_method: "Please select a payment method"

--- a/config/locales/services/payments/fr.yml
+++ b/config/locales/services/payments/fr.yml
@@ -1,0 +1,6 @@
+---
+fr:
+  services:
+    payments:
+      errors:
+        select_payment_method: "Choisissez une méthode de paiement"

--- a/config/locales/services/payments/fr.yml
+++ b/config/locales/services/payments/fr.yml
@@ -3,4 +3,4 @@ fr:
   services:
     payments:
       errors:
-        select_payment_method: "Choisissez une méthode de paiement"
+        select_payment_method: "Please choose a payment method"

--- a/spec/services/payments/process_credit_purchase_spec.rb
+++ b/spec/services/payments/process_credit_purchase_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Payments::ProcessCreditPurchase, type: :service do
+  describe ".call" do
+    let(:purchase_options) { {} }
+
+    it "sets error if no payment method" do
+      purchase = described_class.call(:nouser, :nocredits, purchase_options: purchase_options)
+
+      expect(purchase.error).to eq(I18n.t("services.payments.errors.select_payment_method"))
+    end
+
+    context "when a payment error occurs" do
+      let(:customer) { Stripe::Customer.create }
+      let(:user) { instance_double(User, id: :id, stripe_id_code: customer.id) }
+      let(:purchase_options) { { stripe_token: :token } }
+
+      before do
+        StripeMock.start
+      end
+
+      after do
+        StripeMock.stop
+      end
+
+      it "sets error if less than 1 credit ordered" do
+        purchase = described_class.call(user, 0, purchase_options: purchase_options)
+
+        expect(purchase.error).to eq("Invalid positive integer")
+      end
+
+      it "sets error if payment error is raised" do
+        # this customer get call is the first thing call does
+        allow(Payments::Customer)
+          .to receive(:get)
+          .with(customer.id)
+          .and_raise(Payments::PaymentsError, "Message")
+
+        purchase = described_class.call(user, 1, purchase_options: purchase_options)
+
+        expect(purchase.error).to eq("Message")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This prevents sending an empty card to stripe (and raising an error in the `find_or_create_card` method when providing an empty selected card to the Payments::Customer.get_source (which is resulting in a 500 error being returned from the credits purchase page).

This does not prevent submission, but handles submission by setting appropriate user facing error messages rather than raising an unhandled error when selected card is nil.

## Related Tickets & Documents

#15454 (I still think disabling the button in the frontend is a better experience)

## QA Instructions, Screenshots, Recordings

Visit /credits/purchase

Select 1 credit (you won't have any card selected locally since stripe isn't connecting)

Complete purchase.

An error should be shown and you should be returned to the purchase page 

```
Please select a payment method
```

Because this adds translation keys, you might see a missing translation error, this is resolvable by restarting the rails server or `bin/startup` process (locale files are not hotloaded)


### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not:  mostly a bugfix
 
