### PR TITLE
Renaming method to reduce surprise

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -55,7 +55,7 @@ class NotificationsController < ApplicationController
   private
 
   def user_to_view
-    if params[:username] && current_user.admin?
+    if params[:username] && current_user.super_admin?
       User.find_by(username: params[:username])
     else
       current_user
@@ -83,6 +83,6 @@ class NotificationsController < ApplicationController
   end
 
   def allowed_user?
-    @user.org_member?(params[:org_id]) || @user.admin?
+    @user.org_member?(params[:org_id]) || @user.super_admin?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -356,7 +356,7 @@ class User < ApplicationRecord
   # Included as a courtesy but let's consider removing it.
   alias warned warned?
 
-  def admin?
+  def super_admin?
     has_role?(:super_admin)
   end
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -30,7 +30,7 @@ Doorkeeper.configure do
     # Example implementation:
 
     if current_user
-      head :forbidden unless current_user.admin?
+      head :forbidden unless current_user.super_admin?
     else
       warden.authenticate!(scope: :user)
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Given that we have the roles of `:tech_admin`, `:admin`, and
`:super_admin`, I don't want the surprise of assuming that `user.admin?`
means that they have the role of `:admin`.

## Related Tickets & Documents

Related to #15624

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: It's a complete replace of an existing method.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
