### PR TITLE
Ensure COC and TOS Links Open on the Creator Settings Form

### DIFF
--- a/app/javascript/packs/onboardingRedirectCheck.jsx
+++ b/app/javascript/packs/onboardingRedirectCheck.jsx
@@ -14,6 +14,8 @@ function redirectableLocation() {
     window.location.pathname !== '/onboarding' &&
     window.location.pathname !== '/signout_confirm' &&
     window.location.pathname !== '/privacy' &&
+    window.location.pathname !== '/code-of-conduct' &&
+    window.location.pathname !== '/terms' &&
     window.location.pathname !== '/admin/creator_settings/new'
   );
 }

--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -98,7 +98,7 @@
       <div>
         <%= hidden_field_tag :checked_terms_and_conditions, "0" %>
         <%= check_box_tag :checked_terms_and_conditions, "1", false, class: "crayons-checkbox", required: true %>
-        <label for="checked_terms_and_conditions">I agree to our <a href="/terms" target="terms-and-conditions">>Terms and Conditions</a>.</label>
+        <label for="checked_terms_and_conditions">I agree to our <a href="/terms" target="terms-and-conditions">Terms and Conditions</a>.</label>
       </div>
     </div>
   </fieldset>

--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -93,12 +93,12 @@
       <div class="mb-2">
         <%= hidden_field_tag :checked_code_of_conduct, "0" %>
         <%= check_box_tag :checked_code_of_conduct, "1", false, class: "crayons-checkbox", required: true %>
-        <label for="checked_code_of_conduct">I agree to uphold our <a href="/code-of-conduct">Code of Conduct</a>.</label>
+        <label for="checked_code_of_conduct">I agree to uphold our <a href="/code-of-conduct" target="code-of-conduct">Code of Conduct</a>.</label>
       </div>
       <div>
         <%= hidden_field_tag :checked_terms_and_conditions, "0" %>
         <%= check_box_tag :checked_terms_and_conditions, "1", false, class: "crayons-checkbox", required: true %>
-        <label for="checked_terms_and_conditions">I agree to our <a href="/terms">Terms and Conditions</a>.</label>
+        <label for="checked_terms_and_conditions">I agree to our <a href="/terms" target="terms-and-conditions">>Terms and Conditions</a>.</label>
       </div>
     </div>
   </fieldset>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR ensures that both the COC and TOS links open in a new window, without any redirects, upon link click. To accomplish this, this PR does the following:
- [x] Adds a `target` to both the COC and TOS links 
- [x] Adds `/terms` and `/code-of-conduct` to `onboardingRedirectCheck.jsx` to ensure that the links do not redirect off of the Creator Settings page upon click

## Related Tickets & Documents
Closes issue #15546 

## QA Instructions, Screenshots, Recordings
#### Please note that you will need to essentially clear out your database to take this feature for a spin. 🏎️  

To do so, you can either drop your entire database via `rails:db drop` 

_**or**_

You can open a rails console via `rails c` and do the following:
 ```
# Enable the feature flag
FeatureFlag.enable(:creator_onboarding)

# Delete all users 
User.destroy_all

# Set `waiting_on_first_user` to be true
Settings::General.waiting_on_first_user = true

# If you've logged in before set the mascot id to nil
 Settings::General.mascot_user_id = nil
```

Now, run your server and navigate to `http://localhost:3000/` and complete the "Create Account" form. After completing the "Create Account" form, you should be brought to the new Creator Setup page, `${baseUrl}/admin/creator_settings/new?referrer=${baseUrl}`.

Once on the Creator Settings page, you will want to test the changes outlined below:
<img width="904" alt="Screen Shot 2021-12-01 at 3 02 57 PM" src="https://user-images.githubusercontent.com/32834804/144321366-cfaca5af-73c3-4587-87cb-973526532e46.png">
⚠️ **To test that the changes work**, please ensure that you are able to view the COC and TOS without being redirected, upon link click. The links should open in a new window so that the Creator's onboarding flow remains uninterrupted. Finally, please ensure that you are unable to submit the form via the "Finish" button until both the COC and TOS checkboxes are checked.

### UI accessibility concerns?
Possibly? I hope not! 🙈 

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: this feature is already covered by existing tests.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Gordon Ramsey yelling "Start again"](https://media.giphy.com/media/3oFzlY0DO131GoCFva/giphy.gif)
