### PR TITLE
Save article (to cache tags) before updating follow points

### DIFF
--- a/spec/workers/follows/update_points_worker_spec.rb
+++ b/spec/workers/follows/update_points_worker_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Follows::UpdatePointsWorker, type: :worker do
 
       user.follow(second_tag)
       user.follow(tag)
+      article.save
     end
 
     it "calculates scores", :aggregate_failures do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes a failure where the follow did not calculate implicit
points correctly.

The underlying issue was that the factory created `article` did not have
a cached_tags value containing `tag.name`
saved (`article.tags.pluck(:name)` was correct, but the cached_tags
was not). This happens automatically when saving an article from the
post editor, and any time we subsequently modify an article.


## Related Tickets & Documents

Supersedes #15456

## QA Instructions, Screenshots, Recordings


```
bundle exec rspec spec/workers/follows/update_points_worker_spec.rb
```

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._
- [x] This change does not need to be communicated, and this is why not: test only update

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
