### PR TITLE
Use the tag_list method, rather than the cached_tag_list attribute

### DIFF
--- a/app/workers/follows/update_points_worker.rb
+++ b/app/workers/follows/update_points_worker.rb
@@ -31,7 +31,7 @@ module Follows
         .pluck(:reactable_id).last(100)
       last_100_long_page_view_article_ids = user.page_views.where(time_tracked_in_seconds: 45..)
         .pluck(:article_id).last(100)
-      articles = Article.where(id: last_100_reactable_ids + last_100_long_page_view_article_ids).joins(:tags)
+      articles = Article.where(id: last_100_reactable_ids + last_100_long_page_view_article_ids)
       tags = articles.map(&:tag_list).flatten
       occurrences = tags.count(tag.name)
       bonus = inverse_popularity_bonus(tag)

--- a/app/workers/follows/update_points_worker.rb
+++ b/app/workers/follows/update_points_worker.rb
@@ -11,7 +11,7 @@ module Follows
       adjust_other_tag_follows_of_user(user.id)
       followed_tag_names =
         user.cached_followed_tag_names + user.cached_antifollowed_tag_names
-      article.decorate.cached_tag_list_array.each do |tag_name|
+      article.tag_list.each do |tag_name|
         if followed_tag_names.include?(tag_name)
           recalculate_tag_follow_points(tag_name, user)
         end
@@ -31,8 +31,8 @@ module Follows
         .pluck(:reactable_id).last(100)
       last_100_long_page_view_article_ids = user.page_views.where(time_tracked_in_seconds: 45..)
         .pluck(:article_id).last(100)
-      articles = Article.where(id: last_100_reactable_ids + last_100_long_page_view_article_ids)
-      tags = articles.pluck(:cached_tag_list).compact.flat_map { |list| list.split(", ") }
+      articles = Article.where(id: last_100_reactable_ids + last_100_long_page_view_article_ids).joins(:tags)
+      tags = articles.map(&:tag_list).flatten
       occurrences = tags.count(tag.name)
       bonus = inverse_popularity_bonus(tag)
       finalized_points(occurrences, bonus)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a follow on to #15456 and #15637


Saving the article in #15637 was a work-around to force the article to
have a valid cached tag list (would reload have worked just as well?). 

Update the worker to use tag_list (rather than the decorator's
cached_tag_list.array) and flatten the tag list rather than flat
mapping String#split over the non-nil cached_tag_lists.


https://github.com/forem/forem/pull/15456#discussion_r754649095 @atsmith813 I believe suggested this change (rather than the change to Article forcing the cache to update), if we can rely on tag_list always to be correct and cached_tag_list appears to be an implementation detail. I don't know if it makes sense in the decorator to continue splitting the cached tags list into any array (as a presentation concern), this changes a backend worker to not rely on that being consistent. Other cases where we rely on this include blackbox, many frontend representations of article, Commentable (where Podcast Episodes already use tag_list since they don't have a cached tag list at all)

## Related Tickets & Documents

#15637 (will close if this is merged).
#15456 (closed)

## QA Instructions, Screenshots, Recordings

```
bundle exec rspec spec/workers/follows/update_points_worker_spec.rb
```

https://app.travis-ci.com/github/forem/forem/jobs/549160000 failure had looked like this.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: behavior neutral change, fixes a currently failing spec
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: behavior neutral

## [optional] Are there any post deployment tasks we need to perform?

Monitoring job duration for any performance impact (we will make more db requests per invocation, it's unclear what that will mean in terms of time or stress). 

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
