### PR TITLE
Deprecating User#trusted in favor of User#trusted?

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -54,7 +54,7 @@ class AsyncInfoController < ApplicationController
         checked_terms_and_conditions: @user.checked_terms_and_conditions,
         display_sponsors: @user.display_sponsors,
         display_announcements: @user.display_announcements,
-        trusted: @user.trusted,
+        trusted: @user.trusted?,
         moderator_for_tags: @user.moderator_for_tags,
         config_body_class: @user.config_body_class,
         feed_style: feed_style_preference,

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -172,7 +172,7 @@ class Reaction < ApplicationRecord
   def negative_reaction_from_untrusted_user?
     return if user&.any_admin? || user&.id == Settings::General.mascot_user_id
 
-    negative? && !user.trusted
+    negative? && !user.trusted?
   end
 
   def notify_slack_channel_about_vomit_reaction

--- a/app/models/response_template.rb
+++ b/app/models/response_template.rb
@@ -38,7 +38,7 @@ class ResponseTemplate < ApplicationRecord
 
   def template_count
     return unless user
-    return if user.trusted || user.response_templates.count <= 30
+    return if user.trusted? || user.response_templates.count <= 30
 
     errors.add(:user, "Response template limit of 30 per user has been reached")
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -353,8 +353,10 @@ class User < ApplicationRecord
     has_role?(:warned)
   end
 
-  # Included as a courtesy but let's consider removing it.
-  alias warned warned?
+  def warned
+    ActiveSupport::Deprecation.warn("User#warned is deprecated, favor User#warned?")
+    warned?
+  end
 
   def super_admin?
     has_role?(:super_admin)
@@ -376,7 +378,7 @@ class User < ApplicationRecord
     Reaction.exists?(reactable_id: id, reactable_type: "User", category: "vomit", status: "confirmed")
   end
 
-  def trusted
+  def trusted?
     return @trusted if defined? @trusted
 
     @trusted = Rails.cache.fetch("user-#{id}/has_trusted_role", expires_in: 200.hours) do
@@ -384,7 +386,10 @@ class User < ApplicationRecord
     end
   end
 
-  alias trusted? trusted
+  def trusted
+    ActiveSupport::Deprecation.warn("User#trusted is deprecated, favor User#trusted?")
+    trusted?
+  end
 
   def moderator_for_tags
     Rails.cache.fetch("user-#{id}/tag_moderators_list", expires_in: 200.hours) do

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -135,7 +135,7 @@ module Mailchimp
     end
 
     def unsub_community_mod
-      return unless Settings::General.mailchimp_community_moderators_id.present? && user.trusted
+      return unless Settings::General.mailchimp_community_moderators_id.present? && user.trusted?
 
       gibbon.lists(Settings::General.mailchimp_community_moderators_id).members(target_md5_email).update(
         body: {

--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -123,7 +123,7 @@ module Moderator
 
     def update_trusted_cache
       Rails.cache.delete("user-#{@user.id}/has_trusted_role")
-      @user.trusted
+      @user.trusted?
     end
 
     def update_roles

--- a/app/services/re_captcha/check_enabled.rb
+++ b/app/services/re_captcha/check_enabled.rb
@@ -20,7 +20,7 @@ module ReCaptcha
       # recaptcha will always be enabled when not logged in
       return true if @user.nil?
       # recaptcha will not be enabled for tag moderator/trusted/admin users
-      return false if @user.tag_moderator? || @user.trusted || @user.any_admin?
+      return false if @user.tag_moderator? || @user.trusted? || @user.any_admin?
       # recaptcha will be enabled if the user has been suspended
       return true if @user.suspended?
 

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -26,7 +26,7 @@
           <span class="badge badge-warning">Member is Warned</span>
         <% elsif @user.comment_suspended? %>
           <span class="badge badge-warning">Member is Comment Suspended</span>
-        <% elsif @user.trusted %>
+        <% elsif @user.trusted? %>
           <span class="badge badge-success">Member is Trusted</span>
         <% else %>
           <span class="badge badge-info">Member is in Good Standing</span>

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -88,7 +88,7 @@
     </div>
   </div>
 
-  <% if current_user.trusted %>
+  <% if current_user.trusted? %>
     <div class="crayons-card crayons-card--content-rows">
       <h2 class="crayons-subtitle-1">
         Moderator notifications


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

`User#trusted?` is more Ruby idiomatic than `User#trusted`.  This helps
align the various "User#question?" methods.

I've added a deprecation warning, but don't believe that this is active
in the code-base.

## Related Tickets & Documents

Related, kind of sorta, to #15624.

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: This is a refactor without removing functionality.

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why
      not: The deprecation warning should be adequate.
