### PR TITLE
Extracting cross-model uniqueness validator

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -67,7 +67,7 @@ class Organization < ApplicationRecord
   validates :unspent_credits_count, presence: true
   validates :url, length: { maximum: 200 }, url: { allow_blank: true, no_local: true }
 
-  validate :unique_slug_including_users_and_podcasts, if: :slug_changed?
+  validates :slug, unique_cross_model_slug: true, if: :slug_changed?
 
   mount_uploader :profile_image, ProfileImageUploader
   mount_uploader :nav_image, ProfileImageUploader
@@ -149,16 +149,5 @@ class Organization < ApplicationRecord
 
   def bust_cache
     Organizations::BustCacheWorker.perform_async(id, slug)
-  end
-
-  def unique_slug_including_users_and_podcasts
-    slug_taken = (
-      User.exists?(username: slug) ||
-      Podcast.exists?(slug: slug) ||
-      Page.exists?(slug: slug) ||
-      slug&.include?("sitemap-")
-    )
-
-    errors.add(:slug, "is taken.") if slug_taken
   end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -6,7 +6,7 @@ class Page < ApplicationRecord
   validates :slug, presence: true, format: /\A[0-9a-z\-_]*\z/
   validates :template, inclusion: { in: TEMPLATE_OPTIONS }
   validate :body_present
-  validate :unique_slug_including_users_and_orgs, if: :slug_changed?
+  validates :slug, unique_cross_model_slug: true, if: :slug_changed?
 
   before_validation :set_default_template
   before_save :evaluate_markdown
@@ -48,18 +48,6 @@ class Page < ApplicationRecord
     return unless body_markdown.blank? && body_html.blank? && body_json.blank?
 
     errors.add(:body_markdown, "must exist if body_html or body_json doesn't exist.")
-  end
-
-  def unique_slug_including_users_and_orgs
-    slug_exists = (
-      User.exists?(username: slug) ||
-      Organization.exists?(slug: slug) ||
-      Podcast.exists?(slug: slug) ||
-      slug.include?("sitemap-")
-    )
-    return unless slug_exists
-
-    errors.add(:slug, "is taken.")
   end
 
   # As there can only be one global landing page, we want to ensure that

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -20,7 +20,8 @@ class Podcast < ApplicationRecord
             uniqueness: true,
             format: { with: /\A[a-zA-Z0-9\-_]+\Z/ },
             exclusion: { in: ReservedWords.all, message: "slug is reserved" }
-  validate :unique_slug_including_users_and_orgs, if: :slug_changed?
+
+  validates :slug, unique_cross_model_slug: true, if: :slug_changed?
 
   after_save :bust_cache
 
@@ -53,11 +54,6 @@ class Podcast < ApplicationRecord
   end
 
   private
-
-  def unique_slug_including_users_and_orgs
-    slug_exists = User.exists?(username: slug) || Organization.exists?(slug: slug) || Page.exists?(slug: slug)
-    errors.add(:slug, "is taken.") if slug_exists
-  end
 
   def bust_cache
     return unless path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -162,7 +162,7 @@ class User < ApplicationRecord
   end
 
   validate :non_banished_username, :username_changed?
-  validate :unique_including_orgs_and_podcasts, if: :username_changed?
+  validates :username, unique_cross_model_slug: true, if: :username_changed?
   validate :can_send_confirmation_email
   validate :update_rate_limit
   # NOTE: when updating the password on a Devise enabled model, the :encrypted_password
@@ -431,16 +431,6 @@ class User < ApplicationRecord
 
   def blocked_by?(blocker_id)
     UserBlock.blocking?(blocker_id, id)
-  end
-
-  def unique_including_orgs_and_podcasts
-    username_taken = (
-      Organization.exists?(slug: username) ||
-      Podcast.exists?(slug: username) ||
-      Page.exists?(slug: username)
-    )
-
-    errors.add(:username, "is taken.") if username_taken
   end
 
   def non_banished_username

--- a/app/validators/unique_cross_model_slug_validator.rb
+++ b/app/validators/unique_cross_model_slug_validator.rb
@@ -1,11 +1,11 @@
 ##
 # Validates if the give attribute is used across the reserved spaces.
 class UniqueCrossModelSlugValidator < ActiveModel::EachValidator
-  class_attribute :model_and_attribute_name_for_uniquness_test
+  class_attribute :model_and_attribute_name_for_uniqueness_test
 
   # Why a class attribute?  Allow for other implementations to extend
   # this behavior.
-  self.model_and_attribute_name_for_uniquness_test = {
+  self.model_and_attribute_name_for_uniqueness_test = {
     Organization => :slug,
     Page => :slug,
     Podcast => :slug,
@@ -36,7 +36,7 @@ class UniqueCrossModelSlugValidator < ActiveModel::EachValidator
     return false unless value
     return true if value.include?("sitemap-")
 
-    model_and_attribute_name_for_uniquness_test.detect do |model, attribute|
+    model_and_attribute_name_for_uniqueness_test.detect do |model, attribute|
       next if record.is_a?(model)
 
       model.exists?(attribute => value)

--- a/app/validators/unique_cross_model_slug_validator.rb
+++ b/app/validators/unique_cross_model_slug_validator.rb
@@ -1,0 +1,45 @@
+##
+# Validates if the give attribute is used across the reserved spaces.
+class UniqueCrossModelSlugValidator < ActiveModel::EachValidator
+  class_attribute :model_and_attribute_name_for_uniquness_test
+
+  # Why a class attribute?  Allow for other implementations to extend
+  # this behavior.
+  self.model_and_attribute_name_for_uniquness_test = {
+    Organization => :slug,
+    Page => :slug,
+    Podcast => :slug,
+    User => :username
+  }
+
+  DEFAULT_MESSAGE = "is taken".freeze
+
+  def validate_each(record, attribute, value)
+    return unless already_exists?(value: value, record: record)
+
+    record.errors.add(attribute, options[:message] || DEFAULT_MESSAGE)
+  end
+
+  private
+
+  ##
+  # Answers the question if it's okay for the record to use the given value.
+  #
+  # @param value [String] the value we're to check in the various classes
+  # @param record [ActiveRecord::Base] the record that we're attempting to validate
+  #
+  # @return [TrueClass] if the value already exists across the various classes.
+  # @return [FalseClass] if the given value is not already used.
+  #
+  # @see CLASS_AND_ATTRIBUTE_NAME_FOR_UNIQUNESS_TEST
+  def already_exists?(value:, record:)
+    return false unless value
+    return true if value.include?("sitemap-")
+
+    model_and_attribute_name_for_uniquness_test.detect do |model, attribute|
+      next if record.is_a?(klass)
+
+      model.exists?(attribute => value)
+    end
+  end
+end

--- a/app/validators/unique_cross_model_slug_validator.rb
+++ b/app/validators/unique_cross_model_slug_validator.rb
@@ -37,7 +37,7 @@ class UniqueCrossModelSlugValidator < ActiveModel::EachValidator
     return true if value.include?("sitemap-")
 
     model_and_attribute_name_for_uniquness_test.detect do |model, attribute|
-      next if record.is_a?(klass)
+      next if record.is_a?(model)
 
       model.exists?(attribute => value)
     end

--- a/spec/validators/unique_cross_model_slug_validator_spec.rb
+++ b/spec/validators/unique_cross_model_slug_validator_spec.rb
@@ -11,8 +11,23 @@ RSpec.describe UniqueCrossModelSlugValidator do
       include ActiveModel::Validations
       attr_accessor :name
 
-      validates :name, unique_cross_model_slug: true
+      def initialize
+        @enforce_validation = true
+      end
+
+      attr_accessor :enforce_validation
+      alias_method :enforce_validation?, :enforce_validation
+
+      validates :name, unique_cross_model_slug: true, if: :enforce_validation?
     end
+  end
+
+  context "when if option is false" do
+    let(:name) { "sitemap-happy" }
+
+    before { record.enforce_validation = false }
+
+    it { is_expected.to be_valid }
   end
 
   context "when name includes sitemap-" do

--- a/spec/validators/unique_cross_model_slug_validator_spec.rb
+++ b/spec/validators/unique_cross_model_slug_validator_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe UniqueCrossModelSlugValidator do
+  subject(:record) { validatable.new.tap { |m| m.name = name } }
+
+  let(:validatable) do
+    Class.new do
+      def self.name
+        "Validatable"
+      end
+      include ActiveModel::Validations
+      attr_accessor :name
+
+      validates :name, unique_cross_model_slug: true
+    end
+  end
+
+  context "when name includes sitemap-" do
+    let(:name) { "sitemap-happy" }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when name exists in User model" do
+    let(:user) { create(:user) }
+    let(:name) { user.username }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when name exists in Organization model" do
+    let(:org) { create(:organization) }
+    let(:name) { org.slug }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when name exists in Podcast model" do
+    let(:org) { create(:podcast) }
+    let(:name) { org.slug }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when name exists in Page model" do
+    let(:org) { create(:page) }
+    let(:name) { org.slug }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when name is something different" do
+    let(:org) { create(:organization) }
+    let(:name) { "not-#{org.slug}" }
+
+    it { is_expected.to be_valid }
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Prior to this commit, we had somewhat duplicated logic across four
models.  In adding this validator we're consolidating the logic and
tidying up each of the other models; letting the validator know which
models are part of the "uniqueness gang."

I made the decision to include the test for `sitemap-` as this was
partially applied to two of the models.

## Related Tickets & Documents

None.

## QA Instructions, Screenshots, Recordings

None, though please read through my logic.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
