### PR TITLE
Fixing blank home page for anonymous/visitor

### DIFF
--- a/app/services/articles/feeds/find_featured_story.rb
+++ b/app/services/articles/feeds/find_featured_story.rb
@@ -13,7 +13,9 @@ module Articles
       #       `Articles.where(featured: true)` but in my sleuthing,
       #       the origin of this method's inner logic never included a
       #       consideration for `featured == true`.  Perhaps that
-      #       should change?
+      #       should change?  This has been reported in
+      #       https://github.com/forem/forem/issues/15613 and impacts
+      #       Articles::Feeds::WeightedQueryStrategy.
       def self.call(stories, must_have_main_image: true)
         featured_story =
           if must_have_main_image

--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -273,7 +273,6 @@ module Articles
           user: @user,
           days_since_published: @days_since_published,
         )
-        @must_have_main_image = true
       end
 
       # The goal of this query is to generate a list of articles that
@@ -407,21 +406,26 @@ module Articles
       #       in the featured story.  For non-signed in users, we may
       #       want to use a completely different set of scoring
       #       methods.
+      #
+      # @note The logic of Articles::Feeds::FindFeaturedStory does not
+      #       (at present) filter apply an `Article.featured` scope.
+      #       [@jeremyf] I have reported this in
+      #       https://github.com/forem/forem/issues/15613 to get clarity
+      #       from product.
       def featured_story_and_default_home_feed(**)
-        # We could parameterize this, but callers would need to
-        # consider the impact of that decision, and it would break the
-        # current contract.
-        number_of_featured_stories = 1
-        featured_story = call(
-          only_featured: true,
-          must_have_main_image: @must_have_main_image,
-          limit: number_of_featured_stories,
-          offset: 0,
-        ).first
-        articles = call(
-          # Make sure that we don't include the featured_story
-          omit_article_ids: [featured_story&.id],
-        )
+        # NOTE: See the
+        # https://github.com/forem/forem/blob/c1a3ba99ebec2e1ca220e9530c26cac7757c690b/app/services/articles/feeds/weighted_query_strategy.rb#L410-L426
+        # state of the codebase for the implementation of first selecting
+        # the feature story (using the same query logic) then selecting
+        # the related articles.  With the below implementation, we need to
+        # do antics in the upstream javascript file to remove the featured
+        # file.  See the
+        # https://github.com/forem/forem/blob/c1a3ba99ebec2e1ca220e9530c26cac7757c690b/app/javascript/articles/Feed.jsx#L42-L63
+        # for that process.
+        #
+        # tl;dr - the below implementation creates additional downstream complexities.
+        articles = call
+        featured_story = Articles::Feeds::FindFeaturedStory.call(articles)
         [featured_story, articles]
       end
 
@@ -436,7 +440,9 @@ module Articles
 
       # The sql statement for selecting based on relevance scores that
       # are for nil users.
-      def sql_sub_query_for_nil_user(only_featured:, must_have_main_image:, limit:, offset:, omit_article_ids:)
+      # rubocop:disable Layout/LineLength
+      def sql_sub_query_for_nil_user(limit:, offset:, omit_article_ids:, only_featured: false, must_have_main_image: false)
+        # rubocop:enable Layout/LineLength
         where_clause = build_sql_with_where_clauses(
           only_featured: only_featured,
           must_have_main_image: must_have_main_image,
@@ -481,7 +487,11 @@ module Articles
         where_clauses = "articles.published = true AND articles.published_at > :oldest_published_at"
         # See Articles.published scope discussion regarding the query planner
         where_clauses += " AND articles.published_at < :now"
-        where_clauses += " AND articles.id NOT IN (:omit_article_ids)" unless omit_article_ids.empty?
+
+        # Without the compact, if we have `omit_article_ids: [nil]` we
+        # have the following SQL clause: `articles.id NOT IN (NULL)`
+        # which will immediately omit EVERYTHING from the query.
+        where_clauses += " AND articles.id NOT IN (:omit_article_ids)" unless omit_article_ids.compact.empty?
         where_clauses += " AND articles.featured = true" if only_featured
         where_clauses += " AND articles.main_image IS NOT NULL" if must_have_main_image
         where_clauses

--- a/spec/services/articles/feeds/weighted_query_strategy_spec.rb
+++ b/spec/services/articles/feeds/weighted_query_strategy_spec.rb
@@ -11,25 +11,56 @@ RSpec.describe Articles::Feeds::WeightedQueryStrategy, type: :service do
     it "receives `user_signed_in: false` and behaves" do
       response = feed_strategy.default_home_feed(user_signed_in: false)
       expect(response).to be_a(ActiveRecord::Relation)
+
+      create_list(:article, 3)
     end
   end
 
   describe "with a nil user" do
     let(:user) { nil }
 
-    it "#call performs a successful query" do
-      article = create(:article)
-      response = feed_strategy.call
-      expect(response).to be_a(ActiveRecord::Relation)
-      expect(response).to match_array([article])
+    describe "#featured_story_and_default_home_feed" do
+      it "returns an array with two elements and entries", aggregate_failures: true do
+        create_list(:article, 3)
+        response = feed_strategy.featured_story_and_default_home_feed(user_signed_in: false)
+        expect(response).to be_a(Array)
+        expect(response[0]).to be_a(Article)
+        expect(response[1]).to be_a(ActiveRecord::Relation)
+        # You cannot use "count" because the constructed query
+        # includes a select clause which gums up the counting
+        # mechanism.
+        expect(response[1].length).to eq(3)
+      end
     end
 
-    it "#call is successful with parameterization" do
-      # NOTE: I'm not testing the SQL logic, merely that the SQL is
-      # valid.
-      response = feed_strategy.call(only_featured: true)
-      expect(response).to be_a(ActiveRecord::Relation)
-      expect(response).to match_array([])
+    describe "#call" do
+      it "performs a successful query" do
+        article = create(:article)
+        response = feed_strategy.call
+        expect(response).to be_a(ActiveRecord::Relation)
+        expect(response).to match_array([article])
+      end
+
+      it "is successful with parameterization" do
+        # NOTE: I'm not testing the SQL logic, merely that the SQL is
+        # valid.
+        response = feed_strategy.call(only_featured: true)
+        expect(response).to be_a(ActiveRecord::Relation)
+        expect(response).to match_array([])
+      end
+
+      it "returns handles omit_article_ids scenarios as detailed below", aggregate_failures: true do
+        articles = create_list(:article, 3)
+
+        # This scenario can happen with
+        # `Articles::Feeds::WeightedQueryStrategy#featured_story_and_default_home_feed`
+        # when we look for a "featured" article and don't find any.
+        # So let's make sure we get back the articles we were
+        # expecting instead of none of them.
+        expect(feed_strategy.call(omit_article_ids: [nil]).length).to eq(articles.length)
+        expect(feed_strategy.call(omit_article_ids: []).length).to eq(articles.length)
+        expect(feed_strategy.call(omit_article_ids: [articles.first.id]).length).to eq(articles.length - 1)
+      end
     end
   end
 

--- a/spec/services/articles/feeds_spec.rb
+++ b/spec/services/articles/feeds_spec.rb
@@ -7,7 +7,15 @@ RSpec.describe Articles::Feeds do
     context "when the given user is nil" do
       let(:user) { nil }
 
-      it { is_expected.to be_a ActiveSupport::TimeWithZone }
+      it "returns Article::Feeds::DEFAULT_DAYS_SINCE_PUBLISHED days ago" do
+        # Why the to_date coercion?  Because Integer.days.ago is an
+        # ActiveSupport::TimeWithZone variable that includes
+        # microseconds, and in the time between the function_call and
+        # the expectation test, there's a few microseconds that passed
+        # (based on your processor).  In theory, this test might fail
+        # if someone ran the test right around the stroke of midnight.
+        expect(function_call.to_date).to eq(Articles::Feeds::DEFAULT_DAYS_SINCE_PUBLISHED.days.ago.to_date)
+      end
     end
 
     context "when the given user has no page views" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix

**Note: I am working on an internal retrospective regarding the discovery and impact of this bug.**

## Description

Prior to this fix, in the production rails console we ran the following:

```ruby
Articles::Feeds::WeightedQueryStrategy
  .new(user: nil, page: 1, tags: nil)
  .featured_story_and_default_home_feed(user_signed_in: false)
```

The result was: `[nil, []]`.  Which in the
[StoriesController#assign_feed_stories][1] is where we have the
following:

```ruby
@featured_story, @stories = feed
  .featured_story_and_default_home_feed(
    user_signed_in: user_signed_in?)
```

In Blazer, I ran the following query at 2021-12-02 Thu 20:41 EST:

```sql
SELECT * FROM articles
WHERE featured = true
AND published = true
AND published_at > (NOW() - interval '7 days')
AND published_at < NOW()
AND main_image IS NOT NULL
```

So the logic of filtering with `only_featured` resulted in the
`@featured_story` being `nil`.  Which then cascaded into the logic for
determining the remainder of the results.

For further discussion see the inline comments and specs that I wrote.

In addition to the above, I'm also reusing
`Articles::Feeds::FindFeaturedStory`

Prior to this commit, the `Articles::Feeds::WeightedQueryStrategy` first
grabbed the featured story, then grabbed the remaining articles.  This
is different than the implementation of the
`Articles::Feeds::LargeForemExperimental` in which we first grab all the
articles then claim one as the featured.

In the WeightedQueryStrategy, the articles would not include the
featured.  However, in the LargeForemExperimental it would.  This
results in upstream logic in [app/javascript/articles/Feed.jsx][2]
going through and removing one of the articles.

[1]:https://github.com/forem/forem/blob/c1a3ba99ebec2e1ca220e9530c26cac7757c690b/app/controllers/stories_controller.rb#L237-L271
[2]:https://github.com/forem/forem/blob/c1a3ba99ebec2e1ca220e9530c26cac7757c690b/app/javascript/articles/Feed.jsx#L57-L63

## Related Tickets & Documents

None.

## QA Instructions, Screenshots, Recordings

I think you're going to have to read the specs to make sure it's working.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
