### PR TITLE
Moving engine mount points to admin

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,17 +28,6 @@ Rails.application.routes.draw do
   # begin supporting i18n.
   scope "(/locale/:locale)", defaults: { locale: nil } do
     get "/locale/:locale", to: "stories#index"
-    require "sidekiq/web"
-    require "sidekiq_unique_jobs/web"
-    require "sidekiq/cron/web"
-
-    authenticated :user, ->(user) { user.tech_admin? } do
-      Sidekiq::Web.class_eval do
-        use Rack::Protection, permitted_origins: [URL.url] # resolve Rack Protection HttpOrigin
-      end
-      mount Sidekiq::Web => "/sidekiq"
-      mount FieldTest::Engine, at: "abtests"
-    end
 
     draw :admin
 

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -4,6 +4,16 @@ namespace :admin do
 
   authenticate :user, ->(user) { user.tech_admin? } do
     mount Blazer::Engine, at: "blazer"
+    require "sidekiq/web"
+    require "sidekiq_unique_jobs/web"
+    require "sidekiq/cron/web"
+
+    Sidekiq::Web.class_eval do
+      use Rack::Protection, permitted_origins: [URL.url] # resolve Rack Protection HttpOrigin
+    end
+
+    mount Sidekiq::Web => "sidekiq"
+    mount FieldTest::Engine, at: "abtests"
 
     flipper_ui = Flipper::UI.app(Flipper,
                                  { rack_protection: { except: %i[authenticity_token form_token json_csrf
@@ -11,6 +21,7 @@ namespace :admin do
     mount flipper_ui, at: "feature_flags"
     mount PgHero::Engine, at: "pghero"
   end
+
   resources :invitations, only: %i[index new create destroy]
   resources :organization_memberships, only: %i[update destroy create]
   resources :permissions, only: %i[index]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

These are administrative engines, and should be mounted within the
`/admin` path.

## Related Tickets & Documents

In a vague way #15640.

## QA Instructions, Screenshots, Recordings

Goto:

* `/abtests`, you should get a 404 error.
* `/admin/abtests`, you should see the abtests currently running
* `/sidekiq`, you should get a 404 error.
* `/admin/sidekiq`, you should see the sidekiq queue.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: there were none

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
0