### PR TITLE
Specify a single base image for builder and production

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,7 @@
-FROM quay.io/forem/ruby:3.0.2 as builder
+FROM quay.io/forem/ruby:3.0.2 as base
+
+
+FROM base as builder
 
 USER root
 
@@ -49,7 +52,7 @@ RUN echo $(date -u +'%Y-%m-%dT%H:%M:%SZ') >> "${APP_HOME}"/FOREM_BUILD_DATE && \
 RUN rm -rf node_modules vendor/assets spec
 
 ## Production
-FROM quay.io/forem/ruby:3.0.2 as production
+FROM base as production
 
 USER root
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently we have a FROM at the top of the dockerfile (normal, what you would be looking for if you'd seen a dockerfile before) and a nearly identical FROM line half way down, when, having built the builder for the testing image, we build fresh, from the same base image for production. 

I'm naming the common base image `base` and changing the two FROM lines to use it (FROM base). This prevents missing the second (and needless?) `FROM ruby:... as production` line farther down. 

I think I've tripped over this twice already. The next time someone changes the ruby  version tag on the base image, they'll only need to do it once (and maybe in the .ruby-version file, but who's counting).

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

If buildkite succeeds that's probably the most important thing. Local confirmation can be done via

```
docker build .
```

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: build infrastructure is tested by building from it.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: It's a tiny change (I don't think this even adds any images or layers you weren't already going to download)

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

