### PR TITLE
Disable failing test cases

### DIFF
--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -231,20 +231,20 @@ RSpec.describe "StoriesIndex", type: :request do
         create(:article, approved: false, body_markdown: u_body, score: 1)
       end
 
-      it "doesn't display posts with the campaign tags when sidebar is disabled" do
+      xit "doesn't display posts with the campaign tags when sidebar is disabled" do
         allow(Settings::Campaign).to receive(:sidebar_enabled).and_return(false)
         get "/"
         expect(response.body).not_to include(CGI.escapeHTML("Super-sheep"))
       end
 
-      it "doesn't display low-score posts" do
+      xit "doesn't display low-score posts" do
         allow(Settings::Campaign).to receive(:sidebar_enabled).and_return(true)
         allow(Settings::Campaign).to receive(:articles_require_approval).and_return(true)
         get "/"
         expect(response.body).not_to include(CGI.escapeHTML("Unapproved-post"))
       end
 
-      it "doesn't display unapproved posts" do
+      xit "doesn't display unapproved posts" do
         allow(Settings::Campaign).to receive(:sidebar_enabled).and_return(true)
         allow(Settings::Campaign).to receive(:sidebar_image).and_return("https://example.com/image.png")
         allow(Settings::Campaign).to receive(:articles_require_approval).and_return(true)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I think this is related to some requests triggering the weighted query
field test (which changes the rules for the home feed in a way that
may include these campaign tags and handles relevancy differently from
the scoring), for home page requests where the user is not signed in. 

Signing in and calling GET "/" restores the expected behavior, and the user has original feed strategy set.

```ruby
[7] pry(#<RSpec::ExampleGroups::StoriesIndex::GETStoriesIndex::WithCampaignSidebar>)> get "/"
=> 200                                                                         
[8] pry(#<RSpec::ExampleGroups::StoriesIndex::GETStoriesIndex::WithCampaignSidebar>)> response.body.include?("Unapproved-post")
=> true               

[9] pry(#<RSpec::ExampleGroups::StoriesIndex::GETStoriesIndex::WithCampaignSidebar>)> user.field_test_memberships
=> [#<FieldTest::Membership:0x000055793b0d7988
  id: 616,
  converted: false,
  created_at: Sat, 04 Dec 2021 00:52:35.434216000 +03 +03:00,
  experiment: "feed_strategy",
  participant_id: "7148",
  participant_type: "User",
  variant: "original">]

[10] pry(#<RSpec::ExampleGroups::StoriesIndex::GETStoriesIndex::WithCampaignSidebar>)> sign_in user
=> [[#<Proc:0x000055793bdce9c0 /home/djuber/src/forem/spec/support/initializers/warden.rb:9>, {}]] 
[11] pry(#<RSpec::ExampleGroups::StoriesIndex::GETStoriesIndex::WithCampaignSidebar>)> get "/"
=> 200
[12] pry(#<RSpec::ExampleGroups::StoriesIndex::GETStoriesIndex::WithCampaignSidebar>)> response.body.include?("Unapproved-post")                                                                
=> false         

[13] pry(#<RSpec::ExampleGroups::StoriesIndex::GETStoriesIndex::WithCampaignSidebar>)> sign_out user
=> [[#<Proc:0x000055793bdce9c0 /home/djuber/src/forem/spec/support/initializers/warden.rb:9>, {}],  
 [#<Proc:0x0000557939db2b78 /home/djuber/src/forem/spec/support/initializers/warden.rb:16>, {}]]
[14] pry(#<RSpec::ExampleGroups::StoriesIndex::GETStoriesIndex::WithCampaignSidebar>)> get "/"
=> 200                                                                                        
[15] pry(#<RSpec::ExampleGroups::StoriesIndex::GETStoriesIndex::WithCampaignSidebar>)> response.body.include?("Unapproved-post")                                                                
=> true   
```

It's reasonable to revisit these. Either the entire context should
include an assertion that all field tests return the original
strategy, never weighted, or we should determine their importance if
we expect the weighted query strategy to be universally deployed (or
widely deployed).

It also looks like the "displays only approved posts with the campaign tags, so won't see 'Super-puper'" test might just always pass and assert nothing useful.

Additional findings

Signed out user fetches by a uuid (participant type is null)

```
  FieldTest::Membership Load (0.3ms)  SELECT "field_test_memberships".* FROM "field_test_memberships" WHERE "field_test_memberships"."experiment" = $1 AND "field_test_memberships"."participant_type" IS NULL AND "field_test_memberships"."participant_id" = $2 LIMIT $3 /*application:PracticalDeveloper,controller:stories,action:index*/  [["experiment", "feed_strategy"], ["participant_id", "64dcde66-9659-5473-897e-5abd59f8b89f"], ["LIMIT", 1]]
```

Signed in user field test memberships have variant: "original"

```
  FieldTest::Membership Load (1.5ms)  SELECT "field_test_memberships".* FROM "field_test_memberships" WHERE "field_test_memberships"."participant_id" = $1 AND "field_test_memberships"."participant_type" = $2 /*application:PracticalDeveloper*/  [["participant_id", "7148"], ["participant_type", "User"]]
```

## Related Tickets & Documents

https://github.com/forem/forem/pull/15665 I believe introduced this immediate issue of non-determinate test behavior - by ensuring the home feed was non-empty for anonymous requests when using the weighted query strategy, the possibility to get these unexpected items (filtered by the original strategy) during request specs began. 

In determining whether this is important to maintain or something that's expected to be less relevant in the future, it's useful to look at the context where the code came from. 

https://github.com/forem/forem/pull/6141/ looks like the initial PR that added the functionality we're testing for here (including the tests).
https://github.com/forem/forem/pull/5892 links to the initial issues/specifications (https://github.com/forem/forem/issues/5701 and related figma links for the design)


## QA Instructions, Screenshots, Recordings


Run this successfully 10 times? It should fail 20% of the time if I understand what I'm doing.

```
 bundle exec rspec "spec/requests/stories_index_spec.rb"
```

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: I'm disabling tests for the time being.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._
- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

Fix or address these pending tests

One tiny test I tried was to sign in the user in this context - however that caused other (positive/presence) specs to fail - "displays unapproved if approval not required" and "displays sidebar url if url is set".

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
