### PR TITLE
Refactoring instance variable usage in tagged articles controller

### DIFF
--- a/app/controllers/stories/tagged_articles_controller.rb
+++ b/app/controllers/stories/tagged_articles_controller.rb
@@ -69,7 +69,7 @@ module Stories
       elsif params[:timeframe] == "latest"
         stories.where("score > ?", -20).order(published_at: :desc)
       else
-        stories.order(hotness_score: :desc).where("score >= ?", Settings::UserExperience.home_feed_minimum_score)
+        stories.order(hotness_score: :desc).where(score: Settings::UserExperience.home_feed_minimum_score..)
       end
     end
   end

--- a/app/controllers/stories/tagged_articles_controller.rb
+++ b/app/controllers/stories/tagged_articles_controller.rb
@@ -55,7 +55,7 @@ module Stories
     end
 
     def tagged_count(tag:)
-      tag.articles.published.where("score >= ?", Settings::UserExperience.tag_feed_minimum_score).count
+      tag.articles.published.where(score: Settings::UserExperience.tag_feed_minimum_score..).count
     end
 
     def not_found_if_not_established(stories:, tag:)
@@ -63,11 +63,11 @@ module Stories
     end
 
     def stories_by_timeframe(stories:)
-      if %w[week month year infinity].include?(params[:timeframe])
+      if Timeframe::FILTER_TIMEFRAMES.include?(params[:timeframe])
         stories.where("published_at > ?", Timeframe.datetime(params[:timeframe]))
           .order(public_reactions_count: :desc)
-      elsif params[:timeframe] == "latest"
-        stories.where("score > ?", -20).order(published_at: :desc)
+      elsif params[:timeframe] == Timeframe::LATEST_TIMEFRAME
+        stories.where(score: -20..).order(published_at: :desc)
       else
         stories.order(hotness_score: :desc).where(score: Settings::UserExperience.home_feed_minimum_score..)
       end

--- a/app/controllers/stories/tagged_articles_controller.rb
+++ b/app/controllers/stories/tagged_articles_controller.rb
@@ -7,20 +7,21 @@ module Stories
     rescue_from ArgumentError, with: :bad_request
 
     def index
-      @page = (params[:page] || 1).to_i
-      @article_index = true
-      @tag = params[:tag].downcase
-      @tag_model = Tag.find_by(name: @tag) || not_found
-      @moderators = User.with_role(:tag_moderator, @tag_model).select(:username, :profile_image, :id)
+      @tag = Tag.find_by(name: params[:tag].downcase) || not_found
 
-      if @tag_model.alias_for.present?
-        redirect_permanently_to("/t/#{@tag_model.alias_for}")
+      if @tag.alias_for.present?
+        redirect_permanently_to("/t/#{@tag.alias_for}")
         return
       end
 
-      set_number_of_articles
-      set_stories
-      not_found_if_not_established
+      @page = (params[:page] || 1).to_i
+      @article_index = true
+      @moderators = User.with_role(:tag_moderator, @tag).select(:username, :profile_image, :id)
+
+      set_number_of_articles(tag: @tag)
+
+      set_stories(number_of_articles: @number_of_articles, tag: @tag, page: @page)
+      not_found_if_not_established(tag: @tag, stories: @stories)
 
       set_surrogate_key_header "articles-#{@tag}"
       set_cache_control_headers(600,
@@ -30,45 +31,45 @@ module Stories
 
     private
 
-    def set_number_of_articles
-      @num_published_articles = if @tag_model.requires_approval?
-                                  @tag_model.articles.published.approved.count
+    def set_number_of_articles(tag:)
+      @num_published_articles = if tag.requires_approval?
+                                  tag.articles.published.approved.count
                                 elsif Settings::UserExperience.feed_strategy == "basic"
-                                  tagged_count
+                                  tagged_count(tag: tag)
                                 else
-                                  Rails.cache.fetch("article-cached-tagged-count-#{@tag}", expires_in: 2.hours) do
-                                    tagged_count
+                                  Rails.cache.fetch("article-cached-tagged-count-#{tag.name}", expires_in: 2.hours) do
+                                    tagged_count(tag: tag)
                                   end
                                 end
 
       @number_of_articles = user_signed_in? ? 5 : SIGNED_OUT_RECORD_COUNT
     end
 
-    def set_stories
-      @stories = Articles::Feeds::Tag.call(@tag, number_of_articles: @number_of_articles, page: @page)
+    def set_stories(number_of_articles:, page:, tag:)
+      stories = Articles::Feeds::Tag.call(tag.name, number_of_articles: number_of_articles, page: page)
 
-      @stories = @stories.approved if @tag_model&.requires_approval
+      stories = stories.approved if tag.requires_approval?
 
-      @stories = stories_by_timeframe
-      @stories = @stories.decorate
+      stories = stories_by_timeframe(stories: stories)
+      @stories = stories.decorate
     end
 
-    def tagged_count
-      @tag_model.articles.published.where("score >= ?", Settings::UserExperience.tag_feed_minimum_score).count
+    def tagged_count(tag:)
+      tag.articles.published.where("score >= ?", Settings::UserExperience.tag_feed_minimum_score).count
     end
 
-    def not_found_if_not_established
-      not_found if @stories.none? && !@tag_model.supported
+    def not_found_if_not_established(stories:, tag:)
+      not_found if stories.none? && !tag.supported?
     end
 
-    def stories_by_timeframe
+    def stories_by_timeframe(stories:)
       if %w[week month year infinity].include?(params[:timeframe])
-        @stories.where("published_at > ?", Timeframe.datetime(params[:timeframe]))
+        stories.where("published_at > ?", Timeframe.datetime(params[:timeframe]))
           .order(public_reactions_count: :desc)
       elsif params[:timeframe] == "latest"
-        @stories.where("score > ?", -20).order(published_at: :desc)
+        stories.where("score > ?", -20).order(published_at: :desc)
       else
-        @stories.order(hotness_score: :desc).where("score >= ?", Settings::UserExperience.home_feed_minimum_score)
+        stories.order(hotness_score: :desc).where("score >= ?", Settings::UserExperience.home_feed_minimum_score)
       end
     end
   end

--- a/app/views/stories/tagged_articles/_meta.html.erb
+++ b/app/views/stories/tagged_articles/_meta.html.erb
@@ -1,28 +1,28 @@
 <% title_with_timeframe(
-     page_title: @tag.capitalize + (@page.present? && @page > 1 ? t("views.stories.meta.page", page: @page) : ""),
+     page_title: @tag.name.capitalize + (@page.present? && @page > 1 ? t("views.stories.meta.page", page: @page) : ""),
      timeframe: params[:timeframe],
      content_for: true,
    ) %>
 
-<link rel="canonical" href="<%= tag_url(@tag_model, @page) %>" />
-<meta name="description" content="<%= t("views.stories.meta.description_tagged", tag: @tag, name: community_name) %>">
-<%= meta_keywords_tag(@tag) %>
+<link rel="canonical" href="<%= tag_url(@tag, @page) %>" />
+<meta name="description" content="<%= t("views.stories.meta.description_tagged", tag: @tag.name, name: community_name) %>">
+<%= meta_keywords_tag(@tag.name) %>
 
 <meta property="og:type" content="website" />
-<meta property="og:url" content="<%= tag_url(@tag_model, @page) %>" />
-<meta property="og:title" content="<%= title_with_timeframe(page_title: @tag.capitalize, timeframe: params[:timeframe]) %>" />
-<meta property="og:description" content="<%= t("views.stories.meta.description_tagged", tag: @tag.capitalize, name: community_name) %>" />
+<meta property="og:url" content="<%= tag_url(@tag, @page) %>" />
+<meta property="og:title" content="<%= title_with_timeframe(page_title: @tag.name.capitalize, timeframe: params[:timeframe]) %>" />
+<meta property="og:description" content="<%= t("views.stories.meta.description_tagged", tag: @tag.name.capitalize, name: community_name) %>" />
 <meta property="og:site_name" content="<%= community_name %>" />
 
 <meta name="twitter:site" content="@<%= Settings::General.social_media_handles["twitter"] %>">
-<meta name="twitter:creator" content="@<%= @tag.capitalize %>">
-<meta name="twitter:title" content="<%= title_with_timeframe(page_title: @tag.capitalize, timeframe: params[:timeframe]) %>">
-<meta name="twitter:description" content="<%= t("views.stories.meta.description_tagged", tag: @tag.capitalize, name: community_name) %>">
+<meta name="twitter:creator" content="@<%= @tag.name.capitalize %>">
+<meta name="twitter:title" content="<%= title_with_timeframe(page_title: @tag.name.capitalize, timeframe: params[:timeframe]) %>">
+<meta name="twitter:description" content="<%= t("views.stories.meta.description_tagged", tag: @tag.name.capitalize, name: community_name) %>">
 
-<% if @tag_model %>
+<% if @tag %>
   <meta name="twitter:card" content="summary_large_image">
-  <meta property="og:image" content="<%= tag_social_preview_url(@tag_model, format: :png) %>">
-  <meta name="twitter:image:src" content="<%= tag_social_preview_url(@tag_model, format: :png) %>">
+  <meta property="og:image" content="<%= tag_social_preview_url(@tag, format: :png) %>">
+  <meta name="twitter:image:src" content="<%= tag_social_preview_url(@tag, format: :png) %>">
 <% else %>
   <meta property="og:image" content="<%= Settings::General.main_social_image %>">
   <meta name="twitter:image:src" content="<%= Settings::General.main_social_image %>">

--- a/app/views/stories/tagged_articles/_meta.html.erb
+++ b/app/views/stories/tagged_articles/_meta.html.erb
@@ -1,5 +1,6 @@
+<% display_tag_name = @tag.name.capitalize %>
 <% title_with_timeframe(
-     page_title: @tag.name.capitalize + (@page.present? && @page > 1 ? t("views.stories.meta.page", page: @page) : ""),
+     page_title: display_tag_name + (@page.present? && @page > 1 ? t("views.stories.meta.page", page: @page) : ""),
      timeframe: params[:timeframe],
      content_for: true,
    ) %>
@@ -10,14 +11,14 @@
 
 <meta property="og:type" content="website" />
 <meta property="og:url" content="<%= tag_url(@tag, @page) %>" />
-<meta property="og:title" content="<%= title_with_timeframe(page_title: @tag.name.capitalize, timeframe: params[:timeframe]) %>" />
-<meta property="og:description" content="<%= t("views.stories.meta.description_tagged", tag: @tag.name.capitalize, name: community_name) %>" />
+<meta property="og:title" content="<%= title_with_timeframe(page_title: display_tag_name, timeframe: params[:timeframe]) %>" />
+<meta property="og:description" content="<%= t("views.stories.meta.description_tagged", tag: display_tag_name, name: community_name) %>" />
 <meta property="og:site_name" content="<%= community_name %>" />
 
 <meta name="twitter:site" content="@<%= Settings::General.social_media_handles["twitter"] %>">
-<meta name="twitter:creator" content="@<%= @tag.name.capitalize %>">
-<meta name="twitter:title" content="<%= title_with_timeframe(page_title: @tag.name.capitalize, timeframe: params[:timeframe]) %>">
-<meta name="twitter:description" content="<%= t("views.stories.meta.description_tagged", tag: @tag.name.capitalize, name: community_name) %>">
+<meta name="twitter:creator" content="@<%= display_tag_name %>">
+<meta name="twitter:title" content="<%= title_with_timeframe(page_title: display_tag_name, timeframe: params[:timeframe]) %>">
+<meta name="twitter:description" content="<%= t("views.stories.meta.description_tagged", tag: display_tag_name, name: community_name) %>">
 
 <% if @tag %>
   <meta name="twitter:card" content="summary_large_image">

--- a/app/views/stories/tagged_articles/_sidebar.html.erb
+++ b/app/views/stories/tagged_articles/_sidebar.html.erb
@@ -1,37 +1,37 @@
-<% cache "tag-sidebar-#{@tag}-#{@tag_model&.updated_at}-#{@tag_model&.taggings_count}-#{user_signed_in?}-#{@page}", expires_in: 5.hours do %>
+<% cache "tag-sidebar-#{@tag.name}-#{@tag&.updated_at}-#{@tag&.taggings_count}-#{user_signed_in?}-#{@page}", expires_in: 5.hours do %>
   <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left">
     <div class="sidebar-bg" id="sidebar-bg-left"></div>
     <aside class="side-bar">
-      <% if @tag_model && @tag_model.rules_html.present? %>
+      <% if @tag && @tag.rules_html.present? %>
         <div class="widget">
           <header>
             <h4><%= t("views.tags.sidebar.guidelines") %></h4>
           </header>
           <div class="widget-body">
-            <%= sanitize @tag_model.rules_html %>
-            <a class="crayons-btn crayons-btn--s" href="/new/<%= @tag %>">
+            <%= sanitize @tag.rules_html %>
+            <a class="crayons-btn crayons-btn--s" href="/new/<%= @tag.name %>">
               <%= t("views.tags.sidebar.new") %>
             </a>
           </div>
         </div>
       <% end %>
-      <% if @tag_model && @tag_model.wiki_body_html.present? %>
+      <% if @tag && @tag.wiki_body_html.present? %>
         <div class="widget">
           <header>
-            <h4><%= t("views.tags.sidebar.about", tag: @tag) %></h4>
+            <h4><%= t("views.tags.sidebar.about", tag: @tag.name) %></h4>
           </header>
           <div class="widget-body">
-            <%= sanitize @tag_model.wiki_body_html %>
+            <%= sanitize @tag.wiki_body_html %>
           </div>
         </div>
       <% end %>
-      <% if @tag_model.sponsorship && @tag_model.sponsorship.status == "live" && @tag_model.sponsorship.expires_at > Time.current %>
+      <% if @tag.sponsorship && @tag.sponsorship.status == "live" && @tag.sponsorship.expires_at > Time.current %>
         <div class="widget">
           <header>
-            <h4><%= t("views.tags.sidebar.sponsor", tag: @tag) %></h4>
+            <h4><%= t("views.tags.sidebar.sponsor", tag: @tag.name) %></h4>
           </header>
           <div class="widget-body">
-            <%= render "articles/single_sponsor", sponsorship: @tag_model.sponsorship %>
+            <%= render "articles/single_sponsor", sponsorship: @tag.sponsorship %>
           </div>
         </div>
       <% end %>
@@ -59,27 +59,27 @@
           <div class="crayons-btn-group mt-3">
             <a style="display:none;"
                 id="tag-edit-button"
-                data-tag="<%= @tag_model.name %>"
+                data-tag="<%= @tag.name %>"
                 class="crayons-btn crayons-btn--outlined mod-action-button fs-s"
-                href="<%= tag_url(@tag_model, @page) %>/edit"
-                style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
+                href="<%= tag_url(@tag, @page) %>/edit"
+                style="color:<%= @tag.text_color_hex %>;background-color:<%= @tag.bg_color_hex %>">
               <%= t("views.tags.sidebar.edit") %>
             </a>
             <a style="display:none;"
                id="tag-admin-button"
-               data-tag="<%= @tag_model.name %>"
+               data-tag="<%= @tag.name %>"
                class="crayons-btn crayons-btn--outlined mod-action-button fs-s"
-               href="<%= edit_admin_tag_path(@tag_model.id) %>"
-               style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>"
+               href="<%= edit_admin_tag_path(@tag.id) %>"
+               style="color:<%= @tag.text_color_hex %>;background-color:<%= @tag.bg_color_hex %>"
                data-no-instant>
               <%= t("views.tags.sidebar.admin") %>
             </a>
             <a style="display:none;"
                id="tag-mod-button"
-               data-tag="<%= @tag_model.name %>"
+               data-tag="<%= @tag.name %>"
                class="crayons-btn crayons-btn--outlined mod-action-button fs-s"
-               href="/mod/<%= @tag_model.name %>"
-               style="color:<%= @tag_model.text_color_hex %>;background-color:<%= @tag_model.bg_color_hex %>">
+               href="/mod/<%= @tag.name %>"
+               style="color:<%= @tag.text_color_hex %>;background-color:<%= @tag.bg_color_hex %>">
               <%= t("views.tags.sidebar.moderate") %>
             </a>
           </div>
@@ -88,19 +88,19 @@
           <% range = number_of_pages < 10 || @page < 4 ? 1..[number_of_pages, 9].min : [@page - 3, 1].max..[@page + 5, number_of_pages].min %>
           <% if number_of_pages > 1 %>
             <hr />
-            <div class="olderposts-header"><%= t("views.tags.sidebar.older", tag: @tag) %></div>
+            <div class="olderposts-header"><%= t("views.tags.sidebar.older", tag: @tag.name) %></div>
             <div class="olderposts-links">
               <% range.each do |n| %>
                 <% if @page == n %>
                     <span class="olderposts-pagenumber"><%= n %></span>
                 <% else %>
-                    <a href="<%= tag_url(@tag_model, n) %>" class="olderposts-pagenumber"><%= n %></a>
+                    <a href="<%= tag_url(@tag, n) %>" class="olderposts-pagenumber"><%= n %></a>
                 <% end %>
               <% end %>
               <% if @page == 1 && number_of_pages > 100 %>
                 <div>
-                  …<a href="<%= tag_url(@tag_model, 75) %>" class="olderposts-pagenumber">75</a>
-                  …<a href="<%= tag_url(@tag_model, number_of_pages) %>" class="olderposts-pagenumber"><%= number_of_pages %></a>
+                  …<a href="<%= tag_url(@tag, 75) %>" class="olderposts-pagenumber">75</a>
+                  …<a href="<%= tag_url(@tag, number_of_pages) %>" class="olderposts-pagenumber"><%= number_of_pages %></a>
                 </div>
               <% end %>
             </div>

--- a/app/views/stories/tagged_articles/_sidebar_additional.html.erb
+++ b/app/views/stories/tagged_articles/_sidebar_additional.html.erb
@@ -2,7 +2,7 @@
   <div id="sidebar-wrapper-right" class="sidebar-wrapper sidebar-wrapper-right">
     <div class="sidebar-bg" id="sidebar-bg-right"></div>
     <aside class="side-bar sidebar-additional showing" id="sidebar-additional">
-      <% active_threads = active_threads(tags: [@tag, "discuss"], time_ago: Timeframe.datetime(params[:timeframe])) %>
+      <% active_threads = active_threads(tags: [@tag.name, "discuss"], time_ago: Timeframe.datetime(params[:timeframe])) %>
       <% if active_threads.present? %>
         <div class="widget">
           <header>
@@ -17,11 +17,11 @@
       <% end %>
       <% if user_signed_in? %>
         <%= javascript_packs_with_chunks_tag "sidebarWidget", defer: true %>
-        <div id="sidebarWidget__pack" data-tag-info="<%= @tag_model.attributes.slice("id", "text_color_hex", "bg_color_hex", "name").to_json %>">
+        <div id="sidebarWidget__pack" data-tag-info="<%= @tag.attributes.slice("id", "text_color_hex", "bg_color_hex", "name").to_json %>">
         </div>
       <% else %>
-        <% cache("seo-boostable-posts-for-tag-#{@tag}-#{params[:timeframe]}", expires_in: 18.hours) do %>
-          <% boostable_posts = Article.seo_boostable(@tag, Timeframe.datetime(params[:timeframe])) %>
+        <% cache("seo-boostable-posts-for-tag-#{@tag.name}-#{params[:timeframe]}", expires_in: 18.hours) do %>
+          <% boostable_posts = Article.seo_boostable(@tag.name, Timeframe.datetime(params[:timeframe])) %>
           <% if boostable_posts.present? %>
             <div class="widget">
               <header>
@@ -34,7 +34,7 @@
               </div>
             </div>
           <% end %>
-          <% recent_preamble_optimized_posts = Article.search_optimized(@tag) %>
+          <% recent_preamble_optimized_posts = Article.search_optimized(@tag.name) %>
           <% if params[:timeframe].blank? && recent_preamble_optimized_posts.present? %>
             <div class="widget">
               <header>

--- a/app/views/stories/tagged_articles/index.html.erb
+++ b/app/views/stories/tagged_articles/index.html.erb
@@ -3,49 +3,49 @@
 <% end %>
 <% expiry_minutes = params[:timeframe].blank? || params[:timeframe] == "latest" ? 4 : 20 %>
 <% flag = true %>
-<% cache("tag-stories-index-#{params}-#{flag}-#{@tag_model.updated_at}-#{user_signed_in?}", expires_in: expiry_minutes.minutes) do %>
+<% cache("tag-stories-index-#{params}-#{flag}-#{@tag.updated_at}-#{user_signed_in?}", expires_in: expiry_minutes.minutes) do %>
   <div class="crayons-layout">
-    <header class="crayons-card branded-4 p-4 l:p-6 spec__tag-header" style="border-top-color: <%= @tag_model.bg_color_hex %> ">
+    <header class="crayons-card branded-4 p-4 l:p-6 spec__tag-header" style="border-top-color: <%= @tag.bg_color_hex %> ">
       <div class="flex">
-        <% if @tag_model.badge_id && @tag_model.badge %>
-            <img src="<%= optimized_image_url(@tag_model.badge.badge_image_url, width: 64) %>" alt="" class="mr-4" style="transform: rotate(<%= -25 + (@tag_model.id.digits.first * 5) %>deg); width: 64px; height: 64px;" />
+        <% if @tag.badge_id && @tag.badge %>
+            <img src="<%= optimized_image_url(@tag.badge.badge_image_url, width: 64) %>" alt="" class="mr-4" style="transform: rotate(<%= -25 + (@tag.id.digits.first * 5) %>deg); width: 64px; height: 64px;" />
         <% end %>
         <div class="flex flex-col w-100 justify-center">
           <div class="flex justify-between items-center">
             <h1 class="crayons-title">
-              <% if @tag_model && @tag_model.pretty_name.present? %>
-                <%= @tag_model.pretty_name %>
+              <% if @tag && @tag.pretty_name.present? %>
+                <%= @tag.pretty_name %>
               <% else %>
                 <span class="opacity-50">#</span>
-                <%= @tag %>
+                <%= @tag.name %>
               <% end %>
             </h1>
-            <% if @tag_model %>
+            <% if @tag %>
               <button
                 id="user-follow-butt"
                 class="crayons-btn follow-action-button"
-                data-info='{"id":<%= @tag_model.id %>,"className":"Tag", "name": "<%= @tag_model.pretty_name || @tag %>"}'>
+                data-info='{"id":<%= @tag.id %>,"className":"Tag", "name": "<%= @tag.pretty_name || @tag.name %>"}'>
                 <%= t("views.stories.follow") %>
               </button>
             <% end %>
           </div>
-          <% if @tag_model && @tag_model.short_summary.present? %>
+          <% if @tag && @tag.short_summary.present? %>
             <p class="max-w-100 m:max-w-75 pt-2 s:pt-4">
-              <%= strip_tags(@tag_model.short_summary) %>
+              <%= strip_tags(@tag.short_summary) %>
             </p>
           <% end %>
         </div>
       </div>
-      <% if @tag_model && @tag_model.short_summary.present? %>
+      <% if @tag && @tag.short_summary.present? %>
       <% end %>
     </header>
   </div>
 
   <div class="home sub-home" id="index-container"
       data-params="<%= params.merge(sort_by: "hotness_score", sort_direction: "desc").to_json(only: %i[tag username sort_by sort_direction]) %>" data-which=""
-      data-tag="<%= @tag %>"
+      data-tag="<%= @tag.name %>"
       data-feed="<%= params[:timeframe] || "base-feed" %>"
-      data-requires-approval="<%= @tag_model.requires_approval %>"
+      data-requires-approval="<%= @tag.requires_approval %>"
       data-articles-since="<%= Timeframe.datetime_iso8601(params[:timeframe]) %>">
     <%= render "stories/tagged_articles/sidebar" %>
     <main class="articles-list" id="main-content" data-follow-button-container="true">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Having both `@tag` and `@tag_model` as variable names can be confusing.

Given that in the prior implementation `@tag_model.name == @tag`, I
figured I would refactor the controller to remove an instance variable.

In addition, this refactor addresses the temporal coupling of methods;
that is to say we call a method which sets an instance variable then
call another dependent on that instance variable.

Yes, ivars are useful to allow for implicit state.  However, by favoring
parameters its easier to notice temporal dependencies in method calls.

This helps ensure that we're calling methods in the right order.

Futher, we have a guard clause in place, so let's avoid setting any
additional instance variables that aren't needed if the guard clause
executes.

## Related Tickets & Documents

Related to #15359

## QA Instructions, Screenshots, Recordings

The tests cover this refactor.

### UI accessibility concerns?

No concerns.

## Added/updated tests?

- [X] No, and this is why: a refactor to replace two ivars in a view with one, and a bit of method rework.

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: it's a refactor with test coverage.