### PR TITLE
Creator Settings: Fixed the resizing of the preview logo

### DIFF
--- a/app/javascript/admin/controllers/creator_settings_controller.js
+++ b/app/javascript/admin/controllers/creator_settings_controller.js
@@ -3,7 +3,7 @@ import { isLowContrast } from '@utilities/color/contrastValidator';
 import { brightness } from '@utilities/color/accentCalculator';
 
 const MAX_LOGO_PREVIEW_HEIGHT = 80;
-const MAX_LOGO_PREVIEW_WIDTH = 220;
+const MAX_LOGO_PREVIEW_WIDTH = 200;
 
 /**
  * Manages interactions on the Creator Settings page.
@@ -46,17 +46,18 @@ export class CreatorSettingsController extends Controller {
           } = event;
 
           if (height > MAX_LOGO_PREVIEW_HEIGHT) {
-            width = (width / height) * MAX_LOGO_PREVIEW_HEIGHT;
+            width = (MAX_LOGO_PREVIEW_HEIGHT / height) * width;
             height = MAX_LOGO_PREVIEW_HEIGHT;
           }
 
           if (width > MAX_LOGO_PREVIEW_WIDTH) {
+            height = (MAX_LOGO_PREVIEW_WIDTH / width) * height;
             width = MAX_LOGO_PREVIEW_WIDTH;
-            height = (height / width) * MAX_LOGO_PREVIEW_WIDTH;
           }
 
-          image.style.width = `${width}px`;
-          image.style.height = `${height}px`;
+          image.width = width;
+          image.height = height;
+          image.className = 'site-logo';
 
           this.previewLogoTarget.replaceChild(
             image,

--- a/app/javascript/admin/controllers/creator_settings_controller.js
+++ b/app/javascript/admin/controllers/creator_settings_controller.js
@@ -3,7 +3,6 @@ import { isLowContrast } from '@utilities/color/contrastValidator';
 import { brightness } from '@utilities/color/accentCalculator';
 
 const MAX_LOGO_PREVIEW_HEIGHT = 80;
-const MAX_LOGO_PREVIEW_WIDTH = 200;
 
 /**
  * Manages interactions on the Creator Settings page.
@@ -34,6 +33,7 @@ export class CreatorSettingsController extends Controller {
       const imageURL = reader.result;
       const image = document.createElement('img');
       image.src = imageURL;
+      image.className = 'site-logo';
 
       // The logo preview image is purely visual so no need to communicate this to assistive technology.
       image.alt = 'preview of logo selected';
@@ -45,24 +45,28 @@ export class CreatorSettingsController extends Controller {
             target: { width, height },
           } = event;
 
+          this.previewLogoTarget.replaceChild(
+            image,
+            this.previewLogoTarget.firstChild,
+          );
+
+          const maxLogoPreviewWidth = parseInt(
+            getComputedStyle(image).getPropertyValue('--max-width'),
+            10,
+          );
+
           if (height > MAX_LOGO_PREVIEW_HEIGHT) {
             width = (MAX_LOGO_PREVIEW_HEIGHT / height) * width;
             height = MAX_LOGO_PREVIEW_HEIGHT;
           }
 
-          if (width > MAX_LOGO_PREVIEW_WIDTH) {
-            height = (MAX_LOGO_PREVIEW_WIDTH / width) * height;
-            width = MAX_LOGO_PREVIEW_WIDTH;
+          if (width > maxLogoPreviewWidth) {
+            height = (maxLogoPreviewWidth / width) * height;
+            width = maxLogoPreviewWidth;
           }
 
           image.width = width;
           image.height = height;
-          image.className = 'site-logo';
-
-          this.previewLogoTarget.replaceChild(
-            image,
-            this.previewLogoTarget.firstChild,
-          );
         },
         { once: true },
       );


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There was an issue with the logo preview resizing algorithm.

## Related Tickets & Documents

#15499

## QA Instructions, Screenshots, Recordings

1. Ensure you're logged out from the Forem instance.
2. Set up the database to be in a state where you are about to create the Forem creator role

```ruby
# Enable the feature flag
FeatureFlag.enable(:creator_onboarding)

# Delete all users 
User.destroy_all

# Set `waiting_on_first_user` to be true
Settings::General.waiting_on_first_user = true

# If you've logged in before set the mascot id to nil
Settings::General.mascot_user_id = nil

# If you've logged in before set the logo SVG to nil
Settings::General.logo_svg = nil
```

3. Click on the login link. Since the feature flag is enabled, you'll be redirected to Creator Signup Form.
4. Fill in the necessary information and submit the form.
5. On the next page select an image for the logo.
6. The preview of the logo should no longer be skewed. You can test this with the CodeNewbie logo below.

![image](https://user-images.githubusercontent.com/833231/144886093-fdbf29c1-6c36-45fc-82cf-80045bb3419f.png)

### Before

![image](https://user-images.githubusercontent.com/833231/144885652-7c1beacb-31b4-47bb-a23a-41ffb6c345ce.png)

### After

![image](https://user-images.githubusercontent.com/833231/144885559-b77bd461-a7e0-40ba-82c1-558813b908fd.png)


### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Tests already cover this.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/W2KcfZICjiFtdBOMvF/giphy.gif)
