### PR TITLE
Remove manual require of view_component from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ gem "uglifier", "~> 4.2" # Uglifier minifies JavaScript files
 gem "ulid", "~> 1.3" # Universally Unique Lexicographically Sortable Identifier implementation for Ruby
 gem "validate_url", "~> 1.0" # Library for validating urls in Rails
 gem "vault", "~> 0.16" # Used to store secrets
-gem "view_component", "~> 2.46", require: "view_component/engine" # View components for Rails
+gem "view_component", "~> 2.46" # View components for Rails
 gem "wcag_color_contrast", "~> 0.1" # Detect contrast of colors to determine readability and a11y.
 gem "webpacker", "~> 5.4.3" # Use webpack to manage app-like JavaScript modules in Rails
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Don't require view_component/engine in the gemfile. Let it load automatically.

## Related Tickets & Documents

fixes #15689

## QA Instructions, Screenshots, Recordings

Startup should not include a deprecation warning about requiring the engine (was first two lines when running `rails s` or rake tasks, indicating application.rb:20 as the source).

Expected/desired output:
```
djuber@forem:~/src/forem$ bundle exec rails s
=> Booting Puma
```

View components (at http://localhost:3000/admin/users/1 or http://localhost:3000/admin/users/1/tools or http://localhost:3000/admin/users/1/tools/emails) should still render correctly (the tools and tools/emails components are raw forms and exclude most styling, they are intended to be embedded in the parent view at /admin/users/:user_id). 

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: should not introduce or change behavior
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![instructions](https://user-images.githubusercontent.com/1237369/144895481-37515e9e-d58d-42dd-be43-b723c602aeb4.gif)
