### PR TITLE
Don't test for article score filtering in home feed

### DIFF
--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -237,13 +237,6 @@ RSpec.describe "StoriesIndex", type: :request do
         expect(response.body).not_to include(CGI.escapeHTML("Super-sheep"))
       end
 
-      xit "doesn't display low-score posts" do
-        allow(Settings::Campaign).to receive(:sidebar_enabled).and_return(true)
-        allow(Settings::Campaign).to receive(:articles_require_approval).and_return(true)
-        get "/"
-        expect(response.body).not_to include(CGI.escapeHTML("Unapproved-post"))
-      end
-
       xit "doesn't display unapproved posts" do
         allow(Settings::Campaign).to receive(:sidebar_enabled).and_return(true)
         allow(Settings::Campaign).to receive(:sidebar_image).and_return("https://example.com/image.png")


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Remove one example that was overspecifying the context (stories index when a campaign is active). 

We're revisiting the behavior of the feed scoring, and the selection
of articles will be independent of the article's score in some cases.

This test was nested within a group related to active campaigns, but
the minimum score is a user experience setting (so if we want to test
for that it should happen outside the context), and minimum article
score will not be a reliable criterion for filtering the home
feed in the future (and was failing based on the feed strategy experiment).

Remove this example (it was already skipped), as it adds little value, 
and is at a minimum misplaced (wrong surrounding context), 
at worst it's wrong or likely to be wrong soon.


## Related Tickets & Documents

https://forem.team/danuber/campaign-tags-and-the-home-feed-2bi4

https://github.com/forem/forem/pull/15680

## QA Instructions, Screenshots, Recordings

Nothing to do - deleting a skipped test. :ok: 

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes (deleted a test counts?)

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._
- [x] I will share this change internally with the appropriate teams

