### PR TITLE
Removed resaving users' articles in a before_validation callback

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -601,10 +601,6 @@ class User < ApplicationRecord
 
     self.old_old_username = old_username
     self.old_username = username_was
-    articles.find_each do |article|
-      article.path = article.path.gsub(username_was, username)
-      article.save
-    end
   end
 
   def bust_cache

--- a/spec/services/users/update_spec.rb
+++ b/spec/services/users/update_spec.rb
@@ -64,6 +64,43 @@ RSpec.describe Users::Update, type: :service do
     expect(service.errors_as_sentence).to eq "filename too long - the max is 250 characters."
   end
 
+  context "when changing username" do
+    let(:new_username) { "#{user.username}_changed" }
+
+    it "sets old_username and old_old_username when username was changed" do
+      old_username = user.username
+      old_old_username = user.old_username
+      described_class.call(user, user: { username: new_username })
+      user.reload
+      expect(user.username).to eq(new_username)
+      expect(user.old_username).to eq(old_username)
+      expect(user.old_old_username).to eq(old_old_username)
+    end
+
+    it "changes user's articles path" do
+      article = create(:article, user: user)
+      old_path = article.path
+      sidekiq_perform_enqueued_jobs do
+        described_class.call(user, user: { username: new_username })
+      end
+      article.reload
+      expect(article.path).not_to eq(old_path)
+      expect(article.path).to eq("/#{new_username}/#{article.slug}")
+    end
+
+    # testing against gsub'ing username
+    it "sets the correct article path when its slug contains username" do
+      article = create(:article, user: user, slug: "#{user.username}-hello")
+      old_path = article.path
+      sidekiq_perform_enqueued_jobs do
+        described_class.call(user, user: { username: new_username })
+      end
+      article.reload
+      expect(article.path).not_to eq(old_path)
+      expect(article.path).to eq("/#{new_username}/#{article.slug}")
+    end
+  end
+
   context "when conditionally resaving articles" do
     it "enqueues resave articles job when changing username" do
       sidekiq_assert_resave_article_worker(user) do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Removed updating user's articles' path and resaving articles in a `before_validation` callback `check_for_username_change`.
When updating via `Users::Update`, the articles will be resaved and the path will be updated in the `Article#set_cache` callback.

Concerns:
When a user is updated without using `Users::Update` service, the articles won't be resaved. Currently, we only update via `user.update` when requesting export and updating user's payment pointer. 

I consider moving the logic related to setting `old_username` and `old_old_username` from the callback to the `Users::Update` service in one of the next prs. 

## Related Tickets & Documents
#15424

## QA Instructions, Screenshots, Recordings
When a user changes their username from `/settings/profile`, their articles' URLs should be updated to contain the new username. (the logic wasn't changed)

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: no logic changes