### PR TITLE
Fix markup for API key metadata

### DIFF
--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -34,7 +34,7 @@
           <div class="flex pt-2">
             <div class="flex-1 pl-4">
               <p class="ff-monospace"><%= api_secret.secret %></p>
-              <p class="fs-s"><%= t("views.settings.account.api.active.created", time: tag.time(api_secret.created_at.to_s, datetime: api_secret.created_at.rfc3339)) %></p>
+              <p class="fs-s"><%== t("views.settings.account.api.active.created", time: tag.time(api_secret.created_at.to_s, datetime: api_secret.created_at.rfc3339)) %></p>
             </div>
             <%= form_tag users_api_secret_path(api_secret.id), class: "api__secret__revoke", method: :delete do %>
               <%= button_tag t("views.settings.account.api.revoke"), class: "crayons-btn crayons-btn--danger" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Rails was escaping the HTML `<time>` tag

<img width="651" alt="Screenshot of the API key list that shows the markup rendered into the document, indicating the HTML was escaped" src="https://user-images.githubusercontent.com/108205/145095838-f786b188-888b-4fb7-94d8-b90ecd75efdd.png">

This PR tells Rails not to do that:

<img width="658" alt="Screenshot of the API key list with the markup processed by browser as actual HTML as intended" src="https://user-images.githubusercontent.com/108205/145095887-666cc1d4-d33c-462c-b776-621f51a14c03.png">

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Simple markup bug that only happens in the browser. If we tested this, it would imply we need testing that all markup is escaped. I feel like these tests would be more of a burden than a boon.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: It happens. 🤷🏼 