### PR TITLE
Renaming constant to reflect intention

### DIFF
--- a/app/queries/admin/moderators_query.rb
+++ b/app/queries/admin/moderators_query.rb
@@ -4,7 +4,7 @@ module Admin
       state: :trusted
     }.with_indifferent_access.freeze
 
-    VALID_ROLES = %i[comment_suspended suspended trusted warned].freeze
+    POTENTIAL_ROLE_NAMES = %i[comment_suspended suspended trusted warned].freeze
 
     def self.call(relation: User.all, options: {})
       options = DEFAULT_OPTIONS.merge(options)
@@ -29,7 +29,7 @@ module Admin
     end
 
     def self.potential_role_ids
-      @potential_role_ids ||= Role.where(name: VALID_ROLES).select(:id)
+      @potential_role_ids ||= Role.where(name: POTENTIAL_ROLE_NAMES).select(:id)
     end
 
     def self.search_relation(relation, search)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While in it's own namespace, the `VALID_ROLES` constant is used
throughout the Policies and Liquid Tags to reflect permissions.  In this
case, the constant is not related to granting permissions but to see who
has these roles.

## Related Tickets & Documents

Only loosely related to [Analysis and remediation [likely] required for creating a Role system · Issue #15624 · forem/forem](https://github.com/forem/forem/issues/15624)

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] No, and this is why: This constant is only referenced internally

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: This is a bit of light house keeping.
