### PR TITLE
Adjust Spacing Beneath Logo Upload Field on the Creator Settings Page

### DIFF
--- a/app/assets/stylesheets/setup-mode.scss
+++ b/app/assets/stylesheets/setup-mode.scss
@@ -20,7 +20,6 @@ body.default-header {
 
 [data-creator-settings-target='previewLogo'] {
   max-height: 80px;
-  height: 80px;
 }
 
 // This ID is tied the global "Setup not complete" banner


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adjusts the spacing beneath the logo upload field on the Creator Settings page so that the spacing beneath the field is more in line with the spacing on the rest of the page. To accomplish this, this PR removes `height` from `setup-mode.scss`.

## Related Tickets & Documents
Relates to issue #15524 

## QA Instructions, Screenshots, Recordings
#### Please note that you will need to essentially clear out your database to take this feature for a spin. 🏎️  

To do so, you can either drop your entire database via `rails:db drop` 

_**or**_

You can open a rails console via `rails c` and do the following:
 ```
# Enable the feature flag
FeatureFlag.enable(:creator_onboarding)

# Delete all users 
User.destroy_all

# Set `waiting_on_first_user` to be true
Settings::General.waiting_on_first_user = true

# If you've logged in before set the mascot id to nil
 Settings::General.mascot_user_id = nil
```

Now, run your server and navigate to `http://localhost:3000/` and complete the "Create Account" form. After completing the "Create Account" form, you should be brought to the new Creator Setup page, `${baseUrl}/admin/creator_settings/new?referrer=${baseUrl}`.

Once on the Creator Settings page, you will want to test the changes outlined below:
#### Before:
#### Without image uploaded:
![Screen Shot 2021-12-08 at 8 15 51 AM](https://user-images.githubusercontent.com/32834804/145233290-727d1abe-17eb-40f1-a601-8364eb557615.png)
#### With image uploaded:
![Screen Shot 2021-12-08 at 8 16 14 AM](https://user-images.githubusercontent.com/32834804/145233350-4140ae7b-686e-4597-8e12-b22598f8a552.png)

#### After:
#### Without image uploaded:
![Screen Shot 2021-12-08 at 8 14 46 AM](https://user-images.githubusercontent.com/32834804/145233093-651eca37-5526-4b47-826b-98d17ebd47d5.png)
#### With image uploaded:
![Screen Shot 2021-12-08 at 8 15 12 AM](https://user-images.githubusercontent.com/32834804/145233183-b0fb88e1-22f3-4c22-89ac-e3aa37f1cb82.png)

### UI accessibility concerns?
N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: there are already tests for the Creator Settings page
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Taking a picture](https://media.giphy.com/media/NMBqdKUKQ3aLe/giphy.gif)
