### PR TITLE
Fix Fastly bot block for Ruby `Net::HTTP` clients

### DIFF
--- a/config/fastly/snippets/bad_bot_detection.vcl
+++ b/config/fastly/snippets/bad_bot_detection.vcl
@@ -114,7 +114,7 @@ sub vcl_recv {
     || req.http.user-agent == "RSurf15a 51"
     || req.http.user-agent == "RSurf15a 81"
     # Block Ruby bots unless they're interacting with the API
-    || (req.http.user-agent == "Ruby" && !(req.http.url ~ "^/api"))
+    || (req.http.user-agent == "Ruby" && !(req.url ~ "^/api"))
     || req.http.user-agent == "searchbot admin@google.com"
     || req.http.user-agent == "ShablastBot 1.0"
     || req.http.user-agent == "snap.com beta crawler v0"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

I used the wrong VCL property in #15626. It's [`req.url`](https://developer.fastly.com/reference/vcl/variables/client-request/req-url/), not `req.http.url`. This bug led to [some bugs with legit Ruby clients](https://github.com/orbit-love/community-ruby-dev-orbit/issues/22) that didn't explicitly set a `User-Agent` header. That VCL rule was intended to let those clients continue to come in through the front door (the API, a well defined and regulated HTTP entrypoint), but I think my monkey brain got hypnotized by all the `req.http` in the file while writing that rule and ended up writing it again.

## Related Tickets & Documents

- #15626 

## QA Instructions, Screenshots, Recordings

This can only be QAed on a Fastly-fronted Forem instance, so we'll just test in production:

```
curl https://dev.to/api/articles -H 'User-Agent: Ruby'
```

… should return `HTTP 200` and the API articles response.

## Added/updated tests?

- [x] No, and this is why: Infrastructure configuration

## [Forem core team only] How will this change be communicated?

## [optional] Are there any post deployment tasks we need to perform?

Test in prod

## [optional] What gif best describes this PR or how it makes you feel?

![It's leviOSa, not leviosA](https://user-images.githubusercontent.com/108205/145246672-42575a52-cd75-4eec-b4cb-ddfc203405b2.gif)

