### PR TITLE
Blocking subdomains of domains marked as spam

### DIFF
--- a/app/models/settings/authentication.rb
+++ b/app/models/settings/authentication.rb
@@ -46,7 +46,10 @@ module Settings
     #
     # @return [Boolean] do we allow this domain?
     def self.acceptable_domain?(domain:)
-      return false if blocked_registration_email_domains.include?(domain)
+      return false if blocked_registration_email_domains.detect do |blocked|
+        domain == blocked ||
+          domain.ends_with?(".#{blocked}")
+      end
       return true if allowed_registration_email_domains.empty?
       return true if allowed_registration_email_domains.include?(domain)
 

--- a/spec/models/settings/authentication_spec.rb
+++ b/spec/models/settings/authentication_spec.rb
@@ -14,6 +14,22 @@ RSpec.describe Settings::Authentication, type: :model do
       it { is_expected.to be_falsey }
     end
 
+    context "when given a subdomain of a blocked domain" do
+      subject { described_class.acceptable_domain?(domain: "world.#{domain}") }
+
+      before { allow(described_class).to receive(:blocked_registration_email_domains).and_return([domain]) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when the given domain has a suffix of the blocked domain" do
+      subject { described_class.acceptable_domain?(domain: "world#{domain}") }
+
+      before { allow(described_class).to receive(:blocked_registration_email_domains).and_return([domain]) }
+
+      it { is_expected.to be_truthy }
+    end
+
     context "with allowed domain" do
       before do
         allow(described_class).to receive(:allowed_registration_email_domains).and_return([domain])


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix

## Description

When blocking domain `hello.com` we want to block subdomains as well (e.g. `world.hello.com`) but not different domains (e.g. `hello-world.com`).

## Related Tickets & Documents

Closes #15714

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
