### PR TITLE
Don't raise error when empty community emoji setting submitted

### DIFF
--- a/app/validators/emoji_only_validator.rb
+++ b/app/validators/emoji_only_validator.rb
@@ -2,7 +2,7 @@ class EmojiOnlyValidator < ActiveModel::EachValidator
   DEFAULT_MESSAGE = "contains non-emoji characters or invalid emoji".freeze
 
   def validate_each(record, attribute, value)
-    return if value.gsub(EmojiRegex::RGIEmoji, "").blank?
+    return if !value || value.gsub(EmojiRegex::RGIEmoji, "").blank?
 
     record.errors.add(attribute, options[:message] || DEFAULT_MESSAGE)
   end

--- a/app/validators/emoji_only_validator.rb
+++ b/app/validators/emoji_only_validator.rb
@@ -2,7 +2,8 @@ class EmojiOnlyValidator < ActiveModel::EachValidator
   DEFAULT_MESSAGE = "contains non-emoji characters or invalid emoji".freeze
 
   def validate_each(record, attribute, value)
-    return if !value || value.gsub(EmojiRegex::RGIEmoji, "").blank?
+    return unless value 
+    return if value.gsub(EmojiRegex::RGIEmoji, "").blank?
 
     record.errors.add(attribute, options[:message] || DEFAULT_MESSAGE)
   end

--- a/spec/validators/emoji_only_validator_spec.rb
+++ b/spec/validators/emoji_only_validator_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe EmojiOnlyValidator do
+  subject(:record) { validatable.new.tap { |m| m.name = name } }
+
+  let(:validatable) do
+    Class.new do
+      def self.name
+        "👍"
+      end
+      include ActiveModel::Validations
+      attr_accessor :name
+
+      def initialize
+        @enforce_validation = true
+      end
+
+      attr_accessor :enforce_validation
+      alias_method :enforce_validation?, :enforce_validation
+
+      validates :name, emoji_only: true, if: :enforce_validation?
+    end
+  end
+
+  context "when if option is false" do
+    let(:name) { "not-an-emoji" }
+
+    before { record.enforce_validation = false }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when name includes non-emoji" do
+    let(:name) { "not-an-emoji" }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when name is an emoji" do
+    let(:name) { "🍀" }
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when name is nil" do
+    let(:name) { nil }
+
+    it "does not raise no method error" do
+      expect { record.valid? }.not_to raise_error
+    end
+
+    it { is_expected.to be_valid }
+  end
+
+  context "when name is empty" do
+    let(:name) { "" }
+
+    it { is_expected.to be_valid }
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Don't raise an error when validating a nil emoji, and assert nil and
empty string are permitted values.

This expects no non-emoji characters (so an empty string would be
permitted), and nil should be permitted.

~I believe this might have been introduced by the string settings
cleaner (exchanging "" for nil in form inputs).~

I cargo culted the unique cross model slug validator setup (which is why
value is called name here in the validatable). Replacing with "emoji" or 
"value" seems perfectly sane.

This doesn't actually override the default value for the setting, as #14228 nullifies the `value` and the `default: "🌱"` replaces the nil when loading this setting. Special casing that to permit a blank value (or removing the seedling default) seems like a separate issue from the no method error raised when an admin clears this field.

Testing from the backend I was able to set the setting to an empty string `Settings::Community.community_emoji = ""` - in which case the title changed to "DEV(local) - Latest posts" (with no emoji) - but there's no user facing way to make this change because of the Settings::Upsert behavior nullifying the blank.



## Related Tickets & Documents

fixes https://github.com/forem/forem/issues/15722  (in a narrow sense, the server error goes away)

https://app.honeybadger.io/projects/72638/faults/82982791

Pawel's comment on https://forem.dev/afr/how-to-strip-out-all-emojis-4b7h (linked as related from the issue) seems related as well for future possibilities - do we need or want this, and should it be required.

## QA Instructions, Screenshots, Recordings

Follow the steps to reproduce in the linked issue

To Reproduce

-    Go to admin > customization > config > community content
-    Remove the "Community emoji"
-    Hit "Update Settings"
-    (and this time, expect not to) Get an "Internal Server Error"


Places where this community emoji is used should be checked for view errors after updating the setting (actually, because a blank value is persisted as nil and this setting has a default, the /latest page and a refresh of the form contain the "🌱" emoji instead of nothing, so there's no danger here). 

### UI accessibility concerns?

None. 

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

