### PR TITLE
Remove reactions to a user when deleting the user

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -42,6 +42,7 @@ class Reaction < ApplicationRecord
       .or(user_vomits.where(user_id: user.id))
   }
   scope :privileged_category, -> { where(category: PRIVILEGED_CATEGORIES) }
+  scope :for_user, ->(user) { where(reactable: user) }
 
   validates :category, inclusion: { in: CATEGORIES }
   validates :reactable_type, inclusion: { in: REACTABLE_TYPES }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -536,6 +536,10 @@ class User < ApplicationRecord
     notification_setting.email_follower_notifications
   end
 
+  def reactions_to
+    Reaction.for_user(self)
+  end
+
   protected
 
   # Send emails asynchronously

--- a/app/services/users/delete_activity.rb
+++ b/app/services/users/delete_activity.rb
@@ -37,7 +37,7 @@ module Users
     def delete_profile_info(user)
       user.notifications.delete_all
       user.reactions.delete_all
-      Reaction.where(reactable_type: "User", reactable_id: user.id).delete_all
+      user.reactions_to.delete_all
       user.follows.delete_all
       Follow.followable_user(user.id).delete_all
       user.mentions.delete_all

--- a/app/services/users/delete_activity.rb
+++ b/app/services/users/delete_activity.rb
@@ -37,6 +37,7 @@ module Users
     def delete_profile_info(user)
       user.notifications.delete_all
       user.reactions.delete_all
+      Reaction.where(reactable_type: "User", reactable_id: user.id).delete_all
       user.follows.delete_all
       Follow.followable_user(user.id).delete_all
       user.mentions.delete_all

--- a/lib/data_update_scripts/20211209213849_remove_dangling_user_reactions.rb
+++ b/lib/data_update_scripts/20211209213849_remove_dangling_user_reactions.rb
@@ -1,0 +1,11 @@
+module DataUpdateScripts
+  class RemoveDanglingUserReactions
+    def run
+      # reactions to users who have been deleted should be removed:
+      Reaction
+        .where(reactable_type: "User")
+        .where.not(reactable_id: User.all.select(:id))
+        .delete_all
+    end
+  end
+end

--- a/spec/factories/reactions.rb
+++ b/spec/factories/reactions.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
   end
 
   factory :vomit_reaction, class: "Reaction" do
-    user
+    user { create(:user, :trusted) }
     association :reactable, factory: :article
     category { "vomit" }
 

--- a/spec/lib/data_update_scripts/remove_dangling_user_reactions_spec.rb
+++ b/spec/lib/data_update_scripts/remove_dangling_user_reactions_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20211209213849_remove_dangling_user_reactions.rb",
+)
+
+describe DataUpdateScripts::RemoveDanglingUserReactions do
+  let(:user_to_delete) { create(:user) }
+
+  before do
+    create(:vomit_reaction, reactable: user_to_delete)
+
+    # there's no dependent callback on reactions_to so the reaction is not removed
+    user_to_delete.destroy
+  end
+
+  it "removes reactions to deleted users" do
+    expect { described_class.new.run }.to change(Reaction, :count).by(-1)
+  end
+end

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -68,6 +68,14 @@ RSpec.describe Users::Delete, type: :service do
     end.to change(FieldTest::Membership, :count).by(-1)
   end
 
+  it "deletes reactions to the user" do
+    build(:vomit_reaction, reactable: user).save!
+
+    expect do
+      described_class.call(user)
+    end.to change(Reaction, :count).by(-1)
+  end
+
   # check that all the associated records are being destroyed,
   # except for those that are kept explicitly (kept_associations)
   describe "deleting associations" do

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Users::Delete, type: :service do
   end
 
   it "deletes reactions to the user" do
-    create(:vomit_reaction, user: create(:user, :trusted), reactable: user)
+    create(:vomit_reaction, reactable: user)
 
     expect do
       described_class.call(user)

--- a/spec/services/users/delete_spec.rb
+++ b/spec/services/users/delete_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Users::Delete, type: :service do
   end
 
   it "deletes reactions to the user" do
-    build(:vomit_reaction, reactable: user).save!
+    create(:vomit_reaction, user: create(:user, :trusted), reactable: user)
 
     expect do
       described_class.call(user)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a moderator has reacted _to_ a user, and the user is deleted, remove the (now unneeded) reaction.

We had been removing the user's reactions (created by the user, not applying to the user) already.

## Related Tickets & Documents

Fixes #15245, when combined with a data update script.

## QA Instructions, Screenshots, Recordings

Flag a user. Delete the flagged user. Visit http://localhost:3000/admin/moderation/privileged_reactions

(this had been "hidden" already by [another PR](https://github.com/forem/forem/pull/15249) so no error is expected in main either)

Ideally the added test case is sufficient demonstration.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

