### PR TITLE
Adjust Creator Settings Form Width

### DIFF
--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -4,7 +4,7 @@
     <span class="crayons-field__required crayons-tooltip" data-tooltip="This will set the primary name for your Forem" aria-describedby="community-name-subtitle"></span>
     <p id="community-name-subtitle" class="crayons-field__description">Used as the primary name for your Forem.</p>
   <% end %>
-  <%= text_field_tag :community_name, "", placeholder: "Climbing Life", class: "crayons-textfield flex w-100 m:w-50", required: true %>
+  <%= text_field_tag :community_name, "", placeholder: "Climbing Life", class: "crayons-textfield flex w-100 m:w-100", required: true %>
 </div>
 
 <%= render partial: "admin/shared/logo_upload", locals: { allowed_types: @logo_allowed_types, max_file_size: @max_file_size } %>
@@ -16,7 +16,7 @@
     <p id="color-selector-subtitle" class="crayons-field__description">This will be the "accent" color used for buttons, links, etc.</p>
   <% end %>
 
-  <div class="flex w-100 m:w-50 crayons-field">
+  <div class="flex w-100 m:w-100 crayons-field">
     <div class="flex">
       <%= text_field_tag :primary_brand_color_hex,
                          ::Settings::UserExperience.primary_brand_color_hex,

--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -4,7 +4,7 @@
     <span class="crayons-field__required crayons-tooltip" data-tooltip="This will set the primary name for your Forem" aria-describedby="community-name-subtitle"></span>
     <p id="community-name-subtitle" class="crayons-field__description">Used as the primary name for your Forem.</p>
   <% end %>
-  <%= text_field_tag :community_name, "", placeholder: "Climbing Life", class: "crayons-textfield m:w-50", required: true %>
+  <%= text_field_tag :community_name, "", placeholder: "Climbing Life", class: "crayons-textfield flex w-100 m:w-50", required: true %>
 </div>
 
 <%= render partial: "admin/shared/logo_upload", locals: { allowed_types: @logo_allowed_types, max_file_size: @max_file_size } %>

--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -4,7 +4,7 @@
     <span class="crayons-field__required crayons-tooltip" data-tooltip="This will set the primary name for your Forem" aria-describedby="community-name-subtitle"></span>
     <p id="community-name-subtitle" class="crayons-field__description">Used as the primary name for your Forem.</p>
   <% end %>
-  <%= text_field_tag :community_name, "", placeholder: "Climbing Life", class: "crayons-textfield flex w-100 m:w-100", required: true %>
+  <%= text_field_tag :community_name, "", placeholder: "Climbing Life", class: "crayons-textfield", required: true %>
 </div>
 
 <%= render partial: "admin/shared/logo_upload", locals: { allowed_types: @logo_allowed_types, max_file_size: @max_file_size } %>
@@ -16,7 +16,7 @@
     <p id="color-selector-subtitle" class="crayons-field__description">This will be the "accent" color used for buttons, links, etc.</p>
   <% end %>
 
-  <div class="flex w-100 m:w-100 crayons-field">
+  <div class="crayons-field">
     <div class="flex">
       <%= text_field_tag :primary_brand_color_hex,
                          ::Settings::UserExperience.primary_brand_color_hex,

--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -4,7 +4,7 @@
     <span class="crayons-field__required crayons-tooltip" data-tooltip="This will set the primary name for your Forem" aria-describedby="community-name-subtitle"></span>
     <p id="community-name-subtitle" class="crayons-field__description">Used as the primary name for your Forem.</p>
   <% end %>
-  <%= text_field_tag :community_name, "", placeholder: "Climbing Life", class: "crayons-textfield", required: true %>
+  <%= text_field_tag :community_name, "", placeholder: "Climbing Life", class: "crayons-textfield m:w-50", required: true %>
 </div>
 
 <%= render partial: "admin/shared/logo_upload", locals: { allowed_types: @logo_allowed_types, max_file_size: @max_file_size } %>

--- a/app/views/admin/creator_settings/new.html.erb
+++ b/app/views/admin/creator_settings/new.html.erb
@@ -37,7 +37,7 @@
       <br>
       <%= render "form" %>
       <div class="crayons-field mt-6 align-left">
-        <%= submit_tag "Finish", class: "crayons-btn btn--primary" %>
+        <%= submit_tag "Finish", class: "crayons-btn btn--primary m:w-50" %>
       </div>
       <% if @help_url %>
         <%= render "shared/help_icon" %>

--- a/app/views/admin/creator_settings/new.html.erb
+++ b/app/views/admin/creator_settings/new.html.erb
@@ -37,7 +37,7 @@
       <br>
       <%= render "form" %>
       <div class="crayons-field mt-6 align-left">
-        <%= submit_tag "Finish", class: "crayons-btn btn--primary m:w-50" %>
+        <%= submit_tag "Finish", class: "crayons-btn btn--primary w-100 m:w-50" %>
       </div>
       <% if @help_url %>
         <%= render "shared/help_icon" %>

--- a/app/views/admin/creator_settings/new.html.erb
+++ b/app/views/admin/creator_settings/new.html.erb
@@ -37,7 +37,7 @@
       <br>
       <%= render "form" %>
       <div class="crayons-field mt-6 align-left">
-        <%= submit_tag "Finish", class: "crayons-btn btn--primary w-100 m:w-50" %>
+        <%= submit_tag "Finish", class: "crayons-btn btn--primary w-100 m:w-100" %>
       </div>
       <% if @help_url %>
         <%= render "shared/help_icon" %>

--- a/app/views/admin/creator_settings/new.html.erb
+++ b/app/views/admin/creator_settings/new.html.erb
@@ -37,7 +37,7 @@
       <br>
       <%= render "form" %>
       <div class="crayons-field mt-6 align-left">
-        <%= submit_tag "Finish", class: "crayons-btn btn--primary w-100 m:w-100" %>
+        <%= submit_tag "Finish", class: "crayons-btn btn--primary" %>
       </div>
       <% if @help_url %>
         <%= render "shared/help_icon" %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adjusts the width of the "Community Name" field, the "Finish" button, and the "Brand Color
 field on the Creator Settings form so that both fields are now the same size as the color selector field, creating more of a "block" feel to the form.

For more information on why this change is being made, please refer to the design critique in the issue referenced below.

## Related Tickets & Documents
Closes issue #15524 

## QA Instructions, Screenshots, Recordings
#### Please note that you will need to essentially clear out your database to take this feature for a spin. 🏎️  

To do so, you can either drop your entire database via `rails:db drop` 

_**or**_

You can open a rails console via `rails c` and do the following:
 ```
# Enable the feature flag
FeatureFlag.enable(:creator_onboarding)

# Delete all users 
User.destroy_all

# Set `waiting_on_first_user` to be true
Settings::General.waiting_on_first_user = true

# If you've logged in before set the mascot id to nil
 Settings::General.mascot_user_id = nil
```

Now, run your server and navigate to `http://localhost:3000/` and complete the "Create Account" form. After completing the "Create Account" form, you should be brought to the new Creator Setup page, `${baseUrl}/admin/creator_settings/new?referrer=${baseUrl}`.

Once on the Creator Settings page, you will want to test the changes outlined below:
#### Before:
![Screen Shot 2021-12-10 at 6 16 34 AM](https://user-images.githubusercontent.com/32834804/145579804-4aaa1995-cd8b-4c3f-b0ac-c0151d22d839.png)

#### After:
![Screen Shot 2021-12-10 at 6 11 22 AM](https://user-images.githubusercontent.com/32834804/145579645-c9ccbf81-3069-467c-ae5f-ca069e9d3dc3.png)

#### After (Mobile View):
![Screen Shot 2021-12-10 at 6 17 38 AM](https://user-images.githubusercontent.com/32834804/145579954-5c6207a4-ec6a-484e-b0a5-ac1649cee0fc.png)

### UI accessibility concerns?
N/A - this just changes the width of the form buttons to match the width of the other form fields, like the color selector.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: there are already tests in place for the Creator Onboarding flow.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
