### PR TITLE
Ignore MtPopUpList on Honeybadger

### DIFF
--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -722,6 +722,11 @@ var instantClick
     ignorePatterns: [/ResizeObserver/i, /MetaMask/i],
   });
 
+  Honeybadger.beforeNotify(function(notice) {
+    if (/MtPopUpList/.test(notice.message)) { return false; }
+  });
+
+
 // INITIALIZE AHOY TRACKING
 // Setting cookies to false matches what we do in ahoy's initializer.
 // Setting trackVisits to false prevents ahoy from creating a visit on the server-side.

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -726,7 +726,6 @@ var instantClick
     if (/MtPopUpList/.test(notice.message)) { return false; }
   });
 
-
 // INITIALIZE AHOY TRACKING
 // Setting cookies to false matches what we do in ahoy's initializer.
 // Setting trackVisits to false prevents ahoy from creating a visit on the server-side.

--- a/app/assets/javascripts/base.js.erb
+++ b/app/assets/javascripts/base.js.erb
@@ -723,7 +723,7 @@ var instantClick
   });
 
   Honeybadger.beforeNotify(function(notice) {
-    if (/MtPopUpList/.test(notice.message)) { return false; }
+    return !/MtPopUpList/.test(notice.message);
   });
 
 // INITIALIZE AHOY TRACKING


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Observability

## Description
`MtPopUpList is not defined` is one of the most frequent error ([over 100k](https://app.honeybadger.io/projects/67192/faults?sort=last_seen_desc&q=-is%3Aresolved%E2%80%81-is%3Aignored%E2%80%81MtPopUpList+is+not+defined)) caught by Honeybadger. I, for the life of me, could not reproduce it or trigger locally via Firefox or Chrome. I double-checked with @nickytonline and we are quite certain it's not part of our codebase but potentially a ad-block plugin. This PR is going to mute that by following the [guide provided by Honeybadger](https://docs.honeybadger.io/lib/javascript/guides/reducing-noise/).

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
Let's test on production!