### PR TITLE
Logo style updates

### DIFF
--- a/app/assets/stylesheets/base/main.scss
+++ b/app/assets/stylesheets/base/main.scss
@@ -69,14 +69,29 @@ a {
 
   display: inline-flex;
   flex-shrink: 0;
-  align-self: stretch;
+  align-self: center;
   align-items: center;
   vertical-align: middle;
   color: var(--base-100);
   text-decoration: none;
-  letter-spacing: -0.01em;
-  line-height: var(--lh-tight);
+  letter-spacing: -0.02em;
+  line-height: 1;
+  outline: 0;
+  border-radius: var(--radius);
   overflow-wrap: anywhere;
+
+  &__img,
+  svg {
+    max-width: 100%;
+    max-height: calc(
+      var(--header-height) - var(--su-2) * 2
+    ); // making calculations instead of setting fixed value so should be smooth change if we ever decide to change header's height.
+    height: auto;
+    width: auto;
+    vertical-align: middle;
+    display: inline-block;
+    outline: 0;
+  }
 
   @media (min-width: $breakpoint-s) {
     --max-width: 150px;
@@ -95,14 +110,24 @@ a {
 
   &:hover {
     color: var(--base-80);
-    text-decoration: none;
+    text-decoration: underline;
   }
 
-  svg {
-    max-width: 100%;
-    width: auto;
-    height: calc(var(--header-height) - var(--su-2) * 2);
-    vertical-align: middle;
-    display: inline-block;
+  // Both focus declarations below are the same but we unfortunately can't
+  // combine them because Safari doesn't recognize it properly.
+  //  • First declaration is for all browsers that support :focus-visible
+  //    which is basically almost all of them
+  //  • Second declaration is for browsers that do not support :focus-visible
+  //    which basically is only Safari right now.
+  &:focus-visible {
+    z-index: var(--z-elevate);
+    box-shadow: var(--focus-ring);
+    text-decoration: underline;
+  }
+
+  .js-focus-visible &.focus-visible:focus {
+    z-index: var(--z-elevate);
+    box-shadow: var(--focus-ring);
+    text-decoration: underline;
   }
 }

--- a/app/assets/stylesheets/base/main.scss
+++ b/app/assets/stylesheets/base/main.scss
@@ -85,8 +85,7 @@ a {
     max-height: calc(
       var(--header-height) - var(--su-2) * 2
     ); // making calculations instead of setting fixed value so should be smooth change if we ever decide to change header's height.
-    height: auto;
-    width: auto;
+    object-fit: contain;
     vertical-align: middle;
     display: inline-block;
     outline: 0;

--- a/app/assets/stylesheets/base/main.scss
+++ b/app/assets/stylesheets/base/main.scss
@@ -77,7 +77,6 @@ a {
   letter-spacing: -0.02em;
   line-height: 1;
   outline: 0;
-  border-radius: var(--radius);
   overflow-wrap: anywhere;
 
   &__img,

--- a/app/views/layouts/_logo.html.erb
+++ b/app/views/layouts/_logo.html.erb
@@ -1,6 +1,6 @@
 <a href="<%= root_path %>" class="site-logo" aria-label="<%= t("views.main.aria_home", community: community_name) %>">
   <% if FeatureFlag.enabled?(:creator_onboarding) %>
-      <img class="site-logo__img" src="<%= Settings::General.resized_logo %>" alt="<%= community_name %>">
+    <img class="site-logo__img" src="<%= Settings::General.resized_logo %>" alt="<%= community_name %>">
   <% elsif Settings::General.logo_svg.present? %>
     <%= logo_svg %>
   <% else %>

--- a/app/views/layouts/_logo.html.erb
+++ b/app/views/layouts/_logo.html.erb
@@ -1,8 +1,8 @@
-<a href="/" class="<%= "site-logo" unless FeatureFlag.enabled?(:creator_onboarding) %>" aria-label="<%= t("views.main.aria_home") %>">
-  <% if Settings::General.logo_svg.present? %>
-    <%= logo_svg %>
-  <% elsif FeatureFlag.enabled?(:creator_onboarding) %>
+<a href="/" class="<%= "site-logo" unless FeatureFlag.enabled?(:creator_onboarding) %>" aria-label="<%= t("views.main.aria_home", community: community_name) %>">
+  <% if FeatureFlag.enabled?(:creator_onboarding) %>
       <img class="site-logo" src="<%= Settings::General.resized_logo %>" alt="<%= community_name %>">
+  <% elsif Settings::General.logo_svg.present? %>
+    <%= logo_svg %>
   <% else %>
     <span class="truncate-at-2">
       <%= community_name %>

--- a/app/views/layouts/_logo.html.erb
+++ b/app/views/layouts/_logo.html.erb
@@ -1,6 +1,6 @@
-<a href="/" class="<%= "site-logo" unless FeatureFlag.enabled?(:creator_onboarding) %>" aria-label="<%= t("views.main.aria_home", community: community_name) %>">
+<a href="<%= root_path %>" class="site-logo" aria-label="<%= t("views.main.aria_home", community: community_name) %>">
   <% if FeatureFlag.enabled?(:creator_onboarding) %>
-      <img class="site-logo" src="<%= Settings::General.resized_logo %>" alt="<%= community_name %>">
+      <img class="site-logo__img" src="<%= Settings::General.resized_logo %>" alt="<%= community_name %>">
   <% elsif Settings::General.logo_svg.present? %>
     <%= logo_svg %>
   <% else %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Ensure that the logo shows up properly within the navbar container whether the Feature Flag is enabled or not.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

In your rails console set the following:  

```
Settings::General.original_logo = "https://canary1.forem.wtf/remoteimages/uploads/articles/bcvmn496boszdko7jb09.jpeg"
Settings::General.resized_logo = "https://canary1.forem.wtf/remoteimages/uploads/articles/zn14x1elppv4frwlnbo9.jpeg"

Settings::General.logo_svg = '<svg width="50" height="40" viewBox="0 0 50 40" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="50" height="40" rx="3" style="fill: currentColor;"></rect><path d="M19.099 23.508c0 1.31-.423 2.388-1.27 3.234-.838.839-1.942 1.258-3.312 1.258h-4.403V12.277h4.492c1.31 0 2.385.423 3.224 1.27.846.838 1.269 1.912 1.269 3.223v6.738zm-2.808 0V16.77c0-.562-.187-.981-.562-1.258-.374-.285-.748-.427-1.122-.427h-1.685v10.107h1.684c.375 0 .75-.138 1.123-.415.375-.285.562-.708.562-1.27zM28.185 28h-5.896c-.562 0-1.03-.187-1.404-.561-.375-.375-.562-.843-.562-1.404V14.243c0-.562.187-1.03.562-1.404.374-.375.842-.562 1.404-.562h5.896v2.808H23.13v3.65h3.088v2.808h-3.088v3.65h5.054V28zm7.12 0c-.936 0-1.684-.655-2.246-1.965l-3.65-13.758h3.089l2.807 10.804 2.808-10.804H41.2l-3.65 13.758C36.99 27.345 36.241 28 35.305 28z" style="fill: var(--base-inverted);"></path></svg>'
```

Go to the home page with the logo and run:
```
FeatureFlag.enable(:creator_onboarding)
```
to see it with the new updates with the  `<img` tag .

Go to the home page with the logo  and run:
```
FeatureFlag.disable(:creator_onboarding)
```
to see it with the the rendered `logo_svg`.

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: style related change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
