### PR TITLE
Wait for async data in forem mobile cypress test

### DIFF
--- a/cypress/integration/seededFlows/mobileFlows/namespacedForemMobile.spec.js
+++ b/cypress/integration/seededFlows/mobileFlows/namespacedForemMobile.spec.js
@@ -1,5 +1,3 @@
-import { getInterceptsForLingeringUserRequests } from '../../../util/networkUtils';
-
 // This E2E test focuses on ensuring the mobile bridge integration
 describe('Namespaced ForemMobile functions', () => {
   function waitForBaseDataLoaded() {
@@ -86,11 +84,7 @@ describe('Namespaced ForemMobile functions', () => {
     describe('when logged out', () => {
       it('should return empty user data when logged out', () => {
         cy.testSetup();
-        // visitAndWaitForUserSideEffects passes true to getIntercepts, waiting for notifications
-        // but we don't expect them here.
-        const intercepts = getInterceptsForLingeringUserRequests('/', false);
-        cy.visit('/', runtimeStub);
-        cy.wait(intercepts);
+        cy.visitAndWaitForUserSideEffects('/', runtimeStub, false);
         waitForBaseDataLoaded();
 
         cy.window().then((win) => {

--- a/cypress/integration/seededFlows/mobileFlows/namespacedForemMobile.spec.js
+++ b/cypress/integration/seededFlows/mobileFlows/namespacedForemMobile.spec.js
@@ -87,6 +87,9 @@ describe('Namespaced ForemMobile functions', () => {
         cy.visitAndWaitForUserSideEffects('/', runtimeStub, false);
         waitForBaseDataLoaded();
 
+        // ensures the dynamic import had time to complete before
+        // referencing the attribute
+        cy.window().should('have.attr', 'ForemMobile');
         cy.window().then((win) => {
           assert.isUndefined(win.ForemMobile.getUserData());
         });

--- a/cypress/integration/seededFlows/mobileFlows/namespacedForemMobile.spec.js
+++ b/cypress/integration/seededFlows/mobileFlows/namespacedForemMobile.spec.js
@@ -22,7 +22,7 @@ describe('Namespaced ForemMobile functions', () => {
         cy.fixture('users/adminUser.json').as('user');
         cy.get('@user').then((user) => {
           cy.loginUser(user).then(() => {
-            cy.visit('/', runtimeStub);
+            cy.visitAndWaitForUserSideEffects('/', runtimeStub);
             cy.get('body').should('have.attr', 'data-user-status', 'logged-in');
             waitForBaseDataLoaded();
           });

--- a/cypress/integration/seededFlows/mobileFlows/namespacedForemMobile.spec.js
+++ b/cypress/integration/seededFlows/mobileFlows/namespacedForemMobile.spec.js
@@ -1,3 +1,5 @@
+import { getInterceptsForLingeringUserRequests } from '../../../util/networkUtils';
+
 // This E2E test focuses on ensuring the mobile bridge integration
 describe('Namespaced ForemMobile functions', () => {
   function waitForBaseDataLoaded() {
@@ -84,7 +86,11 @@ describe('Namespaced ForemMobile functions', () => {
     describe('when logged out', () => {
       it('should return empty user data when logged out', () => {
         cy.testSetup();
+        // visitAndWaitForUserSideEffects passes true to getIntercepts, waiting for notifications
+        // but we don't expect them here.
+        const intercepts = getInterceptsForLingeringUserRequests('/', false);
         cy.visit('/', runtimeStub);
+        cy.wait(intercepts);
         waitForBaseDataLoaded();
 
         cy.window().then((win) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -52,17 +52,23 @@ Cypress.Commands.add('loginAndVisit', (user, url) => {
  * Visits the given URL, waiting for all user-related network requests to complete.
  * This ensures that no user side effects bleed into subsequent tests.
  */
-Cypress.Commands.add('visitAndWaitForUserSideEffects', (url, options) => {
-  // If navigating directly to an admin route, no relevant network requests to intercept
-  const { baseUrl } = Cypress.config().baseUrl;
-  if (url === `${baseUrl}/admin` || url.includes('/admin/')) {
-    cy.visit(url, options);
-  } else {
-    const intercepts = getInterceptsForLingeringUserRequests(url, true);
-    cy.visit(url, options);
-    cy.wait(intercepts);
-  }
-});
+Cypress.Commands.add(
+  'visitAndWaitForUserSideEffects',
+  (url, options, userLoggedIn = true) => {
+    // If navigating directly to an admin route, no relevant network requests to intercept
+    const { baseUrl } = Cypress.config().baseUrl;
+    if (url === `${baseUrl}/admin` || url.includes('/admin/')) {
+      cy.visit(url, options);
+    } else {
+      const intercepts = getInterceptsForLingeringUserRequests(
+        url,
+        userLoggedIn,
+      );
+      cy.visit(url, options);
+      cy.wait(intercepts);
+    }
+  },
+);
 
 /**
  * Runs necessary test setup to run a clean test.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The forem mobile cypress test is sometimes failing due to userData not being ready (base data request has not returned a response before we check the content, leading to attribute errors on `undefined`).

The [`loginAndVisit(url)`](https://github.com/forem/forem/blob/main/cypress/support/commands.js#L40-L49) command would _normally_ be used for this, but doesn't accept an option argument to pass to the [visitAndWaitForUserSideEffects](https://github.com/forem/forem/blob/main/cypress/support/commands.js#L51-L65) (which does take an option arg, required to stub out the user agent in the request for this test).

The visitAndWaitForUserSideEffects command relies on a utility to intercept the pending user requests, but assumes the user is logged in (and always passes true to this utility method, while for the logged out spec we need to pass it false). 

The second commit (inlining the wait for user side effects logic but passing the [getIntercept function](https://github.com/forem/forem/blob/main/cypress/util/networkUtils.js#L19) a false flag for user logged in to skip waiting for notifications) is the fastest way to do what's necessary, but is a cry for help in deciding what the "real" interface for this looks like - either a visitAndWaitForLoggedOutUserData command is wanted (just like visit and wait for user but passing false), or an extension to the existing method allowing us to flag handling this when we're logged out.

This might be an unusual situation in that we're relying on the async base data (normally for user details) in a context where the user is signed out. I'm not sure if it's worth making it more usable if it's unlikely to be used outside this specific test. 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Locally, on main, I was seeing failures in both the logged in and logged out contexts when running bin/e2e, at least half of the time. 

On this branch I'm not seeing those issues.

### UI accessibility concerns?

None, test only change.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: test fix only

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
