### PR TITLE
Implement Unified Embed for Forem Article/Post URLs

### DIFF
--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -1,6 +1,7 @@
 class LinkTag < LiquidTagBase
   include ActionView::Helpers
   PARTIAL = "articles/liquid".freeze
+  REGISTRY_REGEXP = %r{#{URL.url}/[a-zA-Z0-9_]+/[a-zA-Z0-9-]+(/)?}
 
   def initialize(_tag_name, slug_or_path_or_url, _parse_context)
     super
@@ -16,7 +17,7 @@ class LinkTag < LiquidTagBase
   end
 
   def get_article(slug)
-    slug = ActionController::Base.helpers.strip_tags(slug).strip
+    slug = strip_tags(slug).strip
     find_article_by_user(article_hash(slug)) || find_article_by_org(article_hash(slug))
   end
 
@@ -33,7 +34,7 @@ class LinkTag < LiquidTagBase
     path.slice!(0) if path.starts_with?("/") # remove leading slash if present
     path.slice!(-1) if path.ends_with?("/") # remove trailing slash if present
     extracted_hash = Addressable::Template.new("{username}/{slug}").extract(path)&.symbolize_keys
-    raise StandardError, "The article you're looking for does not exist: {% link #{slug} %}" unless extracted_hash
+    raise StandardError, "The article you're looking for does not exist: #{slug}" unless extracted_hash
 
     extracted_hash
   end
@@ -55,3 +56,5 @@ end
 
 Liquid::Template.register_tag("link", LinkTag)
 Liquid::Template.register_tag("post", LinkTag)
+
+UnifiedEmbed.register(LinkTag, regexp: LinkTag::REGISTRY_REGEXP)

--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -1,7 +1,7 @@
 class LinkTag < LiquidTagBase
   include ActionView::Helpers
   PARTIAL = "articles/liquid".freeze
-  REGISTRY_REGEXP = %r{#{URL.url}/\w]+/[a-zA-Z0-9-]+/?}
+  REGISTRY_REGEXP = %r{#{URL.url}/\w+/[a-zA-Z0-9-]+/?}
 
   def initialize(_tag_name, slug_or_path_or_url, _parse_context)
     super

--- a/app/liquid_tags/link_tag.rb
+++ b/app/liquid_tags/link_tag.rb
@@ -1,7 +1,7 @@
 class LinkTag < LiquidTagBase
   include ActionView::Helpers
   PARTIAL = "articles/liquid".freeze
-  REGISTRY_REGEXP = %r{#{URL.url}/[a-zA-Z0-9_]+/[a-zA-Z0-9-]+(/)?}
+  REGISTRY_REGEXP = %r{#{URL.url}/\w]+/[a-zA-Z0-9-]+/?}
 
   def initialize(_tag_name, slug_or_path_or_url, _parse_context)
     super
@@ -17,7 +17,7 @@ class LinkTag < LiquidTagBase
   end
 
   def get_article(slug)
-    slug = strip_tags(slug).strip
+    slug = strip_tags(slug.strip)
     find_article_by_user(article_hash(slug)) || find_article_by_org(article_hash(slug))
   end
 

--- a/spec/lib/liquid/raw_spec.rb
+++ b/spec/lib/liquid/raw_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Liquid::Raw, type: :lib do
   it "raise error message when link tag contain non article URL" do
     invalid_markdown = "{% link /some-random-link/ %}"
     expect { Liquid::Template.parse(invalid_markdown) }.to(
-      raise_error(StandardError, "The article you're looking for does not exist: {% link /some-random-link/ %}"),
+      raise_error(StandardError, "The article you're looking for does not exist: /some-random-link/"),
     )
   end
 end

--- a/spec/liquid_tags/unified_embed_spec.rb
+++ b/spec/liquid_tags/unified_embed_spec.rb
@@ -3,6 +3,9 @@ require "rails_helper"
 RSpec.describe UnifiedEmbed do
   subject(:unified_embed) { described_class }
 
+  let(:user) { create(:user) }
+  let(:article) { create(:article, user_id: user.id) }
+
   describe ".find_liquid_tag_for" do
     valid_youtube_url_formats = [
       "https://www.youtube.com/embed/dQw4w9WgXcQ",
@@ -34,6 +37,11 @@ RSpec.describe UnifiedEmbed do
     it "returns JsFiddle for a jsfiddle url" do
       expect(described_class.find_liquid_tag_for(link: "http://jsfiddle.net/link2twenty/v2kx9jcd"))
         .to eq(JsFiddleTag)
+    end
+
+    it "returns Forem Link for a forem url" do
+      expect(described_class.find_liquid_tag_for(link: URL.url + article.path))
+        .to eq(LinkTag)
     end
 
     it "returns NextTechTag for a nexttech url" do

--- a/spec/liquid_tags/unified_embed_spec.rb
+++ b/spec/liquid_tags/unified_embed_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 RSpec.describe UnifiedEmbed do
   subject(:unified_embed) { described_class }
 
-  let(:user) { create(:user) }
-  let(:article) { create(:article, user_id: user.id) }
+  let(:article) { create(:article) }
 
   describe ".find_liquid_tag_for" do
     valid_youtube_url_formats = [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Forem posts/articles.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15564

## QA Instructions, Screenshots, Recordings

- Before testing, grab (or create then grab) the URLs of an article in your localhost.
- As a user, create a Forem Article liquid tag using this format: `{% embed <forem-article-url> %}`. The Article Liquid Tag should render properly.
- Also create article liquid tag using the old methods: `{% link <forem-article-url> %}` or `{% post <forem-article-url> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.