### PR TITLE
Clear changes to settings after checking form saves them

### DIFF
--- a/spec/forms/creator_settings_form_spec.rb
+++ b/spec/forms/creator_settings_form_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe CreatorSettingsForm, type: :model do
   describe "#save" do
     let(:current_user) { create(:user) }
 
+    after do
+      # prevent changes here from leaking into other tests
+      Settings::Community.clear_cache
+      Settings::UserExperience.clear_cache
+      Settings::Authentication.clear_cache
+    end
+
     # rubocop:disable RSpec/ExampleLength
     it "saves the updated attributes to the correct Settings values", :aggregate_failures do
       # NOTE: override the profile migration hack from rails_helper.rb

--- a/spec/system/admin/admin_creates_new_page_spec.rb
+++ b/spec/system/admin/admin_creates_new_page_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "Admin creates new page", type: :system do
     before do
       allow(ForemInstance).to receive(:private?).and_return(true)
       sign_in admin
-      Settings::Community.clear_cache # in case community name had been modified
       visit new_admin_page_path(slug: "code-of-conduct")
     end
 

--- a/spec/system/admin/admin_creates_new_page_spec.rb
+++ b/spec/system/admin/admin_creates_new_page_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Admin creates new page", type: :system do
     before do
       allow(ForemInstance).to receive(:private?).and_return(true)
       sign_in admin
+      Settings::Community.clear_cache # in case community name had been modified
       visit new_admin_page_path(slug: "code-of-conduct")
     end
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Running the admin creates new page spec after the creator settings form spec had updated settings was triggering a test failure (`community_name` in the response didn't match the one in the test runner).

Clear the cached settings after updating them.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

The sequence of spec files:

```
bundle exec rspec spec/forms/creator_settings_form_spec.rb spec/system/admin/admin_creates_new_page_spec.rb 
```

should pass. 

### UI accessibility concerns?

None, test only change.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: Tiny cleanup.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![clean up](https://user-images.githubusercontent.com/1237369/145888873-1e007dfb-0415-4a0e-ac66-8889f5f7b0de.gif)
