### PR TITLE
Remove Doorkeeper from API

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -70,9 +70,7 @@ module Api
       end
 
       def authenticated_user
-        if doorkeeper_token
-          User.find(doorkeeper_token.resource_owner_id)
-        elsif request.headers["api-key"]
+        if request.headers["api-key"]
           authenticate_with_api_key
         elsif current_user
           current_user

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -2,8 +2,6 @@ module Api
   module V0
     class ArticlesController < ApiController
       before_action :authenticate!, only: %i[create update me]
-      before_action -> { doorkeeper_authorize! :public }, only: %w[index show show_by_slug], if: -> { doorkeeper_token }
-      before_action -> { doorkeeper_authorize! :write_articles }, only: %w[create update], if: -> { doorkeeper_token }
 
       before_action :validate_article_param_is_hash, only: %w[create update]
 
@@ -87,9 +85,6 @@ module Api
       end
 
       def me
-        doorkeeper_scope = %w[unpublished all].include?(params[:status]) ? :read_articles : :public
-        doorkeeper_authorize! doorkeeper_scope if doorkeeper_token
-
         per_page = (params[:per_page] || 30).to_i
         num = [per_page, 1000].min
 

--- a/app/controllers/api/v0/readinglist_controller.rb
+++ b/app/controllers/api/v0/readinglist_controller.rb
@@ -2,7 +2,6 @@ module Api
   module V0
     class ReadinglistController < ApiController
       before_action :authenticate!
-      before_action -> { doorkeeper_authorize! :public }, only: %w[index], if: -> { doorkeeper_token }
 
       INDEX_REACTIONS_ATTRIBUTES_FOR_SERIALIZATION = %i[id reactable_id created_at status].freeze
       private_constant :INDEX_REACTIONS_ATTRIBUTES_FOR_SERIALIZATION

--- a/app/controllers/api/v0/users_controller.rb
+++ b/app/controllers/api/v0/users_controller.rb
@@ -2,7 +2,6 @@ module Api
   module V0
     class UsersController < ApiController
       before_action :authenticate!, only: %i[me]
-      before_action -> { doorkeeper_authorize! :public }, only: :me, if: -> { doorkeeper_token }
 
       SHOW_ATTRIBUTES_FOR_SERIALIZATION = %i[
         id username name summary twitter_username github_username website_url

--- a/app/controllers/api/v0/webhooks_controller.rb
+++ b/app/controllers/api/v0/webhooks_controller.rb
@@ -2,7 +2,6 @@ module Api
   module V0
     class WebhooksController < ApiController
       before_action :authenticate!
-      before_action -> { doorkeeper_authorize! :public }, if: -> { doorkeeper_token }
 
       skip_before_action :verify_authenticity_token, only: %w[create destroy]
 
@@ -15,7 +14,6 @@ module Api
 
       def create
         @webhook = @user.webhook_endpoints.new(webhook_params)
-        @webhook.oauth_application_id = doorkeeper_token.application_id if doorkeeper_token
         @webhook.save!
 
         render "show", status: :created
@@ -35,13 +33,7 @@ module Api
       private
 
       def webhooks_scope
-        relation = if doorkeeper_token
-                     @user.webhook_endpoints.for_app(doorkeeper_token.application_id)
-                   else
-                     @user.webhook_endpoints
-                   end
-
-        relation.select(ATTRIBUTES_FOR_SERIALIZATION)
+        @user.webhook_endpoints.select(ATTRIBUTES_FOR_SERIALIZATION)
       end
 
       def webhook_params

--- a/spec/requests/api/v0/listings_spec.rb
+++ b/spec/requests/api/v0/listings_spec.rb
@@ -430,19 +430,6 @@ RSpec.describe "Api::V0::Listings", type: :request do
         expect(listing.cached_tag_list).to eq("discuss, javascript")
       end
     end
-
-    describe "with oauth token" do
-      include_context "when param list is valid"
-
-      it "fails with oauth token" do
-        user = create(:user)
-        access_token = create(:doorkeeper_access_token, resource_owner_id: user.id)
-        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
-
-        post api_listings_path, params: { listing: listing_params }.to_json, headers: headers
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
   end
 
   describe "PUT /api/listings/:id" do

--- a/spec/requests/api/v0/readinglist_spec.rb
+++ b/spec/requests/api/v0/readinglist_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "Api::V0::ReadingList", type: :request do
+  let(:api_secret) { create(:api_secret, user: user) }
+  let(:headers) { { "api-key" => api_secret.secret } }
+
   describe "GET /api/readinglist" do
     let(:readinglist) { create_list(:reading_reaction, 3, user: user) }
 
@@ -12,19 +15,10 @@ RSpec.describe "Api::V0::ReadingList", type: :request do
     end
 
     context "when request is authenticated" do
-      let(:access_token) { create :doorkeeper_access_token, resource_owner: user, scopes: "public read_articles" }
       let(:user) { create(:user) }
 
-      it "works with bearer authorization" do
-        headers = { "authorization" => "Bearer #{access_token.token}", "content-type" => "application/json" }
-
-        get api_readinglist_index_path, headers: headers
-        expect(response.media_type).to eq("application/json")
-        expect(response).to have_http_status(:ok)
-      end
-
       it "returns proper response specification" do
-        get api_readinglist_index_path, params: { access_token: access_token.token }
+        get api_readinglist_index_path, headers: headers
         expect(response.media_type).to eq("application/json")
         expect(response).to have_http_status(:ok)
       end
@@ -32,13 +26,13 @@ RSpec.describe "Api::V0::ReadingList", type: :request do
       it "doesn't return archived reactions" do
         create(:reading_reaction, user: user)
         create(:reading_reaction, user: user, status: :archived)
-        get api_readinglist_index_path, params: { access_token: access_token.token }
+        get api_readinglist_index_path, headers: headers
         expect(response.parsed_body.length).to eq(1)
       end
 
       it "supports pagination" do
         create_list(:reading_reaction, 3, user: user)
-        get api_readinglist_index_path, params: { access_token: access_token.token, page: 2, per_page: 2 }
+        get api_readinglist_index_path, headers: headers, params: { page: 2, per_page: 2 }
         expect(response.parsed_body.length).to eq(1)
       end
     end

--- a/spec/requests/api/v0/users_spec.rb
+++ b/spec/requests/api/v0/users_spec.rb
@@ -64,11 +64,12 @@ RSpec.describe "Api::V0::Users", type: :request do
     end
 
     context "when request is authenticated" do
-      let(:user)         { create(:user) }
-      let(:access_token) { create(:doorkeeper_access_token, resource_owner: user, scopes: "public") }
+      let(:user) { create(:user) }
+      let(:api_secret) { create(:api_secret, user: user) }
+      let(:headers) { { "api-key" => api_secret.secret } }
 
       it "returns the correct json representation of the user", :aggregate_failures do
-        get me_api_users_path, params: { access_token: access_token.token }
+        get me_api_users_path, headers: headers
 
         response_user = response.parsed_body
 
@@ -88,7 +89,7 @@ RSpec.describe "Api::V0::Users", type: :request do
 
       it "returns 200 if no authentication and the Forem instance is set to private but user is authenticated" do
         allow(Settings::UserExperience).to receive(:public).and_return(false)
-        get me_api_users_path, params: { access_token: access_token.token }
+        get me_api_users_path, headers: headers
 
         response_user = response.parsed_body
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

In order to be able to completely remove Doorkeeper from our application I needed to remove it from our API. This feature was labeled as "private alpha" before so should be safe to remove. I'll try to get clarity on whether or not this needs a changelog post.

NOTE: I originally tried to remove all of Doorkeeper in a single PR (https://github.com/forem/forem/pull/15749) but that got unwieldy so I intend to break things down as seems appropriate.

## Related Tickets & Documents

https://github.com/forem/forem/issues/15748

## QA Instructions, Screenshots, Recordings

All specs should be green

### UI accessibility concerns?

No UI changes

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] I've updated the [Developer Docs](https://developers.forem.com), see https://github.com/forem/forem-docs/pull/39
- [X] I will share this change internally with the appropriate teams
