### PR TITLE
add cypress-pipe, fix flaky test

### DIFF
--- a/app/javascript/actionsPanel/initializeActionsPanelToggle.js
+++ b/app/javascript/actionsPanel/initializeActionsPanelToggle.js
@@ -29,9 +29,11 @@ export function initializeActionsPanel(user, path) {
     const panelDocument = modContainer.contentDocument;
 
     if (panelDocument) {
-      panelDocument
-        .getElementsByClassName('close-actions-panel')[0]
-        .classList.remove('hidden');
+      const closePanel = panelDocument.getElementsByClassName(
+        'close-actions-panel',
+      )[0];
+
+      closePanel && closePanel.classList.remove('hidden');
     }
   }
 

--- a/cypress/integration/seededFlows/moderationFlows/adjustPostTags.spec.js
+++ b/cypress/integration/seededFlows/moderationFlows/adjustPostTags.spec.js
@@ -100,6 +100,9 @@ describe('Adjust post tags', () => {
   });
 
   describe('from article page', () => {
+    // Helper function for pipe command
+    const click = ($el) => $el.click();
+
     beforeEach(() => {
       cy.testSetup();
       cy.fixture('users/adminUser.json').as('user');
@@ -117,7 +120,13 @@ describe('Adjust post tags', () => {
 
       cy.findByRole('button', { name: 'Moderation' }).click();
       cy.getIframeBody('#mod-container').within(() => {
-        cy.findByRole('button', { name: 'Open adjust tags section' }).click();
+        // Click listeners are attached async so we use pipe() to retry click until condition met
+        cy.findByRole('button', {
+          name: 'Open adjust tags section',
+        })
+          .pipe(click)
+          .should('have.attr', 'aria-expanded', 'true');
+
         cy.findByPlaceholderText('Add a tag').type('tag2');
         cy.findByPlaceholderText('Reason for tag adjustment').type('testing');
         cy.findByRole('button', { name: 'Submit' }).click();
@@ -136,7 +145,13 @@ describe('Adjust post tags', () => {
       cy.findByRole('button', { name: 'Moderation' }).click();
 
       cy.getIframeBody('#mod-container').within(() => {
-        cy.findByRole('button', { name: 'Open adjust tags section' }).click();
+        // Click listeners are attached async so we use pipe() to retry click until condition met
+        cy.findByRole('button', {
+          name: 'Open adjust tags section',
+        })
+          .pipe(click)
+          .should('have.attr', 'aria-expanded', 'true');
+
         cy.findByPlaceholderText('Reason for tag adjustment').type('testing');
         cy.findByRole('button', { name: '#tag1 Remove tag' }).click();
 

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,5 +21,8 @@ import 'cypress-failed-log';
 // Import commands.js using ES2015 syntax:
 import './commands';
 
+// Helper for retriable actions (e.g. to account for asynchronously attached event listeners) https://github.com/NicholasBoll/cypress-pipe
+import 'cypress-pipe';
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "cypress": "^8.7.0",
     "cypress-failed-log": "^2.9.2",
     "cypress-file-upload": "^5.0.8",
+    "cypress-pipe": "^2.0.0",
     "eslint": "^7.32.0",
     "eslint-config-preact": "^1.2.0",
     "eslint-config-prettier": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6580,6 +6580,11 @@ cypress-file-upload@^5.0.8:
   resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
   integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
 
+cypress-pipe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/cypress-pipe/-/cypress-pipe-2.0.0.tgz#577df7a70a8603d89a96dfe4092a605962181af8"
+  integrity sha512-KW9s+bz4tFLucH3rBGfjW+Q12n7S4QpUSSyxiGrgPOfoHlbYWzAGB3H26MO0VTojqf9NVvfd5Kt0MH5XMgbfyg==
+
 cypress@^8.7.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.7.0.tgz#2ee371f383d8f233d3425b6cc26ddeec2668b6da"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

The `adjustPostTags` spec had been occasionally flaking in CI, due to a race condition between the Cypress click event, and the click handler being added asynchronously in `initializeActionsPanelToggle.js`. 

This kind of race condition has tripped us up a few times, and we've solved it ad hoc around the code by adding data attributes when click handlers are attached (so we can then await the data attribute being present in the DOM). This workaround however is far from ideal, leaving random data attributes around our production HTML.

Clicks aren't retriable in Cypress, because normally if X action doesn't occur on click, it should represent a test failure. However they point towards a package called `cypress-pipe` to account for these kind of situations where listeners are attached async. [See their blog post on the same](https://www.cypress.io/blog/2019/01/22/when-can-the-test-click/).

I've added that package to our dev dependencies, which lets us retry an action until a particular condition is met. The test step retries and times out/fails according the assertion's standard timeout. 

If we're in agreement to add this package in, I'll add to the developer documentation / write up a post explaining how and when we would use this. I'll also look at places where we're using the old data-attribute approach and refactor to rely on `pipe` instead 🙂 

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Not much to QA here, CI tests should be green

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


