### PR TITLE
Update a11y of ButtonGroup component

### DIFF
--- a/app/javascript/CommentSubscription/CommentSubscription.jsx
+++ b/app/javascript/CommentSubscription/CommentSubscription.jsx
@@ -70,6 +70,7 @@ export class CommentSubscription extends Component {
     return (
       <div className={positionType}>
         <ButtonGroup
+          labelText="Comment subscription options"
           ref={(element) => {
             this.buttonGroupElement = element;
           }}

--- a/app/javascript/crayons/ButtonGroup/ButtonGroup.jsx
+++ b/app/javascript/crayons/ButtonGroup/ButtonGroup.jsx
@@ -1,8 +1,15 @@
 import { h } from 'preact';
+import PropTypes from 'prop-types';
 import { defaultChildrenPropTypes } from '../../common-prop-types/default-children-prop-types';
 
-export const ButtonGroup = ({ children }) => (
-  <div role="presentation" className="crayons-btn-group">
+/**
+ * Used to group related buttons together
+ *
+ * @param {string} labelText Used to form the aria-label providing to assistive technologies to describe the control
+ * @param {HTMLElement[]} children The buttons rendered inside the group
+ */
+export const ButtonGroup = ({ children, labelText }) => (
+  <div role="group" aria-label={labelText} className="crayons-btn-group">
     {children}
   </div>
 );
@@ -11,4 +18,5 @@ ButtonGroup.displayName = 'ButtonGroup';
 
 ButtonGroup.propTypes = {
   children: defaultChildrenPropTypes,
+  labelText: PropTypes.string.isRequired,
 };

--- a/app/javascript/crayons/ButtonGroup/__stories__/ButtonGroup.stories.jsx
+++ b/app/javascript/crayons/ButtonGroup/__stories__/ButtonGroup.stories.jsx
@@ -9,7 +9,7 @@ export default {
 
 export const Default = () => {
   return (
-    <ButtonGroup>
+    <ButtonGroup labelText="Example group of buttons">
       <Button variant="outlined">Action 1</Button>
       <Button variant="outlined">Action 2</Button>
     </ButtonGroup>
@@ -33,7 +33,7 @@ export const TextIcon = () => {
   );
 
   return (
-    <ButtonGroup>
+    <ButtonGroup labelText="Example group of buttons including an icon">
       <Button variant="secondary">Action 1</Button>
       <Button variant="secondary" icon={Icon} contentType="icon" />
     </ButtonGroup>

--- a/app/javascript/crayons/ButtonGroup/__tests__/ButtonGroup.test.jsx
+++ b/app/javascript/crayons/ButtonGroup/__tests__/ButtonGroup.test.jsx
@@ -17,7 +17,7 @@ describe('<ButtonGroup /> component', () => {
 
   it('should have no a11y violations when rendered', async () => {
     const { container } = render(
-      <ButtonGroup>
+      <ButtonGroup labelText="Test button group">
         <Button>Hello World!</Button>
         <Button variant="secondary">Hello again!</Button>
       </ButtonGroup>,
@@ -29,7 +29,7 @@ describe('<ButtonGroup /> component', () => {
 
   it('should render', () => {
     const { container } = render(
-      <ButtonGroup>
+      <ButtonGroup labelText="Test button group">
         <Button>Hello World!</Button>
         <Button icon={Icon} />
       </ButtonGroup>,

--- a/app/javascript/crayons/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.jsx.snap
+++ b/app/javascript/crayons/ButtonGroup/__tests__/__snapshots__/ButtonGroup.test.jsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ButtonGroup /> component should render 1`] = `"<div role=\\"presentation\\" class=\\"crayons-btn-group\\"><button class=\\"crayons-btn\\" type=\\"button\\">Hello World!</button><button class=\\"crayons-btn\\" type=\\"button\\"></button></div>"`;
+exports[`<ButtonGroup /> component should render 1`] = `"<div role=\\"group\\" aria-label=\\"Test button group\\" class=\\"crayons-btn-group\\"><button class=\\"crayons-btn\\" type=\\"button\\">Hello World!</button><button class=\\"crayons-btn\\" type=\\"button\\"></button></div>"`;

--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -7,7 +7,7 @@
                 num: tag.span(t("views.articles.comments.num", num: @article.comments_count), class: "js-comments-count", data: { comments_count: @article.comments_count })) %>
         </h2>
         <div id="comment-subscription" class="print-hidden">
-          <div role="presentation" class="crayons-btn-group">
+          <div class="crayons-btn-group">
             <span class="crayons-btn crayons-btn--outlined"><%= t("views.articles.comments.subscribe") %></span>
           </div>
         </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [X] Optimization
- [ ] Documentation Update

## Description

I noticed our ButtonGroup currently isn't providing any semantic value to screen reader users due to the `role="presentation"` - I can see why we did this, but we're missing out on a little accessibility boost 😄 

I've updated this to `role="group"`, and added the requirement for a label to describe the group. The impact is that now when you first visit a button inside the group, screen reader users will be informed the current button is one of a group of related controls (with the label text describing the purpose of the group).

The only place we were using this group was the comment subscription component - i.e. when you click "Subscribe" on an article.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

This can only really be checked by screen reader, but here is a screenshot showing how the button is now announced as part of a group:

![screenshot of VoiceOver on Safari on the article page. The screen reader output is shown, and the comment subscription button is noted as part of "Comment subscription options"](https://user-images.githubusercontent.com/20773163/146025376-1b574e2a-f552-42b2-8713-2aa054bfc3eb.png)


### UI accessibility concerns?

It's a small a11y boost

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: it's a very small tweak


