### PR TITLE
Strip surrounding whitespace from HTMLVariant name

### DIFF
--- a/app/models/html_variant.rb
+++ b/app/models/html_variant.rb
@@ -8,6 +8,8 @@ class HtmlVariant < ApplicationRecord
   has_many :html_variant_successes, dependent: :destroy
   has_many :html_variant_trials, dependent: :destroy
 
+  before_validation :strip_whitespace
+
   validates :group, inclusion: { in: GROUP_NAMES }
   validates :html, presence: true
   validates :name, uniqueness: true
@@ -76,5 +78,9 @@ class HtmlVariant < ApplicationRecord
 
   def allowed_image_host?(src)
     src.start_with?("https://res.cloudinary.com/") || src.start_with?(Images::Optimizer.get_imgproxy_endpoint)
+  end
+
+  def strip_whitespace
+    name.strip!
   end
 end

--- a/spec/models/html_variant_spec.rb
+++ b/spec/models/html_variant_spec.rb
@@ -70,4 +70,9 @@ RSpec.describe HtmlVariant, type: :model do
     html_variant.save
     expect(Images::Optimizer).not_to have_received(:call)
   end
+
+  it "strips whitespace from the name" do
+    variant = create(:html_variant, name: " hello world ")
+    variant.reload.name.should eq "hello world"
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Feature (minor)
- [x] Optimization (minor workflow optimization)

## Description

Discovered while investigating [a problem reported by @SGGregory in Slack]([this was actually the catalyst for this PR](https://forem-team.slack.com/archives/C7GE84DEJ/p1639508636380800?thread_ts=1639506098.374400&cid=C7GE84DEJ)).

The `HtmlVariant` model is used to populate banners and is keyed on the `name` property. If the name specified in the site settings does not match a variant's name _precisely_ it will not show. It's really easy for a human to overlook leading or trailing whitespace, so this PR strips it out.

## QA Instructions, Screenshots, Recordings

Adapted for local development from [Gracie's instructions in Slack](https://forem-team.slack.com/archives/C7GE84DEJ/p1639508207380300?thread_ts=1639506098.374400&cid=C7GE84DEJ):

- Create an [HTML variant](http://localhost:3000/admin/customization/html_variants/new) with a name that contains leading and/or trailing whitespace
- Mark that bad boy as `approved` and `published`
- Copy the title
- Paste that thang into the Campaign hero HTML variant name in [campaign settings](http://localhost:3000/admin/customization/config)
- Add in various details (go wild with it, it doesn't matter what these details are)
- Go back to HTML variant page and make sure `published` flag is still set
- Go to [the home page](http://localhost:3000) and see that, despite your best efforts to ruin things with your trailing whitespace, the banner should still show up
- ???
- PROFIT!

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] What gif best describes this PR or how it makes you feel?

![These whitespaces are dangerous](https://user-images.githubusercontent.com/108205/146066046-fe9a9b4e-411d-4e3e-8453-03c0ba14aa23.png)
