### PR TITLE
Moved setting old_username from before_validation to Users::Update

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -207,7 +207,6 @@ class User < ApplicationRecord
       ),
     )
   }
-  before_validation :check_for_username_change
   before_validation :downcase_email
 
   # make sure usernames are not empty, to be able to use the database unique index
@@ -609,13 +608,6 @@ class User < ApplicationRecord
 
   def downcase_email
     self.email = email.downcase if email
-  end
-
-  def check_for_username_change
-    return unless username_changed?
-
-    self.old_old_username = old_username
-    self.old_username = username_was
   end
 
   def bust_cache

--- a/app/services/users/update.rb
+++ b/app/services/users/update.rb
@@ -27,7 +27,7 @@ module Users
       @profile = user.profile || user.create_profile
       @users_setting = user.setting
       @updated_profile_attributes = updated_attributes[:profile] || {}
-      @updated_user_attributes = updated_attributes[:user].to_h || {}
+      @updated_user_attributes = prepare_user_attributes(updated_attributes[:user], user)
       @updated_users_setting_attributes = updated_attributes[:users_setting].to_h || {}
       @errors = []
       @success = false
@@ -59,6 +59,22 @@ module Users
     private
 
     attr_reader :errors
+
+    def prepare_user_attributes(updated_user_attributes, user)
+      attrs = updated_user_attributes.to_h || {}
+      if attrs[:username] != user.username
+        attrs[:old_username] = user.username
+        attrs[:old_old_username] = user.old_username
+      end
+      attrs
+    end
+
+    def prepare_for_username_change
+      return if @updated_user_attributes[:username] == @user.username
+
+      @updated_user_attributes[:old_username] = @user.username
+      @updated_user_attributes[:old_old_username] = @user.old_username
+    end
 
     def update_successful?
       return false unless verify_profile_image

--- a/app/services/users/update.rb
+++ b/app/services/users/update.rb
@@ -69,13 +69,6 @@ module Users
       attrs
     end
 
-    def prepare_for_username_change
-      return if @updated_user_attributes[:username] == @user.username
-
-      @updated_user_attributes[:old_username] = @user.username
-      @updated_user_attributes[:old_old_username] = @user.old_username
-    end
-
     def update_successful?
       return false unless verify_profile_image
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -323,23 +323,6 @@ RSpec.describe User, type: :model do
         expect(user).not_to be_valid
       end
     end
-
-    context "when the past value is relevant" do
-      let(:user) { create(:user) }
-
-      it "changes old_username and old_old_username properly if username changes" do
-        old_username = user.username
-        random_new_username = "username_#{rand(100_000_000)}"
-        user.update(username: random_new_username)
-        expect(user.username).to eq(random_new_username)
-        expect(user.old_username).to eq(old_username)
-
-        new_username = user.username
-        user.update(username: "username_#{rand(100_000_000)}")
-        expect(user.old_username).to eq(new_username)
-        expect(user.old_old_username).to eq(old_username)
-      end
-    end
   end
 
   context "when callbacks are triggered before and after create" do

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -150,25 +150,31 @@ RSpec.describe "StoriesShow", type: :request do
 
     it "redirects to appropriate page if user changes username" do
       old_username = user.username
-      user.update(username: "new_hotness_#{rand(10_000)}")
+      user.update_columns(username: "new_hotness_#{rand(10_000)}", old_username: old_username,
+                          old_old_username: user.old_username)
       get "/#{old_username}/#{article.slug}"
+      user.reload
       expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
       expect(response).to have_http_status(:moved_permanently)
     end
 
     it "redirects to appropriate page if user changes username twice" do
       old_username = user.username
-      user.update(username: "new_hotness_#{rand(10_000)}")
-      user.update(username: "new_new_username_#{rand(10_000)}")
+      user.update_columns(username: "new_hotness_#{rand(10_000)}", old_username: old_username,
+                          old_old_username: user.old_username)
+      user.update_columns(username: "new_new_username_#{rand(10_000)}", old_username: user.username,
+                          old_old_username: user.old_username)
       get "/#{old_username}/#{article.slug}"
       expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
       expect(response).to have_http_status(:moved_permanently)
     end
 
     it "redirects to appropriate page if user changes username twice and go to middle username" do
-      user.update(username: "new_hotness_#{rand(10_000)}")
+      user.update_columns(username: "new_hotness_#{rand(10_000)}", old_username: user.username,
+                          old_old_username: user.old_username)
       middle_username = user.username
-      user.update(username: "new_new_username_#{rand(10_000)}")
+      user.update_columns(username: "new_new_username_#{rand(10_000)}", old_username: user.username,
+                          old_old_username: user.old_username)
       get "/#{middle_username}/#{article.slug}"
       expect(response.body).to redirect_to("/#{user.username}/#{article.slug}")
       expect(response).to have_http_status(:moved_permanently)

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -31,15 +31,18 @@ RSpec.describe "UserProfiles", type: :request do
 
     it "renders profile page of user after changed username" do
       old_username = user.username
-      user.update(username: "new_username_yo_#{rand(10_000)}")
+      user.update_columns(username: "new_username_yo_#{rand(10_000)}", old_username: old_username,
+                          old_old_username: user.old_username)
       get "/#{old_username}"
       expect(response).to redirect_to("/#{user.username}")
     end
 
     it "renders profile page of user after two changed usernames" do
       old_username = user.username
-      user.update(username: "new_hotness_#{rand(10_000)}")
-      user.update(username: "new_new_username_#{rand(10_000)}")
+      user.update_columns(username: "new_hotness_#{rand(10_000)}", old_username: old_username,
+                          old_old_username: user.old_username)
+      user.update_columns(username: "new_new_username_#{rand(10_000)}", old_username: user.username,
+                          old_old_username: user.old_username)
       get "/#{old_username}"
       expect(response).to redirect_to("/#{user.username}")
     end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Moved code related to changing username from a `before_validation` callback in `User` model  to `Users::Update` service.

## Related Tickets & Documents
#15424
I mentioned this change in #15704

## QA Instructions, Screenshots, Recordings
When a user changes their username from /settings/profile, their `old_username` and `old_old_username` should be updated to the previous `username` and previous `old_username` values accordingly (the logic wasn't changed)

## Added/updated tests?
- [x] No, and this is why: the tests were added in a previous pr

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: no logic changes

