### PR TITLE
Bust cache after we update the Settings in the Creator Onboarding 

### DIFF
--- a/app/controllers/admin/creator_settings_controller.rb
+++ b/app/controllers/admin/creator_settings_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class CreatorSettingsController < Admin::ApplicationController
+    after_action :bust_content_change_caches, only: %i[create]
+
     ALLOWED_PARAMS = %i[checked_code_of_conduct checked_terms_and_conditions community_name
                         invite_only_mode logo primary_brand_color_hex public].freeze
 

--- a/spec/requests/admin/creator_settings_spec.rb
+++ b/spec/requests/admin/creator_settings_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe "/creator_settings/new", type: :request do
         expect(current_user.checked_terms_and_conditions).to eq(true)
         expect(response).to redirect_to(:root).and have_http_status(:found)
       end
+
+      it "updates settings admin action taken" do
+        expect do
+          post admin_creator_settings_path, params: params
+        end.to change(Settings::General, :admin_action_taken_at)
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

With the new creator onboarding settings, we allow the creator to upload a png/jpg logo and then we want display it in the header. However, the logo doesn't update instantly when changed  because the application shell is cached as per this codeblock, which includes the logo.

Hence, we needed to bust the cache after the create action to ensure that we the logo gets updated :) 
 
## Related Tickets & Documents


## QA Instructions, Screenshots, Recordings

Firstly take note of ``Settings::General.admin_action_taken_at`.

Thereafter, let's update the logo by going through the Creator Settings config. 

Firstly to mirror a new Forem, You can open a rails console via rails c and do the following:

```
# Enable the feature flag
FeatureFlag.enable(:creator_onboarding)

# Delete all users 
User.destroy_all

# Set `waiting_on_first_user` to be true
Settings::General.waiting_on_first_user = true

# If you've logged in before set the mascot id to nil
Settings::General.mascot_user_id = nil
```

Now, run your server and navigate to http://localhost:3000/ and complete the "Create Account" form. After completing the "Create Account" form, you should be brought to the new Creator Setup page, ${baseUrl}/admin/creator_settings/new?referrer=${baseUrl}.

When you hit submit on the Creator settings page, you should open up a console and look at `Settings::General.admin_action_taken_at`. The value should reflect the current time. This value forms part of the cache key and will refresh the application shell cache, which in turn should immediately update the logo on production 🎉 

### UI accessibility concerns?

None.

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [] I will share this change internally with the appropriate team
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: I think it does not need to be communicated because its not really a visible change.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/h4aUqWa5RZVVpBuZCJ/giphy.gif)
