### PR TITLE
Automatically create user profile if it's missing

### DIFF
--- a/app/services/users/update.rb
+++ b/app/services/users/update.rb
@@ -24,7 +24,7 @@ module Users
 
     def initialize(user, updated_attributes)
       @user = user
-      @profile = user.profile
+      @profile = user.profile || user.create_profile
       @users_setting = user.setting
       @updated_profile_attributes = updated_attributes[:profile] || {}
       @updated_user_attributes = updated_attributes[:user].to_h || {}

--- a/spec/services/users/update_spec.rb
+++ b/spec/services/users/update_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Users::Update, type: :service do
   end
   let(:user) { profile.user }
 
+  it "automatically creates a profile for a user if it does not exist" do
+    user = create(:user, _skip_creating_profile: true)
+
+    expect(user.profile).to be_nil
+
+    described_class.call user, profile: { location: "Over here" }
+
+    expect(user.profile).to be_a Profile
+  end
+
   it "correctly typecasts new attributes", :aggregate_failures do
     described_class.call(user, profile: { location: 123 })
     expect(user.profile.location).to eq "123"


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We had 2 users on DEV this morning with `nil` profiles stuck in onboarding because their profiles had not been created. I haven't figure out _why_ they weren't created, but creating the profiles here will help out regardless of reason.

## Related Tickets & Documents

- [Datadog trace](https://app.datadoghq.com/apm/traces?query=env%3Aproduction%20service%3Apractical_developer%20operation_name%3Arack.request%20status%3Aerror%20resource_name%3AUsersController%23onboarding_update&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=true&messageDisplay=inline&sort=desc&spanID=1508691058460892819&streamTraces=true&timeHint=1639573200000&trace=AQAAAX2-YHKFzy8pqwAAAABBWDItWUlVb0FBQ1dBMXVlOHBtbHc3Y1Q&traceID=1420705037609487267&start=1639554228279&end=1639583028279&paused=true)
- [Honeybadger notice](https://app.honeybadger.io/projects/66984/faults/81036034/01FPZ60WN9M4MKET2GQ5YXYWGE?q=message%3A%22assign_attributes%22)

## QA Instructions, Screenshots, Recordings

I'm not sure how to get a user into this state. I'm assuming there's a race condition or something that almost never comes up.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams