### PR TITLE
Implement Unified Embed for Instagram Post URLs

### DIFF
--- a/app/liquid_tags/instagram_tag.rb
+++ b/app/liquid_tags/instagram_tag.rb
@@ -1,9 +1,13 @@
 class InstagramTag < LiquidTagBase
   PARTIAL = "liquids/instagram".freeze
+  REGISTRY_REGEXP = %r{(?:https?://)?(?:www\.)?(?:instagram.com/p/)(?<video_id>[a-zA-Z0-9_-]{11})/?}
+  VALID_ID_REGEXP = /\A(?<video_id>[a-zA-Z0-9_-]{11})\Z/
+  REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 
   def initialize(_tag_name, id, _parse_context)
     super
-    @id = parse_id(id)
+    input   = CGI.unescape_html(strip_tags(id))
+    @id     = parse_id_or_url(input)
   end
 
   def render(_context)
@@ -17,16 +21,14 @@ class InstagramTag < LiquidTagBase
 
   private
 
-  def parse_id(input)
-    input_no_space = input.delete(" ")
-    raise StandardError, "Invalid Instagram Id" unless valid_id?(input_no_space)
+  def parse_id_or_url(input)
+    match = pattern_match_for(input, REGEXP_OPTIONS)
+    raise StandardError, "Invalid Instagram ID" unless match
 
-    input_no_space
-  end
-
-  def valid_id?(id)
-    id.length == 11 && id =~ /[a-zA-Z0-9_-]{11}/
+    match[:video_id]
   end
 end
 
 Liquid::Template.register_tag("instagram", InstagramTag)
+
+UnifiedEmbed.register(InstagramTag, regexp: InstagramTag::REGISTRY_REGEXP)

--- a/app/liquid_tags/liquid_tag_base.rb
+++ b/app/liquid_tags/liquid_tag_base.rb
@@ -19,6 +19,12 @@ class LiquidTagBase < Liquid::Tag
     ActionController::Base.helpers.strip_tags(string).strip
   end
 
+  def pattern_match_for(input, regex_options)
+    regex_options
+      .filter_map { |regex| input.match(regex) }
+      .first
+  end
+
   private
 
   def validate_contexts

--- a/app/liquid_tags/youtube_tag.rb
+++ b/app/liquid_tags/youtube_tag.rb
@@ -35,7 +35,7 @@ class YoutubeTag < LiquidTagBase
   private
 
   def parse_id_or_url(input)
-    match = pattern_match_for(input)
+    match = pattern_match_for(input, REGEXP_OPTIONS)
     raise StandardError, "Invalid YouTube ID" unless match
 
     video_id       = match[:video_id]
@@ -44,12 +44,6 @@ class YoutubeTag < LiquidTagBase
     return video_id if time_parameter.blank?
 
     translate_start_time(video_id, time_parameter)
-  end
-
-  def pattern_match_for(input)
-    REGEXP_OPTIONS
-      .filter_map { |regex| input.match(regex) }
-      .first
   end
 
   def translate_start_time(video_id, time_parameter)

--- a/spec/liquid_tags/unified_embed_spec.rb
+++ b/spec/liquid_tags/unified_embed_spec.rb
@@ -6,16 +6,24 @@ RSpec.describe UnifiedEmbed do
   let(:article) { create(:article) }
 
   describe ".find_liquid_tag_for" do
-    valid_youtube_url_formats = [
-      "https://www.youtube.com/embed/dQw4w9WgXcQ",
-      "https://www.youtube.com/watch?v=rc5AyncB_Xw&t=18s",
-      "https://youtu.be/rc5AyncB_Xw",
+    valid_instagram_url_formats = [
+      "https://www.instagram.com/p/CXgzXWXroHK/",
+      "https://instagram.com/p/CXgzXWXroHK/",
+      "http://www.instagram.com/p/CXgzXWXroHK/",
+      "www.instagram.com/p/CXgzXWXroHK/",
+      "instagram.com/p/CXgzXWXroHK/",
     ]
 
     valid_vimeo_url_formats = [
       "https://player.vimeo.com/video/652446985?h=a68f6ed1f5",
       "https://vimeo.com/ondemand/withchude/647355334",
       "https://vimeo.com/636725488",
+    ]
+
+    valid_youtube_url_formats = [
+      "https://www.youtube.com/embed/dQw4w9WgXcQ",
+      "https://www.youtube.com/watch?v=rc5AyncB_Xw&t=18s",
+      "https://youtu.be/rc5AyncB_Xw",
     ]
 
     it "returns GistTag for a gist url" do
@@ -31,6 +39,13 @@ RSpec.describe UnifiedEmbed do
     it "returns CodepenTag for a codepen url" do
       expect(described_class.find_liquid_tag_for(link: "https://codepen.io/elisavetTriant/pen/KKvRRyE"))
         .to eq(CodepenTag)
+    end
+
+    valid_instagram_url_formats.each do |url|
+      it "returns InstagramTag for a valid instagram url format" do
+        expect(described_class.find_liquid_tag_for(link: url))
+          .to eq(InstagramTag)
+      end
     end
 
     it "returns JsFiddle for a jsfiddle url" do
@@ -68,17 +83,17 @@ RSpec.describe UnifiedEmbed do
         .to eq(WikipediaTag)
     end
 
-    valid_youtube_url_formats.each do |url|
-      it "returns YoutubeTag for a valid youtube url format" do
-        expect(described_class.find_liquid_tag_for(link: url))
-          .to eq(YoutubeTag)
-      end
-    end
-
     valid_vimeo_url_formats.each do |url|
       it "returns VimeoTag for a valid vimeo url format" do
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(VimeoTag)
+      end
+    end
+
+    valid_youtube_url_formats.each do |url|
+      it "returns YoutubeTag for a valid youtube url format" do
+        expect(described_class.find_liquid_tag_for(link: url))
+          .to eq(YoutubeTag)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Instagram posts.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15560

## QA Instructions, Screenshots, Recordings

Example Instagram URLs:
https://www.instagram.com/p/CXgzXWXroHK/
https://instagram.com/p/CXgzXWXroHK/
http://www.instagram.com/p/CXgzXWXroHK/
www.instagram.com/p/CXgzXWXroHK/
instagram.com/p/CXgzXWXroHK/

- As a user, create an Instagram (IG) liquid tag using this format: `{% embed <instagram-post-url> %}`. Please use all the example URLs provided above. The Instagram Liquid Tag should render properly.
_NOTE: the IG Liquid Tag renders as though it has been truncated, i.e. the height looks too short. I have verified that this is the current appearance in production._
- Also create IG liquid tag using the old method: `{% instagram <instagram-post-id> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.