### PR TITLE
Disabled Spring for E2E databse when run locally

### DIFF
--- a/bin/e2e
+++ b/bin/e2e
@@ -21,7 +21,8 @@ read -t 10 -p "Choose yes to setup a test database or if you're running the scri
 
 if [[ $REPLY =~ ^[Yy]$ ]]; then
   printf "\n\nSetting up the E2E database before running E2E tests...\n\n"
-  RAILS_ENV=test E2E=true bin/e2e-setup
+  # Spring is disabled only for E2E tests run locally. Otherwise, there are all kinds of errors.
+  DISABLE_SPRING=1 RAILS_ENV=test E2E=true bin/e2e-setup
 else
    printf "\n\nSkipping database setup...\n\n"
 fi


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] DX

## Description

Now Spring is disabled when creating a database for end-to-end tests that run locally. Prior to this fix, it was pretty consistent to see this error.

```
Doing a quick bundle check to make sure gems are all up to date.

The Gemfile's dependencies are satisfied
yarn install v1.22.5
[1/6] 🔍  Validating package.json...
[2/6] 🔍  Resolving packages...
success Already up-to-date.
$ husky install
husky - Git hooks installed
✨  Done in 1.09s.

Choose yes to setup a test database or if you're running the script for the first time, choose no or wait 10 seconds otherwise (y/n) y

Setting up the E2E database before running E2E tests...

[TEST PROF INFO] Spring detected
/Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/spring-4.0.0/lib/spring/application.rb:101:in `block in preload': Spring reloads, and therefore needs the application to have reloading enabled.
Please, set config.cache_classes to false in config/environments/test.rb.
 (RuntimeError)
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.3/lib/rails/initializable.rb:32:in `instance_exec'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.3/lib/rails/initializable.rb:32:in `run'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.3/lib/rails/initializable.rb:61:in `block in run_initializers'
        from /Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/tsort.rb:228:in `block in tsort_each'
        from /Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        from /Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/tsort.rb:431:in `each_strongly_connected_component_from'
        from /Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/tsort.rb:349:in `block in each_strongly_connected_component'
        from /Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/tsort.rb:347:in `each'
        from /Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/tsort.rb:347:in `call'
        from /Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/tsort.rb:347:in `each_strongly_connected_component'
        from /Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/tsort.rb:226:in `tsort_each'
        from /Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/tsort.rb:205:in `tsort_each'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.3/lib/rails/initializable.rb:60:in `run_initializers'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/railties-6.1.4.3/lib/rails/application.rb:391:in `initialize!'
        from /Users/taco/dev/forem/config/environment.rb:5:in `<main>'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.9.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.9.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.9.3/lib/bootsnap/load_path_cache/loaded_features_index.rb:100:in `register'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.9.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/bootsnap-1.9.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/zeitwerk-2.5.1/lib/zeitwerk/kernel.rb:35:in `require'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.3/lib/active_support/dependencies.rb:332:in `block in require'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.3/lib/active_support/dependencies.rb:299:in `load_dependency'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/activesupport-6.1.4.3/lib/active_support/dependencies.rb:332:in `require'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/spring-4.0.0/lib/spring/application.rb:108:in `preload'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/spring-4.0.0/lib/spring/application.rb:162:in `serve'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/spring-4.0.0/lib/spring/application.rb:144:in `block in run'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/spring-4.0.0/lib/spring/application.rb:138:in `loop'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/spring-4.0.0/lib/spring/application.rb:138:in `run'
        from /Users/taco/dev/forem/vendor/bundle/ruby/3.0.0/gems/spring-4.0.0/lib/spring/application/boot.rb:19:in `<top (required)>'
        from <internal:/Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:/Users/taco/.rbenv/versions/3.0.2/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from -e:1:in `<main>'
```

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

1. Run `bin/e2e` from the root of the project.
2. Type `Y` or `y` when asked `Choose yes to setup a test database or if you're running the script for the first time, choose no or wait 10 seconds otherwise (y/n)`
3. End-to-end tests should start up without the Spring error mentioned above.

### UI accessibility concerns?

N/A This is fixing testing infrastructure.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: N/A This is fixing testing infrastructure.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Han Solo giving a thumbs up](https://media.giphy.com/media/OE6FE4GZF78nm/giphy.gif)
