### PR TITLE
Changed members only copy for radio button label to invite only.

### DIFF
--- a/app/views/admin/creator_settings/_form.html.erb
+++ b/app/views/admin/creator_settings/_form.html.erb
@@ -47,7 +47,7 @@
       </div>
       <div>
         <%= f.radio_button :invite_only_mode, true, class: "crayons-radio", role: "radio" %>
-        <%= label_tag "creator_settings_form_invite_only_mode_true", "Members Only" %>
+        <%= label_tag "creator_settings_form_invite_only_mode_true", "Invite Only" %>
       </div>
     </div>
   </fieldset>

--- a/cypress/integration/creatorOnboardingFlows/creatorSettings.spec.js
+++ b/cypress/integration/creatorOnboardingFlows/creatorSettings.spec.js
@@ -41,18 +41,32 @@ describe('Creator Settings Page', () => {
     cy.findByText(/^Brand color/).invoke('attr', 'value', '#ff0000');
 
     // should contain a 'Who can join this community?' radio selector field and allow selection upon click
-    cy.findByRole('group', { name: /^Who can join this community/i }).should(
-      'be.visible',
-    );
-    cy.findAllByRole('radio', { name: /everyone/i }).check();
-    cy.findAllByRole('radio').should('be.checked');
+    cy.findByRole('group', { name: /^Who can join this community/i })
+      .as('joinCommunity')
+      .should('be.visible');
+
+    cy.get('@joinCommunity').within(() => {
+      cy.findByRole('radio', { name: /everyone/i })
+        .check()
+        .should('be.checked');
+
+      cy.findByRole('radio', { name: /invite only/i }).should('not.be.checked');
+    });
 
     // should contain a 'Who can view content in this community?' radio selector field and allow selection upon click
     cy.findByRole('group', {
       name: /^Who can view content in this community/i,
-    }).should('be.visible');
-    cy.findAllByRole('radio', { name: /members only/i }).check();
-    cy.findAllByRole('radio').should('be.checked');
+    })
+      .as('viewCommunity')
+      .should('be.visible');
+
+    cy.get('@viewCommunity').within(() => {
+      cy.findByRole('radio', { name: /members only/i })
+        .check()
+        .should('be.checked');
+
+      cy.findByRole('radio', { name: /everyone/i }).should('not.be.checked');
+    });
 
     // should contain a 'I agree to uphold our Code of Conduct' checkbox field and allow selection upon click
     cy.findByRole('group', {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Changed the copy for a checkbox label for the "Who can join this community?" section of the creator settings form.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

1. Ensure you're logged out from the Forem instance.
2. Set up the database to be in a state where you are about to create the Forem creator role

```ruby
# Enable the feature flag
FeatureFlag.enable(:creator_onboarding)

# Delete all users 
User.destroy_all

# Set `waiting_on_first_user` to be true
Settings::General.waiting_on_first_user = true

# If you've logged in before set the mascot id to nil
Settings::General.mascot_user_id = nil

# If you've logged in before set the logo SVG to nil
Settings::General.logo_svg = nil
```

3. Click on the login link. Since the feature flag is enabled, you'll be redirected to Creator Signup Form.
4. Fill in the necessary information and submit the form.
5. Notice in the "Who can join this community?" section that it now says _Invite Only_ instead of _Members Only_ for the second radio button.
6. Ensure both the Terms and Conditions and Code of Conduct checkboxes are checked off and submit the form.
8. You are redirected to the home page of the Forem instance.

### Before

![image](https://user-images.githubusercontent.com/833231/146375983-d05bff78-9162-40f6-aa0a-fb431da4fe2b.png)

### After

![image](https://user-images.githubusercontent.com/833231/146375864-0d7fb92d-5f58-4ea6-932e-1185e79d9ba2.png)

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Betty White dabbing](https://media.giphy.com/media/A4R8sdUG7G9TG/giphy.gif)
