### PR TITLE
Implement Unified Embed for Blogcast URLs

### DIFF
--- a/app/liquid_tags/vimeo_tag.rb
+++ b/app/liquid_tags/vimeo_tag.rb
@@ -27,7 +27,6 @@ class VimeoTag < LiquidTagBase
 
   def get_id(input)
     match = input.match(REGISTRY_REGEXP)
-    # binding.pry
     match ? match[:video_id] : input
   end
 end

--- a/app/views/liquids/_blogcast.html.erb
+++ b/app/views/liquids/_blogcast.html.erb
@@ -3,7 +3,7 @@
     scrolling="no"
     id="blogcast_<%= id %>"
     mozallowfullscreen="true"
-    src="https://blogcast.host/embed/<%= id %>"
+    src="https://app.blogcast.host/embed/<%= id %>"
     style="width:100%;min-height:132px;overflow:hidden;margin:0;"
     loading="lazy"
     webkitallowfullscreen="true"></iframe>

--- a/spec/liquid_tags/unified_embed_spec.rb
+++ b/spec/liquid_tags/unified_embed_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe UnifiedEmbed do
   let(:article) { create(:article) }
 
   describe ".find_liquid_tag_for" do
+    valid_blogcast_url_formats = [
+      "https://blogcast.host/embed/4942",
+      "https://app.blogcast.host/embed/4942",
+    ]
+
     valid_instagram_url_formats = [
       "https://www.instagram.com/p/CXgzXWXroHK/",
       "https://instagram.com/p/CXgzXWXroHK/",
@@ -26,6 +31,13 @@ RSpec.describe UnifiedEmbed do
       "https://youtu.be/rc5AyncB_Xw",
     ]
 
+    valid_blogcast_url_formats.each do |url|
+      it "returns BlogcastTag for a valid blogcast url" do
+        expect(described_class.find_liquid_tag_for(link: url))
+          .to eq(BlogcastTag)
+      end
+    end
+
     it "returns GistTag for a gist url" do
       expect(described_class.find_liquid_tag_for(link: "https://gist.github.com/jeremyf/662585f5c4d22184a6ae133a71bf891a"))
         .to eq(GistTag)
@@ -42,7 +54,7 @@ RSpec.describe UnifiedEmbed do
     end
 
     valid_instagram_url_formats.each do |url|
-      it "returns InstagramTag for a valid instagram url format" do
+      it "returns InstagramTag for a valid instagram url" do
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(InstagramTag)
       end
@@ -84,14 +96,14 @@ RSpec.describe UnifiedEmbed do
     end
 
     valid_vimeo_url_formats.each do |url|
-      it "returns VimeoTag for a valid vimeo url format" do
+      it "returns VimeoTag for a valid vimeo url" do
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(VimeoTag)
       end
     end
 
     valid_youtube_url_formats.each do |url|
-      it "returns YoutubeTag for a valid youtube url format" do
+      it "returns YoutubeTag for a valid youtube url" do
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(YoutubeTag)
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Blogcast embeds.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15553

## QA Instructions, Screenshots, Recordings

Example Blogcast URLs:
https://blogcast.host/embed/4942
https://app.blogcast.host/embed/4942

- As a user, create a Blogcast liquid tag using this format: `{% embed <blogcast-url> %}`. Please use the example URLs provided above. The Blogcast Liquid Tag should render properly.
- Also create Blogcast liquid tag using the old method: `{% blogcast <blogcast-id> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?

None

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.
