### PR TITLE
Add DISABLE_SPRING environment variable to gitpod forem server task

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,6 +13,8 @@ ports:
 
 tasks:
   - name: Forem Server
+    env:
+      DISABLE_SPRING: 1
     before: >
       redis-server &
       gp await-port 5432 &&


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The gitpod-init.sh runs a command to get the expected url for this host when viewing port 3000 (`gp url 3000`) and sets that as the app domain in the .env file. However, the site is not allowing access via this url (it shows blocked host and suggests you update the config.hosts list).


https://www.gitpod.io/docs/environment-variables#terminal-specific-environment-variables

Without this I'm seeing the ENV["APP_DOMAIN"] not set when spring is
loaded (this prevents browsing the site from within gitpod), suggesting the .env file was not loaded the first time a ruby process (gem install? bin/setup) started and consequently is not present when the app starts up here.

![Screenshot from 2021-12-16 12-45-02](https://user-images.githubusercontent.com/1237369/146441176-0b996d0f-cc82-4c82-a85a-19734ce02125.png)

Exploration of the issue showed the Settings::General.app_domain was correct, but ENV["APP_DOMAIN"] and ApplicationConfig.app_domain_with_port were both empty

Disabling spring restored the expected behavior.
 
```ruby
gitpod /workspace/forem $ bundle exec rails console
DEBUGGER[spring app    | forem | started 23 mins ago | development mode#6851]: Attaching after process 4226 fork to child process 6851
Running via Spring preloader in process 6851
Loading development environment (Rails 6.1.4.3)
[4] pry(main)> ApplicationConfig.app_domain_no_port
Unset ENV variable: APP_DOMAIN.
=> nil
[5] pry(main)> ENV["APP_DOMAIN"]
=> nil
[6] pry(main)> Settings::General.app_domain
  Settings::General Load (0.5ms)  SELECT "site_configs"."var", "site_configs"."value" FROM "site_configs"
=> "3000-plum-viper-yw1h0qjs.ws-us23.gitpod.io"
[7] pry(main)> PracticalDeveloper::Application.config.hosts
=> [".localhost",
 /\A([a-z0-9-]+\.)?localhost:\d+\z/,
 #<IPAddr: IPv4:0.0.0.0/0.0.0.0>,
 #<IPAddr: IPv6:0000:0000:0000:0000:0000:0000:0000:0000/0000:0000:0000:0000:0000:0000:0000:0000>,
 "3000-plum-viper-yw1h0qjs.ws-us23.gitpod.io",
 /.*plum-viper-yw1h0qjs.ws-us23.gitpod.io/]
[8] pry(main)> PracticalDeveloper::Application.config.hosts.include?(Settings::General.app_domain)
=> true

# looks good with spring disabled:
gitpod /workspace/forem $ DISABLE_SPRING=1 bundle exec rails console
Loading development environment (Rails 6.1.4.3)
[1] pry(main)> ApplicationConfig.app_domain_no_port
=> "3000-plum-viper-yw1h0qjs.ws-us23.gitpod.io"
```

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Click the link in the checks section to view a gitpod workspace for this branch/pr. Confirm the browser opens to a preview of the local site, not an error page.

![Screenshot from 2021-12-16 14-24-08](https://user-images.githubusercontent.com/1237369/146444028-2825053f-13b0-46a4-b88a-9011ce046698.png)


### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: development environment infrastructure
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: apart from wishing spring would go away forever (it's off by default in rails 7, :stuck_out_tongue_winking_eye: ) there's nothing to say.


