### PR TITLE
Removing reference to CHANGELOG

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -64,10 +64,7 @@ will share this change with the people who need to know about it._
       issue template so Community Success can help update the Admin Docs
       appropriately.
 - [ ] I've updated the README or added inline documentation
-- [ ] I've added an entry to
-      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
-- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
-      or in a [forem.dev](http://forem.dev) post
+- [ ] I will share this change in a [forem.dev](http://forem.dev) post
 - [ ] I will share this change internally with the appropriate teams
 - [ ] I'm not sure how best to communicate this change and need help
 - [ ] This change does not need to be communicated, and this is why not: _please

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-## 2021-07-23
-
-Initial versioned release


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Documentation Update

## Description

Given that the CHANGELOG file had one entry from 2021-07-23, it seems
that we are not at a place where we are feeding that file.

This commit, partially a point of discussion, is to remove that file and
references in the pull request process.

## Related Tickets & Documents

None

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: documentation update

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: documentation update.
