### PR TITLE
Disallow null user agent and obsolete browser

### DIFF
--- a/config/fastly/snippets/bad_bot_detection.vcl
+++ b/config/fastly/snippets/bad_bot_detection.vcl
@@ -1,7 +1,8 @@
 sub vcl_recv {
   # Disallow bot traffic based on user-agent
   if (
-    req.http.user-agent ~ "^$"
+    req.http.user-agent ~ "^$" # Disallow empty User-Agent
+    || req.http.user-agent !~ "." # Disallow null User-Agent
     || req.http.user-agent ~ "^Java"
     || req.http.user-agent ~ "^Jakarta"
     || req.http.user-agent ~ "IDBot"
@@ -39,6 +40,9 @@ sub vcl_recv {
     # Spoofed user agent, Firefox 62 was released in Sep 2018, this line added
     # in Dec 2021.
     || (req.http.user-agent ~ "Firefox/62.0" && req.http.user-agent ~ "Win64")
+    # Spoofed user agent, Chrome 74 was released in April 2019, this line added
+    # in Dec 2021.
+    || req.http.user-agent ~ "Chrome/74"
     # DEV gets an order of magnitude more traffic from AhrefsBot than any other
     # search crawler.
     || req.http.user-agent ~ "AhrefsBot"


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] MOAR BOTS
- [x] OKAY STOP BOTS

## Description

We were previously disallowing empty user agents, but we weren't blocking requests where the User-Agent header wasn't set at all. This commit blocks those requests.

This commit also blocks Chrome 74. It's a 2.5-year-old version of an evergreen browser that releases every 6 weeks, so this is clearly a bot spoofing this header.

## Added/updated tests?

- [x] No, and this is why: Fastly config gets tested in prod. I've already tested this with a temporary experimental rule in DEV's Fastly config.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

