### PR TITLE
Remove profile when banish

### DIFF
--- a/app/services/users/delete_activity.rb
+++ b/app/services/users/delete_activity.rb
@@ -47,6 +47,10 @@ module Users
       user.organization_memberships.delete_all
       user.profile_pins.delete_all
       user.profile.update(summary: "", location: "", website_url: "", data: {})
+      user.github_username = ""
+      user.twitter_username = ""
+      user.facebook_username = ""
+      user.save
     end
   end
 end

--- a/app/services/users/delete_activity.rb
+++ b/app/services/users/delete_activity.rb
@@ -46,6 +46,7 @@ module Users
       user.credits.delete_all
       user.organization_memberships.delete_all
       user.profile_pins.delete_all
+      user.profile.update(summary: "", location: "", website_url: "", data: {})
     end
   end
 end

--- a/spec/services/moderator/banish_user_spec.rb
+++ b/spec/services/moderator/banish_user_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe Moderator::BanishUser, type: :service do
     expect(user.profile.location).to be_blank
     expect(user.profile.website_url).to be_blank
     expect(user.profile.data).to be_empty
+    expect(user.github_username).to be_blank
+    expect(user.twitter_username).to be_blank
+    expect(user.facebook_username).to be_blank
   end
 
   it "removes all their articles" do

--- a/spec/services/moderator/banish_user_spec.rb
+++ b/spec/services/moderator/banish_user_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe Moderator::BanishUser, type: :service do
     expect(user.username).to include "spam_"
   end
 
+  it "clears their profile" do
+    sidekiq_perform_enqueued_jobs do
+      described_class.call(user: user, admin: admin)
+    end
+    expect(user.profile.summary).to be_blank
+    expect(user.profile.location).to be_blank
+    expect(user.profile.website_url).to be_blank
+    expect(user.profile.data).to be_empty
+  end
+
   it "removes all their articles" do
     create(:article, user: user, published: true)
     sidekiq_perform_enqueued_jobs


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a bug where we don't clear an account's `profile` properly when banishing. This fixes that.

## Related Tickets & Documents
https://github.com/forem/internalCommunity/issues/127

## QA Instructions, Screenshots, Recordings
1. Edit a user's profile via /settings or in console:
```ruby
User.first.profile.update(summary: "blahblah blah", website_url: "www.spam.com")
```
2. banish the user via /admin/users/:id/edit
3. See that the user profile is properly cleared

### UI accessibility concerns?
Nope

## Added/updated tests?

- [x] Yes

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![A dachshund runs in slow motion toward the camera!!!](https://media.giphy.com/media/26DN3US3zaEJ5WZtC/giphy-downsized-large.gif)
