### PR TITLE
Escape periods and display the group name properly

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -12,6 +12,6 @@ module AdminHelper
   end
 
   def dom_safe_name(group_name)
-    group_name.gsub(/\s+|\./, "_")
+    group_name.gsub(/\s+|\./, "_").gsub(/\A(\d)/, '_\1')
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -10,4 +10,8 @@ module AdminHelper
   def display_name(group_name)
     group_name.to_s.tr("_", " ").titleize
   end
+
+  def dom_safe_name(group_name)
+    group_name.gsub(/\s+|\./, "_")
+  end
 end

--- a/app/views/admin/profile_fields/_add_profile_field_modal.html.erb
+++ b/app/views/admin/profile_fields/_add_profile_field_modal.html.erb
@@ -1,16 +1,16 @@
-<span data-controller="modal" data-modal-root-selector-value="#add-<%= escaped_group_name %>-profile-field-modal-root" data-modal-content-selector-value="#add-<%= escaped_group_name %>-profile-field-modal" data-modal-title-value="Add Profile Field" data-modal-size-value="s" class="mx-1">
+<span data-controller="modal" data-modal-root-selector-value="#add-<%= dom_safe_name %>-profile-field-modal-root" data-modal-content-selector-value="#add-<%= dom_safe_name %>-profile-field-modal" data-modal-title-value="Add Profile Field" data-modal-size-value="s" class="mx-1">
   <button data-action="modal#toggleModal" class="crayons-btn">
     Add Field
   </button>
 
-  <div id="add-<%= escaped_group_name %>-profile-field-modal" class="hidden">
+  <div id="add-<%= dom_safe_name %>-profile-field-modal" class="hidden">
     <div class="form-group grid p-6 mb-6 gap-1">
       <%= form_for [:admin, ProfileField.new] do |form| %>
-        <%= render "profile_field_form", form: form, group: group, group_name: escaped_group_name %>
+        <%= render "profile_field_form", form: form, group: group, group_name: dom_safe_name %>
         <%= form.submit class: "btn btn-primary" %>
       <% end %>
     </div>
   </div>
 
-  <div id="add-<%= escaped_group_name %>-profile-field-modal-root"></div>
+  <div id="add-<%= dom_safe_name %>-profile-field-modal-root"></div>
 </span>

--- a/app/views/admin/profile_fields/_add_profile_field_modal.html.erb
+++ b/app/views/admin/profile_fields/_add_profile_field_modal.html.erb
@@ -1,16 +1,16 @@
-<span data-controller="modal" data-modal-root-selector-value="#add-<%= group_name %>-profile-field-modal-root" data-modal-content-selector-value="#add-<%= group_name %>-profile-field-modal" data-modal-title-value="Add Profile Field" data-modal-size-value="s" class="mx-1">
+<span data-controller="modal" data-modal-root-selector-value="#add-<%= escaped_group_name %>-profile-field-modal-root" data-modal-content-selector-value="#add-<%= escaped_group_name %>-profile-field-modal" data-modal-title-value="Add Profile Field" data-modal-size-value="s" class="mx-1">
   <button data-action="modal#toggleModal" class="crayons-btn">
     Add Field
   </button>
 
-  <div id="add-<%= group_name %>-profile-field-modal" class="hidden">
+  <div id="add-<%= escaped_group_name %>-profile-field-modal" class="hidden">
     <div class="form-group grid p-6 mb-6 gap-1">
       <%= form_for [:admin, ProfileField.new] do |form| %>
-        <%= render "profile_field_form", form: form, group: group, group_name: group_name %>
+        <%= render "profile_field_form", form: form, group: group, group_name: escaped_group_name %>
         <%= form.submit class: "btn btn-primary" %>
       <% end %>
     </div>
   </div>
 
-  <div id="add-<%= group_name %>-profile-field-modal-root"></div>
+  <div id="add-<%= escaped_group_name %>-profile-field-modal-root"></div>
 </span>

--- a/app/views/admin/profile_fields/_edit_group_modal.html.erb
+++ b/app/views/admin/profile_fields/_edit_group_modal.html.erb
@@ -1,9 +1,9 @@
-<span data-controller="modal" data-modal-root-selector-value="#edit-group-<%= group_name %>-modal-root" data-modal-content-selector-value="#edit-group-<%= group_name %>-modal" data-modal-title-value="Edit Group <%= group_name %>" data-modal-size-value="s" class="mx-1">
+<span data-controller="modal" data-modal-root-selector-value="#edit-group-<%= escaped_group_name %>-modal-root" data-modal-content-selector-value="#edit-group-<%= escaped_group_name %>-modal" data-modal-title-value="Edit Group <%= group.name %>" data-modal-size-value="s" class="mx-1">
   <button data-action="modal#toggleModal" class="crayons-btn crayons-btn--secondary">
     Edit group
   </button>
 
-  <div id="edit-group-<%= group_name %>-modal" class="hidden">
+  <div id="edit-group-<%= escaped_group_name %>-modal" class="hidden">
     <div class="form-group grid p-6 mb-6 gap-1">
       <%= form_for [:admin, group] do |form| %>
         <div class="form-group">
@@ -19,5 +19,5 @@
     </div>
   </div>
 
-  <div id="edit-group-<%= group_name %>-modal-root"></div>
+  <div id="edit-group-<%= escaped_group_name %>-modal-root"></div>
 </span>

--- a/app/views/admin/profile_fields/_edit_group_modal.html.erb
+++ b/app/views/admin/profile_fields/_edit_group_modal.html.erb
@@ -1,9 +1,9 @@
-<span data-controller="modal" data-modal-root-selector-value="#edit-group-<%= escaped_group_name %>-modal-root" data-modal-content-selector-value="#edit-group-<%= escaped_group_name %>-modal" data-modal-title-value="Edit Group <%= group.name %>" data-modal-size-value="s" class="mx-1">
+<span data-controller="modal" data-modal-root-selector-value="#edit-group-<%= dom_safe_name %>-modal-root" data-modal-content-selector-value="#edit-group-<%= dom_safe_name %>-modal" data-modal-title-value="Edit Group <%= group.name %>" data-modal-size-value="s" class="mx-1">
   <button data-action="modal#toggleModal" class="crayons-btn crayons-btn--secondary">
     Edit group
   </button>
 
-  <div id="edit-group-<%= escaped_group_name %>-modal" class="hidden">
+  <div id="edit-group-<%= dom_safe_name %>-modal" class="hidden">
     <div class="form-group grid p-6 mb-6 gap-1">
       <%= form_for [:admin, group] do |form| %>
         <div class="form-group">
@@ -19,5 +19,5 @@
     </div>
   </div>
 
-  <div id="edit-group-<%= escaped_group_name %>-modal-root"></div>
+  <div id="edit-group-<%= dom_safe_name %>-modal-root"></div>
 </span>

--- a/app/views/admin/profile_fields/_grouped_profile_fields.html.erb
+++ b/app/views/admin/profile_fields/_grouped_profile_fields.html.erb
@@ -1,10 +1,10 @@
 <% @grouped_profile_fields.each do |group| %>
-  <% group_name = group.name.gsub(/\s+/, "_") %>
+  <% escaped_group_name = group.name.gsub(/\s+|\./, "_") %>
   <article id="profile-field-group-<%= group.id %>" class="row my-3">
     <div class="card w-100">
       <div class="card-header">
         <div class="card-header__information">
-          <div class="fw-bold fs-l"><%= group_name %></div>
+          <div class="fw-bold fs-l"><%= group.name %></div>
           <div class="fw-bold fs-s">&nbsp;(<%= group.profile_fields.length %>)</div>
           <% if group.description %>
             <div class="fs-s group__description"><%= group.description %></div>
@@ -12,17 +12,17 @@
         </div>
 
         <div class="card-header__actions">
-          <%= render partial: "add_profile_field_modal", locals: { group: group, group_name: group_name } %>
-          <%= render partial: "edit_group_modal", locals: { group: group, group_name: group_name } %>
+          <%= render partial: "add_profile_field_modal", locals: { group: group, escaped_group_name: escaped_group_name } %>
+          <%= render partial: "edit_group_modal", locals: { group: group, escaped_group_name: escaped_group_name } %>
           <%= button_to "Delete Group", admin_profile_field_group_path(group), data: { confirm: "Are you sure?" }, method: :delete, class: "crayons-btn crayons-btn--danger mx-1" %>
-          <button id="<%= group_name %>Header" data-toggle="collapse" class="crayons-btn crayons-btn--secondary mx-1"
-                  data-target="#<%= group_name %>BodyContainer" aria-expanded="false" aria-controls="<%= group_name %>BodyContainer">
+          <button id="<%= escaped_group_name %>Header" data-toggle="collapse" class="crayons-btn crayons-btn--secondary mx-1"
+                  data-target="#<%= escaped_group_name %>BodyContainer" aria-expanded="false" aria-controls="<%= escaped_group_name %>BodyContainer">
             Toggle
           </button>
         </div>
       </div>
 
-      <div id="<%= group_name %>BodyContainer" class="collapse hide p-3" aria-labelledby="<%= group_name %>Header">
+      <div id="<%= escaped_group_name %>BodyContainer" class="collapse hide p-3" aria-labelledby="<%= escaped_group_name %>Header">
         <% if group.profile_fields.empty? %>
           <div> There are no profile fields configured for this group. </div>
         <% else %>

--- a/app/views/admin/profile_fields/_grouped_profile_fields.html.erb
+++ b/app/views/admin/profile_fields/_grouped_profile_fields.html.erb
@@ -1,5 +1,4 @@
 <% @grouped_profile_fields.each do |group| %>
-  <% escaped_group_name = group.name.gsub(/\s+|\./, "_") %>
   <article id="profile-field-group-<%= group.id %>" class="row my-3">
     <div class="card w-100">
       <div class="card-header">
@@ -12,17 +11,17 @@
         </div>
 
         <div class="card-header__actions">
-          <%= render partial: "add_profile_field_modal", locals: { group: group, escaped_group_name: escaped_group_name } %>
-          <%= render partial: "edit_group_modal", locals: { group: group, escaped_group_name: escaped_group_name } %>
+          <%= render partial: "add_profile_field_modal", locals: { group: group, dom_safe_name: dom_safe_name(group.name) } %>
+          <%= render partial: "edit_group_modal", locals: { group: group, dom_safe_name: dom_safe_name(group.name) } %>
           <%= button_to "Delete Group", admin_profile_field_group_path(group), data: { confirm: "Are you sure?" }, method: :delete, class: "crayons-btn crayons-btn--danger mx-1" %>
-          <button id="<%= escaped_group_name %>Header" data-toggle="collapse" class="crayons-btn crayons-btn--secondary mx-1"
-                  data-target="#<%= escaped_group_name %>BodyContainer" aria-expanded="false" aria-controls="<%= escaped_group_name %>BodyContainer">
+          <button id="<%= dom_safe_name(group.name) %>Header" data-toggle="collapse" class="crayons-btn crayons-btn--secondary mx-1"
+                  data-target="#<%= dom_safe_name(group.name) %>BodyContainer" aria-expanded="false" aria-controls="<%= dom_safe_name(group.name) %>BodyContainer">
             Toggle
           </button>
         </div>
       </div>
 
-      <div id="<%= escaped_group_name %>BodyContainer" class="collapse hide p-3" aria-labelledby="<%= escaped_group_name %>Header">
+      <div id="<%= dom_safe_name(group.name) %>BodyContainer" class="collapse hide p-3" aria-labelledby="<%= dom_safe_name(group.name) %>Header">
         <% if group.profile_fields.empty? %>
           <div> There are no profile fields configured for this group. </div>
         <% else %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a bug where using a period `.` causes some issues with `document.querySelector`, and therefore prevents the buttons from being used when an admin has made a profile field group with a period. For example, a `ProfileFieldGroup` with a `name` of `1. Favorites` will break the buttons, because the HTML IDs that are passed along in the view are not escaped. 

In lieu of trying to escape periods (and any other non-DOM friendly characters), I decided to go with a quicker fix of converting any periods to underscores so that we avoid any problems here. The original intention of using a `profile_field_group.name` of `1. Favorites` was to order them (right now they are alphabetically ordered). Ordering will probably be a feature in the future, so for now the quick fix seems like the right call.

## Related Tickets & Documents
https://forem-team.slack.com/archives/CAA200SH5/p1639764999158700

## QA Instructions, Screenshots, Recordings
1. Enable profile fields in the feature flag: http://localhost:3000/admin/feature_flags
2. Make a profile field group with a name of `1. Favorites` or something similar
3. See that the buttons still work (edit, add, toggle -- bug did not affect destroy)
4. See that the name is displayed appropriately (spaces are still present and not substituted with underscores)

### UI accessibility concerns?
Don't think so!

## Added/updated tests?

- [x] No, and this is why: quick fix that we want deployed sooner rather than later

## [optional] Are there any post deployment tasks we need to perform?
Deploy to Forem Cloud