### PR TITLE
Add comment notification test to Cypress, including a11y improvements to notification page

### DIFF
--- a/app/assets/javascripts/initializers/initNotifications.js
+++ b/app/assets/javascripts/initializers/initNotifications.js
@@ -70,6 +70,8 @@ function initReactions() {
 
       for (var i = 0; i < butts.length; i++) {
         var butt = butts[i];
+        butt.setAttribute('aria-pressed', butt.classList.contains('reacted'));
+
         butt.onclick = function (event) {
           event.preventDefault();
           sendHapticMessage('medium');
@@ -79,8 +81,10 @@ function initReactions() {
           function successCb(response) {
             if (response.result === 'create') {
               thisButt.classList.add('reacted');
+              thisButt.setAttribute('aria-pressed', true);
             } else {
               thisButt.classList.remove('reacted');
+              thisButt.setAttribute('aria-pressed', false);
             }
           }
 

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -68,6 +68,9 @@
     <%= render "articles/fitvids" %>
   </main>
   <%= javascript_packs_with_chunks_tag "followButtons", defer: true %>
+  <script>
+    <%== RunkitTag.script %>
+  </script>
 <% else %>
   <%= render "devise/registrations/registration_form" %>
 <% end %>

--- a/app/views/notifications/shared/_comment_box.html.erb
+++ b/app/views/notifications/shared/_comment_box.html.erb
@@ -40,23 +40,24 @@
             data-reactable-id="<%= json_data["comment"]["id"] %>"
             data-category="like"
             data-reactable-type="Comment"
+            aria-label="<%= t("views.reactions.like.aria_label") %>"
             title="heart">
-            <%= inline_svg_tag("small-heart.svg", aria: true, class: "crayons-icon reaction-icon not-reacted", title: t("views.comments.footer.heart.icon")) %>
-            <%= inline_svg_tag("small-heart-filled.svg", aria: true, class: "crayons-icon reaction-icon--like reaction-icon reacted", title: t("views.comments.footer.heart.icon")) %>
+            <%= inline_svg_tag("small-heart.svg", aria_hidden: true, class: "crayons-icon reaction-icon not-reacted", title: t("views.comments.footer.heart.icon")) %>
+            <%= inline_svg_tag("small-heart-filled.svg", aria_hidden: true, class: "crayons-icon reaction-icon--like reaction-icon reacted", title: t("views.comments.footer.heart.icon")) %>
             <span class="hidden m:inline-block"><%= t("views.comments.footer.heart.text") %></span>
           </button>
 
           <% cache "comment-box-comment-reply-#{@last_user_comment}-#{json_data['comment']['updated_at']}-#{json_data['comment']['id']}" do %>
             <% reply = Comment.select(:id, :user_id, :ancestry).find_by(id: json_data["comment"]["id"])&.children&.find_by(user_id: current_user.id) %>
             <% if reply %>
-              <a class="crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon-left mr-1 inline-flex reaction-comment reacted" href="<%= reply.path %>">
-                <%= inline_svg_tag("small-comment-filled.svg", aria: true, class: "crayons-icon reaction-icon--comment reaction-icon reacted", title: t("views.comments.footer.reply.icon")) %>
+              <a class="crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon-left mr-1 inline-flex reaction-comment reacted" href="<%= reply.path %>" aria-label="<%= t("views.comments.footer.reply.done") %>">
+                <%= inline_svg_tag("small-comment-filled.svg", aria_hidden: true, class: "crayons-icon reaction-icon--comment reaction-icon reacted", title: t("views.comments.footer.reply.icon")) %>
                 <span class="hidden m:inline-block"><%= t("views.comments.footer.reply.done") %></span>
               </a>
             <% else %>
-              <a class="crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon-left toggle-reply-form mr-1 inline-flex" data-reactable-id="<%= json_data["comment"]["id"] %>" href="#<%= json_data["comment"]["path"] %>">
-                <%= inline_svg_tag("small-comment.svg", aria: true, class: "crayons-icon reaction-icon not-reacted", title: t("views.comments.footer.reply.icon")) %>
-                <%= inline_svg_tag("small-comment-filled.svg", aria: true, class: "crayons-icon reaction-icon--comment reaction-icon reacted", title: t("views.comments.footer.reply.icon")) %>
+              <a class="crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon-left toggle-reply-form mr-1 inline-flex" data-reactable-id="<%= json_data["comment"]["id"] %>" href="#<%= json_data["comment"]["path"] %>" aria-label="<%= t("views.comments.footer.reply.text") %>">
+                <%= inline_svg_tag("small-comment.svg", aria_hidden: true, class: "crayons-icon reaction-icon not-reacted", title: t("views.comments.footer.reply.icon")) %>
+                <%= inline_svg_tag("small-comment-filled.svg", aria_hidden: true, class: "crayons-icon reaction-icon--comment reaction-icon reacted", title: t("views.comments.footer.reply.icon")) %>
                 <span class="hidden m:inline-block"><%= t("views.comments.footer.reply.text") %></span>
               </a>
             <% end %>
@@ -74,7 +75,8 @@
           <%= f.hidden_field :commentable_type, value: json_data["comment"]["commentable"]["class"]["name"] %>
 
           <%= f.hidden_field :parent_id, value: json_data["comment"]["id"] %>
-          <%= f.text_area :body_markdown, id: "comment-textarea-for-#{json_data['comment']['id']}", class: "crayons-textfield mb-2 resize-y", placeholder: t("views.comments.footer.reply.placeholder"), "aria-label": t("views.comments.footer.reply.aria_label"), onfocus: "handleFocus(event)" %>
+          <%= f.text_area :body_markdown, id: "comment-textarea-for-#{json_data['comment']['id']}", class: "comment-textarea crayons-textfield mb-2 resize-y", placeholder: t("views.comments.footer.reply.placeholder"), "aria-label": t("views.comments.footer.reply.aria_label"),
+                                          onfocus: "handleFocus(event)" %>
           <div class="actions">
             <button type="submit" class="crayons-btn comment-action-button" onclick="validateField(event)"><%= t("views.comments.write.submit") %></button>
           </div>

--- a/cypress/integration/seededFlows/notificationsFlows/commentNotifications.spec.js
+++ b/cypress/integration/seededFlows/notificationsFlows/commentNotifications.spec.js
@@ -1,0 +1,41 @@
+describe('Comment notifications', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.fixture('users/notificationsUser.json').as('user');
+
+    cy.get('@user').then((user) => {
+      cy.loginAndVisit(user, '/notifications');
+      cy.findByRole('heading', { name: 'Notifications', level: 1 });
+    });
+  });
+
+  it('Likes and unlikes a comment', () => {
+    cy.get('main').within(() => {
+      cy.findByRole('button', { name: 'Like' }).as('like');
+
+      // User can like a comment
+      cy.get('@like')
+        .should('have.attr', 'aria-pressed', 'false')
+        .click()
+        .should('have.attr', 'aria-pressed', 'true');
+
+      // User can unlike a comment
+      cy.get('@like').click().should('have.attr', 'aria-pressed', 'false');
+    });
+  });
+
+  it('Shows the comment reply form', () => {
+    cy.get('main').within(() => {
+      // Check that comment form is initially hidden
+      cy.findByRole('textbox', { name: 'Reply to a comment...' }).should(
+        'not.exist',
+      );
+
+      // Check the textbox appears and received immediate focus
+      cy.findByRole('link', { name: 'Reply' }).click();
+      cy.findByRole('textbox', { name: 'Reply to a comment...' }).should(
+        'have.focus',
+      );
+    });
+  });
+});

--- a/cypress/integration/seededFlows/notificationsFlows/commentNotifications.spec.js
+++ b/cypress/integration/seededFlows/notificationsFlows/commentNotifications.spec.js
@@ -24,7 +24,7 @@ describe('Comment notifications', () => {
     });
   });
 
-  it('Shows the comment reply form', () => {
+  it('Replies to a comment', () => {
     cy.get('main').within(() => {
       // Check that comment form is initially hidden
       cy.findByRole('textbox', { name: 'Reply to a comment...' }).should(
@@ -33,9 +33,13 @@ describe('Comment notifications', () => {
 
       // Check the textbox appears and received immediate focus
       cy.findByRole('link', { name: 'Reply' }).click();
-      cy.findByRole('textbox', { name: 'Reply to a comment...' }).should(
-        'have.focus',
-      );
+      cy.findByRole('textbox', { name: 'Reply to a comment...' })
+        .should('have.focus')
+        .type('Example reply text');
+
+      cy.findByRole('button', { name: 'Submit' }).click();
+      // Check the confirmation is displayed on the page
+      cy.findByRole('link', { name: 'Check it out' });
     });
   });
 });

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -208,8 +208,51 @@ seeder.create_if_doesnt_exist(User, "email", "notifications-user@forem.local") d
     website_url: Faker::Internet.url,
   )
 
+  # Create a follow notification to test against
   follow = admin_user.follows.create!(followable: user)
   Notification.send_new_follower_notification_without_delay(follow)
+
+  # Create an article comment notification to test against
+  seeder.create_if_doesnt_exist(Article, "slug", "notification-article-slug") do
+    markdown = <<~MARKDOWN
+      ---
+      title:  Notification article
+      published: true
+      cover_image: #{Faker::Company.logo}
+      ---
+      #{Faker::Hipster.paragraph(sentence_count: 2)}
+      #{Faker::Markdown.random}
+      #{Faker::Hipster.paragraph(sentence_count: 2)}
+    MARKDOWN
+    article = Article.create!(
+      body_markdown: markdown,
+      featured: true,
+      show_comments: true,
+      user_id: user.id,
+      slug: "notification-article-slug",
+    )
+
+    parent_comment_attributes = {
+      body_markdown: Faker::Hipster.paragraph(sentence_count: 1),
+      user_id: user.id,
+      commentable_id: article.id,
+      commentable_type: "Article"
+    }
+
+    parent_comment = Comment.create!(parent_comment_attributes)
+
+    reply_comment_attributes = {
+      body_markdown: Faker::Hipster.paragraph(sentence_count: 1),
+      user_id: admin_user.id,
+      commentable_id: article.id,
+      commentable_type: "Article",
+      parent: parent_comment
+    }
+
+    reply = Comment.create!(reply_comment_attributes)
+
+    Notification.send_new_comment_notifications_without_delay(reply)
+  end
 end
 
 ##############################################################################

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -199,6 +199,7 @@ seeder.create_if_doesnt_exist(User, "email", "notifications-user@forem.local") d
     checked_code_of_conduct: true,
     checked_terms_and_conditions: true,
   )
+
   user.notification_setting.update(
     email_comment_notifications: false,
     email_follower_notifications: false,
@@ -240,6 +241,7 @@ seeder.create_if_doesnt_exist(User, "email", "notifications-user@forem.local") d
     }
 
     parent_comment = Comment.create!(parent_comment_attributes)
+    Notification.send_new_comment_notifications_without_delay(parent_comment)
 
     reply_comment_attributes = {
       body_markdown: Faker::Hipster.paragraph(sentence_count: 1),

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -219,7 +219,6 @@ seeder.create_if_doesnt_exist(User, "email", "notifications-user@forem.local") d
       ---
       title:  Notification article
       published: true
-      cover_image: #{Faker::Company.logo}
       ---
       #{Faker::Hipster.paragraph(sentence_count: 2)}
       #{Faker::Markdown.random}

--- a/spec/system/notifications/notifications_page_spec.rb
+++ b/spec/system/notifications/notifications_page_spec.rb
@@ -25,35 +25,6 @@ RSpec.describe "Notifications page", type: :system, js: true do
     expect(page).not_to have_css("span#notifications-number", text: "1")
   end
 
-  xit "allows user to interact with replies" do
-    sidekiq_perform_enqueued_jobs do
-      article = create(:article, user: alex)
-      comment = create(:comment, commentable: article, user: alex)
-      reply = create(:comment, commentable: article, user: leslie, parent: comment)
-      Notification.send_new_comment_notifications_without_delay(reply)
-    end
-
-    visit "/notifications"
-
-    expect(page).to have_css("div.spec-notification")
-    click_button("heart")
-
-    expect(page).to have_css(".reacted")
-
-    click_link("Reply")
-
-    validate_reply(leslie.comments.first.id)
-  end
-
-  it "allows user to follow other users back" do
-    follow = leslie.follow(alex)
-    Notification.send_new_follower_notification_without_delay(follow, is_read: true)
-    visit "/notifications"
-    expect(page).to have_css("div.spec-notification")
-    click_button(I18n.t("core.follow_back"))
-    expect(page).to have_text(I18n.t("core.following"))
-  end
-
   xcontext "when user is trusted" do
     before do
       dev_user = create(:user)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In https://github.com/forem/forem/pull/15799/ we skipped some rspec tests relating to notification interactions due to flakiness. This PR moves one of those sets of tests over to Cypress, making necessary bug fixes to do that reliably.

The user-facing bugs fixed in this PR include:

- Adding the RunKit script to the notifications page. Previously, if you submitted a reply to a comment from the notifications page, an unhandled error was shown in the console where `activateRunKitTags` was not defined. Although this wasn't hugely impacting user experience, unhandled exceptions cause Cypress tests to fail, so I've fixed it by including the script on that page.
- Accessibility fixes for the accessible name of the 'like' and 'reply' controls. Previously various SVG titles were being relied on and the results weren't great
- Accessibility fixes for the liked/unliked state. This now uses `aria-pressed` the same as comments elsewhere in the app

## Related Tickets & Documents

Partially addresses https://github.com/forem/forem/issues/15800

## QA Instructions, Screenshots, Recordings

Running the app locally check:
- You can still like/unlike a comment from the notifications page
- You can reply to a comment from the notifications page
- When you click the "like"/"unlike" button, the `aria-pressed` state changes between true/false (this can be checked using the dev tools of your browser)

### UI accessibility concerns?

This PR includes some small accessibility wins as described above

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: minimal user-facing changes


