### PR TITLE
Refactoring and documenting class

### DIFF
--- a/app/services/articles/suggest_stickies.rb
+++ b/app/services/articles/suggest_stickies.rb
@@ -1,6 +1,10 @@
 module Articles
   class SuggestStickies
+    # @todo Should we make this configurable in the admin interface?
     SUGGESTION_TAGS = %w[career productivity discuss explainlikeimfive].freeze
+
+    DEFAULT_TAG_ARTICLES_LIMIT = 3
+    DEFAULT_MORE_ARTICLES_LIMIT = 7
 
     # @api public
     #
@@ -10,6 +14,12 @@ module Articles
     # @param sample_size [Integer] How many Articles in the return set?
     #
     # @return [Array<Article>] An array Article records
+    #
+    # @note The resulting array of articles will be 30% articles that
+    #       share tags with the given article, and 70% of articles
+    #       that have tags in the SUGGESTION_TAGS constant.  These
+    #       percentages are related to the DEFAULT_TAG_ARTICLES_LIMIT
+    #       and DEFAULT_MORE_ARTICLES_LIMIT.
     def self.call(article, sample_size: 3)
       new(article, sample_size: sample_size).call
     end
@@ -34,7 +44,7 @@ module Articles
 
       scope = Article
         .where("public_reactions_count > ? OR comments_count > ?", reaction_count_num, comment_count_num)
-        .limit(3)
+        .limit(DEFAULT_TAG_ARTICLES_LIMIT)
 
       apply_common_scope(scope: scope, tags: article_tags)
     end
@@ -48,7 +58,7 @@ module Articles
     def more_articles
       scope = Article
         .where("comments_count > ?", comment_count_num)
-        .limit(7)
+        .limit(DEFAULT_MORE_ARTICLES_LIMIT)
 
       apply_common_scope(scope: scope, tags: SUGGESTION_TAGS)
     end

--- a/app/services/articles/suggest_stickies.rb
+++ b/app/services/articles/suggest_stickies.rb
@@ -2,18 +2,27 @@ module Articles
   class SuggestStickies
     SUGGESTION_TAGS = %w[career productivity discuss explainlikeimfive].freeze
 
-    def self.call(article)
-      new(article).call
+    # @api public
+    #
+    # A set of suggested articles related to the given :article.
+    #
+    # @param article [ArticleDecorator]
+    # @param sample_size [Integer] How many Articles in the return set?
+    #
+    # @return [Array<Article>] An array Article records
+    def self.call(article, sample_size: 3)
+      new(article, sample_size: sample_size).call
     end
 
-    def initialize(article)
+    def initialize(article, sample_size:)
       @article = article
       @reaction_count_num = Rails.env.production? ? 15 : -1
       @comment_count_num = Rails.env.production? ? 7 : -2
+      @sample_size = sample_size
     end
 
     def call
-      (tag_articles.load + more_articles).sample(3)
+      (tag_articles + more_articles).sample(@sample_size)
     end
 
     private
@@ -23,31 +32,37 @@ module Articles
     def tag_articles
       article_tags = article.cached_tag_list_array - ["discuss"]
 
-      Article
-        .published
-        .tagged_with(article_tags, any: true).unscope(:select)
-        .limited_column_select
+      scope = Article
         .where("public_reactions_count > ? OR comments_count > ?", reaction_count_num, comment_count_num)
-        .where.not(id: article.id)
-        .where.not(user_id: article.user_id)
-        .where("featured_number > ?", 5.days.ago.to_i)
-        .order(Arel.sql("RANDOM()"))
         .limit(3)
+
+      apply_common_scope(scope: scope, tags: article_tags)
     end
 
+    # @note This previously used a `.limit(10 - tag_articles.count)`,
+    #       which meant we were running an unnecessary count query.
+    #       We also had a guard clause that said if we have more than
+    #       6 tag_articles, we should return an empty array.  However,
+    #       with the initial limit of 3 for tag articles, that guard
+    #       was unnecessary.
     def more_articles
-      return [] if tag_articles.size > 6
-
-      Article
-        .published
-        .tagged_with(SUGGESTION_TAGS, any: true).unscope(:select)
-        .limited_column_select
+      scope = Article
         .where("comments_count > ?", comment_count_num)
+        .limit(7)
+
+      apply_common_scope(scope: scope, tags: SUGGESTION_TAGS)
+    end
+
+    # A helper method to ensure a consistent lookup
+    def apply_common_scope(scope:, tags:)
+      scope.published
+        .cached_tagged_with_any(tags)
+        .unscope(:select)
+        .limited_column_select
         .where.not(id: article.id)
         .where.not(user_id: article.user_id)
         .where("featured_number > ?", 5.days.ago.to_i)
         .order(Arel.sql("RANDOM()"))
-        .limit(10 - tag_articles.size)
     end
   end
 end

--- a/spec/services/articles/suggest_stickies_spec.rb
+++ b/spec/services/articles/suggest_stickies_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe Articles::SuggestStickies, type: :services do
+  let(:article) { create(:article).decorate }
+
+  describe ".call" do
+    subject(:method_call) { described_class.call(article) }
+
+    it { is_expected.to be_a Array }
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Documentation Update

## Description

I came to this commit by looking for raw `where` method calls to the
Article object.  Originally, I was looking at `where.not(user_id: :id)`
but found this service class.

In this class, I saw some significant duplication and went with a bit of
refactoring and some documentation.

This refactoring removed some unnecessary guards and calculations (as
documented inline).

## Related Tickets & Documents

None.

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes; I mean the test is rather "Hey this results in valid SQL"

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: it's an isolated refactor and documentation update.

