### PR TITLE
Refactoring to leverage an Article scope

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -21,8 +21,7 @@ class ArticlesController < ApplicationController
                     .includes(:user)
                 else
                   @articles
-                    .featured
-                    .or(@articles.where(score: Settings::UserExperience.home_feed_minimum_score..))
+                    .with_at_least_home_feed_minimum_score
                     .includes(:user)
                 end
 

--- a/app/controllers/stories/tagged_articles_controller.rb
+++ b/app/controllers/stories/tagged_articles_controller.rb
@@ -69,7 +69,7 @@ module Stories
       elsif params[:timeframe] == Timeframe::LATEST_TIMEFRAME
         stories.where(score: -20..).order(published_at: :desc)
       else
-        stories.order(hotness_score: :desc).where(score: Settings::UserExperience.home_feed_minimum_score..)
+        stories.order(hotness_score: :desc).with_at_least_home_feed_minimum_score
       end
     end
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -298,6 +298,16 @@ class Article < ApplicationRecord
     order(column => dir.to_sym)
   }
 
+  # @note This includes the `featured` scope, which may or may not be
+  #       something we expose going forward.  However, it was
+  #       something used in two of the three queries we had that
+  #       included the where `score > Settings::UserExperience.home_feed_minimum_score`
+  scope :with_at_least_home_feed_minimum_score, lambda {
+    featured.or(
+      where(score: Settings::UserExperience.home_feed_minimum_score..),
+    )
+  }
+
   scope :featured, -> { where(featured: true) }
 
   scope :feed, lambda {

--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -85,7 +85,7 @@ module Articles
         else
           hot_stories = Article.published.limited_column_select
             .page(@page).per(@number_of_articles)
-            .where("score >= ? OR featured = ?", Settings::UserExperience.home_feed_minimum_score, true)
+            .with_at_least_home_feed_minimum_score
             .order(hotness_score: :desc)
           featured_story = featured_story_from(stories: hot_stories, must_have_main_image: must_have_main_image)
         end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

I've been looking at the queries that involve filtering articles based
on scores.  There's several places that seem to be close to consistent,
but have some nuanced difference.

This refactor consolidates one of those "almost the same" cases.

## Related Tickets & Documents

None.  Although tangentially related to Feed algorithm, as I'm trying
to wrestle with how we filter on score.

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: I extracted a scope and then used that scope.

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: This is a developer facing refactor.
