### PR TITLE
User correct username in mobile mention notifications

### DIFF
--- a/app/services/notifications/new_mention/send.rb
+++ b/app/services/notifications/new_mention/send.rb
@@ -42,7 +42,7 @@ module Notifications
           title: "🗣️ New Mention",
           body: "#{I18n.t(
             message_key,
-            user: mention.user.username,
+            user: mention.mentionable.user.username,
             title: mentionable_title, # For an article this should be title, for comment should be article's title
           )}:\n" \
               "#{strip_tags(mention.mentionable.processed_html).strip}",


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

@amywtlin reporting seeing mobile notifications that read something like "Amy mentioned you in a post": the mentionee is being listed as the author of a comment/post instead of the actual author! This PR fixes that, and adds a test to check it.

## Related Tickets & Documents

https://github.com/forem/forem/pull/15780

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] What gif best describes this PR or how it makes you feel?
![spider-man](https://user-images.githubusercontent.com/37842/147118721-19a360a3-f221-4870-b52a-d6715eab646d.gif)


