### PR TITLE
Favoring single SQL and computation over enum

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -91,12 +91,18 @@ class Tag < ActsAsTaggableOn::Tag
     self.wiki_body_html = MarkdownProcessor::Parser.new(wiki_body_markdown).evaluate_markdown
   end
 
+  # @note The following implementation echoes the past hotness score,
+  #       but favors expected values instead of random numbers for
+  #       each article (see SHA
+  #       98e97e7aa8e0fc163cd7d9b063f51f01ab10a189).
   def calculate_hotness_score
-    self.hotness_score = Article.tagged_with(name)
+    score_attributes = Article.cached_tagged_with(name)
       .where("articles.featured_number > ?", 7.days.ago.to_i)
-      .sum do |article|
-        (article.comments_count * 14) + article.score + rand(6) + ((taggings_count + 1) / 2)
-      end
+      .select("(SUM(comments_count) * 14 + SUM(score)) AS partial_score, COUNT(id) AS article_count")
+
+    self.hotness_score =
+      score_attributes[:partial_score].to_i +
+      (score_attributes[:articles_count].to_i * ((taggings_count + 6) / 2))
   end
 
   def bust_cache

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -96,13 +96,27 @@ class Tag < ActsAsTaggableOn::Tag
   #       each article (see SHA
   #       98e97e7aa8e0fc163cd7d9b063f51f01ab10a189).
   def calculate_hotness_score
+    # SELECT
+    #     (SUM(comments_count) * 14 + SUM(score)) AS partial_score,
+    #     COUNT(id) AS article_count
+    #   FROM articles
+    #   WHERE
+    #     (cached_tag_list ~ '[[:<:]]javascript[[:>:]]')
+    #     AND (articles.featured_number > 1639594999)
+    #
+    # Due to the construction of the query, there will be one entry.
+    # Furthermore, we need to first convert to an array then call
+    # `.first`.  The ActiveRecord query handler is ill-prepared to
+    # call "first" on this.
     score_attributes = Article.cached_tagged_with(name)
       .where("articles.featured_number > ?", 7.days.ago.to_i)
       .select("(SUM(comments_count) * 14 + SUM(score)) AS partial_score, COUNT(id) AS article_count")
+      .to_a
+      .first
 
     self.hotness_score =
-      score_attributes[:partial_score].to_i +
-      (score_attributes[:articles_count].to_i * ((taggings_count + 6) / 2))
+      score_attributes.partial_score.to_i +
+      (score_attributes.article_count.to_i * ((taggings_count + 6) / 2))
   end
 
   def bust_cache


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

Prior to this commit, we ran a SQL statement to generate a list of
articles then applied some minor randomization.

With this commit, I'm removing the randomization in favor of expected
values, and collapsing the result set into a single inline SQL and some
post query simple arithmatic.

Let's check my math.  For each article we sum:

* `article.score`
* `article.comments_count` * 14
* a random number between 0 and 5 (`rand(6)`) with expected value of 2.5
* the tag's (taggings_count + 1) / 2

The new SQL query sums the `article.score` and the
`article.comments_count` * 14.  I then reduce the remainder of the
equation.  From "for each article sum `(rand(5) + (taggings_count + 1) /
2)`" we have the following:

`article_count * (2.5 + (taggings_count + 1) / 2)`

Which is equivalent to:

`article_count * ((taggings_count + 1 + (2.5 * 2)) / 2)`

Which is equivalent to:

`article_count * ((taggings_count + 6) / 2)`

This change reduces computation time by favoring expected values.

## Related Tickets & Documents

None.  Though this relates to my quest to better understand the
implications of the "score".

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: existing tests cover this.

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: it's a low-level optimization.
