### PR TITLE
Remove slash characters from user name search term

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,8 +185,8 @@ class User < ApplicationRecord
   # => https://stackoverflow.com/a/11007216/4186181
   #
   scope :search_by_name_and_username, lambda { |term|
-    term = term.delete("\\") # prevents syntax error in tsquery
-    return none if term.empty?
+    term = term&.delete("\\") # prevents syntax error in tsquery
+    return none if term.blank?
 
     where(
       sanitize_sql_array(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -185,6 +185,7 @@ class User < ApplicationRecord
   # => https://stackoverflow.com/a/11007216/4186181
   #
   scope :search_by_name_and_username, lambda { |term|
+    term = term.delete("\\") # prevents syntax error in tsquery
     where(
       sanitize_sql_array(
         [

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -186,6 +186,8 @@ class User < ApplicationRecord
   #
   scope :search_by_name_and_username, lambda { |term|
     term = term.delete("\\") # prevents syntax error in tsquery
+    return none if term.empty?
+
     where(
       sanitize_sql_array(
         [

--- a/spec/services/search/username_spec.rb
+++ b/spec/services/search/username_spec.rb
@@ -80,5 +80,9 @@ RSpec.describe Search::Username, type: :service do
       expect(results.size).to eq(max_results)
       expect([alex.username, alexsmith.username]).to include(results.first[:username])
     end
+
+    it "sanitizes the input when given slashes" do
+      expect(described_class.search_documents("\\")).to eq([])
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Prevents an error when the username search term includes '\'

    PG::SyntaxError: ERROR:  syntax error in tsquery

https://app.honeybadger.io/projects/66984/faults/79391397

I had originally thought to add this cleanup to [Search::Username.search_documents](https://github.com/forem/forem/blob/main/app/services/search/username.rb#L12), but
decided to move it as close to the generated (invalid) query as
possible to prevent alternate paths finding their way here.

It was much easier to add the test case to the search service, however. 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

```ruby
string = %{"')\}
Search::Username.search_documents(string)
=> []
```

On main this raises the above error (syntax error in tsquery due to the \ character).

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: bugfix

