### PR TITLE
Favor `destroy_by` over `where.first&.destroy`

### DIFF
--- a/app/controllers/profile_pins_controller.rb
+++ b/app/controllers/profile_pins_controller.rb
@@ -18,7 +18,7 @@ class ProfilePinsController < ApplicationController
 
   def update
     # for removing pinnable
-    current_user.profile_pins.where(id: params[:id]).first&.destroy
+    current_user.profile_pins.destroy_by(id: params[:id])
     bust_user_profile
     flash[:pins_success] = "🗑 Pin removed"
     redirect_back(fallback_location: "/dashboard")

--- a/app/models/consumer_app.rb
+++ b/app/models/consumer_app.rb
@@ -51,9 +51,9 @@ class ConsumerApp < ApplicationRecord
   def clear_rpush_app
     case ConsumerApp.platforms[platform_was]
     when Device::IOS
-      Rpush::Apns2::App.destroy_by(name: app_bundle_was)
+      Rpush::Apns2::App.where(name: app_bundle_was).first&.destroy
     when Device::ANDROID
-      Rpush::Gcm::App.destroy_by(name: app_bundle_was)
+      Rpush::Gcm::App.where(name: app_bundle_was).first&.destroy
     end
 
     # This prevents the `destroy` method to return true or false in a callback

--- a/app/models/consumer_app.rb
+++ b/app/models/consumer_app.rb
@@ -51,9 +51,9 @@ class ConsumerApp < ApplicationRecord
   def clear_rpush_app
     case ConsumerApp.platforms[platform_was]
     when Device::IOS
-      Rpush::Apns2::App.where(name: app_bundle_was).first&.destroy
+      Rpush::Apns2::App.destroy_by(name: app_bundle_was)
     when Device::ANDROID
-      Rpush::Gcm::App.where(name: app_bundle_was).first&.destroy
+      Rpush::Gcm::App.destroy_by(name: app_bundle_was)
     end
 
     # This prevents the `destroy` method to return true or false in a callback


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

We can use [ActiveRecord::Relation.destroy_by][1] instead of the method
chain.

[1]:https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-destroy_by

## Related Tickets & Documents

None.

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] No, and this is why: covered by existing tests.

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why
      not: leveraging a framework method over a chain of framework
      methods.
