### PR TITLE
Fixed setting Identity#auth_data_dump in seeds and factory

### DIFF
--- a/spec/factories/identities.rb
+++ b/spec/factories/identities.rb
@@ -6,12 +6,6 @@ FactoryBot.define do
     provider { "github" }
     token { rand(100_000) }
     secret { rand(100_000) }
-    auth_data_dump do
-      {
-        "info" => {
-          "nickname" => "something"
-        }
-      }
-    end
+    auth_data_dump { OmniAuth.config.mock_auth.fetch(provider.to_sym) }
   end
 end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Identity, type: :model do
   let(:identity) { create(:identity, user: create(:user), uid: SecureRandom.hex) }
 
   describe "validations" do
+    before do
+      omniauth_mock_providers_payload
+    end
+
     describe "builtin validations" do
       subject { identity }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Fixed setting `Identity#auth_data_dump` in the seeds and the factory.
`auth_data_dump` was set to a hash in the seeds instead of an instance of `OmniAuth::AuthHash`  which caused an error
```
undefined method `info' for {"extra"=>{"raw_info"=>{"lang"=>"en"}}, "info"=>{"nickname"=>"..."}}:Hash  in Identity#email
```
 when accessing `Identity#email`:
https://github.com/forem/forem/blob/c7902a32611ab8b342e70a80112184114ba75cba/app/models/identity.rb#L47-L49
e.g. on `/settings/account` page

## QA Instructions, Screenshots, Recordings
- create a user via seeds
- log in as the user
- make sure that enabled providers are not empty (`Authentication::Providers.enabled `, `Settings::Authentication.providers `)
- visit `/settings/account` page
- the page should render successfully, and contain identity email in the `Account emails` block

## Added/updated tests?

- [x] No, and this is why: the tests for the described functionality already exist, the identity is created via `User`'s `with_identity` trait. I wrote another test for development purposes to test the `Identity` factory itself, but later decided that it's redundant because all the functionality is tested by the existing tests.

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: no logic changes
