### PR TITLE
When returning a json error, don't use a raw unescaped string

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,12 +74,12 @@ class ApplicationController < ActionController::Base
   end
 
   def not_authorized
-    render json: "Error: not authorized", status: :unauthorized
+    render json: {error: "Error: not authorized"}, status: :unauthorized
     raise NotAuthorizedError, "Unauthorized"
   end
 
   def bad_request
-    render json: "Error: Bad Request", status: :bad_request
+    render json: {error: "Error: Bad Request"}, status: :bad_request
   end
 
   def error_too_many_requests(exc)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The 400 and 401 error pages show json parsing errors in most browsers,
since "Error: Bad Request" is not a valid json body ('"Error: Bad
Request"' would be, or the object with key error and value of the
string which I've selected is _also_ valid).

In firefox I see the following (the body is parsed because the content type was set to json):

```
SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data
```

Do we have frontend code that's looking for this body before it parses
for some reason, or was this just a mistaken copying from the api
controller in the initial PRs (#2293 for not_authorized, and #6248 for
the bad_request method, which may have just replicated the decision
for not_authorized)? I think in 2293 an api method was added to the 
application controller, which was subsequently added to the api controller, 
and may not be needed.

Reasonable alternatives here would be to `render :plain` or to pass just 
the string `'"Error: Bad Request"'`

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

I added this line to the beginning of app/views/articles/show.html.erb

`<% raise ArgumentError, "oops!" %>`

And visited an article's page locally.

![parsed json](https://user-images.githubusercontent.com/1237369/147490581-d52dd7a5-bec1-44ff-9ebb-e2db697b7100.png)
![raw error](https://user-images.githubusercontent.com/1237369/147490636-2e01eb77-53da-4be2-af9d-6c61518f3f3a.png)


On main, I see a different behavior

![syntax error](https://user-images.githubusercontent.com/1237369/147490600-80cc4234-afb2-4794-999f-1e739bd01a37.png)

![raw string body](https://user-images.githubusercontent.com/1237369/147490622-45dae215-0390-4f10-902c-c4a8613b7954.png)


### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: bugfix
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
