### PR TITLE
Mock omniauth payload before creating identities

### DIFF
--- a/spec/requests/admin/users_manage_spec.rb
+++ b/spec/requests/admin/users_manage_spec.rb
@@ -109,6 +109,8 @@ RSpec.describe "Admin::Users", type: :request do
     end
 
     it "merges an identity on a single account into the other" do
+      omniauth_mock_twitter_payload
+      omniauth_mock_github_payload
       create(:identity, user: user, provider: "twitter")
       deleted_user_identity = create(:identity, user: user2)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Mock omniauth payload before creating identities.
This pr is created to fix the build of the main branch after merging #15874
I plan to refactor the code so that we wouldn't have to mock the payload explicitly before using `Identity` factory each time.

## Related Tickets & Documents
#15874