### PR TITLE
Update trusted user welcome email copy with Discord link

### DIFF
--- a/app/views/mailers/notify_mailer/trusted_role_email.html.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.html.erb
@@ -19,6 +19,11 @@
   <b>For details on all available features and how to access them, visit our <a href="<%= app_url("/community-moderation") %>"><%= community_name %> Trusted User Guide</a>.</b>
 </p>
 <p>
+  Also, we hope that you'll use <a href="https://discord.com/invite/f5ARW5gxES">this link</a> to join our moderator chat channels on DEV Discord!
+  Once inside, visit the #mod-verification channel and drop a link to your DEV profile so we can verify which set of privileges you have (<a href="<%= app_url("/community-moderation") %>">Trusted User</a>
+  and/or <a href="<%= app_url("/tag-moderation") %>">Tag Moderator</a>) and invite you to the correct moderator channels. We hope to see you there! 😀
+</p>
+<p>
   You may occasionally receive notifications about optional moderation actions; please <a href="<%= app_url(user_settings_path(:notifications)) %>">unsubscribe</a> if you do not want to receive these updates.
 </p>
 <p>

--- a/app/views/mailers/notify_mailer/trusted_role_email.html.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.html.erb
@@ -18,11 +18,13 @@
 <p>
   <b>For details on all available features and how to access them, visit our <a href="<%= app_url("/community-moderation") %>"><%= community_name %> Trusted User Guide</a>.</b>
 </p>
-<p>
-  Also, we hope that you'll use <a href="https://discord.com/invite/f5ARW5gxES">this link</a> to join our moderator chat channels on DEV Discord!
-  Once inside, visit the #mod-verification channel and drop a link to your DEV profile so we can verify which set of privileges you have (<a href="<%= app_url("/community-moderation") %>">Trusted User</a>
-  and/or <a href="<%= app_url("/tag-moderation") %>">Tag Moderator</a>) and invite you to the correct moderator channels. We hope to see you there! 😀
-</p>
+<% if ForemInstance.dev_to? %>
+  <p>
+    Also, we hope that you'll use <a href="https://discord.com/invite/f5ARW5gxES">this link</a> to join our moderator chat channels on DEV Discord!
+    Once inside, visit the #mod-verification channel and drop a link to your DEV profile so we can verify which set of privileges you have (<a href="<%= app_url("/community-moderation") %>">Trusted User</a>
+    and/or <a href="<%= app_url("/tag-moderation") %>">Tag Moderator</a>) and invite you to the correct moderator channels. We hope to see you there! 😀
+  </p>
+<% end %>
 <p>
   You may occasionally receive notifications about optional moderation actions; please <a href="<%= app_url(user_settings_path(:notifications)) %>">unsubscribe</a> if you do not want to receive these updates.
 </p>

--- a/app/views/mailers/notify_mailer/trusted_role_email.text.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.text.erb
@@ -10,9 +10,11 @@ Here's an overview of your new abilities:
 - Quickly flag rule-breaking behavior with 🤢 to <%= community_name %> staff
 - Rate the experience level of a post
 
+<% if ForemInstance.dev_to? %>
   Also, we hope that you'll use this link (https://discord.com/invite/f5ARW5gxES) to join our moderator chat channels on DEV Discord!
   Once inside, visit the #mod-verification channel and drop a link to your DEV profile so we can verify which set of privileges you have (Trusted User [<%= app_url("/community-moderation") %>]
   and/or Tag Moderator [<%= app_url("/tag-moderation") %>]) and invite you to the correct moderator channels. We hope to see you there! 😀
+<% end %>
 
 You may occasionally receive notifications about optional moderation actions; please unsubscribe (<%= app_url(user_settings_path(:notifications)) %>) if you do not want to receive these updates.
 

--- a/app/views/mailers/notify_mailer/trusted_role_email.text.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.text.erb
@@ -10,6 +10,8 @@ Here's an overview of your new abilities:
 - Quickly flag rule-breaking behavior with 🤢 to <%= community_name %> staff
 - Rate the experience level of a post
 
+For details on all available features and how to access them, visit our <%= community_name %> Trusted User Guide: <%= app_url("/community-moderation") %>
+
 <% if ForemInstance.dev_to? %>
   Also, we hope that you'll use this link (https://discord.com/invite/f5ARW5gxES) to join our moderator chat channels on DEV Discord!
   Once inside, visit the #mod-verification channel and drop a link to your DEV profile so we can verify which set of privileges you have (Trusted User [<%= app_url("/community-moderation") %>]

--- a/app/views/mailers/notify_mailer/trusted_role_email.text.erb
+++ b/app/views/mailers/notify_mailer/trusted_role_email.text.erb
@@ -10,9 +10,11 @@ Here's an overview of your new abilities:
 - Quickly flag rule-breaking behavior with 🤢 to <%= community_name %> staff
 - Rate the experience level of a post
 
-You may occasionally receive notifications about optional moderation actions; please unsubscribe (<%= app_url(user_settings_path(:notifications)) %>) if you do not want to receive these updates.
+  Also, we hope that you'll use this link (https://discord.com/invite/f5ARW5gxES) to join our moderator chat channels on DEV Discord!
+  Once inside, visit the #mod-verification channel and drop a link to your DEV profile so we can verify which set of privileges you have (Trusted User [<%= app_url("/community-moderation") %>]
+  and/or Tag Moderator [<%= app_url("/tag-moderation") %>]) and invite you to the correct moderator channels. We hope to see you there! 😀
 
-For details on all available features and how to access them, visit our <%= community_name %> Trusted User Guide: <%= app_url("/community-moderation") %>
+You may occasionally receive notifications about optional moderation actions; please unsubscribe (<%= app_url(user_settings_path(:notifications)) %>) if you do not want to receive these updates.
 
 If you have any questions or feedback for us, please write to <%= ForemInstance.email %> and share your thoughts.
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Documentation Update

## Description
This adds new copy with an invitation link to our moderators' Discord.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
Preview the two links here to see if they look consistent with the copy from https://github.com/forem/internalCommunity/issues/248:
http://localhost:3000/rails/mailers/notify_mailer/trusted_role_email.html?locale=en
http://localhost:3000/rails/mailers/notify_mailer/trusted_role_email.txt?locale=en

## [optional] What gif best describes this PR or how it makes you feel?

![A lawyer shows two documents to the judge.](https://media.giphy.com/media/UyPpKZScnl7na/giphy.gif)
