### PR TITLE
Periodic Digest Email frequency should be in days

### DIFF
--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -48,14 +48,13 @@ class EmailDigestArticleCollector
   private
 
   def should_receive_email?
-    return true unless last_email_sent_at
+    return true unless last_email_sent
 
-    # Has it been at least x days since @user received an email?
-    last_email_sent_at < Settings::General.periodic_email_digest.days.ago
+    last_email_sent.before? Settings::General.periodic_email_digest.days.ago
   end
 
-  def last_email_sent_at
-    @last_email_sent_at ||=
+  def last_email_sent
+    @last_email_sent ||=
       @user.email_messages
         .where(mailer: "DigestMailer#digest_email")
         .maximum(:sent_at)
@@ -63,9 +62,9 @@ class EmailDigestArticleCollector
 
   def cutoff_date
     a_few_days_ago = 4.days.ago.utc
-    return a_few_days_ago unless last_email_sent_at
+    return a_few_days_ago unless last_email_sent
 
-    [a_few_days_ago, last_email_sent_at].max
+    [a_few_days_ago, last_email_sent].max
   end
 
   def user_has_followings?

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -51,7 +51,7 @@ class EmailDigestArticleCollector
     return true unless last_email_sent_at
 
     # Has it been at least x days since @user received an email?
-    Time.current - last_email_sent_at >= Settings::General.periodic_email_digest.days
+    last_email_sent_at < Settings::General.periodic_email_digest.days.ago
   end
 
   def last_email_sent_at

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -51,7 +51,7 @@ class EmailDigestArticleCollector
     return true unless last_email_sent_at
 
     # Has it been at least x days since @user received an email?
-    Time.current - last_email_sent_at >= Settings::General.periodic_email_digest
+    Time.current - last_email_sent_at >= Settings::General.periodic_email_digest.days
   end
 
   def last_email_sent_at

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -55,7 +55,10 @@ class EmailDigestArticleCollector
   end
 
   def last_email_sent_at
-    last_user_emails.last&.sent_at
+    @last_email_sent_at ||=
+      @user.email_messages
+        .where(mailer: "DigestMailer#digest_email")
+        .maximum(:sent_at)
   end
 
   def cutoff_date
@@ -69,9 +72,5 @@ class EmailDigestArticleCollector
     @user.following_users_count.positive? ||
       @user.cached_followed_tag_names.any? ||
       @user.cached_antifollowed_tag_names.any?
-  end
-
-  def last_user_emails
-    @last_user_emails ||= @user.email_messages.select(:sent_at).where(mailer: "DigestMailer#digest_email").limit(10)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We're sometimes sending digest emails to users without respecting their frequency preferences.

At first I thought the was tied to not sorting the 10 messages we sampled to compare (it might be, but I doubt it), and then I tried testing it and found that `should_send_email?` was true when the only message was sent even just a few seconds earlier. The setting for periodic email frequency is an integer, and we were comparing it to a difference between two timestamps (in seconds) - so anything farther apart than a default 2 seconds qualified for resending articles.

~Cast the setting to days prior to comparing `(now - last_time) > setting` to ensure we're not doing this more than we intended to.~

Compare the last time an email was sent to a timestamp a few days ago (based on the setting) to determine whether it's time to send the digest email. 

## Related Tickets & Documents

fixes https://github.com/forem/forem/issues/10940

https://github.com/forem/forem/pull/10107 (where I think the issue was introduced)

## QA Instructions, Screenshots, Recordings

```ruby
user = User.first
EmailMessage.create(user: user, mailer: "DigestMailer#digest_email", sent_at: 2.hours.ago)
collector = EmailDigestArticleCollector.new(user)
collector.send(:should_receive_email?)
```

This is expected to be false (2 hours is less than the default 2 days).

```ruby
collector.articles_to_send()
```

This is expected to be empty.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: I probably should.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
