### PR TITLE
Remove sign in/up link from navlinks

### DIFF
--- a/app/views/layouts/_main_nav.html.erb
+++ b/app/views/layouts/_main_nav.html.erb
@@ -9,14 +9,6 @@
         <%= t("views.main.home") %>
       </a>
     </li>
-    <li>
-      <% unless user_signed_in? %>
-        <a href="<%= sign_up_path %>" class="c-link c-link--block c-link--icon-left fw-bold">
-          <%= inline_svg_tag("twemoji/handshake.svg", class: "crayons-icon crayons-icon--default c-link__icon", aria_hidden: true) %>
-          <%= t("views.main.signup") %>
-        </a>
-      <% end %>
-    </li>
     <% default_nav_links.each do |link| %>
       <%= render "layouts/sidebar_nav_link", link: link %>
     <% end %>

--- a/config/locales/views/main/en.yml
+++ b/config/locales/views/main/en.yml
@@ -69,4 +69,3 @@ en:
       home: Home
       create_post: Create Post
       signout: Sign Out
-      signup: Sign In/Up

--- a/config/locales/views/main/fr.yml
+++ b/config/locales/views/main/fr.yml
@@ -69,4 +69,3 @@ fr:
       home: Page D'Accueil
       create_post: Créer une publication
       signout: Se déconnecter
-      signup: Sign In/Up

--- a/spec/system/homepage/user_visits_homepage_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe "User visits a homepage", type: :system do
         visit "/"
 
         within("#main-navigation", match: :first) do
-          expect(page).to have_selector(".default-navigation-links li:nth-child(3)", text: "Shop")
-          expect(page).to have_selector(".default-navigation-links li:nth-child(4)", text: "Mock")
+          expect(page).to have_selector(".default-navigation-links li:nth-child(2)", text: "Shop")
+          expect(page).to have_selector(".default-navigation-links li:nth-child(3)", text: "Mock")
         end
       end
     end
@@ -220,7 +220,7 @@ RSpec.describe "User visits a homepage", type: :system do
 
       it "shows link when display_only_when_signed_in is true" do
         within("#main-navigation", match: :first) do
-          expect(page).to have_selector(".default-navigation-links li:nth-child(4)", text: "Beauty")
+          expect(page).to have_selector(".default-navigation-links li:nth-child(3)", text: "Beauty")
         end
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR removes the hardcoded "Sign In/Up" link from the left-hand nav menu. So far we only displayed this for non-logged in users which is redudant with the bigger CTA right above:

![image](https://user-images.githubusercontent.com/47985/147905557-f61c36f8-22fb-4960-b07b-3b3f969ef752.png)

## Related Tickets & Documents

Closes #15921 15921

## QA Instructions, Screenshots, Recordings

The link should be gone

### UI accessibility concerns?

None

## Added/updated tests?

- [X] No, and this is why: this wasn't covered by any tests

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: I think this is a small enough change to not need an announcement or specific communication.