### PR TITLE
Send custom user agent string when fetching feeds

### DIFF
--- a/app/services/feeds/import.rb
+++ b/app/services/feeds/import.rb
@@ -71,7 +71,9 @@ module Feeds
         next if cleaned_url.blank?
 
         response = ForemStatsClient.time("feeds::import::fetch_feed", tags: ["user_id:#{user_id}", "url:#{url}"]) do
-          HTTParty.get(cleaned_url, timeout: 10)
+          HTTParty.get(cleaned_url,
+                       timeout: 10,
+                       headers: { "User-Agent" => "Forem Feeds Import" })
         end
 
         [user_id, response.body]

--- a/app/services/feeds/import.rb
+++ b/app/services/feeds/import.rb
@@ -73,7 +73,7 @@ module Feeds
         response = ForemStatsClient.time("feeds::import::fetch_feed", tags: ["user_id:#{user_id}", "url:#{url}"]) do
           HTTParty.get(cleaned_url,
                        timeout: 10,
-                       headers: { "User-Agent" => "Forem Feeds Import" })
+                       headers: { "User-Agent" => "Forem Feeds Importer" })
         end
 
         [user_id, response.body]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

dev.to blocks access to the feeds for user agent "Ruby"

Use "Forem Feeds Import" as alternate user agent when fetching feeds.

## Related Tickets & Documents

fixes https://github.com/forem/forem/issues/15939

## QA Instructions, Screenshots, Recordings

```ruby
url = "https://dev.to/feed/vickilanger"
HTTParty.get(url, timeout: 10, headers: { "User-agent" => "Forem Feeds Import" })
```

on main the request uses no user agent header, Net::HTTP's default "Ruby" is sent, and we block that in the fastly bad bot detection - gives a 403 response.

on this branch, the custom user agent is permitted (and descriptive), we get a 200 status with xml body.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: nothing to test?
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: bugfix
