### PR TITLE
Add faraday 1.8.0 before deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ before_install:
     /etc/postgresql/12/main/pg_hba.conf
   - sudo service postgresql@12-main restart
   - gem install bundler:"<2.3"
+  - gem install faraday:"<2.0"
 install:
   - date --rfc-3339=seconds
   - nvm install


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Travis's dpl tool is including faraday 2.0 which doesn't work well after https://github.com/lostisland/faraday/pull/1354

Can we install faraday here before installing dpl and make this work?



## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

I have no clue how to test this? Maybe debugging the deploy job (that has lots of bad implications w.r.t secrets like the deploy key, I'm hesitant to do that). 

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: deployment infrastructure only
