### PR TITLE
Work around travis deploy (take two)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ before_install:
     /etc/postgresql/12/main/pg_hba.conf
   - sudo service postgresql@12-main restart
   - gem install bundler:"<2.3"
+  - gem install faraday:"<2.0"
 install:
   - date --rfc-3339=seconds
   - nvm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ before_install:
     /etc/postgresql/12/main/pg_hba.conf
   - sudo service postgresql@12-main restart
   - gem install bundler:"<2.3"
-  - gem install faraday:"<2.0"
 install:
   - date --rfc-3339=seconds
   - nvm install
@@ -133,7 +132,8 @@ jobs:
     - stage: Deploy
       name: Deploy DEV
       if: type != pull_request
-      install: skip
+      install:
+        -  rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install faraday:"<2.0" dpl
       script: skip
       after_script: skip
       deploy:
@@ -146,7 +146,8 @@ jobs:
     - stage: Deploy
       name: Deploy BenHalpern
       if: type != pull_request
-      install: skip
+      install:
+        -  rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install faraday:"<2.0" dpl
       script: skip
       after_script: skip
       deploy:


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The [last PR]( https://github.com/forem/forem/pull/15951 ) installed faraday 1.8.0 in _our_ ruby (3.0) but travis's internal ruby is 2.7 and didn't install the gem before calling dpl.

Explicitly (in the deploy stages) install this package (and dpl, why not) before deploying to heroku.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Deploy succeeds? 

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: deploy success is the only test
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: infrastructure
