### PR TITLE
Stop removing canvas files from CI build cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ cache:
   bundler: true
   directories:
     - node_modules
-before_cache:
-  - find node_modules -type f -name "*.node" -delete
 rvm:
   - 3.0.2
 addons:


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This was part of the node 16 upgrade and is no longer helpful - occassionally restoring node modules from cache is resulting in a string of failures where canvas is not available to the frontend tests.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: test infrastructure
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: test infrastructure configuration
