### PR TITLE
Require UnifiedEmbed Tag for UnifiedEmbed Registry

### DIFF
--- a/app/liquid_tags/unified_embed.rb
+++ b/app/liquid_tags/unified_embed.rb
@@ -1,3 +1,5 @@
+require_relative "./unified_embed/tag"
+
 # A namespacing module to help organize the concepts of embedding.
 module UnifiedEmbed
   # A convenience method for registering tags as part of the


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The deploy of [this PR](https://github.com/forem/forem/pull/15911) broke the use of the `embed` keyword in UnifiedEmbeds in the UI. Upon saving a unified embed of the form `{% embed <url-being-embeded> %}`, the error `Liquid syntax error: Unknown tag 'embed'` was generated.
This PR fixes the above by requiring the `UnfiedEmbed::Tag` for the UnifiedEmbed Registry.

## Related Tickets & Documents
None

## QA Instructions, Screenshots, Recordings

Create a post with a Youtube embed like so: `{% embed https://youtu.be/DDWKuo3gXMQ %}`. It should render correctly.

### UI accessibility concerns?
None

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: _previous tests covered the touched files_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: _fixing an internal bug_

## [optional] Are there any post deployment tasks we need to perform?
None

![Michael Jackson closeup singing Beat It](https://media.giphy.com/media/3o7bu1d6h3RiGnuNwY/giphy-downsized.gif)
