### PR TITLE
Stop removing canvas before yarn during bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -22,15 +22,6 @@ FileUtils.chdir APP_ROOT do
 
   system! "gem list \"^foreman$\" -i --silent || gem install foreman"
 
-  # TODO: temporary fix for node 16 upgrade, remove after release as this triggers reinstallation
-  # of the canvas library (with its extension compiled against the versioned node symbol)
-  if File.exist?("node_modules/canvas/")
-    FileUtils.rm_rf("node_modules/canvas/")
-    # having removed the module ourselves,
-    # we need to coerce yarn, or remove the .yarn-integrity file
-    system("yarn install --check-files")
-  end
-
   # Install JavaScript dependencies if using Yarn
   system("bin/yarn")
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We had added a forceful removal of a compiled package (canvas) during the setup step to ease the node 16 transition.

This is safe to remove (as it causes canvas to be reinstalled every time setup is called). 

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Run bin/setup twice. Yarn should do nothing (install no packages) the second time.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: developer infrastructure change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

I'll add this to the github discussion @cmgorton opened about the node update.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
