### PR TITLE
Skip google analytics when ga_tracking_id is nil

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -117,7 +117,7 @@ HONEYCOMB_API_KEY=""
 
 # Google analytics
 # (https://developers.google.com/analytics/devguides/reporting/core/v4)
-GA_TRACKING_ID="Optional"
+# GA_TRACKING_ID="Optional"
 
 # Mailchimp for mails
 # (https://mailchimp.com/developer/)

--- a/.env_sample
+++ b/.env_sample
@@ -117,7 +117,8 @@ HONEYCOMB_API_KEY=""
 
 # Google analytics
 # (https://developers.google.com/analytics/devguides/reporting/core/v4)
-# GA_TRACKING_ID="Optional"
+# When blank don't render Google Analytics.
+GA_TRACKING_ID=""
 
 # Mailchimp for mails
 # (https://mailchimp.com/developer/)

--- a/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
+++ b/app/assets/javascripts/initializers/initializeBaseTracking.js.erb
@@ -2,28 +2,30 @@ function initializeBaseTracking() {
   var wait = 0;
   var addedGA = false;
   var gaTrackingCode = document.body.dataset.gaTracking;
-  var waitingOnGA = setInterval(function() {
-    if (!addedGA) {
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    }
-    addedGA = true;
-    wait++;
-    if (window.ga && ga.create) {
-      ga('create', gaTrackingCode, 'auto');
-      ga('set', 'anonymizeIp', true);
-      ga('send', 'pageview', location.pathname + location.search);
-      clearInterval(waitingOnGA);
-    }
-    if (wait > 85) {
-      clearInterval(waitingOnGA);
-      fallbackActivityRecording();
-    }
-  }, 25);
-  eventListening();
-  trackCustomImpressions();
+  if (gaTrackingCode) {
+    var waitingOnGA = setInterval(function() {
+      if (!addedGA) {
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                                 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      }
+      addedGA = true;
+      wait++;
+      if (window.ga && ga.create) {
+        ga('create', gaTrackingCode, 'auto');
+        ga('set', 'anonymizeIp', true);
+        ga('send', 'pageview', location.pathname + location.search);
+        clearInterval(waitingOnGA);
+      }
+      if (wait > 85) {
+        clearInterval(waitingOnGA);
+        fallbackActivityRecording();
+      }
+    }, 25);
+    eventListening();
+    trackCustomImpressions();
+  }
 }
 
 function fallbackActivityRecording() {

--- a/app/controllers/ga_events_controller.rb
+++ b/app/controllers/ga_events_controller.rb
@@ -6,24 +6,26 @@ class GaEventsController < ApplicationController
   # IP is scrambled as to not be persisted to limit fingerprinting abilities on our end.
 
   def create
-    json = JSON.parse(request.raw_post)
-    user_id = user_signed_in? ? current_user.id : nil
-    client_id = "#{scrambled_ip[0..12]}_#{json['user_agent']}_#{user_id}"
-    tracker = Staccato.tracker(Settings::General.ga_tracking_id, client_id)
-    tracker.pageview(
-      path: json["path"],
-      user_id: user_id,
-      user_language: json["user_language"],
-      referrer: (json["referrer"] if json["referrer"] && !json["referrer"].start_with?(app_url)),
-      user_agent: json["user_agent"],
-      viewport_size: json["viewport_size"],
-      screen_resolution: json["screen_resolution"],
-      document_title: json["document_title"],
-      document_encoding: json["document_encoding"],
-      document_path: json["document_path"],
-      cache_buster: rand(100_000_000_000).to_s,
-      data_source: "web",
-    )
+    if Settings::General.ga_tracking_id.present?
+      json = JSON.parse(request.raw_post)
+      user_id = user_signed_in? ? current_user.id : nil
+      client_id = "#{scrambled_ip[0..12]}_#{json['user_agent']}_#{user_id}"
+      tracker = Staccato.tracker(Settings::General.ga_tracking_id, client_id)
+      tracker.pageview(
+        path: json["path"],
+        user_id: user_id,
+        user_language: json["user_language"],
+        referrer: (json["referrer"] if json["referrer"] && !json["referrer"].start_with?(app_url)),
+        user_agent: json["user_agent"],
+        viewport_size: json["viewport_size"],
+        screen_resolution: json["screen_resolution"],
+        document_title: json["document_title"],
+        document_encoding: json["document_encoding"],
+        document_path: json["document_path"],
+        cache_buster: rand(100_000_000_000).to_s,
+        data_source: "web",
+      )
+    end
     render body: nil
   end
 

--- a/app/views/pages/badge.html.erb
+++ b/app/views/pages/badge.html.erb
@@ -103,24 +103,26 @@
         }
       }
     </script>
-    <script>
-      (function (i, s, o, g, r, a, m) {
-        i['GoogleAnalyticsObject'] = r;
-        i[r] = i[r] || function () {
-          (i[r].q = i[r].q || []).push(arguments)
-        }, i[r].l = 1 * new Date();
-        a = s.createElement(o),
+    <% if Settings::General.ga_tracking_id %>
+      <script>
+        (function (i, s, o, g, r, a, m) {
+          i['GoogleAnalyticsObject'] = r;
+          i[r] = i[r] || function () {
+            (i[r].q = i[r].q || []).push(arguments)
+          }, i[r].l = 1 * new Date();
+          a = s.createElement(o),
           m = s.getElementsByTagName(o)[0];
-        a.async = 1;
-        a.src = g;
-        m.parentNode.insertBefore(a, m)
-      })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+          a.async = 1;
+          a.src = g;
+          m.parentNode.insertBefore(a, m)
+        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-      ga('create', '<%= Settings::General.ga_tracking_id %>', 'auto');
-      ga('set', 'anonymizeIp', true);
-      ga('send', 'pageview');
-      ga('send', 'event', 'view', '/badge version impression', '<%= @html_variant.name %>', null);
-    </script>
+        ga('create', '<%= Settings::General.ga_tracking_id %>', 'auto');
+        ga('set', 'anonymizeIp', true);
+        ga('send', 'pageview');
+        ga('send', 'event', 'view', '/badge version impression', '<%= @html_variant.name %>', null);
+      </script>
+    <% end %>
   <% end %>
 </body>
 </html>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This commit involves short-circuiting Google Analytics calls when the
Forem has not configured a `Settings::General.ga_tracking_id`.  Note,
depending on your local `.env` file (or configured ENV variables) you
may have a `GA_TRACKING_ID` value set; I did, it was set to "Optional"
which overrode the database setting.

We set the HTML data properites in two places: [admin.html.erb][1] and
[application.html.erb][2].

In addition, I'm short-circuiting the local fallback analytics call (via
[Stacato][https://github.com/tpitale/staccato]).  My understanding of
Stacato, based on a cursory read, requires a Google Analytics Tracking
ID to work.

And last, we have a one off of javascript for Google Analytics tracking.

[1]:https://github.com/forem/forem/blob/528bd2baa608292f3e603c7a7587832a46cc791a/app/views/layouts/admin.html.erb#L31
[2]:https://github.com/forem/forem/blob/528bd2baa608292f3e603c7a7587832a46cc791a/app/views/layouts/application.html.erb#L55

## Related Tickets & Documents

This closes #15962.

## QA Instructions, Screenshots, Recordings

- Check your .env file to see if you have set GA_TRACKING_ID.  If so,
  unset it.
- Start with a fresh Forem instance.

- Open your browser and open the developer tools to inspect the Network
  activity.
- Open the homepage of your local Forem instance (http://localhost:3000)
- Filter your Network results for analytics.  You shouldn't see any.

Also, make sure you're disabling any blockers you might have as that
influences things.

## Added/updated tests?

- [x] No, and this is why: I'm uncertain the value of the test.
- [x] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
