### PR TITLE
Remove Faraday work-around for deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,8 +131,7 @@ jobs:
     - stage: Deploy
       name: Deploy DEV
       if: type != pull_request
-      install:
-        -  rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install faraday:"<2.0" dpl
+      install: skip
       script: skip
       after_script: skip
       deploy:
@@ -145,8 +144,7 @@ jobs:
     - stage: Deploy
       name: Deploy BenHalpern
       if: type != pull_request
-      install:
-        -  rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install faraday:"<2.0" dpl
+      install: skip
       script: skip
       after_script: skip
       deploy:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

[Faraday 2.0.1](https://github.com/lostisland/faraday/releases/tag/v2.0.1) 
re-introduces the default adapter (net_http), which
makes the prior work around (installing faraday 1.8 prior to
installing dpl, preventing it from bringing in 2.0.0 as the current
release).

There's currently a related dependency [issue](https://app.travis-ci.com/github/forem/forem/jobs/554550408) where a circular
dependency between dpl, faraday, and faraday-patron was causing deploy
failures (faraday-patron requiring faraday 2.0.x but we had
specified otherwise).

Remove the temporary shim to enable travis heroku deploys, and let
their team manage that.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

This is a change to the deploy stage. I'm not sure how to test this without... deploying?

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: deployment infrastructure/config
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

## [optional] What gif best describes this PR or how it makes you feel?

![ralphie](https://user-images.githubusercontent.com/1237369/148416658-84aa9c9a-3f62-4c66-b5d3-53251f632c89.gif)
