### PR TITLE
Fixes a name conflict in Rpush models

### DIFF
--- a/app/models/consumer_app.rb
+++ b/app/models/consumer_app.rb
@@ -49,11 +49,12 @@ class ConsumerApp < ApplicationRecord
   # [@forem/backend] `.where().first` is necessary because we use Redis data storage
   # https://github.com/rpush/rpush/wiki/Using-Redis#find_by_name-cannot-be-used-in-rpush-redis
   def clear_rpush_app
+    app_name = "#{app_bundle_was}.#{platform}"
     case ConsumerApp.platforms[platform_was]
     when Device::IOS
-      Rpush::Apns2::App.where(name: "#{app_bundle_was}.#{platform}").first&.destroy
+      Rpush::Apns2::App.where(name: app_name).first&.destroy
     when Device::ANDROID
-      Rpush::Gcm::App.where(name: "#{app_bundle_was}.#{platform}").first&.destroy
+      Rpush::Gcm::App.where(name: app_name).first&.destroy
     end
 
     # This prevents the `destroy` method to return true or false in a callback

--- a/app/models/consumer_app.rb
+++ b/app/models/consumer_app.rb
@@ -51,9 +51,9 @@ class ConsumerApp < ApplicationRecord
   def clear_rpush_app
     case ConsumerApp.platforms[platform_was]
     when Device::IOS
-      Rpush::Apns2::App.where(name: app_bundle_was).first&.destroy
+      Rpush::Apns2::App.where(name: "#{app_bundle_was}.#{platform}").first&.destroy
     when Device::ANDROID
-      Rpush::Gcm::App.where(name: app_bundle_was).first&.destroy
+      Rpush::Gcm::App.where(name: "#{app_bundle_was}.#{platform}").first&.destroy
     end
 
     # This prevents the `destroy` method to return true or false in a callback

--- a/app/queries/consumer_apps/rpush_app_query.rb
+++ b/app/queries/consumer_apps/rpush_app_query.rb
@@ -7,7 +7,7 @@ module ConsumerApps
     def initialize(app_bundle:, platform:)
       @app_bundle = app_bundle
       @platform = platform
-      @app_name ||= "#{app_bundle}.#{platform}"
+      @app_name = "#{app_bundle}.#{platform}"
 
       @consumer_app = ConsumerApps::FindOrCreateByQuery.call(
         app_bundle: @app_bundle,

--- a/app/queries/consumer_apps/rpush_app_query.rb
+++ b/app/queries/consumer_apps/rpush_app_query.rb
@@ -7,6 +7,7 @@ module ConsumerApps
     def initialize(app_bundle:, platform:)
       @app_bundle = app_bundle
       @platform = platform
+      @app_name ||= "#{app_bundle}.#{platform}"
 
       @consumer_app = ConsumerApps::FindOrCreateByQuery.call(
         app_bundle: @app_bundle,
@@ -16,24 +17,24 @@ module ConsumerApps
 
     def call
       if consumer_app.android?
-        android_app = Rpush::Gcm::App.where(name: app_bundle).first
+        android_app = Rpush::Gcm::App.where(name: app_name).first
         android_app || recreate_android_app!
       elsif consumer_app.ios?
-        ios_app = Rpush::Apns2::App.where(name: app_bundle).first
+        ios_app = Rpush::Apns2::App.where(name: app_name).first
         ios_app || recreate_ios_app!
       end
     end
 
     private
 
-    attr_reader :app_bundle, :consumer_app
+    attr_reader :app_bundle, :platform, :app_name, :consumer_app
 
     def recreate_ios_app!
       # If the ConsumerApp doesn't have credentials there's no need to create it
       return if consumer_app.auth_credentials.blank?
 
       app = Rpush::Apns2::App.new
-      app.name = app_bundle
+      app.name = app_name
       app.certificate = consumer_app.auth_credentials.to_s.gsub("\\n", "\n")
       app.environment = Rails.env
       app.password = ""
@@ -48,7 +49,7 @@ module ConsumerApps
       return if consumer_app.auth_credentials.blank?
 
       app = Rpush::Gcm::App.new
-      app.name = app_bundle
+      app.name = app_name
       app.auth_key = consumer_app.auth_credentials.to_s
       app.connections = 1
       app.save!

--- a/app/queries/consumer_apps/rpush_app_query.rb
+++ b/app/queries/consumer_apps/rpush_app_query.rb
@@ -27,7 +27,7 @@ module ConsumerApps
 
     private
 
-    attr_reader :app_bundle, :platform, :app_name, :consumer_app
+    attr_reader :app_bundle, :app_name, :consumer_app, :platform
 
     def recreate_ios_app!
       # If the ConsumerApp doesn't have credentials there's no need to create it

--- a/spec/queries/consumer_apps/rpush_app_query_spec.rb
+++ b/spec/queries/consumer_apps/rpush_app_query_spec.rb
@@ -1,19 +1,22 @@
 require "rails_helper"
 
 RSpec.describe ConsumerApps::RpushAppQuery, type: :query do
-  let(:consumer_app) do
+  let(:ios_consumer_app) do
     ConsumerApps::FindOrCreateByQuery.call(app_bundle: ConsumerApp::FOREM_BUNDLE, platform: :ios)
+  end
+  let(:android_consumer_app) do
+    ConsumerApps::FindOrCreateByQuery.call(app_bundle: ConsumerApp::FOREM_BUNDLE, platform: :android)
   end
 
   describe "Rpush app" do
     it "is recreated after updating a ConsumerApp" do
-      mock_rpush(consumer_app)
+      mock_rpush(ios_consumer_app)
 
       # Fetch rpush app associated to the target
-      rpush_app = described_class.call(app_bundle: consumer_app.app_bundle, platform: :ios)
+      rpush_app = described_class.call(app_bundle: ios_consumer_app.app_bundle, platform: :ios)
 
       expect(rpush_app).to be_instance_of(Rpush::Apns2::App)
-      expect(rpush_app.name).to eq(consumer_app.app_bundle)
+      expect(rpush_app.name).to eq(ios_consumer_app.app_bundle)
     end
 
     it "returns nil if ConsumerApp is not operational" do
@@ -25,6 +28,24 @@ RSpec.describe ConsumerApps::RpushAppQuery, type: :query do
 
       expect(bad_consumer_app.operational?).to be false
       expect(rpush_app).to be_nil
+    end
+
+    it "works when ConsumerApps have the same bundle but different platform" do
+      # This is a regression test to avoid conflicting `name` in either
+      # Rpush::Apns2::App or Rpush::Gcm::App to break the app
+      allow(ApplicationConfig).to receive(:[]).with("RPUSH_IOS_PEM").and_return("asdf123")
+      allow(ApplicationConfig).to receive(:[]).with("RPUSH_FCM_KEY").and_return("asdf123")
+
+      mock_rpush(ios_consumer_app)
+      mock_rpush(android_consumer_app)
+
+      # Fetch rpush app associated to the target
+      ios_rpush_app = described_class.call(app_bundle: ios_consumer_app.app_bundle, platform: :ios)
+      expect(ios_rpush_app).to be_instance_of(Rpush::Apns2::App)
+
+      # Fetch rpush app associated to the target
+      android_rpush_app = described_class.call(app_bundle: android_consumer_app.app_bundle, platform: :android)
+      expect(android_rpush_app).to be_instance_of(Rpush::Gcm::App)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

[Rpush models are stored in Redis](https://developers.forem.com/backend/push-notifications#rpush-implementation) and we started running into a problem where we couldn't fetch Android Rpush app models (`Rpush::Apns2::App` or `Rpush::Gcm::App`). This started happening after some time of having the Android mobile app in closed beta.

The cause of the error was a conflict in the `name` attribute of the Rpush app models. Since they use Redis storage and not postgres these models rely on different ways to query them. Since the introduction of Android support there was now a case where `app_bundle` was the same for two different `ConsumerApp`s, and this conflict caused the issue reported.

## Related Tickets & Documents

#15959

## QA Instructions, Screenshots, Recordings

This is a tricky one to QA. A quick way to try this out locally would be:

1. Boot app locally
   - Make sure to include `RPUSH_IOS_PEM` and `RPUSH_FCM_KEY` to your `.env` file
   - I think this ^ will work with garbage values (i.e. `asdf123`) what we're testing locally isn't the delivery itself but could be wrong (let me know if you need more help in trying this out)
2.  Boot up the console `bundle exec rails c`
    - `ConsumerApps::RpushAppQuery.call(app_bundle: 'com.forem.app', platform: 'ios')` should return the iOS Redis model
    - `ConsumerApps::RpushAppQuery.call(app_bundle: 'com.forem.app', platform: 'android')` should return the Android Redis model

### UI accessibility concerns?

None - Backend fix

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![you. me. same.](https://media.giphy.com/media/ukCFEU6Cg5MCCDoaVN/giphy-downsized-large.gif)
