### PR TITLE
Remove extra faraday install from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ before_install:
     /etc/postgresql/12/main/pg_hba.conf
   - sudo service postgresql@12-main restart
   - gem install bundler:"<2.3"
-  - gem install faraday:"<2.0"
 install:
   - date --rfc-3339=seconds
   - nvm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,8 +131,7 @@ jobs:
     - stage: Deploy
       name: Deploy DEV
       if: type != pull_request
-      install:
-        -  rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install faraday:"<2.0" dpl
+      install: skip
       script: skip
       after_script: skip
       deploy:
@@ -145,8 +144,7 @@ jobs:
     - stage: Deploy
       name: Deploy BenHalpern
       if: type != pull_request
-      install:
-        -  rvm $(travis_internal_ruby) --fuzzy do ruby -S gem install faraday:"<2.0" dpl
+      install: skip
       script: skip
       after_script: skip
       deploy:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This was an initial attempt at the work-around used yesterday. It was unsuccessful (since the faraday gem installed on _our_ version of ruby, but the conflict was happening in travis's internal ruby used for deployment).

This is safe to remove, since it's not needed, and we'll be uselessly installing a gem during each test build.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] No, and this is why: test config only

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: test config/dead code elimination

