### PR TITLE
Fix goal conversion field test typo

### DIFF
--- a/app/workers/users/record_field_test_event_worker.rb
+++ b/app/workers/users/record_field_test_event_worker.rb
@@ -27,7 +27,7 @@ module Users
         when "user_creates_comment" # comments goal. Only page views and comments are currently active.
           field_test_converted(@experiment, participant: @user, goal: goal) # base single comment goal.
           comment_goal(7.days.ago, "DATE(created_at)", 4,
-                       "user_creates_comment_on_at_lest_four_different_days_within_a_week")
+                       "user_creates_comment_on_at_least_four_different_days_within_a_week")
         else
           field_test_converted(@experiment, participant: @user, goal: goal) # base single comment goal.
         end
@@ -46,7 +46,7 @@ module Users
     end
 
     def comment_goal(time_start, group_value, min_count, goal_name)
-      comment_counts = @user.comments.where("created_at > ?", time_start)
+      comment_counts = User.first.comments.where("created_at > ?", time_start)
         .group(group_value).count.values
       comment_counts.delete(0)
       return unless comment_counts.size >= min_count

--- a/app/workers/users/record_field_test_event_worker.rb
+++ b/app/workers/users/record_field_test_event_worker.rb
@@ -46,7 +46,7 @@ module Users
     end
 
     def comment_goal(time_start, group_value, min_count, goal_name)
-      comment_counts = User.first.comments.where("created_at > ?", time_start)
+      comment_counts = @user.comments.where("created_at > ?", time_start)
         .group(group_value).count.values
       comment_counts.delete(0)
       return unless comment_counts.size >= min_count

--- a/spec/workers/users/record_field_test_event_worker_spec.rb
+++ b/spec/workers/users/record_field_test_event_worker_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe Users::RecordFieldTestEventWorker, type: :worker do
         expect(FieldTest::Event.last.name).to eq("user_creates_comment")
       end
 
-      it "records user_creates_comment_on_at_lest_four_different_days_within_a_week field test conversion if qualifies" do
+      it "records user_creates_comment_on_at_least_four_different_days_within_a_week field test conversion if qualifies" do
         7.times do |n|
           create(:comment, user_id: user.id, created_at: n.days.ago)
         end
         worker.perform(user.id, "user_creates_comment")
         expect(FieldTest::Event.last.field_test_membership.participant_id).to eq(user.id.to_s)
-        expect(FieldTest::Event.last.name).to eq("user_creates_comment_on_at_lest_four_different_days_within_a_week")
+        expect(FieldTest::Event.last.name).to eq("user_creates_comment_on_at_least_four_different_days_within_a_week")
       end
 
       it "records user_views_pages_on_at_least_four_different_days_within_a_week field test conversion if qualifies" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is the "hardest" goal to reach, but I didn't think it made sense for _no_ conversions yet, especially since I knew at least my own account should have converted. So I found this typo which created the mismatch between the config and the code. Dutifully the tests also included the same typo 😅

## Related Tickets & Documents

Introduced here: https://github.com/forem/forem/pull/15789/files#diff-c604816b4c652e5a874508ece2d282d0dd9fdaa10deb66a45401e1536d278b65R30

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

Not a great public-facing concern — but a note will be made in this test period's retro.

## [optional] Are there any post deployment tasks we need to perform?

I am going to manually modify the name of the converted `FieldTest::Events` to sync things back up as they should once this is shipped. I don't think this needs a data update script, this is very much a one-off concern that would work itself out for next time.

