### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      # Ignoring binding_of_caller 1.0 temporarily until we find a solution for it breaking Docker
-      # see <https://github.com/forem/forem/issues/12068>
-      - dependency-name: "binding_of_caller"
-        versions: [">= 1.0"]
     labels: []
 
   # Set update schedule for Yarn/NPM
@@ -21,6 +16,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Ignoring the update to 4.x for now as it involves a lot of manual work
+      - dependency-name: "webpack-dev-server"
+        versions: ["4.x"]
     labels: []
 
   # Set update schedule for GitHub Actions


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Developer experience

## Description

This PR updates `.github/dependabot.yml` for two reasons:

1. We were ignoring a Ruby dependency (`binding-of-caller`) that no longer exists since our move to Ruby 3 a while ago.
2. I added an ignore for the update to `webpack-dev-server` as the update process from 3.x to 4.x is very manual (see #14630) and we don't have the capacity for it right now.