### PR TITLE
Proposing feed experiment 3: More comment count weight

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -35,14 +35,20 @@ module Stories
     end
 
     def signed_in_base_feed
-      strategy = AbExperiment.get(experiment: :feed_strategy_round_2, controller: self, user: current_user,
-                                  default_value: "original")
-      feed = if strategy.weighted_query_strategy?
-               Articles::Feeds::WeightedQueryStrategy.new(user: current_user, page: @page, tags: params[:tag])
-             elsif Settings::UserExperience.feed_strategy == "basic"
+      feed = if Settings::UserExperience.feed_strategy == "basic"
                Articles::Feeds::Basic.new(user: current_user, page: @page, tag: params[:tag])
              else
-               Articles::Feeds::LargeForemExperimental.new(user: current_user, page: @page, tag: params[:tag])
+               strategy = AbExperiment.get(
+                 experiment: :feed_strategy_round_2,
+                 controller: self, user: current_user,
+                 default_value: "original"
+                )
+               Articles::Feeds::WeightedQueryStrategy.new(
+                 user: current_user,
+                 page: @page,
+                 tags: params[:tag],
+                 strategy: strategy,
+               )
              end
       Datadog.tracer.trace("feed.query",
                            span_type: "db",

--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -39,9 +39,9 @@ module Stories
                Articles::Feeds::Basic.new(user: current_user, page: @page, tag: params[:tag])
              else
                strategy = AbExperiment.get(
-                 experiment: :feed_strategy_round_2,
+                 experiment: :feed_strategy_round_3,
                  controller: self, user: current_user,
-                 default_value: "original"
+                 default_value: AbExperiment::ORIGINAL_VARIANT
                )
                Articles::Feeds::WeightedQueryStrategy.new(
                  user: current_user,
@@ -64,8 +64,8 @@ module Stories
     end
 
     def signed_out_base_feed
-      strategy = AbExperiment.get(experiment: :feed_strategy_round_2, controller: self, user: current_user,
-                                  default_value: "original")
+      strategy = AbExperiment.get(experiment: :feed_strategy_round_3, controller: self, user: current_user,
+                                  default_value: AbExperiment::ORIGINAL_VARIANT)
       feed = if strategy.weighted_query_strategy?
                Articles::Feeds::WeightedQueryStrategy.new(user: current_user, page: @page, tags: params[:tag])
              elsif Settings::UserExperience.feed_strategy == "basic"

--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -42,7 +42,7 @@ module Stories
                  experiment: :feed_strategy_round_2,
                  controller: self, user: current_user,
                  default_value: "original"
-                )
+               )
                Articles::Feeds::WeightedQueryStrategy.new(
                  user: current_user,
                  page: @page,

--- a/app/models/ab_experiment.rb
+++ b/app/models/ab_experiment.rb
@@ -11,11 +11,13 @@ class AbExperiment < SimpleDelegator
   # public
   private_class_method :new
 
+  ORIGINAL_VARIANT = "original".freeze
+
   # Sometimes we might want to repurpose the same AbExperiment logic
   # for different experiments.  This provides the tooling for that
   # exact thing.
   EXPERIMENT_TO_METHOD_NAME_MAP = {
-    feed_strategy_round_2: :feed_strategy
+    feed_strategy_round_3: :feed_strategy
   }.freeze
 
   # This method helps us leverage existing methods for different

--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -266,7 +266,7 @@ module Articles
       #
       # @todo I envision that we will tweak the factors we choose, so
       #   those will likely need some kind of structured consideration.
-      def initialize(user: nil, number_of_articles: 50, page: 1, tag: nil, strategy: "original", **config)
+      def initialize(user: nil, number_of_articles: 50, page: 1, tag: nil, strategy: AbExperiment::ORIGINAL_VARIANT, **config)
         @user = user
         @number_of_articles = number_of_articles.to_i
         @page = (page || 1).to_i
@@ -612,8 +612,8 @@ module Articles
       end
 
       def inject_config_ab_test(valid_method_name, scoring_config)
-        # Change a value if the strategy is not original
-        return scoring_config unless valid_method_name == :comments_count_factor && @strategy != "original"
+        return scoring_config unless valid_method_name == :comments_count_factor # Only proceed on this one factor
+        return scoring_config if @strategy == AbExperiment::ORIGINAL_VARIANT # Don't proceed if not testing new strategy
 
         # Rewards comment count with slightly more weight up to 10 comments.
         # Testing two case weights beyond what we currently have

--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -265,12 +265,13 @@ module Articles
       #
       # @todo I envision that we will tweak the factors we choose, so
       #   those will likely need some kind of structured consideration.
-      def initialize(user: nil, number_of_articles: 50, page: 1, tag: nil, **config)
+      def initialize(user: nil, number_of_articles: 50, page: 1, tag: nil, strategy: "original", **config)
         @user = user
         @number_of_articles = number_of_articles.to_i
         @page = (page || 1).to_i
         # TODO: The tag parameter is vestigial, there's no logic around this value.
         @tag = tag
+        @strategy = strategy
         @default_user_experience_level = config.fetch(:default_user_experience_level) { DEFAULT_USER_EXPERIENCE_LEVEL }
         @negative_reaction_threshold = config.fetch(:negative_reaction_threshold, DEFAULT_NEGATIVE_REACTION_THRESHOLD)
         @positive_reaction_threshold = config.fetch(:positive_reaction_threshold, DEFAULT_POSITIVE_REACTION_THRESHOLD)

--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -616,7 +616,12 @@ module Articles
         return scoring_config unless valid_method_name == :comments_count_factor && @strategy != "original"
 
         # Rewards comment count with slightly more weight up to 10 comments.
-        scoring_config[:cases] = (0..9).map { |n| [n, 0.8 + (n / 50.0)] }
+        # Testing two case weights beyond what we currently have
+        scoring_config[:cases] = if @strategy == "slightly_more_comments_count_case_weight"
+                                   (0..9).map { |n| [n, 0.8 + (n / 50.0)] }
+                                 else # much_more_comments_count_case_weight
+                                   (0..19).map { |n| [n, 0.6 + (n / 50.0)] }
+                                 end
         scoring_config
       end
 

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -5,48 +5,15 @@ experiments:
   # Do not change the goals unless you intend to also change the corresponding code in
   # app/workers/users/record_field_test_event_worker.rb
 
-  # variant_name:
-  #   variants:
-  #     - base
-  #     - variant_1
-  #     - variant_2
-  #     - variant_3
-  #     - variant_4
-  #   weights: # "base" gets a few more rolls of the dice
-  #     - 20
-  #     - 20
-  #     - 20
-  #     - 20
-  #     - 20
-  #   goals:
-  #     - user_creates_comment
-  #     - user_creates_comment_four_days_in_week
-  #     - user_views_article_four_days_in_week
-  #     - user_views_article_four_hours_in_day
-  #     - user_views_article_nine_days_in_two_week
-  #     - user_views_article_twelve_hours_in_five_days
-  # feed_strategy:
-  #   winner: original
-  #   variants:
-  #     - original
-  #     - weighted_query_strategy
-  #   weights:
-  #     - 80
-  #     - 20
-  #   goals:
-  #     - user_creates_comment
-  #     - user_creates_comment_four_days_in_week
-  #     - user_views_article_four_days_in_week
-  #     - user_views_article_four_hours_in_day
-  #     - user_views_article_nine_days_in_two_week
-  #     - user_views_article_twelve_hours_in_five_days
-  feed_strategy_round_2:
+  feed_strategy_round_3:
     variants:
       - original
-      - weighted_query_strategy
+      - slightly_more_comments_count_case_weight
+      - much_more_comments_count_case_weight
     weights:
-      - 80
+      - 70
       - 20
+      - 10
     goals:
       - user_creates_comment
       - user_creates_comment_on_at_least_four_different_days_within_a_week

--- a/spec/models/ab_experiment_spec.rb
+++ b/spec/models/ab_experiment_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe AbExperiment do
 
   describe ".get" do
     before do
-      allow(controller).to receive(:field_test).with(:feed_strategy_round_2, participant: user).and_return("special")
+      allow(controller).to receive(:field_test).with(:feed_strategy_round_3, participant: user).and_return("special")
     end
 
-    context "with :feed_strategy_round_2 experiment" do
+    context "with :feed_strategy_round_3 experiment" do
       it "repurposes the :feed_strategy experiment" do
-        expect(described_class.get(experiment: :feed_strategy_round_2,
+        expect(described_class.get(experiment: :feed_strategy_round_3,
                                    user: user,
                                    controller: controller,
                                    default_value: "default")).to eq("special")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

With the challenger winning this round, we feel comfortable moving strictly to the "Weighted Query Strategy", which is more flexible for further adaptation and has the highest potential for computer resources and relevance performance.

I have discussed this with @jeremyf, the original maker of this strategy, and we are in alignment that this is a solid way to continue experimenting. We anticipate future refactors where entire configs are injected into the algorithm, but that is not the most nimble way to achieve our near term goal of ensuring the network gets the relevant feed it deserves.

- Drop "Large Forem experimental" from signed in testing — Weighted Query Strategy seems to be successful this time around and I think we can put more effort into going deep in testing ways to go with it. Not wholesale removing LFE yet or modifying logged-out logic, but that could come later.
- This injects an a/b strategy into the WQS and then can make any internal changes based on current strategy. So here I have a test which further weights towards rewarding comment threads in order to generate more congregation in general. Hardly the only thing we'll test in the coming weeks and months, but I still want to put focus here.

### Hypothesis for this change.

Assigning a bit more weight to threads with healthy discussions will lead to more engaging and interesting community congregation and create more a more relevant feed.

Relevance here is a matter of separating signal from noise in terms of interesting discussions. If comment threads are rewarded for more action, it will help people eyeball where they might find insights that matter to them. This is only in conjunction with the other topical relevance measures which will get plenty of exercise in future tests.

Because we can't just eyeball which case weight change will be the one we want, this test includes two variations of the change, with the more subtle variation getting 20% play and the bigger var getting 10%.

## Related Tickets & Documents
Builds on https://github.com/forem/forem/pull/15789

## QA Instructions, Screenshots, Recordings

Inspecting that the logic, in fact, works as it should and alert to anything missed here. Once live in prod we can catch any additional problems that could have been created.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Current tests should monitor for the i/o we expect here from this interface.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

This will be part of a series of posts documenting changes.

