### PR TITLE
Copy `.env_sample` to `.env` in `bin/setup`

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -30,6 +30,10 @@ FileUtils.chdir APP_ROOT do
     FileUtils.cp "config/database.yml.sample", "config/database.yml"
   end
 
+  unless File.exists?(".env")
+    FileUtils.cp ".env_sample", ".env"
+  end
+
   puts "\n== Initializing the application =="
   system! "bin/rails app_initializer:setup forem:setup"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Developer experience

## Description

 Based on the discussion in #15876 it seems reasonable to include the copying of `.env_sample` to `.env` in our `bin/setup` script, similar to what we're already doing for `database.yml`.

## Related Tickets & Documents

#15876

## QA Instructions, Screenshots, Recordings

* Remove `.env` (back it up if you customized it)
* Run `bin/setup`
* You should now have a default `.env` file

### UI accessibility concerns?

No UI changes

## Added/updated tests?

- [X] No, and this is why: we have no tests for our setup script

## [Forem core team only] How will this change be communicated?

- [X] I've updated the [Developer Docs](https://developers.forem.com): unfortunately I was working on the wrong branch and https://github.com/forem/forem-docs has no branch protection for `main`, so the changes are already live 😅 
