### PR TITLE
Migrate faker dependency to supported upstream

### DIFF
--- a/app/javascript/Snackbar/__stories__/Snackbar.stories.jsx
+++ b/app/javascript/Snackbar/__stories__/Snackbar.stories.jsx
@@ -1,6 +1,6 @@
 import { h } from 'preact';
 import { action } from '@storybook/addon-actions';
-import faker from 'faker';
+import faker from '@faker-js/faker';
 import { number } from '@storybook/addon-knobs';
 import { Snackbar, addSnackbarItem } from '..';
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-plugin-react": "^7.28.0",
-    "faker": "^5.5.3",
+    "@faker-js/faker": "^5.5.3",
     "husky": "^7.0.4",
     "jest": "27.4.7",
     "jest-axe": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,6 +1448,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@faker-js/faker@^5.5.3":
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-5.5.3.tgz#18e3af6b8eae7984072bbeb0c0858474d7c4cefe"
+  integrity sha512-R11tGE6yIFwqpaIqcfkcg7AICXzFg14+5h5v0TfF/9+RMDL6jhzCy/pxHVOfbALGdtVYdt6JdR21tuxEgl34dw==
+
 "@gar/promisify@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
@@ -8233,11 +8238,6 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
-
-faker@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
-  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 fast-deep-equal@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The author of the faker package has decided to no longer maintain the software. The [faker-js](https://github.com/faker-js/faker/#faq---what-happened-to-the-original-fakerjs) project looks like a reasonable alternative (currently they've copied the original packages from the node repo).

This prevents dependabot suggesting we upgrade to the (non-functional) version [6.6.6 of faker](https://github.com/Marak/faker.js/commit/2c4f82f0af819e2bdb2623f0e429754f38c2c2f2), and provides an update path if there's more added in the future.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

No changes to behavior expected.

### UI accessibility concerns?

None, this is a test time dependency

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: expected to be a drop-in replacement for Marak's faker package
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams
