### PR TITLE
Enable AR cache versioning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -44,11 +44,6 @@ module PracticalDeveloper
     # Explorer to submit forms encoded in UTF-8
     config.action_view.default_enforce_utf8 = true
 
-    # Enables the same cache key to be reused when the object being cached of type ActiveRecord::Relation
-    # changes by moving the volatile information (max updated at and count) of the relation's cache
-    # key into the cache version to support recycling cache key.
-    config.active_record.collection_cache_versioning = false
-
     # Enables writing cookies with the purpose metadata embedded.
     config.action_dispatch.use_cookies_with_metadata = false
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Optimization

## Description

Rails 5.2 added AR collection cache versioning and 6.0 added collection cache versioning. We haven't used this option so far but now that we're slowly moving to newer framework defaults (see [recent PR](https://github.com/forem/forem/pull/15988)) I'd like to turn it on. 

Detailed writeup: https://www.bigbinary.com/blog/rails-adds-support-for-recyclable-cache-keys

I believe deploying this may result in cache misses at first but I think there's enough long-term benefit to be ok with this.

### UI accessibility concerns?

No UI changes

## Added/updated tests?

- [X] No, and this is why: framework settings, not testable logic

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: configuration setting change only