### PR TITLE
Raise Error with Invalid UnifiedEmbed URL

### DIFF
--- a/app/liquid_tags/unified_embed/tag.rb
+++ b/app/liquid_tags/unified_embed/tag.rb
@@ -21,22 +21,16 @@ module UnifiedEmbed
     # @return [LiquidTagBase]
     def self.new(tag_name, link, parse_context)
       klass = UnifiedEmbed::Registry.find_liquid_tag_for(link: link)
+      # If we don't know how to handle the embed, raise an error.
+      # This avoids an A-tag that goes nowhere, and gives the user
+      # a chance to correct the embed URL or choose how else to include
+      # their content.
+      raise StandardError, "Embed URL not valid" unless klass
 
-      if klass
-        # Why the __send__?  Because a LiquidTagBase class "privatizes"
-        # the `.new` method.  And we want to instantiate the specific
-        # liquid tag for the given link.
-        klass.__send__(:new, tag_name, link, parse_context)
-      else
-        # If we don't know how to handle the embed, let's just give the
-        # user an A-tag.
-        super
-      end
-    end
-
-    def render(_context)
-      link, _options = strip_tags(@markup)
-      %(<a href="#{link}">#{link}</a>)
+      # Why the __send__?  Because a LiquidTagBase class "privatizes"
+      # the `.new` method.  And we want to instantiate the specific
+      # liquid tag for the given link.
+      klass.__send__(:new, tag_name, link, parse_context)
     end
   end
 end

--- a/app/liquid_tags/unified_embed/tag.rb
+++ b/app/liquid_tags/unified_embed/tag.rb
@@ -21,10 +21,14 @@ module UnifiedEmbed
     # @return [LiquidTagBase]
     def self.new(tag_name, link, parse_context)
       klass = UnifiedEmbed::Registry.find_liquid_tag_for(link: link)
-      # If we don't know how to handle the embed, raise an error.
-      # This avoids an A-tag that goes nowhere, and gives the user
-      # a chance to correct the embed URL or choose how else to include
-      # their content.
+      # If we can't find a registered "embed" tag, let's raise an exception.
+      # This exception will give the user an opportunity to adjust their approach.
+      #
+      # In a prior implementation, we chose to render an A-tag using the given URL.
+      # With that prior implementation, a user expecting a "rich embed" might not
+      # notice that they didn't have a rich embed and instead published a basic
+      # A-tag. In addition, said A-tag would goes nowhere; which may confuse
+      # users and/or Forem readers.
       raise StandardError, "Embed URL not valid" unless klass
 
       # Why the __send__?  Because a LiquidTagBase class "privatizes"

--- a/spec/liquid_tags/unified_embed/tag_spec.rb
+++ b/spec/liquid_tags/unified_embed/tag_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
   it "renders an A-tag when no link-matching class is found" do
     link = "https://takeonrules.com/about"
     parsed_tag = Liquid::Template.parse("{% embed #{link} %}")
-    expect(parsed_tag.render).to eq(%(<a href="#{link}">#{link}</a>))
+    expect { parsed_tag.render }.to raise_error(StandardError, "Embed URL not valid")
   end
 end

--- a/spec/liquid_tags/unified_embed/tag_spec.rb
+++ b/spec/liquid_tags/unified_embed/tag_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     expect(GistTag).to have_received(:new)
   end
 
-  it "renders an A-tag when no link-matching class is found" do
+  it "raises an error when no link-matching class is found" do
     link = "https://takeonrules.com/about"
-    parsed_tag = Liquid::Template.parse("{% embed #{link} %}")
-    expect { parsed_tag.render }.to raise_error(StandardError, "Embed URL not valid")
+
+    expect do
+      Liquid::Template.parse("{% embed #{link} %}")
+    end.to raise_error(StandardError, "Embed URL not valid")
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [X] Implementation Rework

## Description
When a user passes in a non-URL (or invalid URL) into a unified-embed(`{% embed <non-URL or invalid URL> %}`), the current treatment is to return an `href` (see Image 1 below). However, this is problematic because it creates a link that goes nowhere, but yet sends the message that, though the embed did not work, the resulting link is "valid".

This PR instead raises a `StandardError`, sending a clear message that the embed did not work (see Image 2 below), AND giving the user the opportunity to correct the URL passed in, or decide how else to include their intended content.

### IMAGE 1
![Screen Shot 2022-01-11 at 10 30 32 AM](https://user-images.githubusercontent.com/32520970/148974964-24c1f0e0-1864-46eb-8c60-01c8d98d0a2a.png)

### IMAGE 2
![Screen Shot 2022-01-11 at 10 34 11 AM](https://user-images.githubusercontent.com/32520970/148975017-4ba22226-0a7e-409d-ba66-2a33527f000f.png)


## QA Instructions, Screenshots, Recordings
As a user, create a post with an embed with a non-URL (`{% embed @msarit/Shell-Challenge %}`) or an invalid URL (`{% embed https://replit.com/msarit/Shell-Challenge %}`). An error message should appear, and the post should not save.

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams