### PR TITLE
Modify welcome notification generator to handle errors per-message

### DIFF
--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -13,19 +13,27 @@ module Broadcasts
       def call
         return unless user.subscribed_to_welcome_notifications?
 
-        send_welcome_notification unless notification_enqueued
-        send_authentication_notification unless notification_enqueued
-        send_feed_customization_notification unless notification_enqueued
-        send_ux_customization_notification unless notification_enqueued
-        send_discuss_and_ask_notification unless notification_enqueued
-        send_download_app_notification unless notification_enqueued
-      rescue ActiveRecord::RecordNotFound => e
-        Honeybadger.notify(e)
+        notification_methods.each do |method|
+          send method unless notification_enqueued # rubocop:disable Style/Send
+        rescue ActiveRecord::RecordNotFound => e
+          Honeybadger.notify(e)
+        end
       end
 
       private
 
       attr_reader :user, :notification_enqueued
+
+      def notification_methods
+        %i[
+          send_welcome_notification
+          send_authentication_notification
+          send_feed_customization_notification
+          send_ux_customization_notification
+          send_discuss_and_ask_notification
+          send_download_app_notification
+        ]
+      end
 
       def send_welcome_notification
         return if

--- a/spec/services/broadcasts/welcome_notification/generator_spec.rb
+++ b/spec/services/broadcasts/welcome_notification/generator_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe Broadcasts::WelcomeNotification::Generator, type: :service do
     it "does not send a notification if no active broadcast exists" do
       welcome_broadcast.update!(active: false)
       expect do
-        sidekiq_perform_enqueued_jobs { described_class.call(user.id) }
+        Timecop.freeze(1.week.ago + 4.hours) do
+          sidekiq_perform_enqueued_jobs { described_class.call(user.id) }
+        end
       end.to change(user.notifications, :count).by(0)
     end
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The original flow aborted all processing when any
ActiveRecord::RecordNotFound exception was raised. This causes a
situation where a missing broadcast message (by title) causes that
notification message to fail, and each day the same failure to
occur (since it wasn't successfully sent the day before), blocking all
further messages.

We want these to proceed on the schedule implicit in the checks, and
failing early prevents that.

Modify the error handling to catch RecordNotFound on each message, and
continue throught the checks until a notification is enqueued or all
checks have been attempted.

## Related Tickets & Documents

partial fix for https://github.com/forem/forem/issues/16059 (there's a data update script to create a broadcast needed as well).

## QA Instructions, Screenshots, Recordings

Set the user's created_at time to 6 days ago. Clear the user's notifications.
Run the SendWelcomeNotificationWorker multiple times.
It's expected that the auth message fails, but subsequent notifications should be sent.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: hopefully this is what the existing tests expected to happen
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._
- [x] I will share this change internally with the appropriate teams

