### PR TITLE
Now HTML validation works for the adjust tags section of the moderation tools panel

### DIFF
--- a/app/javascript/actionsPanel/actionsPanel.js
+++ b/app/javascript/actionsPanel/actionsPanel.js
@@ -345,18 +345,16 @@ export function addAdjustTagListeners() {
     },
   );
 
-  const adjustTagSubmitBtn = document.getElementById('tag-adjust-submit');
-  if (adjustTagSubmitBtn) {
-    adjustTagSubmitBtn.addEventListener('click', (e) => {
+  const form = document.getElementById('tag-adjust-submit')?.form;
+  if (form) {
+    form.addEventListener('submit', (e) => {
       e.preventDefault();
-      const textArea = document.getElementById('tag-adjustment-reason');
+
       const dataSource =
-        document.querySelector('button.adjustable-tag.active') ||
+        document.querySelector('button.adjustable-tag.active') ??
         document.getElementById('admin-add-tag');
 
-      if (textArea.checkValidity()) {
-        adjustTag(dataSource);
-      }
+      adjustTag(dataSource);
     });
 
     handleAdminInput();

--- a/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
@@ -40,4 +40,24 @@ describe('Moderation Tools for Posts', () => {
       cy.findByRole('button', { name: 'Moderation' }).should('not.exist');
     });
   });
+
+  it('should not alter tags from a post if a reason is not specified', () => {
+    cy.fixture('users/adminUser.json').as('user');
+    cy.get('@user').then((user) => {
+      cy.loginAndVisit(user, '/admin_mcadmin/tag-test-article').then(() => {
+        cy.findByRole('button', { name: 'Moderation' }).click();
+
+        cy.getIframeBody('[title="Moderation panel actions"]').within(() => {
+          cy.findByRole('button', { name: 'Open adjust tags section' }).click({
+            force: true,
+          });
+
+          cy.findByRole('button', { name: '#tag1 Remove tag' }).click();
+          cy.findByRole('button', { name: 'Submit' }).click();
+        });
+
+        cy.findByTestId('snackbar').should('not.exist');
+      });
+    });
+  });
 });

--- a/cypress/integration/seededFlows/moderationFlows/adjustPostTags.spec.js
+++ b/cypress/integration/seededFlows/moderationFlows/adjustPostTags.spec.js
@@ -47,6 +47,22 @@ describe('Adjust post tags', () => {
         cy.findByRole('link', { name: /# tag1/ }).should('not.exist');
       });
     });
+
+    it('should not alter tags from a post if a reason is not specified', () => {
+      cy.findByRole('heading', { name: 'Tag test article' }).click();
+      cy.getIframeBody('.article-iframe').findByRole('link', {
+        name: /# tag1/,
+      });
+
+      cy.getIframeBody('.actions-panel-iframe').within(() => {
+        cy.findByRole('button', { name: 'Open adjust tags section' }).click();
+        cy.findByRole('button', { name: '#tag1 Remove tag' }).click();
+
+        cy.findByRole('button', { name: 'Submit' }).click();
+      });
+
+      cy.findByTestId('snackbar').should('not.exist');
+    });
   });
 
   describe('from /mod/tagname page', () => {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Prior to this PR, there was no feedback to a user if required fields were not filled out. Now, the HTML validation that was present now runs when the form is submitted.

## Related Tickets & Documents

Closes #16050

## QA Instructions, Screenshots, Recordings

There are other scenarios other than the two below, but the main fix is displaying the HTML validation error when the reason for tag adjustment text field is not filled out.

## Setup

1. Log in as the default Forem admin account
email: admin@forem.local
password: password
2. Navigate to any article
3. Click on the shield icon in the sidebar of the article (bottom bar if on mobile)

**Large screen**

![image](https://user-images.githubusercontent.com/833231/149006599-0549f044-49b7-45bd-a339-42665d933bc8.png)

**Small screen**

![image](https://user-images.githubusercontent.com/833231/149006716-e666fdcc-35e3-4dcd-8b42-607d730beebc.png)



4. The moderation tools panel opens

![image](https://user-images.githubusercontent.com/833231/149006890-75a39c38-0b58-4b1f-8d48-4883ab9147ff.png)

5. Click on the Adjust tags section to open the tag panel.

![image](https://user-images.githubusercontent.com/833231/149006957-a0116480-0ac6-41ec-9d34-067e3f65f445.png)

## Validation Failing

1. Click the Submit button.
2. The form does not submit and the user is notified why.

![image](https://user-images.githubusercontent.com/833231/149007128-61b263df-c8cf-41a4-839e-39d76f882c29.png)

## Validation Succeeding

1. Add or remove a tag. Tags that can be added have a white plus sign in a green circle; tags that can be removed have a white minus sign in a red circle.
2. Add a reason in the reason for tag adjustment text field.
3. Click the submit button

![image](https://user-images.githubusercontent.com/833231/149008123-bf0d30fb-2065-4319-8375-9f8963c0ce95.png)

4. The form is posted and the user is notified of the response.

![CleanShot 2022-01-11 at 14 26 48](https://user-images.githubusercontent.com/833231/149008555-f26496fb-b316-48c6-a6e9-99817bae4628.png)

### UI accessibility concerns?

Now that validation occurs, a user receives feedback that a field is required.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/kspZ16RxgvAaxwq1Al/giphy.gif)
