### PR TITLE
Add apple_connect welcome notification broadcast

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -370,7 +370,7 @@ seeder.create_if_none(Broadcast) do
     github_connect: "You're on a roll! 🎉  Do you have a GitHub account? " \
                     "Consider <a href='/settings'>connecting it</a> so you can pin any of your repos to your profile.",
     apple_connect: "You're on a roll! 🎉  Do you have a Facebook account? " \
-                "Consider <a href='/settings'>connecting it</a>.",
+                   "Consider <a href='/settings'>connecting it</a>.",
     customize_feed:
       "Hi, it's me again! 👋 Now that you're a part of the DEV community, let's focus on personalizing " \
       "your content. You can start by <a href='/tags'>following some tags</a> to help customize your feed! 🎉",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -368,7 +368,9 @@ seeder.create_if_none(Broadcast) do
     facebook_connect: "You're on a roll! 🎉  Do you have a Facebook account? " \
                       "Consider <a href='/settings'>connecting it</a>.",
     github_connect: "You're on a roll! 🎉  Do you have a GitHub account? " \
-                    "Consider <a href='/settings'>connecting it</a> so you can pin any of your repos to your profile.",
+      "Consider <a href='/settings'>connecting it</a> so you can pin any of your repos to your profile.",
+    apple_connect: "You're on a roll! 🎉  Do you have a Facebook account? " \
+                "Consider <a href='/settings'>connecting it</a>.",
     customize_feed:
       "Hi, it's me again! 👋 Now that you're a part of the DEV community, let's focus on personalizing " \
       "your content. You can start by <a href='/tags'>following some tags</a> to help customize your feed! 🎉",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -369,7 +369,7 @@ seeder.create_if_none(Broadcast) do
                       "Consider <a href='/settings'>connecting it</a>.",
     github_connect: "You're on a roll! 🎉  Do you have a GitHub account? " \
                     "Consider <a href='/settings'>connecting it</a> so you can pin any of your repos to your profile.",
-    apple_connect: "You're on a roll! 🎉  Do you have a Facebook account? " \
+    apple_connect: "You're on a roll! 🎉  Do you have an Apple account? " \
                    "Consider <a href='/settings'>connecting it</a>.",
     customize_feed:
       "Hi, it's me again! 👋 Now that you're a part of the DEV community, let's focus on personalizing " \

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -368,7 +368,7 @@ seeder.create_if_none(Broadcast) do
     facebook_connect: "You're on a roll! 🎉  Do you have a Facebook account? " \
                       "Consider <a href='/settings'>connecting it</a>.",
     github_connect: "You're on a roll! 🎉  Do you have a GitHub account? " \
-      "Consider <a href='/settings'>connecting it</a> so you can pin any of your repos to your profile.",
+                    "Consider <a href='/settings'>connecting it</a> so you can pin any of your repos to your profile.",
     apple_connect: "You're on a roll! 🎉  Do you have a Facebook account? " \
                 "Consider <a href='/settings'>connecting it</a>.",
     customize_feed:

--- a/lib/data_update_scripts/20220111192031_insert_apple_connect_broadcast_message.rb
+++ b/lib/data_update_scripts/20220111192031_insert_apple_connect_broadcast_message.rb
@@ -1,9 +1,18 @@
 module DataUpdateScripts
   class InsertAppleConnectBroadcastMessage
     def run
-      # Place your data update logic here
-      # Make sure your code is idempotent and can be run safely
-      # multiple times at any time
+      title = "Welcome Notification: apple_connect"
+      return if Broadcast.find_by title: title
+
+      message = "You're on a roll! 🎉  Do you have an Apple account? " \
+                "Consider <a href='/settings'>connecting it</a>."
+
+      Broadcast.create!(
+        title: title,
+        processed_html: message,
+        type_of: "Welcome",
+        active: true,
+      )
     end
   end
 end

--- a/lib/data_update_scripts/20220111192031_insert_apple_connect_broadcast_message.rb
+++ b/lib/data_update_scripts/20220111192031_insert_apple_connect_broadcast_message.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class InsertAppleConnectBroadcastMessage
+    def run
+      # Place your data update logic here
+      # Make sure your code is idempotent and can be run safely
+      # multiple times at any time
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/insert_apple_connect_broadcast_message_spec.rb
+++ b/spec/lib/data_update_scripts/insert_apple_connect_broadcast_message_spec.rb
@@ -4,5 +4,16 @@ require Rails.root.join(
 )
 
 describe DataUpdateScripts::InsertAppleConnectBroadcastMessage do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "works without a broadcast" do
+    expect do
+      described_class.new.run
+    end.to change(Broadcast, :count).by(1)
+  end
+
+  it "works when a Broadcast already exists" do
+    create(:apple_connect_broadcast)
+    expect do
+      described_class.new.run
+    end.not_to change(Broadcast, :count)
+  end
 end

--- a/spec/lib/data_update_scripts/insert_apple_connect_broadcast_message_spec.rb
+++ b/spec/lib/data_update_scripts/insert_apple_connect_broadcast_message_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220111192031_insert_apple_connect_broadcast_message.rb",
+)
+
+describe DataUpdateScripts::InsertAppleConnectBroadcastMessage do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We expect there to be a Broadcast with title "Welcome Notification: apple_connect", but no such item exists.

## Related Tickets & Documents

fixes #16059 (in conjunction with #16060)

## QA Instructions, Screenshots, Recordings

Run the data update script. A broadcast should be created.

Run it again, nothing should happen.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

