### PR TITLE
Add one day to the welcome notification users range

### DIFF
--- a/app/workers/broadcasts/send_welcome_notifications_worker.rb
+++ b/app/workers/broadcasts/send_welcome_notifications_worker.rb
@@ -5,18 +5,18 @@ module Broadcasts
     sidekiq_options queue: :medium_priority, retry: 15
 
     def perform
-      # In order to prevent new users from receiving multiple welcome notifications in a day,
-      # a feature_live_date is required. The script will only be effective after feature_live_date
-      # and will ultimately be superseded by 7.days.ago when it's larger than feature_live_date.
       return unless Settings::General.welcome_notifications_live_at
 
       User.select(:id).where("created_at > ?", created_after).find_each do |user|
+        # the Generator ensures only one notification is created per user per day
         Broadcasts::WelcomeNotification::Generator.call(user.id)
       end
     end
 
     def created_after
-      [Settings::General.welcome_notifications_live_at, 7.days.ago].max
+      # The script will only be effective after feature_live_date
+      # and will ultimately be superseded by 8.days.ago when it's larger than feature_live_date.
+      [Settings::General.welcome_notifications_live_at, 8.days.ago].max
     end
     private :created_after
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The download app broadcast (in the Generator) returns early if the
user was [created since 7 days ago](https://github.com/forem/forem/blob/main/app/services/broadcasts/welcome_notification/generator.rb#L79). It seems counterproductive to
select _only_ users created in the last 7 days here before calling the generator.

Add one day to the query range, so users created less than 8 days ago,
but more than 7 days ago, receive the final message.

Clean up the comments (the original intent, to not send more than one message per day, is handled elsewhere, but the setting is required and the logic is still valid, either live at or the trailing 8 days will be used).

## Related Tickets & Documents

https://github.com/forem/forem/pull/16052#discussion_r782413219 

## QA Instructions, Screenshots, Recordings

Set user created at to 7 days ago.
Clear user notifications.
Run this worker
User should see a notification to download the forem app.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: The notification is tested inside the Generator's spec
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

![one day more](https://user-images.githubusercontent.com/1237369/149015146-97f4c964-d355-4a59-9184-1a5d1b8d6188.png)
