### PR TITLE
Allow admin control of auth broadcast messages (was: Don't suggest apple authentication)

### DIFF
--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -99,9 +99,13 @@ module Broadcasts
         Comment.where(commentable: welcome_thread, user: user).any?
       end
 
-      def authenticated_with_all_providers?
+      def ga_providers
         # ga_providers refers to Generally Available (not in beta)
-        ga_providers = Authentication::Providers.enabled.reject { |sym| sym == :apple }
+        @ga_providers ||=
+          Authentication::Providers.enabled.reject { |sym| sym == :apple }
+      end
+
+      def authenticated_with_all_providers?
         enabled_providers = identities.pluck(:provider).map(&:to_sym)
         (ga_providers - enabled_providers).empty?
       end
@@ -139,7 +143,7 @@ module Broadcasts
       end
 
       def find_auth_broadcast
-        missing_identities = Authentication::Providers.enabled.filter_map do |provider|
+        missing_identities = ga_providers.filter_map do |provider|
           identities.exists?(provider: provider) ? nil : "#{provider}_connect"
         end
 

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -107,8 +107,8 @@ module Broadcasts
         # we filter the providers to suggest based on the following two criteria
         # - provider is enabled
         # - an acive provider Broadcast message exists
-        # Disabling/deactivating a provider_connect welcome message removes
-        # the provider from suggestions, while you could
+        # Disabling/deactivating a provider_connect broadcast removes
+        # the provider from suggestions sent to users
         @providers ||=
           Authentication::Providers.enabled.select do |provider|
             authentication_broadcasts.exists?(title: "Welcome Notification: #{provider}_connect")

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -106,8 +106,7 @@ module Broadcasts
       end
 
       def authenticated_with_all_providers?
-        enabled_providers = identities.pluck(:provider).map(&:to_sym)
-        (ga_providers - enabled_providers).empty?
+        ga_providers.all? { |sym| identities.exists?(provider: sym) }
       end
 
       def user_following_tags?

--- a/app/services/broadcasts/welcome_notification/generator.rb
+++ b/app/services/broadcasts/welcome_notification/generator.rb
@@ -50,7 +50,7 @@ module Broadcasts
         return if
           user.created_at.after?(1.day.ago) ||
             authenticated_with_all_providers? ||
-            received_notification?(authentication_broadcast)
+            received_notification?(authentication_broadcasts)
 
         Notification.send_welcome_notification(user.id, authentication_broadcast.id)
         @notification_enqueued = true
@@ -99,14 +99,24 @@ module Broadcasts
         Comment.where(commentable: welcome_thread, user: user).any?
       end
 
-      def ga_providers
-        # ga_providers refers to Generally Available (not in beta)
-        @ga_providers ||=
-          Authentication::Providers.enabled.reject { |sym| sym == :apple }
+      def authentication_broadcasts
+        Broadcast.active.where(type_of: "Welcome").where("title like '%_connect'")
+      end
+
+      def providers
+        # we filter the providers to suggest based on the following two criteria
+        # - provider is enabled
+        # - an acive provider Broadcast message exists
+        # Disabling/deactivating a provider_connect welcome message removes
+        # the provider from suggestions, while you could
+        @providers ||=
+          Authentication::Providers.enabled.select do |provider|
+            authentication_broadcasts.exists?(title: "Welcome Notification: #{provider}_connect")
+          end
       end
 
       def authenticated_with_all_providers?
-        ga_providers.all? { |sym| identities.exists?(provider: sym) }
+        providers.all? { |sym| identities.exists?(provider: sym) }
       end
 
       def user_following_tags?
@@ -142,11 +152,11 @@ module Broadcasts
       end
 
       def find_auth_broadcast
-        missing_identities = ga_providers.filter_map do |provider|
+        missing_identities = providers.filter_map do |provider|
           identities.exists?(provider: provider) ? nil : "#{provider}_connect"
         end
 
-        Broadcast.active.find_by!(title: "Welcome Notification: #{missing_identities.first}")
+        authentication_broadcasts.find_by!(title: "Welcome Notification: #{missing_identities.sample}")
       end
 
       def find_discuss_ask_broadcast


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently we have `:apple` as a restricted provider (you can enable it in admin,
but it's treated as beta here for checking user setup).

While we were correctly checking if you had all GA providers enabled
in `authenticated_with_all_providers?`, we were incorrectly pulling
all enabled provider names in `find_auth_broadcast` (the message to send
the user), and picking `apple_connect`.

Since it doesn't make sense to omit apple id login from consideration
when checking if all available auth methods are used, then recommend
that it be used consistently, capture this "GA" state as a method, and
use it both in the test "does this user have all available identity
providers enabled?" and the selection "which identity provider can I
suggest they setup?" consistently.

Alternately, define "GA" to mean "broadcast message for provider is active,
and provider is enabled" rather than "symbol is not apple" as before. The 
follow on to that is that a DEV admin should disable the apple_connect 
broadcast, or a data update script could do modify it for all forems (the 
apple_connect message was created in #16063 ).

Since we're about to enable google as an auth source (in #15986) I'll
check with Josh if he expects this to be GA on release or in limited
beta.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Set user's created at time to 7 days ago.
Remove all user notifications
Run Broadcasts::WelcomeNotification::Generator.call(user.id) twice (once for the welcome thread, once for auth)
Disable some "Welcome... _connect" broadcast messages (/admin/advanced/broadcasts)
Query `user.notifications.last.json_data.dig("broadcast", "title")`
Expect a title not from the disabled set. If you're careful, you set all but one message active: false, and check that you get the desired response. 

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: bugfix
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

