### PR TITLE
Remove IE-specific setting

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,10 +40,6 @@ module PracticalDeveloper
     config.action_controller.per_form_csrf_tokens = false
 
     ## Rails 6.0
-    # Determines whether forms are generated with a hidden tag that forces older versions of Internet
-    # Explorer to submit forms encoded in UTF-8
-    config.action_view.default_enforce_utf8 = true
-
     # Enables writing cookies with the purpose metadata embedded.
     config.action_dispatch.use_cookies_with_metadata = false
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR is part of my ongoing effort to bring us closer to modern Rails defaults. It removes a setting that specifically targets older versions of IE:

```ruby
# Determines whether forms are generated with a hidden tag that forces older versions of Internet
# Explorer to submit forms encoded in UTF-8
config.action_view.default_enforce_utf8 = true
```

Given that our codebase generally assumes quite modern browsers, it seems safe to remove this now.

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: Minor setting change