### PR TITLE
Don't load ActiveJob railtie

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@ require_relative "boot"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-require "active_job/railtie"
+# require "active_job/railtie"
 require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"
@@ -75,8 +75,6 @@ module PracticalDeveloper
     Dir["#{config.root}/app/middlewares/**/*.rb"].each do |file|
       require_dependency(file)
     end
-
-    config.active_job.queue_adapter = :sidekiq
 
     config.middleware.use Rack::Deflater
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,10 +76,6 @@ Rails.application.configure do
   default_expiration = 24.hours.to_i
   config.cache_store = :redis_cache_store, { url: redis_url, expires_in: default_expiration }
 
-  # Use a real queuing backend for Active Job (and separate queues per environment)
-  # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "practical_developer_production"
-
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,8 +58,6 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  config.active_job.queue_adapter = :test
-
   # Debug is the default log_level, but can be changed per environment.
   config.log_level = :debug
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

In `config/application.rb` we generally only load the railties for frameworks we actually use. However, we were still loading the one for `ActiveJob`, even though we use Sidekiq directly. This PR changes that.

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: internal cleanup