### PR TITLE
Adding ApplicationRecord#polymorphic_type_name

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -25,7 +25,7 @@ module Admin
     protected
 
     def authorization_resource
-      self.class.name.sub("Admin::", "").sub("Controller", "").singularize.constantize
+      polymorphic_type_name.sub("Admin::", "").sub("Controller", "").singularize.constantize
     end
 
     def authorize_admin

--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -134,7 +134,7 @@ module Api
       def validate_article_param_is_hash
         return if params.to_unsafe_h[:article].is_a?(Hash)
 
-        message = I18n.t("api.v0.articles_controller.must_be_json", type: params[:article].class.name)
+        message = I18n.t("api.v0.articles_controller.must_be_json", type: params[:article].polymorphic_type_name)
         render json: { error: message, status: 422 }, status: :unprocessable_entity
       end
     end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -26,7 +26,7 @@ class CommentsController < ApplicationController
       not_found unless comment_should_be_visible?
     end
 
-    @commentable_type = @commentable.class.name if @commentable
+    @commentable_type = @commentable.polymorphic_type_name if @commentable
 
     set_surrogate_key_header "comments-for-#{@commentable.id}-#{@commentable_type}" if @commentable
   end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -62,7 +62,7 @@ class FollowsController < ApplicationController
 
     followable = followable_klass.find(params[:followable_id])
 
-    need_notification = Follow.need_new_follower_notification_for?(followable.class.name)
+    need_notification = Follow.need_new_follower_notification_for?(followable.polymorphic_type_name)
 
     @result = if params[:verb] == "unfollow"
                 unfollow(followable, params[:followable_type], need_notification: need_notification)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -21,7 +21,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # Callback for third party failures (shared by all providers)
   def failure
     error = request.env["omniauth.error"]
-    class_name = error.present? ? error.class.name : ""
+    class_name = error.present? ? error.polymorphic_type_name : ""
 
     ForemStatsClient.increment(
       "omniauth.failure",

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -109,12 +109,7 @@ module ApplicationHelper
     return if followable == Users::DeletedUser
 
     user_follow = followable.instance_of?(User) ? "follow-user" : ""
-    followable_type = if followable.respond_to?(:decorated?) && followable.decorated?
-                        followable.object.class.name
-                      else
-                        followable.class.name
-                      end
-
+    followable_type = followable.object.polymorphic_type_name
     followable_name = followable.name
 
     tag.button(
@@ -135,8 +130,9 @@ module ApplicationHelper
   end
 
   def user_colors_style(user)
-    "border: 2px solid #{user.decorate.darker_color}; \
-    box-shadow: 5px 6px 0px #{user.decorate.darker_color}"
+    darker_color = user.decorate.darker_color
+    "border: 2px solid #{darker_color}; \
+    box-shadow: 5px 6px 0px #{darker_color}"
   end
 
   def user_colors(user)

--- a/app/liquid_tags/liquid_tag_base.rb
+++ b/app/liquid_tags/liquid_tag_base.rb
@@ -65,7 +65,7 @@ class LiquidTagBase < Liquid::Tag
     source = parse_context.partial_options[:source]
     raise LiquidTags::Errors::InvalidParseContext, "No source found" unless source
 
-    is_valid_source = self.class::VALID_CONTEXTS.include? source.class.name
+    is_valid_source = self.class::VALID_CONTEXTS.include? source.polymorphic_type_name
     return if is_valid_source
 
     valid_contexts = self.class::VALID_CONTEXTS.map(&:pluralize).join(", ")

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -12,7 +12,7 @@ class ApplicationMailer < ActionMailer::Base
 
   default(
     from: -> { email_from },
-    template_path: ->(mailer) { "mailers/#{mailer.class.name.underscore}" },
+    template_path: ->(mailer) { "mailers/#{mailer.polymorphic_type_name.underscore}" },
     reply_to: -> { ForemInstance.email },
   )
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -26,6 +26,29 @@ class ApplicationRecord < ActiveRecord::Base
     count
   end
 
+  # Throughout the code base we make use of a lot of polymorphic relations (e.g. acts_as_follower,
+  # acts_as_taggable, etc.).  Which means we often want to know the name of the relationship.
+  #
+  # Furthermore in our views and controllers we've often relied on using `object.class.name` for
+  # branching logic.
+  #
+  # However, with the sometimes transparent usage of the ApplicationDecorator, we can get unexpected
+  # results.
+  #
+  # This method is here to help us move past the somewhat fragile method chain of
+  # `object.class.name`.
+  #
+  # @return [String]
+  #
+  # @see ApplicationDecorator
+  # @see #decorate
+  #
+  # @todo We may want to consider adding a class method that is polymorphic_type_name; but for now
+  #       we'll use an instance variable.
+  def polymorphic_type_name
+    self.class.name
+  end
+
   # Decorate object with appropriate decorator
   def decorate
     self.class.decorator_class.new(self)
@@ -50,7 +73,7 @@ class ApplicationRecord < ActiveRecord::Base
 
     return superclass.decorator_class(called_on) if superclass.respond_to?(:decorator_class)
 
-    raise UninferrableDecoratorError, "Could not infer a decorator for #{called_on.class.name}."
+    raise UninferrableDecoratorError, "Could not infer a decorator for #{called_on.polymorphic_type_name}."
   end
 
   def self.statement_timeout

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -412,7 +412,7 @@ class Article < ApplicationRecord
   end
 
   def class_name
-    self.class.name
+    polymorphic_type_name
   end
 
   def flare_tag

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -116,7 +116,7 @@ class Comment < ApplicationRecord
   end
 
   def parent_type
-    parent_or_root_article.class.name.downcase
+    parent_or_root_article.polymorphic_type_name.downcase
       .gsub("article", "post")
       .gsub("podcastepisode", "episode")
   end
@@ -292,7 +292,7 @@ class Comment < ApplicationRecord
 
   def should_send_email_notification?
     parent_exists? &&
-      parent_user.class.name != "Podcast" &&
+      parent_user.polymorphic_type_name != "Podcast" &&
       parent_user != user &&
       parent_user.notification_setting.email_comment_notifications &&
       parent_user.email &&

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -22,7 +22,7 @@ class Credit < ApplicationRecord
     return unless amount.positive?
 
     now = Time.current
-    association_id = "#{user_or_org.class.name.underscore}_id"
+    association_id = "#{user_or_org.polymorphic_type_name.underscore}_id"
     attributes = Array.new(amount) do
       {
         association_id => user_or_org.id,

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -9,15 +9,14 @@ class Mention < ApplicationRecord
   belongs_to :user
   belongs_to :mentionable, polymorphic: true
 
-  validates :user_id, presence: true, uniqueness: { scope: %i[mentionable_id mentionable_type] }
-  validates :mentionable_id, presence: true
+  validates :user_id, uniqueness: { scope: %i[mentionable_id mentionable_type] }
   validates :mentionable_type, presence: true
   validate :permission
 
   after_create_commit :send_email_notification
 
   def self.create_all(notifiable)
-    Mentions::CreateAllWorker.perform_async(notifiable.id, notifiable.class.name)
+    Mentions::CreateAllWorker.perform_async(notifiable.id, notifiable.polymorphic_type_name)
   end
 
   private

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -56,7 +56,7 @@ class Notification < ApplicationRecord
     end
 
     def send_to_followers(notifiable, action = nil)
-      Notifications::NotifiableActionWorker.perform_async(notifiable.id, notifiable.class.name, action)
+      Notifications::NotifiableActionWorker.perform_async(notifiable.id, notifiable.polymorphic_type_name, action)
     end
 
     def send_new_comment_notifications_without_delay(comment)
@@ -135,7 +135,7 @@ class Notification < ApplicationRecord
     end
 
     def update_notifications(notifiable, action = nil)
-      Notifications::UpdateWorker.perform_async(notifiable.id, notifiable.class.name, action)
+      Notifications::UpdateWorker.perform_async(notifiable.id, notifiable.polymorphic_type_name, action)
     end
 
     def fast_destroy_old_notifications(destroy_before_timestamp = 3.months.ago)
@@ -162,7 +162,7 @@ class Notification < ApplicationRecord
         reactable_type: reaction.reactable_type,
         reactable_user_id: reaction.reactable.user_id
       }
-      receiver_data = { klass: receiver.class.name, id: receiver.id }
+      receiver_data = { klass: receiver.polymorphic_type_name, id: receiver.id }
       [reactable_data, receiver_data]
     end
   end

--- a/app/models/notification_subscription.rb
+++ b/app/models/notification_subscription.rb
@@ -10,7 +10,6 @@ class NotificationSubscription < ApplicationRecord
   belongs_to :user
 
   validates :config, presence: true, inclusion: { in: %w[all_comments top_level_comments only_author_comments] }
-  validates :notifiable_id, presence: true
   validates :notifiable_type, presence: true, inclusion: { in: %w[Comment Article] }
   validates :user_id, uniqueness: { scope: %i[notifiable_type notifiable_id] }
 
@@ -18,7 +17,7 @@ class NotificationSubscription < ApplicationRecord
     def update_notification_subscriptions(notifiable)
       NotificationSubscriptions::UpdateWorker.perform_async(
         notifiable.id,
-        notifiable.class.name,
+        notifiable.polymorphic_type_name,
       )
     end
   end

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -80,7 +80,7 @@ class PodcastEpisode < ApplicationRecord
   alias public_reactions_count zero_method
 
   def class_name
-    self.class.name
+    polymorphic_type_name
   end
 
   def tag_keywords_for_search

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -70,7 +70,7 @@ class Reaction < ApplicationRecord
     end
 
     def cached_any_reactions_for?(reactable, user, category)
-      class_name = reactable.instance_of?(ArticleDecorator) ? "Article" : reactable.class.name
+      class_name = reactable.instance_of?(ArticleDecorator) ? "Article" : reactable.polymorphic_type_name
       cache_name = "any_reactions_for-#{class_name}-#{reactable.id}-" \
                    "#{user.reactions_count}-#{user.public_reactions_count}-#{category}"
       Rails.cache.fetch(cache_name, expires_in: 24.hours) do

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -25,7 +25,7 @@ class AnalyticsService
     return {} unless start_date && end_date
 
     # cache all stats in the date range for the requested user or organization
-    cache_key = "analytics-for-dates-#{start_date}-#{end_date}-#{user_or_org.class.name}-#{user_or_org.id}"
+    cache_key = "analytics-for-dates-#{start_date}-#{end_date}-#{user_or_org.polymorphic_type_name}-#{user_or_org.id}"
     cache_key = "#{cache_key}-article-#{article_id}" if article_id
 
     Rails.cache.fetch(cache_key, expires_in: 7.days) do
@@ -73,7 +73,7 @@ class AnalyticsService
   )
 
   def load_data
-    @article_data = Article.published.where("#{user_or_org.class.name.downcase}_id" => user_or_org.id)
+    @article_data = Article.published.where("#{user_or_org.polymorphic_type_name.downcase}_id" => user_or_org.id)
     if @article_id
       @article_data = @article_data.where(id: @article_id)
 
@@ -90,7 +90,7 @@ class AnalyticsService
       .where(commentable_id: article_ids, commentable_type: "Article")
       .where("score > 0")
     @follow_data = Follow
-      .where(followable_type: user_or_org.class.name, followable_id: user_or_org.id)
+      .where(followable_type: user_or_org.polymorphic_type_name, followable_id: user_or_org.id)
     @reaction_data = Reaction.public_category
       .where(reactable_id: article_ids, reactable_type: "Article")
     @page_view_data = PageView.where(article_id: article_ids)

--- a/app/services/credits/buyer.rb
+++ b/app/services/credits/buyer.rb
@@ -16,7 +16,7 @@ module Credits
       purchaser.credits.unspent.limit(cost).update_all(
         spent: true,
         spent_at: Time.current,
-        purchase_type: purchase.class.name,
+        purchase_type: purchase.polymorphic_type_name,
         purchase_id: purchase.id,
       )
       purchaser.save

--- a/app/services/github/oauth_client.rb
+++ b/app/services/github/oauth_client.rb
@@ -20,7 +20,7 @@ module Github
 
     # Hides private credentials when printed
     def inspect
-      "#<#{self.class.name}:#{object_id}>"
+      "#<#{polymorphic_type_name}:#{object_id}>"
     end
 
     private
@@ -69,7 +69,7 @@ module Github
     end
 
     def record_error(exception)
-      class_name = exception.class.name.demodulize
+      class_name = exception.polymorphic_type_name.demodulize
 
       Honeycomb.add_field("github.result", "error")
       Honeycomb.add_field("github.error", class_name)
@@ -80,7 +80,7 @@ module Github
     end
 
     def handle_error(exception)
-      class_name = exception.class.name.demodulize
+      class_name = exception.polymorphic_type_name.demodulize
 
       # raise specific error if known, generic one if unknown
       error_class = "::Github::Errors::#{class_name}".safe_constantize

--- a/app/services/images/generate_social_image.rb
+++ b/app/services/images/generate_social_image.rb
@@ -20,13 +20,13 @@ module Images
     end
 
     def call
-      if resource.class.name.include?("Article")
+      if resource.polymorphic_type_name.include?("Article")
         article_image
       elsif resource.instance_of?(User)
         optimize_image "/user/#{resource.id}?bust=#{resource.profile_image_url}"
       elsif resource.instance_of?(Organization)
         optimize_image "/organization/#{resource.id}?bust=#{resource.profile_image_url}"
-      elsif resource.class.name.include?("Tag")
+      elsif resource.polymorphic_type_name.include?("Tag")
         optimize_image "/tag/#{@resource.id}?bust=#{@resource.pretty_name}"
       end
     end

--- a/app/services/mentions/create_all.rb
+++ b/app/services/mentions/create_all.rb
@@ -76,7 +76,7 @@ module Mentions
 
       # The mentionable_type is the model that created the mention, the user is the user to be mentioned.
       mention = Mention.create(user_id: user.id, mentionable_id: notifiable.id,
-                               mentionable_type: notifiable.class.name)
+                               mentionable_type: notifiable.polymorphic_type_name)
 
       # If notifiable is an Article, we need to create the notification for the mention immediately so
       # that the notification exists in the database before we attempt to create other Article-related notifications.

--- a/app/services/notification_subscriptions/update.rb
+++ b/app/services/notification_subscriptions/update.rb
@@ -13,7 +13,7 @@ module NotificationSubscriptions
 
       notification_subscriptions = NotificationSubscription.where(
         notifiable_id: notifiable.id,
-        notifiable_type: notifiable.class.name,
+        notifiable_type: notifiable.polymorphic_type_name,
       )
 
       return if notification_subscriptions.none?

--- a/app/services/notifications.rb
+++ b/app/services/notifications.rb
@@ -28,7 +28,7 @@ module Notifications
         title: comment.commentable.title,
         path: comment.commentable.path,
         class: {
-          name: comment.commentable.class.name
+          name: comment.commentable.polymorphic_type_name
         }
       }
     }

--- a/app/services/notifications/moderation/send.rb
+++ b/app/services/notifications/moderation/send.rb
@@ -21,11 +21,12 @@ module Notifications
         return if moderator == notifiable.user
 
         json_data = { user: user_data(User.staff_account) }
-        json_data[notifiable.class.name.downcase] = public_send "#{notifiable.class.name.downcase}_data", notifiable
+        json_data[notifiable.polymorphic_type_name.downcase] =
+          public_send "#{notifiable.polymorphic_type_name.downcase}_data", notifiable
         new_notification = Notification.create!(
           user_id: moderator.id,
           notifiable_id: notifiable.id,
-          notifiable_type: notifiable.class.name,
+          notifiable_type: notifiable.polymorphic_type_name,
           action: "Moderation",
           json_data: json_data,
         )

--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -30,7 +30,7 @@ module Notifications
           Notification.create(
             user_id: user_id,
             notifiable_id: comment.id,
-            notifiable_type: comment.class.name,
+            notifiable_type: comment.polymorphic_type_name,
             action: nil,
             json_data: json_data,
           )
@@ -57,7 +57,7 @@ module Notifications
         Notification.create(
           organization_id: comment.commentable.organization_id,
           notifiable_id: comment.id,
-          notifiable_type: comment.class.name,
+          notifiable_type: comment.polymorphic_type_name,
           action: nil,
           json_data: json_data,
         )

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -42,7 +42,7 @@ module Notifications
           notifications_attributes.push(
             user_id: follower.id,
             notifiable_id: notifiable.id,
-            notifiable_type: notifiable.class.name,
+            notifiable_type: notifiable.polymorphic_type_name,
             action: action,
             json_data: json_data,
             created_at: now,

--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -135,7 +135,7 @@ module Notifications
               path: recent_reaction.reactable.path,
               title: recent_reaction.reactable.title,
               class: {
-                name: recent_reaction.reactable.class.name
+                name: recent_reaction.reactable.polymorphic_type_name
               }
             },
             aggregated_siblings: siblings,

--- a/app/services/notifications/tag_adjustment_notification/send.rb
+++ b/app/services/notifications/tag_adjustment_notification/send.rb
@@ -22,7 +22,7 @@ module Notifications
         Notification.create(
           user_id: article.user_id,
           notifiable_id: tag_adjustment.id,
-          notifiable_type: tag_adjustment.class.name,
+          notifiable_type: tag_adjustment.polymorphic_type_name,
           json_data: json_data,
         )
       end

--- a/app/services/notifications/update.rb
+++ b/app/services/notifications/update.rb
@@ -16,7 +16,7 @@ module Notifications
 
       notifications = Notification.where(
         notifiable_id: notifiable.id,
-        notifiable_type: notifiable.class.name,
+        notifiable_type: notifiable.polymorphic_type_name,
         action: action,
       )
       # as we only select the first notification right after, there is no need
@@ -24,7 +24,8 @@ module Notifications
       return if notifications.none?
 
       new_json_data = {}
-      new_json_data[notifiable.class.name.downcase] = public_send("#{notifiable.class.name.downcase}_data", notifiable)
+      new_json_data[notifiable.polymorphic_type_name.downcase] =
+        public_send("#{notifiable.polymorphic_type_name.downcase}_data", notifiable)
       new_json_data[:user] = user_data(notifiable.user)
       add_organization_data = notifiable.is_a?(Article) && notifiable.organization
       new_json_data[:organization] = organization_data(notifiable.organization) if add_organization_data

--- a/app/services/twitter_client/client.rb
+++ b/app/services/twitter_client/client.rb
@@ -27,7 +27,7 @@ module TwitterClient
       end
 
       def record_error(exception)
-        class_name = exception.class.name.demodulize
+        class_name = exception.polymorphic_type_name.demodulize
 
         Honeycomb.add_field("twitter.result", "error")
         Honeycomb.add_field("twitter.error", class_name)
@@ -38,7 +38,7 @@ module TwitterClient
       end
 
       def handle_error(exception)
-        class_name = exception.class.name.demodulize
+        class_name = exception.polymorphic_type_name.demodulize
 
         # raise specific error if known, generic one if unknown
         error_class = "::TwitterClient::Errors::#{class_name}".safe_constantize

--- a/app/views/api/v0/profile_images/show.json.jbuilder
+++ b/app/views/api/v0/profile_images/show.json.jbuilder
@@ -1,5 +1,5 @@
 json.type_of "profile_image"
 
-json.image_of @profile_image_owner.class.name.downcase
+json.image_of @profile_image_owner.polymorphic_type_name.downcase
 json.profile_image Images::Profile.call(@profile_image_owner.profile_image_url, length: 640)
 json.profile_image_90 Images::Profile.call(@profile_image_owner.profile_image_url, length: 90)

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -36,7 +36,7 @@
     <meta property="og:url" content="<%= app_url("#{@commentable.path}/comments") %>" />
     <meta property="og:title" content="<%= t("views.comments.meta.og.title_root", title: @commentable.title, site: community_name) %>" />
     <meta name="twitter:title" content="<%= t("views.comments.meta.og.title_root", title: @commentable.title, site: community_name) %>">
-    <% if @commentable.class.name == "Article" && @commentable.published %>
+    <% if @commentable.polymorphic_type_name == "Article" && @commentable.published %>
       <meta property="og:image" content="<%= article_social_image_url(@commentable) %>" />
       <meta name="twitter:image" content="<%= article_social_image_url(@commentable) %>">
     <% end %>
@@ -47,7 +47,7 @@
 <%= javascript_packs_with_chunks_tag "commentDropdowns", "followButtons", defer: true %>
 
 <div class="crayons-layout crayons-layout--limited-l gap-0" data-follow-button-container="true">
-  <% if @commentable && @commentable.class.name == "Article" %>
+  <% if @commentable && @commentable.polymorphic_type_name == "Article" %>
     <%= render "shared/payment_pointer", user: @commentable.user %>
     <span id="comment-article-indicator" data-article-id="<%= @commentable.id %>"></span>
   <% end %>

--- a/app/views/credits/_ledger.html.erb
+++ b/app/views/credits/_ledger.html.erb
@@ -20,12 +20,12 @@
         <% end %>
           <td>
             <% if item.purchase %>
-              <%= item.purchase.instance_of?(Listing) ? t("views.credits.ledger.class.listing") : item.purchase.class.name.titleize %>
+              <%= item.purchase.instance_of?(Listing) ? t("views.credits.ledger.class.listing") : item.purchase.polymorphic_type_name.titleize %>
             <% end %>
           </td>
           <td>
             <% if item.purchase %>
-              <%= render "ledger_#{item.purchase.class.name.underscore}", purchase: item.purchase %>
+              <%= render "ledger_#{item.purchase.polymorphic_type_name.underscore}", purchase: item.purchase %>
             <% else %>
               <span><%= t("views.credits.ledger.misc") %></span>
             <% end %>

--- a/app/views/credits/_ledger_sponsorship.html.erb
+++ b/app/views/credits/_ledger_sponsorship.html.erb
@@ -1,4 +1,4 @@
-<% if purchase.sponsorable && purchase.sponsorable.class.name.include?("Tag") %>
+<% if purchase.sponsorable && purchase.sponsorable.polymorphic_type_name.include?("Tag") %>
   <a href="<%= tag_path(purchase.sponsorable.name) %>">
     <%= t("views.credits.tag", name: purchase.sponsorable.name) %>
   </a>

--- a/app/views/dashboards/subscriptions.html.erb
+++ b/app/views/dashboards/subscriptions.html.erb
@@ -32,7 +32,7 @@
       </div>
     <% else %>
       <div class="p-9 crayons-card crayons-card--secondary align-center fs-l h-100 flex items-center justify-center">
-        <%= t("views.dashboard.subscriptions.empty", kind: @source.class.name.downcase) %>
+        <%= t("views.dashboard.subscriptions.empty", kind: @source.polymorphic_type_name.downcase) %>
       </div>
     <% end %>
   </main>

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -22,7 +22,7 @@
       <button class="reaction-button <%= Reaction.cached_any_reactions_for?(@moderatable, current_user, "thumbsup") ? "reacted" : "" %>"
               data-reactable-id="<%= @moderatable.id %>"
               data-category="thumbsup"
-              data-reactable-type="<%= @moderatable.class.name %>">
+              data-reactable-type="<%= @moderatable.polymorphic_type_name %>">
         <div class="reaction-button-circle">
           <%= inline_svg_tag("twemoji/thumb-up.svg", aria: true, class: "crayons-icon crayons-icon--default", width: 32, height: 32, title: t("views.moderations.actions.thumb_up")) %>
           <%= inline_svg_tag("checkmark.svg", aria: true, class: "crayons-icon reaction-checkmark", title: t("views.moderations.actions.checkmark")) %>
@@ -32,7 +32,7 @@
       <button class="reaction-button <%= Reaction.cached_any_reactions_for?(@moderatable, current_user, "thumbsdown") ? "reacted" : "" %>"
               data-reactable-id="<%= @moderatable.id %>"
               data-category="thumbsdown"
-              data-reactable-type="<%= @moderatable.class.name %>">
+              data-reactable-type="<%= @moderatable.polymorphic_type_name %>">
         <div class="reaction-button-circle">
           <%= inline_svg_tag("twemoji/thumb-down.svg", aria: true, class: "crayons-icon crayons-icon--default", width: 32, height: 32, title: t("views.moderations.actions.thumb_down")) %>
           <%= inline_svg_tag("checkmark.svg", aria: true, class: "crayons-icon reaction-checkmark", title: t("views.moderations.actions.checkmark")) %>
@@ -43,7 +43,7 @@
     <button class="reaction-vomit-button <%= Reaction.cached_any_reactions_for?(@moderatable, current_user, "vomit") ? "reacted" : "" %>"
             data-reactable-id="<%= @moderatable.id %>"
             data-category="vomit"
-            data-reactable-type="<%= @moderatable.class.name %>">
+            data-reactable-type="<%= @moderatable.polymorphic_type_name %>">
       <%= inline_svg_tag("twemoji/suspicious.svg", aria: true, class: "crayons-icon crayons-icon--default mr-1", title: "Suspicious...") %>
       <span></span>
       <%= inline_svg_tag("checkmark.svg", aria: true, class: "crayons-icon vomit-checkmark", title: t("views.moderations.actions.checkmark")) %>

--- a/app/views/moderations/mod.html.erb
+++ b/app/views/moderations/mod.html.erb
@@ -17,7 +17,7 @@
 <div class="container mod-container" style="text-align: center">
   <h2><a href="<%= @moderatable.path %>" rel="nofollow"><%= @moderatable.title %></a></h2>
   <h3><a href="<%= @moderatable.user.path %>">@<%= @moderatable.user.username %></a></h3>
-  <% if @moderatable.class.name == "Article" &&
+  <% if @moderatable.polymorphic_type_name == "Article" &&
        (Tag.where(requires_approval: true).pluck(:name) & @moderatable.decorate.cached_tag_list_array).any? &&
        (current_user.any_admin? || @tag_moderator_tags.any? { |tag| @moderatable.tag_list.include?(tag.name) }) %>
     <%= form_tag "/article_approvals", method: "post" do %>
@@ -37,7 +37,7 @@
   <button class="reaction-button <%= Reaction.cached_any_reactions_for?(@moderatable, current_user, "thumbsup") ? "reacted" : "" %>"
           data-reactable-id="<%= @moderatable.id %>"
           data-category="thumbsup"
-          data-reactable-type="<%= @moderatable.class.name %>">
+          data-reactable-type="<%= @moderatable.polymorphic_type_name %>">
     <div class="reaction-button-circle">
       <%= inline_svg_tag("twemoji/thumb-up.svg", aria: true, class: "crayons-icon crayons-icon--default", width: 32, height: 32, title: t("views.moderations.actions.thumb_up")) %>
       <%= inline_svg_tag("checkmark.svg", aria: true, class: "crayons-icon reaction-checkmark", title: t("views.moderations.actions.checkmark")) %>
@@ -47,7 +47,7 @@
     <button class="reaction-button <%= Reaction.cached_any_reactions_for?(@moderatable, current_user, "thumbsdown") ? "reacted" : "" %>"
             data-reactable-id="<%= @moderatable.id %>"
             data-category="thumbsdown"
-            data-reactable-type="<%= @moderatable.class.name %>">
+            data-reactable-type="<%= @moderatable.polymorphic_type_name %>">
       <div class="reaction-button-circle">
         <%= inline_svg_tag("twemoji/thumb-down.svg", aria: true, class: "crayons-icon crayons-icon--default", width: 32, height: 32, title: t("views.moderations.actions.thumb_down")) %>
         <%= inline_svg_tag("checkmark.svg", aria: true, class: "crayons-icon reaction-checkmark", title: t("views.moderations.actions.checkmark")) %>
@@ -57,7 +57,7 @@
     <button class="reaction-button <%= Reaction.cached_any_reactions_for?(@moderatable, current_user, "vomit") ? "reacted" : "" %>"
             data-reactable-id="<%= @moderatable.id %>"
             data-category="vomit"
-            data-reactable-type="<%= @moderatable.class.name %>">
+            data-reactable-type="<%= @moderatable.polymorphic_type_name %>">
       <div class="reaction-button-circle">
         <%= inline_svg_tag("twemoji/suspicious.svg", aria: true, class: "crayons-icon crayons-icon--default", width: 32, height: 32, title: t("views.moderations.actions.suspicious")) %>
         <%= inline_svg_tag("checkmark.svg", aria: true, class: "crayons-icon reaction-checkmark", title: t("views.moderations.actions.checkmark")) %>
@@ -66,11 +66,11 @@
     </button>
   </div>
 
-  <% if current_user.super_admin? && @moderatable.class.name == "Article" %>
+  <% if current_user.super_admin? && @moderatable.polymorphic_type_name == "Article" %>
     <h3> <a href="<%= @moderatable.path %>/edit"><%= t("views.moderations.actions.edit.post") %></a> |
       <a href="/resource_admin/articles/<%= @moderatable.id %>" data-no-instant><%= t("views.moderations.actions.edit.resource_admin") %></a> |
       <a href="<%= admin_article_path(@moderatable.id) %>" data-no-instant><%= t("views.moderations.actions.edit.article_admin") %></a></h3>
-  <% elsif current_user.super_admin? && @moderatable.class.name == "Comment" %>
+  <% elsif current_user.super_admin? && @moderatable.polymorphic_type_name == "Comment" %>
     <h3> <a href="/admin/comments/<%= @moderatable.id %>" data-no-instant><%= t("views.moderations.actions.edit.comment_admin") %></a> |
       <a href="<%= admin_user_path(@moderatable.user_id) %>" data-no-instant><%= t("views.moderations.actions.edit.user_admin") %></a></h3>
   <% end %>
@@ -85,7 +85,7 @@
     <button class="reaction-button <%= Reaction.cached_any_reactions_for?(@moderatable, current_user, "vomit") ? "reacted" : "" %>"
             data-reactable-id="<%= @moderatable.user.id %>"
             data-category="vomit"
-            data-reactable-type="<%= @moderatable.user.class.name %>">
+            data-reactable-type="<%= @moderatable.user.polymorphic_type_name %>">
       <div class="reaction-button-circle">
         <%= inline_svg_tag("twemoji/suspicious.svg", aria: true, class: "crayons-icon crayons-icon--default", width: 32, height: 32, title: t("views.moderations.actions.suspicious")) %>
         <%= inline_svg_tag("checkmark.svg", aria: true, class: "crayons-icon reaction-checkmark", title: t("views.moderations.actions.checkmark")) %>
@@ -96,7 +96,7 @@
       <%= t("views.moderations.actions.abusive.desc_html") %>
     </p>
   </div>
-  <% if current_user.any_admin? && @moderatable.class.name == "Comment" && !@moderatable.deleted %>
+  <% if current_user.any_admin? && @moderatable.polymorphic_type_name == "Comment" && !@moderatable.deleted %>
     <div class="crayons-card crayons-card--secondary p-4 flex items-center">
       <div class="fw-medium flex-1" style="text-align: left;">
         <p class="fw-bold fs-xl"><%= t("views.moderations.actions.delete.subtitle") %></p>
@@ -170,7 +170,7 @@
     </div>
   <% end %>
 
-  <% if @moderatable.class.name == "Article" %>
+  <% if @moderatable.polymorphic_type_name == "Article" %>
     <div class="tag-mod-form">
       <% @rating_vote = RatingVote.where(article_id: @moderatable.id, user_id: current_user.id).first %>
       <% rating_hash = { "Novice" => 1, "Beginner" => 2, "Mid-level" => 3, "Advanced" => 4, "Expert" => 5 } %>

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -20,7 +20,7 @@
           <button
             id="user-follow-butt"
             class="crayons-btn whitespace-nowrap follow-action-button"
-            data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>", "name": "<%= @user.name %>"}'>
+            data-info='{"id":<%= @user.id %>,"className":"<%= @user.polymorphic_type_name %>", "name": "<%= @user.name %>"}'>
             <%= t("views.organizations.follow") %>
           </button>
         </div>

--- a/app/views/podcast_episodes/index.html.erb
+++ b/app/views/podcast_episodes/index.html.erb
@@ -20,7 +20,7 @@
               id="user-follow-butt"
               class="crayons-btn crayons-btn--inverted follow-action-button"
               style="min-width: 100px;"
-              data-info='{"id":<%= @podcast.id %>,"className":"<%= @podcast.class.name %>", "name": "<%= @podcast.name %>"}'>
+              data-info='{"id":<%= @podcast.id %>,"className":"<%= @podcast.polymorphic_type_name %>", "name": "<%= @podcast.name %>"}'>
                 &nbsp;
             </button>
           </p>

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -38,7 +38,7 @@
         <button
           id="user-follow-butt"
           class="crayons-btn follow-action-button"
-          data-info='{"id":<%= @podcast.id %>,"className":"<%= @podcast.class.name %>", "name": "<%= @podcast.name %>"}'>
+          data-info='{"id":<%= @podcast.id %>,"className":"<%= @podcast.polymorphic_type_name %>", "name": "<%= @podcast.name %>"}'>
           &nbsp;
         </button>
       </h2>

--- a/app/views/shared/_logo_design.html.erb
+++ b/app/views/shared/_logo_design.html.erb
@@ -1,6 +1,6 @@
 <div class="grid gap-6 m:grid-cols-2">
   <div class="grid gap-6">
-    <% if account.class.name == "User" %>
+    <% if account.polymorphic_type_name == "User" %>
       <% account.setting.brand_color1 = user_colors(account)[:bg] if account.setting && account.setting.brand_color1.blank? %>
       <% account.setting.brand_color2 = user_colors(account)[:text] if account.setting && account.setting.brand_color2.blank? %>
     <% else %>
@@ -20,7 +20,7 @@
     </div>
 
     <div class="crayons-field">
-      <% if account.class.name == "User" %>
+      <% if account.polymorphic_type_name == "User" %>
         <% account.setting.brand_color1 = user_colors(account)[:text] if account.setting && account.setting.brand_color2.blank? %>
       <% else %>
         <% account.bg_color_hex = user_colors(account)[:text] if account.text_color_hex.blank? %>

--- a/app/views/shared/_profile_card_content.html.erb
+++ b/app/views/shared/_profile_card_content.html.erb
@@ -1,7 +1,7 @@
 <div class="-mt-4">
   <a href="<%= actor.path %>" class="flex">
-    <span class="<% if actor.class.name == "User" %>crayons-avatar crayons-avatar--xl<% elsif actor.class.name == "Organization" %>crayons-logo crayons-logo--xl<% end %>  mr-2 shrink-0">
-      <img src="<%= Images::Profile.call(actor.profile_image_url, length: 90) %>" class="<% if actor.class.name == "User" %>crayons-avatar__image<% elsif actor.class.name == "Organization" %>crayons-logo__image<% end %>" alt="" loading="lazy" />
+    <span class="<% if actor.polymorphic_type_name == "User" %>crayons-avatar crayons-avatar--xl<% elsif actor.polymorphic_type_name == "Organization" %>crayons-logo crayons-logo--xl<% end %>  mr-2 shrink-0">
+      <img src="<%= Images::Profile.call(actor.profile_image_url, length: 90) %>" class="<% if actor.polymorphic_type_name == "User" %>crayons-avatar__image<% elsif actor.polymorphic_type_name == "Organization" %>crayons-logo__image<% end %>" alt="" loading="lazy" />
     </span>
     <span class="crayons-link crayons-subtitle-2 mt-5"><%= actor.name %></span>
   </a>
@@ -16,7 +16,7 @@
   </div>
 <% end %>
 
-<% if actor.class.name == "User" %>
+<% if actor.polymorphic_type_name == "User" %>
   <div class="user-metadata-details">
     <ul class="user-metadata-details-inner">
       <% if actor.setting.display_email_on_profile && context != "sidebar" %>
@@ -61,7 +61,7 @@
       </li>
     </ul>
   </div>
-<% elsif actor.class.name == "Organization" && actor.approved_and_filled_out_cta? %>
+<% elsif actor.polymorphic_type_name == "Organization" && actor.approved_and_filled_out_cta? %>
   <div>
     <%= sanitize_rendered_markdown(actor.cta_processed_html) %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -32,7 +32,7 @@
           </span>
 
           <div class="profile-header__actions">
-              <button id="user-follow-butt" class="crayons-btn whitespace-nowrap follow-action-button follow-user" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>", "name": "<%= @user.name %>"}'><%= t("views.users.follow") %></button>
+              <button id="user-follow-butt" class="crayons-btn whitespace-nowrap follow-action-button follow-user" data-info='{"id":<%= @user.id %>,"className":"<%= @user.polymorphic_type_name %>", "name": "<%= @user.name %>"}'><%= t("views.users.follow") %></button>
         <div class="profile-dropdown ml-2 s:relative hidden" data-username="<%= @user.username %>">
               <button id="user-profile-dropdown" aria-expanded="false" aria-controls="user-profile-dropdownmenu" aria-haspopup="true" class="crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon">
                 <%= crayons_icon_tag("overflow-horizontal", css_class: "dropdown-icon", title: t("views.users.dropdown")) %>
@@ -110,7 +110,7 @@
                 <p class="fw-bold mb-2">@<%= @user.username %>'s guidelines:</p>
                 <p class="mb-6"><%= @user.setting.inbox_guidelines %></p>
               <% end %>
-              <form id="new-message-form" class="message-form mb-4" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>","username":"<%= @user.username %>", "showChat":"<%= @user.setting.inbox_type %>"}'>
+              <form id="new-message-form" class="message-form mb-4" data-info='{"id":<%= @user.id %>,"className":"<%= @user.polymorphic_type_name %>","username":"<%= @user.username %>", "showChat":"<%= @user.setting.inbox_type %>"}'>
                 <textarea id="new-message" rows="4" cols="70" placeholder="<%= t("views.users.send_pm.placeholder") %>" class="crayons-textfield"></textarea>
                 <button type="submit" class="submit-message crayons-btn"><%= t("views.users.send_pm.submit") %></button>
               </form>

--- a/spec/decorators/notification_decorator_spec.rb
+++ b/spec/decorators/notification_decorator_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe NotificationDecorator, type: :decorator do
       result = notification.decorate.mocked_object("user")
 
       expect(result.class).to be_a(Struct)
-      expect(result.class.name).to be_empty
+      expect(result.polymorphic_type_name).to be_empty
     end
 
     it "returns class name and id for the reactable in a struct" do
@@ -48,7 +48,7 @@ RSpec.describe NotificationDecorator, type: :decorator do
       result = notification.decorate.mocked_object("user")
 
       expect(result.class).to be_a(Struct)
-      expect(result.class.name).to eq("User")
+      expect(result.polymorphic_type_name).to eq("User")
     end
   end
 

--- a/spec/models/application_record_spec.rb
+++ b/spec/models/application_record_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe ApplicationRecord, type: :model do
     end
   end
 
+  describe "#polymorphic_type_name" do
+    it "is the class's name" do
+      article = Article.new
+      expect(article.polymorphic_type_name).to eq("Article")
+    end
+
+    context "when using a decorator" do
+      it "is the decorated object's polymorphic_type_name" do
+        article = Article.new
+        expect(article.decorate.polymorphic_type_name).to eq(article.polymorphic_type_name)
+      end
+    end
+  end
+
   describe "#decorate" do
     it "decorates an object that has a decorator" do
       sponsorship = build(:sponsorship)

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -107,7 +107,8 @@ RSpec.describe Notification, type: :model do
 
         notification = user2.notifications.last
         notifiable_data = { notifiable_id: notification.notifiable_id, notifiable_type: notification.notifiable_type }
-        follow_data = { notifiable_id: user_follows_user2.id, notifiable_type: user_follows_user2.class.name }
+        follow_data = { notifiable_id: user_follows_user2.id,
+                        notifiable_type: user_follows_user2.polymorphic_type_name }
         expect(notifiable_data).to eq(follow_data)
       end
     end
@@ -139,7 +140,7 @@ RSpec.describe Notification, type: :model do
         notifiable_data = { notifiable_id: notification.notifiable_id, notifiable_type: notification.notifiable_type }
         follow_data = {
           notifiable_id: user_follows_organization.id,
-          notifiable_type: user_follows_organization.class.name
+          notifiable_type: user_follows_organization.polymorphic_type_name
         }
         expect(notifiable_data).to eq(follow_data)
       end

--- a/spec/requests/credits_spec.rb
+++ b/spec/requests/credits_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Credits", type: :request do
 
       it "shows listing purchases" do
         listing = create(:listing, user: user, title: "Awesome opportunity")
-        purchase_params = { user: user, purchase_type: listing.class.name, purchase_id: listing.id }
+        purchase_params = { user: user, purchase_type: listing.polymorphic_type_name, purchase_id: listing.id }
         create(:credit, params.merge(purchase_params))
 
         sign_in user
@@ -46,7 +46,8 @@ RSpec.describe "Credits", type: :request do
       it "does not show sponsorship purchases to org members" do
         org = org_member.organizations.first
         sponsorship = create(:sponsorship, organization: org, user: org_admin)
-        purchase_params = { organization: org, purchase_type: sponsorship.class.name, purchase_id: sponsorship.id }
+        purchase_params = { organization: org, purchase_type: sponsorship.polymorphic_type_name,
+                            purchase_id: sponsorship.id }
         create(:credit, params.merge(purchase_params))
 
         sign_in org_member
@@ -60,7 +61,8 @@ RSpec.describe "Credits", type: :request do
       it "shows sponsorship purchases to org admins" do
         org = org_admin.organizations.first
         sponsorship = create(:sponsorship, organization: org, user: org_admin)
-        purchase_params = { organization: org, purchase_type: sponsorship.class.name, purchase_id: sponsorship.id }
+        purchase_params = { organization: org, purchase_type: sponsorship.polymorphic_type_name,
+                            purchase_id: sponsorship.id }
         create(:credit, params.merge(purchase_params))
 
         sign_in org_admin
@@ -75,7 +77,8 @@ RSpec.describe "Credits", type: :request do
         org = org_admin.organizations.first
         tag = create(:tag)
         sponsorship = create(:sponsorship, organization: org, user: org_admin, level: :tag, sponsorable: tag)
-        purchase_params = { organization: org, purchase_type: sponsorship.class.name, purchase_id: sponsorship.id }
+        purchase_params = { organization: org, purchase_type: sponsorship.polymorphic_type_name,
+                            purchase_id: sponsorship.id }
         create(:credit, params.merge(purchase_params))
 
         sign_in org_admin

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -305,7 +305,8 @@ RSpec.describe "Dashboards", type: :request do
     let(:author) { create(:user) }
     let(:article_with_user_subscription_tag) { create(:article, user: author, with_user_subscription_tag: true) }
     let(:params) do
-      { source_type: article_with_user_subscription_tag.class.name, source_id: article_with_user_subscription_tag.id }
+      { source_type: article_with_user_subscription_tag.polymorphic_type_name,
+        source_id: article_with_user_subscription_tag.id }
     end
 
     before do
@@ -340,7 +341,8 @@ RSpec.describe "Dashboards", type: :request do
              subscriber_email: second_user.email,
              author_id: unauthorized_article.user_id,
              user_subscription_sourceable: unauthorized_article)
-      unauthorized_article_params = { source_type: unauthorized_article.class.name, source_id: unauthorized_article.id }
+      unauthorized_article_params = { source_type: unauthorized_article.polymorphic_type_name,
+                                      source_id: unauthorized_article.id }
 
       expect do
         get "/dashboard/subscriptions", params: unauthorized_article_params
@@ -355,7 +357,7 @@ RSpec.describe "Dashboards", type: :request do
     end
 
     it "raises an error when the source can't be found" do
-      nonexistent_article_params = { source_type: article.class.name, source_id: article.id + 999 }
+      nonexistent_article_params = { source_type: article.polymorphic_type_name, source_id: article.id + 999 }
       expect do
         get "/dashboard/subscriptions", params: nonexistent_article_params
       end.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe "NotificationsIndex", type: :request do
             :reaction,
             user_id: user.id,
             reactable_id: reactable.id,
-            reactable_type: reactable.class.name,
+            reactable_type: reactable.polymorphic_type_name,
             category: categories.sample,
           )
         end

--- a/spec/services/credits/ledger_spec.rb
+++ b/spec/services/credits/ledger_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Credits::Ledger, type: :service do
     params = {
       spent: true,
       spent_at: Time.current,
-      purchase_type: purchase.class.name,
+      purchase_type: purchase.polymorphic_type_name,
       purchase_id: purchase.id
     }
     params.merge!((

--- a/spec/services/notifications/tag_adjustment_notification/send_spec.rb
+++ b/spec/services/notifications/tag_adjustment_notification/send_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Notifications::TagAdjustmentNotification::Send, type: :service do
   specify "notification to have valid attributes", :aggregate_failures do
     expect(notification.user_id).to eq(article.user_id)
     expect(notification.notifiable_id).to eq(tag_adjustment.id)
-    expect(notification.notifiable_type).to eq(tag_adjustment.class.name)
+    expect(notification.notifiable_type).to eq(tag_adjustment.polymorphic_type_name)
   end
 
   it "tests JSON data" do

--- a/spec/services/user_subscriptions/create_from_controller_params_spec.rb
+++ b/spec/services/user_subscriptions/create_from_controller_params_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UserSubscriptions::CreateFromControllerParams, type: :service do
 
   it "returns an error for an invalid source type" do
     source = create(:comment)
-    user_subscription_params = { source_type: source.class.name, source_id: source.id,
+    user_subscription_params = { source_type: source.polymorphic_type_name, source_id: source.id,
                                  subscriber_email: subscriber.email }
     user_subscription = described_class.call(subscriber, user_subscription_params)
 
@@ -16,7 +16,7 @@ RSpec.describe UserSubscriptions::CreateFromControllerParams, type: :service do
 
   it "returns an error for an invalid source" do
     source = create(:article, :with_user_subscription_tag_role_user, with_user_subscription_tag: true)
-    user_subscription_params = { source_type: source.class.name, source_id: source.id + 999,
+    user_subscription_params = { source_type: source.polymorphic_type_name, source_id: source.id + 999,
                                  subscriber_email: subscriber.email }
     user_subscription = described_class.call(subscriber, user_subscription_params)
 
@@ -28,7 +28,7 @@ RSpec.describe UserSubscriptions::CreateFromControllerParams, type: :service do
   # TODO: [@forem/delightful]: re-enable this once email confirmation is re-enabled
   xit "returns an error for an email mismatch" do
     source = create(:article, :with_user_subscription_tag_role_user, with_user_subscription_tag: true)
-    user_subscription_params = { source_type: source.class.name, source_id: source.id,
+    user_subscription_params = { source_type: source.polymorphic_type_name, source_id: source.id,
                                  subscriber_email: "old@email.com" }
     user_subscription = described_class.call(subscriber, user_subscription_params)
 
@@ -39,7 +39,7 @@ RSpec.describe UserSubscriptions::CreateFromControllerParams, type: :service do
 
   it "returns an error if a UserSubscription can't be created" do
     source = create(:article, :with_user_subscription_tag_role_user)
-    user_subscription_params = { source_type: source.class.name, source_id: source.id,
+    user_subscription_params = { source_type: source.polymorphic_type_name, source_id: source.id,
                                  subscriber_email: subscriber.email }
     user_subscription = described_class.call(subscriber, user_subscription_params)
 
@@ -50,12 +50,12 @@ RSpec.describe UserSubscriptions::CreateFromControllerParams, type: :service do
 
   it "creates a UserSubscription" do
     source = create(:article, :with_user_subscription_tag_role_user, with_user_subscription_tag: true)
-    user_subscription_params = { source_type: source.class.name, source_id: source.id,
+    user_subscription_params = { source_type: source.polymorphic_type_name, source_id: source.id,
                                  subscriber_email: subscriber.email }
     user_subscription = described_class.call(subscriber, user_subscription_params)
 
     expect(user_subscription.data).to be_an_instance_of UserSubscription
-    expect(user_subscription.data.user_subscription_sourceable_type).to eq source.class.name
+    expect(user_subscription.data.user_subscription_sourceable_type).to eq source.polymorphic_type_name
     expect(user_subscription.data.user_subscription_sourceable_id).to eq source.id
     expect(user_subscription.data.subscriber_email).to eq subscriber.email
     expect(user_subscription.data.subscriber_id).to eq subscriber.id

--- a/spec/support/omniauth_helpers.rb
+++ b/spec/support/omniauth_helpers.rb
@@ -158,7 +158,7 @@ module OmniauthHelpers
   end
 
   def omniauth_failure_args(error, provider, params)
-    class_name = error.present? ? error.class.name : ""
+    class_name = error.present? ? error.polymorphic_type_name : ""
 
     [
       { tags: [

--- a/spec/workers/mentions/create_all_worker_spec.rb
+++ b/spec/workers/mentions/create_all_worker_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Mentions::CreateAllWorker, type: :worker do
 
     context "when comment is valid" do
       it "calls on Mentions::CreateAll" do
-        worker.perform(comment.id, comment.class.name)
+        worker.perform(comment.id, comment.polymorphic_type_name)
 
         expect(Mentions::CreateAll).to have_received(:call).with(comment)
       end

--- a/spec/workers/users/follow_worker_spec.rb
+++ b/spec/workers/users/follow_worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Users::FollowWorker, type: :worker do
     context "when followable doesn't exist" do
       it "doesn't follow user" do
         expect do
-          worker.perform(user.id, invalid_id, followable.class.name)
+          worker.perform(user.id, invalid_id, followable.polymorphic_type_name)
         end.not_to change(Follow, :count)
       end
     end
@@ -18,7 +18,7 @@ RSpec.describe Users::FollowWorker, type: :worker do
     context "when user doesn't exist" do
       it "doesn't follow user" do
         expect do
-          worker.perform(invalid_id, followable.id, followable.class.name)
+          worker.perform(invalid_id, followable.id, followable.polymorphic_type_name)
         end.not_to change(Follow, :count)
       end
     end
@@ -32,7 +32,7 @@ RSpec.describe Users::FollowWorker, type: :worker do
 
       it "follows user" do
         expect do
-          worker.perform(user.id, followable.id, followable.class.name)
+          worker.perform(user.id, followable.id, followable.polymorphic_type_name)
         end.to change(Follow, :count).by(1)
       end
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Documentation Update

## Description

Throughout the code base we make use of a lot of polymorphic
relations (e.g. acts_as_follower, acts_as_taggable, etc.).  Which means
we often want to know the name of the relationship.

Furthermore in our views and controllers we've often relied on using
`object.class.name` for branching logic.

However, with the sometimes transparent usage of the
ApplicationDecorator, we can get unexpected results.

This change is intended to help us move past the somewhat fragile method
chain of `object.class.name`.

## Related Tickets & Documents

Quasi-related to #16067, #15916, #14704, and #15983.

## QA Instructions, Screenshots, Recordings

None.  We shall look to our test suite.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
