### PR TITLE
Implement Forem Comment Unified Embed

### DIFF
--- a/app/liquid_tags/comment_tag.rb
+++ b/app/liquid_tags/comment_tag.rb
@@ -1,9 +1,14 @@
 class CommentTag < LiquidTagBase
   PARTIAL = "comments/liquid".freeze
+  REGISTRY_REGEXP = %r{#{URL.url}/\w+/comment/(?<comment_id>\w+)}
+  VALID_ID_REGEXP = /\A(?<comment_id>\w+)\Z/
+  REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 
   def initialize(_tag_name, id_code, _parse_context)
     super
-    @comment = find_comment(id_code.strip)
+
+    input    = CGI.unescape_html(strip_tags(id_code))
+    @comment = find_comment(parse_id_code(input))
   end
 
   def render(_context)
@@ -16,8 +21,19 @@ class CommentTag < LiquidTagBase
   def find_comment(id_code)
     Comment.find_by(id_code: id_code)
   end
+
+  private
+
+  def parse_id_code(input)
+    match = pattern_match_for(input, REGEXP_OPTIONS)
+    raise StandardError, "Invalid Comment ID or URL" unless match
+
+    match[:comment_id]
+  end
 end
 
 Liquid::Template.register_tag("comment", CommentTag)
 # kept for compatibility with existing comments embeds on DEV
 Liquid::Template.register_tag("devcomment", CommentTag)
+
+UnifiedEmbed.register(CommentTag, regexp: CommentTag::REGISTRY_REGEXP)

--- a/spec/liquid_tags/comment_tag_spec.rb
+++ b/spec/liquid_tags/comment_tag_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CommentTag, type: :liquid_tag do
     end
 
     it "renders 'Comment Not Found' message if comment ID does not exist" do
-      liquid = generate_comment_tag("nonexistent ID")
+      liquid = generate_comment_tag("nonexistentid")
 
       expect(liquid.render).to include("Comment Not Found")
     end
@@ -50,6 +50,14 @@ RSpec.describe CommentTag, type: :liquid_tag do
 
       expect(liquid.render).to include(comment.body_markdown)
       expect(liquid.render).to include(user.name)
+    end
+  end
+
+  context "when given invalid id_code" do
+    it "raises an error" do
+      expect do
+        generate_comment_tag("Invalid%ID").render
+      end.to raise_error(StandardError, "Invalid Comment ID or URL")
     end
   end
 end

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 RSpec.describe UnifiedEmbed::Registry do
   subject(:unified_embed) { described_class }
 
+  let(:user) { create(:user) }
   let(:article) { create(:article) }
+  let(:comment) do
+    create(:comment, commentable: article, user: user, body_markdown: "TheComment")
+  end
 
   describe ".find_liquid_tag_for" do
     valid_blogcast_url_formats = [
@@ -72,6 +76,11 @@ RSpec.describe UnifiedEmbed::Registry do
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(CodesandboxTag)
       end
+    end
+
+    it "returns CommentTag for a Forem comment url" do
+      expect(described_class.find_liquid_tag_for(link: "#{URL.url}/#{user.username}/comment/#{comment.id_code}"))
+        .to eq(CommentTag)
     end
 
     it "returns GistTag for a gist url" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Forem comment embeds.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15555

## QA Instructions, Screenshots, Recordings
- As a user, grab the URLs of some comments. Create a Forem Comment liquid tag using this format: `{% embed <forem-comment-url> %}`. The Comment Liquid Tag should render properly.
- Also create Forem Comment liquid tag using the old method: `{% comment <forem-comment-idcode> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?
None

## Added/updated tests?
- [X] Yes


## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.

## [optional] Are there any post deployment tasks we need to perform?
None