### PR TITLE
[feed] Change weighted query limit from 50 (default) to 25

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -45,6 +45,7 @@ module Stories
                )
                Articles::Feeds::WeightedQueryStrategy.new(
                  user: current_user,
+                 number_of_articles: 25,
                  page: @page,
                  tags: params[:tag],
                  strategy: strategy,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This is a minimal adjustment that will affect the functionality of all feed results — I'm curious to a/b test the precise number in the future, but for now consider this a really safe improvement on what we're currently seeing.

The current algorithm creates an `order` for making the initial query, ultimately does not return the results in the order of total compiled order from the prior step.

```ruby
        Article.where(
          Article.arel_table[:id].in(
            Arel.sql(
              Article.sanitize_sql(unsanitized_sub_sql),
            ),
          ),
        ).limited_column_select.includes(top_comments: :user)
```

The ultimate query has no order clause, it just takes articles with ids from the `Article.sanitize_sql(unsanitized_sub_sql)` but doesn't order them by their original fetch.

I'm not entirely sure whether this is _intentional_, but I'll make some changes which can be submitted as a future test. For now, I just felt like making an _very minimal change_ that shouldn't really affect the test, but should make all results _just a bit more_ relevant. 😊 

All else equal, we really don't need to return 50 results here anyway — that number made a bit more sense in the old approach, so this will be a small optimization for all of these queries... Memory and bandwidth.

## Related Tickets & Documents
https://forem.dev/foremteam/feed-test-experiment-2-results-new-query-strategy-has-pulled-even-j07

## QA Instructions, Screenshots, Recordings

rspec tests should suffice here.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Not a substantial technical change
- [ ] I need help with writing tests

