### PR TITLE
Replacing custom call with existing cached method

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -160,7 +160,12 @@ class Article < ApplicationRecord
     SQL
   end
 
+  # @todo Enforce the serialization class (e.g., Articles::CachedEntity)
+  # @see https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize
   serialize :cached_user
+
+  # @todo Enforce the serialization class (e.g., Articles::CachedEntity)
+  # @see https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Serialization/ClassMethods.html#method-i-serialize
   serialize :cached_organization
 
   # TODO: [@rhymes] Rename the article column and the trigger name.

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -30,7 +30,7 @@
           <% end %>
 
           <a href="/<%= story.cached_user.username %>" class="crayons-avatar <% if story.cached_organization && !@organization_article_index %> crayons-avatar--s absolute -right-2 -bottom-2 border-solid border-2 border-base-inverted <% else %> crayons-avatar--l <% end %> ">
-            <img src="<%= story.cached_user.profile_image_url_for(length: 90) %>" alt="<%= story.cached_user.username %> profile" class="crayons-avatar__image" loading="lazy" />
+            <img src="<%= story.cached_user.profile_image_90 %>" alt="<%= story.cached_user.username %> profile" class="crayons-avatar__image" loading="lazy" />
           </a>
         </div>
         <div>
@@ -54,7 +54,7 @@
                     <a href="/<%= story.cached_user.username %>" class="flex">
                       <span class="crayons-avatar crayons-avatar--xl mr-2 shrink-0">
                         <img
-                          src="<%= story.cached_user.profile_image_url_for(length: 90) %>"
+                          src="<%= story.cached_user.profile_image_90 %>"
                           class="crayons-avatar__image"
                           alt=""
                           loading="lazy" />

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1008,6 +1008,7 @@ RSpec.describe Article, type: :model do
     end
 
     it "assigns cached_user on save" do
+      expect(article.cached_user).to be_a(Articles::CachedEntity)
       expect(article.cached_user.name).to eq(article.user.name)
       expect(article.cached_user.username).to eq(article.user.username)
       expect(article.cached_user.slug).to eq(article.user.username)
@@ -1017,6 +1018,7 @@ RSpec.describe Article, type: :model do
 
     it "assigns cached_organization on save" do
       article = create(:article, user: user, organization: create(:organization))
+      expect(article.cached_organization).to be_a(Articles::CachedEntity)
       expect(article.cached_organization.name).to eq(article.organization.name)
       expect(article.cached_organization.username).to eq(article.organization.username)
       expect(article.cached_organization.slug).to eq(article.organization.slug)

--- a/spec/models/articles/cached_entity_spec.rb
+++ b/spec/models/articles/cached_entity_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Articles::CachedEntity, type: :model do
+  subject(:struct) { described_class.from_object(object) }
+
+  let(:object) { build(:user) }
+
+  it { is_expected.to respond_to(:profile_image_url_for) }
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [x] Documentation Update

## Description

There's a few things going on:

1. I introduced [a change][1].
2. There was a [data script][2] that should've completed successfully, but
   some data was not converted (see [Blazer query on DEV.to][3])

Thus the current state of the data means that we have have serialized
data in an `OpenStruct` format and `Articles::CachedEntity` format.

This patch should work because the OpenStruct should previously have an
`image_profile_90` attribute.

In addition, I have added some recommendations and tests to better
describe what's happening.

[1]:https://github.com/forem/forem/blob/9780dba3807e53e01c4999b863d4d8392d1b8d63/app/models/articles/cached_entity.rb#L4
[2]:https://github.com/forem/forem/blob/9780dba3807e53e01c4999b863d4d8392d1b8d63/lib/data_update_scripts/20200723070918_update_articles_cached_entities.rb#L1
[3]:https://dev.to/admin/blazer/queries/609-serialized-data-in-mixed-forms

## Related Tickets & Documents

See https://app.honeybadger.io/projects/66984/faults/83505994#notice-trace

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
