### PR TITLE
Moving from 'should' syntax to 'expect'

### DIFF
--- a/spec/models/html_variant_spec.rb
+++ b/spec/models/html_variant_spec.rb
@@ -73,6 +73,6 @@ RSpec.describe HtmlVariant, type: :model do
 
   it "strips whitespace from the name" do
     variant = create(:html_variant, name: " hello world ")
-    variant.reload.name.should eq "hello world"
+    expect(variant.reload.name).to eq "hello world"
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

In Travis I found the following message:

> Using `should` from rspec-expectations' old `:should` syntax without
> explicitly enabling the syntax is deprecated. Use the new `:expect`
> syntax or explicitly enable `:should` with
> `config.expect_with(:rspec) > { |c| c.syntax = :should }`
> instead. Called from
> /home/travis/build/forem/forem/spec/models/html_variant_spec.rb:76:in
> `block (2 levels) in <main>'.

## Related Tickets & Documents

None.

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: Removing a deprecation notice.
