### PR TITLE
Remove explicit Zeitwerk config, require hack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,11 +48,6 @@ module PracticalDeveloper
     config.active_support.hash_digest_class = ::Digest::MD5 # New default is ::Digest::SHA1
     ### END FRAMEWORK DEFAULT OVERIDES
 
-    # Zeitwerk is the new autoloader in Rails 6+
-    # As we don't have `load_defaults 6.0` yet, it has to be enabled manually
-    # See <https://guides.rubyonrails.org/autoloading_and_reloading_constants.html>
-    config.autoloader = :zeitwerk
-
     # Disable auto adding of default load paths to $LOAD_PATH
     # Setting this to false saves Ruby from checking these directories when
     # resolving require calls with relative paths, and saves Bootsnap work and
@@ -66,11 +61,6 @@ module PracticalDeveloper
     # the framework and any gems in your application.
     config.autoload_paths += Dir["#{config.root}/lib"]
     config.eager_load_paths += Dir["#{config.root}/lib"]
-
-    # Middlewares folder is not otherwise autorequired.
-    Dir["#{config.root}/app/middlewares/**/*.rb"].each do |file|
-      require_dependency(file)
-    end
 
     config.middleware.use Rack::Deflater
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

More cleanup of our `config/application.rb`:

1. We enabled the Rails 6.0 defaults so we can remove the explicit enabling of Zeitwerk as autoloader
2. We were explicitly requiring files from `app/middlewares`. However, we don't even have this directory anymore, the files are now in `app/lib/middlewares` and are correctly autoloaded anyway.

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: config changes only