### PR TITLE
Enable use_cookies_with_metadata option

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,10 +39,6 @@ module PracticalDeveloper
     # Therefore we disable "per_form_csrf_tokens" for the time being.
     config.action_controller.per_form_csrf_tokens = false
 
-    ## Rails 6.0
-    # Enables writing cookies with the purpose metadata embedded.
-    config.action_dispatch.use_cookies_with_metadata = false
-
     ## Rails 6.1
     # This replaces the old config.active_support.use_sha1_digests from Rails 5.2
     config.active_support.hash_digest_class = ::Digest::MD5 # New default is ::Digest::SHA1


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

Rails 6 added a handy `config.use_cookies_with_metadata` option which provides some added security by preventing user's from using one cookie's values in a different cookie.

More details: [Rails 6 adds Purpose Metadata to Cookies](https://blog.saeloun.com/2019/11/12/rails-6-adds-purpose-metadata-to-cookies.html)

As the linked article states

> Cookies previously set without this metadata will continue to be honored.

which means this option should be safe to enable. However, in case SRE wants to test this separately on a Canary first I made a separate PR for this change instead of making it part of #16086.

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: config change