### PR TITLE
Move work from template to controller

### DIFF
--- a/app/controllers/liquid_embeds_controller.rb
+++ b/app/controllers/liquid_embeds_controller.rb
@@ -7,7 +7,12 @@ class LiquidEmbedsController < ApplicationController
     set_surrogate_key_header params.to_s
 
     begin
-      @liquid_node = Liquid::Template.parse("{% #{params[:embeddable]} #{params[:args]} %}").root.nodelist.first
+      @rendered_node = Liquid::Template
+        .parse("{% #{params[:embeddable]} #{params[:args]} %}")
+        .root
+        .nodelist
+        .first
+        .render({})
     rescue StandardError
       raise ActionController::RoutingError, "Not Found"
     end

--- a/app/controllers/liquid_embeds_controller.rb
+++ b/app/controllers/liquid_embeds_controller.rb
@@ -5,6 +5,12 @@ class LiquidEmbedsController < ApplicationController
 
   def show
     set_surrogate_key_header params.to_s
+
+    begin
+      @liquid_node = Liquid::Template.parse("{% #{params[:embeddable]} #{params[:args]} %}").root.nodelist.first
+    rescue StandardError
+      raise ActionController::RoutingError, "Not Found"
+    end
   end
 
   private

--- a/app/views/liquid_embeds/show.html.erb
+++ b/app/views/liquid_embeds/show.html.erb
@@ -2,11 +2,7 @@
 <% cache "liquid_tag_styles_#{ForemInstance.deployed_at}", expires_in: 8.hours do #TODO: Render specific ltag class instead of everything %>
   <style><%= Rails.application.assets["ltags/LiquidTags.css"].to_s.html_safe %></style>
 <% end %>
-<% begin %>
-  <% @liquid_node = Liquid::Template.parse("{% #{params[:embeddable]} #{params[:args]} %}").root.nodelist.first %>
-  <%= @liquid_node.render({}) %>
-<% rescue %>
-  <% raise ActionController::RoutingError, "Not Found" %>
-<% end %>
+
+<%= @liquid_node.render({}) %>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.1.1/iframeResizer.contentWindow.min.js" integrity="sha384-G6tHzK74z1pvDJPpiekQQg/Ad3+gDzJkLvIheIjfKjYVFG7Wpsot40rOJkXT92B2" crossorigin="anonymous" defer="defer"></script>

--- a/app/views/liquid_embeds/show.html.erb
+++ b/app/views/liquid_embeds/show.html.erb
@@ -3,6 +3,6 @@
   <style><%= Rails.application.assets["ltags/LiquidTags.css"].to_s.html_safe %></style>
 <% end %>
 
-<%= @liquid_node.render({}) %>
+<%= @rendered_node %>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.1.1/iframeResizer.contentWindow.min.js" integrity="sha384-G6tHzK74z1pvDJPpiekQQg/Ad3+gDzJkLvIheIjfKjYVFG7Wpsot40rOJkXT92B2" crossorigin="anonymous" defer="defer"></script>

--- a/spec/requests/liquid_embeds_spec.rb
+++ b/spec/requests/liquid_embeds_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "LiquidEmbeds", type: :request, vcr: { cassette_name: "twitter_cl
     it "renders 404 if improper tweet" do
       expect do
         get liquid_embed_path("tweet", args: "improper")
-      end.to raise_error(ActionView::Template::Error)
+      end.to raise_error(ActionController::RoutingError)
     end
 
     it "contains base target parent" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While tracking down an exception that came through, I noticed we were doing some work inside a template that made more sense in the controller.

This is technically slightly semantically different in that an error in `@liquid_node.render` would previously have returned a 404 and this turns that into a 500. Arguably, the behavior of this PR is more correct. An error in rendering the Liquid template that it did find seems like it shouldn't return a "Not Found" error since it's an internal logic error. All other behavior should be identical.

When reviewing, it might help to remove whitespace-only changes. This will highlight that only the `@liquid_node.render` call stayed in the template. I simply unindented it since it was no longer inside a `begin` block.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Most behavior is the same
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: Simple refactor

## [optional] Are there any post deployment tasks we need to perform?

I'm probably gonna cry but I wouldn't say it's _necessary_