### PR TITLE
Turn featured back on as query scoring weight

### DIFF
--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -146,7 +146,7 @@ module Articles
           fallback: 0.85,
           requires_user: false,
           group_by: "articles.featured",
-          enabled: false
+          enabled: true
         },
         # Weight to give when the given user follows the article's
         # author.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A prior iteration on the feed disabled this scoring factor config under this pretense:

> Disable a few levers that did little. There really aren't any articles.featured = true articles in the database.

Yes, there are relatively few featured articles (28k total which is _relatively_ few)

Featured has been consistently used as an option for admins to _bump_ any posts within the algorithm. It's not as powerful as pinning, and will still not beat out other ranking factors (appropriate weight is subject to further experimentation), but it is a lever to gently promote content which the _admin_ considers to be valuable to the community.

It is accessible via admin section, but we have not made instructions on how to use it clear. Through the lens of DEV, this adjustment will be paired with finer orientation around how and why to use it.

I intend to propose faste access to certain admin tooling via our mod page, something like this:

<img width="353" alt="Screen Shot 2022-01-10 at 1 48 21 PM" src="https://user-images.githubusercontent.com/3102842/149363746-330a4e7c-05b1-4af7-8c33-249dbca29465.png">

But in the mean time, this will generally be useful to begin editorially nudging content which is generally valuable to the community and promotes effective congregation.

There are too many variables at play with reintroducing this for it to be worth split testing — but in the future, there could be value in testing the impact of this scoring factor.

## Related Tickets & Documents
This is where it was disabled: https://github.com/forem/forem/pull/15789
All changes like this will be noted in the feed report, whether or not we are explicitly testing them.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: We don't test this granularly
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

Monday's feed report.