### PR TITLE
Convert admin/config text fields with static options to dropdowns

### DIFF
--- a/app/models/settings/user_experience.rb
+++ b/app/models/settings/user_experience.rb
@@ -4,12 +4,18 @@ module Settings
     self.table_name = :settings_user_experiences
 
     HEX_COLOR_REGEX = /\A#(\h{6}|\h{3})\z/
+    FEED_STRATEGIES = %w[basic large_forem_experimental].freeze
+    FEED_STYLES = %w[basic rich compact].freeze
 
     # The default font for all users that have not chosen a custom font yet
     setting :default_font, type: :string, default: "sans_serif"
-    setting :feed_strategy, type: :string, default: "basic"
+    setting :feed_strategy, type: :string, default: "basic", validates: {
+      inclusion: { in: FEED_STRATEGIES }
+    }
     # basic (current default), rich (cover image on all posts), compact (more minimal)
-    setting :feed_style, type: :string, default: "basic"
+    setting :feed_style, type: :string, default: "basic", validates: {
+      inclusion: { in: FEED_STYLES }
+    }
     setting :home_feed_minimum_score, type: :integer, default: 0
     setting :index_minimum_score, type: :integer, default: 0
     setting :primary_brand_color_hex, type: :string, default: "#3b49df", validates: {

--- a/app/views/admin/settings/forms/_user_experience.html.erb
+++ b/app/views/admin/settings/forms/_user_experience.html.erb
@@ -60,7 +60,7 @@
                            Settings::UserExperience.default_font,
                          ),
                          multiple: false,
-                         class: "selectpicker" %>
+                         class: "crayons-select" %>
         </div>
         <div class="crayons-field">
           <%= admin_config_label :default_locale, model: Settings::UserExperience %>
@@ -71,7 +71,7 @@
                            Settings::UserExperience.default_locale,
                          ),
                          multiple: false,
-                         class: "selectpicker" %>
+                         class: "crayons-select" %>
         </div>
         <div class="crayons-field">
           <%= admin_config_label :primary_brand_color_hex, model: Settings::UserExperience %>

--- a/app/views/admin/settings/forms/_user_experience.html.erb
+++ b/app/views/admin/settings/forms/_user_experience.html.erb
@@ -14,18 +14,18 @@
         <div class="crayons-fieldx">
           <%= admin_config_label :feed_style, model: Settings::UserExperience %>
           <%= admin_config_description Constants::Settings::UserExperience::DETAILS[:feed_style][:description] %>
-          <%= f.text_field :feed_style,
-                           class: "crayons-textfield",
-                           value: Settings::UserExperience.feed_style,
-                           placeholder: Constants::Settings::UserExperience::DETAILS[:feed_style][:placeholder] %>
+          <%= select_tag "settings_user_experience[feed_style]",
+                         options_for_select(Settings::UserExperience::FEED_STYLES, Settings::UserExperience.feed_style),
+                         multiple: false,
+                         class: "crayons-select" %>
         </div>
         <div class="crayons-field">
           <%= admin_config_label :feed_strategy, model: Settings::UserExperience %>
           <%= admin_config_description Constants::Settings::UserExperience::DETAILS[:feed_strategy][:description] %>
-          <%= f.text_field :feed_strategy,
-                           class: "crayons-textfield",
-                           value: Settings::UserExperience.feed_strategy,
-                           placeholder: Constants::Settings::UserExperience::DETAILS[:feed_strategy][:placeholder] %>
+          <%= select_tag "settings_user_experience[feed_strategy]",
+                         options_for_select(Settings::UserExperience::FEED_STRATEGIES, Settings::UserExperience.feed_strategy),
+                         multiple: false,
+                         class: "crayons-select" %>
         </div>
         <div class="crayons-field">
           <%= admin_config_label :tag_feed_minimum_score, model: Settings::UserExperience %>

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -734,7 +734,7 @@ RSpec.describe "/admin/customization/config", type: :request do
         end
 
         it "updates the feed_strategy" do
-          feed_strategy = "optimized"
+          feed_strategy = "large_forem_experimental"
           post admin_settings_user_experiences_path, params: {
             settings_user_experience: { feed_strategy: feed_strategy }
           }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description
This changes two text fields in the config section of the admin panel to dropdowns. The text fields required specific inputs, so instead of leaving room for invalid entries, typos, etc. we decided to change it to dropdowns.

I did an audit of other text fields but couldn't find any additional ones that had static options.

## Related Tickets & Documents
https://github.com/forem/rfcs/issues/286

## QA Instructions, Screenshots, Recordings
1. Go to the User Experience section of [/admin/customization/config](http://localhost:3000/admin/customization/config)
2. Try to update the feed strategy, feed style, default font, and default locale dropdowns
3. See that the values persisted

![image](https://user-images.githubusercontent.com/17884966/149370313-908f92ad-9713-4d57-96e9-c702f745421c.png)


### UI accessibility concerns?
Nope, using native `<select>` tag should make a11y better.

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: small change

## [optional] Are there any post deployment tasks we need to perform?
No

## [optional] What gif best describes this PR or how it makes you feel?

![Two hot dogs face off, with the option to "Select your fighter" from a variety of condiments.](https://media.giphy.com/media/mQacSL1DrfPFA1ZJmH/giphy.gif)
