### PR TITLE
Implement DotNetFiddle Unified Embed

### DIFF
--- a/app/liquid_tags/dotnet_fiddle_tag.rb
+++ b/app/liquid_tags/dotnet_fiddle_tag.rb
@@ -2,11 +2,11 @@ require "uri"
 
 class DotnetFiddleTag < LiquidTagBase
   PARTIAL = "liquids/dotnetfiddle".freeze
-  LINK_REGEXP = %r{\A(https)://(dotnetfiddle\.net)/(Widget)/[a-zA-Z0-9\-/]*\z}
+  REGISTRY_REGEXP = %r{https://dotnetfiddle.net(?:/Widget)?/(?<id>[\w\-]+)}
 
   def initialize(_tag_name, link, _parse_context)
     super
-    @link = parse_link(link)
+    @link = parse_link(strip_tags(link))
   end
 
   def render(_context)
@@ -22,28 +22,20 @@ class DotnetFiddleTag < LiquidTagBase
   private
 
   def parse_link(link)
-    stripped_link = ActionController::Base.helpers.strip_tags(link)
-    the_link = stripped_link.split.first
-    raise StandardError, "Invalid DotnetFiddle URL" unless valid_link?(the_link)
+    match = pattern_match_for(link, [REGISTRY_REGEXP])
+    raise StandardError, "Invalid DotnetFiddle URL" unless match
 
-    insert_widget(the_link)
+    insert_widget(link, match)
   end
 
-  def insert_widget(link)
+  def insert_widget(link, match)
     uri = URI(link)
-    if "Widget".in? uri.path
-      link
-    else
-      # URI.path gives us strings like "/abcde", use substring to get rid of forward slash
-      # otherwise join won't work
-      URI.join("https://dotnetfiddle.net", "/Widget/", uri.path[1..]).to_s
-    end
-  end
+    return link if uri.path.include?("Widget")
 
-  def valid_link?(link)
-    link_no_space = link.delete(" ")
-    link_no_space.match?(LINK_REGEXP)
+    "https://dotnetfiddle.net/Widget/#{match[:id]}"
   end
 end
 
 Liquid::Template.register_tag("dotnetfiddle", DotnetFiddleTag)
+
+UnifiedEmbed.register(DotnetFiddleTag, regexp: DotnetFiddleTag::REGISTRY_REGEXP)

--- a/app/liquid_tags/youtube_tag.rb
+++ b/app/liquid_tags/youtube_tag.rb
@@ -36,7 +36,7 @@ class YoutubeTag < LiquidTagBase
 
   def parse_id_or_url(input)
     match = pattern_match_for(input, REGEXP_OPTIONS)
-    raise StandardError, "Invalid YouTube ID" unless match
+    raise StandardError, "Invalid YouTube ID or URL" unless match
 
     video_id       = match[:video_id]
     time_parameter = match[:time_parameter]

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -89,6 +89,11 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(CodepenTag)
     end
 
+    it "returns DotnetFiddleTag for a dotnetfiddle url" do
+      expect(described_class.find_liquid_tag_for(link: "https://dotnetfiddle.net/PmoDip"))
+        .to eq(DotnetFiddleTag)
+    end
+
     it "returns InstagramTag for a valid instagram url" do
       valid_instagram_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))

--- a/spec/liquid_tags/youtube_tag_spec.rb
+++ b/spec/liquid_tags/youtube_tag_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe YoutubeTag, type: :liquid_tag do
     end
     # rubocop:enable Style/StringLiterals
 
-    it "raises an error for invalid IDs" do
-      expect { generate_new_liquid(invalid_id).render }.to raise_error("Invalid YouTube ID")
+    it "raises an error for invalid IDs or URLs" do
+      expect { generate_new_liquid(invalid_id).render }.to raise_error("Invalid YouTube ID or URL")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for DotNetFiddle embeds.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15556

## QA Instructions, Screenshots, Recordings
Example DotNetFiddle URLs:
https://dotnetfiddle.net/PmoDip
https://dotnetfiddle.net/Widget/PmoDip

- As a user, create a DotNet Fiddle liquid tag using this format: `{% embed <dotnetfiddle-url> %}`. The Liquid Tag should render properly.
- Also create DotNet Fiddle liquid tag using the old method: `{% dotnetfiddle <dotnetfiddle-url> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?
None

## Added/updated tests?
- [X] Yes


## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.

## [optional] Are there any post deployment tasks we need to perform?
None