### PR TITLE
Update crayons_icon_tag helper

### DIFF
--- a/app/helpers/crayons_helper.rb
+++ b/app/helpers/crayons_helper.rb
@@ -3,29 +3,30 @@ module CrayonsHelper
   #
   # @param name [String|Symbol] the icon name. The ".svg" file extension will
   #   be added automatically if missing.
-  # @param css_class [String] additional CSS classes, "crayons-icon" is always
-  #   included.
   # @param native [Boolean] when set to +true+ the icon will not inherit its
   #   parent's color.
-  # @param **opts additional keyword arguments to be passed through to the
-  #   +inline_svg_tag+ helper.
+  # @param **opts additional keyword arguments (like e.g. +class+) to be passed
+  #   through to the +inline_svg_tag+ helper.
   # @return [String] the SVG tag.
   #
   # @example Simplest form
   #   crayons_icon_tag(:twitter)
   #
   # @example Disabling color inheritance
-  #   crayons_icon_tag(:twitter, native: true)
+  #   crayons_icon_tag("twemoji/heart", native: true)
   #
   # @example Specifying additional CSS classes
-  #   crayons_icon_tag("twitter.svg", css_class: "pointer-events-none")
-  def crayons_icon_tag(name, css_class: nil, native: false, **opts)
+  #   crayons_icon_tag("twitter.svg", class: "pointer-events-none")
+  #
+  # @example Specifying additional kwards to be passed to +inline_svg_tag+
+  #   crayons_icon_tag(:home, title: "Home")
+  def crayons_icon_tag(name, native: false, **opts)
     name = name.to_s
     icon_name = name.ends_with?(".svg") ? name : "#{name}.svg"
     icon_class = [
       "crayons-icon",
-      css_class,
       ("crayons-icon--default" if native),
+      opts.delete(:class),
     ].compact.join(" ")
 
     inline_svg_tag(icon_name, aria: true, width: 24, height: 24, class: icon_class, **opts)

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -30,7 +30,7 @@
     <div id="mod-actions-menu-btn-area" class="print-hidden hidden align-center"></div>
     <div class="align-center m:relative">
       <button id="article-show-more-button" aria-controls="article-show-more-dropdown" aria-expanded="false" aria-haspopup="true" class="dropbtn crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon-rounded" aria-label="<%= t("views.actions.more.aria_label") %>">
-        <%= crayons_icon_tag("overflow-horizontal", css_class: "dropdown-icon", aria_hidden: true, title: t("views.actions.more.title")) %>
+        <%= crayons_icon_tag("overflow-horizontal", class: "dropdown-icon", aria_hidden: true, title: t("views.actions.more.title")) %>
       </button>
 
       <div id="article-show-more-dropdown" class="crayons-dropdown side-bar left-2 right-2 m:right-auto m:left-100 s:left-auto mb-1 m:mb-0 top-unset bottom-100 m:top-0 m:bottom-unset">
@@ -40,7 +40,7 @@
             class="flex justify-between crayons-link crayons-link--block w-100 bg-transparent border-0"
             data-postUrl="<%= article_url(@article) %>">
             <span class="fw-bold"><%= t("views.actions.copy.button") %></span>
-            <%= crayons_icon_tag(:copy, css_class: "mx-2 shrink-0", id: "article-copy-icon", aria_hidden: true, title: t("views.actions.copy.button")) %>
+            <%= crayons_icon_tag(:copy, class: "mx-2 shrink-0", id: "article-copy-icon", aria_hidden: true, title: t("views.actions.copy.button")) %>
           </button>
           <div id="article-copy-link-announcer" aria-live="polite" class="crayons-notice crayons-notice--success my-2 p-1" aria-live="polite" hidden><%= t("views.actions.copy.text") %></div>
         </div>

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -36,13 +36,13 @@
         <div class="profile-header__meta">
           <% if @organization.location.present? %>
             <span class="profile-header__meta__item">
-              <%= crayons_icon_tag(:location, css_class: "mr-2 shrink-0", title: t("views.organizations.location.icon")) %>
+              <%= crayons_icon_tag(:location, class: "mr-2 shrink-0", title: t("views.organizations.location.icon")) %>
               <%= sanitize @organization.location %>
             </span>
           <% end %>
 
           <span class="profile-header__meta__item">
-            <%= crayons_icon_tag(:cake, css_class: "mr-2 shrink-0", title: t("views.organizations.joined.icon")) %>
+            <%= crayons_icon_tag(:cake, class: "mr-2 shrink-0", title: t("views.organizations.joined.icon")) %>
             <%= t("views.organizations.joined.text_html", date: local_date(@user.created_at)) %>
           </span>
 

--- a/app/views/users/_main_feed.html.erb
+++ b/app/views/users/_main_feed.html.erb
@@ -2,7 +2,7 @@
   <div class="crayons-card mb-2 border-2 border-solid border-accent-brand">
     <header>
       <h3 class="crayons-subtitle-3 inline-flex items-center bg-accent-brand color-base-inverted pl-3 pr-4 py-2 ml-4 -mt-2 radius-default">
-        <%= crayons_icon_tag(:pin, css_class: "mr-2", title: t("views.users.pin_icon")) %>
+        <%= crayons_icon_tag(:pin, class: "mr-2", title: t("views.users.pin_icon")) %>
         <%= t("views.users.pinned") %>
       </h3>
     </header>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -50,7 +50,7 @@
   <% cache "user-profile-sidebar-stats-#{@user.id}-#{@user.last_article_at&.rfc3339}-#{@user.last_comment_at&.rfc3339}-#{@user.following_tags_count}-#{@user.last_followed_at&.rfc3339}", expires_in: 10.days do %>
     <div class="crayons-card crayons-card--secondary p-4">
       <div class="flex items-center mb-4">
-        <%= crayons_icon_tag(:post, css_class: "mr-3 color-base-50", title: t("views.users.side.post.icon")) %>
+        <%= crayons_icon_tag(:post, class: "mr-3 color-base-50", title: t("views.users.side.post.icon")) %>
         <%= t "views.users.side.post.text", count: @user.articles.published.size %>
       </div>
       <div class="flex items-center mb-4">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,7 +35,7 @@
               <button id="user-follow-butt" class="crayons-btn whitespace-nowrap follow-action-button follow-user" data-info='{"id":<%= @user.id %>,"className":"<%= @user.class.name %>", "name": "<%= @user.name %>"}'><%= t("views.users.follow") %></button>
         <div class="profile-dropdown ml-2 s:relative hidden" data-username="<%= @user.username %>">
               <button id="user-profile-dropdown" aria-expanded="false" aria-controls="user-profile-dropdownmenu" aria-haspopup="true" class="crayons-btn crayons-btn--ghost-dimmed crayons-btn--icon">
-                <%= crayons_icon_tag("overflow-horizontal", css_class: "dropdown-icon", title: t("views.users.dropdown")) %>
+                <%= crayons_icon_tag("overflow-horizontal", class: "dropdown-icon", title: t("views.users.dropdown")) %>
               </button>
 
               <div id="user-profile-dropdownmenu" class="crayons-dropdown left-2 right-2 s:right-0 s:left-auto top-100 mt-1">
@@ -65,33 +65,33 @@
           <div class="profile-header__meta">
             <% if @user.profile.location.present? %>
               <span class="profile-header__meta__item">
-                <%= crayons_icon_tag(:location, css_class: "mr-2 shrink-0", title: t("views.users.location_icon")) %>
+                <%= crayons_icon_tag(:location, class: "mr-2 shrink-0", title: t("views.users.location_icon")) %>
                 <%= @user.profile.location %>
               </span>
             <% end %>
 
             <span class="profile-header__meta__item">
-              <%= crayons_icon_tag(:cake, css_class: "mr-2 shrink-0", title: t("views.users.joined.icon")) %>
+              <%= crayons_icon_tag(:cake, class: "mr-2 shrink-0", title: t("views.users.joined.icon")) %>
               <%= t("views.users.joined.text_html", date: local_date(@user.created_at)) %>
             </span>
 
             <% if @user.setting.display_email_on_profile %>
               <a href="mailto:<%= @user.email %>" class="profile-header__meta__item">
-                <%= crayons_icon_tag(:email, css_class: "mr-2 shrink-0", title: t("views.users.email_icon")) %>
+                <%= crayons_icon_tag(:email, class: "mr-2 shrink-0", title: t("views.users.email_icon")) %>
                 <%= @user.email %>
               </a>
             <% end %>
 
             <% if @user.profile.website_url.present? %>
               <a href="<%= @user.profile.website_url %>" target="_blank" rel="noopener me <%= "ugc" unless @user.trusted? %>" class="profile-header__meta__item">
-                <%= crayons_icon_tag("external-link", css_class: "mr-2 shrink-0", title: t("views.users.website")) %>
+                <%= crayons_icon_tag("external-link", class: "mr-2 shrink-0", title: t("views.users.website")) %>
                 <%= @user.profile.website_url %>
               </a>
             <% end %>
 
             <% social_authentication_links_for(@user).each do |provider_name, url| %>
               <a href="<%= url %>" target="_blank" rel="noopener me" class="profile-header__meta__item p-1">
-                <%= crayons_icon_tag(provider_name, css_class: "shrink-0", title: t("views.users.social", service: provider_name)) %>
+                <%= crayons_icon_tag(provider_name, class: "shrink-0", title: t("views.users.social", service: provider_name)) %>
               </a>
             <% end %>
           </div>

--- a/spec/helpers/crayons_helper_spec.rb
+++ b/spec/helpers/crayons_helper_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CrayonsHelper, type: :helper do
       expect(icon_tag).to match(%r{<title.*>Test</title>})
     end
 
-    it "mixing extra classes and the native option" do
+    it "allows mixing extra classes and the native option" do
       icon_tag = helper.crayons_icon_tag(:twitter, class: "test", native: true)
       expect(icon_tag).to match(/class="crayons-icon crayons-icon--default test"/)
     end

--- a/spec/helpers/crayons_helper_spec.rb
+++ b/spec/helpers/crayons_helper_spec.rb
@@ -30,13 +30,18 @@ RSpec.describe CrayonsHelper, type: :helper do
     end
 
     it "allows specifying additional CSS classes" do
-      icon_tag = helper.crayons_icon_tag("twitter", css_class: "pointer-events-none")
+      icon_tag = helper.crayons_icon_tag("twitter", class: "pointer-events-none")
       expect(icon_tag).to match(/class="crayons-icon pointer-events-none"/)
     end
 
     it "passes additional keyword arguments to the wrapped tag" do
       icon_tag = helper.crayons_icon_tag("twitter", title: "Test")
       expect(icon_tag).to match(%r{<title.*>Test</title>})
+    end
+
+    it "mixing extra classes and the native option" do
+      icon_tag = helper.crayons_icon_tag(:twitter, class: "test", native: true)
+      expect(icon_tag).to match(/class="crayons-icon crayons-icon--default test"/)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This PR refactors `crayons_icon_tag` so we no longer need the dedicated `css_class` keyword argument but instead pass through `class` from `**opts` to `inline_svg_tag`. It also updates all existing usages of the helper.

## QA Instructions, Screenshots, Recordings

Updated documetation (mention `class`, add new example):

![Screen Shot 2022-01-14 at 11 26 40](https://user-images.githubusercontent.com/47985/149451491-0050700e-bdbd-402a-8b4e-215ef9d0bb6b.png)

### UI accessibility concerns?

No UI changes

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I've updated the README or added inline documentation
- [X] I will share this change internally with the appropriate teams
