### PR TITLE
Finishes adding all the codepen embed options available

### DIFF
--- a/app/liquid_tags/codepen_tag.rb
+++ b/app/liquid_tags/codepen_tag.rb
@@ -1,10 +1,11 @@
 class CodepenTag < LiquidTagBase
   PARTIAL = "liquids/codepen".freeze
   REGISTRY_REGEXP =
-    %r{\A(http|https)://(codepen\.io|codepen\.io/team)/[a-zA-Z0-9_\-]{1,30}/(pen|pen/preview)/([a-zA-Z0-9]{5,32})/{0,1}\z}
+    %r{\A(http|https)://(codepen\.io|codepen\.io/team)/[a-zA-Z0-9_\-]{1,30}/(pen|embed)(/preview)?/([a-zA-Z0-9]{5,32})/{0,1}\z}
 
   def initialize(_tag_name, link, _parse_context)
     super
+    link = CGI.unescape_html(link)
     @link = parse_link(link)
     valid_options = parse_options(link)
     @build_options = valid_options.gsub(/height=\d{3,4}&(amp;)?/, '')

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -286,7 +286,7 @@
 
       <dt><strong>preview</strong></dt>
       <dd>
-        <p>Change the codepen URL path from /pen/ to /pen/preview/ to use codepen's Click-to-Load preview embed feature in the resulting iframe.</p>
+        <p>Change the codepen URL path from /pen/ to /pen/preview/ (or to /embed/preview/) to use codepen's Click-to-Load preview embed feature in the resulting iframe.</p>
         <pre>{% codepen https://codepen.io/propjockey/pen/preview/dyVMgBg %}</pre>
       </dd>
 
@@ -308,7 +308,7 @@
         <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg editable=true %}</pre>
       </dd>
 
-      <dt><strong>multiple-params/strong></dt>
+      <dt><strong>multiple-params</strong></dt>
       <dd>
         <p>Add multiple parameters to your CodePen embed tag.</p>
         <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg height=300 default-tab=css,result editable=true %}</pre>

--- a/app/views/pages/_editor_guide_text.html.erb
+++ b/app/views/pages/_editor_guide_text.html.erb
@@ -283,6 +283,36 @@
         <p>Add default-tab parameter to your CodePen embed tag. Defaults to <i>result</i>.</p>
         <pre>{% codepen https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result %}</pre>
       </dd>
+
+      <dt><strong>preview</strong></dt>
+      <dd>
+        <p>Change the codepen URL path from /pen/ to /pen/preview/ to use codepen's Click-to-Load preview embed feature in the resulting iframe.</p>
+        <pre>{% codepen https://codepen.io/propjockey/pen/preview/dyVMgBg %}</pre>
+      </dd>
+
+      <dt><strong>height</strong></dt>
+      <dd>
+        <p>Add height parameter to your CodePen embed tag and to the resulting iframe itself. Defaults to <i>600</i></p>
+        <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg height=300 %}</pre>
+      </dd>
+
+      <dt><strong>theme-id</strong></dt>
+      <dd>
+        <p>Add theme-id parameter to your CodePen embed tag. The pen and theme-id must be from a codepen pro user to have an effect.</p>
+        <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148 %}</pre>
+      </dd>
+
+      <dt><strong>editable=true</strong></dt>
+      <dd>
+        <p>Add editable=true parameter to your CodePen embed tag. Editable Embeds require more resources than non-editable Embeds. The pen must be from a codepen pro user to have an effect.</p>
+        <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg editable=true %}</pre>
+      </dd>
+
+      <dt><strong>multiple-params/strong></dt>
+      <dd>
+        <p>Add multiple parameters to your CodePen embed tag.</p>
+        <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg height=300 default-tab=css,result editable=true %}</pre>
+      </dd>
     </dl>
 
     <%= render partial: "editor_guide_h3", locals: { id: "kotlin-playground", title: "Kotlin Playground" } %>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -146,31 +146,31 @@
         <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result %}</code>
       </dd>
 
-      <dt><strong>preview</strong></dt>
+      <dt><code>preview</code></dt>
       <dd>
-        <p>Change the codepen URL path from /pen/ to /pen/preview/ to use codepen's Click-to-Load preview embed feature in the resulting iframe.</p>
+        <p>Change the codepen URL path from /pen/ to /pen/preview/ (or to /embed/preview/) to use codepen's Click-to-Load preview embed feature in the resulting iframe.</p>
         <pre>{% codepen https://codepen.io/propjockey/pen/preview/dyVMgBg %}</pre>
       </dd>
 
-      <dt><strong>height</strong></dt>
+      <dt><code>height</code></dt>
       <dd>
         <p>Add height parameter to your CodePen embed tag and to the resulting iframe itself. Defaults to <i>600</i></p>
         <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg height=300 %}</pre>
       </dd>
 
-      <dt><strong>theme-id</strong></dt>
+      <dt><code>theme-id</code></dt>
       <dd>
         <p>Add theme-id parameter to your CodePen embed tag. The pen and theme-id must be from a codepen pro user to have an effect.</p>
         <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148 %}</pre>
       </dd>
 
-      <dt><strong>editable=true</strong></dt>
+      <dt><code>editable=true</code></dt>
       <dd>
         <p>Add editable=true parameter to your CodePen embed tag. Editable Embeds require more resources than non-editable Embeds. The pen must be from a codepen pro user to have an effect.</p>
         <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg editable=true %}</pre>
       </dd>
 
-      <dt><strong>multiple-params/strong></dt>
+      <dt><code>multiple-params</code></dt>
       <dd>
         <p>Add multiple parameters to your CodePen embed tag.</p>
         <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg height=300 default-tab=css,result editable=true %}</pre>

--- a/app/views/pages/_editor_liquid_help.html.erb
+++ b/app/views/pages/_editor_liquid_help.html.erb
@@ -145,6 +145,36 @@
         Add default-tab parameter to your CodePen embed tag. Default to <i>result</i><br>
         <code>{% codepen https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result %}</code>
       </dd>
+
+      <dt><strong>preview</strong></dt>
+      <dd>
+        <p>Change the codepen URL path from /pen/ to /pen/preview/ to use codepen's Click-to-Load preview embed feature in the resulting iframe.</p>
+        <pre>{% codepen https://codepen.io/propjockey/pen/preview/dyVMgBg %}</pre>
+      </dd>
+
+      <dt><strong>height</strong></dt>
+      <dd>
+        <p>Add height parameter to your CodePen embed tag and to the resulting iframe itself. Defaults to <i>600</i></p>
+        <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg height=300 %}</pre>
+      </dd>
+
+      <dt><strong>theme-id</strong></dt>
+      <dd>
+        <p>Add theme-id parameter to your CodePen embed tag. The pen and theme-id must be from a codepen pro user to have an effect.</p>
+        <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148 %}</pre>
+      </dd>
+
+      <dt><strong>editable=true</strong></dt>
+      <dd>
+        <p>Add editable=true parameter to your CodePen embed tag. Editable Embeds require more resources than non-editable Embeds. The pen must be from a codepen pro user to have an effect.</p>
+        <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg editable=true %}</pre>
+      </dd>
+
+      <dt><strong>multiple-params/strong></dt>
+      <dd>
+        <p>Add multiple parameters to your CodePen embed tag.</p>
+        <pre>{% codepen https://codepen.io/propjockey/pen/dyVMgBg height=300 default-tab=css,result editable=true %}</pre>
+      </dd>
     </dl>
     <h3>Kotlin Playground</h3>
     <p>To create a runnable kotlin snippet, create a Kotlin Snippet at <a href="https://play.kotlinlang.org">https://play.kotlinlang.org</a></p>

--- a/spec/liquid_tags/codepen_tag_spec.rb
+++ b/spec/liquid_tags/codepen_tag_spec.rb
@@ -1,188 +1,184 @@
 require "rails_helper"
 
 RSpec.describe CodepenTag, type: :liquid_tag do
-  describe "#link" do
-    let(:codepen_private_link) { "https://codepen.io/quezo/pen/e10ca45c611b9cf3c98a1011dedc1471" }
-    let(:codepen_link) { "https://codepen.io/twhite96/pen/XKqrJX" }
-    let(:codepen_team_private_link) { "https://codepen.io/team/codepen/pen/fb02c34281cb08966ec44b4e1ae22bc3" }
-    let(:codepen_team_link) { "https://codepen.io/team/keyframers/pen/ZMRMEw" }
-    let(:codepen_link_with_default_tab) { "https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result" }
-    let(:codepen_link_with_theme_id) { "https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148" }
-    let(:codepen_link_with_preview_indicator) { "https://codepen.io/propjockey/pen/preview/dyVMgBg" }
-    let(:codepen_link_with_height_param) { "https://codepen.io/propjockey/pen/dyVMgBg height=300" }
-    let(:codepen_link_with_editable_true) { "https://codepen.io/propjockey/pen/dyVMgBg editable=true" }
-    let(:codepen_link_with_multiple_params) { "https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148 default-tab=js,result height=250 editable=true" }
-    let(:codepen_link_with_preview_and_params) { "https://codepen.io/propjockey/pen/preview/dyVMgBg theme-id=40148 default-tab=js,result" }
+  describe "#link" do
+    let(:codepen_private_link) { "https://codepen.io/quezo/pen/e10ca45c611b9cf3c98a1011dedc1471" }
+    let(:codepen_link) { "https://codepen.io/twhite96/pen/XKqrJX" }
+    let(:codepen_team_private_link) { "https://codepen.io/team/codepen/pen/fb02c34281cb08966ec44b4e1ae22bc3" }
+    let(:codepen_team_link) { "https://codepen.io/team/keyframers/pen/ZMRMEw" }
+    let(:codepen_link_with_default_tab) { "https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result" }
+    let(:codepen_link_with_theme_id) { "https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148" }
+    let(:codepen_link_with_preview_indicator) { "https://codepen.io/propjockey/pen/preview/dyVMgBg" }
+    let(:codepen_link_with_height_param) { "https://codepen.io/propjockey/pen/dyVMgBg height=300" }
+    let(:codepen_link_with_editable_true) { "https://codepen.io/propjockey/pen/dyVMgBg editable=true" }
+    let(:codepen_link_with_multiple_params) do
+      "https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148 default-tab=js,result height=250 editable=true"
+    end
+    let(:codepen_link_with_preview_and_params) do
+      "https://codepen.io/propjockey/pen/preview/dyVMgBg theme-id=40148 default-tab=js,result"
+    end
 
-    xss_links = %w(
-      //evil.com/?codepen.io
-      https://codepen.io.evil.com
-      https://codepen.io/some_username/pen/" onload='alert("xss")'
-    )
+    xss_links = %w(
+      //evil.com/?codepen.io
+      https://codepen.io.evil.com
+      https://codepen.io/some_username/pen/" onload='alert("xss")'
+    )
 
-    def generate_new_liquid(link)
-      Liquid::Template.register_tag("codepen", CodepenTag)
-      Liquid::Template.parse("{% codepen #{link} %}")
-    end
+    def generate_new_liquid(link)
+      Liquid::Template.register_tag("codepen", CodepenTag)
+      Liquid::Template.parse("{% codepen #{link} %}")
+    end
 
-    it "accepts codepen link" do
-      liquid = generate_new_liquid(codepen_link)
+    it "accepts codepen link" do
+      liquid = generate_new_liquid(codepen_link)
 
-      expect(liquid.render).to include("<iframe")
-        .and include(
-          'src="https://codepen.io/twhite96/embed/XKqrJX?height=600&default-tab=result&embed-version=2"',
-        )
-    end
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/twhite96/embed/XKqrJX?height=600&default-tab=result&embed-version=2"',
+        )
+    end
 
-    it "accepts codepen private link" do
-      liquid = generate_new_liquid(codepen_private_link)
+    it "accepts codepen private link" do
+      liquid = generate_new_liquid(codepen_private_link)
 
-      expect(liquid.render).to include("<iframe")
-        .and include(
-          'src="https://codepen.io/quezo/embed/e10ca45c611b9cf3c98a1011dedc1471?height=600&default-tab=result&embed-version=2"',
-        )
-    end
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/quezo/embed/e10ca45c611b9cf3c98a1011dedc1471?height=600&default-tab=result&embed-version=2"',
+        )
+    end
 
-    it "accepts codepen link with a / at the end" do
-      codepen_link = "https://codepen.io/twhite96/pen/XKqrJX/"
-      expect do
-        generate_new_liquid(codepen_link)
-      end.not_to raise_error
-    end
+    it "accepts codepen link with a / at the end" do
+      codepen_link = "https://codepen.io/twhite96/pen/XKqrJX/"
+      expect do
+        generate_new_liquid(codepen_link)
+      end.not_to raise_error
+    end
 
-    it "accepts codepen team link" do
-      codepen_link = codepen_team_link
-      expect do
-        generate_new_liquid(codepen_link)
-      end.not_to raise_error
-    end
+    it "accepts codepen team link" do
+      codepen_link = codepen_team_link
+      expect do
+        generate_new_liquid(codepen_link)
+      end.not_to raise_error
+    end
 
-    it "accepts codepen team private link" do
-      codepen_link = codepen_team_private_link
-      expect do
-        generate_new_liquid(codepen_link)
-      end.not_to raise_error
-    end
+    it "accepts codepen team private link" do
+      codepen_link = codepen_team_private_link
+      expect do
+        generate_new_liquid(codepen_link)
+      end.not_to raise_error
+    end
 
-    it "accepts codepen link with an underscore in the username" do
-      codepen_link = "https://codepen.io/t_white96/pen/XKqrJX/"
-      expect do
-        generate_new_liquid(codepen_link)
-      end.not_to raise_error
-    end
+    it "accepts codepen link with an underscore in the username" do
+      codepen_link = "https://codepen.io/t_white96/pen/XKqrJX/"
+      expect do
+        generate_new_liquid(codepen_link)
+      end.not_to raise_error
+    end
 
-    it "rejects invalid codepen link" do
-      expect do
-        generate_new_liquid("invalid_codepen_link")
-      end.to raise_error(StandardError)
-    end
+    it "rejects invalid codepen link" do
+      expect do
+        generate_new_liquid("invalid_codepen_link")
+      end.to raise_error(StandardError)
+    end
 
-    it "rejects codepen link with more than 30 characters in the username" do
-      codepen_link = "https://codepen.io/t_white96_this_is_31_characters/pen/XKqrJX/"
-      expect do
-        generate_new_liquid(codepen_link)
-      end.to raise_error(StandardError)
-    end
+    it "rejects codepen link with more than 30 characters in the username" do
+      codepen_link = "https://codepen.io/t_white96_this_is_31_characters/pen/XKqrJX/"
+      expect do
+        generate_new_liquid(codepen_link)
+      end.to raise_error(StandardError)
+    end
 
-    it "accepts codepen link with a default-tab parameter" do
-      expect do
-        generate_new_liquid(codepen_link_with_default_tab)
-      end.not_to raise_error
-    end
+    it "accepts codepen link with a default-tab parameter" do
+      expect do
+        generate_new_liquid(codepen_link_with_default_tab)
+      end.not_to raise_error
+    end
 
-    it "accepts codepen link with a theme-id parameter" do
-      expect do
-        generate_new_liquid(codepen_link_with_theme_id)
-      end.not_to raise_error
+    it "accepts codepen link with a theme-id parameter" do
+      expect do
+        generate_new_liquid(codepen_link_with_theme_id)
+      end.not_to raise_error
 
-      liquid = generate_new_liquid(codepen_link_with_theme_id)
+      liquid = generate_new_liquid(codepen_link_with_theme_id)
 
-      expect(liquid.render).to include("<iframe")
-        .and include(
-          'src="https://codepen.io/propjockey/embed/dyVMgBg?height=600&theme-id=40148',
-        )
-    end
+      expect(liquid.render).to include("<iframe")
+        .and include('src="https://codepen.io/propjockey/embed/dyVMgBg?height=600&theme-id=40148')
+    end
 
-    it "accepts codepen link with pen/preview in the url" do
-      expect do
-        generate_new_liquid(codepen_link_with_preview_indicator)
-      end.not_to raise_error
+    it "accepts codepen link with pen/preview in the url" do
+      expect do
+        generate_new_liquid(codepen_link_with_preview_indicator)
+      end.not_to raise_error
 
-      liquid = generate_new_liquid(codepen_link_with_preview_indicator)
+      liquid = generate_new_liquid(codepen_link_with_preview_indicator)
 
-      expect(liquid.render).to include("<iframe")
-        .and include(
-          'src="https://codepen.io/propjockey/embed/preview/dyVMgBg',
-        )
-    end
+      expect(liquid.render).to include("<iframe")
+        .and include('src="https://codepen.io/propjockey/embed/preview/dyVMgBg')
+    end
 
-    it "accepts codepen link with a height parameter" do
-      expect do
-        generate_new_liquid(codepen_link_with_height_param)
-      end.not_to raise_error
+    it "accepts codepen link with a height parameter" do
+      expect do
+        generate_new_liquid(codepen_link_with_height_param)
+      end.not_to raise_error
 
-      liquid = generate_new_liquid(codepen_link_with_height_param)
+      liquid = generate_new_liquid(codepen_link_with_height_param)
 
-      expect(liquid.render).to include("<iframe")
-        .and include('height="300"')
-        .and include(
-          'src="https://codepen.io/propjockey/embed/dyVMgBg?height=300',
-        )
-    end
+      expect(liquid.render).to include("<iframe")
+        .and include('height="300"')
+        .and include('src="https://codepen.io/propjockey/embed/dyVMgBg?height=300')
+    end
 
-    it "accepts codepen link with a editable=true parameter" do
-      expect do
-        generate_new_liquid(codepen_link_with_editable_true)
-      end.not_to raise_error
+    it "accepts codepen link with a editable=true parameter" do
+      expect do
+        generate_new_liquid(codepen_link_with_editable_true)
+      end.not_to raise_error
 
-      liquid = generate_new_liquid(codepen_link_with_editable_true)
+      liquid = generate_new_liquid(codepen_link_with_editable_true)
 
-      expect(liquid.render).to include("<iframe")
-        .and include(
-          'src="https://codepen.io/propjockey/embed/dyVMgBg?height=600&editable=true',
-        )
-    end
+      expect(liquid.render).to include("<iframe")
+        .and include('src="https://codepen.io/propjockey/embed/dyVMgBg?height=600&editable=true')
+    end
 
-    it "accepts codepen link with multiple params" do
-      expect do
-        generate_new_liquid(codepen_link_with_multiple_params)
-      end.not_to raise_error
+    it "accepts codepen link with multiple params" do
+      expect do
+        generate_new_liquid(codepen_link_with_multiple_params)
+      end.not_to raise_error
 
-      liquid = generate_new_liquid(codepen_link_with_multiple_params)
+      liquid = generate_new_liquid(codepen_link_with_multiple_params)
 
-      expect(liquid.render).to include("<iframe")
-      .and include('height="250"')
-        .and include(
-          'src="https://codepen.io/propjockey/embed/dyVMgBg?height=250&theme-id=40148&amp;default-tab=js,result&amp;editable=true',
-        )
-    end
+      expect(liquid.render).to include("<iframe")
+        .and include('height="250"')
+        .and include(
+          'src="https://codepen.io/propjockey/embed/dyVMgBg?height=250&theme-id=40148&amp;default-tab=js,result&amp;editable=true',
+        )
+    end
 
-    it "accepts codepen link with preview and params" do
-      expect do
-        generate_new_liquid(codepen_link_with_preview_and_params)
-      end.not_to raise_error
+    it "accepts codepen link with preview and params" do
+      expect do
+        generate_new_liquid(codepen_link_with_preview_and_params)
+      end.not_to raise_error
 
-      liquid = generate_new_liquid(codepen_link_with_preview_and_params)
+      liquid = generate_new_liquid(codepen_link_with_preview_and_params)
 
-      expect(liquid.render).to include("<iframe")
-        .and include(
-          'src="https://codepen.io/propjockey/embed/preview/dyVMgBg?height=600&theme-id=40148&amp;default-tab=js,result',
-        )
-    end
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/propjockey/embed/preview/dyVMgBg?height=600&theme-id=40148&amp;default-tab=js,result',
+        )
+    end
 
-    it "rejects XSS attempts" do
-      xss_links.each do |link|
-        expect { generate_new_liquid(link) }.to raise_error(StandardError)
-      end
-    end
+    it "rejects XSS attempts" do
+      xss_links.each do |link|
+        expect { generate_new_liquid(link) }.to raise_error(StandardError)
+      end
+    end
 
-    it "rejects multiline XSS attempt" do
-      xss_multiline_link = <<~XSS
-        javascript:exploit_code();/*
-        #{codepen_link}
-        */
-      XSS
-      expect { generate_new_liquid(xss_multiline_link) }.to raise_error(StandardError)
-    end
-  end
+    it "rejects multiline XSS attempt" do
+      xss_multiline_link = <<~XSS
+        javascript:exploit_code();/*
+        #{codepen_link}
+        */
+      XSS
+      expect { generate_new_liquid(xss_multiline_link) }.to raise_error(StandardError)
+    end
+  end
 end

--- a/spec/liquid_tags/codepen_tag_spec.rb
+++ b/spec/liquid_tags/codepen_tag_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe CodepenTag, type: :liquid_tag do
     let(:codepen_link_with_default_tab) { "https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result" }
     let(:codepen_link_with_theme_id) { "https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148" }
     let(:codepen_link_with_preview_indicator) { "https://codepen.io/propjockey/pen/preview/dyVMgBg" }
+    let(:codepen_link_with_embed_path) { "https://codepen.io/propjockey/embed/dyVMgBg" }
+    let(:codepen_link_with_embed_preview_path) { "https://codepen.io/propjockey/embed/preview/dyVMgBg" }
     let(:codepen_link_with_height_param) { "https://codepen.io/propjockey/pen/dyVMgBg height=300" }
     let(:codepen_link_with_editable_true) { "https://codepen.io/propjockey/pen/dyVMgBg editable=true" }
     let(:codepen_link_with_multiple_params) do
@@ -16,6 +18,9 @@ RSpec.describe CodepenTag, type: :liquid_tag do
     end
     let(:codepen_link_with_preview_and_params) do
       "https://codepen.io/propjockey/pen/preview/dyVMgBg theme-id=40148 default-tab=js,result"
+    end
+    let(:codepen_link_with_embed_path_and_params) do
+      "https://codepen.io/propjockey/embed/dyVMgBg theme-id=40148 default-tab=js,result"
     end
 
     xss_links = %w(
@@ -116,6 +121,28 @@ RSpec.describe CodepenTag, type: :liquid_tag do
         .and include('src="https://codepen.io/propjockey/embed/preview/dyVMgBg')
     end
 
+    it "accepts codepen link with embed path in the url" do
+      expect do
+        generate_new_liquid(codepen_link_with_embed_path)
+      end.not_to raise_error
+
+      liquid = generate_new_liquid(codepen_link_with_embed_path)
+
+      expect(liquid.render).to include("<iframe")
+        .and include('src="https://codepen.io/propjockey/embed/dyVMgBg')
+    end
+
+    it "accepts codepen link with embed/preview in the url" do
+      expect do
+        generate_new_liquid(codepen_link_with_embed_preview_path)
+      end.not_to raise_error
+
+      liquid = generate_new_liquid(codepen_link_with_embed_preview_path)
+
+      expect(liquid.render).to include("<iframe")
+        .and include('src="https://codepen.io/propjockey/embed/preview/dyVMgBg')
+    end
+
     it "accepts codepen link with a height parameter" do
       expect do
         generate_new_liquid(codepen_link_with_height_param)
@@ -163,6 +190,19 @@ RSpec.describe CodepenTag, type: :liquid_tag do
       expect(liquid.render).to include("<iframe")
         .and include(
           'src="https://codepen.io/propjockey/embed/preview/dyVMgBg?height=600&theme-id=40148&amp;default-tab=js,result',
+        )
+    end
+
+    it "accepts codepen link with embed and params" do
+      expect do
+        generate_new_liquid(codepen_link_with_embed_path_and_params)
+      end.not_to raise_error
+
+      liquid = generate_new_liquid(codepen_link_with_embed_path_and_params)
+
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/propjockey/embed/dyVMgBg?height=600&theme-id=40148&amp;default-tab=js,result',
         )
     end
 

--- a/spec/liquid_tags/codepen_tag_spec.rb
+++ b/spec/liquid_tags/codepen_tag_spec.rb
@@ -1,102 +1,188 @@
 require "rails_helper"
 
 RSpec.describe CodepenTag, type: :liquid_tag do
-  describe "#link" do
-    let(:codepen_private_link) { "https://codepen.io/quezo/pen/e10ca45c611b9cf3c98a1011dedc1471" }
-    let(:codepen_link) { "https://codepen.io/twhite96/pen/XKqrJX" }
-    let(:codepen_team_private_link) { "https://codepen.io/team/codepen/pen/fb02c34281cb08966ec44b4e1ae22bc3" }
-    let(:codepen_team_link) { "https://codepen.io/team/keyframers/pen/ZMRMEw" }
-    let(:codepen_link_with_default_tab) { "https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result" }
+  describe "#link" do
+    let(:codepen_private_link) { "https://codepen.io/quezo/pen/e10ca45c611b9cf3c98a1011dedc1471" }
+    let(:codepen_link) { "https://codepen.io/twhite96/pen/XKqrJX" }
+    let(:codepen_team_private_link) { "https://codepen.io/team/codepen/pen/fb02c34281cb08966ec44b4e1ae22bc3" }
+    let(:codepen_team_link) { "https://codepen.io/team/keyframers/pen/ZMRMEw" }
+    let(:codepen_link_with_default_tab) { "https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result" }
+    let(:codepen_link_with_theme_id) { "https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148" }
+    let(:codepen_link_with_preview_indicator) { "https://codepen.io/propjockey/pen/preview/dyVMgBg" }
+    let(:codepen_link_with_height_param) { "https://codepen.io/propjockey/pen/dyVMgBg height=300" }
+    let(:codepen_link_with_editable_true) { "https://codepen.io/propjockey/pen/dyVMgBg editable=true" }
+    let(:codepen_link_with_multiple_params) { "https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148 default-tab=js,result height=250 editable=true" }
+    let(:codepen_link_with_preview_and_params) { "https://codepen.io/propjockey/pen/preview/dyVMgBg theme-id=40148 default-tab=js,result" }
 
-    xss_links = %w(
-      //evil.com/?codepen.io
-      https://codepen.io.evil.com
-      https://codepen.io/some_username/pen/" onload='alert("xss")'
-    )
+    xss_links = %w(
+      //evil.com/?codepen.io
+      https://codepen.io.evil.com
+      https://codepen.io/some_username/pen/" onload='alert("xss")'
+    )
 
-    def generate_new_liquid(link)
-      Liquid::Template.register_tag("codepen", CodepenTag)
-      Liquid::Template.parse("{% codepen #{link} %}")
-    end
+    def generate_new_liquid(link)
+      Liquid::Template.register_tag("codepen", CodepenTag)
+      Liquid::Template.parse("{% codepen #{link} %}")
+    end
 
-    it "accepts codepen link" do
-      liquid = generate_new_liquid(codepen_link)
+    it "accepts codepen link" do
+      liquid = generate_new_liquid(codepen_link)
 
-      expect(liquid.render).to include("<iframe")
-        .and include(
-          'src="https://codepen.io/twhite96/embed/XKqrJX?height=600&default-tab=result&embed-version=2"',
-        )
-    end
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/twhite96/embed/XKqrJX?height=600&default-tab=result&embed-version=2"',
+        )
+    end
 
-    it "accepts codepen private link" do
-      liquid = generate_new_liquid(codepen_private_link)
+    it "accepts codepen private link" do
+      liquid = generate_new_liquid(codepen_private_link)
 
-      expect(liquid.render).to include("<iframe")
-        .and include(
-          'src="https://codepen.io/quezo/embed/e10ca45c611b9cf3c98a1011dedc1471?height=600&default-tab=result&embed-version=2"',
-        )
-    end
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/quezo/embed/e10ca45c611b9cf3c98a1011dedc1471?height=600&default-tab=result&embed-version=2"',
+        )
+    end
 
-    it "accepts codepen link with a / at the end" do
-      codepen_link = "https://codepen.io/twhite96/pen/XKqrJX/"
-      expect do
-        generate_new_liquid(codepen_link)
-      end.not_to raise_error
-    end
+    it "accepts codepen link with a / at the end" do
+      codepen_link = "https://codepen.io/twhite96/pen/XKqrJX/"
+      expect do
+        generate_new_liquid(codepen_link)
+      end.not_to raise_error
+    end
 
-    it "accepts codepen team link" do
-      codepen_link = codepen_team_link
-      expect do
-        generate_new_liquid(codepen_link)
-      end.not_to raise_error
-    end
+    it "accepts codepen team link" do
+      codepen_link = codepen_team_link
+      expect do
+        generate_new_liquid(codepen_link)
+      end.not_to raise_error
+    end
 
-    it "accepts codepen team private link" do
-      codepen_link = codepen_team_private_link
-      expect do
-        generate_new_liquid(codepen_link)
-      end.not_to raise_error
-    end
+    it "accepts codepen team private link" do
+      codepen_link = codepen_team_private_link
+      expect do
+        generate_new_liquid(codepen_link)
+      end.not_to raise_error
+    end
 
-    it "accepts codepen link with an underscore in the username" do
-      codepen_link = "https://codepen.io/t_white96/pen/XKqrJX/"
-      expect do
-        generate_new_liquid(codepen_link)
-      end.not_to raise_error
-    end
+    it "accepts codepen link with an underscore in the username" do
+      codepen_link = "https://codepen.io/t_white96/pen/XKqrJX/"
+      expect do
+        generate_new_liquid(codepen_link)
+      end.not_to raise_error
+    end
 
-    it "rejects invalid codepen link" do
-      expect do
-        generate_new_liquid("invalid_codepen_link")
-      end.to raise_error(StandardError)
-    end
+    it "rejects invalid codepen link" do
+      expect do
+        generate_new_liquid("invalid_codepen_link")
+      end.to raise_error(StandardError)
+    end
 
-    it "rejects codepen link with more than 30 characters in the username" do
-      codepen_link = "https://codepen.io/t_white96_this_is_31_characters/pen/XKqrJX/"
-      expect do
-        generate_new_liquid(codepen_link)
-      end.to raise_error(StandardError)
-    end
+    it "rejects codepen link with more than 30 characters in the username" do
+      codepen_link = "https://codepen.io/t_white96_this_is_31_characters/pen/XKqrJX/"
+      expect do
+        generate_new_liquid(codepen_link)
+      end.to raise_error(StandardError)
+    end
 
-    it "accepts codepen link with a default-tab parameter" do
-      expect do
-        generate_new_liquid(codepen_link_with_default_tab)
-      end.not_to raise_error
-    end
+    it "accepts codepen link with a default-tab parameter" do
+      expect do
+        generate_new_liquid(codepen_link_with_default_tab)
+      end.not_to raise_error
+    end
 
-    it "rejects XSS attempts" do
-      xss_links.each do |link|
-        expect { generate_new_liquid(link) }.to raise_error(StandardError)
-      end
-    end
+    it "accepts codepen link with a theme-id parameter" do
+      expect do
+        generate_new_liquid(codepen_link_with_theme_id)
+      end.not_to raise_error
 
-    it "rejects multiline XSS attempt" do
-      xss_multiline_link = <<~XSS
-        javascript:exploit_code();/*
-        #{codepen_link}
-        */
-      XSS
-      expect { generate_new_liquid(xss_multiline_link) }.to raise_error(StandardError)
-    end
-  end
+      liquid = generate_new_liquid(codepen_link_with_theme_id)
+
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/propjockey/embed/dyVMgBg?height=600&theme-id=40148',
+        )
+    end
+
+    it "accepts codepen link with pen/preview in the url" do
+      expect do
+        generate_new_liquid(codepen_link_with_preview_indicator)
+      end.not_to raise_error
+
+      liquid = generate_new_liquid(codepen_link_with_preview_indicator)
+
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/propjockey/embed/preview/dyVMgBg',
+        )
+    end
+
+    it "accepts codepen link with a height parameter" do
+      expect do
+        generate_new_liquid(codepen_link_with_height_param)
+      end.not_to raise_error
+
+      liquid = generate_new_liquid(codepen_link_with_height_param)
+
+      expect(liquid.render).to include("<iframe")
+        .and include('height="300"')
+        .and include(
+          'src="https://codepen.io/propjockey/embed/dyVMgBg?height=300',
+        )
+    end
+
+    it "accepts codepen link with a editable=true parameter" do
+      expect do
+        generate_new_liquid(codepen_link_with_editable_true)
+      end.not_to raise_error
+
+      liquid = generate_new_liquid(codepen_link_with_editable_true)
+
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/propjockey/embed/dyVMgBg?height=600&editable=true',
+        )
+    end
+
+    it "accepts codepen link with multiple params" do
+      expect do
+        generate_new_liquid(codepen_link_with_multiple_params)
+      end.not_to raise_error
+
+      liquid = generate_new_liquid(codepen_link_with_multiple_params)
+
+      expect(liquid.render).to include("<iframe")
+      .and include('height="250"')
+        .and include(
+          'src="https://codepen.io/propjockey/embed/dyVMgBg?height=250&theme-id=40148&amp;default-tab=js,result&amp;editable=true',
+        )
+    end
+
+    it "accepts codepen link with preview and params" do
+      expect do
+        generate_new_liquid(codepen_link_with_preview_and_params)
+      end.not_to raise_error
+
+      liquid = generate_new_liquid(codepen_link_with_preview_and_params)
+
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/propjockey/embed/preview/dyVMgBg?height=600&theme-id=40148&amp;default-tab=js,result',
+        )
+    end
+
+    it "rejects XSS attempts" do
+      xss_links.each do |link|
+        expect { generate_new_liquid(link) }.to raise_error(StandardError)
+      end
+    end
+
+    it "rejects multiline XSS attempt" do
+      xss_multiline_link = <<~XSS
+        javascript:exploit_code();/*
+        #{codepen_link}
+        */
+      XSS
+      expect { generate_new_liquid(xss_multiline_link) }.to raise_error(StandardError)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Adds the following options to codepen liquid tag embeds:
1) allow /pen/preview/ paths (which become /embed/preview/) For #12130 
2) allow height param for #5346
3) allow theme-id for codepen pro users (this is the thing I wanted, just decided to take care of the rest while I was in there)
4) and for the sake of completion, add the last embed option codepen has too: editable=true (also for codepen pro users)

## Related Tickets & Documents

#12130
#5346

## QA Instructions, Screenshots, Recordings

Several unit tests are included

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

Celebration and joy

## [optional] What gif best describes this PR or how it makes you feel?

https://i.imgur.com/0JE4B1J.mp4
