### PR TITLE
Allow for skipping navigation link creation

### DIFF
--- a/app/policies/authorizer.rb
+++ b/app/policies/authorizer.rb
@@ -177,6 +177,4 @@ module Authorizer
       user.__send__(:has_any_role?, *args)
     end
   end
-
-  private_constant :RoleBasedQueries
 end

--- a/lib/tasks/add_navigation_links.rake
+++ b/lib/tasks/add_navigation_links.rake
@@ -22,48 +22,90 @@ namespace :navigation_links do
   heart_icon = twemoji_path("heart.svg")
   rainbowdev = image_path("rainbowdev.svg")
 
+  def perform_create_of_navigation_links?
+    # Someone really wants this
+    return true if ApplicationConfig["CREATE_NAVIGATION_LINKS"]
+
+    # This logic echoes the InternalPolicy behavior which is used in the
+    # Admin::AppliciationController.
+    return false if User.with_any_role(*Authorizer::RoleBasedQueries::ANY_ADMIN_ROLES).any?
+
+    true
+  end
+
   desc "Create navigation links for new forem"
   task create: :environment do
-    NavigationLink.where(url: "/readinglist").first_or_create(
-      name: "Reading List",
-      url: URL.url("readinglist"),
-      icon: reading_icon,
-      display_only_when_signed_in: true,
-      position: 0,
-      section: :default,
-    )
-    NavigationLink.where(url: "/contact").first_or_create(
-      name: "Contact",
-      url: URL.url("contact"),
-      icon: contact_icon,
-      display_only_when_signed_in: false,
-      position: 1,
-      section: :default,
-    )
-    NavigationLink.where(url: "/code-of-conduct").first_or_create(
-      name: "Code of Conduct",
-      url: URL.url("code-of-conduct"),
-      icon: thumb_up_icon,
-      display_only_when_signed_in: false,
-      position: 0,
-      section: :other,
-    )
-    NavigationLink.where(url: "/privacy").first_or_create(
-      name: "Privacy Policy",
-      url: URL.url("privacy"),
-      icon: smart_icon,
-      display_only_when_signed_in: false,
-      position: 1,
-      section: :other,
-    )
-    NavigationLink.where(url: "/terms").first_or_create(
-      name: "Terms of Use",
-      url: URL.url("terms"),
-      icon: look_icon,
-      display_only_when_signed_in: false,
-      position: 2,
-      section: :other,
-    )
+    if perform_create_of_navigation_links?
+      puts "Creating navigation links"
+      # [@jeremyf] I went ahead and atomized these tasks so we _could_ call them individually if
+      #            desired.  I did not add descriptions so those tasks will not show up in the task
+      #            list.
+      Rake::Task["navigation_links:find_or_create:readinglist"].invoke
+      Rake::Task["navigation_links:find_or_create:contact"].invoke
+      Rake::Task["navigation_links:find_or_create:code_of_conduct"].invoke
+      Rake::Task["navigation_links:find_or_create:privacy"].invoke
+      Rake::Task["navigation_links:find_or_create:terms"].invoke
+    else
+      # Adding just a bit of logging
+      Rails.logger.info "Skipping creation of navigation links"
+    end
+  end
+
+  namespace :find_or_create do
+    task readinglist: :environment do
+      NavigationLink.where(url: "/readinglist").first_or_create(
+        name: "Reading List",
+        url: URL.url("readinglist"),
+        icon: reading_icon,
+        display_only_when_signed_in: true,
+        position: 0,
+        section: :default,
+      )
+    end
+
+    task contact: :environment do
+      NavigationLink.where(url: "/contact").first_or_create(
+        name: "Contact",
+        url: URL.url("contact"),
+        icon: contact_icon,
+        display_only_when_signed_in: false,
+        position: 1,
+        section: :default,
+      )
+    end
+
+    task code_of_conduct: :environment do
+      NavigationLink.where(url: "/code-of-conduct").first_or_create(
+        name: "Code of Conduct",
+        url: URL.url("code-of-conduct"),
+        icon: thumb_up_icon,
+        display_only_when_signed_in: false,
+        position: 0,
+        section: :other,
+      )
+    end
+
+    task privacy: :environment do
+      NavigationLink.where(url: "/privacy").first_or_create(
+        name: "Privacy Policy",
+        url: URL.url("privacy"),
+        icon: smart_icon,
+        display_only_when_signed_in: false,
+        position: 1,
+        section: :other,
+      )
+    end
+
+    task terms: :environment do
+      NavigationLink.where(url: "/terms").first_or_create(
+        name: "Terms of Use",
+        url: URL.url("terms"),
+        icon: look_icon,
+        display_only_when_signed_in: false,
+        position: 2,
+        section: :other,
+      )
+    end
   end
 
   desc "Update DEV's navigation_links"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This commit provides a possible solution for preventing the re-creation
of a navigation link deleted by a Forem creator.

What I need is a discussion around the life-cycle of the application
installation and updates.

In particular, does this provide a robust enough mechanism for resolving
the issue at hand?

_Note: it pains me to ask about a user's role, but this is provided as a
point of discussion and possible implementationi to address the
underlying issue.  But I'm referencing a constant in the Rake task so
hopefully that will help future refactors.  Also, it's one reason I
needed to remove the `private_constant` declaration._

If we accept this code change, a future task is to document the ENV and
behavior.

### Further considerations

- How might we refine this to not be as "role" reliant?
- Could we have a Site::Setting that we enable/disable
  regarding the navigation links?

## Related Tickets & Documents

Closes #15960


## QA Instructions, Screenshots, Recordings

Here's the steps I took.  Note the guard clause means there are several ways to create or skip creating.

- Start from an empty database
- Run setup
- Verify Navigation Link exists
- Delete Navigation Link
- Run setup again
- Verify Navigation Link exists (because we don't have a user)
- Run seeds
- Delete Navigation Link
- Run setup again
- Verify Navigation Link exists (because we don't have a user)

```shell
$ cd ./path/to/forem/repo

$ rails db:drop db:create db:schema:load

$ bin/setup

$ bin/rails runner "puts NavigationLink.where(url: '/readinglist').exists?"
  => true

$ bin/rails runner "NavigationLink.where(url: '/readinglist').delete_all"

$ bin/rails runner "puts NavigationLink.where(url: '/readinglist').exists?"
  => false

$ bin/setup

$ bin/rails runner "puts NavigationLink.where(url: '/readinglist').exists?"
  => true

$ bin/rails db:seed

$ bin/rails runner "NavigationLink.where(url: '/readinglist').delete_all"

$ bin/rails runner "puts NavigationLink.where(url: '/readinglist').exists?"
  => false

$ bin/setup

$ bin/rails runner "puts NavigationLink.where(url: '/readinglist').exists?"c
  => false
```

### UI accessibility concerns?

## Added/updated tests?

- [x] No, and this is why: We don't have tests for these kind of things; they are a bit hard and slow to run.

## [Forem core team only] How will this change be communicated?

- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [x] I will share this change internally with the appropriate teams

_Note: I have not updated the documentation as this is pending discussion._
