### PR TITLE
Ensuring less obnoxious usernames

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -596,6 +596,10 @@ class User < ApplicationRecord
     self.username = username&.downcase
   end
 
+  # @todo Should we do something to ensure that we don't create a username that violates our
+  # USERNAME_MAX_LENGTH constant?
+  #
+  # @see USERNAME_MAX_LENGTH
   def set_temp_username
     self.username = if temp_name_exists?
                       "#{temp_username}_#{rand(100)}"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,15 +61,16 @@ users_in_random_order = seeder.create_if_none(User, num_users) do
     fname = Faker::Name.unique.first_name
     # Including "\\:/" to help with identifying local issues with
     # character escaping.
-    lname = Faker::Name.unique.last_name + "\\:/"
-    name = [fname, "\"The #{fname}\"", lname].join(" ")
+    lname = Faker::Name.unique.last_name
+    name = [fname, "\"The #{fname}\"", lname, " \\:/"].join(" ")
+    username = "#{fname} #{lname}"
 
     user = User.create!(
       name: name,
       profile_image: File.open(Rails.root.join("app/assets/images/#{rand(1..40)}.png")),
-      twitter_username: Faker::Internet.username(specifier: name),
+      twitter_username: Faker::Internet.username(specifier: username),
       # Emails limited to 50 characters
-      email: Faker::Internet.email(name: name, separators: "+", domain: Faker::Internet.domain_word.first(20)),
+      email: Faker::Internet.email(name: username, separators: "+", domain: Faker::Internet.domain_word.first(20)),
       confirmed_at: Time.current,
       registered_at: Time.current,
       registered: true,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [x] Documentation Update

## Description

This change restores setting usernames to something less obnoxious.

Prior to this commit, I would on occassion get the following error in
seeds:

```shell
❯ bin/rails db:seed
Seeding with multiplication factor: 1

  1. Creating Organizations.
  2. Creating 10 Users.
rake aborted!
ActiveRecord::RecordInvalid: Validation failed: Username is too long (maximum is 30 characters)
./forem/db/seeds.rb:67:in `block (2 levels) in <main>'
./forem/db/seeds.rb:60:in `times'
./forem/db/seeds.rb:60:in `block in <main>'
./forem/app/lib/seeder.rb:30:in `create_if_none'
./forem/db/seeds.rb:57:in `<main>'
<internal:~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
<internal:~/.rbenv/versions/3.0.2/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-e:1:in `<main>'
Tasks: TOP => db:seed
(See full trace by running task with --trace)
```

## Related Tickets & Documents

Related to work done in #16067

## QA Instructions, Screenshots, Recordings

Keep running `bin/rails db:seed` to see if the random error goes away.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated.