### PR TITLE
Fixing regex warning and removing unneeded groups

### DIFF
--- a/app/liquid_tags/organization_tag.rb
+++ b/app/liquid_tags/organization_tag.rb
@@ -2,7 +2,12 @@ class OrganizationTag < LiquidTagBase
   include ApplicationHelper
   include ActionView::Helpers::TagHelper
   PARTIAL = "organizations/liquid".freeze
-  REGISTRY_REGEXP = %r{#{URL.url}/(?<org_slug>[\w-]+)(?:/)?(?:[\w-]+)?}
+
+  # @todo What if someone provides https://dev.to/terms-of-service.  That will meet this criteria.
+  #       How do we want to consider handling that situation?  My assumption is that we might want
+  #       to test if the org_slug is a valid organization before we even let the OrganizationTag say
+  #       there's a match.
+  REGISTRY_REGEXP = %r{#{URL.url}/(?<org_slug>[\w-]+)/?}
 
   def initialize(_tag_name, organization, _parse_context)
     super


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

Prior to this commit, I was seeing a "warning: nested repeat operator
'+' and '?' was replaced with '*' in regular expression"

```shell
> bundle exec rspec spec/liquid_tags/organization_tag_spec.rb
./app/liquid_tags/organization_tag.rb:5: warning: nested repeat operator '+' and '?' was replaced with '*' in regular expression
[Zonebie] Setting timezone: ZONEBIE_TZ="Dublin"
...

Finished in 0.39363 seconds (files took 2.89 seconds to load)
3 examples, 0 failures
```

After this change, when I run the same spec I get the following:

```shell
❯ bundle exec rspec spec/liquid_tags/organization_tag_spec.rb
[Zonebie] Setting timezone: ZONEBIE_TZ="Saskatchewan"
...

Finished in 0.39327 seconds (files took 3.03 seconds to load)
3 examples, 0 failures
```

The warning is gone.

Originally, I had changed `(?:[\w-]+)?` to `(?:[\w-]*)` which resolved
the warning.

But lookinig a bit further, we didn't need that
non-capturing group at all (`(?:[\w-]*)` is equivalent to `[\w-]*`).  So
I further condensed this down by removing it.  Likewise we my
understanding of regex is that `(?:/)?` is equivalent to `/?`.

So I stripped things further out.

I also noted a lingering issue to consider regarding what to do about
a URL that isn't an organization.  This is a larger issue to consider as
we bring in Embed tags that are for Forem resources.

## Related Tickets & Documents

Related to #16110.

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: just removing a warning.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
