### PR TITLE
Prevent banished users from updating their profiles

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -63,7 +63,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def update?
-    current_user?
+    current_user? && !user_suspended?
   end
 
   def destroy?

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -150,7 +150,7 @@ module Authentication
     end
 
     def update_user(user)
-      return if user.suspended?
+      return user if user.suspended?
 
       user.tap do |model|
         model.unlock_access! if model.access_locked?

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -150,6 +150,8 @@ module Authentication
     end
 
     def update_user(user)
+      return if user.suspended?
+
       user.tap do |model|
         model.unlock_access! if model.access_locked?
 

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe UserPolicy, type: :policy do
     context "with suspended status" do
       before { user.add_role(:suspended) }
 
-      it { is_expected.to forbid_actions(%i[join_org moderation_routes]) }
+      it { is_expected.to forbid_actions(%i[join_org moderation_routes update]) }
     end
   end
 

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -428,6 +428,15 @@ RSpec.describe Authentication::Authenticator, type: :service do
         tags = hash_including(tags: array_including("error:StandardError"))
         expect(ForemStatsClient).to have_received(:increment).with("identity.errors", tags)
       end
+
+      it "does not update their github_username if the user is suspended" do
+        new_username = "new_username#{rand(1000)}"
+        auth_payload.info.nickname = new_username
+        user.add_role :suspended
+
+        user = described_class.call(auth_payload)
+        expect(user.github_username).not_to eq(new_username)
+      end
     end
 
     describe "user already logged in" do
@@ -706,6 +715,15 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(
           user.profile_updated_at.to_i > original_profile_updated_at.to_i,
         ).to be(true)
+      end
+
+      it "does not update their twitter_username if the user is suspended" do
+        new_username = "new_username#{rand(1000)}"
+        auth_payload.info.nickname = new_username
+        user.add_role :suspended
+
+        user = described_class.call(auth_payload)
+        expect(user.github_username).not_to eq(new_username)
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
When we `banish` accounts, it's because they were marked as spam. We don't want to allow them to update their profiles after being banished, so this PR adds that (back?) in.

## Related Tickets & Documents
https://github.com/forem/internalCommunity/issues/127

## QA Instructions, Screenshots, Recordings
1. Suspend yourself: `User.find(your_id).add_role :suspended`
2. Go to [/settings](http://localhost:3000/settings)
3. Try to update a field
4. Run into an error

I don't think QAing the login part is worth the effort because I think the tests cover it.

### UI accessibility concerns?
No, backend change

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] Tell community success over Slack

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?

![A blonde woman angrily taps her phone, saying "Unfriend! Unfollow! Blocked! Unsubscribed!"](https://media.giphy.com/media/SsC3FuEjcbm5UyIVft/giphy.gif)
