### PR TITLE
Extracting a not_authored_by scope

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -193,6 +193,8 @@ class Article < ApplicationRecord
   }
   scope :unpublished, -> { where(published: false) }
 
+  scope :not_authored_by, ->(user_id) { where.not(user_id: user_id) }
+
   # [@jeremyf] For approved articles is there always an assumption of
   #            published?  Regardless, the scope helps us deal with
   #            that in the future.

--- a/app/services/articles/feeds/large_forem_experimental.rb
+++ b/app/services/articles/feeds/large_forem_experimental.rb
@@ -75,7 +75,7 @@ module Articles
         # rubocop:enable Layout/LineLength
         if user_signed_in
           hot_stories = experimental_hot_story_grab
-          hot_stories = hot_stories.where.not(user_id: UserBlock.cached_blocked_ids_for_blocker(@user.id))
+          hot_stories = hot_stories.not_authored_by(UserBlock.cached_blocked_ids_for_blocker(@user.id))
           featured_story = featured_story_from(stories: hot_stories, must_have_main_image: must_have_main_image)
           new_stories = Article.published
             .where("score > ?", article_score_threshold)

--- a/app/services/articles/suggest.rb
+++ b/app/services/articles/suggest.rb
@@ -39,7 +39,7 @@ module Articles
       ids_to_ignore << article.id
       Article.published
         .where.not(id: ids_to_ignore)
-        .where.not(user_id: article.user_id)
+        .not_authored_by(article.user_id)
         .order(hotness_score: :desc)
         .offset(rand(0..offset))
         .first(max)
@@ -49,7 +49,7 @@ module Articles
       Article
         .published
         .cached_tagged_with_any(cached_tag_list_array)
-        .where.not(user_id: article.user_id)
+        .not_authored_by(article.user_id)
         .where(tag_suggestion_query)
         .order(hotness_score: :desc)
         .offset(rand(0..offset))

--- a/app/services/articles/suggest_stickies.rb
+++ b/app/services/articles/suggest_stickies.rb
@@ -70,7 +70,7 @@ module Articles
         .unscope(:select)
         .limited_column_select
         .where.not(id: article.id)
-        .where.not(user_id: article.user_id)
+        .not_authored_by(article.user_id)
         .where("featured_number > ?", 5.days.ago.to_i)
         .order(Arel.sql("RANDOM()"))
     end

--- a/app/services/badges/award_tag.rb
+++ b/app/services/badges/award_tag.rb
@@ -15,7 +15,7 @@ module Badges
         past_winner_user_ids = BadgeAchievement.where(badge_id: tag.badge_id).pluck(:user_id)
         winning_article = Article.where("score > 100")
           .published
-          .where.not(user_id: past_winner_user_ids)
+          .not_authored_by(past_winner_user_ids)
           .order(score: :desc)
           .where("published_at > ?", 7.5.days.ago) # More than seven days, to have some wiggle room.
           .cached_tagged_with(tag).first

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -22,7 +22,7 @@ class EmailDigestArticleCollector
                      .published
                      .where("published_at > ?", cutoff_date)
                      .where(email_digest_eligible: true)
-                     .where.not(user_id: @user.id)
+                     .not_authored_by(@user.id)
                      .where("score > ?", 12)
                      .where("experience_level_rating > ? AND experience_level_rating < ?",
                             experience_level_rating_min, experience_level_rating_max)
@@ -34,7 +34,7 @@ class EmailDigestArticleCollector
                      .where("published_at > ?", cutoff_date)
                      .featured
                      .where(email_digest_eligible: true)
-                     .where.not(user_id: @user.id)
+                     .not_authored_by(@user.id)
                      .where("score > ?", 25)
                      .order(score: :desc)
                      .limit(6)

--- a/app/services/users/suggest_for_sidebar.rb
+++ b/app/services/users/suggest_for_sidebar.rb
@@ -31,8 +31,7 @@ module Users
       @active_authors_for_given_tags ||= Article.published.tagged_with([given_tag], any: true)
         .where(public_reactions_count: minimum_reaction_count..)
         .where(published_at: 4.months.ago..)
-        .where.not(user_id: user.id)
-        .where.not(user_id: user.following_by_type("User"))
+        .not_authored_by([user.id] + user.following_by_type("User"))
         .pluck(:user_id)
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

In my quest to find `where(attribute: value)` in controllers and even
services, I stumbled upon this pattern.

As of this commit (and prior) an Article's associated user is it's author.

## Related Tickets & Documents

None.

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No

## [Forem core team only] How will this change be communicated?


- [x] This change does not need to be communicated.


## [optional] Are there any post deployment tasks we need to perform?
