### PR TITLE
Feed experiment 4: Final order

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -39,7 +39,7 @@ module Stories
                Articles::Feeds::Basic.new(user: current_user, page: @page, tag: params[:tag])
              else
                strategy = AbExperiment.get(
-                 experiment: :feed_strategy_round_3,
+                 experiment: :feed_strategy_round_4,
                  controller: self, user: current_user,
                  default_value: AbExperiment::ORIGINAL_VARIANT
                )
@@ -65,7 +65,7 @@ module Stories
     end
 
     def signed_out_base_feed
-      strategy = AbExperiment.get(experiment: :feed_strategy_round_3, controller: self, user: current_user,
+      strategy = AbExperiment.get(experiment: :feed_strategy_round_4, controller: self, user: current_user,
                                   default_value: AbExperiment::ORIGINAL_VARIANT)
       feed = if strategy.weighted_query_strategy?
                Articles::Feeds::WeightedQueryStrategy.new(user: current_user, page: @page, tags: params[:tag])

--- a/app/models/ab_experiment.rb
+++ b/app/models/ab_experiment.rb
@@ -17,7 +17,7 @@ class AbExperiment < SimpleDelegator
   # for different experiments.  This provides the tooling for that
   # exact thing.
   EXPERIMENT_TO_METHOD_NAME_MAP = {
-    feed_strategy_round_3: :feed_strategy
+    feed_strategy_round_4: :feed_strategy
   }.freeze
 
   # This method helps us leverage existing methods for different

--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -447,7 +447,7 @@ module Articles
         when "final_order_by_score"
           articles.order("score DESC")
         when "final_order_by_comment_score"
-          articles.order("comment_score DESC").pluck(:comment_score)
+          articles.order("comment_score DESC")
         when "final_order_by_last_comment_at"
           articles.order("last_comment_at DESC")
         when "final_order_by_random"

--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -449,15 +449,16 @@ module Articles
         when "final_order_by_comment_score"
           articles.order("comment_score DESC")
         when "final_order_by_last_comment_at"
-          articles.order("last_comment_at DESC")
+          articles.order("articles.last_comment_at DESC")
         when "final_order_by_random"
           articles.order("RANDOM()")
         when "final_order_by_random_weighted_to_score"
-          articles.order(Arel.sql("RANDOM() ^ (1.0 / (score + 1)) DESC"))
+          articles.order(Arel.sql("RANDOM() ^ (1.0 / (articles.score + 1)) DESC"))
         when "final_order_by_random_weighted_to_comment_score"
-          articles.order(Arel.sql("RANDOM() ^ (1.0 / (comment_score + 1)) DESC"))
+          articles.order(Arel.sql("RANDOM() ^ (1.0 / (articles.comment_score + 1)) DESC"))
         when "final_order_by_random_weighted_to_last_comment_at"
-          articles.order(Arel.sql("RANDOM() ^ (1.0 / extract(epoch from now() - last_comment_at)::integer) ASC"))
+          articles
+            .order(Arel.sql("RANDOM() ^ (1.0 / extract(epoch from now() - articles.last_comment_at)::integer) ASC"))
         else # original
           articles
         end

--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -608,7 +608,7 @@ module Articles
           scoring_config = default_config unless scoring_config.is_a?(Hash)
 
           # Change an alement of config via a/b test strategy
-          scoring_config = inject_config_ab_test(valid_method_name, scoring_config)
+          # scoring_config = inject_config_ab_test(valid_method_name, scoring_config) # Not currently in use.
 
           # This scoring method requires a group by clause.
           @group_by_fields << default_config[:group_by] if default_config.key?(:group_by)

--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -453,9 +453,9 @@ module Articles
         when "final_order_by_random"
           articles.order("RANDOM()")
         when "final_order_by_random_weighted_to_score"
-          articles.order(Arel.sql("RANDOM() ^ (1.0 / (articles.score + 1)) DESC"))
+          articles.order(Arel.sql("RANDOM() ^ (1.0 / greatest(articles.score, 0.1)) DESC"))
         when "final_order_by_random_weighted_to_comment_score"
-          articles.order(Arel.sql("RANDOM() ^ (1.0 / (articles.comment_score + 1)) DESC"))
+          articles.order(Arel.sql("RANDOM() ^ (1.0 / greatest(articles.comment_score, 0.1)) DESC"))
         when "final_order_by_random_weighted_to_last_comment_at"
           articles
             .order(Arel.sql("RANDOM() ^ (1.0 / extract(epoch from now() - articles.last_comment_at)::integer) ASC"))

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -5,15 +5,25 @@ experiments:
   # Do not change the goals unless you intend to also change the corresponding code in
   # app/workers/users/record_field_test_event_worker.rb
 
-  feed_strategy_round_3:
+  feed_strategy_round_4:
     variants:
       - original
-      - slightly_more_comments_count_case_weight
-      - much_more_comments_count_case_weight
+      - final_order_by_score
+      - final_order_by_comment_score
+      - final_order_by_last_comment_at
+      - final_order_by_random
+      - final_order_by_random_weighted_to_score
+      - final_order_by_random_weighted_to_comment_score
+      - final_order_by_random_weighted_to_last_comment_at
     weights:
-      - 70
-      - 20
-      - 10
+      - 51
+      - 7
+      - 7
+      - 7
+      - 7
+      - 7
+      - 7
+      - 7
     goals:
       - user_creates_comment
       - user_creates_comment_on_at_least_four_different_days_within_a_week

--- a/spec/models/ab_experiment_spec.rb
+++ b/spec/models/ab_experiment_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe AbExperiment do
 
   describe ".get" do
     before do
-      allow(controller).to receive(:field_test).with(:feed_strategy_round_3, participant: user).and_return("special")
+      allow(controller).to receive(:field_test).with(:feed_strategy_round_4, participant: user).and_return("special")
     end
 
     context "with :feed_strategy_round_3 experiment" do
       it "repurposes the :feed_strategy experiment" do
-        expect(described_class.get(experiment: :feed_strategy_round_3,
+        expect(described_class.get(experiment: :feed_strategy_round_4,
                                    user: user,
                                    controller: controller,
                                    default_value: "default")).to eq("special")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We have achieved success in figuring out what an initial relevancy query looks like to surface 25 relevant posts to a feed — but we are presenting these results in no particular order. The hypothesis here is that the lowest hanging fruit for a better overall experience is providing a final order that takes these 25 results and re-orders them in the most effective way to float the most useful posts to the top. The way the algorithm is constructed gives us this area for "final ordering" which can be done with different feedback in mind compared to the initial global ordering query.

Given that this is a new final step, we'll test a variety of options and learn as much as we can. The incumbent gets 51% of the results and leaves room for a variety of challengers.

This test will make the algorithm much more opinionated about what the top 5 results are among the generally relevant returns. Even `random()` is a _possible_ winner over what we have now in that it will more often float results to the top that just don't get there based on what we have, which is _no instructions_. But I suspect one of the weighed algorithms will win. All 25 results will still be the top 25, just in varying orders.

There are still an extra handful of files which need to be touched in order to update the feed. I'll consider refactoring to get rid of those, but given the temporary nature of some of the testing code _for the time being_, it may be fine to sit with that state for now. Eventually the knobs will be more about config and less about inserting lines of code — but we are still in this flexible stage.

## Related Tickets & Documents
Builds on recent feed adjustments
https://github.com/forem/forem/pull/15993
https://github.com/forem/forem/pull/16093
https://github.com/forem/forem/pull/16082

## QA Instructions, Screenshots, Recordings
You may want to swap each variant into the code and check that there are no clear bugs in a single one.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: We have overarching regression tests and have not typically tested this granularly
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?
Weekly feed algorithm update

## [optional] Are there any post deployment tasks we need to perform?
These outcomes will be observed in production post-deploy too make sure no major outliers emerge.

## [optional] What gif best describes this PR or how it makes you feel?

![Optimism](https://media.giphy.com/media/l1KtYs7ZpeBskCQus/giphy.gif)
