### PR TITLE
Remove unused Users::ProfileImageGenerator::BACKGROUND_HEXES

### DIFF
--- a/app/services/users/profile_image_generator.rb
+++ b/app/services/users/profile_image_generator.rb
@@ -16,7 +16,7 @@ module Users
          tiger-face_1f42f.png
          fox_1f98a.png
          wolf_1f43a.png].freeze
-    BACKGROUND_HEXES = %w[#f68d8e #fce289 #f3f096 #55c1ae #88aedc #f8b4d0].freeze
+
     def self.call
       # This pulls from emojipedia source for the liberally open source twemoji lib.
       # TODO: Make this much more interesting than just emojis.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

I noticed that the constant `BACKGROUND_HEXES` in `Users::ProfileImageGenerator` seems to be unused:

```
❯ rg BACKGROUND_HEXES
app/services/users/profile_image_generator.rb
19:    BACKGROUND_HEXES = %w[#f68d8e #fce289 #f3f096 #55c1ae #88aedc #f8b4d0].freeze
```

This PR removes it.

## QA Instructions, Screenshots, Recordings

No behavior changed

### UI accessibility concerns?

None

## Added/updated tests?

- [X] No, and this is why: No behavior changed

## [Forem core team only] How will this change be communicated?

- [ ] This change does not need to be communicated, and this is why not: No behavior changed