### PR TITLE
Addressing rubocop violations

### DIFF
--- a/app/controllers/admin/settings/mandatory_settings_controller.rb
+++ b/app/controllers/admin/settings/mandatory_settings_controller.rb
@@ -14,7 +14,7 @@ module Admin
         configs.each do |key, value|
           settings_model = ::Settings::Mandatory::MAPPINGS[key.to_sym]
           if value.is_a?(Array)
-            settings_model.public_send("#{key}=", value.reject(&:blank?)) if value.present?
+            settings_model.public_send("#{key}=", value.compact_blank) if value.present?
           else
             settings_model.public_send("#{key}=", value.strip) unless value.nil?
           end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -63,7 +63,7 @@ class UsersController < ApplicationController
       @user.touch(:profile_updated_at)
       redirect_to "/settings/#{@tab}"
     else
-      Honeycomb.add_field("error", @user.errors.messages.reject { |_, v| v.empty? })
+      Honeycomb.add_field("error", @user.errors.messages.compact_blank)
       Honeycomb.add_field("errored", true)
 
       if @tab
@@ -277,7 +277,7 @@ class UsersController < ApplicationController
     if @user.update_with_password(password_params)
       redirect_to user_settings_path(@tab)
     else
-      Honeycomb.add_field("error", @user.errors.messages.reject { |_, v| v.empty? })
+      Honeycomb.add_field("error", @user.errors.messages.compact_blank)
       Honeycomb.add_field("errored", true)
 
       if @tab

--- a/app/models/settings/base.rb
+++ b/app/models/settings/base.rb
@@ -108,7 +108,7 @@ module Settings
         when :boolean
           value.in?(["true", "1", 1, true])
         when :array
-          value.split(separator || SEPARATOR_REGEXP).reject(&:empty?).map(&:strip)
+          value.split(separator || SEPARATOR_REGEXP).compact_blank.map(&:strip)
         when :hash
           value = begin
             YAML.safe_load(value).to_h

--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -266,6 +266,8 @@ module Articles
       #
       # @todo I envision that we will tweak the factors we choose, so
       #   those will likely need some kind of structured consideration.
+      #
+      # rubocop:disable Layout/LineLength
       def initialize(user: nil, number_of_articles: 50, page: 1, tag: nil, strategy: AbExperiment::ORIGINAL_VARIANT, **config)
         @user = user
         @number_of_articles = number_of_articles.to_i
@@ -284,6 +286,7 @@ module Articles
           days_since_published: @days_since_published,
         )
       end
+      # rubocop:enable Layout/LineLength
 
       # The goal of this query is to generate a list of articles that
       # are relevant to the user's interest.

--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -24,7 +24,7 @@ module Images
     }.freeze
 
     def self.cloudinary(img_src, **kwargs)
-      options = DEFAULT_CL_OPTIONS.merge(kwargs).reject { |_, v| v.blank? }
+      options = DEFAULT_CL_OPTIONS.merge(kwargs).compact_blank
 
       if img_src&.include?(".gif")
         options[:quality] = 66
@@ -43,7 +43,7 @@ module Images
 
     def self.imgproxy(img_src, **kwargs)
       translated_options = translate_cloudinary_options(kwargs)
-      options = DEFAULT_IMGPROXY_OPTIONS.merge(translated_options).reject { |_, v| v.blank? }
+      options = DEFAULT_IMGPROXY_OPTIONS.merge(translated_options).compact_blank
       Imgproxy.config.endpoint ||= get_imgproxy_endpoint
       Imgproxy.url_for(img_src, options)
     end

--- a/app/services/settings/upsert.rb
+++ b/app/services/settings/upsert.rb
@@ -27,7 +27,7 @@ module Settings
     def upsert_settings
       @settings.each do |key, value|
         if value.is_a?(Array) && value.any?
-          settings_class.public_send("#{key}=", value.reject(&:blank?))
+          settings_class.public_send("#{key}=", value.compact_blank)
         elsif value.respond_to?(:to_h) && value.present?
           settings_class.public_send("#{key}=", value.to_h)
         elsif value.present?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

```shell
❯ bundle exec rubocop -A
Inspecting 1856 files

Offenses:

app/controllers/admin/settings/mandatory_settings_controller.rb:17:57: C: [Corrected] Rails/CompactBlank: Use compact_blank instead.
            settings_model.public_send("#{key}=", value.reject(&:blank?)) if value.present?
                                                        ^^^^^^^^^^^^^^^^
app/controllers/users_controller.rb:66:58: C: [Corrected] Rails/CompactBlank: Use compact_blank instead.
      Honeycomb.add_field("error", @user.errors.messages.reject { |_, v| v.empty? })
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
app/controllers/users_controller.rb:280:58: C: [Corrected] Rails/CompactBlank: Use compact_blank instead.
      Honeycomb.add_field("error", @user.errors.messages.reject { |_, v| v.empty? })
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/settings/base.rb:111:54: C: [Corrected] Rails/CompactBlank: Use compact_blank instead.
          value.split(separator || SEPARATOR_REGEXP).reject(&:empty?).map(&:strip)
                                                     ^^^^^^^^^^^^^^^^
app/services/articles/feeds/weighted_query_strategy.rb:269:121: C: Layout/LineLength: Line is too long. [126/120] (https://rubystyle.guide#max-line-length)
      def initialize(user: nil, number_of_articles: 50, page: 1, tag: nil, strategy: AbExperiment::ORIGINAL_VARIANT, **config)
                                                                                                                        ^^^^^^
app/services/images/optimizer.rb:27:50: C: [Corrected] Rails/CompactBlank: Use compact_blank instead.
      options = DEFAULT_CL_OPTIONS.merge(kwargs).reject { |_, v| v.blank? }
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
app/services/images/optimizer.rb:46:68: C: [Corrected] Rails/CompactBlank: Use compact_blank instead.
      options = DEFAULT_IMGPROXY_OPTIONS.merge(translated_options).reject { |_, v| v.blank? }
                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
app/services/settings/upsert.rb:30:55: C: [Corrected] Rails/CompactBlank: Use compact_blank instead.
          settings_class.public_send("#{key}=", value.reject(&:blank?))
                                                      ^^^^^^^^^^^^^^^^

1856 files inspected, 8 offenses detected, 7 offenses corrected
```

After this commit:

```shell
❯ bundle exec rubocop
Inspecting 1856 files

1856 files inspected, no offenses detected
```

1856 files inspected, no offenses detected

## Related Tickets & Documents

Nope.

## QA Instructions, Screenshots, Recordings

Run `bundle exec rubocop` locally.

### UI accessibility concerns?

Nope.

## Added/updated tests?

- [X] No.

## [Forem core team only] How will this change be communicated?

- [ ] This change does not need to be communicated.
