### PR TITLE
Include badge before serializing tags

### DIFF
--- a/app/services/search/tag.rb
+++ b/app/services/search/tag.rb
@@ -3,7 +3,7 @@ module Search
     ATTRIBUTES = %i[id name hotness_score rules_html supported short_summary bg_color_hex badge_id].freeze
 
     def self.search_documents(term)
-      results = ::Tag.search_by_name(term).supported.reorder(hotness_score: :desc).select(*ATTRIBUTES)
+      results = ::Tag.search_by_name(term).supported.includes(:badge).reorder(hotness_score: :desc).select(*ATTRIBUTES)
       serialize(results)
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We are loading the badge for each included tag in the
Search::TagSerializer and seeing warnings from bullet

```
Bullet::Notification::UnoptimizedQueryError:

GET /search/tags?name=ta
USE eager loading detected
  Tag => [:badge]
  Add to your query: .includes([:badge])

Call stack
  /home/travis/build/forem/forem/app/serializers/search/tag_serializer.rb:5:in `block in <class:TagSerializer>'
  /home/travis/build/forem/forem/app/services/search/tag.rb:11:in `serialize'
  /home/travis/build/forem/forem/app/services/search/tag.rb:7:in `search_documents'
  /home/travis/build/forem/forem/app/controllers/search_controller.rb:54:in `tags'
  /home/travis/build/forem/forem/app/lib/middlewares/set_time_zone.rb:10:in `call'
```

Follow the advice, now when multiple tags are in the result set,
having multiple badges, badges are loaded only once (at query time)
and not one by one (at serialization time).



## Related Tickets & Documents

https://github.com/forem/forem/pull/15810 recently added the badge information to the search results, after which these bullet warnings would have started to appear.

## QA Instructions, Screenshots, Recordings

In my development environment no tags had a badge, and the tag search only responds with supported tags, so something like this worked for the reproduction case (to confirm the queries looked right):

```ruby
Badge.all.each do |b|
  Tag.supported.create(name: "prefix#{b.id}", badge: b)
end

Search::Tag.search_documents("prefix")
```

The resulting query should consist of one Tag Load (select from tags by tsquery on name) and one Badge Load (select from  badges by id in (1,2,3,4,5)).

```
  Tag Load (1.7ms)  SELECT "tags"."id", "tags"."name", "tags"."hotness_score", "tags"."rules_html", "tags"."supported", "tags"."short_summary", "tags"."bg_color_hex", "tags"."badge_id" FROM "tags" INNER JOIN (SELECT "tags"."id" AS pg_search_id, (ts_rank((to_tsvector('simple', coalesce("tags"."name"::text, ''))), (to_tsquery('simple', ''' ' || 'prefix' || ' ''' || ':*')), 0)) AS rank FROM "tags" WHERE ((to_tsvector('simple', coalesce("tags"."name"::text, ''))) @@ (to_tsquery('simple', ''' ' || 'prefix' || ' ''' || ':*')))) AS pg_search_978c2f8941354cf552831b ON "tags"."id" = pg_search_978c2f8941354cf552831b.pg_search_id WHERE "tags"."supported" = $1 ORDER BY "tags"."hotness_score" DESC  [["supported", true]]
  Badge Load (0.7ms)  SELECT "badges".* FROM "badges" WHERE "badges"."id" IN ($1, $2, $3, $4, $5)  [["id", 1], ["id", 2], ["id", 3], ["id", 4], ["id", 5]]
```


The prior behavior would have included 5 separate Badge Load queries (n+1).

```
  Tag Load (2.5ms)  SELECT "tags"."id", "tags"."name", "tags"."hotness_score", "tags"."rules_html", "tags"."supported", "tags"."short_summary", "tags"."bg_color_hex", "tags"."badge_id" FROM "tags" INNER JOIN (SELECT "tags"."id" AS pg_search_id, (ts_rank((to_tsvector('simple', coalesce("tags"."name"::text, ''))), (to_tsquery('simple', ''' ' || 'prefix' || ' ''' || ':*')), 0)) AS rank FROM "tags" WHERE ((to_tsvector('simple', coalesce("tags"."name"::text, ''))) @@ (to_tsquery('simple', ''' ' || 'prefix' || ' ''' || ':*')))) AS pg_search_978c2f8941354cf552831b ON "tags"."id" = pg_search_978c2f8941354cf552831b.pg_search_id WHERE "tags"."supported" = $1 ORDER BY "tags"."hotness_score" DESC  [["supported", true]]
  Badge Load (0.5ms)  SELECT "badges".* FROM "badges" WHERE "badges"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
  Badge Load (1.0ms)  SELECT "badges".* FROM "badges" WHERE "badges"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
  Badge Load (0.9ms)  SELECT "badges".* FROM "badges" WHERE "badges"."id" = $1 LIMIT $2  [["id", 3], ["LIMIT", 1]]
  Badge Load (0.7ms)  SELECT "badges".* FROM "badges" WHERE "badges"."id" = $1 LIMIT $2  [["id", 4], ["LIMIT", 1]]
  Badge Load (0.5ms)  SELECT "badges".* FROM "badges" WHERE "badges"."id" = $1 LIMIT $2  [["id", 5], ["LIMIT", 1]]
```

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: should not change behavior
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [x] This change does not need to be communicated, and this is why not: backend optimization

## Caveat

Since the tag serializer only needs the badge's image, it's possible to restrict the included badge load to `(id, badge_image)`, but badge rows don't appear to be so wide that much would be saved.