### PR TITLE
Remove "connect" feedback message special treatment

### DIFF
--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -12,7 +12,7 @@ class FeedbackMessagesController < ApplicationController
     @feedback_message = FeedbackMessage.new(params)
 
     recaptcha_enabled = ReCaptcha::CheckEnabled.call(current_user)
-    if (!recaptcha_enabled || recaptcha_verified? || connect_feedback?) && !rate_limit? && @feedback_message.save
+    if (!recaptcha_enabled || recaptcha_verified?) && !rate_limit? && @feedback_message.save
       Slack::Messengers::Feedback.call(
         user: current_user,
         type: feedback_message_params[:feedback_type],
@@ -55,10 +55,6 @@ class FeedbackMessagesController < ApplicationController
   def recaptcha_verified?
     recaptcha_params = { secret_key: Settings::Authentication.recaptcha_secret_key }
     params["g-recaptcha-response"] && verify_recaptcha(recaptcha_params)
-  end
-
-  def connect_feedback?
-    feedback_message_params[:feedback_type] == "connect"
   end
 
   def feedback_message_params

--- a/app/views/admin/feedback_messages/_feedback_message.html.erb
+++ b/app/views/admin/feedback_messages/_feedback_message.html.erb
@@ -58,7 +58,7 @@
           </h3>
         </div>
         <div class="col-12">
-          <% if feeedback_message.offender %>
+          <% if feedback_message.offender %>
             <h5 class="fw-bold">
               Message from Offender:
             </h5>

--- a/app/views/admin/feedback_messages/_feedback_message.html.erb
+++ b/app/views/admin/feedback_messages/_feedback_message.html.erb
@@ -19,7 +19,7 @@
       <div class="row">
         <div class="col-9">
           <h5 class="fw-bold">
-          <% if feedback_message.feedback_type == "connect" %>
+          <% if feedback_message.offender %>
             Reporter and Affected:
           <% else %>
             Reporter:
@@ -34,7 +34,7 @@
             <% end %>
           </h5>
 
-          <% if feedback_message.feedback_type == "connect" %>
+          <% if feedback_message.offender %>
             <h5 class="fw-bold">
               Offender:
             </h5>
@@ -55,30 +55,27 @@
         <div class="col-3">
           <h3 class="report__tags">
             <span class="badge badge-warning float-right"><%= feedback_message.category.titleize %></span>
-            <% if feedback_message.feedback_type == "connect" %>
-            <span class="badge badge-warning float-right badge-connect"><%= feedback_message.feedback_type %></span>
-            <% end %>
           </h3>
         </div>
         <div class="col-12">
-          <% if feedback_message.feedback_type != "connect" %>
-          <h5 class="fw-bold">
-            Message:
-          </h5>
-          <p>
-            <% if feedback_message.message.blank? %>
-              <span class="font-italic">No message was left.</span>
-            <% else %>
-              <%= feedback_message.message %>
-            <% end %>
-          </p>
-          <% else %>
+          <% if feeedback_message.offender %>
             <h5 class="fw-bold">
               Message from Offender:
             </h5>
             <div class="reported__message">
               <%= raw(feedback_message.message) %>
             </div>
+            <% else %>
+            <h5 class="fw-bold">
+              Message:
+            </h5>
+            <p>
+            <% if feedback_message.message.blank? %>
+              <span class="font-italic">No message was left.</span>
+            <% else %>
+              <%= feedback_message.message %>
+            <% end %>
+            </p>
           <% end %>
         </div>
       </div>

--- a/app/views/admin/feedback_messages/_style.html.erb
+++ b/app/views/admin/feedback_messages/_style.html.erb
@@ -1,42 +1,36 @@
 <style>
-  .notefield {
-    width: 100%;
-    resize: none;
-    font-size: 18px;
-    height: 50px;
-    border-radius: 3px;
-    padding: 5px;
-    margin: 10px 0px;
-  }
+ .notefield {
+   width: 100%;
+   resize: none;
+   font-size: 18px;
+   height: 50px;
+   border-radius: 3px;
+   padding: 5px;
+   margin: 10px 0px;
+ }
 
-  .email__container {
-    border: 1px solid gray;
-    margin: 10px;
-    padding-left: 50px;
-    padding-top: 5px;
-  }
+ .email__container {
+   border: 1px solid gray;
+   margin: 10px;
+   padding-left: 50px;
+   padding-top: 5px;
+ }
 
-  .to__subject {
-    margin: 5px;
-    font-size: 20px;
-    color: black;
-    text-align: center;
-  }
-  .badge-connect {
-  background-color: #26d9ca;
-  margin-top: 5px;
-  text-transform: capitalize;
-}
-.reported__message {
-  border: 1px solid;
-  margin: 20px auto;
-  padding: 20px;
-  max-height: 300px;
-  overflow: scroll;
-}
-.report__tags{
-  display: grid;
-justify-items: end;
-}
-
+ .to__subject {
+   margin: 5px;
+   font-size: 20px;
+   color: black;
+   text-align: center;
+ }
+ .reported__message {
+   border: 1px solid;
+   margin: 20px auto;
+   padding: 20px;
+   max-height: 300px;
+   overflow: scroll;
+ }
+ .report__tags{
+   display: grid;
+   justify-items: end;
+ }
 </style>

--- a/spec/system/feedback_message_spec.rb
+++ b/spec/system/feedback_message_spec.rb
@@ -5,6 +5,25 @@ RSpec.describe "Feedback report", type: :system do
   let(:message) { Faker::Lorem.paragraph }
   let(:url) { Faker::Lorem.sentence }
 
+  context "when user create a report abuse feedback message" do
+    before do
+      sign_in user
+    end
+
+    it "feedback message should increase by one", js: true do
+      expect do
+        post "/feedback_messages", params: {
+          feedback_message: {
+            message: message,
+            feedback_type: "abuse-reports",
+            category: "rude or vulgar",
+            reported_url: url
+          }
+        }, as: :json
+      end.to change(FeedbackMessage, :count).by(1)
+    end
+  end
+
   context "when user creates too many report abuse feedback messages" do
     let(:rate_limit_checker) { RateLimitChecker.new(user) }
 

--- a/spec/system/feedback_message_spec.rb
+++ b/spec/system/feedback_message_spec.rb
@@ -1,28 +1,9 @@
 require "rails_helper"
 
-RSpec.describe "Feedback report by chat channel messages", type: :system do
+RSpec.describe "Feedback report", type: :system do
   let(:user) { create(:user) }
   let(:message) { Faker::Lorem.paragraph }
   let(:url) { Faker::Lorem.sentence }
-
-  context "when user create a report abuse feedback message" do
-    before do
-      sign_in user
-    end
-
-    it "feedback message should increase by one", js: true do
-      expect do
-        post "/feedback_messages", params: {
-          feedback_message: {
-            message: "Test Message",
-            feedback_type: "connect",
-            category: "rude or vulgar",
-            offender_id: user.id
-          }
-        }, as: :json
-      end.to change(FeedbackMessage, :count).by(1)
-    end
-  end
 
   context "when user creates too many report abuse feedback messages" do
     let(:rate_limit_checker) { RateLimitChecker.new(user) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When deprecating connect chat (and removing it) from the app, the handling of abuse feedback reporting was left in place (displaying created feedback from a chat channel is independent of using the chat).

Remove the special casing of these messages by type. 

- In the controller, no need to special case this when checking rate limiting (they won't happen any more).
- In the view, the connect feedback had a badge (removed) and some special case handling because these messages had both a reporter and an offender (rather than a reporter and a reported url, as abuse reports do). Change the view to check for offender presence instead of connect type, which should permit us handling other two-party reports correctly in the future (if that happens).

In DEV's db, there is a single (resolved) feedback message from connect, so the impact is probably very limited.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings


Create a connect feedback message (there are already _other_ feedback messages in the seed data):

```ruby
FeedbackMessage.where(feedback_type: "connect").create(
  reporter: User.all.sample, 
  offender: User.all.sample, 
  category: "rude or vulgar", 
  status: "Open", 
  message: Faker::Lorem.paragraph
)
```

visit http://localhost:3000/admin/moderation/reports

Should be (top of the page) the newly created connect message, as well as any open/unresolved feedback from the seed data.

Abuse report (one-way, includes reported url) - unchanged from main branch:

![abuse report](https://user-images.githubusercontent.com/1237369/149983001-2c52d459-27dc-40c2-b7be-cb170dd943ba.png)

Connect message (two-way, reporter and offender) on this branch:

![connect message](https://user-images.githubusercontent.com/1237369/149983155-7631e32f-2146-43d0-ae46-2aa8a1cacf4a.png)

Old "connect" badge (removed) - showing on main branch:

![connect message from main](https://user-images.githubusercontent.com/1237369/149983368-759509bc-6d46-48b4-b9a4-46c2d4756049.png)

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] This change does not need to be communicated, and this is why not: minor change to presentation of items that are almost never seen, and view refactoring to clean up domain knowledge in the template.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![onelessthing](https://user-images.githubusercontent.com/1237369/149984574-d501b013-c0bf-4beb-84b3-e018432c0cd4.gif)
