### PR TITLE
Explicitly silence FastImage exceptions

### DIFF
--- a/app/services/articles/enrich_image_attributes.rb
+++ b/app/services/articles/enrich_image_attributes.rb
@@ -40,7 +40,7 @@ module Articles
         attribute_width, attribute_height = image_width_height(img)
         img["width"] = attribute_width
         img["height"] = attribute_height
-        img["data-animated"] = true if FastImage.animated?(image, timeout: TIMEOUT)
+        img["data-animated"] = true if FastImage.animated?(image, timeout: TIMEOUT, raise_on_failure: false)
       end
 
       article.update_columns(processed_html: parsed_html.to_html)
@@ -50,7 +50,7 @@ module Articles
       src = img.attr("src")
       return unless src
 
-      FastImage.size(src, timeout: timeout)
+      FastImage.size(src, timeout: timeout, raise_on_failure: false)
     end
 
     def self.retrieve_image_from_uploader_store(src)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug

## Description
There has been a lot of harmless noise caused by the FastImage gem. 

We're getting a lot of `FastImage::CannotParseImage` errors on Datadog and that shouldn't happen because FastImage gem silences them by default. This is my attempt at silencing this error.

## Related Tickets & Documents
n/a
## QA Instructions, Screenshots, Recordings
n/a

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a