### PR TITLE
Re-enable stories specs

### DIFF
--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -231,13 +231,13 @@ RSpec.describe "StoriesIndex", type: :request do
         create(:article, approved: false, body_markdown: u_body, score: 1)
       end
 
-      xit "doesn't display posts with the campaign tags when sidebar is disabled" do
+      it "doesn't display posts with the campaign tags when sidebar is disabled" do
         allow(Settings::Campaign).to receive(:sidebar_enabled).and_return(false)
         get "/"
         expect(response.body).not_to include(CGI.escapeHTML("Super-sheep"))
       end
 
-      xit "doesn't display unapproved posts" do
+      it "doesn't display unapproved posts" do
         allow(Settings::Campaign).to receive(:sidebar_enabled).and_return(true)
         allow(Settings::Campaign).to receive(:sidebar_image).and_return("https://example.com/image.png")
         allow(Settings::Campaign).to receive(:articles_require_approval).and_return(true)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Tests

## Description

In #15680 we disabled some stories specs because of possible interactions with the new feed strategy we were testing at this time. However, it seems both of these specs pass now so it seems like a good idea to reenable them.

## Related Tickets & Documents

#15680

## Added/updated tests?

- [X] Yes
 
## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: nothing to communicate here, test only change