### PR TITLE
ListingsToolkit refactoring

### DIFF
--- a/app/services/listings/create.rb
+++ b/app/services/listings/create.rb
@@ -1,0 +1,48 @@
+module Listings
+  # This service wraps listing purchses in a transaction which verifies that
+  # the purchaser has enough credits to complete this process.
+  class Create
+    # @param listing [Listing] an initialized but not yet persisted listing
+    # @param purchaser [User] the user attempting to purchase the listing
+    # @param cost [Integer] the number of credits the user has to spend
+    # @return [Listings::Create] the service itself, used for the success? check
+    def self.call(listing, purchaser:, cost:)
+      new(listing, purchaser, cost).call
+    end
+
+    def initialize(listing, purchaser, cost)
+      @listing = listing
+      @purchaser = purchaser
+      @cost = cost
+      @success = false
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        # Subtract credits
+        Credits::Buyer.call(
+          purchaser: @purchaser,
+          purchase: @listing,
+          cost: @cost,
+        )
+
+        # Update the listing
+        @listing.bumped_at = Time.current
+        @listing.published = true
+        @listing.originally_published_at = Time.current
+
+        # Since we can't raise ActiveRecord errors in this transaction
+        # due to the fact that we need to display them in the :new view,
+        # we manually rollback the transaction if there are validation errors
+        raise ActiveRecord::Rollback unless @listing.save
+
+        @success = true
+      end
+      self
+    end
+
+    def success?
+      @success
+    end
+  end
+end

--- a/app/services/listings/create.rb
+++ b/app/services/listings/create.rb
@@ -20,11 +20,13 @@ module Listings
     def call
       ActiveRecord::Base.transaction do
         # Subtract credits
-        Credits::Buyer.call(
+        enough_credits = Credits::Buyer.call(
           purchaser: @purchaser,
           purchase: @listing,
           cost: @cost,
         )
+
+        raise ActiveRecord::Rollback unless enough_credits
 
         # Update the listing
         @listing.bumped_at = Time.current

--- a/spec/services/listings/create_spec.rb
+++ b/spec/services/listings/create_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Listings::Create, type: :service do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/services/listings/create_spec.rb
+++ b/spec/services/listings/create_spec.rb
@@ -1,5 +1,17 @@
 require "rails_helper"
 
 RSpec.describe Listings::Create, type: :service do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:user) { create(:user) }
+  let(:listing) { build(:listing, user: user) }
+
+  it "is successful when the purchaser has enough credits" do
+    create(:credit, user: user)
+    create_result = described_class.call(listing, purchaser: user, cost: 1)
+    expect(create_result.success?).to be true
+  end
+
+  it "fails if the purchaser doesn't have enough credits" do
+    create_result = described_class.call(listing, purchaser: user, cost: 1)
+    expect(create_result.success?).to be false
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

We have a pretty convoluted controller concern called `ListingsToolkit` which is used in 3 different controllers:

* `ListingsController`
* `Admin::ListingsController`
* `Api::V0::ListingsController`

It has several problems, including 

* calling methods that are not defined inside that concern but only exist in the including controllers,
* lots of implicit state in instance variables

If we ever want to extract listings into a plugin as previously discussed we probably should get this code into better shape first. This is a cautious first step, extracting one step of the process into a service. I think I also discovered a bug in the process, see inline comments.

I'm not 100% happy with this service yet, but I think it will do for now. I want to extract functionality from `ListingsToolkit` first, then see if/how we can simplify that further.

## QA Instructions, Screenshots, Recordings

No behavior should change

### UI accessibility concerns?

No UI changes

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: refactoring only