### PR TITLE
Onboarding "improvements"

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -169,7 +169,7 @@ class UsersController < ApplicationController
   def onboarding_update
     authorize User
 
-    user_params = { saw_onboarding: true }
+    user_params = {}
 
     if params[:user]
       if params.dig(:user, :username).blank?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -177,7 +177,7 @@ class UsersController < ApplicationController
       end
 
       sanitize_user_params
-      user_params.merge!(params[:user].permit(ALLOWED_USER_PARAMS))
+      user_params = params[:user].permit(ALLOWED_USER_PARAMS)
     end
 
     update_result = Users::Update.call(current_user, user: user_params, profile: profile_params)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -172,7 +172,7 @@ class UsersController < ApplicationController
     user_params = {}
 
     if params[:user]
-      if params.dig(:user, :username).blank?
+      if params[:user].key?(:username) && params[:user][:username].blank?
         return render_update_response(false, "Username cannot be blank")
       end
 

--- a/spec/requests/users_onboarding_spec.rb
+++ b/spec/requests/users_onboarding_spec.rb
@@ -12,11 +12,6 @@ RSpec.describe "UsersOnboarding", type: :request do
     context "when signed in" do
       before { sign_in user }
 
-      it "updates saw_onboarding boolean" do
-        patch "/onboarding_update.json", params: {}
-        expect(user.saw_onboarding).to eq(true)
-      end
-
       it "updates the user's last_onboarding_page attribute" do
         params = { user: { last_onboarding_page: "v2: personal info form", username: "test" } }
         expect do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Every onboarding page, except the "build your profile" page which asks for a username, is receiving a 422 response (because we're validating a non-empty username, but it's only sent in one of the pages). 

Every onboarding page is setting saw_onboarding to true, but we should only disable onboarding _if_ the user has accepted the code of conduct (logged via onboarding checkbox update). 

## Related Tickets & Documents

related to investigation into https://github.com/forem/forem/issues/14483 (but does not solve that).

## QA Instructions, Screenshots, Recordings

When onboarding, you shouldn't get a 422 from the onboarding_update endpoint.

On main these are happening on every page except the profile page.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes ( I deleted a test for behavior being removed)

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: cleanup (should be behavior neutral)
