### PR TITLE
Expanding the range of followed tags we show

### DIFF
--- a/app/javascript/leftSidebar/TagsFollowed.jsx
+++ b/app/javascript/leftSidebar/TagsFollowed.jsx
@@ -12,7 +12,7 @@ export const TagsFollowed = ({ tags = [] }) => {
   return (
     <Fragment>
       {tags.map(({ name, id, points }) =>
-        points >= 1 ? (
+        points >= 0 ? (
           <Link
             key={id}
             title={`${name} tag`}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

I have talked with @amywtlin about the expectations regarding the tags that one follows.  This is the lightest weight fix to align with expected behavior.

The fix might be a bit of a work-around for a more general approach, but we're fighting against the magic of the points vs. explicit_points tension as defined in the [Follows::UpdatePointsWorker][1].

That is to say, it's possible (and happens) where I have assigned an `explicit_points` of 1 for a tag, but the calculated `points` are less than 1.  The calculated `points` are what we send forward in the [AsyncInfoController][1] (by way of the [UserDecorator#cached_followed_tags][3] method).

In DEV, I ran the following queries:

**User assigned points `>= 1` but calculated `< 1`**

985,352 records

```sql
SELECT count(id)
FROM follows
WHERE followable_type = 'ActsAsTaggableOn::Tag'
  AND points < 1
  AND explicit_points >= 1;
```

**User assigned points `>= 1` but calculated `>= 1`**

5,366,478 records

```sql
SELECT count(id)
FROM follows
WHERE followable_type = 'ActsAsTaggableOn::Tag'
  AND points >= 1
  AND explicit_points >= 1;
```

**User assigned points `>= 1` but calculated `>= 0`**

0 records.

```sql
SELECT count(id)
FROM follows
WHERE followable_type = 'ActsAsTaggableOn::Tag'
  AND points <= 0
  AND explicit_points >= 1;
```

**User assigned points `<= 0` but calculated `> 0`**

1,146 records

```sql
SELECT count(id)
FROM follows
WHERE followable_type = 'ActsAsTaggableOn::Tag'
  AND points > 0
  AND explicit_points <= 0;
```

Synthesizing that, almost 1 million tag follows of the total 6.3 million are not showing up in the user's left navigation.  And 5.3 million are roughly correct.

In adjusting the logic, we're now going to have more tags showing up in the left.  And just over 1,000 might now show up that would be unexpected.


[1]:https://github.com/forem/forem/blob/c63e0b629e1edd0b7f2ce03952cf6bf552c7b8d8/app/workers/follows/update_points_worker.rb
[2]:https://github.com/forem/forem/blob/c63e0b629e1edd0b7f2ce03952cf6bf552c7b8d8/app/controllers/async_info_controller.rb#L40-L65
[3]:https://github.com/forem/forem/blob/c63e0b629e1edd0b7f2ce03952cf6bf552c7b8d8/app/decorators/user_decorator.rb#L23-L34

## Related Tickets & Documents

Closes #14937.

## QA Instructions, Screenshots, Recordings

Hopefully with this change @robertandrews will see some more tags showing up.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No.

## [Forem core team only] How will this change be communicated?

- [ ] I'm not sure how best to communicate this change and need help
