### PR TITLE
Let override of ToS and CoC show in onboarding

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -9,9 +9,9 @@ module Admin
 
     def index
       @pages = Page.all.order(created_at: :desc)
-      @code_of_conduct = Page.find_by(slug: "code-of-conduct")
-      @privacy = Page.find_by(slug: "privacy")
-      @terms = Page.find_by(slug: "terms")
+      @code_of_conduct = Page.find_by(slug: Page::CODE_OF_CONDUCT_SLUG)
+      @privacy = Page.find_by(slug: Page::PRIVACY_SLUG)
+      @terms = Page.find_by(slug: Page::TERMS_SLUG)
     end
 
     def new
@@ -74,7 +74,7 @@ module Admin
                                    email_link: view_context.email_link
                                  }
       @page = case slug
-              when "code-of-conduct"
+              when Page::CODE_OF_CONDUCT_SLUG
                 Page.new(
                   slug: slug,
                   body_html: html,
@@ -82,7 +82,7 @@ module Admin
                   description: "A page that describes how to behave on this platform",
                   is_top_level_path: true,
                 )
-              when "privacy"
+              when Page::PRIVACY_SLUG
                 Page.new(
                   slug: slug,
                   body_html: html,
@@ -90,7 +90,7 @@ module Admin
                   description: "A page that describes the privacy policy",
                   is_top_level_path: true,
                 )
-              when "terms"
+              when Page::TERMS_SLUG
                 Page.new(
                   slug: slug,
                   body_html: html,

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,6 +1,10 @@
 class Page < ApplicationRecord
   TEMPLATE_OPTIONS = %w[contained full_within_layout json].freeze
 
+  TERMS_SLUG = "terms".freeze
+  CODE_OF_CONDUCT_SLUG = "code-of-conduct".freeze
+  PRIVACY_SLUG = "privacy".freeze
+
   validates :title, presence: true
   validates :description, presence: true
   validates :slug, presence: true, format: /\A[0-9a-z\-_]*\z/
@@ -16,6 +20,28 @@ class Page < ApplicationRecord
 
   mount_uploader :social_image, ProfileImageUploader
   resourcify
+
+  # @param slug [String]
+  #
+  # @return An HTML safe String.
+  #
+  # @yield Yield to the calling context if there's no Page match for slug.
+  #
+  # @note Yes, treating this value as HTML safe is risky.  But we already opened that vector by
+  #       letting the administrator of pages write HTML.
+  #
+  # @todo Do we want to only allow certain slugs?
+  #
+  # rubocop:disable Rails/OutputSafety
+  def self.render_safe_html_for(slug:)
+    page = find_by(slug: slug)
+    if page
+      page.processed_html.html_safe
+    else
+      yield
+    end
+  end
+  # rubocop:enable Rails/OutputSafety
 
   def self.landing_page
     find_by(landing_page: true)

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -27,6 +27,8 @@ class Page < ApplicationRecord
   #
   # @yield Yield to the calling context if there's no Page match for slug.
   #
+  # @raise LocalJumpError when no matching slug nor block given.
+  #
   # @note Yes, treating this value as HTML safe is risky.  But we already opened that vector by
   #       letting the administrator of pages write HTML.
   #

--- a/app/views/onboardings/show.html.erb
+++ b/app/views/onboardings/show.html.erb
@@ -20,9 +20,9 @@
 </div>
 
 <div id="terms" style="display: none;">
-  <%= render "pages/terms_text" %>
+  <%= Page.render_safe_html_for(slug: Page::TERMS_SLUG) { render "pages/terms_text" } %>
 </div>
 
 <div id="coc" style="display: none;">
-  <%= render "pages/coc_text" %>
+  <%= Page.render_safe_html_for(slug: Page::CODE_OF_CONDUCT_SLUG) { render "pages/coc_text" } %>
 </div>

--- a/app/views/pages/code_of_conduct.html.erb
+++ b/app/views/pages/code_of_conduct.html.erb
@@ -17,6 +17,6 @@
 <main id="main-content" class="crayons-layout crayons-layout--limited-l">
   <div class="crayons-card text-styles text-padding">
     <h1 class="fs-3xl s:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight mb-4 mt-0">Code of Conduct</h1>
-    <%= render "coc_text" %>
+    <%= Page.render_safe_html_for(slug: Page::CODE_OF_CONDUCT_SLUG) { render "pages/coc_text" } %>
   </div>
 </main>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -22,6 +22,6 @@
 <main id="main-content" class="crayons-layout crayons-layout--limited-l">
   <div class="crayons-card text-styles text-padding">
     <h1 class="fs-3xl s:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight mb-4 mt-0">Web Site Terms and Conditions of Use</h1>
-    <%= render "terms_text" %>
+    <%= Page.render_safe_html_for(slug: Page::TERMS_SLUG) { render "terms_text" } %>
   </div>
 </main>

--- a/lib/tasks/add_navigation_links.rake
+++ b/lib/tasks/add_navigation_links.rake
@@ -77,7 +77,7 @@ namespace :navigation_links do
     task code_of_conduct: :environment do
       NavigationLink.where(url: "/code-of-conduct").first_or_create(
         name: "Code of Conduct",
-        url: URL.url("code-of-conduct"),
+        url: URL.url(Page::CODE_OF_CONDUCT_SLUG),
         icon: thumb_up_icon,
         display_only_when_signed_in: false,
         position: 0,
@@ -88,7 +88,7 @@ namespace :navigation_links do
     task privacy: :environment do
       NavigationLink.where(url: "/privacy").first_or_create(
         name: "Privacy Policy",
-        url: URL.url("privacy"),
+        url: URL.url(Page::PRIVACY_SLUG),
         icon: smart_icon,
         display_only_when_signed_in: false,
         position: 1,
@@ -99,7 +99,7 @@ namespace :navigation_links do
     task terms: :environment do
       NavigationLink.where(url: "/terms").first_or_create(
         name: "Terms of Use",
-        url: URL.url("terms"),
+        url: URL.url(Page::TERMS_SLUG),
         icon: look_icon,
         display_only_when_signed_in: false,
         position: 2,

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,6 +1,28 @@
 require "rails_helper"
 
 RSpec.describe Page, type: :model do
+  describe ".render_safe_html_for" do
+    let(:slug) { "the-given-slug" }
+
+    context "when no matching slug in Page database" do
+      specify { expect { |b| described_class.render_safe_html_for(slug: slug, &b) }.to yield_control }
+    end
+
+    context "when there's a matching slug" do
+      subject(:rendered_html) { described_class.render_safe_html_for(slug: page.slug) }
+
+      let!(:page) { create(:page, slug: "the-given-slug") }
+
+      it { is_expected.to be_html_safe }
+
+      it "returns the html safe version of the processed_html" do
+        expect(rendered_html).to eq(page.processed_html)
+      end
+
+      specify { expect { |b| described_class.render_safe_html_for(slug: slug, &b) }.not_to yield_control }
+    end
+  end
+
   describe "#validations" do
     it "requires either body_markdown, body_html, or body_json" do
       page = build(:page)

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -8,6 +8,14 @@ RSpec.describe Page, type: :model do
       specify { expect { |b| described_class.render_safe_html_for(slug: slug, &b) }.to yield_control }
     end
 
+    context "when no matching slug and the caller didn't pass a block" do
+      # Instead of raising an exception we could "silently" do nothing.  That too might be
+      # reasonable.  But this seems like a good enough test.
+      it "raises an exception" do
+        expect { described_class.render_safe_html_for(slug: slug) }.to raise_error(LocalJumpError)
+      end
+    end
+
     context "when there's a matching slug" do
       subject(:rendered_html) { described_class.render_safe_html_for(slug: page.slug) }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this commit any changes to the terms or code of conduct were
not reflected in the onboarding links.

With this commit, I'm leveraging a newly created method that first
checks if there's a page for the given slug.  If there is, use that
page's copy.

## Related Tickets & Documents

Closes #15296

## QA Instructions, Screenshots, Recordings

To test:

- Overwrite default /terms page on a Forem
- Navigate to /onboarding or sign up as a new user
- Click on Terms of Use link text
- Review Terms of Use

### UI accessibility concerns?

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
