### PR TITLE
Implement Unified Embed for Tweet URLs

### DIFF
--- a/app/liquid_tags/tweet_tag.rb
+++ b/app/liquid_tags/tweet_tag.rb
@@ -1,7 +1,9 @@
 class TweetTag < LiquidTagBase
   include ActionView::Helpers::AssetTagHelper
   PARTIAL = "liquids/tweet".freeze
-  ID_REGEXP = /\A\d{10,20}\z/ # id must be all numbers between 10 and 20 chars
+  REGISTRY_REGEXP = %r{https://twitter.com/(?<username>\w{1,15})/status/(?<id>\d{10,20})}
+  VALID_ID_REGEXP = /\A(?<id>\d{10,20})\Z/
+  REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 
   SCRIPT = <<~JAVASCRIPT.freeze
     var videoPreviews = document.getElementsByClassName("ltag__twitter-tweet__media__video-wrapper");
@@ -50,14 +52,10 @@ class TweetTag < LiquidTagBase
   private
 
   def parse_id(input)
-    input_no_space = input.delete(" ")
-    raise StandardError, I18n.t("liquid_tags.tweet_tag.invalid_twitter_id") unless valid_id?(input_no_space)
+    match = pattern_match_for(input, REGEXP_OPTIONS)
+    raise StandardError, I18n.t("liquid_tags.youtube_tag.invalid_youtube_id") unless match
 
-    input_no_space
-  end
-
-  def valid_id?(id)
-    ID_REGEXP.match?(id)
+    match[:id]
   end
 end
 

--- a/app/liquid_tags/tweet_tag.rb
+++ b/app/liquid_tags/tweet_tag.rb
@@ -1,7 +1,7 @@
 class TweetTag < LiquidTagBase
   include ActionView::Helpers::AssetTagHelper
   PARTIAL = "liquids/tweet".freeze
-  REGISTRY_REGEXP = %r{https://twitter.com/(?<username>\w{1,15})/status/(?<id>\d{10,20})}
+  REGISTRY_REGEXP = %r{https://twitter.com/\w{1,15}/status/(?<id>\d{10,20})}
   VALID_ID_REGEXP = /\A(?<id>\d{10,20})\Z/
   REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 
@@ -29,7 +29,7 @@ class TweetTag < LiquidTagBase
 
   def initialize(_tag_name, id, _parse_context)
     super
-    @id = parse_id(id)
+    @id = parse_id_or_url(strip_tags(id))
     @tweet = Tweet.find_or_fetch(@id)
     @twitter_logo = ActionController::Base.helpers.asset_path("twitter.svg")
   end
@@ -51,9 +51,9 @@ class TweetTag < LiquidTagBase
 
   private
 
-  def parse_id(input)
+  def parse_id_or_url(input)
     match = pattern_match_for(input, REGEXP_OPTIONS)
-    raise StandardError, I18n.t("liquid_tags.youtube_tag.invalid_youtube_id") unless match
+    raise StandardError, "Invalid Tweet ID or URL" unless match
 
     match[:id]
   end
@@ -61,3 +61,4 @@ end
 
 Liquid::Template.register_tag("tweet", TweetTag)
 Liquid::Template.register_tag("twitter", TweetTag)
+UnifiedEmbed.register(TweetTag, regexp: TweetTag::REGISTRY_REGEXP)

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -155,6 +155,11 @@ RSpec.describe UnifiedEmbed::Registry do
       end
     end
 
+    it "returns TweetTag for a tweet url" do
+      expect(described_class.find_liquid_tag_for(link: "https://twitter.com/aritdeveloper/status/1483614684884484099"))
+        .to eq(TweetTag)
+    end
+
     it "returns TwitchTag for a valid twitch url" do
       valid_twitch_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Tweet embeds (not to be confused with TwitterTimeline embeds).

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15581

## QA Instructions, Screenshots, Recordings
Example Tweet URLs:
https://twitter.com/aritdeveloper/status/1483614684884484099
https://twitter.com/aritdeveloper/status/1483775972688240643

Example Tweet IDs
1483614684884484099
1483775972688240643

- As a user, create a Tweet liquid tag using this format: `{% embed <tweet-url> %}`. The Liquid Tag should render properly.
- Also create Tweet liquid tag using the old methods: `{% tweet <tweet-id> %}` and `{% twitter <tweet-id> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?
None

## Added/updated tests?
- [X] Yes


## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.

## [optional] Are there any post deployment tasks we need to perform?
None
