### PR TITLE
Complete implementation and add specs

### DIFF
--- a/app/liquid_tags/medium_tag.rb
+++ b/app/liquid_tags/medium_tag.rb
@@ -5,10 +5,11 @@ class MediumTag < LiquidTagBase
   attr_reader :response
 
   PARTIAL = "liquids/medium".freeze
+  REGISTRY_REGEXP = %r{https://(?:\w+.)?medium.com/(?:@\w+/)?[\w-]+}
 
   def initialize(_tag_name, url, _parse_context)
     super
-    @response = parse_url_for_medium_article(url)
+    @response = parse_url(strip_tags(url))
   end
 
   def render(_context)
@@ -22,10 +23,8 @@ class MediumTag < LiquidTagBase
 
   private
 
-  def parse_url_for_medium_article(url)
-    sanitized_article_url = ActionController::Base.helpers.strip_tags(url).strip
-
-    MediumArticleRetrievalService.new(sanitized_article_url).call
+  def parse_url(url)
+    MediumArticleRetrievalService.new(url).call
   rescue StandardError
     raise_error
   end
@@ -36,3 +35,5 @@ class MediumTag < LiquidTagBase
 end
 
 Liquid::Template.register_tag("medium", MediumTag)
+
+UnifiedEmbed.register(MediumTag, regexp: MediumTag::REGISTRY_REGEXP)

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe UnifiedEmbed::Registry do
       "https://app.codesandbox.io/embed/exciting-knuth-hywlv?file=/index.html&runonclick=0&view=editor",
     ]
 
+    valid_medium_url_formats = [
+      "https://medium.com/@edisonywh/my-ruby-journey-hooking-things-up-91d757e1c59c",
+      "https://themobilist.medium.com/is-universal-basic-mobility-the-route-to-a-sustainable-c-b18e1e2d014c",
+    ]
+
     valid_instagram_url_formats = [
       "https://www.instagram.com/p/CXgzXWXroHK/",
       "https://instagram.com/p/CXgzXWXroHK/",
@@ -119,6 +124,13 @@ RSpec.describe UnifiedEmbed::Registry do
     it "returns Forem Link for a forem url" do
       expect(described_class.find_liquid_tag_for(link: URL.url + article.path))
         .to eq(LinkTag)
+    end
+
+    it "returns MediumTag for a valid medium url" do
+      valid_medium_url_formats.each do |url|
+        expect(described_class.find_liquid_tag_for(link: url))
+          .to eq(MediumTag)
+      end
     end
 
     it "returns NextTechTag for a nexttech url" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Medium embeds.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15566

## QA Instructions, Screenshots, Recordings
Example Medium URLs:
https://medium.com/@edisonywh/my-ruby-journey-hooking-things-up-91d757e1c59c
https://themobilist.medium.com/is-universal-basic-mobility-the-route-to-a-sustainable-c-b18e1e2d014c

- As a user, create a Medium liquid tag using this format: `{% embed <medium-url> %}`. The Liquid Tag should render properly.
- Also create Medium liquid tag using the old method: `{% medium <medium-url> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?
None

## Added/updated tests?
- [X] Yes


## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.

## [optional] Are there any post deployment tasks we need to perform?
None
