### PR TITLE
Add `Settings::Base.to_h`

### DIFF
--- a/app/models/settings/base.rb
+++ b/app/models/settings/base.rb
@@ -45,6 +45,10 @@ module Settings
         @defined_settings.pluck(:key)
       end
 
+      def to_h
+        keys.to_h { |k| [k.to_sym, public_send(k)] }
+      end
+
       private
 
       def cache_key
@@ -108,7 +112,7 @@ module Settings
         when :boolean
           value.in?(["true", "1", 1, true])
         when :array
-          value.split(separator || SEPARATOR_REGEXP).reject(&:empty?).map(&:strip)
+          value.split(separator || SEPARATOR_REGEXP).compact_blank.map(&:strip)
         when :hash
           value = begin
             YAML.safe_load(value).to_h

--- a/spec/models/settings/base_spec.rb
+++ b/spec/models/settings/base_spec.rb
@@ -166,4 +166,15 @@ RSpec.describe Settings::Base, type: :model do
         .to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Host can't be blank")
     end
   end
+
+  describe "conversions" do
+    it "can be converted to a hash", :aggregate_failures do
+      result = TestSetting.to_h
+      expect(result).to be_an_instance_of(Hash)
+      # Chill Rubocop, it's not a hash
+      # rubocop:disable Style/HashEachMethods
+      TestSetting.keys.each { |key| expect(result).to have_key(key.to_sym) }
+      # rubocop:enable Style/HashEachMethods
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

Sparked by a [discussion in a recent PR](https://github.com/forem/forem/pull/16216#discussion_r789306433) I decided to add a `to_h` method to our `Settings::Base` model which will return all the settings as a hash. I remember wanting something similar several times, i.e. to get a quick overview of my local settings, which can get a bit hard to read with something like `Settings::Model.all`. It also makes it easier to extract subsets of settings where we need that, e.g. by using `Hash#slice` or `Hash#except`.

Note: I was also briefly toying with the idea of making our settings classes themselves `Enumerable` as that's very easy now. But looking through the codebase it seems like we don't actually have any places where this would be useful so I'm shelving this idea for now but may revisit it when I notice places where it would come in handy.

## QA Instructions, Screenshots, Recordings

Nothing specific, covered by specs.

### UI accessibility concerns?

No UI changes

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams