### PR TITLE
Stripping tags from "tags.short_summary" column

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -52,6 +52,7 @@ class Tag < ActsAsTaggableOn::Tag
   validate :validate_name, if: :name?
 
   before_validation :evaluate_markdown
+  before_validation :tidy_short_summary
   before_validation :pound_it
 
   before_save :calculate_hotness_score
@@ -130,6 +131,10 @@ class Tag < ActsAsTaggableOn::Tag
   end
 
   private
+
+  def tidy_short_summary
+    self.short_summary = ActionController::Base.helpers.strip_tags(short_summary)
+  end
 
   def evaluate_markdown
     self.rules_html = MarkdownProcessor::Parser.new(rules_markdown).evaluate_markdown

--- a/lib/data_update_scripts/20220121114445_stripping_html_tags_from_tag_short_summary.rb
+++ b/lib/data_update_scripts/20220121114445_stripping_html_tags_from_tag_short_summary.rb
@@ -1,0 +1,11 @@
+module DataUpdateScripts
+  class StrippingHtmlTagsFromTagShortSummary
+    def run
+      Tag.where("short_summary LIKE '%<%'").find_each do |tag|
+        # Choosing to skip validations and mimic the newly added before_validation behavior.
+        new_short_summary = ActionController::Base.helpers.strip_tags(tag.short_summary)
+        tag.update_columns(short_summary: new_short_summary)
+      end
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/stripping_html_tags_from_tag_short_summary_spec.rb
+++ b/spec/lib/data_update_scripts/stripping_html_tags_from_tag_short_summary_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220121114445_stripping_html_tags_from_tag_short_summary.rb",
+)
+
+describe DataUpdateScripts::StrippingHtmlTagsFromTagShortSummary do
+  it "updates a tag that had HTML elements in it's short summary" do
+    tag = create(:tag)
+    tag.update_columns(short_summary: "<p>Welcome to the <a href='#'>tag</a>.</p>")
+    described_class.new.run
+    expect(tag.reload.short_summary).to eq("Welcome to the tag.")
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -111,6 +111,12 @@ RSpec.describe Tag, type: :model do
     end
   end
 
+  it "strips HTML tags from short_summary before saving" do
+    tag.short_summary = "<p>Hello <strong>World</strong>.</p>"
+    tag.save
+    expect(tag.short_summary).to eq("Hello World.")
+  end
+
   it "turns markdown into HTML before saving" do
     tag.rules_markdown = "Hello [Google](https://google.com)"
     tag.save


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

On the DEV.to database, I ran the following SQL:

```sql
SELECT name, short_summary FROM tags WHERE short_summary LIKE '%<%';
```

There were three tags with a `<` in them:

- changelog
- cnc2018
- javascript

This PR will tidy up our short summary as part of saving a tag.  It will
also tidy up the existing tags.

## Related Tickets & Documents

Related to internal conversations.

## QA Instructions, Screenshots, Recordings

Umm...create a tag in the UI, adding HTML tags to that tag.  Then save it and see that there's no HTML tag.

### UI accessibility concerns?

Nope.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not:

## [optional] Are there any post deployment tasks we need to perform?
