### PR TITLE
Adding lightweight structure .coerce methods

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -31,7 +31,7 @@ class Notification < ApplicationRecord
       return unless follow && Follow.need_new_follower_notification_for?(follow.followable_type)
       return if follow.followable_type == "User" && UserBlock.blocking?(follow.followable_id, follow.follower_id)
 
-      follow_data = follow.attributes.slice("follower_id", "followable_id", "followable_type").symbolize_keys
+      follow_data = Notifications::NewFollower::FollowData.coerce(follow).to_h
       Notifications::NewFollowerWorker.perform_async(follow_data, is_read)
     end
 
@@ -39,7 +39,7 @@ class Notification < ApplicationRecord
       return unless follow && Follow.need_new_follower_notification_for?(follow.followable_type)
       return if follow.followable_type == "User" && UserBlock.blocking?(follow.followable_id, follow.follower_id)
 
-      follow_data = follow.attributes.slice("follower_id", "followable_id", "followable_type").symbolize_keys
+      follow_data = Notifications::NewFollower::FollowData.coerce(follow).to_h
       Notifications::NewFollowerWorker.new.perform(follow_data, is_read)
     end
 
@@ -157,11 +157,7 @@ class Notification < ApplicationRecord
     private
 
     def reaction_notification_attributes(reaction, receiver)
-      reactable_data = {
-        reactable_id: reaction.reactable_id,
-        reactable_type: reaction.reactable_type,
-        reactable_user_id: reaction.reactable.user_id
-      }
+      reactable_data = Notifications::Reactions::ReactionData.coerce(reaction).to_h
       receiver_data = { klass: receiver.class.name, id: receiver.id }
       [reactable_data, receiver_data]
     end

--- a/app/services/notifications/new_follower/follow_data.rb
+++ b/app/services/notifications/new_follower/follow_data.rb
@@ -1,5 +1,7 @@
 module Notifications
   module NewFollower
+    # A light-weight(ish) data structure for passing between systems (e.g. from application to
+    # background jobs).
     class FollowData
       class DataError < RuntimeError; end
 
@@ -12,9 +14,40 @@ module Notifications
       validates :followable_type, inclusion: { in: %w[User Organization] }
       validates :follower_id, numericality: { only_integer: true }
 
+      # Coerce the given :object into a Notifications::NewFollower::FollowData
+      #
+      # @param object [Notifications::NewFollower::FollowData, Follow, #symbolize_keys] what we will
+      #        attempt to coerce.
+      #
+      # @return Notifications::NewFollower::FollowData
+      # @raise Notifications::NewFollower::FollowData::DataError when given invalid data.
+      # @raise NoMethodError if we attempt to symbolize_keys an object.
+      def self.coerce(object)
+        case object
+        when Notifications::NewFollower::FollowData
+          object
+        when Follow
+          new(
+            followable_id: object.followable_id,
+            followable_type: object.followable_type,
+            follower_id: object.follower_id,
+          )
+        else
+          new(object.symbolize_keys)
+        end
+      end
+
       def initialize(attributes)
         super
         raise DataError unless valid?
+      end
+
+      def to_h
+        {
+          followable_id: followable_id,
+          followable_type: followable_type,
+          follower_id: follower_id
+        }
       end
     end
   end

--- a/app/services/notifications/new_follower/send.rb
+++ b/app/services/notifications/new_follower/send.rb
@@ -7,10 +7,7 @@ module Notifications
       #   * :followable_type [String] - "User" or "Organization"
       #   * :follower_id [Integer] - user id
       def initialize(follow_data, is_read: false)
-        # we explicitly symbolize_keys because FollowData.new will fail otherwise with an error of
-        # ":followable_id is missing in Hash input". FollowData expects a symbol, not a string.
-        follow_data.symbolize_keys!
-        follow_data = FollowData.new(follow_data) unless follow_data.is_a?(FollowData)
+        follow_data = FollowData.coerce(follow_data)
         @followable_id = follow_data.followable_id # fetch(:followable_id)
         @followable_type = follow_data.followable_type # fetch(:followable_type)
         @follower_id = follow_data.follower_id # fetch(:follower_id)

--- a/app/services/notifications/reactions/reaction_data.rb
+++ b/app/services/notifications/reactions/reaction_data.rb
@@ -1,5 +1,7 @@
 module Notifications
   module Reactions
+    # A light-weight(ish) data structure for passing between systems (e.g. from application to
+    # background jobs).
     class ReactionData
       class DataError < RuntimeError; end
 
@@ -12,9 +14,39 @@ module Notifications
       validates :reactable_type, inclusion: { in: %w[Article Comment] }
       validates :reactable_user_id, numericality: { only_integer: true }
 
+      # Coerce the given :object into a Notifications::Reactions::ReactionData
+      #
+      # @param object [Object] what we will attempt to coerce.
+      #
+      # @return Notifications::Reactions::ReactionData
+      # @raise Notifications::Reactions::ReactionData::DataError when given invalid data.
+      # @raise NoMethodError if we attempt to symbolize_keys an object.
+      def self.coerce(object)
+        case object
+        when Notifications::Reactions::ReactionData
+          object
+        when Reaction
+          new(
+            reactable_id: object.reactable_id,
+            reactable_type: object.reactable_type,
+            reactable_user_id: object.reactable.user_id,
+          )
+        else
+          new(object.symbolize_keys)
+        end
+      end
+
       def initialize(attributes)
         super
         raise DataError unless valid?
+      end
+
+      def to_h
+        {
+          reactable_id: reactable_id,
+          reactable_type: reactable_type,
+          reactable_user_id: reactable_user_id
+        }
       end
     end
   end

--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -10,7 +10,7 @@ module Notifications
       #   * :reactable_user_id [Integer] - user id
       # @param receiver [User] or [Organization]
       def initialize(reaction_data, receiver)
-        @reaction = reaction_data.is_a?(ReactionData) ? reaction_data : ReactionData.new(reaction_data)
+        @reaction = ReactionData.coerce(reaction_data)
         @receiver = receiver
       end
 

--- a/spec/services/notifications/new_follower/follow_data_spec.rb
+++ b/spec/services/notifications/new_follower/follow_data_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+RSpec.describe Notifications::NewFollower::FollowData do
+  let(:valid_attributes) { { followable_id: 1, followable_type: "User", follower_id: 2 } }
+
+  describe ".coerce" do
+    subject(:coercion) { described_class.coerce(coercible) }
+
+    context "when given a Follow" do
+      let(:coercible) { create(:follow) }
+
+      it { is_expected.to be_a(described_class) }
+    end
+
+    context "when given a Notifications::Reactions::ReactionData" do
+      let(:coercible) { described_class.new(valid_attributes) }
+
+      it "returns the given object" do
+        expect(coercion.object_id).to eq(coercible.object_id)
+      end
+    end
+
+    context "when given valid attributes" do
+      let(:coercible) { valid_attributes }
+
+      it { is_expected.to be_a(described_class) }
+    end
+
+    context "when given invalid attributes" do
+      let(:coercible) { valid_attributes.merge(followable_type: "Ruby Slipper") }
+
+      it "raises an DataError exception" do
+        expect { coercion }.to raise_error(described_class::DataError)
+      end
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash" do
+      obj = described_class.new(valid_attributes)
+      expect(obj.to_h).to eq(valid_attributes)
+    end
+  end
+end

--- a/spec/services/notifications/reactions/reaction_data_spec.rb
+++ b/spec/services/notifications/reactions/reaction_data_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe Notifications::Reactions::ReactionData do
+  let(:valid_attributes) { { reactable_id: 1, reactable_type: "Comment", reactable_user_id: 2 } }
+
+  describe ".coerce" do
+    subject(:coercion) { described_class.coerce(coercible) }
+
+    context "when given a Reaction" do
+      let(:coercible) { create(:reaction) }
+
+      it { is_expected.to be_a(described_class) }
+    end
+
+    context "when given a Notifications::Reactions::ReactionData" do
+      let(:coercible) { described_class.new(valid_attributes) }
+
+      it "returns the given object" do
+        expect(coercion.object_id).to eq(coercible.object_id)
+      end
+    end
+
+    context "when given valid attributes" do
+      let(:coercible) { valid_attributes  }
+
+      it { is_expected.to be_a(described_class) }
+    end
+
+    context "when given invalid attributes" do
+      let(:coercible) { valid_attributes.merge(reactable_type: "RubySlipper") }
+
+      it "raises an DataError exception" do
+        expect { coercion }.to raise_error(described_class::DataError)
+      end
+    end
+  end
+
+  describe "#to_h" do
+    it "returns a hash" do
+      obj = described_class.new(valid_attributes)
+      expect(obj.to_h).to eq(valid_attributes)
+    end
+  end
+end

--- a/spec/services/notifications/reactions/send_spec.rb
+++ b/spec/services/notifications/reactions/send_spec.rb
@@ -8,11 +8,7 @@ RSpec.describe Notifications::Reactions::Send, type: :service do
   let(:user3) { create(:user) }
 
   def reaction_data(reaction)
-    {
-      reactable_id: reaction.reactable_id,
-      reactable_type: reaction.reactable_type,
-      reactable_user_id: reaction.reactable.user_id
-    }
+    Notifications::Reactions::ReactionData.coerce(reaction).to_h
   end
 
   context "when data is invalid" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

Adding lightweight structure .coerce methods
    
I saw the following error in Honeybadger:
    
```
[PROJECT_ROOT]/app/services/notifications/reactions/send.rb:61 :in `call`
    
    old_json_data = notification.json_data
    previous_siblings_size = notification.json_data["reaction"]["aggregated_siblings"].size if old_json_data
    
    notification.json_data = json_data
[PROJECT_ROOT]/app/services/notifications/reactions/send.rb:20 :in `call`
[PROJECT_ROOT]/app/workers/notifications/new_reaction_worker.rb:16 :in `perform`
[PROJECT_ROOT]/app/models/notification.rb:84 :in `send_reaction_notification_without_delay`
[PROJECT_ROOT]/app/controllers/reactions_controller.rb:136 :in `destroy_reaction`
[PROJECT_ROOT]/app/controllers/reactions_controller.rb:168 :in `handle_existing_reaction`
[PROJECT_ROOT]/app/controllers/reactions_controller.rb:77 :in `create`
```

As I was exploring the error, I saw that we were making assumptions
about the data coercion.  These are valid and somewhat stable
assumptions, but I wanted to look a little deeper into the situation.

This refactor helps consistently negotiate two situations where we're
transforming request-cycle models into lightweight data structures.  It
also begins to show a path towards a generalizable "macro" for this behavior.


## Related Tickets & Documents

Related to #2122, #9534

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated.
