### PR TITLE
Implement Unified Embeds for Jsitor URLs

### DIFF
--- a/app/liquid_tags/jsitor_tag.rb
+++ b/app/liquid_tags/jsitor_tag.rb
@@ -1,6 +1,6 @@
 class JsitorTag < LiquidTagBase
   PARTIAL = "liquids/jsitor".freeze
-  URL_REGEXP = %r{\A(https|http)://jsitor\.com/embed/\w+[-?a-zA-Z&]*\Z}
+  REGISTRY_REGEXP = %r{\A(https|http)://jsitor\.com/embed/\w+[-?a-zA-Z&]*\Z}
   ID_REGEXP = /\A[\w&?-]+\Z/
 
   def initialize(_tag_name, link, _parse_context)
@@ -26,7 +26,7 @@ class JsitorTag < LiquidTagBase
   end
 
   def validate_link(link)
-    return link if URL_REGEXP.match link
+    return link if REGISTRY_REGEXP.match link
     return "https://jsitor.com/embed/#{link}" if ID_REGEXP.match link
 
     jsitor_error
@@ -38,3 +38,5 @@ class JsitorTag < LiquidTagBase
 end
 
 Liquid::Template.register_tag("jsitor", JsitorTag)
+
+UnifiedEmbed.register(JsitorTag, regexp: JsitorTag::REGISTRY_REGEXP)

--- a/app/liquid_tags/jsitor_tag.rb
+++ b/app/liquid_tags/jsitor_tag.rb
@@ -1,7 +1,7 @@
 class JsitorTag < LiquidTagBase
   PARTIAL = "liquids/jsitor".freeze
-  REGISTRY_REGEXP = %r{\A(https|http)://jsitor\.com/embed/\w+[-?a-zA-Z&]*\Z}
-  ID_REGEXP = /\A[\w&?-]+\Z/
+  REGISTRY_REGEXP = %r{\A(https|http)://jsitor\.com/embed/[\w\-?&]+\Z}
+  ID_REGEXP = /\A[\w\-?&]+\Z/
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -116,6 +116,11 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(JsFiddleTag)
     end
 
+    it "returns JsitorTag for a jsitor url" do
+      expect(described_class.find_liquid_tag_for(link: "https://jsitor.com/embed/B7FQ5tHbY"))
+        .to eq(JsitorTag)
+    end
+
     it "returns Forem Link for a forem url" do
       expect(described_class.find_liquid_tag_for(link: URL.url + article.path))
         .to eq(LinkTag)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Jsitor embeds.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15561

## QA Instructions, Screenshots, Recordings
Example Jsitor URL: https://jsitor.com/embed/B7FQ5tHbY
Example Jsitor ID: B7FQ5tHbY

- As a user, create a Jsitor liquid tag using this format: `{% embed <jsitor-url> %}`. The Liquid Tag should render properly.
- Also create Jsitor liquid tag using the old method: `{% jsitor <jsitor-id> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?
None

## Added/updated tests?
- [X] Yes


## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.

## [optional] Are there any post deployment tasks we need to perform?
None
