### PR TITLE
Added "Tags" category to search results

### DIFF
--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -3,6 +3,23 @@
 /* eslint-disable no-multi-str */
 
 function buildArticleHTML(article) {
+  if (article && article.class_name === 'Tag') {
+    return `<article class="crayons-story crayons-podcast-episode mb-2">
+        <div class="crayons-story__body flex flex-start">
+          <div class="crayons-story__indention">
+            <h3 class="crayons-story__title">
+              <a href="/t/${article.name}" id="article-link-${article.id}">
+                # ${article.name}
+              </a>
+            </h3>\
+            <div class="crayons-story__snippet mb-1">
+              ${article.short_summary || ''}
+            </div>
+          </div>
+        </div>
+      </article>`;
+  }
+
   if (article && article.class_name === 'PodcastEpisode') {
     return `<article class="crayons-story crayons-podcast-episode mb-2">
         <div class="crayons-story__body flex flex-start">

--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -4,14 +4,20 @@
 
 function buildArticleHTML(article) {
   if (article && article.class_name === 'Tag') {
-    return `<article class="crayons-story crayons-podcast-episode mb-2">
-        <div class="crayons-story__body flex flex-start">
+    return `<article class="crayons-story">
+        <div class="crayons-story__body">
+          <div class="crayons-story__top mb-0">
+            <div class="crayons-story__meta">
+              <h3 class="crayons-story__title">
+                <a href="/t/${article.name}" class="crayons-tag crayons-tag--l">
+                  <span class="crayons-tag__prefix">#</span><span class="pl-4">${
+                    article.name
+                  }</span>
+                </a>
+              </h3>\
+            </div>
+          </div>
           <div class="crayons-story__indention">
-            <h3 class="crayons-story__title">
-              <a href="/t/${article.name}" id="article-link-${article.id}">
-                # ${article.name}
-              </a>
-            </h3>\
             <div class="crayons-story__snippet mb-1">
               ${article.short_summary || ''}
             </div>

--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -3,24 +3,26 @@
 /* eslint-disable no-multi-str */
 
 function buildArticleHTML(article) {
+  var tagIcon = `<svg width="24" height="24" viewBox="0 0 24 24" class="crayons-icon" xmlns="http://www.w3.org/2000/svg"><path d="M7.784 14l.42-4H4V8h4.415l.525-5h2.011l-.525 5h3.989l.525-5h2.011l-.525 5H20v2h-3.784l-.42 4H20v2h-4.415l-.525 5h-2.011l.525-5H9.585l-.525 5H7.049l.525-5H4v-2h3.784zm2.011 0h3.99l.42-4h-3.99l-.42 4z"/></svg>`;
   if (article && article.class_name === 'Tag') {
     return `<article class="crayons-story">
-        <div class="crayons-story__body">
-          <div class="crayons-story__top mb-0">
-            <div class="crayons-story__meta">
-              <h3 class="crayons-story__title">
-                <a href="/t/${article.name}" class="crayons-tag crayons-tag--l">
-                  <span class="crayons-tag__prefix">#</span><span class="pl-4">${
-                    article.name
-                  }</span>
-                </a>
-              </h3>\
-            </div>
-          </div>
-          <div class="crayons-story__indention">
-            <div class="crayons-story__snippet mb-1">
-              ${article.short_summary || ''}
-            </div>
+        <div class="crayons-story__body flex items-start gap-2">
+          <span class="radius-default p-2 shrink-0" style="background: ${
+            article.bg_color_hex || '#000000'
+          }1a; color: ${article.bg_color_hex || '#000'}">
+            ${tagIcon}
+          </span>
+          <div>
+            <h3 class="crayons-subtitle-2 lh-tight py-2">
+              <a href="/t/${article.name}" class="c-link">
+                ${article.name}
+              </a>
+            </h3>
+            ${
+              article.short_summary
+                ? `<div class="truncate-at-3">${article.short_summary}</div>`
+                : ''
+            }
           </div>
         </div>
       </article>`;

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -51,7 +51,7 @@ class SearchController < ApplicationController
   ].freeze
 
   def tags
-    result = Search::Tag.search_documents(params[:name])
+    result = Search::Tag.search_documents(term: params[:name])
     render json: { result: result }
   end
 
@@ -134,7 +134,11 @@ class SearchController < ApplicationController
       elsif class_name.Article?
         search_postgres_article
       elsif class_name.Tag?
-        Search::Tag.search_documents(feed_params[:search_fields])
+        Search::Tag.search_documents(
+          term: feed_params[:search_fields],
+          page: feed_params[:page],
+          per_page: feed_params[:per_page],
+        )
       end
     render json: { result: result }
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -134,15 +134,7 @@ class SearchController < ApplicationController
       elsif class_name.Article?
         search_postgres_article
       elsif class_name.Tag?
-        # {"class_name"=>"Tag", "page"=>0, "per_page"=>60, "search_fields"=>"discuss"} permitted: true>
         Search::Tag.search_documents(feed_params[:search_fields])
-        # Search::Tag.search_documents(
-        # term: feed_params[:search_fields],
-        # page: feed_params[:page],
-        # per_page: feed_params[:per_page],
-        # sort_by: feed_params[:sort_by] == "published_at" ? :created_at : nil,
-        # sort_direction: feed_params[:sort_direction],
-        # )
       end
     render json: { result: result }
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -52,7 +52,6 @@ class SearchController < ApplicationController
 
   def tags
     result = Search::Tag.search_documents(params[:name])
-
     render json: { result: result }
   end
 
@@ -134,8 +133,17 @@ class SearchController < ApplicationController
         )
       elsif class_name.Article?
         search_postgres_article
+      elsif class_name.Tag?
+        # {"class_name"=>"Tag", "page"=>0, "per_page"=>60, "search_fields"=>"discuss"} permitted: true>
+        Search::Tag.search_documents(feed_params[:search_fields])
+        # Search::Tag.search_documents(
+        # term: feed_params[:search_fields],
+        # page: feed_params[:page],
+        # per_page: feed_params[:per_page],
+        # sort_by: feed_params[:sort_by] == "published_at" ? :created_at : nil,
+        # sort_direction: feed_params[:sort_direction],
+        # )
       end
-
     render json: { result: result }
   end
 

--- a/app/serializers/search/tag_serializer.rb
+++ b/app/serializers/search/tag_serializer.rb
@@ -1,5 +1,6 @@
 module Search
   class TagSerializer < ApplicationSerializer
+    attribute :class_name, -> { "Tag" }
     attributes :id, :name, :hotness_score, :supported, :short_summary, :rules_html, :bg_color_hex
     attribute :badge do |tag|
       if tag.badge

--- a/app/services/search/tag.rb
+++ b/app/services/search/tag.rb
@@ -2,8 +2,16 @@ module Search
   class Tag
     ATTRIBUTES = %i[id name hotness_score rules_html supported short_summary bg_color_hex badge_id].freeze
 
-    def self.search_documents(term)
-      results = ::Tag.search_by_name(term).supported.includes(:badge).reorder(hotness_score: :desc).select(*ATTRIBUTES)
+    DEFAULT_PER_PAGE = 60
+    MAX_PER_PAGE = 100
+
+    def self.search_documents(
+      page: 0,
+      per_page: DEFAULT_PER_PAGE,
+      term: nil
+    )
+      results = ::Tag.search_by_name(term).supported.includes(:badge)
+        .reorder(hotness_score: :desc).page(page).per(per_page).select(*ATTRIBUTES)
       serialize(results)
     end
 

--- a/app/views/stories/articles_search/_nav_menu.html.erb
+++ b/app/views/stories/articles_search/_nav_menu.html.erb
@@ -8,6 +8,9 @@
   <li><a class="query-filter-button crayons-navigation__item" data-filter="class_name:User" href="javascript:;">
     <%= t("views.search.nav.people") %>
   </a></li>
+  <li><a class="query-filter-button crayons-navigation__item" data-filter="class_name:Tag" href="javascript:;">
+    <%= t("views.search.nav.tags") %>
+  </a></li>
   <li><a class="query-filter-button crayons-navigation__item" data-filter="class_name:Comment" href="javascript:;">
     <%= t("views.search.nav.comments") %>
   </a></li>

--- a/config/locales/views/misc/en.yml
+++ b/config/locales/views/misc/en.yml
@@ -85,6 +85,7 @@ en:
         people: People
         comments: Comments
         my_posts: My posts only
+        tags: Tags
       sort:
         aria_label: Search result sort options
         relevance: Most Relevant

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -219,6 +219,26 @@ RSpec.describe "Search", type: :request, proper_status: true do
         expect(response.parsed_body["result"].first).to include("body_text" => podcast_episode.body_text)
       end
     end
+
+    context "when using searching for tags" do
+      let!(:tag) { create(:tag, name: "webdev") }
+
+      it "returns the correct keys for tags" do
+        get search_feed_content_path(search_fields: "web", class_name: "Tag")
+        expect(response.parsed_body["result"]).to be_present
+      end
+
+      it "supports the search params for tags" do
+        get search_feed_content_path(
+          search_fields: "web",
+          class_name: "Tag",
+          page: 0,
+          per_page: 1,
+        )
+
+        expect(response.parsed_body["result"].first).to include("name" => tag.name)
+      end
+    end
   end
 
   describe "GET /search/reactions" do

--- a/spec/services/search/tag_spec.rb
+++ b/spec/services/search/tag_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Search::Tag, type: :service do
       result = described_class.search_documents(tag.name)
 
       expect(result.first.keys).to match_array(
-        %i[id name hotness_score rules_html supported short_summary badge bg_color_hex],
+        %i[id name class_name hotness_score rules_html supported short_summary badge bg_color_hex],
       )
     end
 

--- a/spec/services/search/tag_spec.rb
+++ b/spec/services/search/tag_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Search::Tag, type: :service do
     it "does not find non supported tags" do
       tag = create(:tag, supported: false)
 
-      expect(described_class.search_documents(tag.name)).to be_empty
+      expect(described_class.search_documents(term: tag.name)).to be_empty
     end
 
     it "returns data in the expected format" do
       tag = create(:tag, supported: true)
 
-      result = described_class.search_documents(tag.name)
+      result = described_class.search_documents(term: tag.name)
 
       expect(result.first.keys).to match_array(
         %i[id name class_name hotness_score rules_html supported short_summary badge bg_color_hex],
@@ -21,13 +21,13 @@ RSpec.describe Search::Tag, type: :service do
     it "finds a tag by its name" do
       tag = create(:tag, supported: true)
 
-      expect(described_class.search_documents(tag.name)).to be_present
+      expect(described_class.search_documents(term: tag.name)).to be_present
     end
 
     it "finds a tag by a partial name" do
       tag = create(:tag, supported: true)
 
-      expect(described_class.search_documents(tag.name.first(1))).to be_present
+      expect(described_class.search_documents(term: tag.name.first(1))).to be_present
     end
 
     it "finds multiple tags whose names have common parts", :aggregate_failures do
@@ -35,7 +35,7 @@ RSpec.describe Search::Tag, type: :service do
       javascript = create(:tag, name: "javascript")
       ruby = create(:tag, name: "ruby")
 
-      result = described_class.search_documents("jav")
+      result = described_class.search_documents(term: "jav")
       tags = result.pluck(:name)
 
       expect(tags).to include(java.name)
@@ -55,7 +55,7 @@ RSpec.describe Search::Tag, type: :service do
       tag1.save!
       tag2.save!
 
-      result = described_class.search_documents("jav")
+      result = described_class.search_documents(term: "jav")
       tags = result.pluck(:name)
 
       expect(tags).to eq([tag2.name, tag1.name])


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description
Added "Tags" category to search results.
Though I added code for pagination, pagination for search results is not working (for both tags and other categories), the bug is described in #16297 by @jeremyf , and is out of the scope of this pr.

## Related Tickets & Documents
#15151 

## QA Instructions, Screenshots, Recordings
1. Type something in the search bar and submit the form
2. There should be `Tags` link in the left navigation bar.
3. If you press `Tags` search results by tags should appear in the feed.

![изображение](https://user-images.githubusercontent.com/30115/151136346-0d345bfd-16ca-49ab-9690-ec21ddb71249.png)

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I'm not sure how best to communicate this change and need help
Should we communicate this change to the community? That's a relatively small improvement, but could be noticeable for some members, what do you think?