### PR TITLE
Simplify implementation of :focus-visible

### DIFF
--- a/app/assets/stylesheets/base/main.scss
+++ b/app/assets/stylesheets/base/main.scss
@@ -107,26 +107,13 @@ a {
     --font-size: var(--fs-xl);
   }
 
-  &:hover {
+  &:hover,
+  .js-focus-visible &.focus-visible:focus {
     color: var(--base-80);
     text-decoration: underline;
   }
 
-  // Both focus declarations below are the same but we unfortunately can't
-  // combine them because Safari doesn't recognize it properly.
-  //  • First declaration is for all browsers that support :focus-visible
-  //    which is basically almost all of them
-  //  • Second declaration is for browsers that do not support :focus-visible
-  //    which basically is only Safari right now.
-  &:focus-visible {
-    z-index: var(--z-elevate);
-    box-shadow: var(--focus-ring);
-    text-decoration: underline;
-  }
-
   .js-focus-visible &.focus-visible:focus {
-    z-index: var(--z-elevate);
     box-shadow: var(--focus-ring);
-    text-decoration: underline;
   }
 }

--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -413,32 +413,16 @@ label[class*='crayons-btn']:focus-within // label for input[type="file"] made to
   background-color: var(--bg);
   color: var(--color);
 
-  &:hover:enabled {
-    background-color: var(--bg-hover);
-    color: var(--color-hover);
-    z-index: var(--z-elevate);
-  }
-
-  // Both focus declarations below are the same but we unfortunately can't
-  // combine them because Safari doesn't handle it properly.
-  //  • First declaration is for all browsers that support :focus-visible
-  //    which is basically almost all of them.
-  //  • Second declaration is for browsers that do not support :focus-visible
-  //    which basically is only Safari right now :shrug:
-  &:focus-visible,
+  &:hover:enabled,
+  .js-focus-visible &.focus-visible:focus,
   &:is(label):focus-within {
-    // label for input[type="file"] made to look like a button as the browse... button can't be styled.
     background-color: var(--bg-hover);
     color: var(--color-hover);
     z-index: var(--z-elevate);
-    box-shadow: var(--focus-ring);
-    outline: 0;
   }
 
-  .js-focus-visible &.focus-visible:focus {
-    background-color: var(--bg-hover);
-    color: var(--color-hover);
-    z-index: var(--z-elevate);
+  .js-focus-visible &.focus-visible:focus,
+  &:is(label):focus-within {
     box-shadow: var(--focus-ring);
     outline: 0;
   }

--- a/app/assets/stylesheets/components/ctas.scss
+++ b/app/assets/stylesheets/components/ctas.scss
@@ -21,36 +21,17 @@
   position: relative;
   overflow-wrap: normal;
 
-  &:hover {
-    background-color: var(--bg-hover);
-    border-color: var(--border-hover);
-    color: var(--color-hover);
-    z-index: var(--z-elevate);
-    text-decoration: underline;
-  }
-
-  // Both focus declarations below are the same but we unfortunately can't
-  // combine them because Safari doesn't recognize it properly.
-  //  • First declaration is for all browsers that support :focus-visible
-  //    which is basically almost all of them
-  //  • Second declaration is for browsers that do not support :focus-visible
-  //    which basically is only Safari right now.
-  &:focus-visible {
-    background-color: var(--bg-hover);
-    border-color: var(--border-hover);
-    color: var(--color-hover);
-    z-index: var(--z-elevate);
-    box-shadow: var(--focus-ring);
-    text-decoration: underline;
-  }
-
+  &:hover,
   .js-focus-visible &.focus-visible:focus {
     background-color: var(--bg-hover);
     border-color: var(--border-hover);
     color: var(--color-hover);
     z-index: var(--z-elevate);
-    box-shadow: var(--focus-ring);
     text-decoration: underline;
+  }
+
+  .js-focus-visible &.focus-visible:focus {
+    box-shadow: var(--focus-ring);
   }
 }
 

--- a/app/assets/stylesheets/components/links.scss
+++ b/app/assets/stylesheets/components/links.scss
@@ -25,37 +25,18 @@
     }
   }
 
-  &:hover {
+  &:hover,
+  .js-focus-visible &.focus-visible:focus {
     color: var(--color-hover);
     z-index: var(--z-elevate);
-    text-decoration: underline;
-  }
-
-  // Both focus declarations below are the same but we unfortunately can't
-  // combine them because Safari doesn't recognize it properly.
-  //  • First declaration is for all browsers that support :focus-visible
-  //    which is basically almost all of them
-  //  • Second declaration is for browsers that do not support :focus-visible
-  //    which basically is only Safari right now.
-  &:focus-visible {
-    color: var(--color-hover);
-    z-index: var(--z-elevate);
-    box-shadow: var(--focus-ring);
     text-decoration: underline;
   }
 
   .js-focus-visible &.focus-visible:focus {
-    color: var(--color-hover);
-    z-index: var(--z-elevate);
     box-shadow: var(--focus-ring);
-    text-decoration: underline;
   }
 
   &--block {
-    &:focus-visible {
-      background-color: var(--bg-hover);
-    }
-
     .js-focus-visible &.focus-visible:focus {
       background-color: var(--bg-hover);
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

We use `:focus-visible` pseudo class in few places for a11y purposes. However it doesn't work in Safari so we've been also using polyfill for that. So we've been using a combination of polyfill and native browser's functionality. It was causing a lot of repetition and redundant code so the idea is to use **only** polyfill for now (which will work in every browser anyway) at least until Safari add proper support. 

## QA Instructions, Screenshots, Recordings

This shouldn't cause any UI changes.

### UI accessibility concerns?

No.

## Added/updated tests?

No.

## [Forem core team only] How will this change be communicated?

No.