### PR TITLE
Clear app cache during `bin/setup`

### DIFF
--- a/lib/tasks/app_initializer.rake
+++ b/lib/tasks/app_initializer.rake
@@ -12,6 +12,7 @@ namespace :app_initializer do
     Rake::Task["data_updates:enqueue_data_update_worker"].execute
 
     puts "\n== Bust Caches =="
+    Rake::Task["cache:clear_app_cache"].execute
     Rake::Task["cache:enqueue_path_bust_workers"].execute
 
     Settings::General.health_check_token ||= SecureRandom.hex(10)

--- a/lib/tasks/app_initializer.rake
+++ b/lib/tasks/app_initializer.rake
@@ -12,7 +12,7 @@ namespace :app_initializer do
     Rake::Task["data_updates:enqueue_data_update_worker"].execute
 
     puts "\n== Bust Caches =="
-    Rake::Task["cache:clear_app_cache"].execute
+    Rake::Task["cache:clear_app_cache"].execute unless Rails.env.production?
     Rake::Task["cache:enqueue_path_bust_workers"].execute
 
     Settings::General.health_check_token ||= SecureRandom.hex(10)

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -7,4 +7,9 @@ namespace :cache do
       BustCachePathWorker.set(queue: :high_priority).perform_in(n.seconds, "/onboarding")
     end
   end
+
+  desc "Clear application cache"
+  task clear_app_cache: :environment do
+    Rails.cache.clear
+  end
 end

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -10,6 +10,8 @@ namespace :cache do
 
   desc "Clear application cache"
   task clear_app_cache: :environment do
+    raise "Attempting to clear Rails cache in production" if Rails.env.production?
+
     Rails.cache.clear
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

During `bin/setup` we display a message saying `== Bust caches ==` which has repeatedly led people to believe that their app cache would be cleared. However, this is not the case:

1. `== Bust Caches ==` is printed from `lib/tasks/app_initializer.rake`
2. This does indeed enqueue a job for clearing caches (`cache:enqueue_path_bust_workers`) so it assumes Sidekiq is running. In all fairness, it should be, we recommend running the app through `Procfile.dev` (e.g. with overmind or with `foreman start -f Procfile.dev, see `bin/startup`) which will start Sidekiq workers.
3. Looking at the tasks in `lib/tasks/cache.rake` you'll notice it calls `BustCachePathWorker`
4. This worker is __not__ about clearing the local Rails cache but the edge cache (it class the `EdgeCache::Bust` service.

To avoid further confusion this PR adds a new taks `cache:clear_app_cache` (just a wrapper around `Rails.cache.clear` and invokes it from the `== Bust Caches ==` section of `lib/tasks/app_initializer.rake`.

## Related Tickets & Documents

Closes #16251

## QA Instructions, Screenshots, Recordings

0. Ensure you have a Redis instance running.
1. Open a Rails console (`rails console`)
2. Add something to the cache (e.g. `Rails.cache.write("My Key", "My Value")`)
3. Verify that it's in the cache (e.g. `Rails.cache.read("My Key")`)
4. In another shell, run `bin/setup`
5. Check the cache (e.g. `Rails.cache.read("My Key", force: true)`), it should return `nil`.

NOTE: I needed `force: true` or `reload!` for the change to show, so altenatively you can verify it via the Redis CLI:

0. Ensure you have a Redis instance running.
1. Open a Rails console (`rails console`)
2. Add something to the cache (e.g. `Rails.cache.write("My Key", "My Value")`), leave the Rails console
3. Start `redis-cli` 
4. Type `get "My Key"`, you'll see the value
5. Run `bin/setup` in another terminal
6. Type `get "My Key"`, you should see `(nil)`.

### UI accessibility concerns?

None

## Added/updated tests?

- [X] No, and this is why: we're not testing our setup script

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: I think the setup script now behaves closer to what the message suggests, so we don't need to update any documentation.