### PR TITLE
Implement Unified Embeds for Slideshare URLs

### DIFF
--- a/app/views/liquids/_slideshare.html.erb
+++ b/app/views/liquids/_slideshare.html.erb
@@ -1,5 +1,5 @@
 <iframe
-  src="//www.slideshare.net/slideshow/embed_code/key/<%= key %>"
+  src="https://www.slideshare.net/slideshow/embed_code/key/<%= key %>"
   alt="<%= key %> on slideshare.net"
   width="100%"
   height="<%= height %>"

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -173,6 +173,11 @@ RSpec.describe UnifiedEmbed::Registry do
       end
     end
 
+    it "returns SlideshareTag for a slideshare url" do
+      expect(described_class.find_liquid_tag_for(link: "https://www.slideshare.net/slideshow/embed_code/key/d5rGkEgXFDRN17"))
+        .to eq(SlideshareTag)
+    end
+
     it "returns SoundcloudTag for a soundcloud url" do
       expect(described_class.find_liquid_tag_for(link: "https://soundcloud.com/before-30-tv/stranger-moni-lati-lo-1"))
         .to eq(SoundcloudTag)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Slideshare embeds.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15572

## QA Instructions, Screenshots, Recordings
Example Slideshare URL: https://www.slideshare.net/slideshow/embed_code/key/9wjYHLKUR6nCZs
Example Slideshare key: 9wjYHLKUR6nCZs

- As a user, create a Slideshare liquid tag using this format: `{% embed <slideshare-url> %}`. The Liquid Tag should render properly.
- Also create Slideshare liquid tag using the old method: `{% slideshare <slideshare-key> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?
None

## Added/updated tests?
- [X] Yes


## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.

## [optional] Are there any post deployment tasks we need to perform?
None

