### PR TITLE
Implement Unified Embeds for Speakerdeck URLs

### DIFF
--- a/app/assets/stylesheets/ltags/LiquidTags.scss
+++ b/app/assets/stylesheets/ltags/LiquidTags.scss
@@ -11,6 +11,7 @@
 @import 'RedditTag';
 @import 'ReplitTag';
 @import 'StackexchangeTag';
+@import 'SpeakerdeckTag';
 @import 'TagTag';
 @import 'TweetTag';
 @import 'TwitterTimelineTag';

--- a/app/assets/stylesheets/ltags/SpeakerdeckTag.scss
+++ b/app/assets/stylesheets/ltags/SpeakerdeckTag.scss
@@ -1,0 +1,10 @@
+.ltag_speakerdeck {
+  border: 0px;
+  background: padding-box padding-box rgba(0, 0, 0, 0.1);
+  margin: 0px;
+  padding: 0px;
+  border-radius: 6px;
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 40px;
+  width: 560px;
+  height: 420px;
+}

--- a/app/liquid_tags/speakerdeck_tag.rb
+++ b/app/liquid_tags/speakerdeck_tag.rb
@@ -1,9 +1,14 @@
 class SpeakerdeckTag < LiquidTagBase
   PARTIAL = "liquids/speakerdeck".freeze
+  REGISTRY_REGEXP = %r{https://speakerdeck.com/player/(?<id>\w{,32})}
+  VALID_ID_REGEXP = /\A(?<id>\w{,32})\Z/
+  REGEXP_OPTIONS  = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 
-  def initialize(_tag_name, id, _parse_context)
+  def initialize(_tag_name, input, _parse_context)
     super
-    @id = parse_id(id)
+
+    stripped_input = strip_tags(input)
+    @id            = parse_input(stripped_input)
   end
 
   def render(_context)
@@ -17,16 +22,14 @@ class SpeakerdeckTag < LiquidTagBase
 
   private
 
-  def parse_id(input)
-    input_no_space = input.delete(" ")
-    raise StandardError, I18n.t("liquid_tags.speakerdeck_tag.invalid_speakerdeck_id") unless valid_id?(input_no_space)
+  def parse_input(input)
+    match = pattern_match_for(input, REGEXP_OPTIONS)
+    raise StandardError, I18n.t("liquid_tags.speakerdeck_tag.invalid_speakerdeck_id") unless match
 
-    input_no_space
-  end
-
-  def valid_id?(id)
-    id =~ /\A[a-z\d]{32}\Z/i
+    match[:id]
   end
 end
 
 Liquid::Template.register_tag("speakerdeck", SpeakerdeckTag)
+
+UnifiedEmbed.register(SpeakerdeckTag, regexp: SpeakerdeckTag::REGISTRY_REGEXP)

--- a/app/views/liquids/_speakerdeck.html.erb
+++ b/app/views/liquids/_speakerdeck.html.erb
@@ -1,21 +1,9 @@
-<%# Padding bottom set for 16:9 aspect ratio https://benmarshall.me/responsive-iframes/ %>
-<div class="ltag_speakerdeck"
-  style="position: relative;
-    width: 100%;
-    height: 0;
-    padding-bottom: 56.25%;">
-  <iframe allowfullscreen="true"
-    allowtransparency="true"
-    frameborder="0"
-    height="463"
-    id="talk_frame_<%= id %>"
-    mozallowfullscreen="true"
-    src="//speakerdeck.com/player/<%= id %>"
-    style="border:0; padding:0; margin:0; background:transparent;position: absolute;
-            width: 100%;
-            height: 100%;
-            left: 0; top: 0;"
-    webkitallowfullscreen="true"
-    width="710"
-    loading="lazy"></iframe>
-</div>
+<iframe
+  class="speakerdeck-iframe ltag_speakerdeck"
+  frameborder="0"
+  src="https://speakerdeck.com/player/<%= id %>"
+  allowfullscreen="true"
+  mozallowfullscreen="true"
+  webkitallowfullscreen="true"
+  data-ratio="1.3333333333333333">
+</iframe>

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -178,6 +178,11 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(SoundcloudTag)
     end
 
+    it "returns SpeakerdeckTag for a speakerdeck url" do
+      expect(described_class.find_liquid_tag_for(link: "https://speakerdeck.com/player/87fa761026bf013092b722000a1d8877"))
+        .to eq(SpeakerdeckTag)
+    end
+
     it "returns SpotifyTag for a valid spotify url" do
       valid_spotify_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Speakerdeck embeds.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15573

## QA Instructions, Screenshots, Recordings
Example Speakerdeck URLs:
https://speakerdeck.com/player/4dd2e0725753084498000001
https://speakerdeck.com/player/87fa761026bf013092b722000a1d8877

Example Speakerdeck IDs:
4dd2e0725753084498000001
87fa761026bf013092b722000a1d8877

- As a user, create a Speakerdeck liquid tag using this format: `{% embed <speakerdeck-url> %}`. The Liquid Tag should render properly.
- Also create Speakerdeck liquid tag using the old method: `{% speakerdeck <speakerdeck-id> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?
None

## Added/updated tests?
- [X] Yes


## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.

## [optional] Are there any post deployment tasks we need to perform?
None