### PR TITLE
Now the close X SVG icon is imported via the inline-react-svg plugin for the Modal component

### DIFF
--- a/app/javascript/crayons/Modal/Modal.jsx
+++ b/app/javascript/crayons/Modal/Modal.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { FocusTrap } from '../../shared/components/focusTrap';
 import { defaultChildrenPropTypes } from '../../common-prop-types';
 import { Button } from '@crayons';
+import CloseIcon from '@images/x.svg';
 
 function getAdditionalClassNames({ size, className }) {
   let additionalClassNames = '';
@@ -17,21 +18,6 @@ function getAdditionalClassNames({ size, className }) {
 
   return additionalClassNames;
 }
-
-const CloseIcon = () => (
-  <svg
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    className="crayons-icon"
-    xmlns="http://www.w3.org/2000/svg"
-    role="img"
-    aria-labelledby="714d29e78a3867c79b07f310e075e824"
-  >
-    <title id="714d29e78a3867c79b07f310e075e824">Close</title>
-    <path d="M12 10.586l4.95-4.95 1.414 1.414-4.95 4.95 4.95 4.95-1.414 1.414-4.95-4.95-4.95 4.95-1.414-1.414 4.95-4.95-4.95-4.95L7.05 5.636l4.95 4.95z" />
-  </svg>
-);
 
 /**
  * A modal component which can be presented with or without an overlay.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We recently added the inline-react-svg babel plugin and migrated icons in Preact components to use it. One was missed in the `<Modal />` component.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

1. Ensure all frontend dependencies are installed by running `yarn`.
2. Start Storybook by running, `yarn storybook`
3. Navigate to http://localhost:6006/?path=/story/components-modals--default and click on the button to open a modal.
4. Notice the x icon is present and if clicked closes the modal.

![image](https://user-images.githubusercontent.com/833231/150850240-aaf25a9a-c386-40e4-b615-e614bdf4715b.png)

### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: It's a visual change only and one that shouldn't have changed anyway. It's just how the SVG icon is rendered now.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/CdUPebPzF2kOQ/giphy.gif)
