### PR TITLE
POC: use `Sidekiq.perform_bulk` for Github repos

### DIFF
--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -27,7 +27,7 @@ class GithubRepo < ApplicationRecord
   end
 
   def self.update_to_latest
-    ids = where("updated_at < ?", 26.hours.ago).ids.each_slice(1).to_a
+    ids = where(updated_at: ...26.hours.ago).ids.map { |id| [id] }
     GithubRepos::RepoSyncWorker.perform_bulk(ids)
   end
 

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -27,9 +27,8 @@ class GithubRepo < ApplicationRecord
   end
 
   def self.update_to_latest
-    where("updated_at < ?", 26.hours.ago).ids.each do |repo_id|
-      GithubRepos::RepoSyncWorker.perform_async(repo_id)
-    end
+    ids = where("updated_at < ?", 26.hours.ago).ids.each_slice(1).to_a
+    GithubRepos::RepoSyncWorker.perform_bulk(ids)
   end
 
   private

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -81,9 +81,9 @@ RSpec.describe GithubRepo, type: :model do
   describe "::update_to_latest" do
     it "enqueues GithubRepos::RepoSyncWorker" do
       repo.update(updated_at: 1.week.ago)
-      allow(GithubRepos::RepoSyncWorker).to receive(:perform_async)
+      allow(GithubRepos::RepoSyncWorker).to receive(:perform_bulk)
       described_class.update_to_latest
-      expect(GithubRepos::RepoSyncWorker).to have_received(:perform_async).with(repo.id)
+      expect(GithubRepos::RepoSyncWorker).to have_received(:perform_bulk).with([[repo.id]])
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Optimization

## Description

**tl;dr:**
This PR changes our `GithuRepo` model to use Sidekiq's recently added `push_bulk` method. If this works as expected we can then change similar code to use the same method.

**Full context:**
For a while now, Sidekiq had a [`push_bulk` method](https://www.rubydoc.info/github/mperham/sidekiq/Sidekiq%2FClient:push_bulk) which allows pushing large numbers of jobs to Sidekiq. The goal is to reduce Redis roundtrip latency by replacing N calls with 1. The recommended number of jobs to push was < 1000.

Sidekiq 6.3.0 added a higher-level wrapper around this, [`perform_bulk`](https://www.rubydoc.info/gems/sidekiq/Sidekiq%2FWorker%2FSetter:perform_bulk). This encodes the best practice of 1000 jobs per call though one can change that number via the `batch_size` argument.

**Further reading:**

* [Sidekiq Wiki: Bulk Queuing](https://github.com/mperham/sidekiq/wiki/Bulk-Queueing)
* [One Ruby Thing: Enqueue Jobs Quickly with Sidekiq’s Bulk Features](https://andycroll.com/ruby/enqueue-jobs-quickly-with-sidekiq-bulk/)

## QA Instructions, Screenshots, Recordings

Specs should pass.

### UI accessibility concerns?

No UI changes

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
