### PR TITLE
Request for Comments: Add Rubocop action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -2,7 +2,7 @@ name: Rubocop
 on: [pull_request]
 jobs:
   rubocop:
-    name: runner / rubocop
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,18 @@
+name: Rubocop
+on: [pull_request]
+jobs:
+  rubocop:
+    name: runner / rubocop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.2
+      - name: rubocop
+        uses: reviewdog/action-rubocop@v2
+        with:
+          rubocop_version: gemfile
+          rubocop_extensions: rubocop-performance:gemfile rubocop-rails:gemfile rubocop-rspec:gemfile
+          reporter: github-pr-review # Default is github-pr-check


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Developer Experience

## Description

**The problem (+ some history and context)**

* We use [Husky](https://typicode.github.io/husky/#/) for git pre-commit hooks in local development.
* We repeatedly had issues where the hooks didn't run for various reasons. This can become annoying for everyone else on the team as they will get unrelated warnings/errors in their next branch. We also regularly have minor PRs just fixing Rubocop errors, see [this list](https://github.com/forem/forem/pulls?q=is%3Apr+sort%3Aupdated-desc+rubocop+NOT+bump+in%3Atitle+).
* I tried to move our linting setup to GH actions before, using [super-linter](https://github.com/github/super-linter). Due to the complicated nature of our overall linting setup, I eventually gave up on the [PR](https://github.com/forem/forem/pull/13790).
* We already have use [codeql-action](https://github.com/github/codeql-action) for JS via actions.

**The proposed solution**

This PR adds [action-rubocop](https://github.com/reviewdog/action-rubocop) by Reviewdog to add a Rubocop GH action. I opted for the `github-pr-review` reporters, which unlike `github-pr-check` will post comments but **not** block deployments which would be annoying for things like emergency deployments, etc.

Please let me know how you feel about this change. Personally, I'm in favor because I hope that this achieves the following:

* No more unrelated Rubocop violations in PRs
* No more (or at least fewer) PRs to make Rubocop happy