### PR TITLE
Improve reset.css to cover all inputs

### DIFF
--- a/app/assets/stylesheets/base/reset.scss
+++ b/app/assets/stylesheets/base/reset.scss
@@ -84,11 +84,8 @@ textarea {
 }
 
 // Drop default outline (Crayons provides custom)
-input[type='text'],
 textarea,
-input[type='url'],
-input[type='email'],
-input[type='password'] {
+input:not([type='hidden']) {
   outline: 0;
 }
 

--- a/app/assets/stylesheets/base/reset.scss
+++ b/app/assets/stylesheets/base/reset.scss
@@ -85,7 +85,8 @@ textarea {
 
 // Drop default outline (Crayons provides custom)
 textarea,
-input:not([type='hidden']) {
+input:not([type='hidden']),
+button {
   outline: 0;
 }
 

--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -409,7 +409,6 @@ label[class*='crayons-btn']:focus-within // label for input[type="file"] made to
   cursor: pointer;
   border: none;
   overflow-wrap: normal;
-  outline: 0;
   background-color: var(--bg);
   color: var(--color);
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

There was a missing declaration for outline style on `input[type="number"]` so I've added it in another PR but @nickytonline suggested we could cover more cases.. So here it is.

## Related Tickets & Documents

- Where I initially added it: https://github.com/forem/forem/pull/16174/files#r791169784

## QA Instructions, Screenshots, Recordings

Just review the code?

### UI accessibility concerns?

We're dropping native outline because Crayons provides its own outline.

## Added/updated tests?

No.

## [Forem core team only] How will this change be communicated?

It won't.