### PR TITLE
Add a minimal test database setup to the docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,11 @@ services:
       - db
       - redis
       - yarn
+      - testdb
     environment:
       RAILS_ENV: development
       DATABASE_URL: postgresql://forem:forem@db:5432/PracticalDeveloper_development
+      DATABASE_URL_TEST: postgresql://forem:forem@testdb:5432/Forem_test
       REDIS_SESSIONS_URL: redis://redis:6379
       REDIS_SIDEKIQ_URL: redis://redis:6379
       REDIS_URL: redis://redis:6379
@@ -21,6 +23,8 @@ services:
       RACK_TIMEOUT_SERVICE_TIMEOUT: 10000
       STATEMENT_TIMEOUT: 10000
       APP_DOMAIN: localhost:3000
+    tmpfs:
+      - /tmp
     volumes:
       - .:/opt/apps/forem:delegated
     entrypoint: ["dockerize", "-wait", "tcp://db:5432", "-wait", "tcp://redis:6379", "-wait", "file:///opt/apps/forem/vendor/bundle/.bundle_finished", "-timeout", "2700s", "-wait-retry-interval", "10s"]
@@ -112,7 +116,7 @@ services:
     command: ["bundle", "exec", "sidekiq","-c","2"]
 
   db:
-    image: postgres:11-alpine
+    image: postgres:13-alpine
     container_name: forem_postgresql
     environment:
       POSTGRES_USER: forem
@@ -123,6 +127,18 @@ services:
     volumes:
       - db_data:/var/lib/postgresql/data:delegated
 
+  testdb:
+    image: postgres:13-alpine
+    container_name: forem_postgresql_test
+    environment:
+      POSTGRES_USER: forem
+      POSTGRES_PASSWORD: forem
+      POSTGRES_DB: Forem_test
+    expose:
+      - "5432"
+    volumes:
+      - testdb_data:/var/lib/postgresql/data:delegated
+
   redis:
     image: redis:6.0.9-alpine
     container_name: forem_redis
@@ -131,3 +147,4 @@ services:
 
 volumes:
   db_data:
+  testdb_data:


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

https://github.com/forem/forem/issues/16225#issuecomment-1021459214 based on a discussion point made here after a contributor had difficulty running tests in docker.

This provides a test environment database for anyone using a docker
based development environment.

Expose, rather than bind, the db port (you won't be able to connect to
the db externally, only from the container).

Add tmpfs storage (this alleviates an issue seen with carrierwave
attachments when trying to write to the tmp directory in the image).

- Upgrade db versions from 11 to 13 (this is a breaking change for
anyone using this who had already provisioned the db, since no attempt
to upgrade has been provided, users may either downgrade to the
11-alpine image or recreate their storage volume). This is
separable (the `db` container was preexisting so is the only upgrade
conflict for users, the `testdb` container is newly created in a newly
added volume, and should not rely on persistence).

- It's possible no second volume is needed for the test db (only the schema
would normally be persisted, since data is truncated after normal test completion).

Right now it's necessary to disable spring when loading the db schema

```shell
DISABLE_SPRING=1 RAILS_ENV=test bin/rails db:schema:load
bin/rspec spec/models/
```

## Related Tickets & Documents

#16225 comments gave the surrounding context here.

## QA Instructions, Screenshots, Recordings

```
$ docker-compose run rails /bin/bash
[root@37ef8f7013e7 forem]# DISABLE_SPRING=1 RAILS_ENV=test bin/rails db:schema:load
[root@37ef8f7013e7 forem]# bin/rspec spec/models/ --format=documentation --order=random


Finished in 3 minutes 1.3 seconds (files took 6.24 seconds to load)
1384 examples, 0 failures, 1 pending

Randomized with seed 43519

[TEST PROF INFO] Time spent in factories: 01:26.274 (47.19% of total time)
```

### UI accessibility concerns?

None.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This is a developer environment (nothing added/changed is part of the app)
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will update the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
