### PR TITLE
No pointer events on tooltips

### DIFF
--- a/app/assets/stylesheets/components/tooltips.scss
+++ b/app/assets/stylesheets/components/tooltips.scss
@@ -17,6 +17,7 @@
     border-radius: var(--radius);
     width: max-content;
     opacity: var(--opacity-0);
+    pointer-events: none;
   }
 
   .js-focus-visible &__activator.focus-visible:focus,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds `pointer-events: none;` to tooltips which should prevent them from being accidentally activated with mouse cursor.

## QA Instructions, Screenshots, Recordings

1. Spin up `yarn storybook` and go to `/?path=/story/components-buttons--with-tooltip`
2. While hovering the button try to quickly move the cursor to the tooltip. 
3. If you can't make it and tooltip disappear - this works! 👍

### UI accessibility concerns?

This should actually improve accessibility.

## Added/updated tests?

No.

## [Forem core team only] How will this change be communicated?

It won't.