### PR TITLE
Ensuring we fetch latest podcasts by pubDate

### DIFF
--- a/app/services/podcasts/feed.rb
+++ b/app/services/podcasts/feed.rb
@@ -7,6 +7,10 @@ module Podcasts
       @podcast = podcast
     end
 
+    # @note While the limit might look generous, the callers are passing the value (which they
+    #       themselves receive elsewhere).  In one case, the :limit is 5
+    #
+    # @see Podcasts::EnqueueGetEpisodesWorker
     def get_episodes(limit: 100, force_update: false)
       # increased the redirect limit from 5 (default) to 7 to be able to handle such urls
       rss = HTTParty.get(podcast.feed_url, limit: 7).body.to_s
@@ -15,7 +19,14 @@ module Podcasts
       set_unreachable(status: :unparsable, force_update: force_update) && return unless feed
 
       get_episode = Podcasts::GetEpisode.new(podcast)
-      feed.items.first(limit).each do |item|
+      # NOTE: `sort { |a, b| b.pubDate <=> a.pubDate }` is logically equivalent to
+      # `sort_by(&:pubDate).reverse` but only iterates once through the array.
+      #
+      # The sort ensures that we're fetching the most recently published episodes.  This addresses
+      # https://github.com/forem/forem/issues/3580, in which some RSS feeds list their episodes in
+      # earliest to latest, whereas others list latest to earliest.  We assume that we're wanting to
+      # track the latest.
+      feed.items.sort { |a, b| b.pubDate <=> a.pubDate }.first(limit).each do |item|
         get_episode.call(item: item, force_update: force_update)
       end
       podcast.update_columns(reachable: true, status_notice: "")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this commit, we fetched the podcasts that were the first(:limit)
XML `item` nodes in the RSS feed.  Some folks might choose to list those
in descending pubDate order, while others list in ascending pubDate
order.


## Related Tickets & Documents

Closes #3580

## QA Instructions, Screenshots, Recordings

Existing tests will cover this.

### UI accessibility concerns?

## Added/updated tests?

- [x] No, and this is why: the updated code is "run" through the existing
      tests.  The comments communicate what's going on.

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
