### PR TITLE
Implement Unified Embeds for Stackery URLs

### DIFF
--- a/app/liquid_tags/stackery_tag.rb
+++ b/app/liquid_tags/stackery_tag.rb
@@ -1,44 +1,55 @@
 class StackeryTag < LiquidTagBase
   PARTIAL = "liquids/stackery".freeze
+  REGISTRY_REGEXP = %r{https://app.stackery.io/editor/design(?<params>\?.*)?}
+  PARAM_REGEXP = /\A(owner=[\w\-]+)|(repo=[\w\-]+)|(file=.*)|(ref=.*)\Z/
 
   def initialize(_tag_name, input, _parse_context)
     super
-    @data = get_data(input.strip)
+
+    stripped_input  = strip_tags(input)
+    unescaped_input = CGI.unescape_html(stripped_input)
+    @params = parsed_input(unescaped_input)
   end
 
   def render(_context)
     ApplicationController.render(
       partial: PARTIAL,
       locals: {
-        owner: @data[:owner],
-        repo: @data[:repo],
-        ref: @data[:ref]
+        params: @params
       },
     )
   end
 
   private
 
-  def get_data(input)
-    items = input.split
-    owner = items.first
-    repo = items.second
-    ref = items.third || "master"
+  def parsed_input(input)
+    if input.split.length > 1
+      params = input.split
+      owner = params.first
+      repo = params.second
+      ref = params.third || "master"
 
-    validate_items(owner, repo)
+      raise StandardError, I18n.t("liquid_tags.stackery_tag.missing_argument") unless owner && repo
 
-    {
-      owner: owner,
-      repo: repo,
-      ref: ref
-    }
+      "owner=#{owner}&repo=#{repo}&ref=#{ref}"
+    else
+      match = pattern_match_for(input, [REGISTRY_REGEXP])
+      raise StandardError, I18n.t("liquid_tags.stackery_tag.missing_argument") unless match
+
+      extract_params(match[:params])
+    end
   end
 
-  def validate_items(owner, repo)
-    return unless owner.blank? || repo.blank?
+  def extract_params(params)
+    params = params.delete("?").split("&")
+    params.filter_map { |param| param if valid_param(param) }.join("&")
+  end
 
-    raise StandardError, I18n.t("liquid_tags.stackery_tag.missing_argument")
+  def valid_param(param)
+    (param =~ PARAM_REGEXP)&.zero?
   end
 end
 
 Liquid::Template.register_tag("stackery", StackeryTag)
+
+UnifiedEmbed.register(StackeryTag, regexp: StackeryTag::REGISTRY_REGEXP)

--- a/app/liquid_tags/stackery_tag.rb
+++ b/app/liquid_tags/stackery_tag.rb
@@ -42,7 +42,7 @@ class StackeryTag < LiquidTagBase
 
   def extract_params(params)
     params = params.delete("?").split("&")
-    params.filter_map { |param| param if valid_param(param) }.join("&")
+    params.select { |param| valid_param(param) }.join("&")
   end
 
   def valid_param(param)

--- a/app/views/liquids/_stackery.html.erb
+++ b/app/views/liquids/_stackery.html.erb
@@ -1,6 +1,6 @@
 <iframe
   title="stackery editor"
-  src="//app.stackery.io/editor/design?owner=<%= owner %>&repo=<%= repo %>&ref=<%= ref %>" width="100%"
+  src="//app.stackery.io/editor/design?<%= params %>" width="100%"
   height="400"
   frameBorder="0">
 </iframe>

--- a/spec/liquid_tags/stackery_tag_spec.rb
+++ b/spec/liquid_tags/stackery_tag_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe StackeryTag, type: :liquid_tag do
 
     it "renders valid input" do
       template = generate_tag(valid_input)
-      expected = 'src="//app.stackery.io/editor/design?owner=deeheber&repo=lambda-layer-example&ref=layer-resource'
+      # rubocop:disable Layout/LineLength
+      expected = "src=\"//app.stackery.io/editor/design?owner=deeheber&amp;repo=lambda-layer-example&amp;ref=layer-resource\""
+      # rubocop:enable Layout/LineLength
       expect(template.render(nil)).to include(expected)
     end
 

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -195,6 +195,11 @@ RSpec.describe UnifiedEmbed::Registry do
       end
     end
 
+    it "returns StackeryTag for a stackery url" do
+      expect(described_class.find_liquid_tag_for(link: "https://app.stackery.io/editor/design?owner=stackery&repo=quickstart-ruby&file=template.yaml"))
+        .to eq(StackeryTag)
+    end
+
     it "returns TweetTag for a tweet url" do
       expect(described_class.find_liquid_tag_for(link: "https://twitter.com/aritdeveloper/status/1483614684884484099"))
         .to eq(TweetTag)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Stackery embeds.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15577

## QA Instructions, Screenshots, Recordings
Example Stackery URLs:
https://app.stackery.io/editor/design?owner=stackery&repo=quickstart-ruby&file=template.yaml

Example Stackery Input: deeheber lambda-layer-example master

- As a user, create a Stackery liquid tag using this format: `{% embed <stackery-url> %}`. The Liquid Tag should render properly.
- Also create Stackery liquid tag using the old method: `{% stackery <stackery-input> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?
None

## Added/updated tests?
- [X] Yes


## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.

## [optional] Are there any post deployment tasks we need to perform?
None