### PR TITLE
Favor tag sort by count over hotness

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -18,7 +18,7 @@ class TagsController < ApplicationController
   def index
     skip_authorization
     @tags_index = true
-    @tags = Tag.direct.includes(:sponsorship).order(hotness_score: :desc).limit(100)
+    @tags = Tag.direct.includes(:sponsorship).order(taggings_count: :desc).limit(100)
   end
 
   def edit


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [x] Optimization

## Description

The hotness score is an "opaque to our users" score, it reflects
"activity" on the tag.  However, by also showing the number of tags on
the associated view, there's a bit of a head scratcher when a "hotter"
tag with less tags is rendered ahead of a popular tag.


## Related Tickets & Documents

Closes #16321

## QA Instructions, Screenshots, Recordings

None, our tests will cover if this 

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] No, and this is why: already covered by tests

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
