### PR TITLE
Use `perform_bulk` in `Podcasts::EnqueueGetEpisodesWorker`

### DIFF
--- a/app/workers/podcasts/enqueue_get_episodes_worker.rb
+++ b/app/workers/podcasts/enqueue_get_episodes_worker.rb
@@ -5,9 +5,9 @@ module Podcasts
     sidekiq_options queue: :medium_priority, retry: 10
 
     def perform
-      Podcast.published.select(:id).find_each do |podcast|
-        Podcasts::GetEpisodesWorker.perform_async("podcast_id" => podcast.id, "limit" => 5)
-      end
+      # `perform_bulk` expects an array of argument arrays we need to wrap the hashes.
+      job_params = Podcast.published.ids.map { |id| [{ "podcast_id" => id, "limit" => 5 }] }
+      Podcasts::GetEpisodesWorker.perform_bulk(job_params)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Optimization

## Description

This is the 3rd PR for updating our code to use Sidekiq's relatively new `perform_bulk` feature.

NOTE: I'm doing one PR per change so we can merge them at different times and monitor if we want.

Previous PRs:

#16293
#16324 

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

Checked that this is covered by an existing spec (`spec/workers/podcasts/enqueue_get_episodes_worker_spec.rb:9`), which is still green.

### UI accessibility concerns?

No UI changes

## Added/updated tests?

- [X] No, and this is why: covered by existing spec

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: refactoring only