### PR TITLE
Removes Redundant, Un-Styled "Verify Email Ownership" Button

### DIFF
--- a/app/views/admin/users/_email_tools.html.erb
+++ b/app/views/admin/users/_email_tools.html.erb
@@ -2,8 +2,6 @@
   <h2>Email Tools</h2>
 
   <div>
-    <%= button_to "Verify Email Ownership", verify_email_ownership_admin_user_path(@user), remote: true %>
-
     <%= form_with url: verify_email_ownership_admin_user_path(@user), local: true do |f| %>
       Email last verified at: <%= @last_email_verification_date || "Never" %>
       <%= f.submit "Verify Email Ownership", class: "btn btn-primary float-right" %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR removes a redundant, un-styled "Verify Email Ownership" button from `/admin/users/#id`. 

## Related Tickets & Documents
Closes #15183 

## QA Instructions, Screenshots, Recordings
### Before:
<img width="959" alt="Screen Shot 2022-01-27 at 1 56 29 PM" src="https://user-images.githubusercontent.com/32834804/151442314-05197db7-5de5-49b0-a9f6-382702b7d330.png">

### After:
<img width="960" alt="Screen Shot 2022-01-27 at 1 55 55 PM" src="https://user-images.githubusercontent.com/32834804/151442221-d0dcdfc5-6ee2-4243-8414-30edf6f54cd7.png">

### UI accessibility concerns?
N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: this PR removes a redundant button and the non-redundant button is already covered by tests.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: this PR merely removes a redundant piece of code and doesn't change any functionality.

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![A cat leaving the room](https://media.giphy.com/media/iPiUxztIL4Sl2/giphy.gif)
