### PR TITLE
Cap tag point sum to 10

### DIFF
--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -625,7 +625,7 @@ module Articles
 
         # Rewards comment count with slightly more weight up to 10 comments.
         # Testing two case weights beyond what we currently have
-        scoring_config[:clause] = "SUM(followed_tags.points)::integer"
+        scoring_config[:clause] = "least(10.0, SUM(followed_tags.points))::integer"
         scoring_config[:cases] = case @strategy
                                  when "tag_follow_points_maximum_spectrum"
                                    (0..9).map { |n| [n, 0.70 + (n / 33.0)] }

--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -625,7 +625,7 @@ module Articles
 
         # Rewards comment count with slightly more weight up to 10 comments.
         # Testing two case weights beyond what we currently have
-        scoring_config[:clause] = "least(10.0, SUM(followed_tags.points))::integer"
+        scoring_config[:clause] = "LEAST(10.0, SUM(followed_tags.points))::integer"
         scoring_config[:cases] = case @strategy
                                  when "tag_follow_points_maximum_spectrum"
                                    (0..9).map { |n| [n, 0.70 + (n / 33.0)] }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We only have 0..9 configured for cases to consider, so treat all "large"
numbers as 10, since it will follow the same path in the weighting.

Use least(value, ...) to cap this. See https://www.postgresql.org/docs/11/functions-conditional.html#FUNCTIONS-GREATEST-LEAST

The generated query in question looks like this

```sql
(CASE SUM(followed_tags.points)::integer
WHEN 0 THEN 0.7
WHEN 1 THEN 0.7303030303030302
WHEN 2 THEN 0.7606060606060605
WHEN 3 THEN 0.7909090909090909
WHEN 4 THEN 0.8212121212121212
WHEN 5 THEN 0.8515151515151514
WHEN 6 THEN 0.8818181818181818
WHEN 7 THEN 0.9121212121212121
WHEN 8 THEN 0.9424242424242424
WHEN 9 THEN 0.9727272727272727
ELSE 1.0 END) 
```

10 looks the same as any other large number in this situation

This branch changes the query component to the following (which looks the same):

```sql
(CASE LEAST(10.0, SUM(followed_tags.points))::integer
WHEN 0 THEN 0.7
WHEN 1 THEN 0.7303030303030302
WHEN 2 THEN 0.7606060606060605
WHEN 3 THEN 0.7909090909090909
WHEN 4 THEN 0.8212121212121212
WHEN 5 THEN 0.8515151515151514
WHEN 6 THEN 0.8818181818181818
WHEN 7 THEN 0.9121212121212121
WHEN 8 THEN 0.9424242424242424
WHEN 9 THEN 0.9727272727272727
ELSE 1.0 END
```


## Related Tickets & Documents

Fixes https://github.com/forem/forem/issues/16341
  which describes a float -> integer conversion triggering a numeric value out of range error.

https://app.honeybadger.io/projects/66984/faults/83716025/


## QA Instructions, Screenshots, Recordings

Follow the reproduction case from the issue (follow a tag, set the tag weight larger than the max value representable by an integer, and exercise the weighted query strategy that considers the tag weights):

```
@user = ...

 Articles::Feeds::WeightedQueryStrategy.new(user: @user, strategy: 'tag_follow_points_maximum_spectrum').more_comments_minimal_weight_randomized.to_a
```

On main, raises an error. On this branch, should return an array of articles.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: My understanding is this is behavior neutral outside of the overflow being addressed.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [x] This change does not need to be communicated, and this is why not: bugfix

### Further thoughts

Why can a user set such high values for tag points? What would a reasonable range for those be? 

Are we using floats to accept decimal/fractional weightings, with the side effect that we're accepting values much larger than the max integer vale?