### PR TITLE
Set config.cache_classes for test env depending on whether Spring is enabled

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,6 +9,8 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # cache_classes should be false when Spring is enabled, and true when it's disabled
+  # https://guides.rubyonrails.org/configuring.html#config-cache-classes
   config.cache_classes = ActiveModel::Type::Boolean.new.cast(ENV["DISABLE_SPRING"])
 
   # See https://github.com/rails/rails/issues/40613#issuecomment-727283155

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,7 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_classes = true
+  config.cache_classes = ActiveModel::Type::Boolean.new.cast(ENV["DISABLE_SPRING"])
 
   # See https://github.com/rails/rails/issues/40613#issuecomment-727283155
   config.action_view.cache_template_loading = true


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Bug Fix

## Description
For a long time, we had `config.cache_classes = true` set for the test environment.
The docs say that `cache_classes` should be set to `false` for the test env when Spring is enabled:
[Spring readme](https://github.com/rails/spring#enable-reloading)
[Rails guides](https://guides.rubyonrails.org/configuring.html#config-cache-classes)

There are situations when having it set to `true` causes problems. E.g. when trying to run specs when there are pending migrations on a test db (or running migrations on a test db explicitly in this case):
```
/home/light/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/spring-4.0.0/lib/spring/application.rb:101:in `block in preload': Spring reloads, and therefore needs the application to have reloading enabled.
Please, set config.cache_classes to false in config/environments/test.rb.
```
But there are certain situations when we run specs with Spring disabled:
- https://github.com/forem/forem/blob/70e233953c4e8ecd98628aba4f30b8e82a5268e4/bin/e2e#L25
- on Travis (?) (https://github.com/forem/forem/blob/70e233953c4e8ecd98628aba4f30b8e82a5268e4/.travis.yml#L45)

So I set `config.cache_classes` value depending on `DISABLE_SPRING` env variable.

A related discussion in [a slack thread](https://forem-team.slack.com/archives/C7GE84DEJ/p1643185397195700)

## QA Instructions, Screenshots, Recordings
Run specs with the updated config in different ways, e.g.:
- running any specs "as is"
- running specs setting `DISABLE_SPRING` env variable
- running `bin/e2e-setup` ( https://github.com/forem/forem/blob/70e233953c4e8ecd98628aba4f30b8e82a5268e4/bin/e2e#L25)

## Added/updated tests?
- [x] No, and this is why: the pr doesn't change app logic

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: it's a small change in our config.