### PR TITLE
Ensuring that test's URL methods are similar

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,8 @@ require "active_support/core_ext/integer/time"
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.configure do
+  config.app_domain = ENV["APP_DOMAIN"] || "test.host"
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.cache_classes = true
@@ -44,7 +46,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Additional setting to make test work. This is possibly useless and can be deleted.
-  config.action_mailer.default_url_options = { host: "test.host" }
+  config.action_mailer.default_url_options = { host: config.app_domain }
 
   # Randomize the order test cases are executed.
   config.active_support.test_order = :random
@@ -90,5 +92,4 @@ Rails.application.configure do
   end
 end
 # rubocop:enable Metrics/BlockLength
-
-Rails.application.routes.default_url_options = { host: "test.host" }
+Rails.application.routes.default_url_options = { host: Rails.application.config.app_domain }

--- a/spec/routing/all_routes_spec.rb
+++ b/spec/routing/all_routes_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe "all routes", type: :routing do
   let(:podcast)     { create(:podcast) }
   let(:user)        { create(:user) }
 
+  describe "#root_url" do
+    it "matches URL.url('/')" do
+      expect(root_url).to eq(URL.url("/"))
+    end
+  end
+
   it "renders a podcast index if there is a podcast with the slug successfully" do
     expect(get: "/#{podcast.slug}").to route_to(
       controller: "stories",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this commit, in test, we had two different answers to "what is
the host of this application?"  For Rails generates
URLs (e.g. `root_url`) we would get one answer.  For our custom
`URL.url("/")` we got another answer.

This resolves and patches that up.

## Related Tickets & Documents

Closes #16347, Related to forem/rfcs#291.

## QA Instructions, Screenshots, Recordings

None.  The tests exercise this.  And the impact is limited to our test suite.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: this
      is a change in our test suite that has minimal impact.
