### PR TITLE
Adding conditional rendering of navigation links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,6 +19,35 @@ module ApplicationHelper
     "#{controller_name}-#{controller.action_name}"
   end
 
+  # Answers the simple question "Should we show this link?"
+  #
+  # @param link [NavigationLink]
+  #
+  # @return [TrueClass] true when we should render the given link.
+  # @return [FalseClass] false when we should **not** render the given link.
+  def display_navigation_link?(link:)
+    # This is a quick short-circuit; we already have the link.  So don't bother asking the "Is this
+    # feature enabled" question if the given link requires a sign in and the user is not signed in.
+    return false if link.display_only_when_signed_in? && !user_signed_in?
+    return true if navigation_link_is_for_an_enabled_feature?(link: link)
+
+    false
+  end
+
+  # @param link [NavigationLink]
+  #
+  # @note [@jeremyf] - making an assumption, namely that the only navigation oriented feature is the
+  #                    Listing.  If this changes, adjust this method accordingly.  Normally I like to have method return
+  def navigation_link_is_for_an_enabled_feature?(link:)
+    return true if Listing.feature_enabled?
+
+    # The "/listings" is an assumption on the routing.  So let's first try :listings_path.
+    listings_url = URL.url(try(:listings_path) || "/listings")
+    return false if listings_url == URL.url(link.url)
+
+    true
+  end
+
   # rubocop:disable Rails/HelperInstanceVariable
   def view_class
     if @podcast_episode_show # custom due to edge cases

--- a/app/views/layouts/_main_nav.html.erb
+++ b/app/views/layouts/_main_nav.html.erb
@@ -15,6 +15,9 @@
   </ul>
 </nav>
 
+<%# Reading Note: There's a faulty assumption that all "other_nav_links" are
+    visible based on the current state (see
+    ApplicationHelper#display_navigation_link? for details).  %>
 <% if other_nav_links.any? %>
   <nav class="mb-4" aria-labelledby="other-nav-heading">
     <h2 id="other-nav-heading" class="crayons-subtitle-3 py-2 pl-3">

--- a/app/views/layouts/_sidebar_nav_link.html.erb
+++ b/app/views/layouts/_sidebar_nav_link.html.erb
@@ -1,4 +1,4 @@
-<% if !link.display_only_when_signed_in || (link.display_only_when_signed_in && user_signed_in?) %>
+<% if display_navigation_link?(link: link) %>
   <li>
     <a href="<%= link.url %>" class="sidebar-navigation-link c-link c-link--block c-link--icon-left">
       <span class="c-link__icon">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature

## Description

Prior to this commit we had an inline logic check on whether or not to
render a navigation link.  As we are looking to rollout the feature flag
for Listings, we needed to add another somewhat complex conditional.

This commit moves the inline conditionals to a helper function, which
makes testing the logic far easier.  Especially since we need to bombard
the tests with the combination of 3 different boolean checks.  (And one
of those boolean checks requires even more but could be stubbed).

## Related Tickets & Documents

Related to forem/rfcs#291

## QA Instructions, Screenshots, Recordings

There should be no UI differences, as we're presently assuming the
Listings feature is enabled.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not: this is a refactor that helps make feasible the "turn off listings feature."
