### PR TITLE
Implement Unified Embeds for Glitch URLs

### DIFF
--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -3,7 +3,7 @@ class GlitchTag < LiquidTagBase
 
   PARTIAL = "liquids/glitch".freeze
 
-  REGISTRY_REGEXP = %r{https://(?<slug_subdomain>[\w\-]{1,110}.)?glitch(?:.me|.com)(?:/edit/#!/)?(?<slug>[\w\-]{1,110})?(?<params>\?.*)?}
+  REGISTRY_REGEXP = %r{https://(?:(?<subdomain>[\w\-]{1,110})\.)?glitch(?:\.me|\.com)(?:/edit/#!/)?(?<slug>[\w\-]{1,110})?(?<params>\?.*)?}
   ID_REGEXP = /\A(?<slug>[\w\-]{1,110})\Z/
   REGEXP_OPTIONS = [REGISTRY_REGEXP, ID_REGEXP].freeze
   # last part of PATH_REGEX handles line & character numbers that may appear at path end

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -39,7 +39,7 @@ class GlitchTag < LiquidTagBase
 
   def parsed_input(input)
     id, *options = input.split
-    stripped_id = id.delete("~") # remove possible preceeding tilde
+    stripped_id = id.gsub(/^~/, "") # remove possible preceeding tilde
     match = pattern_match_for(stripped_id, REGEXP_OPTIONS)
     raise StandardError, I18n.t("liquid_tags.glitch_tag.invalid_glitch_id") unless match
 
@@ -47,8 +47,8 @@ class GlitchTag < LiquidTagBase
   end
 
   def get_slug(match)
-    if match_has_named_capture_group?(match, "slug_subdomain")
-      match[:slug_subdomain]&.delete(".") if match[:slug_subdomain].present?
+    if match_has_named_capture_group?(match, "subdomain")
+      match[:subdomain].presence
     else
       match[:slug]
     end

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -48,7 +48,7 @@ class GlitchTag < LiquidTagBase
 
   def get_slug(match)
     if match_has_named_capture_group?(match, "subdomain")
-      match[:subdomain].presence
+      match[:subdomain]
     else
       match[:slug]
     end
@@ -60,7 +60,7 @@ class GlitchTag < LiquidTagBase
 
   def parse_options(options, match)
     # 'app' and 'code' should cancel each other out
-    options -= %w[app code] if (options & %w[app code]) == %w[app code]
+    options -= %w[app code] if options.include?("app") && options.include?("code")
 
     # check for file= in options or path= in params; fallback is file=index.html
     file_option = options.detect { |option| option.start_with?("file=") }

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -2,9 +2,13 @@ class GlitchTag < LiquidTagBase
   attr_accessor :uri
 
   PARTIAL = "liquids/glitch".freeze
-  ID_REGEXP = /\A[a-zA-Z0-9\-]{1,110}\z/
-  TILDE_PREFIX_REGEXP = /\A~/
-  OPTION_REGEXP = /(app|code|no-files|preview-first|no-attribution|file=\w(\.\w)?)/
+
+  REGISTRY_REGEXP = %r{https://(?<slug_subdomain>[\w\-]{1,110}.)?glitch(?:.me|.com)(?:/edit/#!/)?(?<slug>[\w\-]{1,110})?(?<params>\?.*)?}
+  ID_REGEXP = /\A(?<slug>[\w\-]{1,110})\Z/
+  REGEXP_OPTIONS = [REGISTRY_REGEXP, ID_REGEXP].freeze
+  # last part of PATH_REGEX handles line & character numbers added to filename
+  PATH_REGEX = %r{path=(?:(?<path>[\w/\-.]+)(?:[\d:]+)?)?}
+  OPTION_REGEXP = %r{(app|code|no-files|preview-first|no-attribution|file=([\w/\-.]+)?)}
   OPTIONS_TO_QUERY_PAIR = {
     "app" => %w[previewSize 100],
     "code" => %w[previewSize 0],
@@ -13,10 +17,12 @@ class GlitchTag < LiquidTagBase
     "no-attribution" => %w[attributionHidden true]
   }.freeze
 
-  def initialize(_tag_name, id, _parse_context)
+  def initialize(_tag_name, input, _parse_context)
     super
-    @query = parse_options(id)
-    @id = parse_id(id)
+
+    unescaped_input = CGI.unescape_html(input)
+    stripped_input  = strip_tags(unescaped_input)
+    @id, @query = parsed_input(stripped_input)
   end
 
   def render(_context)
@@ -31,20 +37,53 @@ class GlitchTag < LiquidTagBase
 
   private
 
-  def valid_id?(input)
-    (input =~ ID_REGEXP)&.zero?
+  def parsed_input(input)
+    id, *options = input.split
+    stripped_id = id.delete("~") # remove possible preceeding tilde
+    match = pattern_match_for(stripped_id, REGEXP_OPTIONS)
+    raise StandardError, I18n.t("liquid_tags.glitch_tag.invalid_glitch_id") unless match
+
+    [get_slug(match), parse_options(options, match)]
   end
 
-  def parse_id(input)
-    id = input.split.first
-    id.sub!(TILDE_PREFIX_REGEXP, "")
-    raise StandardError, I18n.t("liquid_tags.glitch_tag.invalid_glitch_id") unless valid_id?(id)
+  def get_slug(match)
+    # the dot comes through the regex
+    return match[:slug_subdomain]&.delete(".") if match[:slug_subdomain].present?
 
-    id
+    match[:slug]
   end
 
-  def valid_option(option)
-    option.match(OPTION_REGEXP)
+  def parse_options(options, match)
+    # 'app' and 'code' should cancel each other out
+    options -= %w[app code] if (options & %w[app code]) == %w[app code]
+    # add file= to options if a path is present within the URL params
+    options += ["file=#{path_within_params(match)}"] if path_within_params(match)
+
+    return if options.blank?
+
+    validated_options = options.select { |option| valid_option?(option) }
+    raise StandardError, I18n.t("liquid_tags.glitch_tag.invalid_options") if validated_options.empty?
+
+    build_options(validated_options)
+  end
+
+  # TODO: See if you can get these to work without the match_has method
+  def path_within_params(match)
+    return unless match_has_named_capture_group?(match, "params")
+
+    path_match = pattern_match_for(match[:params], [PATH_REGEX])
+
+    return unless match_has_named_capture_group?(path_match, "path")
+
+    path_match[:path]
+  end
+
+  def match_has_named_capture_group?(match, group_name)
+    match.names.include?(group_name)
+  end
+
+  def valid_option?(option)
+    option.match?(OPTION_REGEXP)
   end
 
   def build_options(options)
@@ -59,21 +98,8 @@ class GlitchTag < LiquidTagBase
     # Encode the resulting pairs as a query string
     URI.encode_www_form(params)
   end
-
-  def parse_options(input)
-    _, *options = input.split
-
-    # 'app' and 'code' should cancel each other out
-    options -= %w[app code] if (options & %w[app code]) == %w[app code]
-
-    # Validation
-    validated_options = options.filter_map { |option| valid_option(option) }
-    unless options.empty? || !validated_options.empty?
-      raise StandardError, I18n.t("liquid_tags.glitch_tag.invalid_options")
-    end
-
-    build_options(options)
-  end
 end
 
 Liquid::Template.register_tag("glitch", GlitchTag)
+
+UnifiedEmbed.register(GlitchTag, regexp: GlitchTag::REGISTRY_REGEXP)

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -62,7 +62,7 @@ class GlitchTag < LiquidTagBase
     # 'app' and 'code' should cancel each other out
     options -= %w[app code] if options.include?("app") && options.include?("code")
 
-    # check for file= in options or path= in params; fallback is file=index.html
+    # check for file= in options, then path= in params; fallback is file=index.html
     file_option = options.detect { |option| option.start_with?("file=") }
     options += ["file=#{path_within_params(match)}"] unless file_option
 

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe UnifiedEmbed::Registry do
       "https://app.codesandbox.io/embed/exciting-knuth-hywlv?file=/index.html&runonclick=0&view=editor",
     ]
 
+    valid_glitch_url_formats = [
+      "https://zircon-quixotic-attraction.glitch.me",
+      "https://glitch.com/edit/#!/zircon-quixotic-attraction",
+      "https://glitch.com/edit/#!/zircon-quixotic-attraction?path=script.js:1:0",
+    ]
+
     valid_medium_url_formats = [
       "https://medium.com/@edisonywh/my-ruby-journey-hooking-things-up-91d757e1c59c",
       "https://themobilist.medium.com/is-universal-basic-mobility-the-route-to-a-sustainable-c-b18e1e2d014c",
@@ -104,6 +110,13 @@ RSpec.describe UnifiedEmbed::Registry do
     it "returns GistTag for a gist url" do
       expect(described_class.find_liquid_tag_for(link: "https://gist.github.com/jeremyf/662585f5c4d22184a6ae133a71bf891a"))
         .to eq(GistTag)
+    end
+
+    it "returns GlitchTag for a valid glitch url" do
+      valid_glitch_url_formats.each do |url|
+        expect(described_class.find_liquid_tag_for(link: url))
+          .to eq(GlitchTag)
+      end
     end
 
     it "returns AsciinemaTag for an asciinema url" do

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(GistTag)
     end
 
-    it "returns GlitchTag for a valid glitch url" do
+    it "returns GlitchTag for a valid glitch url", :aggregate_failures do
       valid_glitch_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(GlitchTag)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Glitch embeds.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15559

## QA Instructions, Screenshots, Recordings
Example Glitch URLs:
https://zircon-quixotic-attraction.glitch.me
https://glitch.com/edit/#!/zircon-quixotic-attraction
https://glitch.com/edit/#!/zircon-quixotic-attraction?path=index.html

Also test these Glitch URLs with the following options:
`app` inserts the `previewSize=100` param
`code` inserts the `previewSize=0` param
`no-files` inserts the `sidebarCollapsed=true` param
`preview-first` inserts the `previewFirst=true` param
`no-attribution` inserts the `attributionHidden=true` param

Note: `app` and `code` together cancel each other out because they do not make sense together

- As a user, create a Glitch liquid tag using this format: `{% embed <glitch-url> <options> %}`. The Liquid Tag should render properly. Please see my comment below regarding using options for this particular Unified Embed.
- Also create Glitch liquid tag using the old method: `{% glitch <glitch-slug> <options> %}`. This should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?
None

## Added/updated tests?
- [X] Yes

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.

## [optional] Are there any post deployment tasks we need to perform?
None
