### PR TITLE
Fixes for home nav link positioning

### DIFF
--- a/lib/data_update_scripts/20220201114309_update_home_navigation_link_position.rb
+++ b/lib/data_update_scripts/20220201114309_update_home_navigation_link_position.rb
@@ -1,0 +1,14 @@
+module DataUpdateScripts
+  class UpdateHomeNavigationLinkPosition
+    def run
+      NavigationLink.create_or_update_by_identity(
+        name: "Home",
+        url: URL.url("/"),
+        icon: File.read(Rails.root.join("app/assets/images/twemoji/house.svg")),
+        display_only_when_signed_in: false,
+        position: 1,
+        section: :default,
+      )
+    end
+  end
+end

--- a/lib/tasks/add_navigation_links.rake
+++ b/lib/tasks/add_navigation_links.rake
@@ -128,6 +128,7 @@ namespace :navigation_links do
     base_url = "#{protocol}#{domain}".freeze
 
     NavigationLink.create_or_update_by_identity(
+      url: "/",
       name: "Home",
       icon: home_icon,
       display_only_when_signed_in: false,

--- a/spec/lib/data_update_scripts/update_home_navigation_link_position_spec.rb
+++ b/spec/lib/data_update_scripts/update_home_navigation_link_position_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220201114309_update_home_navigation_link_position.rb",
+)
+
+describe DataUpdateScripts::UpdateHomeNavigationLinkPosition do
+  it "creates a home navigation link when it doesn't already exist" do
+    expect do
+      described_class.new.run
+    end.to change { NavigationLink.exists?(url: "/", name: "Home", position: 1) }.from(false).to(true)
+  end
+
+  it "updates any existing home navigation link to have position 1" do
+    link = create(:navigation_link, url: "/", name: "Home", position: 4)
+    described_class.new.run
+    expect(link.reload.position).to eq(1)
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The update in https://github.com/forem/forem/pull/16268 almost went smoothly, but unfortunately there was a logic error in my data update script, which:

- created the new home link
- incremented all links in the section by 2 (including that home link)

This resulted in the Home link appearing below the Reading List link in DEV, and will cause it to appear 2nd in every other Forem once it rolls out to the fleet.

It's my understanding that we can't simply revert that commit, as once a script is marked as "run", the deed is done. To fix the issue, I've instead added _another_ DUS to make sure the home link is placed at position 1. If we can merge this before the fleet deploys this should avoid the Home links appearing in the wrong place.

If there is a more elegant solution, just let me know!

I also noticed I somehow missed the `url` in the local db seeding task (a poorly resolved merge conflict), and this PR adds it back in.

## Related Tickets & Documents

https://github.com/forem/forem/pull/16268

## QA Instructions, Screenshots, Recordings

I think this is covered by the spec

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


