### PR TITLE
Avoid Intent redirect on Runtime Banner for the DEV Android app context

### DIFF
--- a/app/javascript/runtimeBanner/RuntimeBanner.jsx
+++ b/app/javascript/runtimeBanner/RuntimeBanner.jsx
@@ -22,6 +22,13 @@ function removeFromDOM() {
 }
 
 function androidTargetIntent() {
+  if (navigator.userAgent === 'DEV-Native-android') {
+    // The DEV Android app has been decommissioned and it kept a custom UA.
+    // Instead of a custom intent we are redirecting directly to the Play Store
+    // because the app isn't capable of handling these
+    return FOREM_GOOGLE_PLAY_URL;
+  }
+
   return (
     'intent://scan/#Intent;' +
     'action=android.intent.action.SEND;' +


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

The DEV Android app was decommissioned but we're unable to ship an updated build right now. So we're handling the Runtime Banner as the backup to try and migrate users to the Forem mobile app.

## QA Instructions, Screenshots, Recordings

I'd recommend not trying to QA locally (somewhat tricky), I tested this by doing:
1. Boot DEV Android app locally and point to an ngrok endpoint (local forem running this branch)
2. Check the banner opens the Google Play Store when tapped

### UI accessibility concerns?

None - All UI elements used weren't modified

## Added/updated tests?

- [x] No, and this is why: Edge case where we're handling the now decommissioned DEV Android app

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: [A public announcement](https://dev.to/devteam/sunsetting-the-devto-ios-app-44nl) was already made a while ago. This is only improving the current experience

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![installation wizard](https://media.giphy.com/media/kdiLau77NE9Z8vxGSO/giphy.gif)