### PR TITLE
Add "aggregate_failures" metadata to Registry Specs with loops

### DIFF
--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -88,14 +88,14 @@ RSpec.describe UnifiedEmbed::Registry do
       "https://youtu.be/rc5AyncB_Xw",
     ]
 
-    it "returns BlogcastTag for a valid blogcast url" do
+    it "returns BlogcastTag for a valid blogcast url", :aggregate_failures do
       valid_blogcast_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(BlogcastTag)
       end
     end
 
-    it "returns CodesandboxTag for a valid codesandbox url" do
+    it "returns CodesandboxTag for a valid codesandbox url", :aggregate_failures do
       valid_codesandbox_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(CodesandboxTag)
@@ -134,7 +134,7 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(DotnetFiddleTag)
     end
 
-    it "returns InstagramTag for a valid instagram url" do
+    it "returns InstagramTag for a valid instagram url", :aggregate_failures do
       valid_instagram_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(InstagramTag)
@@ -146,7 +146,7 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(JsFiddleTag)
     end
 
-    it "returns KotlinTag for a valid kotlin url" do
+    it "returns KotlinTag for a valid kotlin url", :aggregate_failures do
       valid_kotlin_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(KotlinTag)
@@ -163,7 +163,7 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(LinkTag)
     end
 
-    it "returns MediumTag for a valid medium url" do
+    it "returns MediumTag for a valid medium url", :aggregate_failures do
       valid_medium_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(MediumTag)
@@ -185,7 +185,7 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(RedditTag)
     end
 
-    it "returns ReplitTag for a valid replit url" do
+    it "returns ReplitTag for a valid replit url", :aggregate_failures do
       valid_replit_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(ReplitTag)
@@ -207,14 +207,14 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(SpeakerdeckTag)
     end
 
-    it "returns SpotifyTag for a valid spotify url" do
+    it "returns SpotifyTag for a valid spotify url", :aggregate_failures do
       valid_spotify_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(SpotifyTag)
       end
     end
 
-    it "returns StackblitzTag for a valid stackblitz url" do
+    it "returns StackblitzTag for a valid stackblitz url", :aggregate_failures do
       valid_stackblitz_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(StackblitzTag)
@@ -231,7 +231,7 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(TweetTag)
     end
 
-    it "returns TwitchTag for a valid twitch url" do
+    it "returns TwitchTag for a valid twitch url", :aggregate_failures do
       valid_twitch_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(TwitchTag)
@@ -248,14 +248,14 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(WikipediaTag)
     end
 
-    it "returns VimeoTag for a valid vimeo url" do
+    it "returns VimeoTag for a valid vimeo url", :aggregate_failures do
       valid_vimeo_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(VimeoTag)
       end
     end
 
-    it "returns YoutubeTag for a valid youtube url" do
+    it "returns YoutubeTag for a valid youtube url", :aggregate_failures do
       valid_youtube_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(YoutubeTag)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
In keeping with [MK's suggestion](https://github.com/forem/forem/pull/16378#discussion_r796251306), I am adding `aggregate_failures` metadata to single specs with more than one `expect`. 

## Related Tickets & Documents
None

## QA Instructions, Screenshots, Recordings
Modified spec file should pass

### UI accessibility concerns?
None

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?
- [X] This change does not need to be communicated, and this is why not: straightforward spec update_

## [optional] Are there any post deployment tasks we need to perform?
None