### PR TITLE
Improved article date specs

### DIFF
--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -192,12 +192,16 @@ RSpec.describe Article, type: :model do
 
     describe "dates" do
       it "reject future dates" do
-        expect(build(:article, with_date: true, date: Date.tomorrow).valid?).to be(false)
+        invalid_article = build(:article, with_date: true, date: Date.tomorrow.strftime("%d/%m/%Y"), published_at: nil)
+        expect(invalid_article.valid?).to be(false)
+        expect(invalid_article.errors[:date_time])
+          .to include("must be entered in DD/MM/YYYY format with current or past date")
       end
 
       it "reject future dates even when it's published at" do
         article.published_at = Date.tomorrow
         expect(article.valid?).to be(false)
+        expect(article.errors[:date_time]).to include("must be entered in DD/MM/YYYY format with current or past date")
       end
     end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -191,14 +191,14 @@ RSpec.describe Article, type: :model do
     end
 
     describe "dates" do
-      it "reject future dates" do
+      it "rejects future dates" do
         invalid_article = build(:article, with_date: true, date: Date.tomorrow.strftime("%d/%m/%Y"), published_at: nil)
         expect(invalid_article.valid?).to be(false)
         expect(invalid_article.errors[:date_time])
           .to include("must be entered in DD/MM/YYYY format with current or past date")
       end
 
-      it "reject future dates even when it's published at" do
+      it "rejects future dates even when it's published at" do
         article.published_at = Date.tomorrow
         expect(article.valid?).to be(false)
         expect(article.errors[:date_time]).to include("must be entered in DD/MM/YYYY format with current or past date")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
While working on #15473 I started modifying `Article` specs related to the `published_at` field and found out that one of the specs (`"rejects future dates"`) wasn't serving its purpose.
What was actually happening:
An exception `Psych::DisallowedClass:  Tried to load unspecified class: Date` was raised while evaluating markdown:
https://github.com/forem/forem/blob/c1a60539b9b06298e4ea3d1e83291c5a1c7565d9/app/models/article.rb#L566
Then it was rescued later in the method and an error "Tried to load unspecified class: Date" was added to an article record instead of "must be entered in DD/MM/YYYY format with current or past date".
I added a check for the error message to the spec and changed the passed attributes:
- `FrontMatterParser::Parser` is unable to parse date in a `2022-02-03` format which is returned by `Date#to_s`, and was implicitly used in a test for unknown (for me) reasons. I changed an attribute to use the format specified in an error message ("DD/MM/YYYY").
- I had to pass a `nil` for `published_at` because otherwise, it was set to the `Time.current` (a default value from a factory) instead of a "future" frontmatter date in a `parse_date`:
https://github.com/forem/forem/blob/c1a60539b9b06298e4ea3d1e83291c5a1c7565d9/app/models/article.rb#L660
So passing a date wasn't doing much in the test.

<h3 id="my-question"> I have a question, as it can affect my future work on scheduling posts:</h3>

In general, do we still use setting `published_at` from a frontmatter date? In tests, `with_date` is only used in the test I edited.
In a basic markdown editor there is no `date:` key specified. If we specify `date:` in `YYYY-MM-DD` format, an article won't be saved. That's not a huge problem, as people won't be doing it randomly, but still.
If we are not setting `published_at` from frontmatter date, we could remove the related logic, and simplify the code.

## Related Tickets & Documents
#15473 - slightly related

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams
