### PR TITLE
Profile attribute names should be unique and non-empty

### DIFF
--- a/app/decorators/profile_decorator.rb
+++ b/app/decorators/profile_decorator.rb
@@ -3,10 +3,12 @@ class ProfileDecorator < ApplicationDecorator
   # display area, e.g. :left_sidebar
   def ui_attributes_for(area:)
     names = ProfileField.public_send(area).pluck(:attribute_name)
-    data.slice(*names).select { |_, v| v.present? }.transform_keys { |k| label_for_attribute(k) }
+    data.slice(*names)
+      .transform_keys { |k| label_for_attribute(k) }
+      .select { |k, v| k.present? && v.present? }
   end
 
   def label_for_attribute(attr)
-    ProfileField.find_by(attribute_name: attr).label
+    ProfileField.find_by(attribute_name: attr)&.label
   end
 end

--- a/app/decorators/profile_decorator.rb
+++ b/app/decorators/profile_decorator.rb
@@ -3,6 +3,10 @@ class ProfileDecorator < ApplicationDecorator
   # display area, e.g. :left_sidebar
   def ui_attributes_for(area:)
     names = ProfileField.public_send(area).pluck(:attribute_name)
-    data.slice(*names).select { |_, v| v.present? }
+    data.slice(*names).select { |_, v| v.present? }.transform_keys { |k| label_for_attribute(k) }
+  end
+
+  def label_for_attribute(attr)
+    ProfileField.find_by(attribute_name: attr).label
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -39,6 +39,8 @@ class Profile < ApplicationRecord
   # Lazily add accessors for profile fields on first use
   def method_missing(method_name, *args, **kwargs, &block)
     match = method_name.match(ATTRIBUTE_NAME_REGEX)
+    super unless match
+
     field = ProfileField.find_by(attribute_name: match[:attribute_name])
     super unless field
 
@@ -53,7 +55,7 @@ class Profile < ApplicationRecord
   # an explicit `responds_to?` check.
   def respond_to_missing?(method_name, include_private = false)
     match = method_name.match(ATTRIBUTE_NAME_REGEX)
-    return true if match[:attribute_name].in?(self.class.attributes)
+    return true if match && match[:attribute_name].in?(self.class.attributes)
 
     super
   end

--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -25,6 +25,8 @@ class ProfileField < ApplicationRecord
     self.attribute_name = Sterile.sluggerize(
       label.titleize, delimiter: "_"
     ).scan(WORD_REGEX).join.underscore
+
+    validate(:update)
   end
 
   def maximum_header_field_count

--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -22,7 +22,9 @@ class ProfileField < ApplicationRecord
   private
 
   def generate_attribute_name
-    self.attribute_name = label.titleize.scan(WORD_REGEX).join.underscore
+    self.attribute_name = Sterile.sluggerize(
+      label.titleize, delimiter: "_"
+    ).scan(WORD_REGEX).join.underscore
   end
 
   def maximum_header_field_count

--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -26,7 +26,7 @@ class ProfileField < ApplicationRecord
       label.titleize, delimiter: "_"
     ).scan(WORD_REGEX).join.underscore
 
-    validate(:update)
+    raise_validation_error unless valid?(:update)
   end
 
   def maximum_header_field_count

--- a/app/models/profile_field.rb
+++ b/app/models/profile_field.rb
@@ -22,11 +22,7 @@ class ProfileField < ApplicationRecord
   private
 
   def generate_attribute_name
-    self.attribute_name = Sterile.sluggerize(
-      label.titleize, delimiter: "_"
-    ).scan(WORD_REGEX).join.underscore
-
-    raise_validation_error unless valid?(:update)
+    self.attribute_name = "attribute_#{SecureRandom.uuid.delete('-')}"
   end
 
   def maximum_header_field_count


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We had originally used the field label to generate an attribute name that was friendly, readable, and ruby-like. However, I'm not sure that's a good idea. The method used to generate attribute names could lead to empty input (since we sanitize before generating), and could lead to duplication (since we validate that the label is unique, but may generate two identical attribute names when sanitizing). 

Moreover, since we're calling `profile.public_send(f.attribute_name)` it's important that no method selector like `class` or `association` or (unlikely to be an honest mistake) `destroy` be used as the label, since that will call the profile's built in methods rather than the attribute names.
 
So the changes here are
- generate a random uuid string for the attribute name (prefixed with attribute_ to ensure this is a valid symbol/method selector).
- change the profile decorator (used on the users show page for the sidebar) to use the field label, not the field attribute name (which is now going to be very ugly).
-  harden the profile code for method missing to not call (match)[], if match could possibly be nil. This is probably a non-issue once the methods are not generated by stripping unsafe input from the label (we won't have the case where attribute name is an empty string anymore), but I expect it's neither expensive nor wrong.   

## Related Tickets & Documents

fixes #16391 

## QA Instructions, Screenshots, Recordings

TBD - for the time being useful tests are create a profile field in admin with a non-latin name like `עִבְרִית` and one with a keyword name like `class` or `destroy`, edit the user profile, and view the user's page.

If we're leaking attribute names like attribute_123123123123123 then there's work to do. 

### UI accessibility concerns?

I don't expect any.

## Added/updated tests?

I'm sure I'll need to...

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
