### PR TITLE
Change UI instances of "vomit" to "flag"

### DIFF
--- a/app/components/admin/users/tools/reactions_component.html.erb
+++ b/app/components/admin/users/tools/reactions_component.html.erb
@@ -15,7 +15,7 @@
              class="text-none color-base-60 flex justify-between"
              rel="noopener noreferer"
              target="_blank">
-            <span>🧐 <%= reaction.category.capitalize %></span>
+            <span>🧐 <%= t("views.reactions.category.#{reaction.category}") %></span>
             <span><strong><%= reaction.reactable_type %></strong><%= reaction.reactable_type == "User" ? "" : ": #{reaction.reactable.title}" %></span>
             <span><local-time datetime="<%= reaction.created_at.iso8601 %>"><%= reaction.created_at.strftime("%b %d, %Y") %></local-time></span>
           </a>

--- a/app/javascript/admin/controllers/reaction_controller.js
+++ b/app/javascript/admin/controllers/reaction_controller.js
@@ -51,9 +51,7 @@ export default class ReactionController extends Controller {
   reactableUserCheck() {
     if (this.reactableType === 'user') {
       if (
-        window.confirm(
-          'You are confirming a User vomit reaction; are you sure?',
-        )
+        window.confirm('You are confirming a User flag reaction; are you sure?')
       ) {
         this.updateReaction(this.confirmedStatus);
       }

--- a/app/views/admin/feedback_messages/_abuse_reports.html.erb
+++ b/app/views/admin/feedback_messages/_abuse_reports.html.erb
@@ -14,7 +14,7 @@
   <div id="vomitReactions">
     <div class="crayons-card">
       <div class="card-header flex items-center" id="vomitReactionsHeader">
-        <h4>Vomit Reactions</h4>
+        <h4>Flag Reactions</h4>
         <button class="btn btn-secondary ml-auto" type="button" data-toggle="collapse" data-target="#vomitReactionsBodyContainer" aria-expanded="false" aria-controls="vomitReactionsBodyContainer">
           Toggle
         </button>
@@ -30,7 +30,7 @@
               data-reaction-id-value="<%= reaction.id %>"
               data-reaction-url-value="<%= admin_reaction_path(reaction.id) %>">
               <span>
-                🧐 <a href="<%= reaction.user.path %>" target="_blank" rel="noopener">@<%= reaction.user.username %></a>
+                <%= crayons_icon_tag("twemoji/suspicious", native: true, class: "mr-1", aria_hidden: true) %> <a href="<%= reaction.user.path %>" target="_blank" rel="noopener">@<%= reaction.user.username %></a>
                 <% if reaction.user_id == Settings::General.mascot_user_id %>
                   <strong>(auto-generated)</strong>
                 <% end %>
@@ -42,7 +42,7 @@
                   <span class="badge badge-danger">Suspended</span>
                 <% end %>
                 <% if reaction.reactable_type == "User" && reaction.reactable.vomited_on? %>
-                  <span class="badge badge-warning">Vomited</span>
+                  <span class="badge badge-warning">Flagged</span>
                 <% end %>
               </span>
               <span>

--- a/app/views/admin/privileged_reactions/index.html.erb
+++ b/app/views/admin/privileged_reactions/index.html.erb
@@ -6,7 +6,7 @@
 
     <%= f.select(
           :category_eq,
-          options_for_select(["", "thumbsup", "thumbsdown", "vomit"], @q.category_eq),
+          options_for_select(["", [t("views.reactions.category.thumbsup"), "thumbsup"], [t("views.reactions.category.thumbsdown"), "thumbsdown"], [t("views.reactions.category.vomit"), "vomit"]], @q.category_eq),
           {},
           class: "custom-select mx-3",
           aria: { label: "Action" },
@@ -35,7 +35,7 @@
         <td class="whitespace-nowrap"><%= reaction.id %></td>
         <td><%= link_to reaction.user.username, admin_user_path(reaction.user_id) %></td>
         <td class="whitespace-nowrap"><%= reaction.reactable_type %></td>
-        <td><%= reaction.category %></td>
+        <td><%= t("views.reactions.category.#{reaction.category}") %></td>
         <td>
           <% if reaction.reactable_type == "Article" %>
             <%= link_to reaction.reactable.title, reaction.reactable.path %>

--- a/app/views/admin/users/_negative_reactions.html.erb
+++ b/app/views/admin/users/_negative_reactions.html.erb
@@ -7,7 +7,7 @@
     <% unless @related_vomit_reactions.empty? %>
       <% @related_vomit_reactions.each do |reaction| %>
         <a href="<%= reaction.reactable.path %>" class="list-group-item list-group-item-action px-5 d-flex justify-content-between">
-        <span>🧐 <%= reaction.category.capitalize %></span>
+        <span><%= crayons_icon_tag("twemoji/suspicious", native: true, class: "mr-1", aria_hidden: true) %><%= t("views.reactions.category.#{reaction.category}") %></span>
         <span><strong><%= reaction.reactable_type %></strong><%= reaction.reactable_type == "User" ? "" : ": #{reaction.reactable.title}" %></span>
         <em><%= reaction.created_at&.strftime("%b %e '%y") %></em>
         </a>

--- a/app/views/notifications/shared/_comment_box.html.erb
+++ b/app/views/notifications/shared/_comment_box.html.erb
@@ -27,7 +27,7 @@
             data-reactable-id="<%= json_data["comment"]["id"] %>"
             data-category="vomit"
             data-reactable-type="Comment"
-            title="vomit">
+            title="<%= t("views.reactions.category.vomit") %>">
             <%= crayons_icon_tag("twemoji/suspicious", native: true, class: "reaction-icon", title: "Suspicious") %>
           </button>
         </div>

--- a/config/locales/views/moderations/en.yml
+++ b/config/locales/views/moderations/en.yml
@@ -11,7 +11,7 @@ en:
         subtitle: Rate the quality of this post
         abusive:
           subtitle_html: Flag %{user} as Abusive
-          desc_html: This is the equivalent of vomiting on <b>all</b> of this user's articles and will lower their article scores.
+          desc_html: This is the equivalent of flagging <b>all</b> of this user's articles and will lower their article scores.
         adjust:
           heading: Adjust tags
           subtitle: Add or remove tags

--- a/config/locales/views/moderations/fr.yml
+++ b/config/locales/views/moderations/fr.yml
@@ -11,7 +11,7 @@ fr:
         subtitle: Rate the quality of this post
         abusive:
           subtitle_html: Flag %{user} as Abusive
-          desc_html: This is the equivalent of vomiting on <b>all</b> of this user's articles and will lower their article scores.
+          desc_html: This is the equivalent of flagging <b>all</b> of this user's articles and will lower their article scores.
         adjust:
           heading: Adjust tags
           subtitle: Add or remove tags

--- a/config/locales/views/reactions/en.yml
+++ b/config/locales/views/reactions/en.yml
@@ -10,7 +10,7 @@ en:
         thumbsup: Thumbs up
         thumbsdown: Thumbs down
         unicorn: Unicorn
-        vomit: Vomit
+        vomit: Flag
       summary:
         count_html:
           one: "%{count}%{start}\_reaction%{end}"

--- a/config/locales/views/reactions/fr.yml
+++ b/config/locales/views/reactions/fr.yml
@@ -10,7 +10,7 @@ fr:
         thumbsup: Thumbs up
         thumbsdown: Thumbs down
         unicorn: Unicorn
-        vomit: Vomit
+        vomit: Flag
       summary:
         count_html:
           one: "%{count}%{start}\_réaction%{end}"

--- a/cypress/integration/seededFlows/adminFlows/users/memberToolsSection.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/memberToolsSection.spec.js
@@ -260,7 +260,7 @@ describe('Tools Section', () => {
         cy.findByRole('link', { name: username }).click();
         cy.findByRole('link', { name: /Reactions/ }).click();
 
-        cy.findByRole('link', { name: /vomit\s+user/i }).should('be.visible');
+        cy.findByRole('link', { name: /Flag\s+user/i }).should('be.visible');
       });
     });
   });

--- a/spec/components/admin/users/tools/reactions_component_spec.rb
+++ b/spec/components/admin/users/tools/reactions_component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Admin::Users::Tools::ReactionsComponent, type: :component do
 
       render_inline(described_class.new(user: user))
 
-      expect(rendered_component).to have_text(reaction.category.capitalize)
+      expect(rendered_component).to have_text("Flag")
       expect(rendered_component).to have_text(reaction.reactable_type)
       expect(rendered_component).to have_text(reaction.reactable.title)
     end
@@ -41,7 +41,7 @@ RSpec.describe Admin::Users::Tools::ReactionsComponent, type: :component do
 
       render_inline(described_class.new(user: user))
 
-      expect(rendered_component).to have_text(reaction.category.capitalize)
+      expect(rendered_component).to have_text("Flag")
       expect(rendered_component).to have_text(reaction.reactable_type)
       expect(rendered_component).to have_text(reaction.reactable.title)
     end
@@ -51,7 +51,7 @@ RSpec.describe Admin::Users::Tools::ReactionsComponent, type: :component do
 
       render_inline(described_class.new(user: moderator))
 
-      expect(rendered_component).to have_text(reaction.category.capitalize)
+      expect(rendered_component).to have_text("Flag")
       expect(rendered_component).to have_text(reaction.reactable_type)
     end
   end

--- a/spec/components/admin/users/tools/reactions_component_spec.rb
+++ b/spec/components/admin/users/tools/reactions_component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Admin::Users::Tools::ReactionsComponent, type: :component do
 
       render_inline(described_class.new(user: user))
 
-      expect(rendered_component).to have_text("Flag")
+      expect(rendered_component).to have_text(I18n.t("views.reactions.category.vomit"))
       expect(rendered_component).to have_text(reaction.reactable_type)
       expect(rendered_component).to have_text(reaction.reactable.title)
     end
@@ -41,7 +41,7 @@ RSpec.describe Admin::Users::Tools::ReactionsComponent, type: :component do
 
       render_inline(described_class.new(user: user))
 
-      expect(rendered_component).to have_text("Flag")
+      expect(rendered_component).to have_text(I18n.t("views.reactions.category.vomit"))
       expect(rendered_component).to have_text(reaction.reactable_type)
       expect(rendered_component).to have_text(reaction.reactable.title)
     end
@@ -51,7 +51,7 @@ RSpec.describe Admin::Users::Tools::ReactionsComponent, type: :component do
 
       render_inline(described_class.new(user: moderator))
 
-      expect(rendered_component).to have_text("Flag")
+      expect(rendered_component).to have_text(I18n.t("views.reactions.category.vomit"))
       expect(rendered_component).to have_text(reaction.reactable_type)
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR updates any remaining uses of "vomit" in the UI to "flag". I'm pretty sure I've caught them all here, but the term "vomit" persists in our backend as the category for the reaction. I feel like at some point it would be worth refactoring some of the non-user-facing references to avoid any confusion, but definitely out of scope for this piece of work 🙂 

## Related Tickets & Documents

Fixes https://github.com/forem/forem/issues/15671

## QA Instructions, Screenshots, Recordings

Changes are fairly straightforward, and relate mostly to the admin area. Have a click around and check that the term "vomit" no longer appears.

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: this really just brings remaining odds and ends of terminology in line with previous changes
