### PR TITLE
Place gifs correctly regardless of center tag

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -557,9 +557,6 @@ article {
   --gif-bg: rgb(var(--black));
   --gif-color: rgb(var(--white));
 
-  left: 50%;
-  transform: translateX(-50%);
-
   // Align styles of freezeframed animated images with normal image styles
   canvas {
     border-radius: var(--radius);

--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -557,6 +557,9 @@ article {
   --gif-bg: rgb(var(--black));
   --gif-color: rgb(var(--white));
 
+  left: 50%;
+  transform: translateX(-50%);
+
   // Align styles of freezeframed animated images with normal image styles
   canvas {
     border-radius: var(--radius);
@@ -618,4 +621,10 @@ article {
       display: inline-block;
     }
   }
+}
+
+// When a user has wrapped their gif in a <center> we don't want to manipulate the position
+center .ff-container {
+  left: unset;
+  transform: none;
 }

--- a/app/javascript/utilities/animatedImageUtils.jsx
+++ b/app/javascript/utilities/animatedImageUtils.jsx
@@ -18,7 +18,11 @@ export const initializePausableAnimatedImages = (animatedImages = []) => {
 
     // Remove the surrounding links for the image, so it can be clicked to play/pause
     for (const image of animatedImages) {
-      image.closest('a').outerHTML = image.outerHTML;
+      // Our markdown parser allows use of the <center> element in posts, which could conflict with CSS we apply to center the freezframe container
+      // Centering in this way makes sure the position is correct regardless of whether the user has used their own <center> tag
+      const center = document.createElement('center');
+      center.innerHTML = image.outerHTML;
+      image.closest('a').outerHTML = center.outerHTML;
 
       freezeframes.push(
         new Freezeframe({

--- a/app/javascript/utilities/animatedImageUtils.jsx
+++ b/app/javascript/utilities/animatedImageUtils.jsx
@@ -21,13 +21,8 @@ export const initializePausableAnimatedImages = (animatedImages = []) => {
       // Give the image an ID so that we can uniquely target it in freezeframe
       image.setAttribute('id', `animated-${i}`);
 
-      // Our markdown parser allows use of the <center> element in posts, which could conflict with CSS we apply to center the freezeframe container
-      // Centering in this way makes sure the position is correct regardless of whether the user has used their own <center> tag
-      const center = document.createElement('center');
-      center.innerHTML = image.outerHTML;
-
       // Remove the surrounding links for the image, so it can be clicked to play/pause
-      image.closest('a').outerHTML = center.outerHTML;
+      image.closest('a').outerHTML = image.outerHTML;
 
       freezeframes.push(
         new Freezeframe({

--- a/app/javascript/utilities/animatedImageUtils.jsx
+++ b/app/javascript/utilities/animatedImageUtils.jsx
@@ -16,17 +16,22 @@ export const initializePausableAnimatedImages = (animatedImages = []) => {
   if (animatedImages.length > 0) {
     const freezeframes = [];
 
-    // Remove the surrounding links for the image, so it can be clicked to play/pause
-    for (const image of animatedImages) {
+    for (let i = 0; i < animatedImages.length; i++) {
+      const image = animatedImages[i];
+      // Give the image an ID so that we can uniquely target it in freezeframe
+      image.setAttribute('id', `animated-${i}`);
+
       // Our markdown parser allows use of the <center> element in posts, which could conflict with CSS we apply to center the freezeframe container
       // Centering in this way makes sure the position is correct regardless of whether the user has used their own <center> tag
       const center = document.createElement('center');
       center.innerHTML = image.outerHTML;
+
+      // Remove the surrounding links for the image, so it can be clicked to play/pause
       image.closest('a').outerHTML = center.outerHTML;
 
       freezeframes.push(
         new Freezeframe({
-          selector: `img[src="${image.getAttribute('src')}"]`,
+          selector: `img[id='animated-${i}']`,
           responsive: false,
           trigger: 'click',
         }),

--- a/app/javascript/utilities/animatedImageUtils.jsx
+++ b/app/javascript/utilities/animatedImageUtils.jsx
@@ -18,7 +18,7 @@ export const initializePausableAnimatedImages = (animatedImages = []) => {
 
     // Remove the surrounding links for the image, so it can be clicked to play/pause
     for (const image of animatedImages) {
-      // Our markdown parser allows use of the <center> element in posts, which could conflict with CSS we apply to center the freezframe container
+      // Our markdown parser allows use of the <center> element in posts, which could conflict with CSS we apply to center the freezeframe container
       // Centering in this way makes sure the position is correct regardless of whether the user has used their own <center> tag
       const center = document.createElement('center');
       center.innerHTML = image.outerHTML;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

To follow up on the deploy of https://github.com/forem/forem/pull/16314, I checked in on @nickytonline's DEV posts as I know he uses gifs a lot 😄 

I noticed they were all aligning strangely to the right, and the cause of this was a `<center>` tag surrounding the gif not playing nicely with the CSS I used to center the freezeframe container.

Since we allow use of the `<center>` tag in posts, it makes sense to update the code to ensure gifs are positioned correctly regardless of whether a `<center>` tag has been used or not. 

This is the "before":

![Nick's post with a gif aligned to the right of the page](https://user-images.githubusercontent.com/20773163/152328045-4409770e-2de6-44c1-83b6-b268b48a4838.png)


## Related Tickets & Documents

https://github.com/forem/forem/pull/16314

## QA Instructions, Screenshots, Recordings

- Make sure you have the feature flag enabled: `FeatureFlag.enable(:detect_animated_images)`
- Try creating one post without a `center` tag, e.g.:

```
some text

![some alt](https://i.giphy.com/media/ojmB7lOn3VUU8/giphy.gif)
```


- And one with a `center` tag, e.g.:

```
some text

<center>

![some alt](https://i.giphy.com/media/ojmB7lOn3VUU8/giphy.gif)</center>
```

- In each case publish the post, then refresh the page (the animated images are detected async, so a refresh will be needed)
- Both gifs should be aligned properly in the middle


https://user-images.githubusercontent.com/20773163/152328351-5fa7b205-8565-464a-9915-fd009984a636.mp4


### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: this one is purely visual placement
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: we haven't yet shared the feature


