### PR TITLE
Fix flake in top tags test

### DIFF
--- a/cypress/integration/seededFlows/publishingFlows/addTagsToArticle.spec.js
+++ b/cypress/integration/seededFlows/publishingFlows/addTagsToArticle.spec.js
@@ -39,7 +39,13 @@ describe('Add tags to article', () => {
   });
 
   it('automatically suggests top tags when field is focused', () => {
-    cy.findByRole('textbox', { name: 'Add up to 4 tags' }).focus();
+    // It is possible in slow running tests that the fetched "top tags" will not be available in the autocomplete before the focus event triggered below.
+    // Here we retry the focus event until the combobox expands.
+    const focusInputAndGetParentCombobox = ($el) =>
+      $el.focus().blur().focus().parents('div');
+    cy.findByRole('textbox', { name: 'Add up to 4 tags' })
+      .pipe(focusInputAndGetParentCombobox)
+      .should('have.attr', 'aria-expanded', 'true');
 
     cy.findByRole('heading', { name: 'Top tags' }).should('exist');
     cy.findByRole('option', { name: '# tagone' }).should('exist');


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed this spec was occasionally flaking in CI - I was able to reproduce it locally by throttling my network connection while the test was running... it's a bit strange because the test _does_ wait for the "top tags" to be fetched before checking they appear in the DOM, but it seems even so, it runs that little bit too fast and when the input is focused, the top tags haven't yet reached the autocomplete component via props.

It's not ideal, but it seems like the perfect use case for `cy.pipe`, so we now retry the focus event until the menu expands (there's still a default timeout on the assertion, so if it doesn't pass in a reasonable time frame we'll still get the test failure).

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Just make sure the build goes green 😄 

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


