### PR TITLE
Scoping the :listing routes to feature

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,12 @@ Rails.application.routes.draw do
     get "/locale/:locale", to: "stories#index"
 
     draw :admin
-    draw :listing
+
+    # The lambda (e.g. `->`) allows for dynamic checking.  In other words we check with each
+    # request.
+    constraints(->(_req) { Listing.feature_enabled? }) do
+      draw :listing
+    end
 
     namespace :stories, defaults: { format: "json" } do
       resource :feed, only: [:show] do

--- a/spec/routing/all_routes_spec.rb
+++ b/spec/routing/all_routes_spec.rb
@@ -10,6 +10,22 @@ RSpec.describe "all routes", type: :routing do
     end
   end
 
+  describe "/listings" do
+    subject(:a_request) { { get: "/listings" } }
+
+    context "when enabled" do
+      before { allow(Listing).to receive(:feature_enabled?).and_return(true) }
+
+      it { is_expected.to route_to(controller: "listings", action: "index", locale: nil) }
+    end
+
+    context "when disabled" do
+      before { allow(Listing).to receive(:feature_enabled?).and_return(false) }
+
+      it { is_expected.not_to route_to(controller: "listings", action: "index", locale: nil) }
+    end
+  end
+
   it "renders a podcast index if there is a podcast with the slug successfully" do
     expect(get: "/#{podcast.slug}").to route_to(
       controller: "stories",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

This commit builds on the conditional rendering of navigation links by
adding a routing constraint to all :listing routes.

The impact is, if we were to disable the listing feature (e.g.,
`FeatureFlag.disable(:listing_feature_enabled)`) all requests to `GET
/listings` (and those drawn in the [config/routes/listings.rb][1] file)
would return a 404 response.


This commit is intended to be the penultimate change before we toggle
the listings section off by default.

[1]:https://github.com/forem/forem/blob/c2ce2c32d5bf768673a3b150642c125d97b462ef/config/routes/listing.rb#L1

## Related Tickets & Documents

Related to forem/rfcs#291, #16335, #16338, #16362.
## QA Instructions, Screenshots, Recordings

Testing this change:

1. Start your local application (e.g. `$ bin/startup`)
2. Go to http://localhost:3000/listings
3. You should get a Successful response.
4. Now disable the feature (e.g. `$ bin/rails r \
   "FeatureFlag.disable(:listing_feature_enabled)"`)
5. Refresh http://localhost:3000/listings
6. You should get an `ActiveRecord::RecordNotFound` error; because the
   application is now looking for a user or org named "listings"; in other
   words we're not routing `GET "/listings"` to `listings#index` controller
   action.
7. Now enable the feature (e.g. `$ bin/rails r \
   "FeatureFlag.enable(:listing_feature_enabled)"`)
8. Refresh http://localhost:3000/listings
9. You should get a Successful response.
10. Goto 4

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [X] This change does not need to be communicated, and this is why not:  It's a non-breaking change.
