### PR TITLE
A suspended user returns 403 instead of 500

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,8 +131,11 @@ class ApplicationController < ActionController::Base
     onboarding_path
   end
 
-  def raise_suspended
-    raise SuspendedError if current_user&.suspended?
+  def check_suspended
+    return unless current_user&.suspended?
+
+    response.status = :forbidden
+    render "pages/forbidden"
   end
 
   def internal_navigation?

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,7 +3,7 @@ class ArticlesController < ApplicationController
 
   before_action :authenticate_user!, except: %i[feed new]
   before_action :set_article, only: %i[edit manage update destroy stats admin_unpublish]
-  before_action :raise_suspended, only: %i[new create update]
+  before_action :check_suspended, only: %i[new create update]
   before_action :set_cache_control_headers, only: %i[feed]
   after_action :verify_authorized
 

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -29,7 +29,7 @@ class ListingsController < ApplicationController
   # rubocop:disable Rails/LexicallyScopedActionFilter
   before_action :set_listing, only: %i[edit update destroy]
   before_action :set_cache_control_headers, only: %i[index]
-  before_action :raise_suspended, only: %i[new create update]
+  before_action :check_suspended, only: %i[new create update]
   before_action :authenticate_user!, only: %i[edit update new dashboard]
   after_action :verify_authorized, only: %i[edit update]
   # rubocop:enable Rails/LexicallyScopedActionFilter

--- a/app/controllers/users/notification_settings_controller.rb
+++ b/app/controllers/users/notification_settings_controller.rb
@@ -1,6 +1,6 @@
 module Users
   class NotificationSettingsController < ApplicationController
-    before_action :raise_suspended
+    before_action :check_suspended
     before_action :authenticate_user!
     after_action :verify_authorized
 

--- a/app/controllers/users/settings_controller.rb
+++ b/app/controllers/users/settings_controller.rb
@@ -1,6 +1,6 @@
 module Users
   class SettingsController < ApplicationController
-    before_action :raise_suspended
+    before_action :check_suspended
     before_action :authenticate_user!
     after_action :verify_authorized
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_no_cache_header
-  before_action :raise_suspended, only: %i[update update_password]
+  before_action :check_suspended, only: %i[update update_password]
   before_action :set_user,
                 only: %i[update update_password request_destroy full_delete remove_identity]
   # rubocop:disable Layout/LineLength

--- a/app/errors/suspended_error.rb
+++ b/app/errors/suspended_error.rb
@@ -1,1 +1,0 @@
-class SuspendedError < StandardError; end

--- a/app/views/pages/forbidden.html.erb
+++ b/app/views/pages/forbidden.html.erb
@@ -1,0 +1,8 @@
+<h2>Forbidden</h2>
+
+<p>
+  Your account has been suspended and has limited access.
+  Your ability to post and comment may be limited.
+</p>
+
+<p>For more information, you may send a message to <%= ForemInstance.email %>.</p>

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -4,7 +4,6 @@
 # rubocop:disable Metrics/BlockLength
 Rails.application.reloader.to_prepare do
   message_fingerprints = {
-    "SuspendedError" => "banned",
     "Rack::Timeout::RequestTimeoutException" => "rack_timeout",
     "Rack::Timeout::RequestTimeoutError" => "rack_timeout",
     "PG::QueryCanceled" => "pg_query_canceled"

--- a/spec/initializers/honeybadger_spec.rb
+++ b/spec/initializers/honeybadger_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 describe Honeybadger do
   {
-    "SuspendedError" => "banned",
     "Rack::Timeout::RequestTimeoutException" => "rack_timeout",
     "Rack::Timeout::RequestTimeoutError" => "rack_timeout",
     "PG::QueryCanceled" => "pg_query_canceled"

--- a/spec/requests/listings_spec.rb
+++ b/spec/requests/listings_spec.rb
@@ -333,9 +333,10 @@ RSpec.describe "/listings", type: :request do
     context "when user is suspended" do
       it "raises error" do
         user.add_role(:suspended)
-        expect do
-          post "/listings", params: listing_params
-        end.to raise_error(SuspendedError)
+
+        post "/listings", params: listing_params
+
+        expect(response).to have_http_status :forbidden
       end
     end
 

--- a/spec/system/banned_user_interactions_spec.rb
+++ b/spec/system/banned_user_interactions_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe "Suspended user", type: :system do
 
   it "tries to create an article" do
     sign_in suspended_user
-    expect { visit "/new" }.to raise_error(SuspendedError)
+
+    visit "/new"
+
+    expect(page.status_code).to eq 403
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently, a suspended user requesting certain pages will receive a 500 instead of a 403. This reduces the usefulness of aggregated data about site reliability. If it looks like we're getting 500s all over the place, it makes it so we can't really trust some of our dashboards and burns through SLOs faster than we would like.

Here's a sample of what our error logs look like:

<img width="622" alt="Screenshot from Datadog with a list of request errors. Every single error is SuspendedError." src="https://user-images.githubusercontent.com/108205/152397540-eef8611c-eb2f-442c-9291-094f01074230.png">

The `SuspendedError` eclipses all other request errors _combined_. And since it's a 500, we can't (and shouldn't need to) filter it out. The purpose of this PR is to make this request failure a proper 4xx response. We aren't failing to handle it, but rather choosing not to based on client identity, so a 5xx is inappropriate.

## QA Instructions, Screenshots, Recordings

- Create a banned user account
  - In the Rails console, paste this code to create a suspended user you can login with. It will return that user's email you can login with (the password will be `password`):
    ```ruby
    require 'factory_bot_rails'
    FactoryBot.create(:user, :suspended, password: 'password', password_confirmation: 'password').email
    ```
  - If this fails because you've created users in development via FactoryBot before, run it a few more times until it stops failing. Our model factories are intended for specs and will reset their internal counters every time the app starts.
    - You can also reset your DB or add the `:suspended` role to one of your existing users. Nothing prescriptive here, you really just need to be able to login as a suspended user.
- Login as that suspended user
- Click the "Create post" button
- You should see this: <img width="946" alt="Forbidden page, the page body reads: Forbidden. Your account has been suspended and has limited access. Your ability to post and comment may be limited. 
For more information, you may send a message to yo@dev.to." src="https://user-images.githubusercontent.com/108205/152395018-5c31ff73-f540-4f87-b57e-a96f35290165.png">

### UI accessibility concerns?

I don't know about a11y but will definitely need a designer's touch.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_