### PR TITLE
Feature flag improvements

### DIFF
--- a/app/models/admin_menu.rb
+++ b/app/models/admin_menu.rb
@@ -1,3 +1,6 @@
+# May Cthulhu help us all
+require_dependency "../services/feature_flag"
+
 # This "model" is not backed by the database. Its main purpose is to
 # setup and provide methods to interact with the admin sidebar and tabbed menu
 class AdminMenu
@@ -5,7 +8,7 @@ class AdminMenu
   # rubocop:disable Metrics/BlockLength
   FEATURE_FLAGS = [
     FeatureFlag::PROFILE_ADMIN,
-    FeatureFlag::DATA_UPDATE_SCRIPTS,
+    FeatureFlag::FLAG_DATA_UPDATE_SCRIPTS,
   ].freeze
 
   ITEMS = Menu.define do

--- a/app/models/admin_menu.rb
+++ b/app/models/admin_menu.rb
@@ -8,7 +8,7 @@ class AdminMenu
   # rubocop:disable Metrics/BlockLength
   FEATURE_FLAGS = [
     FeatureFlag::PROFILE_ADMIN,
-    FeatureFlag::FLAG_DATA_UPDATE_SCRIPTS,
+    FeatureFlag::DATA_UPDATE_SCRIPTS,
   ].freeze
 
   ITEMS = Menu.define do

--- a/app/models/admin_menu.rb
+++ b/app/models/admin_menu.rb
@@ -1,15 +1,9 @@
-# May Cthulhu help us all
-require_dependency "../services/feature_flag"
-
 # This "model" is not backed by the database. Its main purpose is to
 # setup and provide methods to interact with the admin sidebar and tabbed menu
 class AdminMenu
   # On second level navigation with more children, we reference the default tabs controller. i.e look at developer_tools
   # rubocop:disable Metrics/BlockLength
-  FEATURE_FLAGS = [
-    FeatureFlag::PROFILE_ADMIN,
-    FeatureFlag::DATA_UPDATE_SCRIPTS,
-  ].freeze
+  FEATURE_FLAGS = %i[profile_admin_enabled? data_update_scripts_enabled?].freeze
 
   ITEMS = Menu.define do
     scope :people, "group-2-line", [
@@ -69,7 +63,7 @@ class AdminMenu
   # rubocop:enable Metrics/BlockLength
 
   def self.navigation_items
-    return ITEMS unless FEATURE_FLAGS.any? { |flag| FeatureFlag.enabled?(flag) }
+    return ITEMS unless FEATURE_FLAGS.any? { |check| FeatureFlag.public_send(check) }
 
     feature_flagged_menu_items
   end

--- a/app/models/admin_menu.rb
+++ b/app/models/admin_menu.rb
@@ -3,7 +3,10 @@
 class AdminMenu
   # On second level navigation with more children, we reference the default tabs controller. i.e look at developer_tools
   # rubocop:disable Metrics/BlockLength
-  FEATURE_FLAGS = %i[profile_admin data_update_scripts].freeze
+  FEATURE_FLAGS = [
+    FeatureFlag::PROFILE_ADMIN,
+    FeatureFlag::DATA_UPDATE_SCRIPTS,
+  ].freeze
 
   ITEMS = Menu.define do
     scope :people, "group-2-line", [
@@ -93,12 +96,12 @@ class AdminMenu
     # turned on, instead of creating the payload dynamically each time.
     menu_items = ITEMS.deep_dup
 
-    if FeatureFlag.enabled?(:profile_admin)
+    if FeatureFlag.profile_admin_enabled?
       profile_hash = menu_items.dig(:customization, :children).detect { |item| item[:controller] == "profile_fields" }
       profile_hash[:visible] = true
     end
 
-    if FeatureFlag.enabled?(:data_update_scripts)
+    if FeatureFlag.data_update_scripts_enabled?
       data_update_script_hash = menu_items.dig(:advanced, :children)
         .detect { |item| item[:controller] ==  "tools" }[:children]
         .detect { |item| item[:controller] ==  "data_update_scripts" }

--- a/config/application.rb
+++ b/config/application.rb
@@ -85,7 +85,6 @@ module PracticalDeveloper
       flag_config = YAML.load_file(Rails.root.join("config/feature_flags.yml"))
 
       flag_config["feature_flags"].each do |flag|
-        FeatureFlag.const_set(flag.underscore.upcase, flag)
         FeatureFlag.define_singleton_method("#{flag}_enabled?") do
           FeatureFlag.enabled?(flag)
         end

--- a/config/application.rb
+++ b/config/application.rb
@@ -67,9 +67,8 @@ module PracticalDeveloper
     # Globally handle Pundit::NotAuthorizedError by serving 404
     config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :not_found
 
-    # After-initialize checker to add routes to reserved words
     config.after_initialize do
-      # Add routes to reserved words
+      # Add routes for reserved words
       Rails.application.reload_routes!
       top_routes = []
       Rails.application.routes.routes.each do |route|
@@ -81,10 +80,8 @@ module PracticalDeveloper
         top_routes << route
       end
       ReservedWords.all = [ReservedWords::BASE_WORDS + top_routes].flatten.compact.uniq
-    end
 
-    # Define predicate methods for all feature flags to avoid typos on strings/symbols
-    config.after_initialize do
+      # Define predicate methods for all feature flags to avoid typos on strings/symbols
       flag_config = YAML.load_file(Rails.root.join("config/feature_flags.yml"))
 
       flag_config["feature_flags"].each do |flag|

--- a/config/application.rb
+++ b/config/application.rb
@@ -83,12 +83,15 @@ module PracticalDeveloper
       ReservedWords.all = [ReservedWords::BASE_WORDS + top_routes].flatten.compact.uniq
     end
 
-    # Add class methods for all feature flags to avoid typos on strings/symbols
+    # Define predicate methods for all feature flags to avoid typos on strings/symbols
     config.after_initialize do
       flag_config = YAML.load_file(Rails.root.join("config/feature_flags.yml"))
 
       flag_config["feature_flags"].each do |flag|
-        FeatureFlag.define_singleton_method(flag) { flag }
+        FeatureFlag.const_set("FLAG_#{flag.underscore.upcase}", flag)
+        FeatureFlag.define_singleton_method("#{flag}_enabled?") do
+          FeatureFlag.enabled?(flag)
+        end
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,7 +88,7 @@ module PracticalDeveloper
       flag_config = YAML.load_file(Rails.root.join("config/feature_flags.yml"))
 
       flag_config["feature_flags"].each do |flag|
-        FeatureFlag.const_set("FLAG_#{flag.underscore.upcase}", flag)
+        FeatureFlag.const_set(flag.underscore.upcase, flag)
         FeatureFlag.define_singleton_method("#{flag}_enabled?") do
           FeatureFlag.enabled?(flag)
         end

--- a/config/application.rb
+++ b/config/application.rb
@@ -82,5 +82,14 @@ module PracticalDeveloper
       end
       ReservedWords.all = [ReservedWords::BASE_WORDS + top_routes].flatten.compact.uniq
     end
+
+    # Add class methods for all feature flags to avoid typos on strings/symbols
+    config.after_initialize do
+      flag_config = YAML.load_file(Rails.root.join("config/feature_flags.yml"))
+
+      flag_config["feature_flags"].each do |flag|
+        FeatureFlag.define_singleton_method(flag) { flag }
+      end
+    end
   end
 end

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,0 +1,2 @@
+feature_flags:
+  - creator_onboarding

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,2 +1,3 @@
 feature_flags:
-  - creator_onboarding
+  - profile_admin
+  - data_update_scripts

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -13,6 +13,7 @@ end
 # Ignoring folders that don't adhere to the new naming conventions
 Rails.autoloaders.main.ignore(Rails.root.join("lib/data_update_scripts"))
 Rails.autoloaders.main.ignore(Rails.root.join("lib/generators/data_update"))
+Rails.autoloaders.main.ignore(Rails.root.join("lib/generators/feature_flag"))
 Rails.autoloaders.main.ignore(Rails.root.join("lib/generators/service"))
 Rails.autoloaders.main.ignore(Rails.root.join("lib/generators/settings_model"))
 Rails.autoloaders.main.ignore(Rails.root.join("lib/cypress-rails"))

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -112,7 +112,7 @@ namespace :admin do
 
     # NOTE: @citizen428 The next two resources have a temporary constraint
     # while profile generalization is still WIP
-    constraints(->(_request) { FeatureFlag.enabled?(:profile_admin) }) do
+    constraints(->(_request) { FeatureFlag.profile_admin_enabled? }) do
       resources :profile_field_groups, only: %i[update create destroy]
       resources :profile_fields, only: %i[index update create destroy]
     end
@@ -145,7 +145,7 @@ namespace :admin do
     end
 
     # We do not expose the Data Update Scripts to all Forems by default.
-    constraints(->(_request) { FeatureFlag.enabled?(:data_update_scripts) }) do
+    constraints(->(_request) { FeatureFlag.data_update_scripts_enabled? }) do
       resources :data_update_scripts, only: %i[index show] do
         member do
           post :force_run

--- a/lib/generators/feature_flag/USAGE
+++ b/lib/generators/feature_flag/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Explain the generator
+
+Example:
+    bin/rails generate feature_flag Thing
+
+    This will create:
+        what/will/it/create

--- a/lib/generators/feature_flag/USAGE
+++ b/lib/generators/feature_flag/USAGE
@@ -2,7 +2,9 @@ Description:
     Explain the generator
 
 Example:
-    bin/rails generate feature_flag Thing
+    bin/rails generate feature_flag the_flag_name
+
+    This will add the_flag_name as last item to config/feature_flags.yml
 
     This will create:
-        what/will/it/create
+	lib/data_update_scripts/<TIMESTAMP>_add_the_flag_name_flag.rb

--- a/lib/generators/feature_flag/feature_flag_generator.rb
+++ b/lib/generators/feature_flag/feature_flag_generator.rb
@@ -1,0 +1,17 @@
+class FeatureFlagGenerator < Rails::Generators::NamedBase
+  REPLACEMENT_REGEX = /(def run).*?(end.*)\z/m
+
+  def create_feature_flag_config
+    append_file "config/feature_flags.yml", %(  - #{file_name}\n)
+  end
+
+  def create_dus
+    script_name = "add_#{file_name}_feature_flag"
+    generate "data_update", script_name, "--no-spec"
+    file = Dir.glob("lib/data_update_scripts/*#{script_name}.rb").first
+    raise "Can't find DataUpdateScript" unless file
+
+    replacement = "\\1\n      FeatureFlag.add(:#{file_name})\n    \\2"
+    gsub_file file, REPLACEMENT_REGEX, replacement
+  end
+end

--- a/lib/generators/feature_flag/feature_flag_generator.rb
+++ b/lib/generators/feature_flag/feature_flag_generator.rb
@@ -1,5 +1,5 @@
 class FeatureFlagGenerator < Rails::Generators::NamedBase
-  REPLACEMENT_REGEX = /(def run).*?(end.*)\z/m
+  REPLACEMENT_REGEX = /(def run).*?(end)/m
 
   def create_feature_flag_config
     append_file "config/feature_flags.yml", %(  - #{file_name}\n)

--- a/spec/generator/feature_flags_generator_spec.rb
+++ b/spec/generator/feature_flags_generator_spec.rb
@@ -1,5 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "FeatureFlags", type: :generator do
-  pending "add some scenarios (or delete) #{__FILE__}"
-end

--- a/spec/generator/feature_flags_generator_spec.rb
+++ b/spec/generator/feature_flags_generator_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe "FeatureFlags", type: :generator do
+  pending "add some scenarios (or delete) #{__FILE__}"
+end

--- a/spec/generator/services_generator_spec.rb
+++ b/spec/generator/services_generator_spec.rb
@@ -1,5 +1,0 @@
-require "rails_helper"
-
-RSpec.describe "Services", type: :generator do
-  pending "add some scenarios (or delete) #{__FILE__}"
-end

--- a/spec/models/profile_field_group_spec.rb
+++ b/spec/models/profile_field_group_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ProfileFieldGroup, type: :model do
   subject { group }
 
   before do
-    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
+    allow(FeatureFlag).to receive(:profile_admin_enabled?).and_return(true)
   end
 
   let!(:group) { create(:profile_field_group) }

--- a/spec/requests/admin/data_update_scripts_spec.rb
+++ b/spec/requests/admin/data_update_scripts_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "/admin/advanced/data_update_scripts", type: :request do
     before do
       sign_in user
       allow(Flipper).to receive(:enabled?).and_call_original
-      allow(Flipper).to receive(:enabled?).with(:data_update_scripts).and_return(true)
+      allow(Flipper).to receive(:data_update_scripts_enabled?).and_return(true)
     end
 
     describe "GET /admin/advanced/data_update_scripts" do
@@ -25,7 +25,7 @@ RSpec.describe "/admin/advanced/data_update_scripts", type: :request do
     before do
       sign_in user
       allow(Flipper).to receive(:enabled?).and_call_original
-      allow(Flipper).to receive(:enabled?).with(:data_update_scripts).and_return(true)
+      allow(Flipper).to receive(:data_update_scripts_enabled?).and_return(true)
     end
 
     describe "GET /admin/advanced/data_update_scripts" do

--- a/spec/requests/admin/data_update_scripts_spec.rb
+++ b/spec/requests/admin/data_update_scripts_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe "/admin/advanced/data_update_scripts", type: :request do
 
     before do
       sign_in user
-      allow(Flipper).to receive(:enabled?).and_call_original
-      allow(Flipper).to receive(:data_update_scripts_enabled?).and_return(true)
+      allow(FeatureFlag).to receive(:data_update_scripts_enabled?).and_return(true)
     end
 
     describe "GET /admin/advanced/data_update_scripts" do
@@ -24,8 +23,7 @@ RSpec.describe "/admin/advanced/data_update_scripts", type: :request do
 
     before do
       sign_in user
-      allow(Flipper).to receive(:enabled?).and_call_original
-      allow(Flipper).to receive(:data_update_scripts_enabled?).and_return(true)
+      allow(FeatureFlag).to receive(:data_update_scripts_enabled?).and_return(true)
     end
 
     describe "GET /admin/advanced/data_update_scripts" do

--- a/spec/requests/admin/nested_sidebar_spec.rb
+++ b/spec/requests/admin/nested_sidebar_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "admin sidebar", type: :request do
 
   before do
     sign_in super_admin
-    allow(FeatureFlag).to receive(:enabled?).and_call_original
   end
 
   describe "sidebar menu options" do
@@ -28,7 +27,7 @@ RSpec.describe "admin sidebar", type: :request do
 
   describe "profile admin feature flag" do
     it "does not show the option in the sidebar when the feature flag is disabled" do
-      allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(false)
+      allow(FeatureFlag).to receive(:profile_admin_enabled?).and_return(false)
 
       get admin_articles_path
 
@@ -36,7 +35,7 @@ RSpec.describe "admin sidebar", type: :request do
     end
 
     it "shows the option in the sidebar when the feature flag is enabled" do
-      allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
+      allow(FeatureFlag).to receive(:enabled?).with(FeatureFlag::PROFILE_ADMIN).and_return(true)
 
       get admin_articles_path
 
@@ -46,7 +45,7 @@ RSpec.describe "admin sidebar", type: :request do
 
   describe "data update script admin feature flag" do
     it "does not show the option in the tabbed header when the feature flag is disabled" do
-      allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(false)
+      allow(FeatureFlag).to receive(:data_update_scripts_enabled?).and_return(false)
 
       get admin_tools_path
 
@@ -54,7 +53,7 @@ RSpec.describe "admin sidebar", type: :request do
     end
 
     it "shows the option in the tabbed header when the feature flag is enabled" do
-      allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(true)
+      allow(FeatureFlag).to receive(:enabled?).with(FeatureFlag::DATA_UPDATE_SCRIPTS).and_return(true)
 
       get admin_tools_path
 

--- a/spec/requests/admin/nested_sidebar_spec.rb
+++ b/spec/requests/admin/nested_sidebar_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "admin sidebar", type: :request do
     end
 
     it "shows the option in the sidebar when the feature flag is enabled" do
-      allow(FeatureFlag).to receive(:enabled?).with(FeatureFlag::PROFILE_ADMIN).and_return(true)
+      allow(FeatureFlag).to receive(:profile_admin_enabled?).and_return(true)
 
       get admin_articles_path
 
@@ -53,7 +53,7 @@ RSpec.describe "admin sidebar", type: :request do
     end
 
     it "shows the option in the tabbed header when the feature flag is enabled" do
-      allow(FeatureFlag).to receive(:enabled?).with(FeatureFlag::DATA_UPDATE_SCRIPTS).and_return(true)
+      allow(FeatureFlag).to receive(:data_update_scripts_enabled?).and_return(true)
 
       get admin_tools_path
 

--- a/spec/requests/admin/profile_field_groups_spec.rb
+++ b/spec/requests/admin/profile_field_groups_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "/admin/customization/profile_field_groups", type: :request do
 
   before do
     sign_in admin
-    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
+    allow(FeatureFlag).to receive(:profile_admin_enabled?).and_return(true)
   end
 
   describe "POST /admin/customization/profile_field_groups" do

--- a/spec/requests/admin/profile_fields_spec.rb
+++ b/spec/requests/admin/profile_fields_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "/admin/customization/profile_fields", type: :request do
   before do
     sign_in admin
     allow(FeatureFlag).to receive(:enabled?).and_call_original
-    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
+    allow(FeatureFlag).to receive(:profile_admin_enabled?).and_return(true)
   end
 
   describe "GET /admin/customization/profile_fields" do

--- a/spec/routing/data_update_scripts_admin_routes_spec.rb
+++ b/spec/routing/data_update_scripts_admin_routes_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Data Update Scripts admin routes", type: :routing do
   it "renders the data update scripts admin route if the feature flag is enabled" do
-    allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(true)
+    allow(FeatureFlag).to receive(:data_update_scripts_enabled?).and_return(true)
 
     expect(get: admin_data_update_scripts_path).to route_to(
       controller: "admin/data_update_scripts",
@@ -12,7 +12,7 @@ RSpec.describe "Data Update Scripts admin routes", type: :routing do
   end
 
   it "does not render the data update scripts admin route if the feature flag is disabled" do
-    allow(FeatureFlag).to receive(:enabled?).with(:data_update_scripts).and_return(false)
+    allow(FeatureFlag).to receive(:data_update_scripts_enabled?).and_return(false)
 
     expect(get: admin_data_update_scripts_path).not_to route_to(
       controller: "admin/data_update_scripts",

--- a/spec/routing/profile_admin_routes_spec.rb
+++ b/spec/routing/profile_admin_routes_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Profile admin routes", type: :routing do
   it "renders the profile admin route if the feature flag is enabled" do
-    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
+    allow(FeatureFlag).to receive(:profile_admin_enabled?).and_return(true)
 
     expect(get: admin_profile_fields_path).to route_to(
       controller: "admin/profile_fields",
@@ -12,7 +12,7 @@ RSpec.describe "Profile admin routes", type: :routing do
   end
 
   it "does not render the profile admin route if the feature flag is disabled" do
-    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(false)
+    allow(FeatureFlag).to receive(:profile_admin_enabled?).and_return(false)
 
     expect(get: admin_profile_fields_path).not_to route_to(
       controller: "admin/profile_fields",

--- a/spec/system/admin/admin_manages_profile_fields_spec.rb
+++ b/spec/system/admin/admin_manages_profile_fields_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Admin manages profile fields", type: :system do
     create(:profile_field, profile_field_group: profile_field_group, label: label)
     Profile.refresh_attributes!
     allow(FeatureFlag).to receive(:enabled?).and_call_original
-    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
+    allow(FeatureFlag).to receive(:profile_admin_enabled?).and_return(true)
 
     sign_in admin
     visit admin_profile_fields_path

--- a/spec/system/user/user_edits_profile_spec.rb
+++ b/spec/system/user/user_edits_profile_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "User edits their profile", type: :system do
 
   describe "editing admin created profile fields" do
     before do
-      allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(true)
+      allow(FeatureFlag).to receive(:profile_admin_enabled?).and_return(true)
       Profile.refresh_attributes!
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature

## Description

**The good**

* We use feature flags 🎉 

**The bad**

* Creating a feature flag involves manual work, like creating a data update script (DUS) which calls `FeatuerFlag.add(...)`.
* There's no place in the codebase where one can see all feature flags, only the Flipper web UI or a DB query.

**The ugly**

* Method calls like `FeatureFlag.add`, `FeatureFlag.enabled?`, etc. work with strings or symbols, so it's easy for typos to sneak in.

**Proposed solution in this PR**

* A new config file (`config/feature_flags.yml`) that lists all available feature flags (so far I added just one for demo purposes). This is the canonical list of all feature flags used in the app. This does NOT need to be manually managed.
* A new generator. Calling `rails generate feature_flag test` will do the following:
    1. It appends a line with the new flag to the YAML list in `config/feature_flags.yml`.
    2. It creates the DUS for adding the feature flag automatically. To avoid duplication of effort this re-uses the existing DUS generator.
* A new block in `application.rb`'s `after_intialize` section that define a predicate method for each new feature flag, e.g. `FeatuereFlag.profile_admin_enabled?`. It also defines a constant (e.g. `FeatureFlag::FLAG_PROFILE_ADMIN`) which can be used wherever the actual flag name as string is required.

Here's the generator in action:

```
❯ rails generate feature_flag test
      append  config/feature_flags.yml
    generate  data_update
       rails  generate data_update add_test_feature_flag --no-spec
      create  lib/data_update_scripts/20220204061126_add_test_feature_flag.rb
        gsub  lib/data_update_scripts/20220204061126_add_test_feature_flag.rb
``` 

And the generated DUS:

```ruby
module DataUpdateScripts
  class AddTestFeatureFlag
    def run
      FeatureFlag.add(:test)
    end
  end
end
```

To illustrate how the changes affect the codebase I updated code related to the `profile_admin` and `data_update_scripts` flags to make use of the constants and predicate methods.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

I mostly QA'd this manually, i.e.run the generator and look at the generated/modified artifacts.

### UI accessibility concerns?

No UI changes

## Added/updated tests?

- [X] No, and this is why: we don't generally test our custom generators. Maybe this should change at one point but I'd like to keep that for a future PR.

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams

## [optional] What gif best describes this PR or how it makes you feel?

![fun with flags](https://user-images.githubusercontent.com/47985/152928763-420438ac-2ca4-4aed-8291-6411ef976712.png)
