### PR TITLE
Implement Unified Embeds for Github Repo, Issue, Pull-Request and Comment URLs

### DIFF
--- a/app/liquid_tags/github_tag.rb
+++ b/app/liquid_tags/github_tag.rb
@@ -1,5 +1,5 @@
 class GithubTag < LiquidTagBase
-  REGISTRY_REGEXP = %r{https://github.com/[\w\-]{1,39}/[\w\-]{1,39}/?((issues|pull)/\d+((#issuecomment-|#discussion_|#pullrequestreview-)\w+)?)?}
+  REGISTRY_REGEXP = %r{https://github\.com/[\w\-]{1,39}/[\w\-]{1,39}/?((issues|pull)/\d+((#issuecomment-|#discussion_|#pullrequestreview-)\w+)?)?}
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/github_tag.rb
+++ b/app/liquid_tags/github_tag.rb
@@ -1,7 +1,12 @@
 class GithubTag < LiquidTagBase
+  REGISTRY_REGEXP = %r{https://github.com/[\w\-]{1,39}/[\w\-]{1,39}/?((issues|pull)/\d+((#issuecomment-|#discussion_|#pullrequestreview-)\w+)?)?}
+
   def initialize(_tag_name, link, _parse_context)
     super
-    @link = link
+
+    stripped_link  = strip_tags(link)
+    unescaped_link = CGI.unescape_html(stripped_link)
+    @link = unescaped_link
     @rendered = pre_render
   end
 
@@ -31,3 +36,5 @@ class GithubTag < LiquidTagBase
 end
 
 Liquid::Template.register_tag("github", GithubTag)
+
+UnifiedEmbed.register(GithubTag, regexp: GithubTag::REGISTRY_REGEXP)

--- a/app/liquid_tags/github_tag/github_issue_tag.rb
+++ b/app/liquid_tags/github_tag/github_issue_tag.rb
@@ -76,10 +76,6 @@ class GithubTag
       Addressable::URI.parse(API_BASE_ENDPOINT).join(path).to_s
     end
 
-    def raise_error
-      raise StandardError, I18n.t("liquid_tags.github_tag.github_issue_tag.invalid_github_issue_pull")
-    end
-
     def title
       content_json[:title] || I18n.t("liquid_tags.github_tag.github_issue_tag.comment_for")
     end

--- a/app/liquid_tags/github_tag/github_issue_tag.rb
+++ b/app/liquid_tags/github_tag/github_issue_tag.rb
@@ -9,7 +9,7 @@ class GithubTag
   class GithubIssueTag
     PARTIAL = "liquids/github_issue".freeze
     API_BASE_ENDPOINT = "https://api.github.com/repos/".freeze
-    ISSUE_REGEXP = %r{https://github.com/[\w\-]{1,39}/[\w\-]{1,39}/(issues|pull)/\d+((#issuecomment-|#discussion_|#pullrequestreview-)\w+)?}
+    ISSUE_REGEXP = %r{https://github\.com/[\w\-]{1,39}/[\w\-]{1,39}/(issues|pull)/\d+((#issuecomment-|#discussion_|#pullrequestreview-)\w+)?}
 
     def initialize(link)
       @orig_link = link

--- a/app/liquid_tags/github_tag/github_issue_tag.rb
+++ b/app/liquid_tags/github_tag/github_issue_tag.rb
@@ -5,15 +5,13 @@
 #   https://api.github.com/repos/facebook/react/pulls/14105
 # getting a comment belonging to an issue
 #   https://api.github.com/repos/facebook/react/issues/comments/287635042
-class GithubTag < LiquidTagBase
-  class GithubIssueTag < GithubTag
+class GithubTag
+  class GithubIssueTag
     PARTIAL = "liquids/github_issue".freeze
     API_BASE_ENDPOINT = "https://api.github.com/repos/".freeze
     ISSUE_REGEXP = %r{https://github.com/[\w\-]{1,39}/[\w\-]{1,39}/(issues|pull)/\d+((#issuecomment-|#discussion_|#pullrequestreview-)\w+)?}
 
     def initialize(link)
-      super
-
       @orig_link = link
       @link = parse_link(link)
       @content = GithubIssue.find_or_fetch(@link)
@@ -46,18 +44,10 @@ class GithubTag < LiquidTagBase
     attr_reader :content_json
 
     def parse_link(link)
-      match = pattern_match_for(link, [ISSUE_REGEXP])
+      match = link.match(ISSUE_REGEXP)
       raise StandardError, I18n.t("liquid_tags.github_tag.github_issue_tag.invalid_github_issue_pull") unless match
 
       generate_api_link(link)
-
-      # link = ActionController::Base.helpers.strip_tags(link)
-      # link_no_space = link.delete(" ")
-      # if valid_link?(link_no_space)
-      #   generate_api_link(link_no_space)
-      # else
-      #   raise_error
-      # end
     end
 
     def generate_api_link(input)
@@ -85,16 +75,6 @@ class GithubTag < LiquidTagBase
 
       Addressable::URI.parse(API_BASE_ENDPOINT).join(path).to_s
     end
-
-    # def valid_link?(link)
-    #   link_without_domain = link.gsub(%r{.*github\.com/}, "").split("/")
-    #   validations = [
-    #     %r{.*github\.com/}.match?(link),
-    #     link_without_domain.length == 4,
-    #     link_without_domain[3].to_i.positive?,
-    #   ]
-    #   validations.all? || raise_error
-    # end
 
     def raise_error
       raise StandardError, I18n.t("liquid_tags.github_tag.github_issue_tag.invalid_github_issue_pull")

--- a/app/liquid_tags/github_tag/github_issue_tag.rb
+++ b/app/liquid_tags/github_tag/github_issue_tag.rb
@@ -5,12 +5,15 @@
 #   https://api.github.com/repos/facebook/react/pulls/14105
 # getting a comment belonging to an issue
 #   https://api.github.com/repos/facebook/react/issues/comments/287635042
-class GithubTag
-  class GithubIssueTag
+class GithubTag < LiquidTagBase
+  class GithubIssueTag < GithubTag
     PARTIAL = "liquids/github_issue".freeze
     API_BASE_ENDPOINT = "https://api.github.com/repos/".freeze
+    ISSUE_REGEXP = %r{https://github.com/[\w\-]{1,39}/[\w\-]{1,39}/(issues|pull)/\d+((#issuecomment-|#discussion_|#pullrequestreview-)\w+)?}
 
     def initialize(link)
+      super
+
       @orig_link = link
       @link = parse_link(link)
       @content = GithubIssue.find_or_fetch(@link)
@@ -43,13 +46,18 @@ class GithubTag
     attr_reader :content_json
 
     def parse_link(link)
-      link = ActionController::Base.helpers.strip_tags(link)
-      link_no_space = link.delete(" ")
-      if valid_link?(link_no_space)
-        generate_api_link(link_no_space)
-      else
-        raise_error
-      end
+      match = pattern_match_for(link, [ISSUE_REGEXP])
+      raise StandardError, I18n.t("liquid_tags.github_tag.github_issue_tag.invalid_github_issue_pull") unless match
+
+      generate_api_link(link)
+
+      # link = ActionController::Base.helpers.strip_tags(link)
+      # link_no_space = link.delete(" ")
+      # if valid_link?(link_no_space)
+      #   generate_api_link(link_no_space)
+      # else
+      #   raise_error
+      # end
     end
 
     def generate_api_link(input)
@@ -78,15 +86,15 @@ class GithubTag
       Addressable::URI.parse(API_BASE_ENDPOINT).join(path).to_s
     end
 
-    def valid_link?(link)
-      link_without_domain = link.gsub(%r{.*github\.com/}, "").split("/")
-      validations = [
-        %r{.*github\.com/}.match?(link),
-        link_without_domain.length == 4,
-        link_without_domain[3].to_i.positive?,
-      ]
-      validations.all? || raise_error
-    end
+    # def valid_link?(link)
+    #   link_without_domain = link.gsub(%r{.*github\.com/}, "").split("/")
+    #   validations = [
+    #     %r{.*github\.com/}.match?(link),
+    #     link_without_domain.length == 4,
+    #     link_without_domain[3].to_i.positive?,
+    #   ]
+    #   validations.all? || raise_error
+    # end
 
     def raise_error
       raise StandardError, I18n.t("liquid_tags.github_tag.github_issue_tag.invalid_github_issue_pull")

--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -1,6 +1,7 @@
 class GithubTag
   class GithubReadmeTag
     PARTIAL = "liquids/github_readme".freeze
+    REPO_REGEXP = %r{https://github.com/[\w\-]{1,39}/[\w\-]{1,39}/?}
     GITHUB_DOMAIN_REGEXP = %r{.*github.com/}
     OPTION_NO_README = "no-readme".freeze
     VALID_OPTIONS = [OPTION_NO_README].freeze

--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -1,7 +1,7 @@
 class GithubTag
   class GithubReadmeTag
     PARTIAL = "liquids/github_readme".freeze
-    REPO_REGEXP = %r{https://github.com/[\w\-]{1,39}/[\w\-]{1,39}/?}
+    README_REGEXP = %r{https://github.com/[\w\-]{1,39}/[\w\-]{1,39}/?}
     GITHUB_DOMAIN_REGEXP = %r{.*github.com/}
     OPTION_NO_README = "no-readme".freeze
     VALID_OPTIONS = [OPTION_NO_README].freeze
@@ -34,7 +34,7 @@ class GithubTag
     attr_reader :repository_path, :options, :content
 
     def parse_input(input)
-      sanitized_input = sanitize_input(input)
+      sanitized_input = input.gsub(GITHUB_DOMAIN_REGEXP, "")
 
       path, *options = sanitized_input.split
 

--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -1,7 +1,7 @@
 class GithubTag
   class GithubReadmeTag
     PARTIAL = "liquids/github_readme".freeze
-    README_REGEXP = %r{https://github.com/[\w\-]{1,39}/[\w\-]{1,39}/?}
+    README_REGEXP = %r{https://github\.com/[\w\-]{1,39}/[\w\-]{1,39}/?}
     GITHUB_DOMAIN_REGEXP = %r{.*github.com/}
     OPTION_NO_README = "no-readme".freeze
     VALID_OPTIONS = [OPTION_NO_README].freeze

--- a/spec/liquid_tags/github_tag/github_issue_tag_spec.rb
+++ b/spec/liquid_tags/github_tag/github_issue_tag_spec.rb
@@ -2,13 +2,13 @@ require "rails_helper"
 
 RSpec.describe GithubTag::GithubIssueTag, type: :liquid_tag, vcr: true do
   describe "#id" do
-    let(:url_issue) { "https://github.com/thepracticaldev/dev.to/issues/7434" }
-    let(:url_issue_fragment) { "https://github.com/thepracticaldev/dev.to/issues/7434#issue-604653303" }
-    let(:url_pull_request) { "https://github.com/thepracticaldev/dev.to/pull/7653" }
-    let(:url_pull_request_issue_fragment) { "https://github.com/thepracticaldev/dev.to/pull/7653#issue-412271322" }
-    let(:url_issue_comment) { "https://github.com/thepracticaldev/dev.to/issues/7434#issuecomment-621043602" }
-    let(:url_pull_request_comment) { "https://github.com/thepracticaldev/dev.to/pull/7653#issuecomment-622572436" }
-    let(:url_not_found) { "https://github.com/thepracticaldev/dev.to/issues/0" }
+    let(:url_issue) { "https://github.com/forem/forem/issues/7434" }
+    let(:url_issue_fragment) { "https://github.com/forem/forem/issues/7434#issue-604653303" }
+    let(:url_pull_request) { "https://github.com/forem/forem/pull/7653" }
+    let(:url_pull_request_issue_fragment) { "https://github.com/forem/forem/pull/7653#issue-412271322" }
+    let(:url_issue_comment) { "https://github.com/forem/forem/issues/7434#issuecomment-621043602" }
+    let(:url_pull_request_comment) { "https://github.com/forem/forem/pull/7653#issuecomment-622572436" }
+    let(:url_not_found) { "https://github.com/forem/forem/issues/0" }
 
     def generate_tag(url)
       Liquid::Template.register_tag("github", GithubTag)

--- a/spec/models/github_issue_spec.rb
+++ b/spec/models/github_issue_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe GithubIssue, type: :model, vcr: true do
-  let(:url_issue) { "https://api.github.com/repos/thepracticaldev/dev.to/issues/7434" }
-  let(:url_pull_request) { "https://api.github.com/repos/thepracticaldev/dev.to/pulls/7653" }
-  let(:url_comment) { "https://api.github.com/repos/thepracticaldev/dev.to/issues/comments/621043602" }
-  let(:url_not_found) { "https://api.github.com/repos/thepracticaldev/dev.to/issues/0" }
+  let(:url_issue) { "https://api.github.com/repos/forem/forem/issues/7434" }
+  let(:url_pull_request) { "https://api.github.com/repos/forem/forem/pulls/7653" }
+  let(:url_comment) { "https://api.github.com/repos/forem/forem/issues/comments/621043602" }
+  let(:url_not_found) { "https://api.github.com/repos/forem/forem/issues/0" }
 
   it { is_expected.to validate_length_of(:url).is_at_most(400) }
   it { is_expected.to validate_inclusion_of(:category).in_array(%w[issue issue_comment]) }

--- a/spec/services/github/oauth_client_spec.rb
+++ b/spec/services/github/oauth_client_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Github::OauthClient, type: :service, vcr: true do
-  let(:repo) { "thepracticaldev/dev.to" }
+  let(:repo) { "forem/forem" }
   let(:issue_id) { 7434 }
 
   describe "initialization" do

--- a/spec/support/fixtures/vcr_cassettes/github_client_comment.yml
+++ b/spec/support/fixtures/vcr_cassettes/github_client_comment.yml
@@ -2,55 +2,58 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.github.com/repos/thepracticaldev/dev.to/issues/comments/621043602?per_page=100
+    uri: https://api.github.com/repos/forem/forem/issues/comments/621043602?per_page=100
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Octokit Ruby Gem 4.18.0 (http://localhost:3000)
+      - Octokit Ruby Gem 4.22.0 (http://localhost:3000)
       Accept:
       - application/vnd.github.v3+json
       Content-Type:
       - application/json
       X-Honeycomb-Trace:
-      - 1;dataset=,trace_id=b7791fdb-dcc2-4751-84d7-6d5b91d4c8d7,parent_id=f98dfdd2-ef73-44bd-a92c-3cc4ffd3f62c,context=e30=
+      - 1;dataset=,trace_id=bbb754e247f18a9396c8c3b36e07aa36,parent_id=b638f84c9184c5b7,context=e30=
       Expect:
       - ''
   response:
     status:
       code: 200
-      message: OK
+      message:
     headers:
+      Server:
+      - GitHub.com
       Date:
-      - Sat, 02 May 2020 23:54:45 GMT
+      - Mon, 07 Feb 2022 17:25:26 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1454'
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4978'
-      X-Ratelimit-Reset:
-      - '1588465848'
+      - '1645'
       Cache-Control:
       - public, max-age=60, s-maxage=60
       Vary:
       - Accept
       - Accept-Encoding, Accept, X-Requested-With
       Etag:
-      - '"1589430fd33ed6b00098c14727a2a9f6"'
+      - '"c153e0989d42ab0f154ef567a85d0f4466896347cb8249657a7102975002f1ea"'
       X-Github-Media-Type:
       - github.v3; format=json
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4986'
+      X-Ratelimit-Reset:
+      - '1644256079'
+      X-Ratelimit-Used:
+      - '14'
+      X-Ratelimit-Resource:
+      - core
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -60,19 +63,18 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Content-Security-Policy:
       - default-src 'none'
       X-Github-Request-Id:
-      - F3AC:786B:2668DF:351A29:5EAE0845
+      - F05F:468D:B62BB:1AFE23:62015606
     body:
       encoding: ASCII-8BIT
-      string: '{"url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/comments/621043602","html_url":"https://github.com/thepracticaldev/dev.to/issues/7434#issuecomment-621043602","issue_url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7434","id":621043602,"node_id":"MDEyOklzc3VlQ29tbWVudDYyMTA0MzYwMg==","user":{"login":"catalinpit","id":25515812,"node_id":"MDQ6VXNlcjI1NTE1ODEy","avatar_url":"https://avatars3.githubusercontent.com/u/25515812?u=2c7e3d9e557cc819c3dd2069f5e4904d6a365ad1&v=4","gravatar_id":"","url":"https://api.github.com/users/catalinpit","html_url":"https://github.com/catalinpit","followers_url":"https://api.github.com/users/catalinpit/followers","following_url":"https://api.github.com/users/catalinpit/following{/other_user}","gists_url":"https://api.github.com/users/catalinpit/gists{/gist_id}","starred_url":"https://api.github.com/users/catalinpit/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/catalinpit/subscriptions","organizations_url":"https://api.github.com/users/catalinpit/orgs","repos_url":"https://api.github.com/users/catalinpit/repos","events_url":"https://api.github.com/users/catalinpit/events{/privacy}","received_events_url":"https://api.github.com/users/catalinpit/received_events","type":"User","site_admin":false},"created_at":"2020-04-29T07:46:28Z","updated_at":"2020-04-29T07:46:28Z","author_association":"CONTRIBUTOR","body":"What
-        do you think, @ludwiczakpawel?"}'
-    http_version: null
-  recorded_at: Sat, 02 May 2020 23:54:45 GMT
+      string: '{"url":"https://api.github.com/repos/forem/forem/issues/comments/621043602","html_url":"https://github.com/forem/forem/issues/7434#issuecomment-621043602","issue_url":"https://api.github.com/repos/forem/forem/issues/7434","id":621043602,"node_id":"MDEyOklzc3VlQ29tbWVudDYyMTA0MzYwMg==","user":{"login":"catalinpit","id":25515812,"node_id":"MDQ6VXNlcjI1NTE1ODEy","avatar_url":"https://avatars.githubusercontent.com/u/25515812?u=63150de0534e31d7a357f43fc78cc5a119a8b02a&v=4","gravatar_id":"","url":"https://api.github.com/users/catalinpit","html_url":"https://github.com/catalinpit","followers_url":"https://api.github.com/users/catalinpit/followers","following_url":"https://api.github.com/users/catalinpit/following{/other_user}","gists_url":"https://api.github.com/users/catalinpit/gists{/gist_id}","starred_url":"https://api.github.com/users/catalinpit/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/catalinpit/subscriptions","organizations_url":"https://api.github.com/users/catalinpit/orgs","repos_url":"https://api.github.com/users/catalinpit/repos","events_url":"https://api.github.com/users/catalinpit/events{/privacy}","received_events_url":"https://api.github.com/users/catalinpit/received_events","type":"User","site_admin":false},"created_at":"2020-04-29T07:46:28Z","updated_at":"2020-04-29T07:46:28Z","author_association":"CONTRIBUTOR","body":"What
+        do you think, @ludwiczakpawel?","reactions":{"url":"https://api.github.com/repos/forem/forem/issues/comments/621043602/reactions","total_count":0,"+1":0,"-1":0,"laugh":0,"hooray":0,"confused":0,"heart":0,"rocket":0,"eyes":0},"performed_via_github_app":null}'
+  recorded_at: Mon, 07 Feb 2022 17:25:26 GMT
 - request:
     method: post
     uri: https://api.github.com/markdown
@@ -81,42 +83,45 @@ http_interactions:
       string: '{"text":"What do you think, @ludwiczakpawel?"}'
     headers:
       User-Agent:
-      - Octokit Ruby Gem 4.18.0 (http://localhost:3000)
+      - Octokit Ruby Gem 4.22.0 (http://localhost:3000)
       Accept:
       - application/vnd.github.raw
       Content-Type:
       - application/json
       X-Honeycomb-Trace:
-      - 1;dataset=,trace_id=c3f4fcd3-12df-4e45-90ed-6eff8690d534,parent_id=7666e3c3-e7c8-4655-b4ab-b6f5f9622c88,context=e30=
+      - 1;dataset=,trace_id=9c7e34747a1ae9427bcb0653b19de5c8,parent_id=1af853b1b2e75e6d,context=e30=
       Expect:
       - ''
   response:
     status:
       code: 200
-      message: OK
+      message:
     headers:
+      Server:
+      - GitHub.com
       Date:
-      - Sat, 02 May 2020 23:54:46 GMT
+      - Mon, 07 Feb 2022 17:25:26 GMT
       Content-Type:
       - text/html;charset=utf-8
       Content-Length:
       - '43'
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
+      X-Commonmarker-Version:
+      - 0.23.2
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4977'
+      - '4985'
       X-Ratelimit-Reset:
-      - '1588465848'
-      X-Commonmarker-Version:
-      - 0.21.0
+      - '1644256079'
+      X-Ratelimit-Used:
+      - '15'
+      X-Ratelimit-Resource:
+      - core
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -126,7 +131,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Content-Security-Policy:
@@ -134,10 +139,9 @@ http_interactions:
       Vary:
       - Accept-Encoding, Accept, X-Requested-With
       X-Github-Request-Id:
-      - F3AD:786C:193245:227CB0:5EAE0846
+      - CA08:4E34:1C2A43:35B54E:62015606
     body:
       encoding: ASCII-8BIT
       string: "<p>What do you think, @ludwiczakpawel?</p>\n"
-    http_version: null
-  recorded_at: Sat, 02 May 2020 23:54:46 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 07 Feb 2022 17:25:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/fixtures/vcr_cassettes/github_client_issue.yml
+++ b/spec/support/fixtures/vcr_cassettes/github_client_issue.yml
@@ -2,57 +2,60 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.github.com/repos/thepracticaldev/dev.to/issues/7434
+    uri: https://api.github.com/repos/forem/forem/issues/7434
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Octokit Ruby Gem 4.18.0 (http://localhost:3000)
+      - Octokit Ruby Gem 4.22.0 (http://localhost:3000)
       Accept:
       - application/vnd.github.v3+json
       Content-Type:
       - application/json
       X-Honeycomb-Trace:
-      - 1;dataset=,trace_id=4085b91d-4649-4fc3-bf1c-96c5a2bc8d57,parent_id=9367c158-33bc-4172-bbbe-b5ac5e8926de,context=e30=
+      - 1;dataset=,trace_id=c8b214fc6dc79afeb1e12e9b0c9c56a8,parent_id=d5b7a51b5951de5e,context=e30=
       Expect:
       - ''
   response:
     status:
       code: 200
-      message: OK
+      message:
     headers:
+      Server:
+      - GitHub.com
       Date:
-      - Sat, 02 May 2020 23:54:39 GMT
+      - Mon, 07 Feb 2022 17:25:25 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '3552'
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4983'
-      X-Ratelimit-Reset:
-      - '1588465848'
+      - '6468'
       Cache-Control:
       - public, max-age=60, s-maxage=60
       Vary:
       - Accept
       - Accept-Encoding, Accept, X-Requested-With
       Etag:
-      - '"54e1b0dd3fed55dc41e2d4affd48d3d7"'
+      - '"311cf9522a06488dcc13c2d01a07917f1103f44ad6203a11558842661ee7665f"'
       Last-Modified:
-      - Sat, 02 May 2020 10:56:49 GMT
+      - Sat, 05 Feb 2022 15:40:06 GMT
       X-Github-Media-Type:
       - github.v3; format=json
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4990'
+      X-Ratelimit-Reset:
+      - '1644256079'
+      X-Ratelimit-Used:
+      - '10'
+      X-Ratelimit-Resource:
+      - core
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -62,31 +65,32 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Content-Security-Policy:
       - default-src 'none'
       X-Github-Request-Id:
-      - F3A7:29D1:25238A:33C5C5:5EAE083E
+      - CA03:221E:1D4F90:396014:62015605
     body:
       encoding: ASCII-8BIT
-      string: '{"url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7434","repository_url":"https://api.github.com/repos/thepracticaldev/dev.to","labels_url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7434/labels{/name}","comments_url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7434/comments","events_url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7434/events","html_url":"https://github.com/thepracticaldev/dev.to/issues/7434","id":604653303,"node_id":"MDU6SXNzdWU2MDQ2NTMzMDM=","number":7434,"title":"Profile
-        page not displaying the name due to theming and custom colors","user":{"login":"catalinpit","id":25515812,"node_id":"MDQ6VXNlcjI1NTE1ODEy","avatar_url":"https://avatars0.githubusercontent.com/u/25515812?v=4","gravatar_id":"","url":"https://api.github.com/users/catalinpit","html_url":"https://github.com/catalinpit","followers_url":"https://api.github.com/users/catalinpit/followers","following_url":"https://api.github.com/users/catalinpit/following{/other_user}","gists_url":"https://api.github.com/users/catalinpit/gists{/gist_id}","starred_url":"https://api.github.com/users/catalinpit/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/catalinpit/subscriptions","organizations_url":"https://api.github.com/users/catalinpit/orgs","repos_url":"https://api.github.com/users/catalinpit/repos","events_url":"https://api.github.com/users/catalinpit/events{/privacy}","received_events_url":"https://api.github.com/users/catalinpit/received_events","type":"User","site_admin":false},"labels":[{"id":1031106689,"node_id":"MDU6TGFiZWwxMDMxMTA2Njg5","url":"https://api.github.com/repos/thepracticaldev/dev.to/labels/accessibility","name":"accessibility","color":"c5aef2","default":false,"description":""},{"id":1290917705,"node_id":"MDU6TGFiZWwxMjkwOTE3NzA1","url":"https://api.github.com/repos/thepracticaldev/dev.to/labels/area:%20profile","name":"area:
-        profile","color":"2a75b2","default":false,"description":"user''s profile"},{"id":1290878626,"node_id":"MDU6TGFiZWwxMjkwODc4NjI2","url":"https://api.github.com/repos/thepracticaldev/dev.to/labels/area:%20themes","name":"area:
-        themes","color":"2a75b2","default":false,"description":"UX theming"},{"id":480869965,"node_id":"MDU6TGFiZWw0ODA4Njk5NjU=","url":"https://api.github.com/repos/thepracticaldev/dev.to/labels/type:%20bug","name":"type:
-        bug","color":"C61C32","default":false,"description":"always open for contribution"}],"state":"open","locked":false,"assignee":null,"assignees":[],"milestone":null,"comments":6,"created_at":"2020-04-22T10:43:38Z","updated_at":"2020-05-02T10:56:49Z","closed_at":null,"author_association":"CONTRIBUTOR","body":"**Describe
+      string: '{"url":"https://api.github.com/repos/forem/forem/issues/7434","repository_url":"https://api.github.com/repos/forem/forem","labels_url":"https://api.github.com/repos/forem/forem/issues/7434/labels{/name}","comments_url":"https://api.github.com/repos/forem/forem/issues/7434/comments","events_url":"https://api.github.com/repos/forem/forem/issues/7434/events","html_url":"https://github.com/forem/forem/issues/7434","id":604653303,"node_id":"MDU6SXNzdWU2MDQ2NTMzMDM=","number":7434,"title":"Profile
+        page not displaying the name due to theming and custom colors","user":{"login":"catalinpit","id":25515812,"node_id":"MDQ6VXNlcjI1NTE1ODEy","avatar_url":"https://avatars.githubusercontent.com/u/25515812?v=4","gravatar_id":"","url":"https://api.github.com/users/catalinpit","html_url":"https://github.com/catalinpit","followers_url":"https://api.github.com/users/catalinpit/followers","following_url":"https://api.github.com/users/catalinpit/following{/other_user}","gists_url":"https://api.github.com/users/catalinpit/gists{/gist_id}","starred_url":"https://api.github.com/users/catalinpit/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/catalinpit/subscriptions","organizations_url":"https://api.github.com/users/catalinpit/orgs","repos_url":"https://api.github.com/users/catalinpit/repos","events_url":"https://api.github.com/users/catalinpit/events{/privacy}","received_events_url":"https://api.github.com/users/catalinpit/received_events","type":"User","site_admin":false},"labels":[{"id":480869965,"node_id":"MDU6TGFiZWw0ODA4Njk5NjU=","url":"https://api.github.com/repos/forem/forem/labels/bug","name":"bug","color":"E99695","default":true,"description":"always
+        open for contribution"},{"id":1031106689,"node_id":"MDU6TGFiZWwxMDMxMTA2Njg5","url":"https://api.github.com/repos/forem/forem/labels/area:%20accessibility","name":"area:
+        accessibility","color":"2a75b2","default":false,"description":"issues that
+        need accessibility improvements (a11y)"},{"id":1290917705,"node_id":"MDU6TGFiZWwxMjkwOTE3NzA1","url":"https://api.github.com/repos/forem/forem/labels/area:%20profile","name":"area:
+        profile","color":"2a75b2","default":false,"description":"user''s profile,
+        settings, dashboard"}],"state":"closed","locked":false,"assignee":{"login":"catalinpit","id":25515812,"node_id":"MDQ6VXNlcjI1NTE1ODEy","avatar_url":"https://avatars.githubusercontent.com/u/25515812?v=4","gravatar_id":"","url":"https://api.github.com/users/catalinpit","html_url":"https://github.com/catalinpit","followers_url":"https://api.github.com/users/catalinpit/followers","following_url":"https://api.github.com/users/catalinpit/following{/other_user}","gists_url":"https://api.github.com/users/catalinpit/gists{/gist_id}","starred_url":"https://api.github.com/users/catalinpit/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/catalinpit/subscriptions","organizations_url":"https://api.github.com/users/catalinpit/orgs","repos_url":"https://api.github.com/users/catalinpit/repos","events_url":"https://api.github.com/users/catalinpit/events{/privacy}","received_events_url":"https://api.github.com/users/catalinpit/received_events","type":"User","site_admin":false},"assignees":[{"login":"catalinpit","id":25515812,"node_id":"MDQ6VXNlcjI1NTE1ODEy","avatar_url":"https://avatars.githubusercontent.com/u/25515812?v=4","gravatar_id":"","url":"https://api.github.com/users/catalinpit","html_url":"https://github.com/catalinpit","followers_url":"https://api.github.com/users/catalinpit/followers","following_url":"https://api.github.com/users/catalinpit/following{/other_user}","gists_url":"https://api.github.com/users/catalinpit/gists{/gist_id}","starred_url":"https://api.github.com/users/catalinpit/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/catalinpit/subscriptions","organizations_url":"https://api.github.com/users/catalinpit/orgs","repos_url":"https://api.github.com/users/catalinpit/repos","events_url":"https://api.github.com/users/catalinpit/events{/privacy}","received_events_url":"https://api.github.com/users/catalinpit/received_events","type":"User","site_admin":false}],"milestone":null,"comments":9,"created_at":"2020-04-22T10:43:38Z","updated_at":"2020-08-21T11:14:26Z","closed_at":"2020-08-21T11:14:26Z","author_association":"CONTRIBUTOR","active_lock_reason":null,"body":"**Describe
         the bug**\r\n\r\nYou are allowed to change the colour for some of the information
         from your profile page. There are cases when the profile page doesn''t work
         properly when the colours are related.\r\n\r\nSee the pictures below or visit
         my profile [dev.to/catalinmpit](https://dev.to/catalinmpit).\r\n\r\n**To Reproduce**\r\n\r\n1.
         Go to [dev.to/catalinmpit](https://dev.to/catalinmpit)\r\n\r\n**Expected behavior**\r\n\r\nMy
-        name and other information should be visible.\r\n\r\n**Screenshots**\r\n\r\n![broken-profile-page](https://i.imgur.com/AJyM7tH.png)\r\n\r\n**Additional
+        name and other information should be visible.\r\n\r\n**Screenshots**\r\n\r\n![broken-profile-page](https://i.imgur.com/AJyM7tH.png)\r\n\r\n**Aditional
         information**\r\n\r\nPlayed around with the settings and I''ve done this:\r\n\r\n![profile-page-ok](https://i.imgur.com/DLiPXFT.png)\r\n\r\n**Question**\r\n\r\nWhat
         do you recommend to fix the issue? If you have any recommendations, I''m happy
-        to pick the issue.\r\n","closed_by":null}'
-    http_version: null
-  recorded_at: Sat, 02 May 2020 23:54:39 GMT
+        to pick the issue.\r\n","closed_by":{"login":"ludwiczakpawel","id":108287,"node_id":"MDQ6VXNlcjEwODI4Nw==","avatar_url":"https://avatars.githubusercontent.com/u/108287?v=4","gravatar_id":"","url":"https://api.github.com/users/ludwiczakpawel","html_url":"https://github.com/ludwiczakpawel","followers_url":"https://api.github.com/users/ludwiczakpawel/followers","following_url":"https://api.github.com/users/ludwiczakpawel/following{/other_user}","gists_url":"https://api.github.com/users/ludwiczakpawel/gists{/gist_id}","starred_url":"https://api.github.com/users/ludwiczakpawel/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ludwiczakpawel/subscriptions","organizations_url":"https://api.github.com/users/ludwiczakpawel/orgs","repos_url":"https://api.github.com/users/ludwiczakpawel/repos","events_url":"https://api.github.com/users/ludwiczakpawel/events{/privacy}","received_events_url":"https://api.github.com/users/ludwiczakpawel/received_events","type":"User","site_admin":false},"reactions":{"url":"https://api.github.com/repos/forem/forem/issues/7434/reactions","total_count":0,"+1":0,"-1":0,"laugh":0,"hooray":0,"confused":0,"heart":0,"rocket":0,"eyes":0},"timeline_url":"https://api.github.com/repos/forem/forem/issues/7434/timeline","performed_via_github_app":null}'
+  recorded_at: Mon, 07 Feb 2022 17:25:25 GMT
 - request:
     method: post
     uri: https://api.github.com/markdown
@@ -97,48 +101,51 @@ http_interactions:
         when the profile page doesn''t work properly when the colours are related.\r\n\r\nSee
         the pictures below or visit my profile [dev.to/catalinmpit](https://dev.to/catalinmpit).\r\n\r\n**To
         Reproduce**\r\n\r\n1. Go to [dev.to/catalinmpit](https://dev.to/catalinmpit)\r\n\r\n**Expected
-        behavior**\r\n\r\nMy name and other information should be visible.\r\n\r\n**Screenshots**\r\n\r\n![broken-profile-page](https://i.imgur.com/AJyM7tH.png)\r\n\r\n**Additional
+        behavior**\r\n\r\nMy name and other information should be visible.\r\n\r\n**Screenshots**\r\n\r\n![broken-profile-page](https://i.imgur.com/AJyM7tH.png)\r\n\r\n**Aditional
         information**\r\n\r\nPlayed around with the settings and I''ve done this:\r\n\r\n![profile-page-ok](https://i.imgur.com/DLiPXFT.png)\r\n\r\n**Question**\r\n\r\nWhat
         do you recommend to fix the issue? If you have any recommendations, I''m happy
         to pick the issue.\r\n"}'
     headers:
       User-Agent:
-      - Octokit Ruby Gem 4.18.0 (http://localhost:3000)
+      - Octokit Ruby Gem 4.22.0 (http://localhost:3000)
       Accept:
       - application/vnd.github.raw
       Content-Type:
       - application/json
       X-Honeycomb-Trace:
-      - 1;dataset=,trace_id=63ab979a-3896-4e70-b54d-bf2bf6d375b8,parent_id=b0559d07-130e-4438-ae4a-4852728336a1,context=e30=
+      - 1;dataset=,trace_id=586d0b189b2c4f63107565d978678704,parent_id=8dad92f35bda2647,context=e30=
       Expect:
       - ''
   response:
     status:
       code: 200
-      message: OK
+      message:
     headers:
+      Server:
+      - GitHub.com
       Date:
-      - Sat, 02 May 2020 23:54:40 GMT
+      - Mon, 07 Feb 2022 17:25:25 GMT
       Content-Type:
       - text/html;charset=utf-8
       Content-Length:
-      - '1759'
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
+      - '1855'
+      X-Commonmarker-Version:
+      - 0.23.2
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4982'
+      - '4989'
       X-Ratelimit-Reset:
-      - '1588465848'
-      X-Commonmarker-Version:
-      - 0.21.0
+      - '1644256079'
+      X-Ratelimit-Used:
+      - '11'
+      X-Ratelimit-Resource:
+      - core
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -148,7 +155,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Content-Security-Policy:
@@ -156,7 +163,7 @@ http_interactions:
       Vary:
       - Accept-Encoding, Accept, X-Requested-With
       X-Github-Request-Id:
-      - F3A8:29D1:2523AC:33C5F9:5EAE0840
+      - CA04:4B30:1A7931:3F3B90:62015605
     body:
       encoding: ASCII-8BIT
       string: |
@@ -171,12 +178,11 @@ http_interactions:
         <p><strong>Expected behavior</strong></p>
         <p>My name and other information should be visible.</p>
         <p><strong>Screenshots</strong></p>
-        <p><a href="https://camo.githubusercontent.com/92af1284df38dd307a8b30ccafbea9f832a82d61/68747470733a2f2f692e696d6775722e636f6d2f414a794d3774482e706e67" target="_blank" rel="nofollow"><img src="https://camo.githubusercontent.com/92af1284df38dd307a8b30ccafbea9f832a82d61/68747470733a2f2f692e696d6775722e636f6d2f414a794d3774482e706e67" alt="broken-profile-page" data-canonical-src="https://i.imgur.com/AJyM7tH.png" style="max-width:100%;"></a></p>
-        <p><strong>Additional information</strong></p>
+        <p><a href="https://camo.githubusercontent.com/2baaf1caa6d554bef4c0cc3d514d82cc6792a726084be523b1a002fa25f8da7e/68747470733a2f2f692e696d6775722e636f6d2f414a794d3774482e706e67" target="_blank" rel="nofollow"><img src="https://camo.githubusercontent.com/2baaf1caa6d554bef4c0cc3d514d82cc6792a726084be523b1a002fa25f8da7e/68747470733a2f2f692e696d6775722e636f6d2f414a794d3774482e706e67" alt="broken-profile-page" data-canonical-src="https://i.imgur.com/AJyM7tH.png" style="max-width:100%;"></a></p>
+        <p><strong>Aditional information</strong></p>
         <p>Played around with the settings and I've done this:</p>
-        <p><a href="https://camo.githubusercontent.com/b2d23465b39fd003c0121c1b87177673d4d96336/68747470733a2f2f692e696d6775722e636f6d2f444c69505846542e706e67" target="_blank" rel="nofollow"><img src="https://camo.githubusercontent.com/b2d23465b39fd003c0121c1b87177673d4d96336/68747470733a2f2f692e696d6775722e636f6d2f444c69505846542e706e67" alt="profile-page-ok" data-canonical-src="https://i.imgur.com/DLiPXFT.png" style="max-width:100%;"></a></p>
+        <p><a href="https://camo.githubusercontent.com/7189e93e614eb335b7394485f9b8fc3d75ec5dde9a088d074a54516ee4c4c1fc/68747470733a2f2f692e696d6775722e636f6d2f444c69505846542e706e67" target="_blank" rel="nofollow"><img src="https://camo.githubusercontent.com/7189e93e614eb335b7394485f9b8fc3d75ec5dde9a088d074a54516ee4c4c1fc/68747470733a2f2f692e696d6775722e636f6d2f444c69505846542e706e67" alt="profile-page-ok" data-canonical-src="https://i.imgur.com/DLiPXFT.png" style="max-width:100%;"></a></p>
         <p><strong>Question</strong></p>
         <p>What do you recommend to fix the issue? If you have any recommendations, I'm happy to pick the issue.</p>
-    http_version: null
-  recorded_at: Sat, 02 May 2020 23:54:40 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 07 Feb 2022 17:25:25 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/fixtures/vcr_cassettes/github_client_issue_access_token.yml
+++ b/spec/support/fixtures/vcr_cassettes/github_client_issue_access_token.yml
@@ -2,63 +2,51 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.github.com/repos/thepracticaldev/dev.to/issues/7434
+    uri: https://api.github.com/repos/forem/forem/issues/7434
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Octokit Ruby Gem 4.18.0 (http://localhost:3000)
+      - Octokit Ruby Gem 4.22.0 (http://localhost:3000)
       Accept:
       - application/vnd.github.v3+json
       Content-Type:
       - application/json
       X-Honeycomb-Trace:
-      - 1;dataset=,trace_id=2352d4ee-4b46-4b8c-88cc-e1fae01cee93,parent_id=bdc8645a-b70e-4bba-b91e-15fde6b50b4d,context=e30=
+      - 1;dataset=,trace_id=6215bf09450789b5bd619b892ac9b195,parent_id=cf57c187e7944a64,context=e30=
       Expect:
       - ''
   response:
     status:
-      code: 200
-      message: OK
+      code: 401
+      message:
     headers:
+      Server:
+      - GitHub.com
       Date:
-      - Mon, 18 May 2020 15:41:07 GMT
+      - Mon, 07 Feb 2022 18:24:37 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '5412'
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4999'
-      X-Ratelimit-Reset:
-      - '1589820067'
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding, Accept, X-Requested-With
-      Etag:
-      - '"158fd43d998383cc948f661b4fba98d2"'
-      Last-Modified:
-      - Fri, 15 May 2020 07:48:16 GMT
-      X-Oauth-Scopes:
-      - user:email
-      X-Accepted-Oauth-Scopes:
-      - repo
-      X-Oauth-Client-Id:
-      - 6e8baa4bae3a9863b576
+      - '80'
       X-Github-Media-Type:
       - github.v3; format=json
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '58'
+      X-Ratelimit-Reset:
+      - '1644261230'
+      X-Ratelimit-Used:
+      - '2'
+      X-Ratelimit-Resource:
+      - core
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -68,29 +56,17 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Content-Security-Policy:
       - default-src 'none'
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
       X-Github-Request-Id:
-      - DF18:3A99F:2F2B6EC:35F34B2:5EC2AC92
+      - CC7E:5427:2568FE:42FF63:620163E5
     body:
       encoding: ASCII-8BIT
-      string: '{"url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7434","repository_url":"https://api.github.com/repos/thepracticaldev/dev.to","labels_url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7434/labels{/name}","comments_url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7434/comments","events_url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7434/events","html_url":"https://github.com/thepracticaldev/dev.to/issues/7434","id":604653303,"node_id":"MDU6SXNzdWU2MDQ2NTMzMDM=","number":7434,"title":"Profile
-        page not displaying the name due to theming and custom colors","user":{"login":"catalinpit","id":25515812,"node_id":"MDQ6VXNlcjI1NTE1ODEy","avatar_url":"https://avatars0.githubusercontent.com/u/25515812?v=4","gravatar_id":"","url":"https://api.github.com/users/catalinpit","html_url":"https://github.com/catalinpit","followers_url":"https://api.github.com/users/catalinpit/followers","following_url":"https://api.github.com/users/catalinpit/following{/other_user}","gists_url":"https://api.github.com/users/catalinpit/gists{/gist_id}","starred_url":"https://api.github.com/users/catalinpit/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/catalinpit/subscriptions","organizations_url":"https://api.github.com/users/catalinpit/orgs","repos_url":"https://api.github.com/users/catalinpit/repos","events_url":"https://api.github.com/users/catalinpit/events{/privacy}","received_events_url":"https://api.github.com/users/catalinpit/received_events","type":"User","site_admin":false},"labels":[{"id":1031106689,"node_id":"MDU6TGFiZWwxMDMxMTA2Njg5","url":"https://api.github.com/repos/thepracticaldev/dev.to/labels/accessibility","name":"accessibility","color":"c5aef2","default":false,"description":""},{"id":1290917705,"node_id":"MDU6TGFiZWwxMjkwOTE3NzA1","url":"https://api.github.com/repos/thepracticaldev/dev.to/labels/area:%20profile","name":"area:
-        profile","color":"2a75b2","default":false,"description":"user''s profile"},{"id":1290878626,"node_id":"MDU6TGFiZWwxMjkwODc4NjI2","url":"https://api.github.com/repos/thepracticaldev/dev.to/labels/area:%20themes","name":"area:
-        themes","color":"2a75b2","default":false,"description":"UX theming"},{"id":480869965,"node_id":"MDU6TGFiZWw0ODA4Njk5NjU=","url":"https://api.github.com/repos/thepracticaldev/dev.to/labels/type:%20bug","name":"type:
-        bug","color":"C61C32","default":false,"description":"always open for contribution"}],"state":"open","locked":false,"assignee":{"login":"catalinpit","id":25515812,"node_id":"MDQ6VXNlcjI1NTE1ODEy","avatar_url":"https://avatars0.githubusercontent.com/u/25515812?v=4","gravatar_id":"","url":"https://api.github.com/users/catalinpit","html_url":"https://github.com/catalinpit","followers_url":"https://api.github.com/users/catalinpit/followers","following_url":"https://api.github.com/users/catalinpit/following{/other_user}","gists_url":"https://api.github.com/users/catalinpit/gists{/gist_id}","starred_url":"https://api.github.com/users/catalinpit/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/catalinpit/subscriptions","organizations_url":"https://api.github.com/users/catalinpit/orgs","repos_url":"https://api.github.com/users/catalinpit/repos","events_url":"https://api.github.com/users/catalinpit/events{/privacy}","received_events_url":"https://api.github.com/users/catalinpit/received_events","type":"User","site_admin":false},"assignees":[{"login":"catalinpit","id":25515812,"node_id":"MDQ6VXNlcjI1NTE1ODEy","avatar_url":"https://avatars0.githubusercontent.com/u/25515812?v=4","gravatar_id":"","url":"https://api.github.com/users/catalinpit","html_url":"https://github.com/catalinpit","followers_url":"https://api.github.com/users/catalinpit/followers","following_url":"https://api.github.com/users/catalinpit/following{/other_user}","gists_url":"https://api.github.com/users/catalinpit/gists{/gist_id}","starred_url":"https://api.github.com/users/catalinpit/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/catalinpit/subscriptions","organizations_url":"https://api.github.com/users/catalinpit/orgs","repos_url":"https://api.github.com/users/catalinpit/repos","events_url":"https://api.github.com/users/catalinpit/events{/privacy}","received_events_url":"https://api.github.com/users/catalinpit/received_events","type":"User","site_admin":false}],"milestone":null,"comments":8,"created_at":"2020-04-22T10:43:38Z","updated_at":"2020-05-13T08:39:52Z","closed_at":null,"author_association":"CONTRIBUTOR","body":"**Describe
-        the bug**\r\n\r\nYou are allowed to change the colour for some of the information
-        from your profile page. There are cases when the profile page doesn''t work
-        properly when the colours are related.\r\n\r\nSee the pictures below or visit
-        my profile [dev.to/catalinmpit](https://dev.to/catalinmpit).\r\n\r\n**To Reproduce**\r\n\r\n1.
-        Go to [dev.to/catalinmpit](https://dev.to/catalinmpit)\r\n\r\n**Expected behavior**\r\n\r\nMy
-        name and other information should be visible.\r\n\r\n**Screenshots**\r\n\r\n![broken-profile-page](https://i.imgur.com/AJyM7tH.png)\r\n\r\n**Additional
-        information**\r\n\r\nPlayed around with the settings and I''ve done this:\r\n\r\n![profile-page-ok](https://i.imgur.com/DLiPXFT.png)\r\n\r\n**Question**\r\n\r\nWhat
-        do you recommend to fix the issue? If you have any recommendations, I''m happy
-        to pick the issue.\r\n","closed_by":null}'
-    http_version: null
-  recorded_at: Mon, 18 May 2020 15:41:08 GMT
-recorded_with: VCR 5.1.0
+      string: '{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}'
+  recorded_at: Mon, 07 Feb 2022 18:24:37 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/fixtures/vcr_cassettes/github_client_issue_not_found.yml
+++ b/spec/support/fixtures/vcr_cassettes/github_client_issue_not_found.yml
@@ -2,48 +2,51 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.github.com/repos/thepracticaldev/dev.to/issues/0
+    uri: https://api.github.com/repos/forem/forem/issues/0
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Octokit Ruby Gem 4.18.0 (http://localhost:3000)
+      - Octokit Ruby Gem 4.22.0 (http://localhost:3000)
       Accept:
       - application/vnd.github.v3+json
       Content-Type:
       - application/json
       X-Honeycomb-Trace:
-      - 1;dataset=,trace_id=7b55123d-9904-435d-b5d3-7db505fe3bce,parent_id=73128408-7991-4aac-8a85-f6569b0e9d3b,context=e30=
+      - 1;dataset=,trace_id=b243e1318ae941869d207a89b3d5b76e,parent_id=e1227105d401469e,context=e30=
       Expect:
       - ''
   response:
     status:
       code: 404
-      message: Not Found
+      message:
     headers:
+      Server:
+      - GitHub.com
       Date:
-      - Sat, 02 May 2020 23:54:41 GMT
+      - Mon, 07 Feb 2022 17:57:47 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
       - '104'
-      Server:
-      - GitHub.com
-      Status:
-      - 404 Not Found
+      X-Github-Media-Type:
+      - github.v3; format=json
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4981'
+      - '4999'
       X-Ratelimit-Reset:
-      - '1588465848'
-      X-Github-Media-Type:
-      - github.v3; format=json
+      - '1644260267'
+      X-Ratelimit-Used:
+      - '1'
+      X-Ratelimit-Resource:
+      - core
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -53,7 +56,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Content-Security-Policy:
@@ -61,10 +64,9 @@ http_interactions:
       Vary:
       - Accept-Encoding, Accept, X-Requested-With
       X-Github-Request-Id:
-      - F3A9:29D1:2523C7:33C61F:5EAE0841
+      - CA7E:0600:2034FF:3C754A:62015D9B
     body:
       encoding: ASCII-8BIT
-      string: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/issues/#get-a-single-issue"}'
-    http_version: null
-  recorded_at: Sat, 02 May 2020 23:54:41 GMT
-recorded_with: VCR 5.1.0
+      string: '{"message":"Not Found","documentation_url":"https://docs.github.com/rest/reference/issues#get-an-issue"}'
+  recorded_at: Mon, 07 Feb 2022 17:57:47 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/fixtures/vcr_cassettes/github_client_pull_request.yml
+++ b/spec/support/fixtures/vcr_cassettes/github_client_pull_request.yml
@@ -2,57 +2,60 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.github.com/repos/thepracticaldev/dev.to/issues/7653
+    uri: https://api.github.com/repos/forem/forem/issues/7653
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Octokit Ruby Gem 4.18.0 (http://localhost:3000)
+      - Octokit Ruby Gem 4.22.0 (http://localhost:3000)
       Accept:
       - application/vnd.github.v3+json
       Content-Type:
       - application/json
       X-Honeycomb-Trace:
-      - 1;dataset=,trace_id=3f8011ec-0d23-49d3-9d19-3acdb553274a,parent_id=e31110e6-dc1e-4884-b01b-ee15846d4236,context=e30=
+      - 1;dataset=,trace_id=29114a0e1d9fac2b9c31c0fd9221c015,parent_id=fc35fee94a2cbb55,context=e30=
       Expect:
       - ''
   response:
     status:
       code: 200
-      message: OK
+      message:
     headers:
+      Server:
+      - GitHub.com
       Date:
-      - Sat, 02 May 2020 23:54:43 GMT
+      - Mon, 07 Feb 2022 17:25:25 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '4233'
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4980'
-      X-Ratelimit-Reset:
-      - '1588465849'
+      - '4474'
       Cache-Control:
       - public, max-age=60, s-maxage=60
       Vary:
       - Accept
       - Accept-Encoding, Accept, X-Requested-With
       Etag:
-      - '"0494d7edd146d9a6161dabf46f66cf6e"'
+      - '"da1ce5f4ec8dd49faa549bbeaa8f3b647de39fc035310a4f30d2beab2be22167"'
       Last-Modified:
-      - Fri, 01 May 2020 21:47:35 GMT
+      - Mon, 31 Jan 2022 19:53:28 GMT
       X-Github-Media-Type:
       - github.v3; format=json
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4988'
+      X-Ratelimit-Reset:
+      - '1644256079'
+      X-Ratelimit-Used:
+      - '12'
+      X-Ratelimit-Resource:
+      - core
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -62,19 +65,19 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Content-Security-Policy:
       - default-src 'none'
       X-Github-Request-Id:
-      - F3AA:4B32:24AC63:32E837:5EAE0842
+      - CA05:7633:B1FF6:1ADB73:62015605
     body:
       encoding: ASCII-8BIT
-      string: '{"url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7653","repository_url":"https://api.github.com/repos/thepracticaldev/dev.to","labels_url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7653/labels{/name}","comments_url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7653/comments","events_url":"https://api.github.com/repos/thepracticaldev/dev.to/issues/7653/events","html_url":"https://github.com/thepracticaldev/dev.to/pull/7653","id":610931120,"node_id":"MDExOlB1bGxSZXF1ZXN0NDEyMjcxMzIy","number":7653,"title":"Log
-        RateLimit hits to Datadog for Better Reporting","user":{"login":"mstruve","id":1813380,"node_id":"MDQ6VXNlcjE4MTMzODA=","avatar_url":"https://avatars3.githubusercontent.com/u/1813380?v=4","gravatar_id":"","url":"https://api.github.com/users/mstruve","html_url":"https://github.com/mstruve","followers_url":"https://api.github.com/users/mstruve/followers","following_url":"https://api.github.com/users/mstruve/following{/other_user}","gists_url":"https://api.github.com/users/mstruve/gists{/gist_id}","starred_url":"https://api.github.com/users/mstruve/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mstruve/subscriptions","organizations_url":"https://api.github.com/users/mstruve/orgs","repos_url":"https://api.github.com/users/mstruve/repos","events_url":"https://api.github.com/users/mstruve/events{/privacy}","received_events_url":"https://api.github.com/users/mstruve/received_events","type":"User","site_admin":false},"labels":[{"id":1123882148,"node_id":"MDU6TGFiZWwxMTIzODgyMTQ4","url":"https://api.github.com/repos/thepracticaldev/dev.to/labels/PR:%20merged","name":"PR:
+      string: '{"url":"https://api.github.com/repos/forem/forem/issues/7653","repository_url":"https://api.github.com/repos/forem/forem","labels_url":"https://api.github.com/repos/forem/forem/issues/7653/labels{/name}","comments_url":"https://api.github.com/repos/forem/forem/issues/7653/comments","events_url":"https://api.github.com/repos/forem/forem/issues/7653/events","html_url":"https://github.com/forem/forem/pull/7653","id":610931120,"node_id":"MDExOlB1bGxSZXF1ZXN0NDEyMjcxMzIy","number":7653,"title":"Log
+        RateLimit hits to Datadog for Better Reporting","user":{"login":"mstruve","id":1813380,"node_id":"MDQ6VXNlcjE4MTMzODA=","avatar_url":"https://avatars.githubusercontent.com/u/1813380?v=4","gravatar_id":"","url":"https://api.github.com/users/mstruve","html_url":"https://github.com/mstruve","followers_url":"https://api.github.com/users/mstruve/followers","following_url":"https://api.github.com/users/mstruve/following{/other_user}","gists_url":"https://api.github.com/users/mstruve/gists{/gist_id}","starred_url":"https://api.github.com/users/mstruve/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mstruve/subscriptions","organizations_url":"https://api.github.com/users/mstruve/orgs","repos_url":"https://api.github.com/users/mstruve/repos","events_url":"https://api.github.com/users/mstruve/events{/privacy}","received_events_url":"https://api.github.com/users/mstruve/received_events","type":"User","site_admin":false},"labels":[{"id":1123882148,"node_id":"MDU6TGFiZWwxMTIzODgyMTQ4","url":"https://api.github.com/repos/forem/forem/labels/PR:%20merged","name":"PR:
         merged","color":"786DBE","default":false,"description":"bot applied label
-        for PR''s that are merged"}],"state":"closed","locked":false,"assignee":null,"assignees":[],"milestone":null,"comments":2,"created_at":"2020-05-01T19:40:23Z","updated_at":"2020-05-01T21:47:35Z","closed_at":"2020-05-01T21:47:32Z","author_association":"COLLABORATOR","pull_request":{"url":"https://api.github.com/repos/thepracticaldev/dev.to/pulls/7653","html_url":"https://github.com/thepracticaldev/dev.to/pull/7653","diff_url":"https://github.com/thepracticaldev/dev.to/pull/7653.diff","patch_url":"https://github.com/thepracticaldev/dev.to/pull/7653.patch"},"body":"\r\n##
+        for PR''s that are merged"}],"state":"closed","locked":false,"assignee":null,"assignees":[],"milestone":null,"comments":2,"created_at":"2020-05-01T19:40:23Z","updated_at":"2020-05-01T21:47:35Z","closed_at":"2020-05-01T21:47:32Z","author_association":"CONTRIBUTOR","active_lock_reason":null,"draft":false,"pull_request":{"url":"https://api.github.com/repos/forem/forem/pulls/7653","html_url":"https://github.com/forem/forem/pull/7653","diff_url":"https://github.com/forem/forem/pull/7653.diff","patch_url":"https://github.com/forem/forem/pull/7653.patch","merged_at":"2020-05-01T21:47:32Z"},"body":"\r\n##
         What type of PR is this? (check all applicable)\r\n- [x] Feature\r\n- [x]
         Optimization\r\n\r\n## Description\r\nRather than sending (almost) every single
         rate limit hit to Slack, lets send a metric to Datadog that we can track and
@@ -86,9 +89,8 @@ http_interactions:
         rate limits rather than every single time which sometimes is not concerning
         if they only hit it once, like a pentester trying to see if a rate limiter
         exists. \r\n\r\n## Related Tickets & Documents\r\nhttps://github.com/thepracticaldev/dev.to/projects/9#card-37397577\r\n\r\n##
-        Added tests?\r\n- [x] yes\r\n\r\n![alt_text](https://media1.giphy.com/media/l2YWsOymHDRFYqyAM/giphy.gif)\r\n","closed_by":{"login":"mstruve","id":1813380,"node_id":"MDQ6VXNlcjE4MTMzODA=","avatar_url":"https://avatars3.githubusercontent.com/u/1813380?v=4","gravatar_id":"","url":"https://api.github.com/users/mstruve","html_url":"https://github.com/mstruve","followers_url":"https://api.github.com/users/mstruve/followers","following_url":"https://api.github.com/users/mstruve/following{/other_user}","gists_url":"https://api.github.com/users/mstruve/gists{/gist_id}","starred_url":"https://api.github.com/users/mstruve/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mstruve/subscriptions","organizations_url":"https://api.github.com/users/mstruve/orgs","repos_url":"https://api.github.com/users/mstruve/repos","events_url":"https://api.github.com/users/mstruve/events{/privacy}","received_events_url":"https://api.github.com/users/mstruve/received_events","type":"User","site_admin":false}}'
-    http_version: null
-  recorded_at: Sat, 02 May 2020 23:54:43 GMT
+        Added tests?\r\n- [x] yes\r\n\r\n![alt_text](https://media1.giphy.com/media/l2YWsOymHDRFYqyAM/giphy.gif)\r\n","closed_by":{"login":"mstruve","id":1813380,"node_id":"MDQ6VXNlcjE4MTMzODA=","avatar_url":"https://avatars.githubusercontent.com/u/1813380?v=4","gravatar_id":"","url":"https://api.github.com/users/mstruve","html_url":"https://github.com/mstruve","followers_url":"https://api.github.com/users/mstruve/followers","following_url":"https://api.github.com/users/mstruve/following{/other_user}","gists_url":"https://api.github.com/users/mstruve/gists{/gist_id}","starred_url":"https://api.github.com/users/mstruve/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mstruve/subscriptions","organizations_url":"https://api.github.com/users/mstruve/orgs","repos_url":"https://api.github.com/users/mstruve/repos","events_url":"https://api.github.com/users/mstruve/events{/privacy}","received_events_url":"https://api.github.com/users/mstruve/received_events","type":"User","site_admin":false},"reactions":{"url":"https://api.github.com/repos/forem/forem/issues/7653/reactions","total_count":0,"+1":0,"-1":0,"laugh":0,"hooray":0,"confused":0,"heart":0,"rocket":0,"eyes":0},"timeline_url":"https://api.github.com/repos/forem/forem/issues/7653/timeline","performed_via_github_app":null}'
+  recorded_at: Mon, 07 Feb 2022 17:25:25 GMT
 - request:
     method: post
     uri: https://api.github.com/markdown
@@ -108,42 +110,45 @@ http_interactions:
         Added tests?\r\n- [x] yes\r\n\r\n![alt_text](https://media1.giphy.com/media/l2YWsOymHDRFYqyAM/giphy.gif)\r\n"}'
     headers:
       User-Agent:
-      - Octokit Ruby Gem 4.18.0 (http://localhost:3000)
+      - Octokit Ruby Gem 4.22.0 (http://localhost:3000)
       Accept:
       - application/vnd.github.raw
       Content-Type:
       - application/json
       X-Honeycomb-Trace:
-      - 1;dataset=,trace_id=40a6d376-ddbd-4054-8f13-16983a5f5d45,parent_id=8229768b-93f5-4952-8408-fec5650f68a9,context=e30=
+      - 1;dataset=,trace_id=c98be95af09d867f337239da9e08fb5d,parent_id=387598550588eaa9,context=e30=
       Expect:
       - ''
   response:
     status:
       code: 200
-      message: OK
+      message:
     headers:
+      Server:
+      - GitHub.com
       Date:
-      - Sat, 02 May 2020 23:54:44 GMT
+      - Mon, 07 Feb 2022 17:25:26 GMT
       Content-Type:
       - text/html;charset=utf-8
       Content-Length:
-      - '2331'
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
+      - '2379'
+      X-Commonmarker-Version:
+      - 0.23.2
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4979'
+      - '4987'
       X-Ratelimit-Reset:
-      - '1588465848'
-      X-Commonmarker-Version:
-      - 0.21.0
+      - '1644256079'
+      X-Ratelimit-Used:
+      - '13'
+      X-Ratelimit-Resource:
+      - core
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -153,7 +158,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Content-Security-Policy:
@@ -161,7 +166,7 @@ http_interactions:
       Vary:
       - Accept-Encoding, Accept, X-Requested-With
       X-Github-Request-Id:
-      - F3AB:29D2:192531:22748D:5EAE0843
+      - CA06:5426:149935:27EC67:62015606
     body:
       encoding: ASCII-8BIT
       string: |
@@ -183,7 +188,6 @@ http_interactions:
         <ul>
         <li>[x] yes</li>
         </ul>
-        <p><a href="https://camo.githubusercontent.com/3972d99d348007c519ae82451b8c52332933b5f4/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f6c325957734f796d48445246597179414d2f67697068792e676966" target="_blank" rel="nofollow"><img src="https://camo.githubusercontent.com/3972d99d348007c519ae82451b8c52332933b5f4/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f6c325957734f796d48445246597179414d2f67697068792e676966" alt="alt_text" data-canonical-src="https://media1.giphy.com/media/l2YWsOymHDRFYqyAM/giphy.gif" style="max-width:100%;"></a></p>
-    http_version: null
-  recorded_at: Sat, 02 May 2020 23:54:44 GMT
-recorded_with: VCR 5.1.0
+        <p><a href="https://camo.githubusercontent.com/c88160a7f2bca8e29fdf15740428ef3e7941128a3eaee9c222291b1d82fcb56e/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f6c325957734f796d48445246597179414d2f67697068792e676966" target="_blank" rel="nofollow"><img src="https://camo.githubusercontent.com/c88160a7f2bca8e29fdf15740428ef3e7941128a3eaee9c222291b1d82fcb56e/68747470733a2f2f6d65646961312e67697068792e636f6d2f6d656469612f6c325957734f796d48445246597179414d2f67697068792e676966" alt="alt_text" data-canonical-src="https://media1.giphy.com/media/l2YWsOymHDRFYqyAM/giphy.gif" style="max-width:100%;"></a></p>
+  recorded_at: Mon, 07 Feb 2022 17:25:26 GMT
+recorded_with: VCR 6.0.0

--- a/spec/support/fixtures/vcr_cassettes/github_client_pull_request_comment.yml
+++ b/spec/support/fixtures/vcr_cassettes/github_client_pull_request_comment.yml
@@ -2,55 +2,58 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.github.com/repos/thepracticaldev/dev.to/issues/comments/622572436?per_page=100
+    uri: https://api.github.com/repos/forem/forem/issues/comments/622572436?per_page=100
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Octokit Ruby Gem 4.18.0 (http://localhost:3000)
+      - Octokit Ruby Gem 4.22.0 (http://localhost:3000)
       Accept:
       - application/vnd.github.v3+json
       Content-Type:
       - application/json
       X-Honeycomb-Trace:
-      - 1;dataset=,trace_id=2130d678-d18a-4c28-a9d9-148409ed2ce1,parent_id=11aec9b3-1ad8-4021-9807-eb96f9426d36,context=e30=
+      - 1;dataset=,trace_id=2d093291532b14f992cce17550ad69b4,parent_id=b81a71cb4047f72d,context=e30=
       Expect:
       - ''
   response:
     status:
       code: 200
-      message: OK
+      message:
     headers:
+      Server:
+      - GitHub.com
       Date:
-      - Mon, 04 May 2020 09:31:20 GMT
+      - Mon, 07 Feb 2022 17:25:27 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1663'
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4999'
-      X-Ratelimit-Reset:
-      - '1588588280'
+      - '1854'
       Cache-Control:
       - public, max-age=60, s-maxage=60
       Vary:
       - Accept
       - Accept-Encoding, Accept, X-Requested-With
       Etag:
-      - '"006cef151248d15abe7e14ac18b6c5df"'
+      - '"dc2926004af4521bb34a976bf3498436f56643a48c69ba7970a71a1d378e3b41"'
       X-Github-Media-Type:
       - github.v3; format=json
+      X-Ratelimit-Limit:
+      - '5000'
+      X-Ratelimit-Remaining:
+      - '4984'
+      X-Ratelimit-Reset:
+      - '1644256079'
+      X-Ratelimit-Used:
+      - '16'
+      X-Ratelimit-Resource:
+      - core
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -60,19 +63,18 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Content-Security-Policy:
       - default-src 'none'
       X-Github-Request-Id:
-      - F1B8:29D1:5382F7:738F6E:5EAFE0E7
+      - CA09:221F:1C013A:415541:62015607
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3RoZXByYWN0aWNhbGRldi9kZXYudG8vaXNzdWVzL2NvbW1lbnRzLzYyMjU3MjQzNiIsImh0bWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL3RoZXByYWN0aWNhbGRldi9kZXYudG8vcHVsbC83NjUzI2lzc3VlY29tbWVudC02MjI1NzI0MzYiLCJpc3N1ZV91cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL3RoZXByYWN0aWNhbGRldi9kZXYudG8vaXNzdWVzLzc2NTMiLCJpZCI6NjIyNTcyNDM2LCJub2RlX2lkIjoiTURFeU9rbHpjM1ZsUTI5dGJXVnVkRFl5TWpVM01qUXpOZz09IiwidXNlciI6eyJsb2dpbiI6Im1pY2hhZWwtdGhhcnJpbmd0b24iLCJpZCI6MTYwMDcwNzUsIm5vZGVfaWQiOiJNRFE2VlhObGNqRTJNREEzTURjMSIsImF2YXRhcl91cmwiOiJodHRwczovL2F2YXRhcnMyLmdpdGh1YnVzZXJjb250ZW50LmNvbS91LzE2MDA3MDc1P3U9ZTVmNDUwNjhhYTYyNDM2NThlYjVkMWQ1MmRiYzhlZWZjOWZlOWE1YiZ2PTQiLCJncmF2YXRhcl9pZCI6IiIsInVybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvbWljaGFlbC10aGFycmluZ3RvbiIsImh0bWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL21pY2hhZWwtdGhhcnJpbmd0b24iLCJmb2xsb3dlcnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9taWNoYWVsLXRoYXJyaW5ndG9uL2ZvbGxvd2VycyIsImZvbGxvd2luZ191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL21pY2hhZWwtdGhhcnJpbmd0b24vZm9sbG93aW5ney9vdGhlcl91c2VyfSIsImdpc3RzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvbWljaGFlbC10aGFycmluZ3Rvbi9naXN0c3svZ2lzdF9pZH0iLCJzdGFycmVkX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvbWljaGFlbC10aGFycmluZ3Rvbi9zdGFycmVkey9vd25lcn17L3JlcG99Iiwic3Vic2NyaXB0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL21pY2hhZWwtdGhhcnJpbmd0b24vc3Vic2NyaXB0aW9ucyIsIm9yZ2FuaXphdGlvbnNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9taWNoYWVsLXRoYXJyaW5ndG9uL29yZ3MiLCJyZXBvc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL21pY2hhZWwtdGhhcnJpbmd0b24vcmVwb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9taWNoYWVsLXRoYXJyaW5ndG9uL2V2ZW50c3svcHJpdmFjeX0iLCJyZWNlaXZlZF9ldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9taWNoYWVsLXRoYXJyaW5ndG9uL3JlY2VpdmVkX2V2ZW50cyIsInR5cGUiOiJVc2VyIiwic2l0ZV9hZG1pbiI6ZmFsc2V9LCJjcmVhdGVkX2F0IjoiMjAyMC0wNS0wMVQyMToxODoxMFoiLCJ1cGRhdGVkX2F0IjoiMjAyMC0wNS0wMVQyMToxODoxMFoiLCJhdXRob3JfYXNzb2NpYXRpb24iOiJDT05UUklCVVRPUiIsImJvZHkiOiJTbyBleGNpdGVkIGZvciB0aGlzISBJJ20gZ29pbmcgdG8gbWFrZSBzdXJlIHdlIHRhbGsgYWJvdXQgdGhpcyBpbiBvdXIgbmV4dCBzdXBwb3J0IG1lZXRpbmcuIEkgdGhpbmsgdGhpcyBpcyBhIHN1cGVyIPCfhpIgdGhpbmcgdG8gbW9uaXRvci4ifQ==
-    http_version: null
-  recorded_at: Mon, 04 May 2020 09:31:20 GMT
+        eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2ZvcmVtL2ZvcmVtL2lzc3Vlcy9jb21tZW50cy82MjI1NzI0MzYiLCJodG1sX3VybCI6Imh0dHBzOi8vZ2l0aHViLmNvbS9mb3JlbS9mb3JlbS9wdWxsLzc2NTMjaXNzdWVjb21tZW50LTYyMjU3MjQzNiIsImlzc3VlX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vcmVwb3MvZm9yZW0vZm9yZW0vaXNzdWVzLzc2NTMiLCJpZCI6NjIyNTcyNDM2LCJub2RlX2lkIjoiTURFeU9rbHpjM1ZsUTI5dGJXVnVkRFl5TWpVM01qUXpOZz09IiwidXNlciI6eyJsb2dpbiI6Im1pY2hhZWwtdGhhcnJpbmd0b24iLCJpZCI6MTYwMDcwNzUsIm5vZGVfaWQiOiJNRFE2VlhObGNqRTJNREEzTURjMSIsImF2YXRhcl91cmwiOiJodHRwczovL2F2YXRhcnMuZ2l0aHVidXNlcmNvbnRlbnQuY29tL3UvMTYwMDcwNzU/dT1lNWY0NTA2OGFhNjI0MzY1OGViNWQxZDUyZGJjOGVlZmM5ZmU5YTViJnY9NCIsImdyYXZhdGFyX2lkIjoiIiwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9taWNoYWVsLXRoYXJyaW5ndG9uIiwiaHRtbF91cmwiOiJodHRwczovL2dpdGh1Yi5jb20vbWljaGFlbC10aGFycmluZ3RvbiIsImZvbGxvd2Vyc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL21pY2hhZWwtdGhhcnJpbmd0b24vZm9sbG93ZXJzIiwiZm9sbG93aW5nX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvbWljaGFlbC10aGFycmluZ3Rvbi9mb2xsb3dpbmd7L290aGVyX3VzZXJ9IiwiZ2lzdHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9taWNoYWVsLXRoYXJyaW5ndG9uL2dpc3Rzey9naXN0X2lkfSIsInN0YXJyZWRfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS91c2Vycy9taWNoYWVsLXRoYXJyaW5ndG9uL3N0YXJyZWR7L293bmVyfXsvcmVwb30iLCJzdWJzY3JpcHRpb25zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvbWljaGFlbC10aGFycmluZ3Rvbi9zdWJzY3JpcHRpb25zIiwib3JnYW5pemF0aW9uc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL21pY2hhZWwtdGhhcnJpbmd0b24vb3JncyIsInJlcG9zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdXNlcnMvbWljaGFlbC10aGFycmluZ3Rvbi9yZXBvcyIsImV2ZW50c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL21pY2hhZWwtdGhhcnJpbmd0b24vZXZlbnRzey9wcml2YWN5fSIsInJlY2VpdmVkX2V2ZW50c191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3VzZXJzL21pY2hhZWwtdGhhcnJpbmd0b24vcmVjZWl2ZWRfZXZlbnRzIiwidHlwZSI6IlVzZXIiLCJzaXRlX2FkbWluIjpmYWxzZX0sImNyZWF0ZWRfYXQiOiIyMDIwLTA1LTAxVDIxOjE4OjEwWiIsInVwZGF0ZWRfYXQiOiIyMDIwLTA1LTAxVDIxOjE4OjEwWiIsImF1dGhvcl9hc3NvY2lhdGlvbiI6IkNPTlRSSUJVVE9SIiwiYm9keSI6IlNvIGV4Y2l0ZWQgZm9yIHRoaXMhIEknbSBnb2luZyB0byBtYWtlIHN1cmUgd2UgdGFsayBhYm91dCB0aGlzIGluIG91ciBuZXh0IHN1cHBvcnQgbWVldGluZy4gSSB0aGluayB0aGlzIGlzIGEgc3VwZXIg8J+GkiB0aGluZyB0byBtb25pdG9yLiIsInJlYWN0aW9ucyI6eyJ1cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL3JlcG9zL2ZvcmVtL2ZvcmVtL2lzc3Vlcy9jb21tZW50cy82MjI1NzI0MzYvcmVhY3Rpb25zIiwidG90YWxfY291bnQiOjAsIisxIjowLCItMSI6MCwibGF1Z2giOjAsImhvb3JheSI6MCwiY29uZnVzZWQiOjAsImhlYXJ0IjowLCJyb2NrZXQiOjAsImV5ZXMiOjB9LCJwZXJmb3JtZWRfdmlhX2dpdGh1Yl9hcHAiOm51bGx9
+  recorded_at: Mon, 07 Feb 2022 17:25:27 GMT
 - request:
     method: post
     uri: https://api.github.com/markdown
@@ -83,42 +85,45 @@ http_interactions:
         to monitor.\"}"
     headers:
       User-Agent:
-      - Octokit Ruby Gem 4.18.0 (http://localhost:3000)
+      - Octokit Ruby Gem 4.22.0 (http://localhost:3000)
       Accept:
       - application/vnd.github.raw
       Content-Type:
       - application/json
       X-Honeycomb-Trace:
-      - 1;dataset=,trace_id=a4437cb5-738c-4169-894b-ee27dd425fc1,parent_id=1d39a812-0a36-4737-85bc-8efe8039dbda,context=e30=
+      - 1;dataset=,trace_id=4d31bdc865de509392e0fdc40732e565,parent_id=57fd5cf070c09ed5,context=e30=
       Expect:
       - ''
   response:
     status:
       code: 200
-      message: OK
+      message:
     headers:
+      Server:
+      - GitHub.com
       Date:
-      - Mon, 04 May 2020 09:31:21 GMT
+      - Mon, 07 Feb 2022 17:25:27 GMT
       Content-Type:
       - text/html;charset=utf-8
       Content-Length:
       - '278'
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
+      X-Commonmarker-Version:
+      - 0.23.2
       X-Ratelimit-Limit:
       - '5000'
       X-Ratelimit-Remaining:
-      - '4998'
+      - '4983'
       X-Ratelimit-Reset:
-      - '1588588280'
-      X-Commonmarker-Version:
-      - 0.21.0
+      - '1644256079'
+      X-Ratelimit-Used:
+      - '17'
+      X-Ratelimit-Resource:
+      - core
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -128,7 +133,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       X-Xss-Protection:
-      - 1; mode=block
+      - '0'
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Content-Security-Policy:
@@ -136,11 +141,10 @@ http_interactions:
       Vary:
       - Accept-Encoding, Accept, X-Requested-With
       X-Github-Request-Id:
-      - F1B9:786A:DA23C:12F2DF:5EAFE0E8
+      - CA0A:7635:1B0382:3745F4:62015607
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         PHA+U28gZXhjaXRlZCBmb3IgdGhpcyEgSSdtIGdvaW5nIHRvIG1ha2Ugc3VyZSB3ZSB0YWxrIGFib3V0IHRoaXMgaW4gb3VyIG5leHQgc3VwcG9ydCBtZWV0aW5nLiBJIHRoaW5rIHRoaXMgaXMgYSBzdXBlciA8Zy1lbW9qaSBjbGFzcz0iZy1lbW9qaSIgYWxpYXM9ImNvb2wiIGZhbGxiYWNrLXNyYz0iaHR0cHM6Ly9naXRodWIuZ2l0aHViYXNzZXRzLmNvbS9pbWFnZXMvaWNvbnMvZW1vamkvdW5pY29kZS8xZjE5Mi5wbmciPvCfhpI8L2ctZW1vamk+IHRoaW5nIHRvIG1vbml0b3IuPC9wPgo=
-    http_version: null
-  recorded_at: Mon, 04 May 2020 09:31:21 GMT
-recorded_with: VCR 5.1.0
+  recorded_at: Mon, 07 Feb 2022 17:25:27 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR implements the [unified embed tag](https://github.com/forem/forem/issues/15099) for Github repository, issue, pull-request and comment embeds.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/15557
closes https://github.com/forem/forem/issues/15558

## QA Instructions, Screenshots, Recordings
Example GitHub URLs:
```
https://github.com/forem/forem
https://github.com/forem/forem/issues/15099
https://github.com/forem/forem/pull/16415
https://github.com/forem/forem/pull/16378#issuecomment-1026386485
```
_(the following two URLs are not handled by GitHub's Issue-Comments API, so the embed should fall back to the PR)_
```
https://github.com/forem/forem/pull/16378#discussion_r796201397
https://github.com/forem/forem/pull/16378#pullrequestreview-869248370
```

Old Embed examples:
```
{% github forem/forem %}
{% github forem/forem no-readme %}
{% github https://github.com/forem/forem/issues/9 %}
```

- As a user, create GitHub liquid tag using this format: {% embed <github-url> %}. The Liquid Tag should render properly.
- Also create liquid tags using the old method (see examples above). This should also work, as I am leaving the old implementation in place for now.


### UI accessibility concerns?
None

## Added/updated tests?
- [X] Yes

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
Considering the project as a whole, I shall update the Liquid Tag documentation at the end. Since I am not changing the current implementation, the present documentation is still valid. Plus, I will avoid updating the docs piecemeal, and risk confusing users.

## [optional] Are there any post deployment tasks we need to perform?
None