### PR TITLE
Conditionally disabling Listings

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -55,7 +55,7 @@ class Listing < ApplicationRecord
   # @return [TrueClass] if the Listing is enabled for this Forem
   # @return [FalseClass] if the Listing is disabled for this Forem
   def self.feature_enabled?
-    FeatureFlag.accessible?(:listing_feature_enabled)
+    FeatureFlag.accessible?(:listing_feature)
   end
 
   # Wrapping the column accessor names for consistency. Aliasing did not work.

--- a/lib/data_update_scripts/20220204190754_disable_listing_feature.rb
+++ b/lib/data_update_scripts/20220204190754_disable_listing_feature.rb
@@ -1,0 +1,11 @@
+module DataUpdateScripts
+  class DisableListingFeature
+    def run
+      if URL.domain == "dev.to"
+        FeatureFlag.enable(:listing_feature)
+      else
+        FeatureFlag.disable(:listing_feature)
+      end
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/disable_listing_feature_spec.rb
+++ b/spec/lib/data_update_scripts/disable_listing_feature_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220204190754_disable_listing_feature.rb",
+)
+
+describe DataUpdateScripts::DisableListingFeature do
+  before { allow(URL).to receive(:domain).and_return(domain) }
+
+  context "when running on dev.to" do
+    let(:domain) { "dev.to" }
+
+    it "keeps the listing feature enabled" do
+      described_class.new.run
+      expect(Listing).to be_feature_enabled
+    end
+  end
+
+  context "when running on some other site" do
+    let(:domain) { "forem.dev" }
+
+    it "keeps the listing feature enabled" do
+      described_class.new.run
+      expect(Listing).not_to be_feature_enabled
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Prior to this commit, we were assuming everyone still had the Listing's
feature turned on.

With this commit, we continue to use the "implicitly on" nature of
`FeatureFlag.accessible?` but are manually updating all sites to have an
explicit value for the FeatureFlag.  In the case of "dev.to" we enabling
the listing page.  In all other cases we're disabling the listing page.

This is a change that will require communication.  Namely, is this the
right list of domains to explicitly enable?  But also, will we be
disabling something and creating a bit of surprise.

At a future point, we could move from an "implicitly on" to requires to
be explicitly on (e.g. via `FeatureFlag.enabled?`).  To turn it off will
require some consideration in regards to the test suite.  But that's a
future us problem that I'm sure we can address.

## Related Tickets & Documents

Closes forem/rfcs#291

Relates #16420, #16461, #16335, #16338, and #16362.

## QA Instructions, Screenshots, Recordings

The instructions of #16406 still apply:

>  Testing this change:
>
>    1. Start your local application (e.g. `$ bin/startup`)
>    2. Go to http://localhost:3000/listings
>    3. You should get a Successful response.
>    4. Now disable the feature (e.g. `$ bin/rails r \
>       "FeatureFlag.disable(:listing_feature)"`)
>    5. Refresh http://localhost:3000/listings
>    6. You should get an `ActiveRecord::RecordNotFound` error; because the
>       application is now looking for a user or org named "listings"; in other
>       words we're not routing `GET "/listings"` to `listings#index` controller
>       action.
>    7. Now enable the feature (e.g. `$ bin/rails r \
>       "FeatureFlag.enable(:listing_feature)"`)
>    8. Refresh http://localhost:3000/listings
>    9. You should get a Successful response.
>    10. Goto 4

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [x] I'm not sure how best to communicate this change and need help