### PR TITLE
Ensuring that body.dataset is JSON parsable

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -23,10 +23,10 @@
 
 </head>
 <body class="admin default-header"
-  data-honeybadger-key="<%= ApplicationConfig["HONEYBADGER_JS_API_KEY"] %>"
-  data-deployed-at="<%= ForemInstance.deployed_at %>"
-  data-latest-commit-id="<%= ForemInstance.latest_commit_id %>"
-  data-ga-tracking="<%= Settings::General.ga_tracking_id %>"
+  data-honeybadger-key="<%= j(ApplicationConfig["HONEYBADGER_JS_API_KEY"]) %>"
+  data-deployed-at="<%= j(ForemInstance.deployed_at) %>"
+  data-latest-commit-id="<%= j(ForemInstance.latest_commit_id) %>"
+  data-ga-tracking="<%= j(Settings::General.ga_tracking_id) %>"
   data-controller="snackbar"
   data-action="snackbar:add@document->snackbar#addItem">
   <div id="body-styles">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,14 +46,14 @@
   <% unless internal_navigation? %>
     <% cache(release_adjusted_cache_key("top-html-and-config--#{user_signed_in?}")) do %>
       <body
-        data-user-status="<%= user_logged_in_status %>"
-        data-community-name="<%= community_name %>"
         class="<%= Settings::UserExperience.default_font.tr("_", "-") %>-article-body default-header"
-        data-locale="<%= I18n.locale %>"
-        data-honeybadger-key="<%= ApplicationConfig["HONEYBADGER_JS_API_KEY"] %>"
-        data-deployed-at="<%= ForemInstance.deployed_at %>"
-        data-latest-commit-id="<%= ForemInstance.latest_commit_id %>"
-        data-ga-tracking="<%= Settings::General.ga_tracking_id %>">
+        data-user-status="<%= j(user_logged_in_status) %>"
+        data-community-name="<%= j(community_name) %>"
+        data-locale="<%= j(I18n.locale) %>"
+        data-honeybadger-key="<%= j(ApplicationConfig["HONEYBADGER_JS_API_KEY"]) %>"
+        data-deployed-at="<%= j(ForemInstance.deployed_at) %>"
+        data-latest-commit-id="<%= j(ForemInstance.latest_commit_id) %>"
+        data-ga-tracking="<%= j(Settings::General.ga_tracking_id) %>">
         <%# Repeat of stylesheets in <head> to fix rendering glitch: https://github.com/forem/forem/issues/12377 %>
         <%= render "layouts/styles", qualifier: "secondary" %>
         <div id="body-styles">

--- a/app/views/onboardings/show.html.erb
+++ b/app/views/onboardings/show.html.erb
@@ -12,8 +12,8 @@
 </style>
 
 <div id="onboarding-container"
-  data-community-name="<%= community_name %>"
-  data-community-description="<%= Settings::Community.community_description %>"
+  data-community-name="<%= j(community_name) %>"
+  data-community-description="<%= j(Settings::Community.community_description) %>"
   data-community-logo="<%= optimized_image_url(Settings::General.logo_png) %>"
   data-community-background="<%= optimized_image_url(Settings::General.onboarding_background_image, width: 1680, quality: 75, random_fallback: false) %>">
   <%= javascript_packs_with_chunks_tag "Onboarding", defer: true %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this commit, if our community name included a `"` we would
encounter a parse error.  Using the [j][1] which is a terse alias for
[escape_javascript][2], we will now be escaping those characters that
cause grief in some of our parsings.

I believe there is a larger audit that needs to occur regarding all
`data-` renderings.

Hopefully this will catch a flakey test.

[1]:https://api.rubyonrails.org/classes/ActionView/Helpers/JavaScriptHelper.html#method-i-j
[2]:https://api.rubyonrails.org/classes/ActionView/Helpers/JavaScriptHelper.html#method-i-escape_javascript

## Related Tickets & Documents

Closes #16440

## QA Instructions, Screenshots, Recordings

See if Travis breaks on these.

### UI accessibility concerns?

## Added/updated tests?

- [x] No, and this is why: Tests should start passing more regularly.  At a
      minimum, if community names include `"` they won't break.

## [Forem core team only] How will this change be communicated?

- [x] I'm not sure how best to communicate this change and need help
