### PR TITLE
remove activex fallback for internet explorer

### DIFF
--- a/app/assets/javascripts/initializers/initNotifications.js
+++ b/app/assets/javascripts/initializers/initNotifications.js
@@ -21,11 +21,7 @@ function markNotificationsAsRead() {
         10,
       );
 
-      if (window.XMLHttpRequest) {
-        xmlhttp = new XMLHttpRequest();
-      } else {
-        xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
-      }
+      xmlhttp = new XMLHttpRequest();
       xmlhttp.onreadystatechange = function () {};
 
       var csrfToken = document.querySelector("meta[name='csrf-token']").content;

--- a/app/assets/javascripts/initializers/initializeArticleReactions.js
+++ b/app/assets/javascripts/initializers/initializeArticleReactions.js
@@ -132,11 +132,7 @@ function setCollectionFunctionality() {
 
 function requestReactionCounts(articleId) {
   var ajaxReq;
-  if (window.XMLHttpRequest) {
-    ajaxReq = new XMLHttpRequest();
-  } else {
-    ajaxReq = new ActiveXObject('Microsoft.XMLHTTP');
-  }
+  ajaxReq = new XMLHttpRequest();
   ajaxReq.onreadystatechange = () => {
     if (ajaxReq.readyState === XMLHttpRequest.DONE) {
       var json = JSON.parse(ajaxReq.response);

--- a/app/assets/javascripts/initializers/initializeBodyData.js
+++ b/app/assets/javascripts/initializers/initializeBodyData.js
@@ -11,11 +11,7 @@ function removeExistingCSRF() {
 
 function fetchBaseData() {
   var xmlhttp;
-  if (window.XMLHttpRequest) {
-    xmlhttp = new XMLHttpRequest();
-  } else {
-    xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
-  }
+  xmlhttp = new XMLHttpRequest();
   xmlhttp.onreadystatechange = () => {
     if (xmlhttp.readyState === XMLHttpRequest.DONE) {
       // Assigning CSRF

--- a/app/assets/javascripts/initializers/initializeBodyData.js
+++ b/app/assets/javascripts/initializers/initializeBodyData.js
@@ -9,6 +9,7 @@ function removeExistingCSRF() {
   }
 }
 
+/* TODO: prefer fetch() to XMLHttpRequest */
 function fetchBaseData() {
   var xmlhttp;
   xmlhttp = new XMLHttpRequest();

--- a/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
+++ b/app/assets/javascripts/initializers/initializeCommentsPage.js.erb
@@ -28,11 +28,7 @@ function initializeCommentsPage() {
         for (var i = 0; i < commentableIdList.length; i++) {
           (function(i){
             var ajaxReq;
-            if (window.XMLHttpRequest) {
-              ajaxReq = new XMLHttpRequest();
-            } else {
-              ajaxReq = new ActiveXObject('Microsoft.XMLHTTP');
-            }
+            ajaxReq = new XMLHttpRequest();
             ajaxReq.onreadystatechange = function () {
               if (ajaxReq.readyState === XMLHttpRequest.DONE) {
                 var responseObj = JSON.parse(ajaxReq.response);

--- a/app/views/admin/articles/_image_upload_script.html.erb
+++ b/app/views/admin/articles/_image_upload_script.html.erb
@@ -21,11 +21,7 @@
    }
 
    function createAjaxReq() {
-     if (window.XMLHttpRequest) {
-       return new XMLHttpRequest();
-     } else {
-       return new ActiveXObject("Microsoft.XMLHTTP");
-     }
+     return new XMLHttpRequest();
    }
  });
 </script>

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -80,11 +80,8 @@
         window.location.pathname !== '/notifications'
       ) {
         var xmlhttp;
-        if (window.XMLHttpRequest) {
-          xmlhttp = new XMLHttpRequest();
-        } else {
-          xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
-        }
+
+        xmlhttp = new XMLHttpRequest();
         xmlhttp.onreadystatechange = function() {
           if (xmlhttp.readyState == XMLHttpRequest.DONE) {
             var count = xmlhttp.response;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The conditional assignment of `XMLHttpRequest` or `ActiveXObject('Microsoft.XMLHTTP')` before use supports IE5 and IE6 (IE7 and later included the XMLHttpRequest methods in the normal namespace).

We don't support IE5 or IE6 in a lot of other ways, does it seem necessary to continue this work-around pattern before using XHR?

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Nothing should break (cypress and  rails js system tests are using chrome, which fully supports this api).

### UI accessibility concerns?

If someone had been using Internet Explorer 6 still, this will worsen their experience. I assume they have other broken experiences throughout the web already.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Please don't be necessary.
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

Not post-deployment, but as a follow up, these calls may want to be updated to use the fetch api before long. I assume the touched files are the only instances where we're building the XMLHttpRequest objects, and all of those instances also had the fallback behavior in place.
