### PR TITLE
Ensuring optionally rendering dashboard listings

### DIFF
--- a/app/views/dashboards/_actions.html.erb
+++ b/app/views/dashboards/_actions.html.erb
@@ -63,12 +63,14 @@
       </a>
     </li>
 
+    <%- if Listing.feature_enabled? %>
     <li>
       <a class="crayons-link crayons-link--block" href="/listings/dashboard" data-no-instant>
         <%= t("views.dashboard.actions.listings") %>
         <%= crayons_icon_tag("external-link", class: "ml-1") %>
       </a>
     </li>
+    <%- end %>
 
     <li>
       <a class="crayons-link crayons-link--block" href="<%= dashboard_analytics_path %>">

--- a/app/views/dashboards/_analytics.html.erb
+++ b/app/views/dashboards/_analytics.html.erb
@@ -11,10 +11,12 @@
     <span class="color-base-60 block fs-base"><%= t("views.dashboard.summary.views") %></span>
   </div>
 
+  <%- if Listing.feature_enabled? %>
   <div class="crayons-card crayons-card--secondary p-3 m:p-6">
     <strong class="fs-2xl m:fs-3xl lh-tight color-base-90"><%= @user.listings.size %></strong>
     <span class="color-base-60 block fs-base"><%= t("views.dashboard.summary.listings") %></span>
   </div>
+  <%- end %>
 
   <div class="crayons-card crayons-card--secondary p-3 m:p-6">
     <strong class="fs-2xl m:fs-3xl lh-tight color-base-90"><%= @user.unspent_credits_count %></strong>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Don't render listing items in the dashboard if the instance disabled the listing feature.

## Related Tickets & Documents

Relates to forem/rfcs#291, #16420, #16437, #16423, and #16416.

## QA Instructions, Screenshots, Recordings

### Disabled Feature
<img width="1604" alt="Screen Shot 2022-02-08 at 9 44 24 AM" src="https://user-images.githubusercontent.com/2130/153010557-bb1f34b4-a43a-4e12-baab-9f1aef28e518.png">

### Enabled Feature
<img width="1611" alt="Screen Shot 2022-02-08 at 9 44 46 AM" src="https://user-images.githubusercontent.com/2130/153010533-a27d9591-268e-45f1-a6b9-d92d6c2b40ac.png">

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: I might if there's a test that asserts the presence.

## [Forem core team only] How will this change be communicated?

- [x] I'm not sure how best to communicate this change and need help
