### PR TITLE
Add color-scheme: dark to dark.css

### DIFF
--- a/app/assets/stylesheets/themes/dark.css
+++ b/app/assets/stylesheets/themes/dark.css
@@ -1,4 +1,6 @@
 :root {
+  color-scheme: dark;
+  
   --theme-secondary-color: #cedae2;
   --theme-container-background: #141f2d;
   --theme-container-accent-background: #202c3d;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `color-scheme: dark` to dark.css, in order to make browsers use dark versions of scrollbars.

dev.to on Chrome before:

![forem-chrome-before](https://user-images.githubusercontent.com/26078826/153091613-7cdbc73a-8199-4500-8c08-90bb87b17acd.PNG)

dev.to on Chrome after:

![forem-chrome-after](https://user-images.githubusercontent.com/26078826/153091616-e1ad2fdc-0118-4c75-bdeb-b899853013f7.PNG)

As described by https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme:

> The color-scheme CSS property allows an element to indicate which color schemes it can comfortably be rendered in.
>
> Common choices for operating system color schemes are "light" and "dark", or "day mode" and "night mode". When a user selects one of these color schemes, the operating system makes adjustments to the user interface. This includes form controls, scrollbars, and the used values of CSS system colors.

### UI accessibility concerns?

Accessibility of dark theme improved — perceived contrast of scrollbar thumb vs scrollbar track is increased.

## Added/updated tests?

- [x] No, and this is why: not sure how one would test such a change, as it's basically just a hint to the browser for how to render some default UI (in this case, scrollbars)