### PR TITLE
Add FeatureFlag.all

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -44,5 +44,13 @@ module FeatureFlag
 
       enabled?(feature_flag_name, *args)
     end
+
+    # Retrieve a list of all currently defined flags and their status. This is
+    # primarily intended for development and wraps +Flipper.features+.
+    #
+    # @return [Hash<Symbol, Symbol>] the defined flags with their status (+:on+ or +:off+).
+    def all
+      Flipper.features.to_h { |feature| [feature.name.to_sym, feature.state] }
+    end
   end
 end

--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -99,4 +99,14 @@ describe FeatureFlag, type: :service do
       end
     end
   end
+
+  describe ".all", :aggregate_failures do
+    it "returns a hash with all feature flags and their status" do
+      described_class.enable(:flag1)
+      expect(described_class.all).to eq({ flag1: :on })
+
+      described_class.disable(:flag2)
+      expect(described_class.all).to eq({ flag1: :on, flag2: :off })
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Feature

## Description

The discussion in https://github.com/forem/forem/pull/16416 unearthed that Flipper has a way to list all defined flags (`Flipper.features`) which we don't expose through our `FeatureFlag` wrapper module. This PR changes that by adding `FeatureFlag.all`.

## QA Instructions, Screenshots, Recordings

Tests should be sufficient.

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams