### PR TITLE
Allowing dependency injection for LiquidTag policy

### DIFF
--- a/app/liquid_tags/liquid_tag_base.rb
+++ b/app/liquid_tags/liquid_tag_base.rb
@@ -29,6 +29,17 @@ class LiquidTagBase < Liquid::Tag
     ""
   end
 
+  # @param _tag_name [String] When you do `{% embed <url> %}` the "embed" is the tag name.
+  # @param _content [String] The stuff between the tag name and the end of the liquid declaration.
+  # @param parse_context [Hash]
+  # @option parse_context [User] :user the user who's using the liquid tag (likely the article's
+  #         author).
+  # @option parse_context [Object] :source we're rendering this liquid tag "in" something, the
+  #         source is that something.  Examples iniclude Article.
+  # @option parse_context [ApplicationPolicy] :policy There are cases where we want to update liquid
+  #         tags en-masse (see https://github.com/forem/forem/pull/16460).  However, it's possible
+  #         the current user doesn't have permission to use this liquid tag.  This is the "backdoor"
+  #         for allowing that feature.  In most cases, however, we should use the LiquidTagPolicy.
   def initialize(_tag_name, _content, parse_context)
     super
     validate_contexts
@@ -37,7 +48,7 @@ class LiquidTagBase < Liquid::Tag
       parse_context.partial_options[:user],
       self,
       :initialize?,
-      policy_class: LiquidTagPolicy,
+      policy_class: parse_context.partial_options.fetch(:policy) { LiquidTagPolicy },
     )
   end
 

--- a/spec/liquid_tags/liquid_tag_base_spec.rb
+++ b/spec/liquid_tags/liquid_tag_base_spec.rb
@@ -5,6 +5,24 @@ RSpec.describe LiquidTagBase, type: :liquid_tag do
   # LiquidTagBase inherits from, so we treat this class as a liquid tag itself.
   before { Liquid::Template.register_tag("liquid_tag_base", described_class) }
 
+  context "when context includes a policy" do
+    let(:policy_klass) do
+      Class.new(ApplicationPolicy) do
+        def initialize?
+          false
+        end
+      end
+    end
+
+    it "is used by Pundit for authorization" do
+      source = create(:article)
+      expect do
+        liquid_tag_options = { source: source, user: source.user, policy: policy_klass }
+        Liquid::Template.parse("{% liquid_tag_base %}", liquid_tag_options)
+      end.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
+
   context "when VALID_CONTEXTS are defined" do
     before { stub_const("#{described_class}::VALID_CONTEXTS", %w[Article]) }
 

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -448,4 +448,28 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
       expect(generate_and_parse_markdown(codeblock)).to include("%}")
     end
   end
+
+  context "with additional_liquid_tag_options" do
+    it "passes those options to Liquid::Template.parse" do
+      # rubocop:disable RSpec/VerifiedDoubles
+      #
+      # I don't want to delve into the implementation details of liquid to test what the parse
+      # method's return value.
+      parse_response = double("parse_response", render: "liquified!")
+      # rubocop:enable RSpec/VerifiedDoubles
+
+      allow(Liquid::Template).to receive(:parse).and_return(parse_response)
+      described_class.new(
+        "{% liquid example %}",
+        source: :my_source,
+        user: :my_user,
+        policy: :my_policy,
+      ).finalize
+      expect(Liquid::Template).to have_received(:parse)
+        .with(
+          "<p>{% liquid example %}</p>\n",
+          { source: :my_source, policy: :my_policy, user: :my_user },
+        )
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature (kind of)

## Description

This is the least effort I can presently think of to allow for us to
reprocess user article's and handle the scenario in which the user may
have once had permission to the liquid tag but no longer.

This DI is not something I imagine using, but may highlight a better
approach for liquid tag permissions.


## Related Tickets & Documents

Related to #12146 and #16460

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
