### PR TITLE
Adding feature flag for Authorization 1-1

### DIFF
--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -1,4 +1,17 @@
 class ArticlePolicy < ApplicationPolicy
+  # @return [TrueClass] when only Forem admins can post an Article.
+  # @return [FalseClass] when most any Forem user can post an Article.
+  #
+  # @note This is for Authorization System: use case 1-1.  At present, this is the quickest way to
+  #       refactor our code to deliver on that feature.
+  #
+  # @see https://github.com/forem/forem/pull/16437 for pattern of adding a predicate method to the
+  #      "most relevant" class.
+  # @see https://github.com/orgs/forem/projects/46 for project details
+  def self.limit_post_creation_to_admins?
+    FeatureFlag.enabled?(:limit_post_creation_to_admins)
+  end
+
   def update?
     user_author? || user_admin? || user_org_admin? || minimal_admin?
   end

--- a/spec/policies/article_policy_spec.rb
+++ b/spec/policies/article_policy_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe ArticlePolicy do
 
   before { allow(article).to receive(:published).and_return(true) }
 
+  describe ".limit_post_creation_to_admins?" do
+    subject(:method_call) { described_class.limit_post_creation_to_admins? }
+
+    # This is articulating the default assumption.  Other tests will likely toggle this behavior.
+    it { is_expected.to be_falsey }
+  end
+
   context "when user is not signed-in" do
     let(:user) { nil }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Documentation Update

## Description

As written in the comments, we're looking at making the smallest change
to deliver on the feature.  The other goal is to move from our
`user.admin?` paradigm towards leveraging Pundit policies.

If we need to move beyond Pundit, it will be easier once we've moved
all of our `user.something_something?` to policy questions.  And please
note, I don't know if we'll move past pundit.

See [Authorization System: use case 1-1 project][1] for details on the
project.


[1]:https://github.com/orgs/forem/projects/46/views/1

## Related Tickets & Documents

Closes #16483


## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
