### PR TITLE
Renaming policy methods for consistency

### DIFF
--- a/app/policies/admin_policy.rb
+++ b/app/policies/admin_policy.rb
@@ -1,9 +1,9 @@
 class AdminPolicy < ApplicationPolicy
   def show?
-    user_admin?
+    user_super_admin?
   end
 
   def minimal?
-    minimal_admin?
+    user_any_admin?
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -59,17 +59,15 @@ class ApplicationPolicy
     end
   end
 
-  def minimal_admin?
-    user.any_admin?
-  end
-
-  def user_admin?
-    user.super_admin?
-  end
-
   delegate :support_admin?, to: :user
 
-  delegate :suspended?, to: :user, prefix: true
+  delegate :super_admin?, :any_admin?, :suspended?, to: :user, prefix: true
+
+  alias minimal_admin? user_any_admin?
+  deprecate minimal_admin?: "Deprecating #{self}#minimal_admin?, use #{self}#user_any_admin?"
+
+  alias user_admin? user_super_admin?
+  deprecate minimal_admin?: "Deprecating #{self}#user_admin?, use #{self}#user_super_admin?"
 
   def user_trusted?
     user.has_trusted_role?

--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -13,11 +13,11 @@ class ArticlePolicy < ApplicationPolicy
   end
 
   def update?
-    user_author? || user_admin? || user_org_admin? || minimal_admin?
+    user_author? || user_super_admin? || user_org_admin? || user_any_admin?
   end
 
   def admin_unpublish?
-    minimal_admin?
+    user_any_admin?
   end
 
   def new?
@@ -41,7 +41,7 @@ class ArticlePolicy < ApplicationPolicy
   alias preview? new?
 
   def stats?
-    user_author? || user_admin? || user_org_admin?
+    user_author? || user_super_admin? || user_org_admin?
   end
 
   def permitted_attributes
@@ -52,7 +52,7 @@ class ArticlePolicy < ApplicationPolicy
   end
 
   def subscriptions?
-    user_author? || user_admin?
+    user_author? || user_super_admin?
   end
 
   private

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -22,7 +22,7 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def moderator_create?
-    user_moderator? || minimal_admin?
+    user_moderator? || user_any_admin?
   end
 
   def hide?
@@ -32,7 +32,7 @@ class CommentPolicy < ApplicationPolicy
   alias unhide? hide?
 
   def admin_delete?
-    minimal_admin?
+    user_any_admin?
   end
 
   def permitted_attributes_for_update

--- a/app/policies/discussion_lock_policy.rb
+++ b/app/policies/discussion_lock_policy.rb
@@ -2,7 +2,7 @@ class DiscussionLockPolicy < ApplicationPolicy
   PERMITTED_ATTRIBUTES = %i[article_id notes reason].freeze
 
   def create?
-    (user_author? || minimal_admin?) && !user_suspended?
+    (user_author? || user_any_admin?) && !user_suspended?
   end
 
   alias destroy? create?

--- a/app/policies/html_variant_policy.rb
+++ b/app/policies/html_variant_policy.rb
@@ -1,6 +1,6 @@
 class HtmlVariantPolicy < ApplicationPolicy
   def index?
-    minimal_admin?
+    user_any_admin?
   end
 
   alias show? minimal_admin?

--- a/app/policies/response_template_policy.rb
+++ b/app/policies/response_template_policy.rb
@@ -6,7 +6,7 @@ class ResponseTemplatePolicy < ApplicationPolicy
   end
 
   def admin_index?
-    minimal_admin?
+    user_any_admin?
   end
 
   def moderator_index?
@@ -41,7 +41,7 @@ class ResponseTemplatePolicy < ApplicationPolicy
   end
 
   def user_moderator?
-    minimal_admin? || user.moderator_for_tags&.present?
+    user_any_admin? || user.moderator_for_tags&.present?
   end
 
   def mod_comment?

--- a/app/policies/tag_policy.rb
+++ b/app/policies/tag_policy.rb
@@ -10,13 +10,13 @@ class TagPolicy < ApplicationPolicy
   alias update? edit?
 
   def admin?
-    user_admin?
+    user_super_admin?
   end
 
   private
 
   def has_mod_permission?
-    user_admin? ||
+    user_super_admin? ||
       user.tag_moderator?(tag: record)
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -81,11 +81,11 @@ class UserPolicy < ApplicationPolicy
   alias remove_identity? edit?
 
   def dashboard_show?
-    current_user? || user_admin? || minimal_admin?
+    current_user? || user_super_admin? || user_any_admin?
   end
 
   def moderation_routes?
-    (user.has_trusted_role? || minimal_admin?) && !user.suspended?
+    (user.has_trusted_role? || user_any_admin?) && !user.suspended?
   end
 
   alias update_password? edit?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Our domain of "admin?" method names is already a bit confounding.  The
policy methods renamed the existing Policy::Authorizer methods, and
further obfuscated and confused intention.

This refactor aligns the policy methods with the Policy::Authorizer
methods.  It is a non-breaking change, but one that may add warnings in
the logs.  If you see those, resolve them per instructions.

## Related Tickets & Documents

Related to #16483

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [X] No, and this is why: the underlying tests did not exercise these methods.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
