### PR TITLE
Avoid gif CLS

### DIFF
--- a/app/assets/stylesheets/article-show.scss
+++ b/app/assets/stylesheets/article-show.scss
@@ -557,8 +557,7 @@ article {
   --gif-bg: rgb(var(--black));
   --gif-color: rgb(var(--white));
 
-  left: 50%;
-  transform: translateX(-50%);
+  width: fit-content;
 
   // Align styles of freezeframed animated images with normal image styles
   canvas {

--- a/app/assets/stylesheets/base/typography.scss
+++ b/app/assets/stylesheets/base/typography.scss
@@ -264,8 +264,10 @@ body {
     margin: 0 0 var(--content-rhythm) 0;
   }
 
+  // This .ff-container classname is added by the freezeframe library we use to play/pause animated images
   img,
-  video {
+  video,
+  .ff-container {
     height: auto;
     display: block;
     margin: var(--content-rhythm) auto;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A small cumulative layout shift was visible as the play/pause functionality for gifs loaded in. This was most noticeable when the gif appeared as the very first item in a post (but also to a smaller degree when within the main content).

This PR addresses the issue by making sure the new `.ff-container` element (inserted by the freezeframe library) receives all the same CSS styles as other images in posts.

## Related Tickets & Documents

Fixes https://github.com/forem/forem/issues/16535

## QA Instructions, Screenshots, Recordings

I've found the easiest way to QA this is to:

- open two browser instances side by side
- in one of them, disable javascript (this prevents the play/pause functionality from loading in)
- in both instances, load the same post which contains a gif
- observe the final positions of the gifs; they should be the same
- test this both with gifs at the very beginning of a post, and mid-way through the content

Here's the side-by-side view (right side has JS disabled):

![two posts side by side](https://user-images.githubusercontent.com/20773163/153599865-c9fc5be7-0ded-4a88-b286-d91b8cf14fe0.png)

And here's the JS-enabled version loading in (slow down the playback speed 😄 ):

https://user-images.githubusercontent.com/20773163/153599900-1296b130-40f0-4e91-9fd5-1670526bc001.mp4


You can also run a Lighthouse performance check on your local page, and the report should not reference the gif as a source of a large CLS (previously it did):

![Lighthouse report](https://user-images.githubusercontent.com/20773163/153600054-b10ab412-05a0-4688-8526-612c1b52e16c.png)

### UI accessibility concerns?

N/A


## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: functionality hasn't changed
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: the feature is deployed widely yet, and it's a fairly minimal change

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![Stay!](https://media.giphy.com/media/P2Of3t8sxcQVXBFDry/giphy.gif)
