### PR TITLE
Render social previews for tags with one of the two custom colors set

### DIFF
--- a/app/controllers/social_previews_controller.rb
+++ b/app/controllers/social_previews_controller.rb
@@ -38,6 +38,7 @@ class SocialPreviewsController < ApplicationController
 
   def tag
     @tag = Tag.find(params[:id])
+    @compare_hex = Color::CompareHex.new([@tag.bg_color_hex || "#000000", @tag.fg_color_hex || "#ffffff"])
 
     set_respond
   end

--- a/app/controllers/social_previews_controller.rb
+++ b/app/controllers/social_previews_controller.rb
@@ -38,7 +38,7 @@ class SocialPreviewsController < ApplicationController
 
   def tag
     @tag = Tag.find(params[:id])
-    @compare_hex = Color::CompareHex.new([@tag.bg_color_hex || "#000000", @tag.fg_color_hex || "#ffffff"])
+    @compare_hex = Color::CompareHex.new([@tag.bg_color_hex || "#000000", @tag.text_color_hex || "#ffffff"])
 
     set_respond
   end

--- a/app/views/social_previews/tag.html.erb
+++ b/app/views/social_previews/tag.html.erb
@@ -1,6 +1,6 @@
-<% accent_color = Color::CompareHex.new([@tag.bg_color_hex, @tag.text_color_hex]).biggest %>
-<% color = Color::CompareHex.new([@tag.bg_color_hex, @tag.text_color_hex]).brightness(1.4) %>
-<% dark_color = Color::CompareHex.new([@tag.bg_color_hex, @tag.text_color_hex]).brightness(0.7) %>
+<% accent_color = @compare_hex.biggest %>
+<% color = @compare_hex.brightness(1.4) %>
+<% dark_color = @compare_hex.brightness(0.7) %>
 <% not_so_rand = Random.new(@tag.id) # Using ID as seed ensures we get the same "random" numbers on each page load, Improves caching %>
 <style>
   body {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds a fallback color choice when there are missing
bg_color_hex or text_color_hex (this is likely going to become more
common as we only show the bg_color_hex in the form).

The choices (black and white) may not be correct - this "custom, or
default" value choice should likely be made in a decorator or on the
model instead.


Moving the object initialization into the controller was only done to avoid repetition


## Related Tickets & Documents

Addresses an error reported in
https://app.honeybadger.io/projects/66984/faults/83671065


## QA Instructions, Screenshots, Recordings

From the console, or blazer, or psql cli, find the id of a tag with colors set, and the id of a tag without (in my case, tag 13 was `#discuss`, which did not have any colors set, and tag 12 was `#webdev` which had both set).

The social preview pages can be shown by tag id - thus
 
http://localhost:3000/social_previews/tag/12.html 
![tag social preview with custom colors](https://user-images.githubusercontent.com/1237369/153912183-3ed557f2-7934-4da2-8190-8cd9deebb9e5.png)


http://localhost:3000/social_previews/tag/13.html  

![tag social preview with default colors](https://user-images.githubusercontent.com/1237369/153912316-4cbd1bc0-e1cf-4bd5-b7d9-384e649cfdfb.png)

While both of _these_ examples work on main, update one of the two colors (set bg_color_hex for #discuss from nil to "#000000") and reload - on main this attempts to sort ["#000000", nil] and raises an error, while in this branch it should be sorting "#000000" and the fallback value for text_color_hex instead (and succeed).


```ruby
# unset the text_color_hex for tag webdev, leaving the bg_color_hex set
Tag.find(12).update(text_color_hex: nil)
```

Comparison of nil with string fails on main:
![error on main](https://user-images.githubusercontent.com/1237369/153914661-fe830a50-ec03-4507-adb9-0a189fe50c3c.png)


fallback to default tag colors succeeds on this branc

![successful render of tag preview on this branch](https://user-images.githubusercontent.com/1237369/153914845-d8025406-550c-48b2-89a4-25363ca67836.png)


### UI accessibility concerns?

None - these social previews are normally only fetched from external sources (twitter links, for example).

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: bugfix
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: bugfix


