### PR TITLE
Fix NoMethodError on Nil for article preview

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -91,11 +91,19 @@ class ArticlesController < ApplicationController
         format.json { render json: @article.errors, status: :unprocessable_entity }
       else
         format.json do
+          front_matter = parsed.front_matter.to_h
+          if front_matter["tags"]
+            tags = Article.new.tag_list.add(front_matter["tags"], parser: ActsAsTaggableOn::TagParser)
+          end
+          if front_matter["cover_image"]
+            cover_image = ApplicationController.helpers.cloud_cover_url(front_matter["cover_image"])
+          end
+
           render json: {
             processed_html: processed_html,
-            title: parsed["title"],
-            tags: (Article.new.tag_list.add(parsed["tags"], parser: ActsAsTaggableOn::TagParser) if parsed["tags"]),
-            cover_image: (ApplicationController.helpers.cloud_cover_url(parsed["cover_image"]) if parsed["cover_image"])
+            title: front_matter["title"],
+            tags: tags,
+            cover_image: cover_image
           }, status: :ok
         end
       end

--- a/spec/requests/editor_spec.rb
+++ b/spec/requests/editor_spec.rb
@@ -63,5 +63,25 @@ RSpec.describe "Editor", type: :request do
         expect(response.media_type).to eq("application/json")
       end
     end
+
+    context "with front matter" do
+      it "returns successfully" do
+        sign_in user
+        article_body = <<~MARKDOWN
+          ---
+          ---
+
+          Hello
+        MARKDOWN
+
+        # binding.pry
+        post "/articles/preview",
+             headers: headers,
+             params: { article_body: article_body },
+             as: :json
+
+        expect(response).to be_successful
+      end
+    end
   end
 end

--- a/spec/requests/editor_spec.rb
+++ b/spec/requests/editor_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe "Editor", type: :request do
           Hello
         MARKDOWN
 
-        # binding.pry
         post "/articles/preview",
              headers: headers,
              params: { article_body: article_body },


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The `FrontMatterParser::Parser#call` method can return `nil` if the front matter is empty. For example:

```markdown
---
---

Body content
```

This causes [this line](https://github.com/forem/forem/blob/0e8089c4046f196aad5bdbb91e3cb5c9abdcd4c3/app/controllers/articles_controller.rb#L95) to raise a `NoMethodError`. We can default this to an empty hash in this case so that it will respond to the right methods.

I _think_ this bug comes from the fact that `---` is valid Markdown (translates to `<hr/>` in HTML), so the front-matter parser doesn't seem to be able to distinguish between front matter and two consecutive `<hr/>` elements. I'm also guessing that this doesn't come up more often because people probably delete the front matter entirely more often than leaving it empty.

## Related Tickets & Documents

- https://app.honeybadger.io/projects/66984/faults/83370648

## QA Instructions, Screenshots, Recordings

- Go to `/new`
- Create a post with empty front matter
- Hit the "Preview" button
- You should see an actual preview of your post

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: Simple fix for a bug most people probably didn't even know existed