### PR TITLE
Removing deprecation warning

### DIFF
--- a/app/controllers/api/v0/listings_controller.rb
+++ b/app/controllers/api/v0/listings_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V0
     class ListingsController < ApiController
-      include Pundit
+      include Pundit::Authorization
       include ListingsToolkit
 
       # actions `create` and `update` are defined in the module `ListingsToolkit`,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   include SessionCurrentUser
   include ValidRequest
-  include Pundit
+  include Pundit::Authorization
   include CachingHeaders
   include ImageUploads
   include DevelopmentDependencyChecks if Rails.env.development?
@@ -74,7 +74,7 @@ class ApplicationController < ActionController::Base
 
   def not_authorized
     render json: { error: I18n.t("application_controller.not_authorized") }, status: :unauthorized
-    raise NotAuthorizedError, "Unauthorized"
+    raise Pundit::NotAuthorizedError, "Unauthorized"
   end
 
   def bad_request


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Prior to this commit, I saw the following in the Rails test log:

```
DEPRECATION WARNING: 'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.
 (called from include at ./app/controllers/application_controller.rb:12)
 ```

## Related Tickets & Documents

Related to #16483

## QA Instructions, Screenshots, Recordings

None.  The tests should cover all of this.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: addressing deprecation

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
