### PR TITLE
Tweaks to the admin flash messages flow

### DIFF
--- a/app/javascript/packs/admin/flashMessages.js
+++ b/app/javascript/packs/admin/flashMessages.js
@@ -3,6 +3,4 @@ const [ firstFlashDismissBtn ] =
 
 // This allows screen reader users to become aware of the message (as well as bringing focus to the top of the main content).
 // (we don't use aria-live or role="alert" on the message text as these are not reliably announced for content that exists from page load)
-if (firstFlashDismissBtn) {
-  firstFlashDismissBtn.focus();
-}
+firstFlashDismissBtn?.focus();

--- a/app/javascript/packs/admin/flashMessages.js
+++ b/app/javascript/packs/admin/flashMessages.js
@@ -1,0 +1,8 @@
+const firstFlashDismissBtn =
+  document.getElementsByClassName('js-flash-close-btn')[0];
+
+// This allows screen reader users to become aware of the message (as well as bringing focus to the top of the main content).
+// (we don't use aria-live or role="alert" on the message text as these are not reliably announced for content that exists from page load)
+if (firstFlashDismissBtn) {
+  firstFlashDismissBtn.focus();
+}

--- a/app/javascript/packs/admin/flashMessages.js
+++ b/app/javascript/packs/admin/flashMessages.js
@@ -1,5 +1,5 @@
-const firstFlashDismissBtn =
-  document.getElementsByClassName('js-flash-close-btn')[0];
+const [ firstFlashDismissBtn ] =
+  document.getElementsByClassName('js-flash-close-btn');
 
 // This allows screen reader users to become aware of the message (as well as bringing focus to the top of the main content).
 // (we don't use aria-live or role="alert" on the message text as these are not reliably announced for content that exists from page load)

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -80,12 +80,13 @@
       </nav>
     </div>
     <main id="main-content" class="crayons-layout__content min-w-0 p-2">
-      <% flash.each do |type, message| %>
+      <%= javascript_packs_with_chunks_tag "admin/flashMessages", defer: true %>
+      <% flash.each_with_index do |(type, message), i| %>
         <div data-testid="flash-<%= type %>" class="alert alert-<%= type == "notice" || type == "success" ? "success" : "danger" %>">
-          <button class="close" data-dismiss="alert" aria-label="Close">
+          <span id="flash-<%= i %>"><%= message %></span>
+          <button class="close js-flash-close-btn" data-dismiss="alert" aria-label="Dismiss message" aria-describedby="flash-<%= i %>">
             <%= crayons_icon_tag(:x, aria_hidden: true) %>
           </button>
-          <%= message %>
         </div>
       <% end %>
 

--- a/cypress/integration/seededFlows/adminFlows/users/manageCredits.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/manageCredits.spec.js
@@ -6,9 +6,11 @@ function openCreditsModal() {
   return cy.getModal();
 }
 
-function closeUserUpdatedMessage(message) {
+function verifyAndDismissUserUpdatedMessage(message) {
   cy.findByText(message).should('exist');
-  cy.findByRole('button', { name: 'Close' }).click();
+  cy.findByRole('button', { name: 'Dismiss message' })
+    .should('have.focus')
+    .click();
   cy.findByText(message).should('not.exist');
 }
 
@@ -38,7 +40,7 @@ describe('Manage User Credits', () => {
       });
 
       cy.getModal().should('not.exist');
-      closeUserUpdatedMessage('Credits have been added!');
+      verifyAndDismissUserUpdatedMessage('Credits have been added!');
       cy.findByTestId('user-credits').should('have.text', '210');
     });
 
@@ -57,7 +59,7 @@ describe('Manage User Credits', () => {
       });
 
       cy.getModal().should('not.exist');
-      closeUserUpdatedMessage('Credits have been removed.');
+      verifyAndDismissUserUpdatedMessage('Credits have been removed.');
       cy.findByTestId('user-credits').should('have.text', '89');
     });
 
@@ -76,7 +78,7 @@ describe('Manage User Credits', () => {
       });
 
       cy.getModal().should('not.exist');
-      closeUserUpdatedMessage('Credits have been removed.');
+      verifyAndDismissUserUpdatedMessage('Credits have been removed.');
       cy.findByTestId('user-credits').should('have.text', '0');
     });
   });

--- a/cypress/integration/seededFlows/adminFlows/users/manageOrganizations.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/manageOrganizations.spec.js
@@ -6,9 +6,11 @@ function openOrgModal(ctaText = 'Add organization') {
   return cy.getModal();
 }
 
-function closeUserUpdatedMessage(message) {
+function verifyAndDismissUserUpdatedMessage(message) {
   cy.findByText(message).should('exist');
-  cy.findByRole('button', { name: 'Close' }).click();
+  cy.findByRole('button', { name: 'Dismiss message' })
+    .should('have.focus')
+    .click();
   cy.findByText(message).should('not.exist');
 }
 
@@ -34,7 +36,9 @@ describe('Manage User Organziations', () => {
         cy.findByRole('button', { name: 'Add organization' }).click();
       });
 
-      closeUserUpdatedMessage('User was successfully added to Bachmanity');
+      verifyAndDismissUserUpdatedMessage(
+        'User was successfully added to Bachmanity',
+      );
       cy.getModal().should('not.exist');
 
       // Focusing on the link is required to make buttons visible.
@@ -60,14 +64,18 @@ describe('Manage User Organziations', () => {
         cy.findByRole('button', { name: 'Add organization' }).click();
       });
 
-      closeUserUpdatedMessage('User was successfully added to Bachmanity');
+      verifyAndDismissUserUpdatedMessage(
+        'User was successfully added to Bachmanity',
+      );
 
       openOrgModal('Add another organization').within(() => {
         cy.findByRole('spinbutton', { name: 'Organization ID' }).type(2);
         cy.findByRole('button', { name: 'Add organization' }).click();
       });
 
-      closeUserUpdatedMessage('User was successfully added to Awesome Org');
+      verifyAndDismissUserUpdatedMessage(
+        'User was successfully added to Awesome Org',
+      );
       cy.getModal().should('not.exist');
 
       // Focusing on the link is required to make buttons visible.
@@ -103,7 +111,9 @@ describe('Manage User Organziations', () => {
         cy.findByRole('button', { name: 'Update' }).click();
       });
 
-      closeUserUpdatedMessage('User was successfully updated to admin');
+      verifyAndDismissUserUpdatedMessage(
+        'User was successfully updated to admin',
+      );
       cy.getModal().should('not.exist');
     });
 
@@ -115,7 +125,9 @@ describe('Manage User Organziations', () => {
         cy.findByRole('button', { name: 'Add organization' }).click();
       });
 
-      closeUserUpdatedMessage('User was successfully added to Bachmanity');
+      verifyAndDismissUserUpdatedMessage(
+        'User was successfully added to Bachmanity',
+      );
       cy.getModal().should('not.exist');
 
       // Two links currently exist for every org (image and name)
@@ -134,7 +146,9 @@ describe('Manage User Organziations', () => {
         name: 'Revoke Awesome Org organization membership',
       }).click();
 
-      closeUserUpdatedMessage('User was successfully removed from Awesome Org');
+      verifyAndDismissUserUpdatedMessage(
+        'User was successfully removed from Awesome Org',
+      );
     });
   });
 });

--- a/cypress/integration/seededFlows/adminFlows/users/manageRoles.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/manageRoles.spec.js
@@ -6,9 +6,11 @@ function openRolesModal() {
   return cy.getModal();
 }
 
-function closeUserUpdatedMessage() {
+function verifyAndDismissUserUpdatedMessage() {
   cy.findByText('User has been updated').should('exist');
-  cy.findByRole('button', { name: 'Close' }).click();
+  cy.findByRole('button', { name: 'Dismiss message' })
+    .should('have.focus')
+    .click();
   cy.findByText('User has been updated').should('not.exist');
 }
 
@@ -44,7 +46,7 @@ describe('Manage User Roles', () => {
         });
 
         cy.getModal().should('not.exist');
-        closeUserUpdatedMessage();
+        verifyAndDismissUserUpdatedMessage();
 
         cy.findByRole('button', { name: 'Remove role: Warned' }).should(
           'exist',
@@ -117,7 +119,7 @@ describe('Manage User Roles', () => {
         });
 
         cy.getModal().should('not.exist');
-        closeUserUpdatedMessage();
+        verifyAndDismissUserUpdatedMessage();
         checkUserStatus('Warned');
 
         cy.findByRole('button', { name: 'Remove role: Warned' }).should(
@@ -131,7 +133,7 @@ describe('Manage User Roles', () => {
         });
 
         cy.getModal().should('not.exist');
-        closeUserUpdatedMessage();
+        verifyAndDismissUserUpdatedMessage();
         checkUserStatus('Warned');
 
         cy.findByRole('button', { name: 'Remove role: Warned' }).should(

--- a/cypress/integration/seededFlows/adminFlows/users/manageUserOptions.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/manageUserOptions.spec.js
@@ -11,7 +11,7 @@ function openUserOptions(callback) {
     });
 }
 
-function closeUserUpdatedMessage(message) {
+function verifyAndDismissUserUpdatedMessage(message) {
   cy.findByTestId('flash-success')
     .as('success')
     .then((element) => {
@@ -19,7 +19,9 @@ function closeUserUpdatedMessage(message) {
     });
 
   cy.get('@success').within(() => {
-    cy.findByRole('button', { name: 'Close' }).click();
+    cy.findByRole('button', { name: 'Dismiss message' })
+      .should('have.focus')
+      .click();
   });
 
   cy.findByTestId('flash-success').should('not.exist');
@@ -39,7 +41,7 @@ describe('Manage User Options', () => {
       openUserOptions(() => {
         cy.findByRole('button', { name: 'Verify email address' }).click();
       });
-      closeUserUpdatedMessage('Verification email sent!');
+      verifyAndDismissUserUpdatedMessage('Verification email sent!');
     });
 
     it(`should export a user's data to an admin`, () => {
@@ -51,7 +53,7 @@ describe('Manage User Options', () => {
         cy.findByRole('button', { name: 'Export to Admin' }).click();
       });
 
-      closeUserUpdatedMessage(
+      verifyAndDismissUserUpdatedMessage(
         'Data exported to the admin. The job will complete momentarily.',
       );
     });
@@ -65,7 +67,7 @@ describe('Manage User Options', () => {
         cy.findByRole('button', { name: 'Export to User' }).click();
       });
 
-      closeUserUpdatedMessage(
+      verifyAndDismissUserUpdatedMessage(
         'Data exported to the user. The job will complete momentarily.',
       );
     });
@@ -90,7 +92,7 @@ describe('Manage User Options', () => {
         cy.findByRole('button', { name: 'Banish User for spam' }).click();
       });
 
-      closeUserUpdatedMessage(
+      verifyAndDismissUserUpdatedMessage(
         'This user is being banished in the background. The job will complete soon.',
       );
     });
@@ -106,7 +108,7 @@ describe('Manage User Options', () => {
         }).click();
       });
 
-      closeUserUpdatedMessage(
+      verifyAndDismissUserUpdatedMessage(
         '@trusted_user_1 (email: trusted-user-1@forem.local, user_id: 2) has been fully deleted. If this is a GDPR delete, delete them from Mailchimp & Google Analytics  and confirm on the page.',
       );
     });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently, flash messages (success/error) aren't announced to screen reader users. The main challenge with this is that the flash messages appear on page reload, and both `aria-live` and `role="alert"` do not reliably announce their content if it is already present in the DOM when the page first loads (they're intended for dynamic changes mid-page use).

I've explored a few different options to solve this, and arrived at the conclusion that the most understandable (and maintainable) way to manage this is to:

- send focus to the message dismiss button (if exists) when the page loads
- add an `aria-describedby` to the button which links the message text with it

I think this is our best option for the time being since we get a few side-effect behaviours that feel like accessibility boosts too:

- Focus is restored to the top of the main content after executing an action (seems like a predictable and preferable behaviour over having to re-use the skip link to get back to where you triggered the action)
- The 'dismiss message' button gains a bit more context too (i.e. what is the message 😄 )
- And, yep, it makes sure a user's attention is drawn to the message and it's announced to screen reader users

## Related Tickets & Documents

https://github.com/forem/forem/issues/16504

## QA Instructions, Screenshots, Recordings

- go to the member detail view
- add a role (or credits, or any other action that will refresh the page and show a notice)
- check that when the page reloads, your focus is on the "close" button in the notice
- either by using a screen-reader and listening to the announcements or by inspecting the "Accessibility" tab of the developer tools, check that the message itself is linked with the button (e.g. announced as "Dismiss message, User has been updated")

### UI accessibility concerns?

This is to address an existing accessibility issue

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

