### PR TITLE
Adjusting ArticlePolicy for admin only posting

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,13 +29,6 @@ class ApplicationController < ActionController::Base
     )
   end
 
-  ##
-  # [@jeremyf] - I want to enable this, but based on our current application configuration, I
-  #              cannot.  Why?  The existing tests assume that when we check a policy, if we don't
-  #              have a user we raise a Pundit::NotAuthorizedError.
-  #
-  # rescue_from ApplicationPolicy::UserRequiredError, with: :respond_with_request_for_authentication
-
   rescue_from ApplicationPolicy::UserSuspendedError, with: :respond_with_user_suspended
 
   PUBLIC_CONTROLLERS = %w[async_info

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -10,7 +10,27 @@ class ArticlesController < ApplicationController
   before_action :set_cache_control_headers, only: %i[feed]
   after_action :verify_authorized
 
+  ##
+  # [@jeremyf] - My dreamiest of dreams is to move this to the ApplicationController.  But it's very
+  #              presence could create some havoc with our edge caching.  So I'm scoping it to the
+  #              place where the code is likely to raise an ApplicationPolicy::UserRequiredError.
+  #
+  #              I still want to enable this, but first want to get things mostly conformant with
+  #              existing expectations.  Note, in config/application.rb, we're rescuing the below
+  #              excpetion as though it was a Pundit::NotAuthorizedError.
+  #
+  #              The difference being that rescue_from is an ALWAYS use case.  Whereas the
+  #              config/application.rb uses the config.consider_all_requests_local to determine if
+  #              we bubble the exception up or handle it.
+  #
+  # rescue_from ApplicationPolicy::UserRequiredError, with: :respond_with_request_for_authentication
+
   def feed
+    # [@jeremyf] - I am a firm believer that we should check authorization.  However, in this case,
+    #              based on our implementation constraints and assumptions, the `#feed` action will
+    #              almost certainly be available to everyone (what's in the feed will vary
+    #              signficantly).  So while I would love an `authorize(Article)` here, I will make
+    #              do with a comment.
     skip_authorization
 
     @articles = Article.feed.order(published_at: :desc).page(params[:page].to_i).per(12)

--- a/app/controllers/concerns/caching_headers.rb
+++ b/app/controllers/concerns/caching_headers.rb
@@ -12,6 +12,11 @@ module CachingHeaders
   #  Surrogate-Control: 'max-age: 86400' - 1 day in seconds
   # custom config example:
   #  {cache_control: 'public, no-cache, maxage=xyz', surrogate_control: 'max-age: 100'}
+  #
+  # @note If you call this for a public Forem, you won't have access to data about the current user.
+  #       You can check if they are authenticated but nothing else.
+  #
+  # @see {EdgeCacheSafetyCheck#current_user} for impact on "current_user"
   def set_cache_control_headers(
     max_age = 1.day.to_i,
     surrogate_control: nil,

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,6 +66,7 @@ module PracticalDeveloper
 
     # Authorization / Authentication exception handling.
     config.action_dispatch.rescue_responses["Pundit::NotAuthorizedError"] = :not_found
+    config.action_dispatch.rescue_responses["ApplicationPolicy::NotAuthorizedError"] = :not_found
 
     # @note [@jeremyf] I have included this to preserve behavior verified in our test suite.  My
     #       plan, however, is to change how we handle authentication and authorization.  In the case

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe "Comments", type: :request do
 
   describe "GET /:username/:slug/comments/:id_code/edit" do
     context "when not logged-in" do
-      it "returns unauthorized error" do
+      it "raises unauthorized error" do
         expect do
           get "/#{user.username}/#{article.slug}/comments/#{comment.id_code_generated}/edit"
         end.to raise_error(Pundit::NotAuthorizedError)

--- a/spec/requests/editor_spec.rb
+++ b/spec/requests/editor_spec.rb
@@ -2,27 +2,35 @@ require "rails_helper"
 
 RSpec.describe "Editor", type: :request do
   describe "GET /new" do
-    context "when not logged-in" do
-      it "asks the non logged in user to sign in" do
-        get new_path
+    subject(:request_call) { get new_path }
 
-        # NOTE: [@jeremyf] This response status seems a bit surprising.  Should the prompt for signin redirect
-        # the user to a login page?  Or are we doing something with Javascript?  For now, paint me
-        # curious, but not enough to pull on this thread.
-        expect(response).to have_http_status(:ok)
-      end
+    let(:user) { create(:user) }
+
+    context "when not authenticated" do
+      it { within_block_is_expected.to raise_error ApplicationPolicy::UserRequiredError }
     end
 
-    context "when email login is allowed in /admin/customization/config" do
+    context "when authenticated but not authorized" do
       before do
-        allow(Settings::Authentication).to receive(:allow_email_password_login).and_return(true)
+        login_as user
+        allow(ArticlePolicy).to receive(:limit_post_creation_to_admins?).and_return(true)
       end
 
-      it "asks the non logged in user to sign in, with email signin enabled" do
-        get new_path
+      # [@jeremyf] We're handling the authentication and authorization exceptions just a bit
+      #            differently.  In this case (e.g. they don't have permission) we are relying on
+      #            the application configuration to gracefully handle the authorization error (as it
+      #            has prior and up to <2022-02-17 Thu>).
+      it { within_block_is_expected.to raise_error(Pundit::NotAuthorizedError) }
+    end
 
-        expect(response.body).to include("Email")
-        expect(response.body).to include("Password")
+    context "when authenticated and authorized" do
+      before { login_as user }
+
+      it "is a successful response" do
+        # We have lots of Cypress tests of the behavior of the `/new` page.  Let's make sure we're
+        # verifying AuthN/AuthZ things.
+        get new_path
+        expect(response).to be_successful
       end
     end
   end
@@ -33,8 +41,8 @@ RSpec.describe "Editor", type: :request do
 
     context "when not logged-in" do
       it "redirects to /enter" do
-        get "/username/article/edit"
-        expect(response).to redirect_to("/enter")
+        get "/#{user.username}/#{article.slug}/edit"
+        expect(response).to redirect_to(sign_up_path)
       end
     end
 

--- a/spec/requests/editor_spec.rb
+++ b/spec/requests/editor_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Editor", type: :request do
         # We have lots of Cypress tests of the behavior of the `/new` page.  Let's make sure we're
         # verifying AuthN/AuthZ things.
         get new_path
-        expect(response).to be_successful
+        expect(response).to have_http_status(:ok)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

The goal of this commit is actually two fold:

1) To add documentation regarding my current emerging understanding of our caching implementation as it relates to our authorization and authentication.
2) Flippiing "on" the feature's core authorization check.

Buried within this is the desired normalization of the authorization between the `ArticlePolicy`'s `#create?`, `#preview?`, `#new?`.

My testing plan for this is to ask for SRE to spin-up a canary, then test.  What does that look like?  I'm uncertain because this is nudge closer towards our edge-caching strategy.  Which makes robust testing more difficult.

## Related Tickets & Documents

- [X] Closes forem/forem#16483
- [X] Related to #16529, #16571, #16536, #16529
- [X] Informs #16490, #16606
	
## QA Instructions, Screenshots, Recordings

As mentioned above, this change likely requires a canary for proper testing.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
