### PR TITLE
Process Comment Embed through ForemTag

### DIFF
--- a/app/liquid_tags/comment_tag.rb
+++ b/app/liquid_tags/comment_tag.rb
@@ -1,8 +1,8 @@
 class CommentTag < LiquidTagBase
   PARTIAL = "comments/liquid".freeze
-  REGISTRY_REGEXP = %r{#{URL.url}/\w+/comment/(?<comment_id>\w+)}
+  VALID_LINK_REGEXP = %r{#{URL.url}/\w+/comment/(?<comment_id>\w+)}
   VALID_ID_REGEXP = /\A(?<comment_id>\w+)\Z/
-  REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
+  REGEXP_OPTIONS = [VALID_LINK_REGEXP, VALID_ID_REGEXP].freeze
 
   def initialize(_tag_name, id_code, _parse_context)
     super
@@ -35,5 +35,3 @@ end
 Liquid::Template.register_tag("comment", CommentTag)
 # kept for compatibility with existing comments embeds on DEV
 Liquid::Template.register_tag("devcomment", CommentTag)
-
-UnifiedEmbed.register(CommentTag, regexp: CommentTag::REGISTRY_REGEXP)

--- a/app/liquid_tags/forem_tag.rb
+++ b/app/liquid_tags/forem_tag.rb
@@ -20,6 +20,7 @@ module ForemTag
   def self.determine_klass(link)
     return ListingTag if link.start_with?("#{URL.url}/listings/")
     return TagTag if link.start_with?("#{URL.url}/t/")
+    return CommentTag if link.include?("/comment/")
 
     process_other_link_types(link)
   end

--- a/spec/liquid_tags/forem_tag_spec.rb
+++ b/spec/liquid_tags/forem_tag_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe ForemTag do
   subject(:forem_tag) { described_class }
 
   let(:article) { create(:article) }
+  let(:comment) do
+    create(:comment, commentable: article, user: user, body_markdown: "TheComment")
+  end
   let(:listing) { create(:listing) }
   let(:organization) { create(:organization) }
   let(:parse_context) { { source: article, user: user } }
@@ -23,6 +26,12 @@ RSpec.describe ForemTag do
   end
 
   describe "determine_klass" do
+    it "returns CommentTag if link contains /comment/ (connotes comment url)" do
+      comment_url = URL.url + comment.path
+
+      expect(described_class.determine_klass(comment_url)).to eq(CommentTag)
+    end
+
     it "returns LinkTag if link is general Forem link" do
       link_url = URL.url + article.path
 

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -4,9 +4,6 @@ RSpec.describe UnifiedEmbed::Registry do
   subject(:unified_embed) { described_class }
 
   let(:article) { create(:article) }
-  let(:comment) do
-    create(:comment, commentable: article, user: user, body_markdown: "TheComment")
-  end
   let(:listing) { create(:listing) }
   let(:organization) { create(:organization) }
   let(:podcast) { create(:podcast) }
@@ -125,11 +122,6 @@ RSpec.describe UnifiedEmbed::Registry do
     it "returns CodepenTag for a codepen url" do
       expect(described_class.find_liquid_tag_for(link: "https://codepen.io/elisavetTriant/pen/KKvRRyE"))
         .to eq(CodepenTag)
-    end
-
-    it "returns CommentTag for a Forem comment url" do
-      expect(described_class.find_liquid_tag_for(link: "#{URL.url}/#{user.username}/comment/#{comment.id_code}"))
-        .to eq(CommentTag)
     end
 
     it "returns DotnetFiddleTag for a dotnetfiddle url" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When building the [ForemTag](https://github.com/forem/forem/pull/16512) (to handle Forem-specific embeds), I neglected to include [Forem Comments](https://github.com/forem/forem/pull/16081). This PR fixes that.

## QA Instructions, Screenshots, Recordings

Grab a comment URL from your localhost.
Create an embed using this format: `{% embed <forem-comment-url> %}`. The Comment embed should render properly.
Also create embed using the 2 old methods (`{% comment forem-comment-slug %}` AND `{% dev-comment forem-comment-slug %}`). These should also work, as I am leaving the old implementation in place for now.

### UI accessibility concerns?
None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams. Related documentation and announcements have already been updated and/or published.
