### PR TITLE
Bootstrap removal: People

### DIFF
--- a/app/views/admin/invitations/index.html.erb
+++ b/app/views/admin/invitations/index.html.erb
@@ -1,4 +1,7 @@
-<%= render "admin/users/menu" %>
+<header>
+  <h1 class="crayons-title">Invitations</h1>
+  <%= render "admin/users/menu" %>
+</header>
 
 <table class="crayons-table" width="100%">
   <thead>

--- a/app/views/admin/users/_menu.html.erb
+++ b/app/views/admin/users/_menu.html.erb
@@ -1,13 +1,13 @@
-<div class="flex justify-between gap-4">
+<nav aria-label="People" class="flex justify-between gap-4">
   <ul class="crayons-navigation crayons-navigation--horizontal">
     <li>
-      <%= link_to "People", admin_users_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users'}" %>
+      <%= link_to "People", admin_users_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users'}", "aria-current": ("page" if params[:controller] == "admin/users") %>
     </li>
     <li>
-      <%= link_to "Invitations", admin_invitations_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/invitations'}" %>
+      <%= link_to "Invitations", admin_invitations_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/invitations'}", "aria-current": ("page" if params[:controller] == "admin/invitations") %>
     </li>
     <li>
-      <%= link_to admin_users_gdpr_delete_requests_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users/gdpr_delete_requests'}" do %>
+      <%= link_to admin_users_gdpr_delete_requests_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users/gdpr_delete_requests'}", "aria-current": ("page" if params[:controller] == "admin/users/gdpr_delete_requests") do %>
         GDPR Delete Requests
         <% if Users::GdprDeleteRequest.any? %>
           &nbsp;<span class="c-indicator c-indicator--danger"><%= Users::GdprDeleteRequest.count %></span>
@@ -19,10 +19,10 @@
   <% if params[:controller] == "admin/invitations" %>
     <%= link_to "New", new_admin_invitation_path, class: "c-cta" %>
   <% end %>
-</div>
+</nav>
 
 <% if params[:controller] == "admin/users" %>
-  <div class="flex justify-between gap-4">
+  <nav aria-label="People groups" class="flex justify-between gap-4">
     <ul class="crayons-navigation crayons-navigation--horizontal">
       <li>
         <%= link_to "All", admin_users_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users' && params[:role].blank?}" %>
@@ -45,5 +45,5 @@
       <%= f.hidden_field :role, value: params[:role] if params[:role].present? %>
       <%= f.submit "Search", class: "c-btn c-btn--secondary" %>
     <% end %>
-  </div>
+  </nav>
 <% end %>

--- a/app/views/admin/users/_menu.html.erb
+++ b/app/views/admin/users/_menu.html.erb
@@ -1,43 +1,13 @@
-<div class="flex mb-6 items-center">
-  <ul class="nav nav-pills">
-    <li class="nav-item">
-      <%= link_to "All", admin_users_path, class: "nav-link #{'active' if params[:controller] == 'admin/users' && params[:role].blank?}" %>
+<div class="flex justify-between gap-4">
+  <ul class="crayons-navigation crayons-navigation--horizontal">
+    <li>
+      <%= link_to "People", admin_users_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users'}" %>
     </li>
-    <li class="nav-item">
-      <%= link_to "Admins", admin_users_path(role: :admin), class: "nav-link #{'active' if params[:controller] == 'admin/users' && params[:role] == 'admin'}" %>
+    <li>
+      <%= link_to "Invitations", admin_invitations_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/invitations'}" %>
     </li>
-    <li class="nav-item">
-      <%= link_to "Super Admins", admin_users_path(role: :super_admin), class: "nav-link #{'active' if params[:controller] == 'admin/users' && params[:role] == 'super_admin'}" %>
-    </li>
-    <li class="nav-item">
-      <%= link_to "Trusted", admin_users_path(role: :trusted), class: "nav-link #{'active' if params[:controller] == 'admin/users' && params[:role] == 'trusted'}" %>
-    </li>
-    <li class="nav-item">
-      <%= link_to "Tag Mods", admin_users_path(role: :tag_moderator), class: "nav-link #{'active' if params[:controller] == 'admin/users' && params[:role] == 'tag_moderator'}" %>
-    </li>
-  </ul>
-  <% if params[:controller] == "admin/users" %>
-    <%= form_with url: admin_users_path, method: :get, local: true, class: "form-inline ml-auto" do |f| %>
-      <div class="form-group">
-        <%= f.text_field :search, value: params[:search], class: "form-control mr-2" %>
-        <%= f.hidden_field :role, value: params[:role] if params[:role].present? %>
-      </div>
-      <%= f.submit "Search", class: "btn btn-light" %>
-    <% end %>
-  <% end %>
-</div>
-<div class="flex mb-6 items-center">
-  <ul class="nav nav-pills">
-    <li class="nav-item">
-      <%= link_to "Invitations", admin_invitations_path, class: "nav-link #{'active' if params[:controller] == 'admin/invitations'}" %>
-    </li>
-    <% if params[:controller] == "admin/invitations" %>
-      <li class="nav-item">
-        <%= link_to "New", new_admin_invitation_path, class: "nav-link" %>
-      </li>
-    <% end %>
-    <li class="nav-item" style=";">
-      <%= link_to admin_users_gdpr_delete_requests_path, class: "nav-link #{'active' if params[:controller] == 'admin/users/gdpr_delete_requests'}" do %>
+    <li>
+      <%= link_to admin_users_gdpr_delete_requests_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users/gdpr_delete_requests'}" do %>
         GDPR Delete Requests
         <% if Users::GdprDeleteRequest.any? %>
           &nbsp;<span class="c-indicator c-indicator--danger"><%= Users::GdprDeleteRequest.count %></span>
@@ -45,4 +15,35 @@
       <% end %>
     </li>
   </ul>
+
+  <% if params[:controller] == "admin/invitations" %>
+    <%= link_to "New", new_admin_invitation_path, class: "c-cta" %>
+  <% end %>
 </div>
+
+<% if params[:controller] == "admin/users" %>
+  <div class="flex justify-between gap-4">
+    <ul class="crayons-navigation crayons-navigation--horizontal">
+      <li>
+        <%= link_to "All", admin_users_path, class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users' && params[:role].blank?}" %>
+      </li>
+      <li>
+        <%= link_to "Admins", admin_users_path(role: :admin), class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users' && params[:role] == 'admin'}" %>
+      </li>
+      <li>
+        <%= link_to "Super Admins", admin_users_path(role: :super_admin), class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users' && params[:role] == 'super_admin'}" %>
+      </li>
+      <li>
+        <%= link_to "Trusted", admin_users_path(role: :trusted), class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users' && params[:role] == 'trusted'}" %>
+      </li>
+      <li>
+        <%= link_to "Tag Mods", admin_users_path(role: :tag_moderator), class: "crayons-navigation__item #{'crayons-navigation__item--current' if params[:controller] == 'admin/users' && params[:role] == 'tag_moderator'}" %>
+      </li>
+    </ul>
+    <%= form_with url: admin_users_path, method: :get, local: true, class: "flex gap-2" do |f| %>
+      <%= f.text_field :search, value: params[:search], class: "crayons-textfield", placeholder: "Search..." %>
+      <%= f.hidden_field :role, value: params[:role] if params[:role].present? %>
+      <%= f.submit "Search", class: "c-btn c-btn--secondary" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/users/gdpr_delete_requests/index.html.erb
+++ b/app/views/admin/users/gdpr_delete_requests/index.html.erb
@@ -1,5 +1,8 @@
-<%= render "admin/users/menu" %>
-<div class="crayons-notice crayons-notice--info" aria-live="polite">
+<header class="mb-4">
+  <h1 class="crayons-title">GDPR Delete Requests</h1>
+  <%= render "admin/users/menu" %>
+</header>
+<div class="crayons-notice mb-4" aria-live="polite">
   <strong>These users' accounts were deleted. Please, destroy GDPR data from external services (GA, Mailchimp) for them.</strong>
 </div>
 <table class="crayons-table" width="100%">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,4 +1,7 @@
-<%= render "menu" %>
+<header>
+  <h1 class="crayons-title">People</h1>
+  <%= render "menu" %>
+</header>
 
 <%= paginate @users, theme: "internal" %>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

This is another step towards removing bootstrap. This one focuses on "People" tab which had some navigations items with bootstrap styling.

It also slightly fixes the behavior of page header and navigation when users jumps between "people", "invitations" and "gdprs"..

## QA Instructions, Screenshots, Recordings

**Before:**

![image](https://user-images.githubusercontent.com/108287/154477434-436a2103-221a-4700-a65c-e966cac59bfe.png)

**After:**

![image](https://user-images.githubusercontent.com/108287/154477486-12d380ee-62c0-427b-b879-1f696b3114ae.png)


## Added/updated tests?

No.

## [Forem core team only] How will this change be communicated?

It won't.