### PR TITLE
Remove detect_animated_images feature flag

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -856,7 +856,6 @@ class Article < ApplicationRecord
   end
 
   def enrich_image_attributes
-    return unless FeatureFlag.enabled?(:detect_animated_images)
     return unless saved_change_to_attribute?(:processed_html)
 
     ::Articles::EnrichImageAttributesWorker.perform_async(id)

--- a/lib/data_update_scripts/20220217144931_remove_detect_animated_images_feature_flag.rb
+++ b/lib/data_update_scripts/20220217144931_remove_detect_animated_images_feature_flag.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class RemoveDetectAnimatedImagesFeatureFlag
+    def run
+      FeatureFlag.remove(:detect_animated_images)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/remove_detect_animated_images_feature_flag_spec.rb
+++ b/spec/lib/data_update_scripts/remove_detect_animated_images_feature_flag_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220217144931_remove_detect_animated_images_feature_flag.rb",
+)
+
+describe DataUpdateScripts::RemoveDetectAnimatedImagesFeatureFlag do
+  it "removes the :detect_animated_images flag" do
+    FeatureFlag.enable(:detect_animated_images)
+
+    described_class.new.run
+
+    expect(FeatureFlag.exist?(:detect_animated_images)).to be(false)
+  end
+
+  it "works if the flag is not available" do
+    described_class.new.run
+
+    expect(FeatureFlag.exist?(:detect_animated_images)).to be(false)
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1074,17 +1074,8 @@ RSpec.describe Article, type: :model do
   end
 
   context "when callbacks are triggered after create" do
-    describe "detect animated images" do
-      it "does not enqueue Articles::EnrichImageAttributesWorker if the feature :enrich_image_attributes is disabled" do
-        allow(FeatureFlag).to receive(:enabled?).with(:detect_animated_images).and_return(false)
-
-        sidekiq_assert_no_enqueued_jobs(only: Articles::EnrichImageAttributesWorker) do
-          build(:article).save
-        end
-      end
-
-      it "enqueues Articles::EnrichImageAttributesWorker if the feature :detect_animated_images is enabled" do
-        allow(FeatureFlag).to receive(:enabled?).with(:detect_animated_images).and_return(true)
+    describe "enrich image attributes" do
+      it "enqueues Articles::EnrichImageAttributesWorker" do
         sidekiq_assert_enqueued_jobs(1, only: Articles::EnrichImageAttributesWorker) do
           build(:article).save
         end
@@ -1166,26 +1157,14 @@ RSpec.describe Article, type: :model do
       end
     end
 
-    describe "detect animated images" do
-      it "does not enqueue Articles::EnrichImageAttributesWorker if the feature :enrich_image_attributes is disabled" do
-        allow(FeatureFlag).to receive(:enabled?).with(:detect_animated_images).and_return(false)
-
-        sidekiq_assert_no_enqueued_jobs(only: Articles::EnrichImageAttributesWorker) do
-          article.update(body_markdown: "a body")
-        end
-      end
-
+    describe "enrich image attributes" do
       it "enqueues Articles::EnrichImageAttributesWorker if the HTML has changed" do
-        allow(FeatureFlag).to receive(:enabled?).with(:detect_animated_images).and_return(true)
-
         sidekiq_assert_enqueued_with(job: Articles::EnrichImageAttributesWorker, args: [article.id]) do
           article.update(body_markdown: "a body")
         end
       end
 
       it "does not Articles::EnrichImageAttributesWorker if the HTML does not change" do
-        allow(FeatureFlag).to receive(:enabled?).with(:detect_animated_images).and_return(true)
-
         sidekiq_assert_no_enqueued_jobs(only: Articles::EnrichImageAttributesWorker) do
           article.update(tag_list: %w[fsharp go])
         end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This feature flag has been enabled for a long time in DEV and has proven stable. It's also enabled in some other Forems like forem.team and VSCodeTips. This PR removes the feature flag, which in turn will allow all Forems to receive the play/pause gif functionality.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- [X] Closes https://github.com/forem/rfcs/pull/188
- [X] Closes https://github.com/forem/forem/issues/16539

## QA Instructions, Screenshots, Recordings

I think in this case the specs should cover it, but if you do want to run things locally, the end outcome is that if you create a post locally with an animated gif in it, it should be play/pausable once published (you will need to refresh the page after publishing, as the worker runs async).

### UI accessibility concerns?

This roles out an accessibility feature to more forems

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: the overarching issue is set to be included in the feature rollup

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![pause](https://media.giphy.com/media/2yrpsTt7ytGEAFIAjH/giphy.gif)
