### PR TITLE
Add new color picker to user settings page

### DIFF
--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_packs_with_chunks_tag "colorPreview", "stickySaveFooter", "userProfileSettings", "validateFileInputs", defer: true %>
+<%= javascript_packs_with_chunks_tag "colorPicker", "stickySaveFooter", "userProfileSettings", "validateFileInputs", defer: true %>
 
 <%= render "users/additional_authentication" %>
 
@@ -167,16 +167,14 @@
         <%= f.public_send(:text_field, "users_setting[brand_color1]",
                           value: users_setting.public_send(:brand_color1),
                           placeholder: "#000000",
-                          class: "crayons-textfield js-color-field") %>
-        <%= f.public_send(:color_field,
-                          "users_setting[brand_color1]",
-                          value: users_setting.public_send(:brand_color1),
-                          class: "crayons-color-selector js-color-field ml-2") %>
+                          class: "crayons-textfield",
+                          data: { color_picker: "true", label_text: t("views.logo.color_1.label") }) %>
+
       </div>
     </div>
 
     <div class="crayons-field ">
-      <label class="crayons-field__label" for="users_setting[brand_color1]">
+      <label class="crayons-field__label" for="users_setting[brand_color2]">
         <%= t("views.logo.color_2.label") %>
       </label>
       <p class="crayons-field__description"><%= t("views.logo.color_2.description_html") %></p>
@@ -184,11 +182,8 @@
         <%= f.public_send(:text_field, "users_setting[brand_color2]",
                           value: users_setting.public_send(:brand_color2),
                           placeholder: "#000000",
-                          class: "crayons-textfield js-color-field") %>
-        <%= f.public_send(:color_field,
-                          "users_setting[brand_color2]",
-                          value: users_setting.public_send(:brand_color2),
-                          class: "crayons-color-selector js-color-field ml-2") %>
+                          class: "crayons-textfield",
+                          data: { color_picker: "true", label_text: t("views.logo.color_2.label") }) %>
       </div>
     </div>
   </div>

--- a/cypress/integration/seededFlows/settingsFlows/updateProfileSettings.spec.js
+++ b/cypress/integration/seededFlows/settingsFlows/updateProfileSettings.spec.js
@@ -1,0 +1,35 @@
+describe('Update profile settings', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.fixture('users/adminUser.json').as('user');
+
+    cy.get('@user').then((user) => {
+      cy.loginAndVisit(user, '/settings');
+    });
+  });
+
+  it('updates brand colors', () => {
+    // Verify both a button and an input exist to update both colors
+    cy.findByRole('button', { name: 'Brand color 1' });
+    cy.findByRole('textbox', { name: 'Brand color 1' }).as('brandColor1');
+
+    cy.findByRole('button', { name: 'Brand color 2' });
+    cy.findByRole('textbox', { name: 'Brand color 2' }).as('brandColor2');
+
+    // Verify that changing the value saves properly
+    cy.get('@brandColor1').clear().type('ababab');
+    cy.get('@brandColor2').clear().type('d22a2a');
+
+    cy.findByRole('button', { name: 'Save Profile Information' }).click();
+    cy.findByText('Your profile has been updated');
+
+    cy.findByRole('textbox', { name: 'Brand color 1' }).should(
+      'have.value',
+      '#ababab',
+    );
+    cy.findByRole('textbox', { name: 'Brand color 2' }).should(
+      'have.value',
+      '#d22a2a',
+    );
+  });
+});


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds the new ColorPicker component to the User settings page (brand colors)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

Related Issue https://github.com/forem/forem/issues/15179

## QA Instructions, Screenshots, Recordings

- Log in and navigate to `/settings`
- Scroll to the bottom and check the new color pickers are present for both brand colors
- Change the values and save the form
- Make sure the user colors are successfully updated

https://user-images.githubusercontent.com/20773163/154517209-2706fec4-a84f-49c2-8696-6dee2524b0eb.mp4




### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: the change will be communicated when the overall issue is completed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![cat with shades](https://media.giphy.com/media/nzcb2ZQ2L48Za/giphy.gif)
