### PR TITLE
Fix integer > nil error when sending reaction notifications

### DIFF
--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -54,11 +54,10 @@ module Notifications
 
           json_data = reaction_json_data(recent_reaction, aggregated_reaction_siblings)
 
-          previous_siblings_size = 0
           notification = Notification.find_or_initialize_by(notification_params)
 
           old_json_data = notification.json_data
-          previous_siblings_size = old_json_data.dig("reaction", "aggregated_siblings")&.size if old_json_data
+          previous_siblings_size = old_json_data&.dig("reaction", "aggregated_siblings")&.size || 0
 
           notification.json_data = json_data
           notification.notified_at = Time.current

--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -56,8 +56,7 @@ module Notifications
 
           notification = Notification.find_or_initialize_by(notification_params)
 
-          old_json_data = notification.json_data
-          previous_siblings_size = old_json_data&.dig("reaction", "aggregated_siblings")&.size || 0
+          previous_siblings_size = notification.json_data&.dig("reaction", "aggregated_siblings")&.size || 0
 
           notification.json_data = json_data
           notification.notified_at = Time.current

--- a/spec/services/notifications/reactions/send_spec.rb
+++ b/spec/services/notifications/reactions/send_spec.rb
@@ -170,6 +170,23 @@ RSpec.describe Notifications::Reactions::Send, type: :service do
     end
   end
 
+  # regression test for #16627 and #16570
+  context "when a found reaction has unexpected json data" do
+    let(:existing_notification) do
+      create(
+        :notification,
+        json_data: { user: {}, article: {} },
+        action: "Reaction",
+        user: user,
+      )
+    end
+
+    it "does not raise error" do
+      reaction = create(:reaction, reactable: existing_notification.notifiable)
+      expect { described_class.call(reaction_data(reaction), user) }.not_to raise_error
+    end
+  end
+
   context "when a receiver is an organization" do
     let(:organization) { create(:organization) }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description


The fix in #16570 worked around an issue where "aggregated_siblings"
wasn't present in the json_data, by only calling size if present.

Unfortunately, this causes a comparison of integer (new json_data
aggregated siblings count) with nil (result of the safe navigation for dig()&.size
assigned nil to `previous_siblings_size`, when we expected it to be
0). The initial error on the same data moved farther down the controller.

If old_json_data is present, but does not have an array in
reaction.aggregated_siblings, we want to have previous size be zero.

Remove guard clause and previous assignment

The issue was not that old_json_data was nil (it came from an existing
notification) but that there were missing keys (or rather that the
json data for some notifications didn't have a reaction key at all).

Remove the guard clause and either set to the size, or zero if there
is none. I don't understand what the guard clause was for, so replace the
safety by adding a nil safe call to dig. I don't _believe_ this is
possible but in case it was we can shorten the check here.


## Related Tickets & Documents

https://app.honeybadger.io/projects/66984/faults/84089160 Comparison of Integer with nil failed
```ruby
          notification.read = false if json_data[:reaction][:aggregated_siblings].size > previous_siblings_size
```

## QA Instructions, Screenshots, Recordings

Still working through this. The underlying data issue is that some reaction notifications do not have json data for "reaction", but instead have comment or article (from a like?).

Added a regression test case since it's happened a few times, and the last fix was only partially effective.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: bugfix
