### PR TITLE
Adjusting suspended user authorizations

### DIFF
--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,5 +1,11 @@
 class CommentPolicy < ApplicationPolicy
   def edit?
+    return false if user_suspended?
+
+    user_author?
+  end
+
+  def destroy?
     user_author?
   end
 
@@ -11,9 +17,7 @@ class CommentPolicy < ApplicationPolicy
 
   alias update? edit?
 
-  alias destroy? edit?
-
-  alias delete_confirm? edit?
+  alias delete_confirm? destroy?
 
   alias settings? edit?
 

--- a/app/policies/follow_policy.rb
+++ b/app/policies/follow_policy.rb
@@ -2,7 +2,7 @@ class FollowPolicy < ApplicationPolicy
   PERMITTED_ATTRIBUTES = %i[id explicit_points].freeze
 
   def create?
-    !user_suspended?
+    true
   end
 
   # record is an object of ActiveRecord_Relation

--- a/app/policies/reaction_policy.rb
+++ b/app/policies/reaction_policy.rb
@@ -4,6 +4,6 @@ class ReactionPolicy < ApplicationPolicy
   end
 
   def create?
-    !user_suspended?
+    true
   end
 end

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe CommentPolicy, type: :policy do
     context "with suspended status" do
       before { user.add_role(:suspended) }
 
-      it { is_expected.to permit_actions(%i[edit update destroy delete_confirm]) }
-      it { is_expected.to forbid_actions(%i[create hide unhide moderator_create admin_delete]) }
+      it { is_expected.to permit_actions(%i[preview destroy delete_confirm]) }
+      it { is_expected.to forbid_actions(%i[edit update create hide unhide moderator_create admin_delete]) }
 
       it do
         expect(comment_policy).to permit_mass_assignment_of(valid_attributes_for_update).for_action(:update)

--- a/spec/policies/follow_policy_spec.rb
+++ b/spec/policies/follow_policy_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FollowPolicy, type: :policy do
     context "when user is suspended" do
       before { user.add_role(:suspended) }
 
-      it { is_expected.to forbid_actions(%i[create]) }
+      it { is_expected.to permit_actions(%i[create]) }
     end
   end
 end

--- a/spec/policies/reaction_policy_spec.rb
+++ b/spec/policies/reaction_policy_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe ReactionPolicy do
     context "when user is suspended" do
       before { user.add_role(:suspended) }
 
-      it { is_expected.to permit_actions(%i[index]) }
-      it { is_expected.to forbid_actions(%i[create]) }
+      it { is_expected.to permit_actions(%i[index create]) }
     end
   end
 end


### PR DESCRIPTION
 ## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

> We heard back from community and product folks on the team and the consensus
> is that we agree with you that suspended users should be able to follow other
> users and add reactions, and they also shouldn't be allowed to edit existing
> comments.

## Related Tickets & Documents

- [x] Closes forem/forem#16537

## QA Instructions, Screenshots, Recordings

None, tests cover this.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
