### PR TITLE
Show missing translation keys when test fails

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -6,20 +6,20 @@ RSpec.describe I18n do
   let(:unused_keys) { i18n.unused_keys }
   let(:inconsistent_interpolations) { i18n.inconsistent_interpolations }
 
-  def missing_keys_details
-    missing_keys.leaves.map do |node|
+  def details(keys)
+    keys.leaves.map do |node|
       { key: node.full_key, file: node.data[:path] }
     end
   end
 
   it "does not have missing keys" do
     expect(missing_keys).to be_empty,
-                            "Missing #{missing_keys.leaves.count} i18n keys\n #{missing_keys_details}"
+                            "Missing #{missing_keys.leaves.count} i18n keys\n #{details(missing_keys)}"
   end
 
   xit "does not have unused keys" do
     expect(unused_keys).to be_empty,
-                           "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+                           "#{unused_keys.leaves.count} unused i18n keys\n #{details(unused_keys)}"
   end
 
   # NOTE: [@rhymes] disabling normalization check for now as it fails on CI but


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [x] Documentation Update

## Description

The i18n tasks were checking whether any missing keys existed, but then directing the user to run the task manually on their own to list them.

It seems like we can extract enough information to say _what_ the problem was when it was found, rather than directing the developer to run a rake task to recreate the state that we have in the test when we count the non-empty leaves.


## Related Tickets & Documents

- [ ] Related Issue #
- [ ] Closes #

## QA Instructions, Screenshots, Recordings


Open config/locales/en.yml and comment out a line (I chose "add_comment"). 
Open config/locales/fr.yml and comment out a line (I choice "comment")

Run `bundle exec rspec spec/i18n_spec.rb`

observe the test fails (there are missing keys) and details about the missing keys is printed in the error 

```

  1) I18n does not have missing keys
     Failure/Error:
       expect(missing_keys).to be_empty,
                               "Missing #{missing_keys.leaves.count} i18n keys\n #{details(missing_keys)}"
     
       Missing 2 i18n keys
        [{:key=>"fr.core.comment", :file=>"config/locales/fr.yml"}, {:key=>"en.core.add_comment", :file=>"config/locales/en.yml"}]
     # ./spec/i18n_spec.rb:16:in `block (2 levels) in <top (required)>'
```

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes (test only change).

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: improved communication when the failure occurs. The user can re-run the spec until it passes silently :)
