### PR TITLE
Escape non-character dots in Embed Regexes

### DIFF
--- a/app/liquid_tags/asciinema_tag.rb
+++ b/app/liquid_tags/asciinema_tag.rb
@@ -1,6 +1,6 @@
 class AsciinemaTag < LiquidTagBase
   PARTIAL = "liquids/asciinema".freeze
-  REGISTRY_REGEXP = %r{https://asciinema.org/a/(?<id>\d+)}
+  REGISTRY_REGEXP = %r{https://asciinema\.org/a/(?<id>\d+)}
 
   def initialize(_tag_name, id, _parse_context)
     super

--- a/app/liquid_tags/dotnet_fiddle_tag.rb
+++ b/app/liquid_tags/dotnet_fiddle_tag.rb
@@ -2,7 +2,7 @@ require "uri"
 
 class DotnetFiddleTag < LiquidTagBase
   PARTIAL = "liquids/dotnetfiddle".freeze
-  REGISTRY_REGEXP = %r{https://dotnetfiddle.net(?:/Widget)?/(?<id>[\w\-]+)}
+  REGISTRY_REGEXP = %r{https://dotnetfiddle\.net(?:/Widget)?/(?<id>[\w\-]+)}
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/instagram_tag.rb
+++ b/app/liquid_tags/instagram_tag.rb
@@ -1,6 +1,6 @@
 class InstagramTag < LiquidTagBase
   PARTIAL = "liquids/instagram".freeze
-  REGISTRY_REGEXP = %r{(?:https?://)?(?:www\.)?(?:instagram.com/p/)(?<video_id>[a-zA-Z0-9_-]{11})/?}
+  REGISTRY_REGEXP = %r{(?:https?://)?(?:www\.)?(?:instagram\.com/p/)(?<video_id>[a-zA-Z0-9_-]{11})/?}
   VALID_ID_REGEXP = /\A(?<video_id>[a-zA-Z0-9_-]{11})\Z/
   REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 

--- a/app/liquid_tags/kotlin_tag.rb
+++ b/app/liquid_tags/kotlin_tag.rb
@@ -1,6 +1,6 @@
 class KotlinTag < LiquidTagBase
   PARTIAL = "liquids/kotlin".freeze
-  REGISTRY_REGEXP = %r{https://pl.kotl.in/(?<id>[\w-]+)(?:\?)?(?<params>[\w=&]+)?}
+  REGISTRY_REGEXP = %r{https://pl\.kotl\.in/(?<id>[\w-]+)(?:\?)?(?<params>[\w=&]+)?}
   PARAM_REGEXP = /\A(theme=darcula)|(readOnly=true)|(from=\d)|(to=\d)\Z/
 
   def initialize(_tag_name, link, _parse_context)

--- a/app/liquid_tags/medium_tag.rb
+++ b/app/liquid_tags/medium_tag.rb
@@ -5,7 +5,7 @@ class MediumTag < LiquidTagBase
   attr_reader :response
 
   PARTIAL = "liquids/medium".freeze
-  REGISTRY_REGEXP = %r{https://(?:\w+.)?medium.com/(?:@\w+/)?[\w-]+}
+  REGISTRY_REGEXP = %r{https://(?:\w+.)?medium\.com/(?:@\w+/)?[\w-]+}
 
   def initialize(_tag_name, url, _parse_context)
     super

--- a/app/liquid_tags/next_tech_tag.rb
+++ b/app/liquid_tags/next_tech_tag.rb
@@ -1,6 +1,6 @@
 class NextTechTag < LiquidTagBase
   PARTIAL = "liquids/nexttech".freeze
-  REGISTRY_REGEXP = %r{https?://nt.dev/s/}
+  REGISTRY_REGEXP = %r{https?://nt\.dev/s/}
 
   def initialize(_tag_name, share_url, _parse_context)
     super

--- a/app/liquid_tags/reddit_tag.rb
+++ b/app/liquid_tags/reddit_tag.rb
@@ -2,7 +2,7 @@ class RedditTag < LiquidTagBase
   include ActionView::Helpers::SanitizeHelper
 
   PARTIAL = "liquids/reddit".freeze
-  REGISTRY_REGEXP = %r{\Ahttps://(www.)?reddit.com}
+  REGISTRY_REGEXP = %r{\Ahttps://(www\.)?reddit\.com}
 
   def initialize(_tag_name, url, _parse_context)
     super

--- a/app/liquid_tags/replit_tag.rb
+++ b/app/liquid_tags/replit_tag.rb
@@ -1,6 +1,6 @@
 class ReplitTag < LiquidTagBase
   PARTIAL = "liquids/replit".freeze
-  REGISTRY_REGEXP = %r{https?://replit.com/(?<address>@\w{2,15}/[a-zA-Z0-9\-]{0,60})(?:#[\w.]+)?}
+  REGISTRY_REGEXP = %r{https?://replit\.com/(?<address>@\w{2,15}/[a-zA-Z0-9\-]{0,60})(?:#[\w.]+)?}
   VALID_ADDRESS = %r{(?<address>@\w{2,15}/[a-zA-Z0-9\-]{0,60})(?:#[\w.]+)?}
   REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ADDRESS].freeze
 

--- a/app/liquid_tags/slideshare_tag.rb
+++ b/app/liquid_tags/slideshare_tag.rb
@@ -1,6 +1,6 @@
 class SlideshareTag < LiquidTagBase
   PARTIAL = "liquids/slideshare".freeze
-  REGISTRY_REGEXP = %r{https://(?:www.)?slideshare.net/slideshow/embed_code/key/(?<id>\w{12,14})}
+  REGISTRY_REGEXP = %r{https://(?:www\.)?slideshare\.net/slideshow/embed_code/key/(?<id>\w{12,14})}
   VALID_ID_REGEXP = /\A(?<id>\w{12,14})\Z/
   REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 

--- a/app/liquid_tags/soundcloud_tag.rb
+++ b/app/liquid_tags/soundcloud_tag.rb
@@ -1,6 +1,6 @@
 class SoundcloudTag < LiquidTagBase
   PARTIAL = "liquids/soundcloud".freeze
-  REGISTRY_REGEXP = %r{https?://soundcloud.com}
+  REGISTRY_REGEXP = %r{https?://soundcloud\.com}
 
   def initialize(_tag_name, link, _parse_context)
     super

--- a/app/liquid_tags/speakerdeck_tag.rb
+++ b/app/liquid_tags/speakerdeck_tag.rb
@@ -1,6 +1,6 @@
 class SpeakerdeckTag < LiquidTagBase
   PARTIAL = "liquids/speakerdeck".freeze
-  REGISTRY_REGEXP = %r{https://speakerdeck.com/player/(?<id>\w{,32})}
+  REGISTRY_REGEXP = %r{https://speakerdeck\.com/player/(?<id>\w{,32})}
   VALID_ID_REGEXP = /\A(?<id>\w{,32})\Z/
   REGEXP_OPTIONS  = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 

--- a/app/liquid_tags/spotify_tag.rb
+++ b/app/liquid_tags/spotify_tag.rb
@@ -1,7 +1,7 @@
 class SpotifyTag < LiquidTagBase
   PARTIAL = "liquids/spotify".freeze
   # rubocop:disable Layout/LineLength
-  REGISTRY_REGEXP = %r{https?://(?:open.spotify.com/)(?<type>track|artist|playlist|album|episode|show)/(?<id>\w{,22})(?:\?si=[\w-]+)?}
+  REGISTRY_REGEXP = %r{https?://(?:open\.spotify\.com/)(?<type>track|artist|playlist|album|episode|show)/(?<id>\w{,22})(?:\?si=[\w-]+)?}
   # rubocop:enable Layout/LineLength
   URI_REGEXP = /\A(?:spotify):(?<type>track|artist|playlist|album|episode|show):(?<id>\w{22})\Z/
   URI_PLAYLIST_REGEXP = /\A(?:spotify):(?:user):(?<type>[a-zA-Z0-9]+):(?:playlist):(?<id>\w{22})\Z/ # legacy support

--- a/app/liquid_tags/stackblitz_tag.rb
+++ b/app/liquid_tags/stackblitz_tag.rb
@@ -1,6 +1,6 @@
 class StackblitzTag < LiquidTagBase
   PARTIAL = "liquids/stackblitz".freeze
-  REGISTRY_REGEXP = %r{https://stackblitz.com/edit/(?<id>[\w\-]{,60})(?<params>\?.*)?}
+  REGISTRY_REGEXP = %r{https://stackblitz\.com/edit/(?<id>[\w\-]{,60})(?<params>\?.*)?}
   ID_REGEXP = /\A(?<id>[\w\-]{,60})\Z/
   REGEXP_OPTIONS = [REGISTRY_REGEXP, ID_REGEXP].freeze
   # rubocop:disable Layout/LineLength

--- a/app/liquid_tags/stackery_tag.rb
+++ b/app/liquid_tags/stackery_tag.rb
@@ -1,6 +1,6 @@
 class StackeryTag < LiquidTagBase
   PARTIAL = "liquids/stackery".freeze
-  REGISTRY_REGEXP = %r{https://app.stackery.io/editor/design(?<params>\?.*)?}
+  REGISTRY_REGEXP = %r{https://app\.stackery\.io/editor/design(?<params>\?.*)?}
   PARAM_REGEXP = /\A(owner=[\w\-]+)|(repo=[\w\-]+)|(file=.*)|(ref=.*)\Z/
 
   def initialize(_tag_name, input, _parse_context)

--- a/app/liquid_tags/tweet_tag.rb
+++ b/app/liquid_tags/tweet_tag.rb
@@ -1,7 +1,7 @@
 class TweetTag < LiquidTagBase
   include ActionView::Helpers::AssetTagHelper
   PARTIAL = "liquids/tweet".freeze
-  REGISTRY_REGEXP = %r{https://twitter.com/\w{1,15}/status/(?<id>\d{10,20})}
+  REGISTRY_REGEXP = %r{https://twitter\.com/\w{1,15}/status/(?<id>\d{10,20})}
   VALID_ID_REGEXP = /\A(?<id>\d{10,20})\Z/
   REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 

--- a/app/liquid_tags/twitch_tag.rb
+++ b/app/liquid_tags/twitch_tag.rb
@@ -1,6 +1,6 @@
 class TwitchTag < LiquidTagBase
   PARTIAL = "liquids/twitch".freeze
-  REGISTRY_REGEXP = %r{https://(?:clips|player|www).twitch.tv/(?:(?:embed\?clip=|\w+/clip/)|(?:\?video=|videos/))(?<id>[a-zA-Z0-9-]{,100})(?:&[^$]+)?}
+  REGISTRY_REGEXP = %r{https://(?:clips|player|www)\.twitch\.tv/(?:(?:embed\?clip=|\w+/clip/)|(?:\?video=|videos/))(?<id>[a-zA-Z0-9-]{,100})(?:&[^$]+)?}
   VALID_VIDEO_REGEXP = /\A(?<video_id>\d+)\Z/
   VALID_CLIP_REGEXP = /\A(?<clip_slug>[a-zA-Z0-9-]{,100})\Z/
   REGEXP_OPTIONS = [VALID_VIDEO_REGEXP, VALID_CLIP_REGEXP, REGISTRY_REGEXP].freeze

--- a/app/liquid_tags/wikipedia_tag.rb
+++ b/app/liquid_tags/wikipedia_tag.rb
@@ -1,6 +1,6 @@
 class WikipediaTag < LiquidTagBase
   PARTIAL = "liquids/wikipedia".freeze
-  REGISTRY_REGEXP = %r{\Ahttps?://([a-z-]+)\.wikipedia.org/wiki/(\S+)\z}
+  REGISTRY_REGEXP = %r{\Ahttps?://([a-z-]+)\.wikipedia\.org/wiki/(\S+)\z}
   TEXT_CLEANUP_XPATH = "//div[contains(@class, 'noprint') or contains(@class, 'hatnote')] | " \
                        "//span[@class='mw-ref'] | //figure | //sup".freeze
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
While working on the Unified Embeds project, I did not yet realize that unescaped dots in regex stand for a single character. This PR escapes all dots within embed regexes so that unintended consequences do not arise.

## Related Tickets & Documents
None; one-off fix

## QA Instructions, Screenshots, Recordings
None; all specs should pass

### UI accessibility concerns?
None

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: _current specs cover code changes and should all still pass_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
