### PR TITLE
Revert "Only make one network call to fetch all existing tags in editor"

### DIFF
--- a/app/controllers/api/v0/tags_controller.rb
+++ b/app/controllers/api/v0/tags_controller.rb
@@ -13,11 +13,7 @@ module Api
         per_page = (params[:per_page] || 10).to_i
         num = [per_page, 1000].min
 
-        if params[:tag_ids].present?
-          @tags = @tags.where(id: params[:tag_ids])
-        elsif params[:tag_names].present?
-          @tags = @tags.where(name: params[:tag_names])
-        end
+        @tags = @tags.where(id: params[:tag_ids]) if params[:tag_ids].present?
 
         @tags = @tags.order(taggings_count: :desc).page(page).per(num)
 

--- a/app/javascript/article-form/components/TagsField.jsx
+++ b/app/javascript/article-form/components/TagsField.jsx
@@ -29,19 +29,20 @@ export const TagsField = ({ onInput, defaultValue, switchHelpContext }) => {
     // Fetching further tag data allows us to display a richer UI
     // This fetch only happens once on first component load
     if (defaultValue && defaultValue !== '' && !defaultsLoaded) {
-      const tagNamesQueryString = defaultValue
-        .split(', ')
-        .reduce((queryString, nextTagName) => {
-          if (nextTagName) {
-            return queryString
-              ? `${queryString}&tag_names[]=${nextTagName}`
-              : `tag_names[]=${nextTagName}`;
-          }
-        }, '');
+      const tagNames = defaultValue.split(', ');
 
-      fetch(`/api/tags.json?${tagNamesQueryString}`)
-        .then((res) => res.json())
-        .then((data) => setDefaultSelections(data));
+      const tagRequests = tagNames.map((tagName) =>
+        fetchSearch('tags', { name: tagName }).then(({ result = [] }) => {
+          const [potentialMatch = {}] = result;
+          return potentialMatch.name === tagName
+            ? potentialMatch
+            : { name: tagName };
+        }),
+      );
+
+      Promise.all(tagRequests).then((data) => {
+        setDefaultSelections(data);
+      });
     }
     setDefaultsLoaded(true);
   }, [defaultValue, defaultsLoaded]);

--- a/spec/requests/api/v0/tags_spec.rb
+++ b/spec/requests/api/v0/tags_spec.rb
@@ -45,25 +45,6 @@ RSpec.describe "Api::V0::Tags", type: :request do
       expect(response.parsed_body.map { |t| t["id"] }).to match_array(tag_ids)
     end
 
-    it "finds tags from array of tag_names" do
-      tags = create_list(:tag, 10, taggings_count: 10)
-      tag_names = tags.sample(4).map(&:name)
-
-      get api_tags_path, params: { tag_names: tag_names }
-
-      expect(response.parsed_body.map { |t| t["name"] }).to match_array(tag_names)
-    end
-
-    it "finds tags from array of tag_ids if both tag_ids and tag_names is passed" do
-      tags = create_list(:tag, 10, taggings_count: 10)
-      tag_names = tags.sample(2).map(&:name)
-      tag_ids = tags.sample(4).map(&:id)
-
-      get api_tags_path, params: { tag_names: tag_names, tag_ids: tag_ids }
-
-      expect(response.parsed_body.map { |t| t["id"] }).to match_array(tag_ids)
-    end
-
     it "supports pagination" do
       create_list(:tag, 3)
 


### PR DESCRIPTION
Reverts forem/forem#16610

This change is causing a bug when editing existing posts in Forems. When a request is made to the `/tags` endpoint, with e.g. 4 tags, a larger number are being returned, which don't seem to bear a relation to the tag names sent.

Reverting for now so I can investigate further without this negatively impacting users in the meantime.

Expected behaviour after this revert:

- Edit an existing post with a list of tags
- The editor should show only the tags currently added to the post, without injecting new ones