### PR TITLE
[Small win] Add display name to campaign settings

### DIFF
--- a/app/decorators/campaign_decorator.rb
+++ b/app/decorators/campaign_decorator.rb
@@ -5,10 +5,19 @@ class CampaignDecorator < ApplicationDecorator
   def sidebar_image(options)
     return unless show_in_sidebar?
 
-    img = image_tag(object.sidebar_image, options)
+    image_url = Images::Optimizer.call(object.sidebar_image, width: 500)
+    img = image_tag(image_url, options)
     return link_to(img, url) if url
 
     img
+  end
+
+  def header_text(count)
+    if display_name.present?
+      "#{Campaign.current.display_name} (#{count})"
+    else
+      I18n.t("views.campaign.subtitle", count: count)
+    end
   end
 
   def main_tag

--- a/app/lib/constants/settings/campaign.rb
+++ b/app/lib/constants/settings/campaign.rb
@@ -10,6 +10,10 @@ module Constants
           description: "",
           placeholder: "Campaign stories show up on sidebar with approval?"
         },
+        display_name: {
+          description: "This text is displayed in reference to the campaign in titles, etc.",
+          placeholder: "My great campaign"
+        },
         call_to_action: {
           description: "This text populates the call to action button on the campaign sidebar",
           placeholder: "Share your project"

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -13,6 +13,7 @@ class Campaign
     articles_expiry_time
     articles_require_approval?
     call_to_action
+    display_name
     featured_tags
     hero_html_variant_name
     sidebar_enabled?

--- a/app/models/settings/campaign.rb
+++ b/app/models/settings/campaign.rb
@@ -5,6 +5,7 @@ module Settings
     # Define your settings
     setting :articles_expiry_time, type: :integer, default: 4
     setting :articles_require_approval, type: :boolean, default: 0
+    setting :display_name, type: :string, default: ""
     setting :call_to_action, type: :string, default: -> { I18n.t("models.settings.campaign.share_your_project") }
     setting :featured_tags, type: :array, default: %w[]
     setting :hero_html_variant_name, type: :string, default: ""

--- a/app/views/admin/settings/forms/_campaign.html.erb
+++ b/app/views/admin/settings/forms/_campaign.html.erb
@@ -12,6 +12,15 @@
     <div id="campaignBodyContainer" class="card-body collapse hide" aria-labelledby="campaignBodyContainer">
       <fieldset class="grid gap-4">
         <div class="crayons-field">
+          <%= admin_config_label :display_name, "Display Name" %>
+          <%= admin_config_description Constants::Settings::Campaign::DETAILS[:display_name][:description] %>
+          <%= f.text_field :display_name,
+                           class: "crayons-textfield",
+                           value: Settings::Campaign.name,
+                           placeholder: Constants::Settings::Campaign::DETAILS[:display_name][:placeholder] %>
+        </div>
+
+        <div class="crayons-field">
           <%= admin_config_label :hero_html_variant_name, "Campaign hero HTML variant name" %>
           <%= admin_config_description Constants::Settings::Campaign::DETAILS[:hero_html_variant_name][:description] %>
           <%= f.text_field :hero_html_variant_name,

--- a/app/views/articles/_sidebar_campaign.html.erb
+++ b/app/views/articles/_sidebar_campaign.html.erb
@@ -2,7 +2,7 @@
 <section class="crayons-card crayons-card--secondary">
   <%= campaign.sidebar_image(class: "block w-100 h-auto radius-default", width: 1000, height: 420) %>
   <header class="crayons-card__header">
-    <h3 class="crayons-subtitle-2"><%= link_to t("views.campaign.subtitle", count: @campaign_articles_count), "/t/#{campaign.main_tag}", class: "crayons-link" %></h3>
+    <h3 class="crayons-subtitle-2"><%= link_to campaign.header_text(@campaign_articles_count), "/t/#{campaign.main_tag}", class: "crayons-link" %></h3>
   </header>
   <div>
     <%= render partial: "articles/widget_list_item", collection: @latest_campaign_articles,

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -231,6 +231,18 @@ RSpec.describe "StoriesIndex", type: :request do
         create(:article, approved: false, body_markdown: u_body, score: 1)
       end
 
+      it "displays display name when it is set" do
+        allow(Settings::Campaign).to receive(:display_name).and_return("Backstreet is back")
+        get "/"
+        expect(response.body).not_to include("Backstreet is back (0)")
+      end
+
+      it "displays Stories fallback when display name is not set" do
+        allow(Settings::Campaign).to receive(:display_name).and_return("")
+        get "/"
+        expect(response.body).not_to include("Stories (0)")
+      end
+
       it "doesn't display posts with the campaign tags when sidebar is disabled" do
         allow(Settings::Campaign).to receive(:sidebar_enabled).and_return(false)
         get "/"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently admins cannot set a custom display name for campaigns explicitly. This is expected functionality and the result, for a while, has been the `Stories (4)` display that only is understandable if lots of context is provided elsewhere on the page.

This PR fixes this by following existing standards and enhances campaign functionality. We already allow for _pretty darn granular configuration such as button CTA_ so this is right in line with the existing product expectations.

This will be immediately impactful for DEV, but will also improve other Forems who have requested this.

Before:

<img width="363" alt="Screen Shot 2022-02-21 at 11 12 54 AM" src="https://user-images.githubusercontent.com/3102842/154991961-829e54e1-979f-45c1-a2e5-6be8fd210480.png">


After:

<img width="389" alt="Screen Shot 2022-02-21 at 11 12 50 AM" src="https://user-images.githubusercontent.com/3102842/154991969-78f2c9e2-d574-4cbd-abd7-e2d17a2b2c7a.png">

The default of "Stories" is still present, so this is entirely optional new functionality.

(This PR also fixes a small image optimization issue in nearby code)

## Related Tickets & Documents
Closes https://github.com/forem/forem/issues/16652
## QA Instructions, Screenshots, Recordings


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

This is a tiny change, but we will reach out to any creators who may have forked the code to make this work.
