### PR TITLE
Update profile image for orgs in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -38,7 +38,7 @@ seeder.create_if_none(Organization) do
     Organization.create!(
       name: Faker::TvShows::SiliconValley.company,
       summary: Faker::Company.bs,
-      remote_profile_image_url: logo = Faker::Company.logo,
+      profile_image: logo = File.open(Rails.root.join("app/assets/images/#{rand(1..40)}.png")),
       nav_image: logo,
       url: Faker::Internet.url,
       slug: "org#{rand(10_000)}",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix?

## Description

Today while trying to re-seed my database I ran into the following:

```
Seeding with multiplication factor: 1

  1. Creating Organizations.
rails aborted!
ActiveRecord::RecordInvalid: Validation failed: Profile image can't be blank, Profile image could not download file: execution expired
...
```

Something similar recently happened to Anna, which she addressed [here](https://github.com/forem/forem/pull/15178/files#diff-9ed171fcb61b660adaad65ce85412195bc1f2b11b93cd4b2ded2acbb8c2c4f07). Since we use the same method for setting user profile images in the seeds file I decided to update organizations too.

## QA Instructions, Screenshots, Recordings

Drop your DB and make sure you can re-seed it without running in the above-mentioned error.

### UI accessibility concerns?

None

## Added/updated tests?

- [X] No, and this is why: we don't test seeds

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams