### PR TITLE
Don't sanitize anchor elements with no href

### DIFF
--- a/app/sanitizers/feed_markdown_scrubber.rb
+++ b/app/sanitizers/feed_markdown_scrubber.rb
@@ -8,6 +8,6 @@ class FeedMarkdownScrubber < Rails::Html::PermitScrubber
   def allowed_node?(node)
     return true if tags.include?(node.name) && node.name != "a"
 
-    node.name == "a" && !node["href"].start_with?("#")
+    node.name == "a" && !node["href"]&.start_with?("#")
   end
 end

--- a/spec/sanitizers/feed_markdown_scrubber_spec.rb
+++ b/spec/sanitizers/feed_markdown_scrubber_spec.rb
@@ -57,4 +57,10 @@ RSpec.describe FeedMarkdownScrubber, type: :permit_scrubber do
     clean = sanitize(bad_html, scrubber: described_class.new)
     expect(clean).to eq(good_html)
   end
+
+  it "does not scrub anchors with no link" do
+    good_html = "I put an anchor <a>here</a>"
+    clean = sanitize(good_html, scrubber: described_class.new)
+    expect(clean).to eq(good_html)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Since `<a>` with no href is valid html - don't call start_with? on nil. Accept anchor elements with no hyperlink as safe (don't sanitize).

~Deserves a test case~

Just to be pedantic - `<a>` without an href is a normal thing we should handle

https://html.spec.whatwg.org/#htmlanchorelement

> If the [a](https://html.spec.whatwg.org/#the-a-element) element has an [href](https://html.spec.whatwg.org/#attr-hyperlink-href) attribute, then it [represents](https://html.spec.whatwg.org/#represents) a [hyperlink](https://html.spec.whatwg.org/#hyperlink) ([a](https://html.spec.whatwg.org/#the-a-element) hypertext anchor) labeled by its contents.

> If the a element has no [href](https://html.spec.whatwg.org/#attr-hyperlink-href) attribute, then the element [represents](https://html.spec.whatwg.org/#represents) a placeholder for where a link might otherwise have been placed, if it had been relevant, consisting of just the element's contents.

## Related Tickets & Documents

Introduced in #16517 

https://app.honeybadger.io/projects/66984/faults/84170943 is the error (triggered a warning about elevated failure rates for articles controlled).

## QA Instructions, Screenshots, Recordings

Test case covers this situation.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
