### PR TITLE
Update identities where the auth data dump is a plain hash

### DIFF
--- a/lib/data_update_scripts/20220223160059_coerce_identity_auth_data_format.rb
+++ b/lib/data_update_scripts/20220223160059_coerce_identity_auth_data_format.rb
@@ -1,0 +1,10 @@
+module DataUpdateScripts
+  class CoerceIdentityAuthDataFormat
+    def run
+      Identity.where("auth_data_dump ~ '---\n'").find_each do |identity|
+        auth_hash = OmniAuth::AuthHash.new(**identity.auth_data_dump)
+        identity.update(auth_data_dump: auth_hash)
+      end
+    end
+  end
+end

--- a/lib/data_update_scripts/20220223160059_coerce_identity_auth_data_format.rb
+++ b/lib/data_update_scripts/20220223160059_coerce_identity_auth_data_format.rb
@@ -1,9 +1,11 @@
 module DataUpdateScripts
   class CoerceIdentityAuthDataFormat
     def run
-      Identity.where("auth_data_dump ~ '---\n'").find_each do |identity|
-        auth_hash = OmniAuth::AuthHash.new(**identity.auth_data_dump)
-        identity.update(auth_data_dump: auth_hash)
+      Identity.with_statement_timeout(5.minutes) do
+        Identity.where("auth_data_dump ~ '^---\n'").find_each do |identity|
+          auth_hash = OmniAuth::AuthHash.new(**identity.auth_data_dump)
+          identity.update_columns(auth_data_dump: auth_hash)
+        end
       end
     end
   end

--- a/spec/lib/data_update_scripts/coerce_identity_auth_data_format_spec.rb
+++ b/spec/lib/data_update_scripts/coerce_identity_auth_data_format_spec.rb
@@ -23,7 +23,7 @@ describe DataUpdateScripts::CoerceIdentityAuthDataFormat do
 
   it "changes hash auth data dumps to AuthHash" do
     # we have two malformed identities (with plain hashes for auth_data_dump)
-    expect(Identity.where("auth_data_dump ~ '---\n'").count).to equal(2)
+    expect(Identity.where("auth_data_dump ~ '^---\n'").count).to equal(2)
 
     described_class.new.run
 

--- a/spec/lib/data_update_scripts/coerce_identity_auth_data_format_spec.rb
+++ b/spec/lib/data_update_scripts/coerce_identity_auth_data_format_spec.rb
@@ -8,7 +8,7 @@ describe DataUpdateScripts::CoerceIdentityAuthDataFormat do
   before do
     # make two we do want to change
     omniauth_mock_twitter_payload
-    2.times do |_t|
+    2.times do
       create(:identity, provider: :twitter, user: create(:user))
     end
 

--- a/spec/lib/data_update_scripts/coerce_identity_auth_data_format_spec.rb
+++ b/spec/lib/data_update_scripts/coerce_identity_auth_data_format_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220223160059_coerce_identity_auth_data_format.rb",
+)
+
+describe DataUpdateScripts::CoerceIdentityAuthDataFormat do
+  # make malformed identities
+  before do
+    # make two we do want to change
+    omniauth_mock_twitter_payload
+    2.times do |_t|
+      create(:identity, provider: :twitter, user: create(:user))
+    end
+
+    Identity.all.each do |identity|
+      hash = { "info" => { "email" => Faker::Internet.email } }
+      identity.update(auth_data_dump: hash)
+    end
+
+    # and one we don't want changed
+    create(:identity, provider: :twitter, user: create(:user))
+  end
+
+  it "changes hash auth data dumps to AuthHash" do
+    # we have two malformed identities (with plain hashes for auth_data_dump)
+    expect(Identity.where("auth_data_dump ~ '---\n'").count).to equal(2)
+
+    described_class.new.run
+
+    # all three should be OmniAuth::AuthHash now
+    expect(Identity.all.map { |i| i.auth_data_dump.class }.uniq).to eq([OmniAuth::AuthHash])
+  end
+
+  it "handles null values safely" do
+    id = create(:identity, provider: :twitter, user: create(:user))
+    id.update_column(:auth_data_dump, nil)
+
+    described_class.new.run
+
+    auth_data_classes = Identity.all.map { |i| i.auth_data_dump.class }.uniq
+    expect(auth_data_classes).to include(OmniAuth::AuthHash, NilClass)
+    expect(auth_data_classes).not_to include(Hash)
+  end
+end

--- a/spec/lib/data_update_scripts/coerce_identity_auth_data_format_spec.rb
+++ b/spec/lib/data_update_scripts/coerce_identity_auth_data_format_spec.rb
@@ -8,14 +8,15 @@ describe DataUpdateScripts::CoerceIdentityAuthDataFormat do
   before do
     # make two we do want to change
     omniauth_mock_twitter_payload
-    2.times do
-      create(:identity, provider: :twitter, user: create(:user))
-    end
 
-    Identity.all.each do |identity|
-      hash = { "info" => { "email" => Faker::Internet.email } }
-      identity.update(auth_data_dump: hash)
+    # rubocop:disable RSpec/FactoryBot/CreateList
+    2.times do
+      create(:identity, provider: :twitter, user: create(:user)) do |identity|
+        hash = { "info" => { "email" => Faker::Internet.email } }
+        identity.update(auth_data_dump: hash)
+      end
     end
+    # rubocop:enable RSpec/FactoryBot/CreateList
 
     # and one we don't want changed
     create(:identity, provider: :twitter, user: create(:user))


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

All but 3 records in DEV have OmniAuth::AuthHash objects serialized as
auth data dump. Normalize the remaining ones so they don't cause no
method errors when we treat the auth_data_dump as an object (sending
`#info` instead of asking for `['info']`).

Add null safety check in a second example (that null values should not
cause an error, and should not be coerced to auth hashes).


## Related Tickets & Documents

should address https://app.honeybadger.io/projects/66984/faults/84183659

## QA Instructions, Screenshots, Recordings

For a  development environment, unless you have unusual data, the script should run with no effect.

The spec constructs 2 identities to be modified, and 2 that should not be (on is an omniauth auth hash, the other is null), and verifies they are changed.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: data cleanup

## [optional] Are there any post deployment tasks we need to perform?

Check the data update script completes successfully on dev after being deployed
