### PR TITLE
Ensuring POST api/v0/articles authorizes by policy

### DIFF
--- a/app/controllers/api/v0/articles_controller.rb
+++ b/app/controllers/api/v0/articles_controller.rb
@@ -1,13 +1,17 @@
 module Api
   module V0
+    # @note This controller partially authorizes with the ArticlePolicy, in an ideal world, it would
+    #       fully authorize.  However, that refactor would require significantly more work.
     class ArticlesController < ApiController
       before_action :authenticate!, only: %i[create update me]
 
-      before_action :validate_article_param_is_hash, only: %w[create update]
+      before_action :validate_article_param_is_hash, only: %i[create update]
 
       before_action :set_cache_control_headers, only: %i[index show show_by_slug]
 
       skip_before_action :verify_authenticity_token, only: %i[create update]
+
+      after_action :verify_authorized, only: %i[create]
 
       INDEX_ATTRIBUTES_FOR_SERIALIZATION = %i[
         id user_id organization_id collection_id
@@ -58,6 +62,8 @@ module Api
       end
 
       def create
+        authorize(Article)
+
         @article = Articles::Creator.call(@user, article_params).decorate
 
         if @article.persisted?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Documentation Update

## Description

As part of the [Authorization System Use Case
1:1](https://github.com/orgs/forem/projects/46) project, we are driving
towards the feature of: "Only admin's may post articles in this Forem."

This commit ensures that the API's "create an article" end-point
delivers on that feature.

Along the way, I've added reading notes and comments, to help us further
flex in the future (namely move all authorization checks into a policy
object).


## Related Tickets & Documents

- Closes forem/forem#16488

## QA Instructions, Screenshots, Recordings

None, we've got tests for this.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
