### PR TITLE
Remove the duplicate verify email button on the admin member view

### DIFF
--- a/app/views/admin/users/show/profile/_actions.html.erb
+++ b/app/views/admin/users/show/profile/_actions.html.erb
@@ -10,13 +10,6 @@
         <% if @user.access_locked? %>
           <li><%= link_to "Unlock access", unlock_access_admin_user_path(@user), method: :patch, class: "c-link c-link--block" %></li>
         <% end %>
-        <% unless @last_email_verification_date %>
-          <li>
-            <%= form_with url: verify_email_ownership_admin_user_path(@user), local: true do |f| %>
-              <%= f.button "Verify email address", class: "c-btn w-100 align-left" %>
-            <% end %>
-          </li>
-        <% end %>
         <li><button type="button" class="c-btn w-100 align-left" data-modal-trigger data-modal-title="Export data" data-modal-size="small" data-modal-content-selector="#export-data">Export data</button></li>
         <li><button type="button" class="c-btn w-100 align-left" data-modal-trigger data-modal-title="Merge accounts" data-modal-size="small" data-modal-content-selector="#merge-accounts">Merge accounts</button></li>
         <% if @user.articles_count > 0 %>

--- a/cypress/integration/seededFlows/adminFlows/users/manageUserOptions.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/manageUserOptions.spec.js
@@ -37,13 +37,6 @@ describe('Manage User Options', () => {
       });
     });
 
-    it(`should verify a user's email address`, () => {
-      openUserOptions(() => {
-        cy.findByRole('button', { name: 'Verify email address' }).click();
-      });
-      verifyAndDismissUserUpdatedMessage('Verification email sent!');
-    });
-
     it(`should export a user's data to an admin`, () => {
       openUserOptions(() => {
         cy.findByRole('button', { name: 'Export data' }).click();


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Removal of the duplicate Verify email button. It will only live in the Emails tab.

## Related Tickets & Documents

- Related Issue #
- Closes #https://github.com/forem/forem/issues/16613


## QA Instructions, Screenshots, Recordings

GO to /admin/users/<id> and ensure that the button is removed.

<img width="1666" alt="Screenshot 2022-02-25 at 08 24 24" src="https://user-images.githubusercontent.com/2786819/155666076-cae7e6d2-7ff6-4d63-aa83-cd7475053bdc.png">

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: removed a test
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/XfuZWTrh7yGRfYnbO9/giphy.gif)
