### PR TITLE
Adding indirection for Tag#name to ease future work

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -126,6 +126,32 @@ class Tag < ActsAsTaggableOn::Tag
     errors.add(:name, I18n.t("errors.messages.contains_prohibited_characters")) unless name.match?(/\A[[:alnum:]]+\z/i)
   end
 
+  # While this non-end user facing flag is "in play", our goal is to say that when it's "false"
+  # we'll preserve existing behavior.  And when true, we're testing out new behavior.  This way we
+  # can push up changes and refactor towards improvements without unleashing a large pull request
+  # with many tendrils.
+  #
+  # @return [TrueClass] when we want to favor the "accessible_name" for the tag.
+  # @return [FalseClass] when we will use the all lower case name for the tag.
+  #
+  # @note This is a feature flag we're using to ease refactoring towards accessible tag labels.
+  #       Eventually, we would remove this method and always favor accessible names.
+  #
+  # @todo When we've fully tested this feature, we'll allways return true, and can effectively
+  #       remove it.
+  def self.favor_accessible_name_for_tag_label?
+    FeatureFlag.enabled?(:favor_accessible_name_for_tag_label)
+  end
+
+  # @note In the future we envision always favoring pretty name over the given name.
+  #
+  # @todo When we "rollout this feature" remove the guard clause and adjust the corresponding spec.
+  def accessible_name
+    return name unless self.class.favor_accessible_name_for_tag_label?
+
+    pretty_name.presence || name
+  end
+
   def errors_as_sentence
     errors.full_messages.to_sentence
   end

--- a/app/views/admin/tags/edit.html.erb
+++ b/app/views/admin/tags/edit.html.erb
@@ -1,6 +1,6 @@
 <header class="flex mb-6 items-center">
   <div>
-    <h2 class="crayons-title">#<%= @tag.name %></h2>
+    <h2 class="crayons-title">#<%= @tag.accessible_name %></h2>
     <p>Tagged <%= @tag.taggings_count %> times</p>
   </div>
 

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -11,7 +11,7 @@
 
       <header class="mod-index-header hidden m:block">
         <h2 class="crayons-subtitle-1">
-          <%= @tag ? "##{@tag.name}" : t("views.moderations.all") %>
+          <%= @tag ? "##{@tag.accessible_name}" : t("views.moderations.all") %>
         </h2>
       </header>
 

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -3,11 +3,7 @@
 <main id="main-content" class="crayons-layout crayons-layout--limited-m">
   <header class="crayons-card flex items-center justify-between branded-4 p-3 pr-1 m:pr-5 m:p-6 m:pt-5" style="border-top-color: <%= @tag.bg_color_hex %>">
     <h1 class="crayons-title">
-      <% if @tag_model && @tag_model.pretty_name.present? %>
-        <%= @tag_model.pretty_name %>
-      <% else %>
-        <span class="opacity-50">#</span><%= @tag %>
-      <% end %>
+      <span class="opacity-50">#</span><%= @tag.accessible_name %>
     </h1>
     <div class="flex">
       <% if current_user.any_admin? %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -50,7 +50,7 @@
       <% @tags.each do |tag| %>
         <div class="tag-card crayons-card branded-4 p-3 pt-2 m:p-6 m:pt-4 relative" style="border-top-color: <%= tag.bg_color_hex %>; ">
           <h3 class="mb-1 -ml-2">
-            <%= render_tag_link(tag.name) %>
+            <%= render_tag_link(tag.accessible_name) %>
           </h3>
           <% if tag.short_summary.present? %>
             <p class="mb-2 color-base-70 truncate-at-3"><%= sanitize tag.short_summary %></p>

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -213,4 +213,9 @@ RSpec.describe Tag, type: :model do
       expect(described_class.new.points).to eq(0)
     end
   end
+
+  # [@jeremyf] TODO: In a future state, we'll commit to what this will be.  But for now, we're
+  #            relying on this as a point of indirection for refactoring our code to favor
+  #            accessible tag names.
+  it { is_expected.to respond_to(:accessible_name) }
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -214,8 +214,39 @@ RSpec.describe Tag, type: :model do
     end
   end
 
-  # [@jeremyf] TODO: In a future state, we'll commit to what this will be.  But for now, we're
-  #            relying on this as a point of indirection for refactoring our code to favor
-  #            accessible tag names.
-  it { is_expected.to respond_to(:accessible_name) }
+  # [@jeremyf] The implementation details of #accessible_name are contingent on a feature flag that
+  #            we're using for this refactoring.  Once we remove the flag, please adjust the specs
+  #            accordingly.
+  describe "#accessible_name" do
+    subject(:accessible_name) { described_class.new(name: name, pretty_name: pretty_name).accessible_name }
+
+    let(:name) { "helloworld" }
+    let(:pretty_name) { "helloWorld" }
+
+    context "when favor_accessible_name_for_tag_label is true" do
+      before { allow(described_class).to receive(:favor_accessible_name_for_tag_label?).and_return(true) }
+
+      it "equals the #pretty_name" do
+        expect(accessible_name).to eq pretty_name
+      end
+    end
+
+    context "when favor_accessible_name_for_tag_label is true but no pretty name given" do
+      before { allow(described_class).to receive(:favor_accessible_name_for_tag_label?).and_return(true) }
+
+      let(:pretty_name) { nil }
+
+      it "equals the #name" do
+        expect(accessible_name).to eq name
+      end
+    end
+
+    context "when favor_accessible_name_for_tag_label is false" do
+      before { allow(described_class).to receive(:favor_accessible_name_for_tag_label?).and_return(false) }
+
+      it "equals the #name" do
+        expect(accessible_name).to eq name
+      end
+    end
+  end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Documentation Update

## Description

In pairing with Arit, we were able to capture a few small wins in
regards to favoring an accessible tag name.  In other words, where ever
you see a tag's name, we want to render it as camel-case.  This will
greatly help those using a screen reader and frankly visually scanning
the tag (idontknowaboutyoubutthisiskindahardtoread).

However, as we explored the
code base, we found several places that will require further
consideration.  These revolve around the API and caching of tags for
articles and listings as well as the JSON documents we use for
populating drop-down lists.

So, instead of unleashing a large pull request, we're opting to provide
a small non-breaking refactor that demonstrates where we're going and
keeps production working as expected while allowing future
development/testing to benefit from these captured gains.

Our next steps are to revisit the related issue and do a proper task
breakdown, becuase there are too many considerations to call this a
"small win".

I also encourage reviewers to read the comments.  This is an emerging
mental pattern that I believe helps us conceptually move our codebase
forward while also guarding against the mega-PR with oodles of commits
and file changes that span numerous contexts.


## Related Tickets & Documents

Related to forem/forem-internal-eng#269

## QA Instructions, Screenshots, Recordings

None.  This is likely a no-op change.

### UI accessibility concerns?

We're working towards them.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
