### PR TITLE
Don't call user_id on user when setting up reaction notifications

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,7 +167,6 @@ class User < ApplicationRecord
   validate :password_matches_confirmation, if: :encrypted_password_changed?
 
   alias_attribute :public_reactions_count, :reactions_count
-  alias_attribute :user_id, :id
 
   scope :eager_load_serialized_data, -> { includes(:roles) }
   scope :registered, -> { where(registered: true) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -167,6 +167,7 @@ class User < ApplicationRecord
   validate :password_matches_confirmation, if: :encrypted_password_changed?
 
   alias_attribute :public_reactions_count, :reactions_count
+  alias_attribute :user_id, :id
 
   scope :eager_load_serialized_data, -> { includes(:roles) }
   scope :registered, -> { where(registered: true) }

--- a/app/services/notifications/reactions/reaction_data.rb
+++ b/app/services/notifications/reactions/reaction_data.rb
@@ -26,10 +26,11 @@ module Notifications
         when Notifications::Reactions::ReactionData
           object
         when Reaction
+          user_id = object.reactable.user_id unless object.reactable_type == "User"
           new(
             reactable_id: object.reactable_id,
             reactable_type: object.reactable_type,
-            reactable_user_id: object.reactable.user_id,
+            reactable_user_id: user_id,
           )
         else
           new(object.symbolize_keys)

--- a/spec/services/notifications/reactions/send_spec.rb
+++ b/spec/services/notifications/reactions/send_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Notifications::Reactions::Send, type: :service do
   context "when reaction is to a user" do
     let(:user_reaction) { create(:reaction, reactable: user, category: "thumbsup") }
 
-    it "creates a notification" do
+    it "raises an error" do
       expect do
         described_class.call(reaction_data(user_reaction), user)
       end.to raise_error(Notifications::Reactions::ReactionData::DataError)

--- a/spec/services/notifications/reactions/send_spec.rb
+++ b/spec/services/notifications/reactions/send_spec.rb
@@ -204,4 +204,14 @@ RSpec.describe Notifications::Reactions::Send, type: :service do
       expect(notification.notifiable).to eq(article)
     end
   end
+
+  context "when reaction is to a user" do
+    let(:user_reaction) { create(:reaction, reactable: user, category: "thumbsup") }
+
+    it "creates a notification" do
+      expect do
+        described_class.call(reaction_data(user_reaction), user)
+      end.to raise_error(Notifications::Reactions::ReactionData::DataError)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

An error was raised when trying to generate a reaction notification for a reaction to a user (rather than to the user's activity like a post or comment).
https://app.honeybadger.io/projects/66984/faults/84240395

Since the user doesn't have a user_id, but the reaction hash tries to access that on the reactable, a no method error is raised.

My first atttempt was to, rather than moving logic into the places we treat users like a reaction (at least ReactionData.coerce, possibly other locations), allow User instances to answer `#user_id` with their id.

However, this immediately failed with a DataError when I tried to exercise it in the context where it raised.

I reverted that change (I'm not opposed to it, it doesn't fix the error) and added an expectation that a data error is raised. We already have an existing spec that this is what we want "when data is invalid, it raises an exception". We have a similar pattern for New Follower notifications. 

I'm not sure anything _handles_ this error (I might just be moving the error farther along)? Following what I expected to be the normal flow I did not see any errors logged in the development.log, and was unable to trigger an error page interactively.

The original error was a vomit category but I wonder if that had a non-negative points somehow. The affected user (moderator) has multiple vomit reactions marked invalid (and having zero points). 

## Related Tickets & Documents

Fixes (?) https://app.honeybadger.io/projects/66984/faults/84240395 

## QA Instructions, Screenshots, Recordings

Added a test case for the narrow situation (no method error when viewing reactions for the user who has received a user level moderation).

The context here is creating, or deleting, a thumbsup (positive) user reaction - since a check Reaction.skip_notification_for? would not send negative feedback.

I had to edit the request (shown as Flag/Unfag user in the profile dropdown) to change from vomit to thumbsup. In main I get a NoMethodError, in this branch I get an unhandled DataError.

I don't know what value there is in raising a different error here.

![initial-request](https://user-images.githubusercontent.com/1237369/156028601-02835e5e-65bb-4c55-b79e-819c3b536dc6.png)

![modified-request](https://user-images.githubusercontent.com/1237369/156028618-7931d3bc-e641-4a69-955d-d3cf396df82b.png)

I'm starting to wonder if this was either old behavior (reacting with like/unlike to a user) or a pentest.


### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

(picture of me looking puzzled) - did we want to notify the user they'd been flagged? I don't think we're doing that now.