### PR TITLE
Revert "Remove IE-specific setting (#16073)"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,11 @@ module PracticalDeveloper
     # Therefore we disable "per_form_csrf_tokens" for the time being.
     config.action_controller.per_form_csrf_tokens = false
 
+    ## Rails 6.0
+    # Determines whether forms are generated with a hidden tag that forces older versions of Internet
+    # Explorer to submit forms encoded in UTF-8
+    config.action_view.default_enforce_utf8 = true
+
     ## Rails 6.1
     # This replaces the old config.active_support.use_sha1_digests from Rails 5.2
     config.active_support.hash_digest_class = ::Digest::MD5 # New default is ::Digest::SHA1


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug fix

## Description
I am reenabling this rails option to fix the broken video upload issue. I believe this stems from it being a really old gem and I would rather get it working first before making a custom patch. It was confusing to track this bug down until I came across this comment https://github.com/dwilkie/carrierwave_direct/issues/199#issuecomment-214806926

## Related Tickets & Documents
:crossed_fingers:  resolves https://github.com/forem/forem/issues/16186

## QA Instructions, Screenshots, Recordings
I believe this rails option is self-explanatory and setting up a video upload feature is not straightforward.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
n/a