### PR TITLE
Don't send notification for invalid reactions

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -101,7 +101,7 @@ class Reaction < ApplicationRecord
   # no need to send notification if:
   # - reaction is negative
   # - receiver is the same user as the one who reacted
-  # - receive_notification is disabled
+  # - reaction status is marked invalid
   def skip_notification_for?(_receiver)
     reactor_id = case reactable
                  when User
@@ -110,7 +110,7 @@ class Reaction < ApplicationRecord
                    reactable.user_id
                  end
 
-    points.negative? || (user_id == reactor_id)
+    (status == "invalid") || points.negative? || (user_id == reactor_id)
   end
 
   def vomit_on_user?

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -141,37 +141,25 @@ RSpec.describe Reaction, type: :model do
     let(:receiver) { build(:user) }
     let(:reaction) { build(:reaction, reactable: build(:article), user: nil) }
 
-    context "when false" do
-      it "is false when points are positive" do
-        reaction.points = 1
-        expect(reaction.skip_notification_for?(receiver)).to be(false)
-      end
-
-      it "is false when the person who reacted is not the same as the reactable owner" do
-        user_id = User.maximum(:id).to_i + 1
-        reaction.user_id = user_id
-        reaction.reactable.user_id = user_id + 1
-        expect(reaction.skip_notification_for?(user)).to be(false)
-      end
-
-      it "is false when receive_notifications is true" do
-        reaction.reactable.receive_notifications = true
-        expect(reaction.skip_notification_for?(receiver)).to be(false)
-      end
+    it "is normally false" do
+      expect(reaction.skip_notification_for?(receiver)).to be(false)
     end
 
-    context "when true" do
-      it "is true when points are negative" do
-        reaction.points = -2
-        expect(reaction.skip_notification_for?(receiver)).to be(true)
-      end
+    it "is true when points are negative" do
+      reaction.points = -2
+      expect(reaction.skip_notification_for?(receiver)).to be(true)
+    end
 
-      it "is true when the person who reacted is the same as the reactable owner" do
-        user_id = User.maximum(:id).to_i + 1
-        reaction.user_id = user_id
-        reaction.reactable.user_id = user_id
-        expect(reaction.skip_notification_for?(user)).to be(true)
-      end
+    it "is true when the person who reacted is the same as the reactable owner" do
+      user_id = User.maximum(:id).to_i + 1
+      reaction.user_id = user_id
+      reaction.reactable.user_id = user_id
+      expect(reaction.skip_notification_for?(user)).to be(true)
+    end
+
+    it "is true for inavlidated reactions" do
+      reaction.status = "invalid"
+      expect(reaction.skip_notification_for?(user)).to be(true)
     end
 
     context "when reactable is a user" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a moderator flags a user,
and an admin marks this invalid
and the moderator tries to flag the user again
then we destroy the existing reaction, and check whether to notify

Since the points for invalid reactions are set to 0, this was not being
skipped. Now it will be.

Also, there were three documented reasons we should skip notification, but only two cases checked - removed the comment that didn't match the code (and added this one).

## Related Tickets & Documents

fixes https://app.honeybadger.io/projects/66984/faults/84240395 - a no method error trying to get reactable.user_id from a reaction to a user (being destroyed).

## QA Instructions, Screenshots, Recordings

As a moderator, flag the user (from the profile page, or the /mod center).
As an admin, select Moderation, visit the Resolved tab, select Toggle flag reactions, and invalidate the created user flag

![Screenshot from 2022-02-28 12-02-44](https://user-images.githubusercontent.com/1237369/156037394-b1b16fc8-2bcf-4500-b54d-6cf5e62ac19e.png)

As the moderator, unflag the user (from the profile page, or flag them if you've refreshed the page). 

On main this raises a no method error
On this branch, since no notification is sent for invalid flag removal, no error is raised.


### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: bugfix
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
