### PR TITLE
Only init mod tools if we're still on article page

### DIFF
--- a/app/javascript/packs/articleModerationTools.js
+++ b/app/javascript/packs/articleModerationTools.js
@@ -19,7 +19,7 @@ getCsrfToken().then(() => {
         if (user?.id !== articleAuthorId && !isModerationPage()) {
           initializeActionsPanel(user, path);
           initializeFlagUserModal(articleAuthorId);
-          // dev.to/mod
+          // "/mod" page
         } else if (isModerationPage()) {
           initializeActionsPanel(user, path);
           initializeFlagUserModal(articleAuthorId);

--- a/app/javascript/packs/articleModerationTools.js
+++ b/app/javascript/packs/articleModerationTools.js
@@ -2,29 +2,31 @@
 import { isModerationPage } from '@utilities/moderation';
 
 getCsrfToken().then(() => {
-  const user = userData();
-  const { authorId: articleAuthorId, path } = document.getElementById(
-    'article-show-container',
-  ).dataset;
+  const articleContainer = document.getElementById('article-show-container');
 
-  const initializeModerationsTools = async () => {
-    const { initializeActionsPanel } = await import(
-      '../actionsPanel/initializeActionsPanelToggle'
-    );
-    const { initializeFlagUserModal } = await import('./flagUserModal');
+  if (articleContainer) {
+    const user = userData();
+    const { authorId: articleAuthorId, path } = articleContainer.dataset;
 
-    // article show page
-    if (user?.trusted) {
-      if (user?.id !== articleAuthorId && !isModerationPage()) {
-        initializeActionsPanel(user, path);
-        initializeFlagUserModal(articleAuthorId);
-        // dev.to/mod
-      } else if (isModerationPage()) {
-        initializeActionsPanel(user, path);
-        initializeFlagUserModal(articleAuthorId);
+    const initializeModerationsTools = async () => {
+      const { initializeActionsPanel } = await import(
+        '../actionsPanel/initializeActionsPanelToggle'
+      );
+      const { initializeFlagUserModal } = await import('./flagUserModal');
+
+      // article show page
+      if (user?.trusted) {
+        if (user?.id !== articleAuthorId && !isModerationPage()) {
+          initializeActionsPanel(user, path);
+          initializeFlagUserModal(articleAuthorId);
+          // dev.to/mod
+        } else if (isModerationPage()) {
+          initializeActionsPanel(user, path);
+          initializeFlagUserModal(articleAuthorId);
+        }
       }
-    }
-  };
+    };
 
-  initializeModerationsTools();
+    initializeModerationsTools();
+  }
 });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There was very occasional flake in some of the publishing flows Cypress specs, caused by us accessing `dataset` of the article container, when the Cypress test runner had already managed to navigate away from the page (therefore the article container didn't exist).

This is _super_ unlikely to happen in production - Cypress can very quickly locate a link on the article page to leave to another location, but I don't think a user would have ever been able to trigger this error. In saying that though, we still want our code to be robust, and we definitely don't want those specs flaking 😄 

The change just makes sure that the article container is still shown, before going ahead an initializing the mod tools.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

N/A

## QA Instructions, Screenshots, Recordings

Specs should continue to pass

### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: existing tests cover it
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


## [optional] What gif best describes this PR or how it makes you feel?

![Moira Rose says you're very speedy](https://media.giphy.com/media/1wpt0Aef5EdGyczbLk/giphy.gif)
