### PR TITLE
Ensuring VideoPolicy#new? is canonical

### DIFF
--- a/app/policies/video_policy.rb
+++ b/app/policies/video_policy.rb
@@ -1,11 +1,11 @@
 class VideoPolicy < ApplicationPolicy
   def new?
-    user.created_at < 2.weeks.ago if user.created_at
+    return false unless Settings::General.enable_video_upload
+    return false if user.suspended?
+    return false unless user.created_at
+
+    user.created_at.before?(2.weeks.ago)
   end
 
   alias create? new?
-
-  def enabled?
-    Settings::General.enable_video_upload
-  end
 end

--- a/app/views/dashboards/_actions.html.erb
+++ b/app/views/dashboards/_actions.html.erb
@@ -86,7 +86,7 @@
     <% end %>
   <% end %>
 
-  <% if policy(:video).new? && policy(:video).enabled? %>
+  <% if policy(:video).new? %>
     <a class="crayons-btn crayons-btn--secondary w-100 mt-4" href="<%= new_video_path %>" data-no-instant><%= t("views.dashboard.actions.upload") %>
     </a>
   <% end %>

--- a/app/views/dashboards/_actions_mobile.html.erb
+++ b/app/views/dashboards/_actions_mobile.html.erb
@@ -17,7 +17,7 @@
       <% end %>
     <% end %>
 
-    <% if policy(:video).new? && policy(:video).enabled? %>
+    <% if policy(:video).new? %>
       <option value="<%= new_video_path %>"><%= t("views.dashboard.actions.upload") %></option>
     <% end %>
   </select>

--- a/spec/policies/video_policy_spec.rb
+++ b/spec/policies/video_policy_spec.rb
@@ -1,27 +1,53 @@
 require "rails_helper"
 
 RSpec.describe VideoPolicy do
-  subject { described_class.new(user, nil) }
-
   let(:user) { User.new }
+  let(:policy) { described_class.new(user, nil) }
+  let(:enabled) { true }
 
-  context "when user is not signed-in" do
-    let(:user) { nil }
+  before { allow(Settings::General).to receive(:enable_video_upload).and_return(enabled) }
 
-    it { within_block_is_expected.to raise_error(Pundit::NotAuthorizedError) }
-  end
+  describe "#new?" do
+    subject(:predicate) { policy.new? }
 
-  context "when user does not have video permission" do
-    let(:user) { build(:user) }
+    context "when user is suspended" do
+      let(:enabled) { true }
+      let(:user) { create(:user, :suspended) }
 
-    it { is_expected.to forbid_actions(%i[new create]) }
-  end
+      it { is_expected.to be_falsey }
+    end
 
-  context "when does have video permission" do
-    let(:user) { build(:user) }
+    context "when user is not signed-in" do
+      let(:enabled) { true }
+      let(:user) { nil }
 
-    before { user.created_at = 3.weeks.ago }
+      it { within_block_is_expected.to raise_error(Pundit::NotAuthorizedError) }
+    end
 
-    it { is_expected.to permit_actions(%i[new create]) }
+    context "when user has been registered for awhile" do
+      let(:user) { build(:user) }
+
+      before { user.created_at = 3.weeks.ago }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when user has just registered" do
+      let(:enabled) { true }
+      let(:user) { build(:user) }
+
+      before { user.created_at = 1.hour.ago }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when video upload is not enabled" do
+      let(:enabled) { false }
+      let(:user) { build(:user) }
+
+      before { user.created_at = 1.hour.ago }
+
+      it { is_expected.to be_falsey }
+    end
   end
 end

--- a/spec/requests/videos_spec.rb
+++ b/spec/requests/videos_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "Videos", type: :request do
   let(:unauthorized_user) { create(:user) }
   let(:authorized_user)   { create(:user, created_at: 1.month.ago) }
 
+  before { allow(Settings::General).to receive(:enable_video_upload).and_return(true) }
+
   describe "GET /videos" do
     it "shows video page" do
       get "/videos"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix

## Description

This commit compresses the policy check that spanned both :new? and :enabled?.  We hide the ability to upload a video (as per the altered html.erb files of this commit) but we didn't enforce the same logic in the controller.

Further, as Videos are a subset of Article, I'm adding the "verify the user is not suspended" test.

For sleuthing this relates:

- #16728
- forem/forem#16537
- #16634

And for historical context, this relates to:

- #10955
- #10954
- forem/internalEngineering#149

## Related Tickets & Documents

- Directly relates to #16483

## QA Instructions, Screenshots, Recordings

None, the tests should be adequate.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
