### PR TITLE
Only fetch RSS of users who can create articles

### DIFF
--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -12,10 +12,10 @@ class ArticlePolicy < ApplicationPolicy
     FeatureFlag.enabled?(:limit_post_creation_to_admins)
   end
 
-  # Helps filter a `:user_scope` to those authorized to the `:action`.  I want a list of all users
+  # Helps filter a `:users_scope` to those authorized to the `:action`.  I want a list of all users
   # who can create an Article.  This policy method can help with that.
   #
-  # @param user_scope [ActiveRecord::Relation] a scope for querying user objects
+  # @param users_scope [ActiveRecord::Relation] a scope for querying user objects
   # @param action [Symbol] the name of one of the ArticlePolicy action predicates (e.g. :create?,
   #        :new?) though as a convenience, we will also accept :new, and :create.
   #
@@ -24,7 +24,7 @@ class ArticlePolicy < ApplicationPolicy
   # @see https://api.rubyonrails.org/classes/ActiveRecord/Scoping/Named/ClassMethods.html#method-i-scope
   #
   # @note With this duplication it would be feasible to alter the instance method logics to use the
-  #       class method (e.g. `ArticlePolicy.scope_authorized(user_scope: User, action:
+  #       class method (e.g. `ArticlePolicy.scope_authorized(users_scope: User, action:
   #       :create?).find_by(user.id)`) but that's a future consideration.
   #
   # @note This is not a Pundit scope (see https://github.com/varvet/pundit#scopes), as those methods
@@ -33,16 +33,16 @@ class ArticlePolicy < ApplicationPolicy
   #
   # @note Why isn't this a User.scope method?  Because the logic of who can take an action on the
   #       resource is the problem domain of the policy.
-  def self.scope_users_authorized_to_action(user_scope:, action:)
+  def self.scope_users_authorized_to_action(users_scope:, action:)
     case action
     when :create?, :new?, :create, :new
       # Note the delicate dance to duplicate logic in a general sense.  [I hope that] this is a
       # stop-gap solution.
-      user_scope = user_scope.without_role(:suspended)
-      return user_scope unless limit_post_creation_to_admins?
+      users_scope = users_scope.without_role(:suspended)
+      return users_scope unless limit_post_creation_to_admins?
 
       # NOTE: Not a fan of reaching over to the constant of another class, but I digress.
-      user_scope.with_any_role(*Authorizer::RoleBasedQueries::ANY_ADMIN_ROLES)
+      users_scope.with_any_role(*Authorizer::RoleBasedQueries::ANY_ADMIN_ROLES)
     else
       # Not going to implement all of the use cases.
       raise "Unhandled predicate: #{action} for #{self}.#{__method__}"

--- a/app/services/feeds/import.rb
+++ b/app/services/feeds/import.rb
@@ -18,7 +18,8 @@ module Feeds
     end
 
     def initialize(users_scope: User, earlier_than: nil)
-      set_users_from(users_scope: users_scope, earlier_than: earlier_than)
+      @earlier_than = earlier_than
+      @users = extract_users_from(users_scope: users_scope, earlier_than: earlier_than)
 
       # NOTE: should these be configurable? Currently they are the result of empiric
       # tests trying to find a balance between memory occupation and speed
@@ -65,18 +66,18 @@ module Feeds
 
     attr_reader :earlier_than, :users_batch_size, :num_fetchers, :num_parsers, :users
 
-    # TODO: jeremyf, the logic around which users is a bit convoluted; now we need to consider Article policies
-    #
-    # using nil here to avoid an unnecessary table count to check presence
-    def set_users_from(users_scope:, earlier_than:)
-      @users = users_scope.where(id: Users::Setting.with_feed.select(:user_id))
-      @earlier_than = earlier_than
+    # @return [ActiveRecord::Relation<User>] you'll likely want to set @users from this, but
+    #         [@jeremyf]'s choosing not to do that as it makes the implementation just a bit
+    #         cleaner.
+    def extract_users_from(users_scope:, earlier_than:)
+      users_scope = ArticlePolicy.scope_users_authorized_to_action(users_scope: users_scope, action: :create)
+      users_scope = users_scope.where(id: Users::Setting.with_feed.select(:user_id))
 
-      return @users unless earlier_than
+      return users_scope unless earlier_than
 
       # Filtering users whose feed hasn't been processed in the last `earlier_than` time span.
       # New users + any user whose feed was processed earlier than the given time
-      @users.where(feed_fetched_at: nil).or(@users.where(feed_fetched_at: ..earlier_than))
+      users_scope.where(feed_fetched_at: nil).or(users_scope.where(feed_fetched_at: ..earlier_than))
     end
 
     # TODO: put this in separate service object

--- a/app/services/feeds/import.rb
+++ b/app/services/feeds/import.rb
@@ -19,7 +19,7 @@ module Feeds
 
     def initialize(users_scope: User, earlier_than: nil)
       @earlier_than = earlier_than
-      @users = extract_users_from(users_scope: users_scope, earlier_than: earlier_than)
+      @users = filter_users_from(users_scope: users_scope, earlier_than: earlier_than)
 
       # NOTE: should these be configurable? Currently they are the result of empiric
       # tests trying to find a balance between memory occupation and speed
@@ -69,7 +69,7 @@ module Feeds
     # @return [ActiveRecord::Relation<User>] you'll likely want to set @users from this, but
     #         [@jeremyf]'s choosing not to do that as it makes the implementation just a bit
     #         cleaner.
-    def extract_users_from(users_scope:, earlier_than:)
+    def filter_users_from(users_scope:, earlier_than:)
       users_scope = ArticlePolicy.scope_users_authorized_to_action(users_scope: users_scope, action: :create)
       users_scope = users_scope.where(id: Users::Setting.with_feed.select(:user_id))
 

--- a/spec/policies/article_policy_spec.rb
+++ b/spec/policies/article_policy_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe ArticlePolicy do
       before { allow(described_class).to receive(:limit_post_creation_to_admins?).and_return(true) }
 
       it "omits suspended and regular users" do
-        results = described_class.scope_users_authorized_to_action(user_scope: User, action: :create?).to_a
+        results = described_class.scope_users_authorized_to_action(users_scope: User, action: :create?).to_a
         expect(results).to match_array([super_admin_user])
       end
     end
@@ -103,7 +103,7 @@ RSpec.describe ArticlePolicy do
       before { allow(described_class).to receive(:limit_post_creation_to_admins?).and_return(false) }
 
       it "omits only suspended users" do
-        results = described_class.scope_users_authorized_to_action(user_scope: User, action: :create?).to_a
+        results = described_class.scope_users_authorized_to_action(users_scope: User, action: :create?).to_a
         expect(results).to match_array([regular_user, super_admin_user])
       end
     end

--- a/spec/services/feeds/import_spec.rb
+++ b/spec/services/feeds/import_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Feeds::Import, type: :service, vcr: true do
   end
 
   describe ".call" do
+    it "ensures that we only fetch users who can create articles", vcr: { cassette_name: "feeds_import" } do
+      allow(ArticlePolicy).to receive(:scope_users_authorized_to_action).and_call_original
+
+      described_class.call
+
+      expect(ArticlePolicy).to have_received(:scope_users_authorized_to_action).with(users_scope: User, action: :create)
+    end
+
     # TODO: We could probably improve these tests by parsing against the items in the feed rather than hardcoding
     it "fetch only articles from a feed_url", vcr: { cassette_name: "feeds_import" } do
       num_articles = described_class.call


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature

## Description

This commit leverages changes from forem/forem#16732 and
forem/forem#16763 to ensure that we're only fetching RSS feeds for
folks who have permission to create articles.

In addition, I chose to rename the variable `user_scope` to
`users_scope` to bring consistency in the variable names.

I also chose to refactor a private method so that it wasn't setting two
instance variables but was instead returning a value that could be used
to set an instance variable.


## Related Tickets & Documents

- Related to forem/forem#16732 and forem/forem#16763
- Closes forem/forem#16487

## QA Instructions, Screenshots, Recordings

None, the tests cover the changes.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
