### PR TITLE
Add new color picker to user experience config

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -294,8 +294,8 @@ module ApplicationHelper
     tag.label(content, class: "site-config__label crayons-field__label", for: "#{label_prefix}_#{method}")
   end
 
-  def admin_config_description(content)
-    tag.p(content, class: "crayons-field__description") unless content.empty?
+  def admin_config_description(content, **opts)
+    tag.p(content, class: "crayons-field__description", **opts) unless content.empty?
   end
 
   def role_display_name(role)

--- a/app/views/admin/settings/forms/_user_experience.html.erb
+++ b/app/views/admin/settings/forms/_user_experience.html.erb
@@ -75,12 +75,9 @@
         </div>
         <div class="crayons-field">
           <%= admin_config_label :primary_brand_color_hex, model: Settings::UserExperience %>
-          <%= admin_config_description Constants::Settings::UserExperience::DETAILS[:primary_brand_color_hex][:description] %>
-          <%= f.color_field :primary_brand_color_hex,
-                            class: "crayons-color-selector",
-                            value: Settings::UserExperience.primary_brand_color_hex,
-                            pattern: "^#+([a-fA-F0-9]{6})$",
-                            placeholder: Constants::Settings::UserExperience::DETAILS[:primary_brand_color_hex][:placeholder] %>
+          <%= admin_config_description Constants::Settings::UserExperience::DETAILS[:primary_brand_color_hex][:description], id: "brand-color-description" %>
+          <%= f.text_field :primary_brand_color_hex, class: "crayons-textfield", value: Settings::UserExperience.primary_brand_color_hex, placeholder: Constants::Settings::UserExperience::DETAILS[:primary_brand_color_hex][:placeholder], pattern: "^#+([a-fA-F0-9]{6})$",
+                                                     data: { color_picker: true, label_text: "Primary brand color hex" }, aria: { describedby: "brand-color-description" } %>
         </div>
         <div class="crayons-field crayons-field--checkbox">
           <%= f.check_box :public, checked: Settings::UserExperience.public, class: "crayons-checkbox" %>
@@ -106,3 +103,4 @@
   </div>
 <% end %>
 </div>
+<%= javascript_packs_with_chunks_tag "enhanceColorPickers", defer: true %>

--- a/cypress/integration/seededFlows/adminFlows/config/userExperienceSection.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/config/userExperienceSection.spec.js
@@ -4,47 +4,79 @@ describe('User experience Section', () => {
     cy.fixture('users/adminUser.json').as('user');
 
     cy.get('@user').then((user) => {
-      cy.loginUser(user);
+      cy.loginAndVisit(user, '/admin/customization/config');
     });
   });
 
-  describe('default font', () => {
-    it('can change the default font', () => {
-      cy.get('@user').then(() => {
-        cy.visit('/admin/customization/config');
-        cy.get('#new_settings_user_experience').as('userExperienceSectionForm');
+  it('can change the default font', () => {
+    cy.get('#new_settings_user_experience').as('userExperienceSectionForm');
 
-        cy.get('@userExperienceSectionForm')
-          .findByText('User Experience and Brand')
-          .click();
-        cy.get('@userExperienceSectionForm')
-          .get('#settings_user_experience_default_font')
-          // We need to use force here because the select is covered by another element.
-          .select('open-dyslexic', { force: true });
+    cy.get('#new_settings_user_experience').within(() => {
+      cy.findByRole('button', { name: 'Show info' }).click();
 
-        cy.get('@userExperienceSectionForm')
-          .findByText('Update Settings')
-          .click();
+      cy.findByRole('combobox', { name: 'Default font' }).select(
+        'open-dyslexic',
+      );
 
-        cy.url().should('contains', '/admin/customization/config');
+      cy.findByText('Update Settings').click();
+    });
 
-        cy.findByTestId('snackbar').within(() => {
-          cy.findByRole('alert').should(
-            'have.text',
-            'Successfully updated settings.',
-          );
-        });
+    cy.findByTestId('snackbar').within(() => {
+      cy.findByRole('alert').should(
+        'have.text',
+        'Successfully updated settings.',
+      );
+    });
 
-        // Page reloaded so need to get a new reference to the form.
-        cy.get('#new_settings_user_experience').as('userExperienceSectionForm');
-        cy.get('@userExperienceSectionForm')
-          .findByText('User Experience and Brand')
-          .click();
-        cy.get('#settings_user_experience_default_font').should(
-          'have.value',
-          'open_dyslexic',
-        );
-      });
+    // Page reloaded so need to get a new reference to the form.
+    cy.get('#new_settings_user_experience').within(() => {
+      cy.findByText('User Experience and Brand').click();
+      cy.get('#settings_user_experience_default_font').should(
+        'have.value',
+        'open_dyslexic',
+      );
+    });
+  });
+
+  it('Should change the primary brand color hex if contrast is sufficient', () => {
+    cy.get('#new_settings_user_experience').within(() => {
+      cy.findByRole('button', { name: 'Show info' }).click();
+
+      // Both a button and an input should exist for the brand color
+      cy.findByRole('button', { name: 'Primary brand color hex' });
+      cy.findByRole('textbox', { name: 'Primary brand color hex' })
+        .clear()
+        .type('#591803')
+        .blur();
+      cy.findByText('Update Settings').click();
+    });
+
+    cy.findByTestId('snackbar').within(() => {
+      cy.findByRole('alert').should(
+        'have.text',
+        'Successfully updated settings.',
+      );
+    });
+  });
+
+  it('should not update brand color if contrast is insufficient', () => {
+    cy.get('#new_settings_user_experience').within(() => {
+      cy.findByRole('button', { name: 'Show info' }).click();
+
+      // Both a button and an input should exist for the brand color
+      cy.findByRole('button', { name: 'Primary brand color hex' });
+      cy.findByRole('textbox', { name: 'Primary brand color hex' })
+        .clear()
+        .type('#ababab')
+        .blur();
+      cy.findByText('Update Settings').click();
+    });
+
+    cy.findByTestId('snackbar').within(() => {
+      cy.findByRole('alert').should(
+        'have.text',
+        'Validation failed: Primary brand color hex must be darker for accessibility',
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR replaces the last of our old-style color pickers with the new accessible one. The relevant app section is in `/admin/customization/config` in the "User experience and brand' section.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/15179

## QA Instructions, Screenshots, Recordings

- Log in as an admin user and visit `/admin/customization/config`
- Expand the 'user experience and brand' section
- You should see the new color picker for the "Primary brand color hex"
- Experiment with setting the color either with the picker or the plain text input
- Submit the form with a low contrast color (e.g. `#ababab`)
- You should see a snackbar advising the color has failed validation
- Submit the form with a strong contrast color (e.g. `#000000`)
- You should see a snackbar advising the setting has been updated
- Refresh the page and check the new setting has taken effect

### UI accessibility concerns?

Makes the color picker here accessible

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: the overall issue will be communicated


## [optional] What gif best describes this PR or how it makes you feel?

![rainbow slinky going down stairs](https://media.giphy.com/media/26AHQCn4Ce8fLedlm/giphy.gif)
