### PR TITLE
Fix grid col overflow in right sidebar in safari

### DIFF
--- a/app/assets/stylesheets/components/cards.scss
+++ b/app/assets/stylesheets/components/cards.scss
@@ -5,6 +5,8 @@
   background: var(--card-bg);
   color: var(--card-color);
   box-shadow: 0 0 0 1px var(--card-border);
+  // overflow-wrap: anywhere isn't supported in Safari, in which case this fallback applies
+  overflow-wrap: break-word;
   overflow-wrap: anywhere;
 
   &--secondary {

--- a/app/views/sidebars/_homepage_content.html.erb
+++ b/app/views/sidebars/_homepage_content.html.erb
@@ -11,7 +11,7 @@
     <%= render "articles/sidebar_listings" if Listing.feature_enabled? %>
 
     <% Settings::General.sidebar_tags.each do |tag| %>
-      <section class="crayons-card crayons-card--secondary">
+      <section class="crayons-card crayons-card--secondary crayons-layout__content">
         <header class="crayons-card__header">
           <h3 class="crayons-subtitle-2"><a href="/t/<%= tag %>" class="crayons-link">#<%= tag %></a></h3>
         </header>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The DEV home page is currently looking less than ideal in Safari:

![Content all overflow in the wrong places](https://user-images.githubusercontent.com/20773163/156566550-b61420f1-c720-4398-b7c0-8130e2a6ce03.png)

This appears to be caused by [this post](https://dev.to/inhuofficial/i-am-warning-you-dont-click-42im) appearing in the "Tags" righthand sidebar list (under multiple tags, but one would be enough!). 

The root issue is the minimum width for a grid column is `auto` and not `0` as you might suspect. Long, unbreakable, content in a column can cause unfortunate overlap and overflow. [See this CSS Tricks article](https://css-tricks.com/preventing-a-grid-blowout/).

We already had a `crayons-layout__content` class which accounted for this, setting `min-width: 0`. The other fix needed was to allow text content to wrap in Safari - we were using `overflow-wrap: anywhere` which isn't supported in Safari, but I've added a fallback 🙂 

## Related Tickets & Documents


<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related https://github.com/forem/forem/issues/16746

This PR fixes the layout in Safari to be in the same state as Chrome/Firefox currently - content appears correctly layed out, but there is horizontal scroll that still needs fixed.

## QA Instructions, Screenshots, Recordings

- Pull down the code, and create a post with the same title as [this one from DEV](https://dev.to/inhuofficial/i-am-warning-you-dont-click-42im) (copy/paste). Add any tag to it.
- In the Admin panel under 'Customization > Tags', add the post's tag to the featured list
- Go to the home page in Safari and check it all looks ok!

### UI accessibility concerns?

Makes content readable again 😅 

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: Needs an 'eyeball check'
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


