### PR TITLE
Prevent hidden link skewing layout of home page

### DIFF
--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -48,6 +48,7 @@
     left: 0;
 
     // Prevent long title content skewing layout
+    // overflow-wrap: anywhere isn't supported in Safari, in which case this fallback applies
     overflow-wrap: break-word;
     overflow-wrap: anywhere;
   }

--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -46,6 +46,10 @@
     right: 0;
     bottom: 0;
     left: 0;
+
+    // Prevent long title content skewing layout
+    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
   }
 
   // Defining additional colors.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We noticed that when [this particular DEV post](https://dev.to/inhuofficial/i-am-warning-you-dont-click-42im) was in the home feed, the whole home page became horizontally scrollable, with lots of empty space at the right-hand side.

The root cause is a visually hidden duplication of the title, which didn't wrap its content. I've applied some overflow wrap styles to fix the issue for now, but I'm going to raise a separate issue for the overall feature with regards to this hidden link.

It looks like we introduced this as part of a keyboard navigation feature (the ability to skip to next article by pressing 'j'). However, the approach taken with this hidden link is unnecessary (every article card on the home page already has _many_ links in it), and is damaging to accessibility (multiplied across all articles, this is a tonne of extra noise for screen reader users). It also is affecting our layouts and isn't as "hidden" as one might hope 😄 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->


- Closes https://github.com/forem/forem/issues/16746

## QA Instructions, Screenshots, Recordings

- Create a post locally that has the [same title as this one](https://dev.to/inhuofficial/i-am-warning-you-dont-click-42im) (copy/paste the title) 
- Go to the home feed and check there is no horizontal scroll
- Check in Safari as well as Firefox and Chrome

### UI accessibility concerns?

No impact here, but like I say I'll raise an issue to look at this UX generally

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: functionality covered by existing tests
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: minor bug fix



## [optional] What gif best describes this PR or how it makes you feel?

![I don't like it](https://media.giphy.com/media/5RFzQsoVWstehJpynp/giphy.gif)
