### PR TITLE
Removing before_action in favor of explicity call

### DIFF
--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -1,9 +1,10 @@
 class VideosController < ApplicationController
   after_action :verify_authorized, except: %i[index]
   before_action :set_cache_control_headers, only: %i[index]
-  before_action :authorize_video, only: %i[new create]
 
-  def new; end
+  def new
+    authorize :video
+  end
 
   def index
     @video_articles = Article.with_video
@@ -16,16 +17,13 @@ class VideosController < ApplicationController
   end
 
   def create
+    authorize :video
     @article = ArticleWithVideoCreationService.new(article_params, current_user).create!
 
     redirect_to "#{@article.path}/edit"
   end
 
   private
-
-  def authorize_video
-    authorize :video
-  end
 
   def article_params
     params.require(:article).permit(:video)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

While in essence an idempotent change the purpose of this PR is to also
favor explicit method calls over callbacks.  Note, we don't have an
associated model (e.g. Video) and instead rely on `:video` which Pundit
converts to VideoPolicy.

From my experience in rails it can become challenging to mentally parse
the various before/after action paired with the only and except.  As
well as considering the timing of what happens when.

Further this commit helps provide a record of "work" towards an issue.

## Related Tickets & Documents

- Closes forem/forem#16729
- Reverses forem/forem#3806

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why:

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
