### PR TITLE
Conditionally removing the "configure" editor

### DIFF
--- a/app/views/users/_customization.html.erb
+++ b/app/views/users/_customization.html.erb
@@ -40,6 +40,7 @@
     </div>
   </div>
 
+  <% if policy(Article).create? %>
   <div class="crayons-card crayons-card--content-rows">
     <h2 class="crayons-subtitle-1">
       <%= t("views.settings.custom.writing") %>
@@ -53,6 +54,7 @@
       </div>
     </div>
   </div>
+  <% end %>
 
   <div class="crayons-card crayons-card--content-rows">
     <h2 class="crayons-subtitle-1">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Note, I'm not overly keen on writing permission tests for this
component.  Why?  Robust permissioning tests can create combinatorial
explosions.  And there are presently no Rspec request specs for this.
So to add an automated test, we'd need to add a set of seed data that
seeds data that conforms to the emerging business logic of the policy.

And while this is easy with use case 1-1, it gets harder as we move
into more nuanced use cases.  Instead we should rely on bombarding our
policy classes with lots of tests to let them demonstrate what we mean
when we say `if policy(Article).create?`

Note, there is a potential relation to forem/forem#14807, namely if we
add a rich text editor to our comments, we may need to explore the
purpose and intention of this setting.


## Related Tickets & Documents

Closes forem/forem#16516

## QA Instructions, Screenshots, Recordings

To test this, you will need to create a non-admin user and then enable the
`:limit_post_creation_to_admins` Feature Flag.  Finally login as the newly
created user, and go to `/settings/customization`.  Then you should not see the
"Writing section".

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: See PR message

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
