### PR TITLE
Redirect appended /moderate and /admin to the same page (admin member view)

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -15,6 +15,7 @@ class StoriesController < ApplicationController
   }.freeze
 
   SIGNED_OUT_RECORD_COUNT = 60
+  REDIRECT_VIEW_PARAMS = %w[moderate admin].freeze
 
   before_action :authenticate_user!, except: %i[index show]
   before_action :set_cache_control_headers, only: %i[index show]
@@ -210,8 +211,7 @@ class StoriesController < ApplicationController
   end
 
   def redirect_if_view_param
-    redirect_to admin_user_path(@user.id) if params[:view] == "moderate"
-    redirect_to edit_admin_user_path(@user.id) if params[:view] == "admin"
+    redirect_to admin_user_path(@user.id) if REDIRECT_VIEW_PARAMS.include?(params[:view])
   end
 
   def redirect_if_show_view_param

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -376,7 +376,7 @@ Rails.application.routes.draw do
     get "/:username/comment/:id_code/settings", to: "comments#settings"
 
     get "/:username/:slug/:view", to: "stories#show",
-                                  constraints: { view: /moderate/ }
+                                  constraints: { view: /moderate|admin/ }
     get "/:username/:slug/mod", to: "moderations#article"
     get "/:username/:slug/actions_panel", to: "moderations#actions_panel"
     get "/:username/:slug/manage", to: "articles#manage", as: :article_manage

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe "UserProfiles", type: :request do
     it "redirects to admin" do
       user = create(:user)
       get "/#{user.username}/admin"
-      expect(response.body).to redirect_to edit_admin_user_path(user.id)
+      expect(response.body).to redirect_to admin_user_path(user.id)
     end
 
     it "redirects to moderate" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This fixes a small bug where `/admin` redirected to a deprecated (but still existing) page. It now redirects to the singular user/member view `/app/admin/users/:id`.

## Related Tickets & Documents
https://forem-team.slack.com/archives/CAA200SH5/p1646313307397169

## QA Instructions, Screenshots, Recordings
1. Append /moderate on a user's profile URL
2. Get redirected to `/app/admin/users/:the_users_id`
3. Repeat and get the same result with /admin

### UI accessibility concerns?
Nope

## Added/updated tests?

- [x] No: there are already tests

## [Forem core team only] How will this change be communicated?
- [x] Message in internal team Slack

## [optional] Are there any post deployment tasks we need to perform?
Nope

## [optional] What gif best describes this PR or how it makes you feel?

![Spongebob Squarepants dusts his hands off like he's done with the job.](https://media.giphy.com/media/26u4lOMA8JKSnL9Uk/giphy.gif)
