### PR TITLE
Fix flake in post mod tools spec

### DIFF
--- a/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
@@ -47,17 +47,15 @@ describe('Moderation Tools for Posts', () => {
       cy.loginAndVisit(user, '/admin_mcadmin/tag-test-article').then(() => {
         cy.findByRole('button', { name: 'Moderation' }).click();
 
+        // Helper function for pipe command
+        const click = ($el) => $el.click();
+
         cy.getIframeBody('[title="Moderation panel actions"]').within(() => {
+          // We use `pipe` here to retry the click, as the animation of the mod tools opening can sometimes cause the button to not be ready yet
           cy.findByRole('button', { name: 'Open adjust tags section' })
             .as('adjustTagsButton')
-            .click({
-              force: true,
-            });
-          cy.get('@adjustTagsButton').should(
-            'have.attr',
-            'aria-expanded',
-            'true',
-          );
+            .pipe(click)
+            .should('have.attr', 'aria-expanded', 'true');
 
           cy.findByRole('button', { name: '#tag1 Remove tag' }).click();
           cy.findByRole('button', { name: 'Submit' }).click();


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description


I've noticed this spec flaking a fair bit in CI, with the tags dropdown not expanding on click. It seems to be to do with the animation of the mod tools panel opening, causing the button to not be fully clickable yet. I've added use of the `pipe` command to get around it

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

N/A

## QA Instructions, Screenshots, Recordings

N/A

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

