### PR TITLE
Allowlist character classes for post titles

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -31,6 +31,48 @@ class Article < ApplicationRecord
   MAX_USER_MENTION_LIVE_AT = Time.utc(2021, 4, 7).freeze
   PROHIBITED_UNICODE_CHARACTERS_REGEX = /[\u202a-\u202e]/ # BIDI embedding controls
 
+  # Filter out anything that isn't a word, space, punctuation mark, or
+  # recognized emoji.
+  # See: https://github.com/forem/forem/pull/16787#issuecomment-1062044359
+  # rubocop:disable Lint/DuplicateRegexpCharacterClassElement
+  TITLE_CHARACTERS_ALLOWED = /[^
+    [:word:]
+    [:space:]
+    [:punct:]
+    \u00a3        # GBP symbol
+    \u00a9        # Copyright symbol
+    \u00ae        # Registered trademark symbol
+    \u200d        # Zero-width joiner, for multipart emojis such as family
+    \u203c        # !! emoji
+    \u20e3        # Combining enclosing keycap
+    \u2122        # Trademark symbol
+    \u2139        # Information symbol
+    \u2194-\u2199 # Arrow symbols
+    \u21a9-\u21aa # More arrows
+    \u231a        # Watch emoji
+    \u231b        # Hourglass emoji
+    \u2328        # Keyboard emoji
+    \u23cf        # Eject symbol
+    \u23e9-\u23f3 # Various VCR-actions emoji and clocks
+    \u23f8-\u23fa # More VCR emoji
+    \u24c2        # Blue circle with a white M in it
+    \u25aa        # Black box
+    \u25ab        # White box
+    \u25b6        # VCR-style play emoji
+    \u25c0        # VCR-style play backwards emoji
+    \u25fb-\u25fe # More black and white squares
+    \u2600-\u273f # Weather, zodiac, coffee, hazmat, cards, music, other misc emoji
+    \u2934        # Curved arrow pointing up to the right
+    \u2935        # Curved arrow pointing down to the right
+    \u2b00-\u2bff # More arrows, geometric shapes
+    \u3030        # Squiggly line
+    \u303d        # Either a line chart plummeting or the letter M, not sure
+    \u3297        # Circled Ideograph Congratulation
+    \u3299        # Circled Ideograph Secret
+    \u{1f000}-\u{1ffff} # More common emoji
+  ]+/m
+  # rubocop:enable Lint/DuplicateRegexpCharacterClassElement
+
   def self.unique_url_error
     I18n.t("models.article.unique_url", email: ForemInstance.contact_email)
   end
@@ -572,11 +614,10 @@ class Article < ApplicationRecord
     return unless title
 
     self.title = title
-      # Filter out anything that isn't a word, space, punctuation mark, or
-      # recognized emoji
-      .gsub(/[^[:word:][:space:][:punct:]\u{1f000}-\u{1ffff}]+/, " ")
+      .gsub(TITLE_CHARACTERS_ALLOWED, " ")
       # Coalesce runs of whitespace into a single space character
       .gsub(/\s+/, " ")
+      .strip
   end
 
   def evaluate_markdown

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -106,7 +106,7 @@ class Article < ApplicationRecord
 
   before_validation :evaluate_markdown, :create_slug
   before_validation :remove_prohibited_unicode_characters
-  before_validation :normalize_spaces
+  before_validation :normalize_title
   before_save :update_cached_user
   before_save :set_all_dates
 
@@ -568,15 +568,15 @@ class Article < ApplicationRecord
     self.path = calculated_path.downcase
   end
 
-  def normalize_spaces
-    if title
-      self.title = title
-        # Filter out anything that isn't a word, space, punctuation mark, or
-        # recognized emoji
-        .gsub(/[^[:word:][:space:][:punct:]\u{1f000}-\u{1ffff}]+/, " ")
-        # Coalesce runs of whitespace into a single space character
-        .gsub(/\s+/, " ")
-    end
+  def normalize_title
+    return unless title
+
+    self.title = title
+      # Filter out anything that isn't a word, space, punctuation mark, or
+      # recognized emoji
+      .gsub(/[^[:word:][:space:][:punct:]\u{1f000}-\u{1ffff}]+/, " ")
+      # Coalesce runs of whitespace into a single space character
+      .gsub(/\s+/, " ")
   end
 
   def evaluate_markdown

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -106,6 +106,7 @@ class Article < ApplicationRecord
 
   before_validation :evaluate_markdown, :create_slug
   before_validation :remove_prohibited_unicode_characters
+  before_validation :normalize_spaces
   before_save :update_cached_user
   before_save :set_all_dates
 
@@ -565,6 +566,17 @@ class Article < ApplicationRecord
     self.cached_user_name = user_name
     self.cached_user_username = user_username
     self.path = calculated_path.downcase
+  end
+
+  def normalize_spaces
+    if title
+      self.title = title
+        # Filter out anything that isn't a word, space, punctuation mark, or
+        # recognized emoji
+        .gsub(/[^[:word:][:space:][:punct:]\u{1f000}-\u{1ffff}]+/, " ")
+        # Coalesce runs of whitespace into a single space character
+        .gsub(/\s+/, " ")
+    end
   end
 
   def evaluate_markdown

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -155,9 +155,9 @@ RSpec.describe Article, type: :model do
     describe "#main_image_background_hex_color" do
       it "must have true hex for image background" do
         article.main_image_background_hex_color = "hello"
-        expect(article.valid?).to eq(false)
+        expect(article.valid?).to be(false)
         article.main_image_background_hex_color = "#fff000"
-        expect(article.valid?).to eq(true)
+        expect(article.valid?).to be(true)
       end
     end
 
@@ -184,9 +184,9 @@ RSpec.describe Article, type: :model do
     describe "#main_image" do
       it "must have url for main image if present" do
         article.main_image = "hello"
-        expect(article.valid?).to eq(false)
+        expect(article.valid?).to be(false)
         article.main_image = "https://image.com/image.png"
-        expect(article.valid?).to eq(true)
+        expect(article.valid?).to be(true)
       end
     end
 
@@ -195,13 +195,13 @@ RSpec.describe Article, type: :model do
 
       it "does not allow the use of admin-only liquid tags for non-admins" do
         article.body_markdown = "hello hey hey hey {% poll #{poll.id} %}"
-        expect(article.valid?).to eq(false)
+        expect(article.valid?).to be(false)
       end
 
       it "allows admins" do
         article.user.add_role(:admin)
         article.body_markdown = "hello hey hey hey {% poll #{poll.id} %}"
-        expect(article.valid?).to eq(true)
+        expect(article.valid?).to be(true)
       end
     end
 
@@ -222,13 +222,18 @@ RSpec.describe Article, type: :model do
     end
 
     describe "title validation" do
-      it "removes extra spaces" do
-        # Rubocop objects to this for many reasons, but it's intentional
-        # rubocop:disable
-        article = create(:article, title: "I⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Am⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Warning⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀You⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Don't⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Click!")
-        # rubocop:enable
+      it "normalizes the title to a narrow set of allowable characters" do
+        article = create(:article, title: "I⠀⠀Am⠀⠀Warning⠀⠀You⠀⠀Don't⠀⠀Click!")
 
         expect(article.title).to eq "I Am Warning You Don't Click!"
+      end
+
+      it "allows useful emojis and extended punctuation" do
+        allowed_title = "Hello! Title — Emdash⁉️ 🤖🤯🔥®™©👨‍👩🏾👦‍👦"
+
+        article = create(:article, title: allowed_title)
+
+        expect(article.title).to eq allowed_title
       end
 
       it "produces a proper title" do
@@ -362,7 +367,7 @@ RSpec.describe Article, type: :model do
       end
 
       it "parses does not assign canonical_url" do
-        expect(article.canonical_url).to eq(nil)
+        expect(article.canonical_url).to be_nil
       end
 
       it "parses canonical_url if canonical_url is present" do
@@ -404,7 +409,7 @@ RSpec.describe Article, type: :model do
       before { article_without_main_image.validate }
 
       it "can parse the main_image" do
-        expect(article_without_main_image.main_image).to eq(nil)
+        expect(article_without_main_image.main_image).to be_nil
       end
 
       it "can parse the main_image when added" do
@@ -430,7 +435,7 @@ RSpec.describe Article, type: :model do
         article_with_main_image.main_image = nil
         article_with_main_image.validate
 
-        expect(article_with_main_image.main_image).to eq(nil)
+        expect(article_with_main_image.main_image).to be_nil
       end
 
       it "can parse the main_image when changed" do
@@ -565,7 +570,7 @@ RSpec.describe Article, type: :model do
 
       it "properly converts underscores and still has a valid slug" do
         underscored_article = build(:article, title: "hey_hey_hey node_modules", published: false)
-        expect(underscored_article.valid?).to eq true
+        expect(underscored_article.valid?).to be true
       end
     end
 
@@ -583,7 +588,7 @@ RSpec.describe Article, type: :model do
 
       it "properly converts underscores and still has a valid slug" do
         underscored_article = build(:article, title: "hey_hey_hey node_modules", published: true)
-        expect(underscored_article.valid?).to eq true
+        expect(underscored_article.valid?).to be true
       end
 
       # rubocop:disable RSpec/NestedGroups
@@ -613,23 +618,23 @@ RSpec.describe Article, type: :model do
     it "returns true if the article has a frontmatter" do
       body = "---\ntitle: Hellohnnnn#{rand(1000)}\npublished: true\ntags: hiring\n---\n\nHello"
       article.body_markdown = body
-      expect(article.has_frontmatter?).to eq(true)
+      expect(article.has_frontmatter?).to be(true)
     end
 
     it "returns false if the article does not have a frontmatter" do
       article.body_markdown = "Hey hey Ho Ho"
-      expect(article.has_frontmatter?).to eq(false)
+      expect(article.has_frontmatter?).to be(false)
     end
 
     it "returns true if parser raises a Psych::DisallowedClass error" do
       allow(FrontMatterParser::Parser).to receive(:new).and_raise(Psych::DisallowedClass.new("msg"))
-      expect(article.has_frontmatter?).to eq(true)
+      expect(article.has_frontmatter?).to be(true)
     end
 
     it "returns true if parser raises a Psych::SyntaxError error" do
       syntax_error = Psych::SyntaxError.new("file", 1, 1, 0, "problem", "context")
       allow(FrontMatterParser::Parser).to receive(:new).and_raise(syntax_error)
-      expect(article.has_frontmatter?).to eq(true)
+      expect(article.has_frontmatter?).to be(true)
     end
   end
 
@@ -647,7 +652,7 @@ RSpec.describe Article, type: :model do
     it "shows year in readable time if not current year" do
       article.edited_at = 1.year.ago
       last_year = 1.year.ago.year % 100
-      expect(article.readable_edit_date.include?("'#{last_year}")).to eq(true)
+      expect(article.readable_edit_date.include?("'#{last_year}")).to be(true)
     end
   end
 
@@ -661,7 +666,7 @@ RSpec.describe Article, type: :model do
     it "shows year in readable time if not current year" do
       article.published_at = 1.year.ago
       last_year = 1.year.ago.year % 100
-      expect(article.readable_publish_date.include?("'#{last_year}")).to eq(true)
+      expect(article.readable_publish_date.include?("'#{last_year}")).to be(true)
     end
   end
 
@@ -735,7 +740,7 @@ RSpec.describe Article, type: :model do
         user: user,
         body_markdown: "---\ntitle: hey\npublished: false\ncover_image: #{Faker::Avatar.image}\n---\nYo",
       )
-      expect(article.main_image_from_frontmatter).to eq(true)
+      expect(article.main_image_from_frontmatter).to be(true)
     end
 
     context "when false" do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -222,6 +222,15 @@ RSpec.describe Article, type: :model do
     end
 
     describe "title validation" do
+      it "removes extra spaces" do
+        # Rubocop objects to this for many reasons, but it's intentional
+        # rubocop:disable
+        article = create(:article, title: "I⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Am⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Warning⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀You⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Don't⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Click!")
+        # rubocop:enable
+
+        expect(article.title).to eq "I Am Warning You Don't Click!"
+      end
+
       it "produces a proper title" do
         test_article = build(:article, title: "An Article Title")
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Rather than deny-listing character classes we want removed, we can instead allow-list the safe ones and remove everything else.

This is in response to a post that broke the DEV homepage yesterday. Its title didn't just use whitespace, which a browser would've merged into a single space, but actually used a whitespace-looking character (`\u2800`, ["Braille Pattern Blank"](https://www.compart.com/en/unicode/U+2800)) so that that wouldn't happen and deliberately messed up the formatting not only of their own post, but any feed the post would appear as a recommended post on (including the homepage).

This PR allow-lists safe character classes:
- Word characters (letters, numbers, underscores)
- Whitespace (spaces, tabs, newlines, etc)
- Punctuation
- Emojis that I could think of

Everything else gets converted into a space character and then all whitespace gets merged into a single space, not just for rendering but for storage, as well.

I'm sure I'm not covering all the bases here, so if anyone has any more examples of characters to add into the test, I'd be happy to update it.

## Related Tickets & Documents

- https://dev.to/inhuofficial/i-am-warning-you-dont-click-42im

## QA Instructions, Screenshots, Recordings

Copy and paste the title from [this article](https://dev.to/inhuofficial/i-am-warning-you-dont-click-42im) and any others you can think of that have formatting implications.

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

Also, tests could be more comprehensive

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_