### PR TITLE
Fix broken email settings documentation link

### DIFF
--- a/app/views/admin/invitations/new.html.erb
+++ b/app/views/admin/invitations/new.html.erb
@@ -8,7 +8,7 @@
         SMTP settings are required so that your Forem can send emails.
         If you wish to send invites, email digests and activity notifications you will need to
         specify which email host will relay those messages for you. You can
-        <a href="https://admin.forem.com/docs/advanced-customization/config/smtp-settings" target="_blank">read more about SMTP Settings in our admin guide</a>.
+        <a href="https://admin.forem.com/docs/advanced-customization/config/email-server-settings" target="_blank">read more about SMTP Settings in our admin guide</a>.
       </div>
       <div class="my-4">
         Please note that you will need to reload this page after configuring your SMTP Settings.

--- a/spec/system/admin/admin_invites_user_spec.rb
+++ b/spec/system/admin/admin_invites_user_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Admin invites user", type: :system do
     end
 
     it "contains a link to the documentation" do
-      expect(page).to have_link("read more about SMTP Settings in our admin guide", href: "https://admin.forem.com/docs/advanced-customization/config/smtp-settings")
+      expect(page).to have_link("read more about SMTP Settings in our admin guide")
     end
 
     it "contains a link to configure SMTP settings" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

When sending an invitation, and smtp isn't configured, we show a broken link
to the old smtp-settings page, which has been renamed email-server-settings in the admin documentation site.

Fix the url to match the documentation site.

## Related Tickets & Documents

- Introduced after the rename in https://github.com/forem/admin-docs/pull/30

## QA Instructions, Screenshots, Recordings

With SMTP settings unconfigured, attempt to send an invitation from http://192.168.0.5:3000/admin/invitations/new

On main, a 404 is shown at https://admin.forem.com/docs/advanced-customization/config/smtp-settings

On this branch, the documentation page is shown at https://admin.forem.com/docs/advanced-customization/config/email-server-settings

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: documentation link update
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [x] This change does not need to be communicated, and this is why not: tiny typo fix
