### PR TITLE
Fan out Feeds::ImportArticlesWorker

### DIFF
--- a/app/workers/feeds/import_articles_worker.rb
+++ b/app/workers/feeds/import_articles_worker.rb
@@ -26,9 +26,9 @@ module Feeds
       end
 
       users_scope.select(:id).find_in_batches do |batch|
-        ids = batch.map { |user| [user.id, earlier_than] }
+        arg_lists = batch.map { |user| [user.id, earlier_than] }
 
-        ForUser.perform_bulk(ids)
+        ForUser.perform_bulk(arg_lists)
       end
     end
 

--- a/app/workers/feeds/import_articles_worker.rb
+++ b/app/workers/feeds/import_articles_worker.rb
@@ -28,7 +28,7 @@ module Feeds
       users_scope.select(:id).find_in_batches do |batch|
         ids = batch.map { |user| [user.id, earlier_than] }
 
-        ForUser.perform_bulk ids
+        ForUser.perform_bulk(ids)
       end
     end
 

--- a/spec/workers/feeds/import_articles_worker_spec.rb
+++ b/spec/workers/feeds/import_articles_worker_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Feeds::ImportArticlesWorker, type: :worker do
+RSpec.describe Feeds::ImportArticlesWorker, type: :worker, sidekiq: :inline do
   let(:worker) { subject }
 
   include_examples "#enqueues_on_correct_queue", "medium_priority"
@@ -8,21 +8,39 @@ RSpec.describe Feeds::ImportArticlesWorker, type: :worker do
   describe "#perform" do
     it "calls the Feeds::Import defaulting to 4 hours ago" do
       allow(Feeds::Import).to receive(:call)
+      alice = create(:user)
+      bob = create(:user)
 
       Timecop.freeze(Time.current) do
         worker.perform
 
-        expect(Feeds::Import).to have_received(:call).with(users_scope: User, earlier_than: 4.hours.ago)
+        # Each user is run separately. Note that this will not be run
+        # sequentially like this in production. This only works like this due
+        # to the `sidekiq: :inline` tag on the `RSpec.describe` block
+        expect(Feeds::Import)
+          .to have_received(:call)
+          .with(users_scope: User.where(id: [alice.id]), earlier_than: 4.hours.ago.iso8601)
+        expect(Feeds::Import)
+          .to have_received(:call)
+          .with(users_scope: User.where(id: [bob.id]), earlier_than: 4.hours.ago.iso8601)
       end
     end
 
     it "calls the Feeds::Import with the given time" do
       allow(Feeds::Import).to receive(:call)
+      alice = create(:user)
+      bob = create(:user)
 
       Timecop.freeze(Time.current) do
         worker.perform([], 1.minute.ago)
 
-        expect(Feeds::Import).to have_received(:call).with(users_scope: User, earlier_than: 1.minute.ago)
+        # Each user is run separately
+        expect(Feeds::Import)
+          .to have_received(:call)
+          .with(users_scope: User.where(id: [alice.id]), earlier_than: 1.minute.ago.iso8601)
+        expect(Feeds::Import)
+          .to have_received(:call)
+          .with(users_scope: User.where(id: [bob.id]), earlier_than: 1.minute.ago.iso8601)
       end
     end
 


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We've been running article imports for all users inside a single Sidekiq job. For a large Forem instance like DEV, that takes forever, tying up a Sidekiq worker thread that long and accumulating memory.

Doing all that work within a single Sidekiq job has begun taking over an hour on DEV. Regardless of the reasons we did it that way originally, we should be able to handle this concurrently. If we cannot, ideally we'll investigate why and handle it properly rather than consigning it to sequential work.

The consumer interface to `Feeds::ImportArticleWorker` should be unchanged. Updating a feed for an individual user will still work if you go in through that front door.


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: API has not changed
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_