### PR TITLE
Removing reference to Generate Personal blog

### DIFF
--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -130,7 +130,6 @@ en:
           remove: Remove
           save: Save template
           saved: Saved templates
-        generate: Generate a personal blog from your %{community} posts
         github:
           heading: GitHub
           desc1: Pin your GitHub repositories to your profile.
@@ -180,7 +179,7 @@ en:
             button:
               aria_label: Copy organization secret code to clipboard
             icon: Copy to clipboard
-            input:  
+            input:
               aria_label: Organization secret (to be rotated regularly)
             text: Copied to clipboard!
           cta: Call-to-action box

--- a/config/locales/views/settings/fr.yml
+++ b/config/locales/views/settings/fr.yml
@@ -130,7 +130,6 @@ fr:
           remove: Remove
           save: Save template
           saved: Saved templates
-        generate: Generate a personal blog from your %{community} posts
         github:
           heading: GitHub
           desc1: Pin your GitHub repositories to your profile.
@@ -177,7 +176,7 @@ fr:
         admin:
           admin: Admin
           copy:
-            button: 
+            button:
               aria_label: Copy organization secret code to clipboard
             icon: Copy to clipboard
             input:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization
- [x] Documentation Update

## Description

As part of removing Stackbit integration, I previously missed removing
the translation key.  This removes an errant key.

This commit was driven by attempting to address the following feature
request:

> Conditional hide "Generate a personal blog from your DEV Community
> posts" in /settings/extensions

There is option for this behavior.

```shell
❯ rg "extensions\.generate"
```

With this commit, the above command exit's status 1 (e.g. nothing found).


## Related Tickets & Documents

- Closes #16819
- Missed as part of #15701

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: we don't test all keys of our i18n config

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
