### PR TITLE
Don't suggest author follows for anonymous visitors

### DIFF
--- a/app/services/users/suggest_for_sidebar.rb
+++ b/app/services/users/suggest_for_sidebar.rb
@@ -13,6 +13,8 @@ module Users
     end
 
     def suggest
+      return User.none unless user
+
       suggested_user_ids = Rails.cache.fetch(generate_cache_name, expires_in: 120.hours) do
         (reputable_user_ids + random_user_ids).uniq
       end

--- a/spec/services/users/suggest_for_sidebar_spec.rb
+++ b/spec/services/users/suggest_for_sidebar_spec.rb
@@ -15,4 +15,9 @@ RSpec.describe Users::SuggestForSidebar, type: :service do
     tags = create_list(:tag, 3)
     expect(described_class.new(user, tags).suggest).to be_empty
   end
+
+  it "returns no user if not signed in" do
+    tags = "html"
+    expect(described_class.new(nil, tags).suggest).to be_empty
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When rendering the sidebar widget, when attempting to find users to follow for the current tag, when a user is not signed in, sometimes we're seeing an error raised (NoMethodError internally, 500 Internal Server Error externally).

Exit early with User.none (empty relation) when the current user is not signed in. Since both the cache key and the queries expect the user to be present and respond to several methods, this is the safest choice.

## Related Tickets & Documents

- Closes https://app.honeybadger.io/projects/66984/faults/79342962/

## QA Instructions, Screenshots, Recordings

Assuming you have a tag locally named "webdev", accessing `http://localhost:3000/users?state=sidebar_suggestions&tag=webdev` as a signed out user (incognito/private window, or a curl request) should raise a 500 error (no method error id for nil) in main, and a 200 response on this branch.

Alternately, as in the test case, calling `Users::SuggestForSidebar.new(nil, "webdev").suggest` should not raise an error, should return an empty relation.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [x] This change does not need to be communicated, and this is why not: bugfix - I'm not even sure why this request was happening (I assume the state tracking between the current user in the front end and the current user in the backend maybe got out of sync?)


