### PR TITLE
Limit per-user feed import fanout to users with feed urls set

### DIFF
--- a/app/workers/feeds/import_articles_worker.rb
+++ b/app/workers/feeds/import_articles_worker.rb
@@ -16,6 +16,7 @@ module Feeds
         # the last time a feed was fetched at
         earlier_than = nil
       else
+        users_scope = users_scope.where(id: Users::Setting.with_feed.select(:user_id))
         earlier_than ||= 4.hours.ago
       end
 

--- a/spec/workers/feeds/import_articles_worker_spec.rb
+++ b/spec/workers/feeds/import_articles_worker_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Feeds::ImportArticlesWorker, type: :worker, sidekiq: :inline do
   include_examples "#enqueues_on_correct_queue", "medium_priority"
 
   describe "#perform" do
-    it "processes jobs for users with feeds", vcr: "feeds_import" do
+    it "processes jobs for users with feeds" do
       allow(Feeds::Import).to receive(:call)
       alice = create(:user)
       bob = create(:user)
-      bob.setting.update(feed_url: feed_url)
+      bob.setting.update_columns(feed_url: feed_url)
 
       # bob has a feed, and alice doesn't, so we only enqueued for bob
 
@@ -27,18 +27,18 @@ RSpec.describe Feeds::ImportArticlesWorker, type: :worker, sidekiq: :inline do
       end
     end
 
-    it "enqueues job for user with the given time", vcr: "feeds_import", sidekiq: :fake do
+    it "enqueues job for user with the given time" do
+      allow(Feeds::Import).to receive(:call)
       user = create(:user)
-      user.setting.update(feed_url: feed_url)
+      user.setting.update_columns(feed_url: feed_url)
 
-      Timecop.freeze(Time.current) do
-        earlier_than = 1.minute.ago
+      earlier_than = 1.minute.ago
+      worker.perform([], earlier_than)
 
-        sidekiq_assert_enqueued_with(job: Feeds::ImportArticlesWorker::ForUser,
-                                     args: [user.id, earlier_than.iso8601]) do
-          worker.perform([], earlier_than)
-        end
-      end
+      expect(Feeds::Import).to have_received(:call).with(
+        users_scope: User.where(id: user.id),
+        earlier_than: earlier_than.iso8601,
+      )
     end
 
     it "calls Feeds::Import with the users from the given user ids and no time" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

https://github.com/forem/forem/pull/16818 added a per-user fan out rather than running the full set of users in the Feeds::Import job (because it was taking a long time to run).

However, the Feeds::Import job includes a filtering of users to only process those who have a feed_url setting present. 

We're needlessly enqueuing hundreds of thousands of these workers for users each hour, that are a noop, increasing the latency on the default queue up to ~30m each hour.


![default queue depth](https://user-images.githubusercontent.com/1237369/157345739-c4a11e11-4c0e-46e1-ad55-ab62f472c68d.png)



## Related Tickets & Documents


## QA Instructions, Screenshots, Recordings

I think I updated the test cases correctly. If you wanted to test this manually, you could set a feed url on one user, and ensure the other is not there, and check the process logs for Feeds::ImportArticlesWorker::ForUser jobs enqueued (should only happen for the user with a feed, not those without).


### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._
- [x] I will share this change internally with the appropriate teams

## [optional] What gif best describes this PR or how it makes you feel?

![philosoraptor 0 times infinity](https://user-images.githubusercontent.com/1237369/157346029-6edf3171-041e-4dca-b08f-d4dbb9696e64.png)
