### PR TITLE
Stop disabling webmock in test, update vcr cassette to match test

### DIFF
--- a/spec/services/articles/enrich_image_attributes_spec.rb
+++ b/spec/services/articles/enrich_image_attributes_spec.rb
@@ -216,13 +216,11 @@ RSpec.describe Articles::EnrichImageAttributes, type: :service do
 
     it "sets width and height with static images mixed with animated images",
        vcr: { cassette_name: "download_mixed_images" } do
-      WebMock.disable!
       article.update(body_markdown: "![image](https://via.placeholder.com/350x150) ![image](#{animated_image_url})")
 
       assert_has_data_width_height_attributes(article, 2)
       expect(article.processed_html).to include('width="350"')
       expect(article.processed_html).to include('height="150"')
-      WebMock.enable!
     end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We had been disabling webmock in this test, which means vcr was _not_ 
intercepting requests and we were making them live.

This appears to have been a [work-around](https://github.com/forem/forem/pull/15170/commits/7e111a242d192b5d0eff61e35bcaaa2495b12140) for an
issue where the captured URL in the cassette pointed to cloudinary,
while the code was fetching from the source directly, and an unhandled
request error was raised when running the spec, so a live request was made.

However, the upstream source (https://via.placeholder.com/350x150)
has activated cloudflare bot detection, and rather than a png image
response, we were getting an unprocessable html gateway page "Checking
your browser..." from cloudflare, and the test was failing (the enriched image is not saved on the article, possibly because it has no size and no data).

Point the vcr cassette at the same url the test checks, and remove the
local webmock disable.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

Tests should run successfully, ideally with the network disconnected, as vcr stubs all network interactions.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._
- [x] This change does not need to be communicated, and this is why not: bugfix in test suite
