### PR TITLE
Update color picker input specs

### DIFF
--- a/cypress/integration/creatorOnboardingFlows/creatorSettings.spec.js
+++ b/cypress/integration/creatorOnboardingFlows/creatorSettings.spec.js
@@ -35,9 +35,9 @@ describe('Creator Settings Page', () => {
 
     // should contain a brand color field, enhanced with popover picker
     cy.findByRole('button', { name: /^Brand color/ }).should('be.visible');
-    cy.findByRole('textbox', { name: /^Brand color/ })
-      .clear()
-      .type('#BC1A90');
+    cy.findByRole('textbox', { name: /^Brand color/ }).enterIntoColorInput(
+      '#BC1A90',
+    );
 
     // should contain a 'Who can join this community?' radio selector field and allow selection upon click
     cy.findByRole('group', { name: /^Who can join this community/i })
@@ -98,14 +98,15 @@ describe('Creator Settings Page', () => {
     cy.url().should('equal', `${baseUrl}admin/creator_settings/new`);
   });
 
-  context.skip('color contrast ratios', () => {
+  context('color contrast ratios', () => {
     it('should show an error when the contrast ratio of a brand color is too low', () => {
       const lowContrastColor = '#a6e8a6';
 
-      cy.findByRole('textbox', { name: /^Brand color/ })
-        .clear()
-        .type(lowContrastColor)
-        .blur();
+      // The rich color picker should render with a button as well as an input
+      cy.findByRole('button', { name: /^Brand color/ });
+      cy.findByRole('textbox', { name: /^Brand color/ }).enterIntoColorInput(
+        lowContrastColor,
+      );
 
       cy.findByText(
         /^The selected color must be darker for accessibility purposes./,
@@ -115,10 +116,11 @@ describe('Creator Settings Page', () => {
     it('should not show an error when the contrast ratio of a brand color is good', () => {
       const adequateContrastColor = '#25544b';
 
-      cy.findByRole('textbox', { name: /^Brand color/ })
-        .clear()
-        .type(adequateContrastColor)
-        .blur();
+      // The rich color picker should render with a button as well as an input
+      cy.findByRole('button', { name: /^Brand color/ });
+      cy.findByRole('textbox', { name: /^Brand color/ }).enterIntoColorInput(
+        adequateContrastColor,
+      );
 
       cy.findByText(
         /^The selected color must be darker for accessibility purposes./,
@@ -126,15 +128,16 @@ describe('Creator Settings Page', () => {
     });
   });
 
-  context.skip('brand color updates', () => {
+  context('brand color updates', () => {
     it('should not update the brand color if the color contrast ratio is low', () => {
       const lowContrastColor = '#a6e8a6';
       const lowContrastRgbColor = 'rgb(166, 232, 166)';
 
-      cy.findByRole('textbox', { name: /^Brand color/ })
-        .clear()
-        .type(lowContrastColor)
-        .blur();
+      // The rich color picker should render with a button as well as an input
+      cy.findByRole('button', { name: /^Brand color/ });
+      cy.findByRole('textbox', { name: /^Brand color/ }).enterIntoColorInput(
+        lowContrastColor,
+      );
 
       cy.findByText(
         /^The selected color must be darker for accessibility purposes./,
@@ -151,10 +154,11 @@ describe('Creator Settings Page', () => {
       const color = '#25544b';
       const rgbColor = 'rgb(37, 84, 75)';
 
-      cy.findByRole('textbox', { name: /^Brand color/ })
-        .clear()
-        .type(color)
-        .blur();
+      // The rich color picker should render with a button as well as an input
+      cy.findByRole('button', { name: /^Brand color/ });
+      cy.findByRole('textbox', { name: /^Brand color/ }).enterIntoColorInput(
+        color,
+      );
 
       cy.findByRole('button', { name: 'Finish' }).should(
         'have.css',

--- a/cypress/integration/seededFlows/adminFlows/apps/editListingCategory.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/apps/editListingCategory.spec.js
@@ -11,10 +11,10 @@ describe('Edit listing category', () => {
   it('Changes the social preview color', () => {
     // Both a button and an input should exist
     cy.findByRole('button', { name: 'Social preview color' });
-    cy.findByRole('textbox', { name: 'Social preview color' })
-      .clear()
-      .type('#32a852')
-      .blur();
+    cy.findByRole('textbox', {
+      name: 'Social preview color',
+    }).enterIntoColorInput('#32a852');
+
     cy.findByRole('button', { name: 'Update Listing Category' }).click();
     cy.findByText('Listing Category has been updated!').should('exist');
     // Check the table entry reflects the new color

--- a/cypress/integration/seededFlows/adminFlows/config/userExperienceSection.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/config/userExperienceSection.spec.js
@@ -44,10 +44,10 @@ describe('User experience Section', () => {
 
       // Both a button and an input should exist for the brand color
       cy.findByRole('button', { name: 'Primary brand color hex' });
-      cy.findByRole('textbox', { name: 'Primary brand color hex' })
-        .clear()
-        .type('#591803')
-        .blur();
+      cy.findByRole('textbox', {
+        name: 'Primary brand color hex',
+      }).enterIntoColorInput('#591803');
+
       cy.findByText('Update Settings').click();
     });
 
@@ -65,10 +65,10 @@ describe('User experience Section', () => {
 
       // Both a button and an input should exist for the brand color
       cy.findByRole('button', { name: 'Primary brand color hex' });
-      cy.findByRole('textbox', { name: 'Primary brand color hex' })
-        .clear()
-        .type('#ababab')
-        .blur();
+      cy.findByRole('textbox', {
+        name: 'Primary brand color hex',
+      }).enterIntoColorInput('#ababab');
+
       cy.findByText('Update Settings').click();
     });
 

--- a/cypress/integration/seededFlows/adminFlows/tags/createATag.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/tags/createATag.spec.js
@@ -33,7 +33,9 @@ describe('Create a tag', () => {
 
     // A button should exist in addition to the input
     cy.findByRole('button', { name: 'Tag color' });
-    cy.findByRole('textbox', { name: 'Tag color' }).clear().type(tagColor);
+    cy.findByRole('textbox', { name: 'Tag color' }).enterIntoColorInput(
+      tagColor,
+    );
     cy.findByRole('button', { name: 'Create Tag' }).click();
 
     cy.findByText('newtag has been created!').should('exist');

--- a/cypress/integration/seededFlows/settingsFlows/organisationSettings.spec.js
+++ b/cypress/integration/seededFlows/settingsFlows/organisationSettings.spec.js
@@ -41,15 +41,13 @@ describe('Organisation settings', () => {
     cy.findByRole('button', { name: 'Brand color 1' });
     cy.findByRole('textbox', { name: 'Brand color 1' })
       .should('have.value', '#000')
-      .clear()
-      .type('AD23AD')
+      .enterIntoColorInput('AD23AD')
       .should('have.value', '#AD23AD');
 
     cy.findByRole('button', { name: 'Brand color 2' });
     cy.findByRole('textbox', { name: 'Brand color 2' })
       .should('have.value', '#000')
-      .clear()
-      .type('23AD23')
+      .enterIntoColorInput('23AD23')
       .should('have.value', '#23AD23');
 
     cy.findByRole('button', { name: 'Save' }).click();

--- a/cypress/integration/seededFlows/settingsFlows/updateProfileSettings.spec.js
+++ b/cypress/integration/seededFlows/settingsFlows/updateProfileSettings.spec.js
@@ -17,8 +17,8 @@ describe('Update profile settings', () => {
     cy.findByRole('textbox', { name: 'Brand color 2' }).as('brandColor2');
 
     // Verify that changing the value saves properly
-    cy.get('@brandColor1').clear().type('ababab');
-    cy.get('@brandColor2').clear().type('d22a2a');
+    cy.get('@brandColor1').enterIntoColorInput('ababab');
+    cy.get('@brandColor2').enterIntoColorInput('d22a2a');
 
     cy.findByRole('button', { name: 'Save Profile Information' }).click();
     cy.findByText('Your profile has been updated');

--- a/cypress/integration/seededFlows/tagsFlows/editTag.spec.js
+++ b/cypress/integration/seededFlows/tagsFlows/editTag.spec.js
@@ -33,7 +33,9 @@ describe('Edit tag', () => {
     // Make sure the enhanced component is now visible
     cy.findByRole('button', { name: 'Tag color' });
 
-    cy.findByRole('textbox', { name: 'Tag color' }).clear().type('ababab');
+    cy.findByRole('textbox', { name: 'Tag color' }).enterIntoColorInput(
+      'ababab',
+    );
     cy.findByRole('button', { name: 'Save' }).click();
 
     // Wait for confirmation

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -373,3 +373,21 @@ Cypress.Commands.add('disableFeatureFlag', (flag) => {
 Cypress.Commands.add('getModal', () => {
   return cy.findByRole('dialog', { name: 'modal' });
 });
+
+/**
+ * The underlying library we use for the ColorPicker can often skip characters when using the `type()` command.
+ * This is due to the validation and state management under the hood, and the speed of input entry when using `type()`.
+ *
+ * This helper command instead uses `invoke` to make sure the entire color is entered correctly without flake.
+ *
+ * @param {string} color The color to enter
+ *
+ * @returns {Cypress.Chainable<HTMLElement>} A reference to the color input.
+ */
+Cypress.Commands.add(
+  'enterIntoColorInput',
+  { prevSubject: true },
+  (subject, color) => {
+    return cy.wrap(subject).invoke('val', color).trigger('input');
+  },
+);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After a bit of investigation into https://github.com/forem/forem/issues/16829, here's what I found:

- I stripped back everything in our `ColorPicker` component to match the simplest version of `react-colorful`'s input - rendering only the input, and the `color`/`setColor` state. This matched the `HexColorInput` in [their example](https://codesandbox.io/s/0k2fx?file=/src/App.js).
- I still pretty reliably saw the issue where if the test entered `#123456`, what arrived in the UI was `#12356`
- I can see in the library's code, that the input value [can be overridden when the `color` prop changes](https://github.com/omgovich/react-colorful/blob/master/src/components/common/ColorInput.tsx#L43)
- The `color` state in our component changes when a valid 3 character hex is entered
- It looks like when our `color` state changes with `#123`, we then pass this in props to the `HexColorInput`, which then inadvertently overwrites the newer value of `#1234` in that input

### Proposed fix

If we want to be able to reliably call `type('#123456')`, I think any code change needs to happen inside the `react-colorful` library, and I'm not sure how straightforward that would be. Longer term, I'm planning to look into this and raise an issue in their repo, but in the short term, I'm proposing we use a cypress custom command `enterIntoColorInput`.

The custom command doesn't rely on `type()` (which simulates individual key strokes), but instead updates the input value all at once to the given color, before triggering the `input` event needed to invoke any callbacks. It's not ideal, but it side-steps the flake, and my hope is that consolidating it in a custom command helps document why we need to treat these color inputs a bit differently for now.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/forem/forem/issues/16829

## QA Instructions, Screenshots, Recordings

Re-run color specs locally and check for reliable passes.

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![it's not ideal](https://media.giphy.com/media/USstHnGShpJOLngLT2/giphy.gif)
