### PR TITLE
Fix missing dc:creator on RSS feed

### DIFF
--- a/app/views/articles/feed.rss.builder
+++ b/app/views/articles/feed.rss.builder
@@ -40,7 +40,7 @@ xml.rss(:version => "2.0",
     articles.each do |article|
       xml.item do
         xml.title article.title
-        xml.tag!("dc:creator") { user.instance_of?(User) ? user.name : article.user.name }
+        xml.tag!("dc:creator", user.instance_of?(User) ? user.name : article.user.name)
         xml.pubDate article.published_at.to_s(:rfc822) if article.published_at
         xml.link app_url(article.path)
         xml.guid app_url(article.path)

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -95,16 +95,15 @@ RSpec.describe "Articles", type: :request do
         expect(response.body).not_to include(organization_article.title)
       end
 
-      it "contains the full user URL" do
-        expect(response.body).to include("<link>#{URL.user(user)}</link>")
-      end
-
-      it "contains a user composite profile image tag", :aggregate_failures do
-        expect(response.body).to include("<image>")
-        expect(response.body).to include("<url>#{app_url(user.profile_image_90)}</url>")
-        expect(response.body).to include("<title>#{community_name}: #{user.name}</title>")
-        expect(response.body).to include("<link>#{URL.user(user)}</link>")
-        expect(response.body).to include("</image>")
+      it "contains a user' name, link, and composite profile image tag", :aggregate_failures do
+        expect(response.body).to include(
+          "<image>",
+          "<url>#{app_url(user.profile_image_90)}</url>",
+          "<title>#{community_name}: #{user.name}</title>",
+          "<link>#{URL.user(user)}</link>",
+          "</image>",
+          "<dc:creator>#{user.name}</dc:creator>",
+        )
       end
     end
 

--- a/spec/requests/articles/articles_spec.rb
+++ b/spec/requests/articles/articles_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Articles", type: :request do
         expect(response.body).not_to include(organization_article.title)
       end
 
-      it "contains a user' name, link, and composite profile image tag", :aggregate_failures do
+      it "contains user's name, link, and composite profile image tag" do
         expect(response.body).to include(
           "<image>",
           "<url>#{app_url(user.profile_image_90)}</url>",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] bug

## Description
Fix incorrect syntax. `#tag!` is weird.

## Related Tickets & Documents
Resolves https://github.com/forem/forem/issues/16865

## QA Instructions, Screenshots, Recordings
Navigate to `localhost:3000/feed` and you should see the author name (within `dc:creator` tag) displaying properly, compared it to DEV where it's currently missing.

## Added tests?
yes!

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a