### PR TITLE
Revert "Refactor editor tags selector to fetch all tag info in one network call"

### DIFF
--- a/app/javascript/article-form/components/TagsField.jsx
+++ b/app/javascript/article-form/components/TagsField.jsx
@@ -29,19 +29,20 @@ export const TagsField = ({ onInput, defaultValue, switchHelpContext }) => {
     // Fetching further tag data allows us to display a richer UI
     // This fetch only happens once on first component load
     if (defaultValue && defaultValue !== '' && !defaultsLoaded) {
-      const tagNamesQueryString = defaultValue
-        .split(', ')
-        .reduce((queryString, nextTagName) => {
-          if (nextTagName) {
-            return queryString
-              ? `${queryString}&tag_names[]=${nextTagName}`
-              : `tag_names[]=${nextTagName}`;
-          }
-        }, '');
+      const tagNames = defaultValue.split(', ');
 
-      fetch(`/tags/bulk?${tagNamesQueryString}`)
-        .then((res) => res.json())
-        .then((data) => setDefaultSelections(data));
+      const tagRequests = tagNames.map((tagName) =>
+        fetchSearch('tags', { name: tagName }).then(({ result = [] }) => {
+          const [potentialMatch = {}] = result;
+          return potentialMatch.name === tagName
+            ? potentialMatch
+            : { name: tagName };
+        }),
+      );
+
+      Promise.all(tagRequests).then((data) => {
+        setDefaultSelections(data);
+      });
     }
     setDefaultsLoaded(true);
   }, [defaultValue, defaultsLoaded]);


### PR DESCRIPTION
Reverts forem/forem#16841

This is once again causing the same bug in production where when a user edits a post, the bulk search for the post's tags is returning 10 top tags, instead of the tags which match the tag names passed in. In the video below - we search for `shecoded` and `career` but we get 10 unrelated tags back.

This is caching related, and was observed when we first attempted to change this network call in https://github.com/forem/forem/pull/16610, but we thought it had been fixed by the API changes in https://github.com/forem/forem/pull/16671. It seems it has not been fixed by this 😓 

https://user-images.githubusercontent.com/20773163/158785231-804b97b4-2995-4e19-a483-9edfda9e7bea.mp4


