### PR TITLE
Remove fastly http purge feature flag and conditional behavior

### DIFF
--- a/app/services/edge_cache/bust/fastly.rb
+++ b/app/services/edge_cache/bust/fastly.rb
@@ -4,17 +4,9 @@ module EdgeCache
       # [@forem/systems] Fastly-enabled Forems don't need "flexible" domains.
       def self.call(path)
         api_key = ApplicationConfig["FASTLY_API_KEY"]
-        return fastly_purge(api_key, path) if FeatureFlag.enabled?(:fastly_http_purge)
 
-        fastly_post(api_key, path)
+        fastly_purge(api_key, path)
       end
-
-      def self.fastly_post(api_key, path)
-        urls(path).map do |url|
-          HTTParty.post("https://api.fastly.com/purge/#{url}", headers: { "Fastly-Key" => api_key })
-        end
-      end
-      private_class_method :fastly_post
 
       def self.fastly_purge(api_key, path)
         fastly = ::Fastly.new(api_key: api_key)

--- a/lib/data_update_scripts/20220317151317_remove_fastly_http_purge_flag.rb
+++ b/lib/data_update_scripts/20220317151317_remove_fastly_http_purge_flag.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class RemoveFastlyHttpPurgeFlag
+    def run
+      FeatureFlag.remove(:fastly_http_purge)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/remove_fastly_http_purge_flag_spec.rb
+++ b/spec/lib/data_update_scripts/remove_fastly_http_purge_flag_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220317151317_remove_fastly_http_purge_flag.rb",
+)
+
+describe DataUpdateScripts::RemoveFastlyHttpPurgeFlag do
+  it "removes the feature flag if present" do
+    FeatureFlag.add(:fastly_http_purge)
+
+    described_class.new.run
+
+    expect(FeatureFlag.exist?(:fastly_http_purge)).to be false
+  end
+
+  it "is safe to run twice" do
+    # this is the same as "does nothing if flag not present"
+    2.times { described_class.new.run }
+
+    expect(FeatureFlag.exist?(:fastly_http_purge)).to be false
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In https://github.com/forem/forem/pull/12627 we added a feature flag to test moving from (deprecated) POST to the fastly api, to using the Fastly gem's `purge` method (and an HTTP [PURGE](https://developer.fastly.com/reference/api/purging/) verb in the request).

This was delivered and enabled and has run without issue for the past year.

We can remove the feature flag and the fallback code (fastly_post), and always use the preferred method.

This should not impact which edge cache we use (the choice between fastly and nginx is not controlled by this feature flag), and only changes how we communicate with fastly. 

As a small bonus, it shifts the knowledge of fastly's api details into their gem, and out of our code.

## Related Tickets & Documents

follow up after #12627

## QA Instructions, Screenshots, Recordings

Unit tests should suffice here.

### UI accessibility concerns?

None, backend only change.

## Added/updated tests?

- [x] Yes (for the update script, the details of the api weren't tested, and now we just call the gem's code)

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

As always, we should check the DUS completes after deployment via the admin page.

## [optional] What gif best describes this PR or how it makes you feel?

![adios](https://user-images.githubusercontent.com/1237369/158841961-6bff6be2-d389-45bd-9bd1-185f7b05e023.gif)
