### PR TITLE
Revert "Allow embedding of Instagram profile URLs"

### DIFF
--- a/app/assets/stylesheets/ltags/InstagramTag.scss
+++ b/app/assets/stylesheets/ltags/InstagramTag.scss
@@ -2,11 +2,8 @@
   background: rgb(255, 255, 255);
   border: 1px solid rgb(219, 219, 219);
   margin: 1px 1px 12px;
-  min-width: 326px;
-  max-width: 540px;
+  max-width: 450px;
   width: calc(100% - 2px);
-  height: 559px;
-  border-radius: 3px;
   box-shadow: none;
   display: block;
   padding: 0px;
@@ -14,6 +11,6 @@
 
 .instagram-position {
   position: relative;
-  max-width: 540px;
+  max-width: 460px;
   margin: 0 auto;
 }

--- a/app/liquid_tags/glitch_tag.rb
+++ b/app/liquid_tags/glitch_tag.rb
@@ -53,6 +53,10 @@ class GlitchTag < LiquidTagBase
     end
   end
 
+  def match_has_named_capture_group?(match, group_name)
+    match.names.include?(group_name)
+  end
+
   def parse_options(options, match)
     # 'app' and 'code' should cancel each other out
     options -= %w[app code] if options.include?("app") && options.include?("code")

--- a/app/liquid_tags/instagram_tag.rb
+++ b/app/liquid_tags/instagram_tag.rb
@@ -1,22 +1,20 @@
 class InstagramTag < LiquidTagBase
   PARTIAL = "liquids/instagram".freeze
-  # rubocop:disable Layout/LineLength
-  REGISTRY_REGEXP = %r{(?:https?://)?(?:www\.)?instagram\.com/(?:(?:(?:p/)(?<post_id>[\w-]{11}))|(?<handle>[\w.]{,30}))/?(?:\?.*)?}
-  # rubocop:enable Layout/LineLength
-  VALID_ID_REGEXP = /\A(?<post_id>[\w-]{11})\Z/
+  REGISTRY_REGEXP = %r{(?:https?://)?(?:www\.)?(?:instagram\.com/p/)(?<video_id>[a-zA-Z0-9_-]{11})/?}
+  VALID_ID_REGEXP = /\A(?<video_id>[a-zA-Z0-9_-]{11})\Z/
   REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 
   def initialize(_tag_name, id, _parse_context)
     super
     input   = CGI.unescape_html(strip_tags(id))
-    @path   = parse_id_or_url(input)
+    @id     = parse_id_or_url(input)
   end
 
   def render(_context)
     ApplicationController.render(
       partial: PARTIAL,
       locals: {
-        path: @path
+        id: @id
       },
     )
   end
@@ -27,11 +25,7 @@ class InstagramTag < LiquidTagBase
     match = pattern_match_for(input, REGEXP_OPTIONS)
     raise StandardError, I18n.t("liquid_tags.instagram_tag.invalid_instagram_id") unless match
 
-    if match_has_named_capture_group?(match, "handle") && match[:handle].present?
-      return "#{match[:handle]}/embed/"
-    end
-
-    "p/#{match[:post_id]}/embed/captioned/"
+    match[:video_id]
   end
 end
 

--- a/app/liquid_tags/liquid_tag_base.rb
+++ b/app/liquid_tags/liquid_tag_base.rb
@@ -62,11 +62,6 @@ class LiquidTagBase < Liquid::Tag
       .first
   end
 
-  # this method checks for presence of named capture group in match
-  def match_has_named_capture_group?(match, group_name)
-    match.names.include?(group_name)
-  end
-
   # A method to help collaborators not need to reach into the class
   # implementation details.
   def user_authorization_method_name

--- a/app/liquid_tags/unified_embed/tag.rb
+++ b/app/liquid_tags/unified_embed/tag.rb
@@ -24,8 +24,8 @@ module UnifiedEmbed
     def self.new(tag_name, input, parse_context)
       stripped_input = ActionController::Base.helpers.strip_tags(input).strip
 
-      # Extract just the URL from the input, without any params, for validation
-      actual_link = extract_only_url(stripped_input)
+      # This line handles the few instances where options are passed in with the embed URL
+      actual_link = stripped_input.split.length > 1 ? stripped_input.split[0] : stripped_input
 
       # Before matching against the embed registry, we check if the link
       # is valid (e.g. no typos).
@@ -54,25 +54,11 @@ module UnifiedEmbed
       path = uri.path.presence || "/"
       response = http.request_head(path)
 
-      case response
-      when Net::HTTPSuccess
-        response
-      when Net::HTTPRedirection
-        warn "redirected to #{response['location']}"
-      when Net::HTTPNotFound
+      unless response.is_a?(Net::HTTPSuccess) || response.is_a?(Net::HTTPMovedPermanently)
         raise StandardError, I18n.t("liquid_tags.unified_embed.tag.not_found")
-      else
-        raise StandardError, I18n.t("liquid_tags.unified_embed.tag.invalid_url")
       end
     rescue SocketError
       raise StandardError, I18n.t("liquid_tags.unified_embed.tag.invalid_url")
-    end
-
-    def self.extract_only_url(input)
-      url_portion = input.split.length > 1 ? input.split[0] : input
-
-      # remove any params
-      url_portion.split("?")[0]
     end
   end
 end

--- a/app/views/liquids/_instagram.html.erb
+++ b/app/views/liquids/_instagram.html.erb
@@ -1,7 +1,7 @@
 <div class="instagram-position">
   <iframe
     id="instagram-liquid-tag"
-    src="https://www.instagram.com/<%= path %>"
+    src="https://www.instagram.com/p/<%= id %>/embed/captioned"
     allowtransparency="true"
     frameborder="0"
     data-instgrm-payload-id="instagram-media-payload-0"

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -36,22 +36,12 @@ RSpec.describe UnifiedEmbed::Registry do
       "https://themobilist.medium.com/is-universal-basic-mobility-the-route-to-a-sustainable-c-b18e1e2d014c",
     ]
 
-    valid_instagram_post_url_formats = [
+    valid_instagram_url_formats = [
       "https://www.instagram.com/p/CXgzXWXroHK/",
-      "https://www.instagram.com/p/CXgzXWXroHK/?utm_source=somesource",
       "https://instagram.com/p/CXgzXWXroHK/",
       "http://www.instagram.com/p/CXgzXWXroHK/",
       "www.instagram.com/p/CXgzXWXroHK/",
       "instagram.com/p/CXgzXWXroHK/",
-    ]
-
-    valid_instagram_profile_url_formats = [
-      "https://www.instagram.com/instagram/",
-      "https://www.instagram.com/instagram/?utm_source=somesource",
-      "https://instagram.com/instagram/",
-      "http://www.instagram.com/instagram/",
-      "www.instagram.com/instagram/",
-      "instagram.com/instagram/",
     ]
 
     valid_kotlin_url_formats = [
@@ -189,15 +179,8 @@ RSpec.describe UnifiedEmbed::Registry do
       end
     end
 
-    it "returns InstagramTag for a valid instagram post url", :aggregate_failures do
-      valid_instagram_post_url_formats.each do |url|
-        expect(described_class.find_liquid_tag_for(link: url))
-          .to eq(InstagramTag)
-      end
-    end
-
-    it "returns InstagramTag for a valid instagram profile url", :aggregate_failures do
-      valid_instagram_profile_url_formats.each do |url|
+    it "returns InstagramTag for a valid instagram url", :aggregate_failures do
+      valid_instagram_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))
           .to eq(InstagramTag)
       end

--- a/spec/liquid_tags/unified_embed/tag_spec.rb
+++ b/spec/liquid_tags/unified_embed/tag_spec.rb
@@ -26,36 +26,13 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     end
   end
 
-  it "doesn't raise an error when link redirects" do
-    link = "https://www.instagram.com/p/Ca2MhbCrK_t/"
-
-    expect do
-      stub_request_head(link, 301)
-      Liquid::Template.parse("{% embed #{link} %}")
-    end.not_to raise_error
-
-    expect do
-      stub_request_head(link, 302)
-      Liquid::Template.parse("{% embed #{link} %}")
-    end.not_to raise_error
-  end
-
-  it "raises an error when link cannot be found" do
+  it "raises an error when link 404s" do
     link = "https://takeonrules.com/goes-nowhere"
 
     expect do
       stub_request_head(link, 404)
       Liquid::Template.parse("{% embed #{link} %}")
     end.to raise_error(StandardError, "URL provided was not found; please check and try again")
-  end
-
-  it "raises an error when link returns unhandled http status" do
-    link = "https://takeonrules.com/unhandled-response"
-
-    expect do
-      stub_request_head(link, 405)
-      Liquid::Template.parse("{% embed #{link} %}")
-    end.to raise_error(StandardError, "URL provided may have a typo or error; please check and try again")
   end
 
   it "raises an error when no link-matching class is found" do


### PR DESCRIPTION
Issues regarding embedding Forem posts have been reported: https://github.com/forem/forem/issues/16917

Reverting this PR, as it contained URL validations that could be failing the Forem URLs (even though they are valid).