### PR TITLE
Fix embed link validation failures

### DIFF
--- a/app/liquid_tags/unified_embed/tag.rb
+++ b/app/liquid_tags/unified_embed/tag.rb
@@ -52,7 +52,7 @@ module UnifiedEmbed
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if http.port == 443
 
-      req = Net::HTTP::Get.new(uri.request_uri)
+      req = Net::HTTP::Head.new(uri.request_uri)
       req["User-Agent"] = "#{Settings::Community.community_name} (#{URL.url})"
       response = http.request(req)
 

--- a/app/liquid_tags/unified_embed/tag.rb
+++ b/app/liquid_tags/unified_embed/tag.rb
@@ -51,8 +51,10 @@ module UnifiedEmbed
       uri = URI.parse(link)
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if http.port == 443
-      path = uri.path.presence || "/"
-      response = http.request_head(path)
+
+      req = Net::HTTP::Get.new(uri.request_uri)
+      req["User-Agent"] = "#{Settings::Community.community_name} (#{URL.url})"
+      response = http.request(req)
 
       case response
       when Net::HTTPSuccess

--- a/spec/liquid_tags/loom_tag_spec.rb
+++ b/spec/liquid_tags/loom_tag_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe LoomTag, type: :liquid_tag do
   describe "rendering" do
     it "returns StandardError for invalid Loom URL", :aggregate_failures do
       invalid_loom_urls.each do |invalid_url|
-        stub_request_head(invalid_url, 404)
+        stub_head_request(invalid_url, 404)
         expect do
           generate_embed(invalid_url)
         end.to raise_error(StandardError, "URL provided was not found; please check and try again")
@@ -41,7 +41,7 @@ RSpec.describe LoomTag, type: :liquid_tag do
     end
 
     it "returns Loom embed for valid Loom share URL" do
-      stub_request_head(loom_share_url)
+      stub_head_request(loom_share_url)
       embed = generate_embed(loom_share_url).render
 
       expect(embed).to include("<iframe")
@@ -49,7 +49,7 @@ RSpec.describe LoomTag, type: :liquid_tag do
     end
 
     it "returns Loom embed for valid Loom embed URL" do
-      stub_request_head(loom_embed_url)
+      stub_head_request(loom_embed_url)
       embed = generate_embed(loom_embed_url).render
 
       expect(embed).to include("<iframe")
@@ -57,7 +57,7 @@ RSpec.describe LoomTag, type: :liquid_tag do
     end
 
     it "returns Loom embed for valid Loom www URL" do
-      stub_request_head(www_loom_url)
+      stub_head_request(www_loom_url)
       embed = generate_embed(www_loom_url).render
 
       expect(embed).to include("<iframe")
@@ -66,7 +66,7 @@ RSpec.describe LoomTag, type: :liquid_tag do
 
     it "returns Loom embed for valid Loom URL with query paramaters" do
       # Loom URLs with params fail valid-URL check
-      stub_request_head(loom_url_with_query.split("?")[0])
+      stub_head_request(loom_url_with_query.split("?")[0])
       embed = generate_embed(loom_url_with_query).render
 
       expect(embed).to include("<iframe")

--- a/spec/liquid_tags/unified_embed/tag_spec.rb
+++ b/spec/liquid_tags/unified_embed/tag_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     link = "https://gist.github.com/jeremyf/662585f5c4d22184a6ae133a71bf891a"
 
     allow(GistTag).to receive(:new).and_call_original
-    stub_request_head(link)
+    stub_get_request(link)
     parsed_tag = Liquid::Template.parse("{% embed #{link} %}")
 
     expect { parsed_tag.render }.not_to raise_error
@@ -18,7 +18,7 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     allow(GithubTag).to receive(:new).and_call_original
 
     VCR.use_cassette("github_client_repository_no_readme") do
-      stub_request_head(link)
+      stub_get_request(link)
       parsed_tag = Liquid::Template.parse("{% embed #{link} noreadme %}")
 
       expect { parsed_tag.render }.not_to raise_error
@@ -30,12 +30,12 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     link = "https://www.instagram.com/p/Ca2MhbCrK_t/"
 
     expect do
-      stub_request_head(link, 301)
+      stub_get_request(link, 301)
       Liquid::Template.parse("{% embed #{link} %}")
     end.not_to raise_error
 
     expect do
-      stub_request_head(link, 302)
+      stub_get_request(link, 302)
       Liquid::Template.parse("{% embed #{link} %}")
     end.not_to raise_error
   end
@@ -44,7 +44,7 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     link = "https://takeonrules.com/goes-nowhere"
 
     expect do
-      stub_request_head(link, 404)
+      stub_get_request(link, 404)
       Liquid::Template.parse("{% embed #{link} %}")
     end.to raise_error(StandardError, "URL provided was not found; please check and try again")
   end
@@ -53,7 +53,7 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     link = "https://takeonrules.com/unhandled-response"
 
     expect do
-      stub_request_head(link, 405)
+      stub_get_request(link, 405)
       Liquid::Template.parse("{% embed #{link} %}")
     end.to raise_error(StandardError, "URL provided may have a typo or error; please check and try again")
   end
@@ -62,7 +62,7 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     link = "https://takeonrules.com/about"
 
     expect do
-      stub_request_head(link)
+      stub_get_request(link)
       Liquid::Template.parse("{% embed #{link} %}")
     end.to raise_error(StandardError, "Embeds for this URL are not supported")
   end

--- a/spec/liquid_tags/unified_embed/tag_spec.rb
+++ b/spec/liquid_tags/unified_embed/tag_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     link = "https://gist.github.com/jeremyf/662585f5c4d22184a6ae133a71bf891a"
 
     allow(GistTag).to receive(:new).and_call_original
-    stub_get_request(link)
+    stub_head_request(link)
     parsed_tag = Liquid::Template.parse("{% embed #{link} %}")
 
     expect { parsed_tag.render }.not_to raise_error
@@ -18,7 +18,7 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     allow(GithubTag).to receive(:new).and_call_original
 
     VCR.use_cassette("github_client_repository_no_readme") do
-      stub_get_request(link)
+      stub_head_request(link)
       parsed_tag = Liquid::Template.parse("{% embed #{link} noreadme %}")
 
       expect { parsed_tag.render }.not_to raise_error
@@ -30,12 +30,12 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     link = "https://www.instagram.com/p/Ca2MhbCrK_t/"
 
     expect do
-      stub_get_request(link, 301)
+      stub_head_request(link, 301)
       Liquid::Template.parse("{% embed #{link} %}")
     end.not_to raise_error
 
     expect do
-      stub_get_request(link, 302)
+      stub_head_request(link, 302)
       Liquid::Template.parse("{% embed #{link} %}")
     end.not_to raise_error
   end
@@ -44,7 +44,7 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     link = "https://takeonrules.com/goes-nowhere"
 
     expect do
-      stub_get_request(link, 404)
+      stub_head_request(link, 404)
       Liquid::Template.parse("{% embed #{link} %}")
     end.to raise_error(StandardError, "URL provided was not found; please check and try again")
   end
@@ -53,7 +53,7 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     link = "https://takeonrules.com/unhandled-response"
 
     expect do
-      stub_get_request(link, 405)
+      stub_head_request(link, 405)
       Liquid::Template.parse("{% embed #{link} %}")
     end.to raise_error(StandardError, "URL provided may have a typo or error; please check and try again")
   end
@@ -62,7 +62,7 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     link = "https://takeonrules.com/about"
 
     expect do
-      stub_get_request(link)
+      stub_head_request(link)
       Liquid::Template.parse("{% embed #{link} %}")
     end.to raise_error(StandardError, "Embeds for this URL are not supported")
   end

--- a/spec/support/embeds_helpers.rb
+++ b/spec/support/embeds_helpers.rb
@@ -1,10 +1,10 @@
 module EmbedsHelpers
-  def stub_request_head(url, status_code = 200)
-    stub_request(:head, url)
+  def stub_get_request(url, status_code = 200)
+    stub_request(:get, url)
       .with(
         headers: {
           Accept: "*/*",
-          "User-Agent": "Ruby"
+          "User-Agent": "#{Settings::Community.community_name} (#{URL.url})"
         },
       ).to_return(status: status_code, body: "", headers: {})
   end

--- a/spec/support/embeds_helpers.rb
+++ b/spec/support/embeds_helpers.rb
@@ -1,6 +1,6 @@
 module EmbedsHelpers
-  def stub_get_request(url, status_code = 200)
-    stub_request(:get, url)
+  def stub_head_request(url, status_code = 200)
+    stub_request(:head, url)
       .with(
         headers: {
           Accept: "*/*",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
A Forem team member reported that valid DEV links were failing embeds. The problem was ascertained to be coming from the embed's `validate_link!` method. This PR fixes the problem.

## Related Tickets & Documents
closes https://github.com/forem/forem/issues/16917

## QA Instructions, Screenshots, Recordings
Create embeds using forem-specific links. The embeds should render successfully.

### UI accessibility concerns?
None

## Added/updated tests?

- [X] Yes


## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams


