### PR TITLE
Adding Admin > Content Manager > Spaces menu item

### DIFF
--- a/app/models/admin_menu.rb
+++ b/app/models/admin_menu.rb
@@ -9,6 +9,7 @@ class AdminMenu
     ]
 
     scope :content_manager, "dashboard-line", [
+      item(name: "spaces", controller: "spaces", visible: -> { FeatureFlag.exist?(:limit_post_creation_to_admins) }),
       item(name: "posts", controller: "articles"),
       item(name: "comments", controller: "comments"),
       item(name: "badges", children: [

--- a/spec/models/admin_menu_spec.rb
+++ b/spec/models/admin_menu_spec.rb
@@ -45,6 +45,28 @@ RSpec.describe AdminMenu do
     it { is_expected.to be_visible }
   end
 
+  describe "scope :content_managers's spaces item" do
+    subject(:spaces) { content_manager.children.detect { |child| child.name == "spaces" } }
+
+    let(:content_manager) { described_class.navigation_items.fetch(:content_manager) }
+
+    context "when the :limit_post_creation_to_admins does not exist" do
+      it { is_expected.not_to be_visible }
+    end
+
+    context "when the :limit_post_creation_to_admins is enabled" do
+      before { FeatureFlag.enable(:limit_post_creation_to_admins) }
+
+      it { is_expected.to be_visible }
+    end
+
+    context "when the :limit_post_creation_to_admins is explicitly disabled" do
+      before { FeatureFlag.disable(:limit_post_creation_to_admins) }
+
+      it { is_expected.to be_visible }
+    end
+  end
+
   describe "scope :customization" do
     subject(:content_manager) { described_class.navigation_items.fetch(:customization) }
 


### PR DESCRIPTION
I have requested Amy to review this to make sure from a product standpoint, she understand the consequences of this being merged.  (Note, they are low stakes but I want to give product an opportunity to understand this bit).

So developers, please review for logical accuracy.

## What type of PR is this? (check all applicable)

- [x] Feature

## Description

This menu item will show up once you have added the
`:limit_post_creation_to_admins` feature flag (regardless of whether
it is enabled or not).

If you wish to add the menu item:

```console
rails runner "FeatureFlag.add(:limit_post_creation_to_admins)"
```

In "adding" the item, it will default to disabled.  However, as an
administrator you should now be able to toggle on and off the
authorization enforcement.

If you wish to remove the menu item:

```console
rails runner "FeatureFlag.remove(:limit_post_creation_to_admins)"
```

Future plans for this will be to remove the `FeatureFlag.exist?`
conditional so that the menu item shows up.  A major consideration is
that we'll assume that all Forem's have a "default space" in which
folks (by default) can post.

## Related Tickets & Documents

Builds on forem/forem#16897
Closes forem/forem#16842

## QA Instructions, Screenshots, Recordings

Using the above runner commands, kick around `/admin`.  You'll want to always refresh and go back to `/admin` before you enable/remove/add the feature flag.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
