### PR TITLE
Match error class using case instead of if/elsif/else

### DIFF
--- a/app/services/twitter_client/client.rb
+++ b/app/services/twitter_client/client.rb
@@ -44,9 +44,10 @@ module TwitterClient
         error_class = "::TwitterClient::Errors::#{class_name}".safe_constantize
         raise error_class, exception.message if error_class
 
-        error_class = if exception.class < Twitter::Error::ClientError
+        error_class = case exception.class
+                      when Twitter::Error::ClientError
                         TwitterClient::Errors::ClientError
-                      elsif exception.class < Twitter::Error::ServerError
+                      when Twitter::Error::ServerError
                         TwitterClient::Errors::ServerError
                       else
                         TwitterClient::Errors::Error

--- a/app/services/twitter_client/client.rb
+++ b/app/services/twitter_client/client.rb
@@ -44,7 +44,7 @@ module TwitterClient
         error_class = "::TwitterClient::Errors::#{class_name}".safe_constantize
         raise error_class, exception.message if error_class
 
-        error_class = case exception.class
+        error_class = case exception
                       when Twitter::Error::ClientError
                         TwitterClient::Errors::ClientError
                       when Twitter::Error::ServerError

--- a/spec/services/twitter_client/client_spec.rb
+++ b/spec/services/twitter_client/client_spec.rb
@@ -27,4 +27,36 @@ RSpec.describe TwitterClient::Client, type: :service, vcr: true do
       end
     end
   end
+
+  describe "handling underlying errors" do
+    let(:client) { instance_double(Twitter::REST::Client) }
+
+    before do
+      allow(Twitter::REST::Client).to receive(:new).and_return(client)
+    end
+
+    it "matches defined errors by name" do
+      allow(client).to receive(:status).and_raise(Twitter::Error::NotFound.new)
+
+      expect { described_class.status(1) }.to raise_error(TwitterClient::Errors::NotFound)
+    end
+
+    it "matches client errors" do
+      allow(client).to receive(:status).and_raise(Twitter::Error::BadRequest.new)
+
+      expect { described_class.status(1) }.to raise_error(TwitterClient::Errors::ClientError)
+    end
+
+    it "matches server errors" do
+      allow(client).to receive(:status).and_raise(Twitter::Error::ServiceUnavailable.new)
+
+      expect { described_class.status(1) }.to raise_error(TwitterClient::Errors::ServerError)
+    end
+
+    it "defaults to a generic error" do
+      allow(client).to receive(:status).and_raise(SocketError.new)
+
+      expect { described_class.status(1) }.to raise_error(TwitterClient::Errors::Error)
+    end
+  end
 end

--- a/spec/services/twitter_client/client_spec.rb
+++ b/spec/services/twitter_client/client_spec.rb
@@ -36,25 +36,25 @@ RSpec.describe TwitterClient::Client, type: :service, vcr: true do
     end
 
     it "matches defined errors by name" do
-      allow(client).to receive(:status).and_raise(Twitter::Error::NotFound.new)
+      allow(client).to receive(:status).and_raise(Twitter::Error::NotFound)
 
       expect { described_class.status(1) }.to raise_error(TwitterClient::Errors::NotFound)
     end
 
     it "matches client errors" do
-      allow(client).to receive(:status).and_raise(Twitter::Error::BadRequest.new)
+      allow(client).to receive(:status).and_raise(Twitter::Error::BadRequest)
 
       expect { described_class.status(1) }.to raise_error(TwitterClient::Errors::ClientError)
     end
 
     it "matches server errors" do
-      allow(client).to receive(:status).and_raise(Twitter::Error::ServiceUnavailable.new)
+      allow(client).to receive(:status).and_raise(Twitter::Error::ServiceUnavailable)
 
       expect { described_class.status(1) }.to raise_error(TwitterClient::Errors::ServerError)
     end
 
     it "defaults to a generic error" do
-      allow(client).to receive(:status).and_raise(SocketError.new)
+      allow(client).to receive(:status).and_raise(Twitter::Error)
 
       expect { described_class.status(1) }.to raise_error(TwitterClient::Errors::Error)
     end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I noticed this branching on parent classes in the twitter client, is there a reason we're not using case for this?


## QA Instructions, Screenshots, Recordings

Ideally tests passing is sufficient.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes (this was refactoring with no test cases, so I added them)

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._
- [x] This change does not need to be communicated, and this is why not: refactor
