### PR TITLE
Adding inline documentation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -66,14 +66,25 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # When called, raise ActiveRecord::RecordNotFound.
+  #
+  # @raise [ActiveRecord::RecordNotFound] when called
   def not_found
     raise ActiveRecord::RecordNotFound, "Not Found"
   end
 
+  # When called, raise ActionController::RoutingError.
+  # @raise [ActionController::RoutingError] when called
   def routing_error
     raise ActionController::RoutingError, "Routing Error"
   end
 
+  # When called render unauthorized JSON status and raise Pundit::NotAuthorizedError
+  #
+  # @raise [Pundit::NotAuthorizedError]
+  #
+  # @note [@jeremyf] It's a little surprising that we both render a JSON response and raise an
+  #       exception.
   def not_authorized
     render json: { error: I18n.t("application_controller.not_authorized") }, status: :unauthorized
     raise Pundit::NotAuthorizedError, "Unauthorized"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Documentation Update

## Description

While exploring the DashboardsController, I came across method calls to
`not_found`.  Idiomatically, I assumed that these methods were returning
a value.  However, in looking at the code, it raises an exception.

_Note: I excpect methods that raise exceptions, especially as the only
thing they do, to end in a `!`._

By adding the documentation my "IntelliSense" provides insight into the
expected behavior of this function (e.g. "Raises an exception").
Without the documentation, I don't see any useful information.

### With Inline Docs

The "proposed" state:

![eglot-with-inline-docs](https://user-images.githubusercontent.com/2130/159354217-c9db90b8-986e-437a-87f4-ff2af0bc3ca2.png)


### Without Inline Docs

The "prior" state.

![eglot-without-inline-docs](https://user-images.githubusercontent.com/2130/159354229-66543a7e-87f1-4a3b-9751-baf1c6c3d8fe.png)

## Related Tickets & Documents

- Related Issue #forem/forem#16913 (but only in the "I'm in the neighborhood looking at things kind of way").

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: It's a documentation only PR.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
