### PR TITLE
Created a utility function for checking the flash success message for user udpates in the admin

### DIFF
--- a/cypress/integration/seededFlows/adminFlows/users/manageCredits.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/manageCredits.spec.js
@@ -1,17 +1,11 @@
+import { verifyAndDismissUserUpdatedMessage } from './userAdminUtilitites';
+
 // More on roles, https://admin.forem.com/docs/forem-basics/user-roles
 function openCreditsModal() {
   cy.getModal().should('not.exist');
   cy.findByRole('button', { name: 'Adjust balance' }).click();
 
   return cy.getModal();
-}
-
-function verifyAndDismissUserUpdatedMessage(message) {
-  cy.findByText(message).should('exist');
-  cy.findByRole('button', { name: 'Dismiss message' })
-    .should('have.focus')
-    .click();
-  cy.findByText(message).should('not.exist');
 }
 
 describe('Manage User Credits', () => {

--- a/cypress/integration/seededFlows/adminFlows/users/manageOrganizations.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/manageOrganizations.spec.js
@@ -1,17 +1,11 @@
+import { verifyAndDismissUserUpdatedMessage } from './userAdminUtilitites';
+
 // More on roles, https://admin.forem.com/docs/forem-basics/user-roles
 function openOrgModal(ctaText = 'Add organization') {
   cy.getModal().should('not.exist');
   cy.findByRole('button', { name: ctaText }).click();
 
   return cy.getModal();
-}
-
-function verifyAndDismissUserUpdatedMessage(message) {
-  cy.findByText(message).should('exist');
-  cy.findByRole('button', { name: 'Dismiss message' })
-    .should('have.focus')
-    .click();
-  cy.findByText(message).should('not.exist');
 }
 
 describe('Manage User Organziations', () => {

--- a/cypress/integration/seededFlows/adminFlows/users/manageRoles.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/manageRoles.spec.js
@@ -1,17 +1,11 @@
+import { verifyAndDismissUserUpdatedMessage } from './userAdminUtilitites';
+
 // More on roles, https://admin.forem.com/docs/forem-basics/user-roles
 function openRolesModal() {
   cy.getModal().should('not.exist');
   cy.findByRole('button', { name: 'Assign role' }).click();
 
   return cy.getModal();
-}
-
-function verifyAndDismissUserUpdatedMessage() {
-  cy.findByText('User has been updated').should('exist');
-  cy.findByRole('button', { name: 'Dismiss message' })
-    .should('have.focus')
-    .click();
-  cy.findByText('User has been updated').should('not.exist');
 }
 
 function checkUserStatus(status) {

--- a/cypress/integration/seededFlows/adminFlows/users/manageUserOptions.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/manageUserOptions.spec.js
@@ -1,3 +1,5 @@
+import { verifyAndDismissUserUpdatedMessage } from './userAdminUtilitites';
+
 function openUserOptions(callback) {
   cy.findByRole('button', { name: 'Options' })
     .should('have.attr', 'aria-haspopup', 'true')
@@ -9,22 +11,6 @@ function openUserOptions(callback) {
 
       cy.get(`#${dropdownId}`).within(callback);
     });
-}
-
-function verifyAndDismissUserUpdatedMessage(message) {
-  cy.findByTestId('flash-success')
-    .as('success')
-    .then((element) => {
-      expect(element.text().trim()).equal(message);
-    });
-
-  cy.get('@success').within(() => {
-    cy.findByRole('button', { name: 'Dismiss message' })
-      .should('have.focus')
-      .click();
-  });
-
-  cy.findByTestId('flash-success').should('not.exist');
 }
 
 describe('Manage User Options', () => {

--- a/cypress/integration/seededFlows/adminFlows/users/userAdminUtilitites.js
+++ b/cypress/integration/seededFlows/adminFlows/users/userAdminUtilitites.js
@@ -1,0 +1,22 @@
+/**
+ * E2E helper function for user admin tests that validates the correct flash success message appears
+ *
+ * @param {string} [message="User has been updated"] The expected flash message text
+ */
+export function verifyAndDismissUserUpdatedMessage(
+  message = 'User has been updated',
+) {
+  cy.findByTestId('flash-success')
+    .as('success')
+    .then((element) => {
+      expect(element.text().trim()).equal(message);
+    });
+
+  cy.get('@success').within(() => {
+    cy.findByRole('button', { name: 'Dismiss message' })
+      .should('have.focus')
+      .click();
+  });
+
+  cy.findByTestId('flash-success').should('not.exist');
+}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There was the same function created in several E2E test files for the user admin. This consolidates those functions into one import.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #16604 
- Closes #

## QA Instructions, Screenshots, Recordings

N/A Code refactor for E2E tests

### UI accessibility concerns?

N/A Code refactor for E2E tests

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![A minion giving a thumbs up](https://media.giphy.com/media/kigfYxdEa5s1ziA2h1/giphy.gif)
