### PR TITLE
Optimize `URL.database_available?`

### DIFF
--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -5,10 +5,16 @@ module URL
   end
 
   def self.database_available?
-    ActiveRecord::Base.connected? && ActiveRecord::Base.connection.table_exists?("site_configs")
+    ActiveRecord::Base.connected? && has_site_configs?
   end
 
   private_class_method :database_available?
+
+  def self.has_site_configs?
+    @has_site_configs ||= ActiveRecord::Base.connection.table_exists?("site_configs")
+  end
+
+  private_class_method :has_site_configs?
 
   def self.domain
     if database_available?


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This method was making a DB query every time, but if the table is there the first time, we can reasonably assume it will continue to exist. This is an assumption generally baked into ActiveRecord — it caches the schema for every table when its corresponding model is used and never checks it again for the life of the process. It's the reason we don't delete tables or even columns until code that uses them is no longer in production.

The reason this is important is that this DB query is now the single most common query, more than 5x the frequency of the second-highest (finding a `User` by their `id`). Results from DEV:

<img width="257" alt="Screenshot from Datadog showing the frequency of the top 2 queries. This query was executed 20 million times, and the find-user-by-ID query was executed 3.8 million times." src="https://user-images.githubusercontent.com/108205/159517292-4bcb0c7b-e7df-4119-adb1-5e4a17768ed3.png">


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

This check was added in #16843. It's perfectly fine that it was done the way it was. It's not putting excessive load on the database (in fact, Postgres is likely caching the single-row query result, especially because it's table metadata that it has to use in the query planner anyway) and none of us expected the resulting query volume to be anywhere near this high in production. It was done exactly as it should have been to avoid premature optimization.

This PR is mainly about noise reduction and to shave a few milliseconds by avoiding a query whose result will never change throughout the life of the Ruby process.

## QA Instructions, Screenshots, Recordings

A test run should be sufficient.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Behavior external to the method has not changed
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: This is a simple memoization

## [optional] Are there any post deployment tasks we need to perform?

Check [this Datadog page for DEV](https://app.datadoghq.com/apm/service/practical_developer-postgres/postgres.query?env=production&sort=requests%2Cdesc&topGraphs=latency%3Alatency%2Cerrors%3Acount%2Chits%3Acount&start=1647959082392&end=1647962682392&paused=false) and ensure that this query is no longer the single highest. It should actually be quite low, maybe single digits if it shows up at all since it will only be executed once per Rails process.

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
