### PR TITLE
Adjusting article copy to be more general

### DIFF
--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -84,7 +84,7 @@
     </div>
     <div class="crayons-field crayons-field--checkbox">
       <%= f.check_box :reaction_notifications, class: "crayons-checkbox" %>
-      <%= f.label :reaction_notifications, "Send notifications when someone reacts to my comments or posts", class: "crayons-field__label" %>
+      <%= f.label :reaction_notifications, "Send notifications when someone reacts to mycontent, such as comments or posts", class: "crayons-field__label" %>
     </div>
   </div>
 

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -84,7 +84,7 @@
     </div>
     <div class="crayons-field crayons-field--checkbox">
       <%= f.check_box :reaction_notifications, class: "crayons-checkbox" %>
-      <%= f.label :reaction_notifications, "Send notifications when someone reacts to mycontent, such as comments or posts", class: "crayons-field__label" %>
+      <%= f.label :reaction_notifications, t("helpers.label.users_notification_setting.reaction_notifications"), class: "crayons-field__label" %>
     </div>
   </div>
 

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -65,7 +65,7 @@ en:
         mobile_mention_notifications: Send me a push notification when someone mentions me
         mobile_comment_notifications: Send me a push notification when someone replies to me in a comment thread
         welcome_notifications: Send me occasional tips on how to enhance my %{community} experience
-        reaction_notifications: Send notifications when someone reacts to my comments or posts
+        reaction_notifications: Send notifications when someone reacts to my content, such as comments or posts
         mod_roundrobin_notifications: Send me occasional community-success mod notifications
       users_setting:
         feed_url: RSS Feed URL

--- a/config/locales/helpers/fr.yml
+++ b/config/locales/helpers/fr.yml
@@ -65,7 +65,7 @@ fr:
         mobile_mention_notifications: Send me a push notification when someone mentions me
         mobile_comment_notifications: Send me a push notification when someone replies to me in a comment thread
         welcome_notifications: Send me occasional tips on how to enhance my %{community} experience
-        reaction_notifications: Send notifications when someone reacts to my comments or posts
+        reaction_notifications: Send notifications when someone reacts to my content, such as comments or posts
         mod_roundrobin_notifications: Send me occasional community-success mod notifications
       users_setting:
         feed_url: RSS Feed URL

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -38,7 +38,7 @@ en:
           submit: Delete Account
         export:
           heading: Export content
-          desc: You can request an export of all your content. Currently we only support the export of your posts and comments. They will be emailed to your inbox.
+          desc: You can request an export of all your content. Currently we only support the export of your posts and comments, if you have any. They will be emailed to your inbox.
           label: Request an export of your content
           requested: You have recently requested an export of your content. Please check your email.
           submit: Submit Data Request

--- a/config/locales/views/settings/fr.yml
+++ b/config/locales/views/settings/fr.yml
@@ -38,7 +38,7 @@ fr:
           submit: Delete Account
         export:
           heading: Export content
-          desc: You can request an export of all your content. Currently we only support the export of your posts and comments. They will be emailed to your inbox.
+          desc: You can request an export of all your content. Currently we only support the export of your posts and comments, if you have any. They will be emailed to your inbox.
           label: Request an export of your content
           requested: You have recently requested an export of your content. Please check your email.
           submit: Submit Data Request


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Documentation Update

## Description

Our language regarding articles needs minor revisions to speak a bit
more generally about content.  This follows on the features of
AuthN/AuthZ work to allow forem admins to configure their forems such
that a subset of their forem members may not have the ability to create
articles.


## Related Tickets & Documents

Closes forem/forem#16890
Closes forem/forem#16891

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: copy change does not warrant tests (unless the exact copy was part of an assertion)

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
