### PR TITLE
Fix redundant slack notifications when article was published

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -156,11 +156,12 @@ class Article < ApplicationRecord
   before_save :fetch_video_duration
   before_save :set_caches
   before_create :create_password
+  after_create :notify_slack_channel_about_publication
+  after_update :notify_slack_channel_about_publication, if: -> { published && saved_change_to_published? }
   before_destroy :before_destroy_actions, prepend: true
 
   after_save :create_conditional_autovomits
   after_save :bust_cache
-  after_save :notify_slack_channel_about_publication
 
   after_update_commit :update_notifications, if: proc { |article|
                                                    article.notifications.any? && !article.saved_changes.empty?

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -156,12 +156,12 @@ class Article < ApplicationRecord
   before_save :fetch_video_duration
   before_save :set_caches
   before_create :create_password
-  after_create :notify_slack_channel_about_publication
-  after_update :notify_slack_channel_about_publication, if: -> { published && saved_change_to_published? }
   before_destroy :before_destroy_actions, prepend: true
 
   after_save :create_conditional_autovomits
   after_save :bust_cache
+  after_create :notify_slack_channel_about_publication
+  after_update :notify_slack_channel_about_publication, if: -> { published && saved_change_to_published? }
 
   after_update_commit :update_notifications, if: proc { |article|
                                                    article.notifications.any? && !article.saved_changes.empty?

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -156,12 +156,12 @@ class Article < ApplicationRecord
   before_save :fetch_video_duration
   before_save :set_caches
   before_create :create_password
+  after_create :notify_slack_channel_about_publication
+  after_update :notify_slack_channel_about_publication, if: -> { published && saved_change_to_published? }
   before_destroy :before_destroy_actions, prepend: true
 
   after_save :create_conditional_autovomits
   after_save :bust_cache
-  after_create :notify_slack_channel_about_publication
-  after_update :notify_slack_channel_about_publication, if: -> { published && saved_change_to_published? }
 
   after_update_commit :update_notifications, if: proc { |article|
                                                    article.notifications.any? && !article.saved_changes.empty?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Send slack notification when an article is created (as published) and when an article is updated (from draft to published), don't send slack notification when an article is updated but the `published` status is not changed. (Previously the notification was sent every time when a published article was updated).

## Related Tickets & Documents
- Related Issue #15858 (indirectly)

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: no major changes, fixing a small bug.

