### PR TITLE
Add unscoped index on articles.feed_source_url

### DIFF
--- a/db/migrate/20220323185428_index_articles_on_feed_source_url.rb
+++ b/db/migrate/20220323185428_index_articles_on_feed_source_url.rb
@@ -1,0 +1,21 @@
+class IndexArticlesOnFeedSourceUrl < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  # We already have a unique index scoped to `published = true`, so we need
+  # this one to be across all articles.
+  INDEX_NAME = :index_articles_on_feed_source_url_unscoped
+
+  def up
+    add_index :articles, :feed_source_url,
+      name: INDEX_NAME,
+      if_not_exists: true,
+      algorithm: :concurrently
+  end
+
+  def down
+    remove_index :articles,
+      name: INDEX_NAME,
+      if_exists: true,
+      algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_26_205052) do
+ActiveRecord::Schema.define(version: 2022_03_23_185428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -162,6 +162,7 @@ ActiveRecord::Schema.define(version: 2022_01_26_205052) do
     t.index ["comments_count"], name: "index_articles_on_comments_count"
     t.index ["featured_number"], name: "index_articles_on_featured_number"
     t.index ["feed_source_url"], name: "index_articles_on_feed_source_url", unique: true, where: "(published IS TRUE)"
+    t.index ["feed_source_url"], name: "index_articles_on_feed_source_url_unscoped"
     t.index ["hotness_score", "comments_count"], name: "index_articles_on_hotness_score_and_comments_count"
     t.index ["hotness_score"], name: "index_articles_on_hotness_score"
     t.index ["path"], name: "index_articles_on_path"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We already have a partial unique index for this column scoped on `published = true`, which is still useful. This index does not make that index redundant because that index is used to enforce a constraint that we *only* want to apply to published articles. This index will be used when `WHERE published` is not part of the query.

On DEV, this query takes 800ms-3s, depending on concurrent DB load. Some Sidekiq jobs query articles on this column alone hundreds of times:

<img width="810" alt="image" src="https://user-images.githubusercontent.com/108205/159789432-39fbc6d4-c847-482d-b8a9-8b564c401b6a.png">

From [this trace](https://ui.honeycomb.io/thepracticaldev/datasets/rails/result/xaqnacJMsoQ/trace/Cp7zpKc6EYG?span=6d8c4c822d44e1a5) on Honeycomb.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Just adding an index
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: Simple query optimization. Worst-case scenario, it doesn't get faster.