### PR TITLE
Add a comment, and a safe default value for cloudinary

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -96,10 +96,11 @@ BUFFER_LISTINGS_PROFILE="Optional"
 
 # Cloudinary for image resizing and cache??
 # (https://cloudinary.com/documentation/rails_integration)
+# don't use quotes for these values
 CLOUDINARY_API_KEY=
 CLOUDINARY_API_SECRET=
 CLOUDINARY_CLOUD_NAME=
-CLOUDINARY_SECURE=
+CLOUDINARY_SECURE=true
 
 # HTML/CSS to Image for generating social preview images
 # (https://docs.htmlcsstoimage.com/example-code/ruby)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

When moving a self-host site from imgproxy to cloudinary, we observed that
wrapping the cloud name in quotes caused off-looking urls (with the
user name in %22 escaped quotes, when it should be "unadorned").

Additionally, if cloudinary is enabled, cloudinary secure should
be set to true. We leave the others blank to prevent conditionally enabling this
service (we check for ENV var presence) mistakenly, but the secure
flag won't turn it on or off and is safe to keep a default value.


## QA Instructions, Screenshots, Recordings

Nothing should change unless you're using cloudinary in production, in which case this is just additional context on how to set the settings.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: documentation update
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: tiny comment change
