### PR TITLE
Favoring re-use of authorization error

### DIFF
--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -4,7 +4,7 @@ module Api
       respond_to :json
 
       rescue_from ArgumentError, with: :error_unprocessable_entity
-      rescue_from UnauthorizedError, with: :error_unauthorized
+      rescue_from ApplicationPolicy::NotAuthorizedError, with: :error_unauthorized
 
       before_action :authenticate_with_api_key_or_current_user!
       before_action :authorize_user_organization
@@ -49,7 +49,7 @@ module Api
         return unless analytics_params[:organization_id]
 
         @org = Organization.find_by(id: analytics_params[:organization_id])
-        raise UnauthorizedError unless @org && @user.org_member?(@org)
+        raise ApplicationPolicy::NotAuthorizedError unless @org && @user.org_member?(@org)
       end
 
       def load_owner

--- a/app/errors/unauthorized_error.rb
+++ b/app/errors/unauthorized_error.rb
@@ -1,1 +1,0 @@
-class UnauthorizedError < StandardError; end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

We only have one reference to the UnauthorizedError, which is shadows
the ApplicationPolicy::NotAuthorizedError.  This commit removes the
exception.


## Related Tickets & Documents

Related to forem/forem#16985 but only barely

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: replacing one constant for another

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
