### PR TITLE
Admin member index: Update pagination layout & styles

### DIFF
--- a/app/assets/images/chevron-left.svg
+++ b/app/assets/images/chevron-left.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" transform="scale(-1 1)">
+    <path d="m13.172 12-4.95-4.95 1.414-1.414L16 12l-6.364 6.364-1.414-1.414 4.95-4.95Z"/>
+</svg>

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -22,6 +22,18 @@ label {
     padding: 8px;
   }
 }
+// New pagination styles as added in Admin Member Index view. As we roll out these styles to other admin views, the above CSS will eventually be removed.
+.admin-pagination {
+  color: var(--link-color-secondary);
+
+  &--link {
+    padding: var(--su-1);
+  }
+
+  &--inactive {
+    color: var(--base-30);
+  }
+}
 
 .bg-featured {
   background: #bbffd2;

--- a/app/views/admin/users/_member_index.html.erb
+++ b/app/views/admin/users/_member_index.html.erb
@@ -6,7 +6,7 @@
 
   <%= render "admin/users/index/controls" %>
 
-  <%= paginate @users, theme: "internal" %>
+  <%= paginate @users, theme: "admin", scope: @users, label: "Paginate users" %>
 
     <table class="crayons-table" width="100%">
       <thead>

--- a/app/views/admin/users/_member_index.html.erb
+++ b/app/views/admin/users/_member_index.html.erb
@@ -4,9 +4,10 @@
     <%= render "admin/users/index/tabs" %>
   </header>
 
-  <%= render "admin/users/index/controls" %>
-
-  <%= paginate @users, theme: "admin", scope: @users, label: "Paginate users" %>
+  <div class="flex justify-between">
+    <%= render "admin/users/index/controls" %>
+    <%= paginate @users, theme: "admin", scope: @users, label: "Paginate users" %>
+  </div>
 
     <table class="crayons-table" width="100%">
       <thead>

--- a/app/views/admin/users/_member_index.html.erb
+++ b/app/views/admin/users/_member_index.html.erb
@@ -27,4 +27,7 @@
       </tbody>
     </table>
 
+    <div class="flex justify-end">
+      <%= paginate @users, theme: "admin", scope: @users, label: "Paginate users" %>
+    </div>
 </div>

--- a/app/views/admin/users/_member_index.html.erb
+++ b/app/views/admin/users/_member_index.html.erb
@@ -27,5 +27,4 @@
       </tbody>
     </table>
 
-    <%= paginate @users, theme: "internal" %>
 </div>

--- a/app/views/kaminari/admin/_next_page.html.erb
+++ b/app/views/kaminari/admin/_next_page.html.erb
@@ -1,0 +1,4 @@
+<li class="flex items-center">
+  <%= link_to_unless current_page.last?, crayons_icon_tag("chevron-right", aria_hidden: true, class: ("admin-pagination--inactive mx-1" if current_page.last?).to_s), url, rel: "next", remote: remote, class: "admin-pagination--link  c-link c-link--icon-alone",
+                                                                                                                                                                           aria: { label: t("views.pagination.aria_next"), describedby: "pagination-description" } %>
+</li>

--- a/app/views/kaminari/admin/_next_page.html.erb
+++ b/app/views/kaminari/admin/_next_page.html.erb
@@ -1,4 +1,4 @@
 <li class="flex items-center">
-  <%= link_to_unless current_page.last?, crayons_icon_tag("chevron-right", aria_hidden: true, class: ("admin-pagination--inactive mx-1" if current_page.last?).to_s), url, rel: "next", remote: remote, class: "admin-pagination--link  c-link c-link--icon-alone",
+  <%= link_to_unless current_page.last?, crayons_icon_tag("chevron-right", aria_hidden: true, class: ("admin-pagination--inactive mx-1" if current_page.last?).to_s), url, rel: "next", remote: remote, class: "admin-pagination--link  c-link c-link--icon-alone c-link--block",
                                                                                                                                                                            aria: { label: t("views.pagination.aria_next"), describedby: "pagination-description" } %>
 </li>

--- a/app/views/kaminari/admin/_paginator.html.erb
+++ b/app/views/kaminari/admin/_paginator.html.erb
@@ -1,0 +1,12 @@
+<%= paginator.render do %>
+  <nav aria-label="<%= label %>" class="admin-pagination flex fs-s items-center">
+    <span id="pagination-description">
+      <span class="screen-reader-only">Currently showing: </span>
+      <%= page_entries_info scope %>
+    </span>
+    <ul class="flex">
+      <%= prev_page_tag %>
+      <%= next_page_tag %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/admin/_prev_page.html.erb
+++ b/app/views/kaminari/admin/_prev_page.html.erb
@@ -1,4 +1,4 @@
 <li class="flex items-center">
-  <%= link_to_unless current_page.first?, crayons_icon_tag("chevron-left", aria_hidden: true, class: ("admin-pagination--inactive mx-1" if current_page.first?).to_s), url, rel: "prev", remote: remote, class: "admin-pagination--link c-link c-link--icon-alone",
+  <%= link_to_unless current_page.first?, crayons_icon_tag("chevron-left", aria_hidden: true, class: ("admin-pagination--inactive mx-1" if current_page.first?).to_s), url, rel: "prev", remote: remote, class: "admin-pagination--link c-link c-link--icon-alone c-link--block",
                                                                                                                                                                             aria: { label: t("views.pagination.aria_previous"), describedby: "pagination-description" } %>
 </li>

--- a/app/views/kaminari/admin/_prev_page.html.erb
+++ b/app/views/kaminari/admin/_prev_page.html.erb
@@ -1,0 +1,4 @@
+<li class="flex items-center">
+  <%= link_to_unless current_page.first?, crayons_icon_tag("chevron-left", aria_hidden: true, class: ("admin-pagination--inactive mx-1" if current_page.first?).to_s), url, rel: "prev", remote: remote, class: "admin-pagination--link c-link c-link--icon-alone",
+                                                                                                                                                                            aria: { label: t("views.pagination.aria_previous"), describedby: "pagination-description" } %>
+</li>

--- a/config/locales/kaminari.en.yml
+++ b/config/locales/kaminari.en.yml
@@ -1,14 +1,9 @@
 ---
-fr:
+en:
   views:
     pagination:
       aria_next: "Next page"
       aria_previous: "Previous page"
-      first: "&laquo; Premier"
-      last: Dernier &raquo;
-      next: Suivant &rsaquo;
-      previous: "&lsaquo; Précédent"
-      truncate: "&hellip;"
   helpers:
     page_entries_info:
       more_pages:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR tackles the pagination aspect of https://github.com/forem/forem/issues/16933

We use a gem (`kaminari`) to handle pagination, so I've worked with their default templating to create the new look. This involved creating a new "theme", so we now have:

- "internal" theme - used by all the admin pagination, aside from the new member index view
- "admin" theme - used by member index view when the `member_index_view` feature flag is enabled

Eventually as we work on other parts of the admin area, "admin" will become the main theme, and eventually "internal" can be phased out. As a small side point - the "internal" theme is currently styled with bootstrap which we are also phasing out.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/16933

## QA Instructions, Screenshots, Recordings

- Seed your DB with more than 50 users. There's a few ways you can do this, but I went into `seeds.rb` and changed the `num_users` variable to a higher number before running `bin/setup`
- Ensure the feature flag `:member_index_view` is enabled and you're logged in as an admin
- View the members list and check that the pagination appears above the table
- Check that the pagination also appears below the table
- Try moving from page to page and check the count updates, and the table rows update
- Check you can't click "next" from the last page, or "previous" from the first page


https://user-images.githubusercontent.com/20773163/159924859-fa5e9556-872d-450f-ae9d-155935f54e8c.mp4


- We also want to check the original pagination isn't affected by these changes, so we can disable the `:member_index_view` feature flag and revisit the same page
- The old style pagination should be present and continue to work as normal


https://user-images.githubusercontent.com/20773163/159920728-40ac0e02-615a-48ad-bb9d-fab2b118f192.mp4



### UI accessibility concerns?

A couple of things I've added for accessibility:
- The `nav` for pagination is now labelled, to help users find it more easily
- The 'next' and 'previous' links are slightly ambiguous to people who can't readily see the "11 - 50 of 100" text, so I've made sure that text is linked to those links in a description so screen reader users will hear e.g. "Next, Currently viewing: 11 - 50 of 100"

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: The actual pagination behaviour is internal to `kaminari`, so I don't think we should/need to test it. This can be considered a "UI only" change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] This change does not need to be communicated, and this is why not: Part of a greater epic


## [optional] What gif best describes this PR or how it makes you feel?

![turning pages animation](https://media.giphy.com/media/xT77Y1T0zY1gR5qe5O/giphy.gif)
