### PR TITLE
Conditionally reducing dashboard chatter for users

### DIFF
--- a/app/views/dashboards/_actions.html.erb
+++ b/app/views/dashboards/_actions.html.erb
@@ -1,5 +1,6 @@
 <nav class="hidden m:block" aria-label="Dashboards">
   <ul class="list-none p-0">
+    <% if policy(Article).has_existing_articles_or_can_create_new_ones? %>
     <li>
       <a class="crayons-link crayons-link--block <%= "crayons-link--current" if params[:action] == "show" && (params[:which] == "organization" || params[:which].blank?) %>"
         href="<%= dashboard_path %>"
@@ -26,6 +27,7 @@
         <span class="c-indicator"><%= @user.followers_count %></span>
       </a>
     </li>
+    <% end %>
 
     <li>
       <a class="crayons-link crayons-link--block <%= "crayons-link--current" if params[:action] == "following_tags" %>"
@@ -72,11 +74,13 @@
     </li>
     <%- end %>
 
+    <%- if policy(Article).has_existing_articles_or_can_create_new_ones? %>
     <li>
       <a class="crayons-link crayons-link--block" href="<%= dashboard_analytics_path %>">
         <%= t("views.dashboard.actions.analytics") %>
       </a>
     </li>
+    <%- end %>
 
   <% if @organizations && (params[:which].blank? || params[:which] == "organization") %>
     <% @organizations.each do |org| %>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -97,6 +97,25 @@ RSpec.describe "Dashboards", type: :request do
       end
     end
 
+    context "when logged but has no articles nor can create them" do
+      it "redirects to /dashboard/following_tags" do
+        sign_in user
+
+        # [@jeremyf] I'm choosing not to setup the exact conditions of the data for this to be true.
+        # Instead, I'm relying on that function to already be tested.
+        #
+        # rubocop:disable RSpec/AnyInstance
+        # Pundit does not make it easy to stub the policy().method questions so I'm using the any instance antics.
+        allow_any_instance_of(ArticlePolicy)
+          .to receive(:has_existing_articles_or_can_create_new_ones?)
+          .and_return(false)
+        # rubocop:enable RSpec/AnyInstance
+
+        get dashboard_path
+        expect(response).to redirect_to("/dashboard/following_tags")
+      end
+    end
+
     context "when logged in as a super admin" do
       it "renders the specified user's articles" do
         article


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

This commit provides two things:

1.  Some notes related to my analysis regarding the dashboard
2.  Conditional redirects and rendering based on article policies

The code comments say most of what I want to say, but to reiterate:

When a user can't create articles nor do they already have published
articles, then we don't want to avoid showing them stats related to
articles.

## Related Tickets & Documents

Closes forem/forem#16913
Related to forem/forem#16908 and forem/forem#16931

## QA Instructions, Screenshots, Recordings

If you want to reproduce this in the browser, you'll need to:

`rails runner "FeatureFlag.enable(::limit_post_creation_to_admins)"`

Then login as a user who has no articles, go to `/dashboard` and you should be
redirected to `/dashboard/following_tags`.  You will also not see Posts,
Series, nor Followers on the side panel.

Now, run `rails runner "FeatureFlag.disable(::limit_post_creation_to_admins)"`.
And refresh your user's page.  You should see Posts, Series, and Followers.
Create and publish an article.

Then run `rails runner "FeatureFlag.enable(::limit_post_creation_to_admins)"`
and go to `/dashboard`.  You should remain on the "Dashboard" and see Posts,
Series, and Followers.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
