### PR TITLE
Adding :internal auditing for admin/spaces#update

### DIFF
--- a/app/controllers/admin/spaces_controller.rb
+++ b/app/controllers/admin/spaces_controller.rb
@@ -5,10 +5,9 @@ module Admin
   class SpacesController < Admin::ApplicationController
     layout "admin"
 
-    # TODO: What kind of logging do we need?  Any?  Looking for guidance.  I can assume we want to
-    # log changes to a space.
-    #
-    # after_action only: %i[update] { Audit::Logger.log(:moderator, current_user, params.dup) }
+    after_action only: %i[update] do
+      Audit::Logger.log(:internal, current_user, params.dup)
+    end
 
     # @note I'm instantiating the @space because in the index view I'm rendering a form that then
     # PUTs to the update action.

--- a/app/services/audit/notification.rb
+++ b/app/services/audit/notification.rb
@@ -1,12 +1,11 @@
 module Audit
+  ##
+  # Main class for wrapping ActiveSupport Instrumentation API.
+  #
+  # This class represent main entry point for receiving and notifying custom
+  # events, implemented according to
+  # https://guides.rubyonrails.org/active_support_instrumentation.html#creating-custom-events
   class Notification
-    ##
-    # Main class for wrapping ActiveSupport Instrumentation API.
-    #
-    # This class represent main entry point for receiving and notifying custom
-    # events, implemented according to
-    # https://guides.rubyonrails.org/active_support_instrumentation.html#creating-custom-events
-
     class << self
       include Audit::Helper
 
@@ -22,7 +21,6 @@ module Audit
       #   payload.user_id = current_user.id
       #   payload.roles = current_user.roles.pluck(:name)
       # end
-
       def notify(listener, &block)
         return unless block
 
@@ -32,7 +30,6 @@ module Audit
       ##
       # Audit::Notification.listen receives Events sent from ActiveSupport Instrumentation API.
       # Then, this event is serialized and send to background job.
-
       def listen(*args)
         event = ActiveSupport::Notifications::Event.new(*args)
         AuditLog.create!(params_hash(event))


### PR DESCRIPTION
There are two existing listeners for the `Audit::Logger`: `:moderator`
and `:internal`.  (Note: during tests we ignore the :moderator and
:internal logs as defined in [config/initializers/audit_events.rb][1].)

## What type of PR is this? (check all applicable)

- [x] Feature

## Description

There are two existing listeners for the `Audit::Logger`: `:moderator`
and `:internal`.  (Note: during tests we ignore the :moderator and
:internal logs as defined in [config/initializers/audit_events.rb][1].)

Using `rg "Audit::Logger\.log\(:internal," --files-with-matches`, the
`:internal` listener is found in:

- app/controllers/admin/secrets_controller.rb
- app/controllers/admin/settings/base_controller.rb
- app/controllers/admin/settings/general_settings_controller.rb

Using `rg "Audit::Logger\.log\(:moderator," --files-with-matches`, the
`:moderator` listener is used in:

- app/controllers/rating_votes_controller.rb
- app/controllers/comments_controller.rb
- app/controllers/stories/pinned_articles_controller.rb
- app/controllers/admin/response_templates_controller.rb
- app/controllers/admin/tags_controller.rb
- app/controllers/admin/articles_controller.rb
- app/controllers/admin/users_controller.rb
- app/controllers/admin/reactions_controller.rb
- app/controllers/admin/tags/moderators_controller.rb
- app/controllers/tag_adjustments_controller.rb
- app/controllers/reactions_controller.rb

The `admin/spaces#update` action is most similar to the `admin#settings`
actions, which is why I chose `:internal`.  I am looking for further
guidance on documenting this little area of the application (in
particular providing a data dictionary of :internal and :moderator).


[1]:https://github.com/forem/forem/blob/main/config/initializers/audit_events.rb#L9-L11

## Related Tickets & Documents

Closes forem/forem#16957

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: we specifically don't record these during test.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

