### PR TITLE
Improvements to home feed profile preview card cypress spec

### DIFF
--- a/app/javascript/packs/homePageFeed.jsx
+++ b/app/javascript/packs/homePageFeed.jsx
@@ -29,7 +29,7 @@ function sendFeaturedArticleAnalytics(articleId) {
 }
 
 const FeedLoading = () => (
-  <div>
+  <div data-testid="feed-loading">
     <LoadingArticle version="featured" />
     <LoadingArticle />
     <LoadingArticle />

--- a/cypress/integration/seededFlows/homeFeedFlows/profilePreviewCards.spec.js
+++ b/cypress/integration/seededFlows/homeFeedFlows/profilePreviewCards.spec.js
@@ -4,41 +4,41 @@ describe('Home feed profile preview cards', () => {
     cy.fixture('users/articleEditorV1User.json').as('user');
     cy.get('@user').then((user) => {
       cy.loginAndVisit(user, '/');
+      // Wait until we're on the home feed, and it's finished loading
+      cy.findByRole('heading', { name: 'Posts' });
+      cy.findByTestId('feed-loading').should('not.exist');
     });
   });
+
+  // Helper function for `pipe` command, allowing us to retry clicks in case JS handler is not yet attached
+  const click = (el) => el.click();
 
   it("shows a profile preview card for a post's author", () => {
     cy.findAllByRole('button', { name: 'Admin McAdmin profile details' })
       .first()
       .as('previewButton');
-    cy.get('@previewButton').should('have.attr', 'data-initialized');
-    cy.get('@previewButton').click();
 
-    cy.findAllByTestId('profile-preview-card')
-      .first()
+    // We add the extra call to focus() because the Cypress click event doesn't reliably trigger the `focusin` listener we use to populate card metadata
+    cy.get('@previewButton')
+      .pipe(click)
+      .should('have.attr', 'aria-expanded', 'true')
+      .focus();
+
+    cy.get('@previewButton')
+      .closest('.profile-preview-card')
       .within(() => {
-        cy.findByRole('link', {
-          name: 'Admin McAdmin',
-        }).should('have.focus');
-
         // Check all the expected user data sections are present
-        cy.findByText('Admin user summary');
+        cy.findByText('Admin user summary').should('exist');
         cy.findByText('Software developer at Company');
         cy.findByText('Edinburgh');
         cy.findByText('University of Life');
 
-        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' }).as(
-          'userFollowButton',
-        );
-        cy.get('@userFollowButton').should(
-          'have.attr',
-          'aria-pressed',
-          'false',
-        );
-        cy.get('@userFollowButton').click();
-
-        cy.get('@userFollowButton').should('have.text', 'Following');
-        cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
+        // Check the follow button works as expected
+        cy.findByRole('button', { name: 'Follow user: Admin McAdmin' })
+          .should('have.attr', 'aria-pressed', 'false')
+          .click()
+          .should('have.text', 'Following')
+          .should('have.attr', 'aria-pressed', 'true');
       });
   });
 
@@ -46,9 +46,13 @@ describe('Home feed profile preview cards', () => {
   it('handles users with punctuation in the name', () => {
     cy.findAllByRole('button', {
       name: 'User "The test breaker" A\'postrophe \\:/ profile details',
-    }).as('previewButton');
-    cy.get('@previewButton').should('have.attr', 'data-initialized');
-    cy.get('@previewButton').click();
+    })
+      .first()
+      .as('previewButton');
+
+    cy.get('@previewButton')
+      .pipe(click)
+      .should('have.attr', 'aria-expanded', 'true');
 
     cy.findByRole('button', {
       name: 'Follow user: User "The test breaker" A\'postrophe \\:/',

--- a/cypress/integration/seededFlows/homeFeedFlows/profilePreviewCards.spec.js
+++ b/cypress/integration/seededFlows/homeFeedFlows/profilePreviewCards.spec.js
@@ -35,6 +35,7 @@ describe('Home feed profile preview cards', () => {
 
         // Check the follow button works as expected
         cy.findByRole('button', { name: 'Follow user: Admin McAdmin' })
+          .should('have.attr', 'data-fetched', 'fetched')
           .should('have.attr', 'aria-pressed', 'false')
           .click()
           .should('have.text', 'Following')
@@ -56,11 +57,11 @@ describe('Home feed profile preview cards', () => {
 
     cy.findByRole('button', {
       name: 'Follow user: User "The test breaker" A\'postrophe \\:/',
-    }).as('userFollowButton');
-    cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'false');
-    cy.get('@userFollowButton').click();
-
-    cy.get('@userFollowButton').should('have.text', 'Following');
-    cy.get('@userFollowButton').should('have.attr', 'aria-pressed', 'true');
+    })
+      .should('have.attr', 'data-fetched', 'fetched')
+      .should('have.attr', 'aria-pressed', 'false')
+      .click()
+      .should('have.text', 'Following')
+      .should('have.attr', 'aria-pressed', 'true');
   });
 });

--- a/cypress/integration/seededFlows/homeFeedFlows/profilePreviewCards.spec.js
+++ b/cypress/integration/seededFlows/homeFeedFlows/profilePreviewCards.spec.js
@@ -29,9 +29,9 @@ describe('Home feed profile preview cards', () => {
       .within(() => {
         // Check all the expected user data sections are present
         cy.findByText('Admin user summary').should('exist');
-        cy.findByText('Software developer at Company');
-        cy.findByText('Edinburgh');
-        cy.findByText('University of Life');
+        cy.findByText('Software developer at Company').should('exist');
+        cy.findByText('Edinburgh').should('exist');
+        cy.findByText('University of Life').should('exist');
 
         // Check the follow button works as expected
         cy.findByRole('button', { name: 'Follow user: Admin McAdmin' })


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor

## Description

This spec has been flaking a bit in CI recently. After a bit of investigation is seems the main issues at play are:

- The spec assumes the correct profile preview card is _always_ the first on the page (it should be given the seed data, but it's partly impacted by point 2...)
- The feed re-render which happens as the loading UI disappears and the feed items appear

My approach to resolving this is:

1. Wait until the feed has loaded before doing anything
2. Use a `closest` selector to choose the right preview card to assert on

I also noticed a couple of our assertions were dodgy (as in, weren't doing anything) and took the opportunity to refactor to use `pipe` instead of relying on attributes like `data-initialized`, and similarly waiting on the `follows` network requests to make sure those buttons are loaded fully before interacting with them.

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Really we just want to see the CI jobs go green

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes


## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] I will share this change internally with the appropriate teams


## [optional] What gif best describes this PR or how it makes you feel?

![a little bit strange](https://media.giphy.com/media/406ZMCwmTzYfo4E9cS/giphy.gif)
