### PR TITLE
Add toggle button to 'New Forem Secret' form

### DIFF
--- a/app/javascript/packs/foremCreatorSignup.js
+++ b/app/javascript/packs/foremCreatorSignup.js
@@ -64,7 +64,7 @@ function hideHintRow() {
   hintRow.classList.add('hidden');
 }
 
-function setTogglePasswordEvent(targetClass) {
+function setTogglePasswordEvent(targetWrapper) {
   function togglePasswordMask(event) {
     event.preventDefault();
     visible = !visible;
@@ -88,7 +88,6 @@ function setTogglePasswordEvent(targetClass) {
   }
 
   let visible = false;
-  const targetWrapper = document.getElementsByClassName(targetClass)[0];
   const eyeIcon = targetWrapper.getElementsByClassName('js-eye')[0];
   const eyeOffIcon = targetWrapper.getElementsByClassName('js-eye-off')[0];
   const passwordField = targetWrapper.getElementsByClassName('js-password')[0];
@@ -98,8 +97,9 @@ function setTogglePasswordEvent(targetClass) {
   visibility.addEventListener('click', togglePasswordMask);
 }
 
-setTogglePasswordEvent('js-password-toggle-wrapper');
-setTogglePasswordEvent('js-forem-owner-secret-toggle-wrapper');
+document.querySelectorAll('.js-password-toggle-wrapper').forEach((el) => {
+  setTogglePasswordEvent(el);
+});
 
 const name = document.getElementsByClassName('js-creator-signup-name')[0];
 name.addEventListener('input', setDefaultUsername);

--- a/app/javascript/packs/foremCreatorSignup.js
+++ b/app/javascript/packs/foremCreatorSignup.js
@@ -99,7 +99,7 @@ function setTogglePasswordEvent(targetClass) {
 }
 
 setTogglePasswordEvent('js-password-toggle-wrapper');
-setTogglePasswordEvent('js-forem_owner_secret-toggle-wrapper');
+setTogglePasswordEvent('js-forem-owner-secret-toggle-wrapper');
 
 const name = document.getElementsByClassName('js-creator-signup-name')[0];
 name.addEventListener('input', setDefaultUsername);

--- a/app/javascript/packs/foremCreatorSignup.js
+++ b/app/javascript/packs/foremCreatorSignup.js
@@ -64,36 +64,42 @@ function hideHintRow() {
   hintRow.classList.add('hidden');
 }
 
-function togglePasswordMask(event) {
-  event.preventDefault();
-  visible = !visible;
-  toggleAriaPressed(visible);
-  togglePasswordType(visible);
-  toggleEyeIcons(visible);
+function setTogglePasswordEvent(targetClass) {
+  function togglePasswordMask(event) {
+    event.preventDefault();
+    visible = !visible;
+    toggleAriaPressed(visible);
+    togglePasswordType(visible);
+    toggleEyeIcons(visible);
+  }
+
+  function toggleAriaPressed(visible) {
+    visibility.setAttribute('aria-pressed', visible);
+  }
+
+  function togglePasswordType(visible) {
+    const passwordType = visible ? 'text' : 'password';
+    passwordField.type = passwordType;
+  }
+
+  function toggleEyeIcons(visible) {
+    eyeOffIcon.classList.toggle('hidden', !visible);
+    eyeIcon.classList.toggle('hidden', visible);
+  }
+
+  let visible = false;
+  const targetWrapper = document.getElementsByClassName(targetClass)[0];
+  const eyeIcon = targetWrapper.getElementsByClassName('js-eye')[0];
+  const eyeOffIcon = targetWrapper.getElementsByClassName('js-eye-off')[0];
+  const passwordField = targetWrapper.getElementsByClassName('js-password')[0];
+  const visibility = targetWrapper.getElementsByClassName(
+    'js-creator-password-visibility',
+  )[0];
+  visibility.addEventListener('click', togglePasswordMask);
 }
 
-function toggleAriaPressed(visible) {
-  visibility.setAttribute('aria-pressed', visible);
-}
-
-function togglePasswordType(visible) {
-  const passwordType = visible ? 'text' : 'password';
-  passwordField.type = passwordType;
-}
-
-function toggleEyeIcons(visible) {
-  eyeOffIcon.classList.toggle('hidden', !visible);
-  eyeIcon.classList.toggle('hidden', visible);
-}
-
-let visible = false;
-const eyeIcon = document.getElementsByClassName('js-eye')[0];
-const eyeOffIcon = document.getElementsByClassName('js-eye-off')[0];
-const passwordField = document.getElementsByClassName('js-password')[0];
-const visibility = document.getElementsByClassName(
-  'js-creator-password-visibility',
-)[0];
-visibility.addEventListener('click', togglePasswordMask);
+setTogglePasswordEvent('js-password-toggle-wrapper');
+setTogglePasswordEvent('js-forem_owner_secret-toggle-wrapper');
 
 const name = document.getElementsByClassName('js-creator-signup-name')[0];
 name.addEventListener('input', setDefaultUsername);

--- a/app/views/shared/authentication/_forem_creator_signup.html.erb
+++ b/app/views/shared/authentication/_forem_creator_signup.html.erb
@@ -92,7 +92,7 @@
         <% else %>
           <div class="crayons-field mt-6">
             <%= f.label :forem_owner_secret, t("views.auth.register.secret.label"), class: "crayons-field__label" %>
-            <div class="relative js-forem-owner-secret-toggle-wrapper">
+            <div class="relative js-password-toggle-wrapper">
               <%= f.password_field :forem_owner_secret, class: "crayons-textfield js-password", required: ForemInstance.needs_owner_secret?, placeholder: t("views.auth.register.secret.placeholder") %>
               <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--s js-creator-password-visibility h-100 absolute z-elevate right-0" aria-label="<%= t("views.auth.register.secret.show") %>" aria-pressed="false">
                 <%= crayons_icon_tag(:eye, class: "js-eye", data: { testid: "mask-icon" }, aria_hidden: true, title: t("views.auth.register.secret.show")) %>

--- a/app/views/shared/authentication/_forem_creator_signup.html.erb
+++ b/app/views/shared/authentication/_forem_creator_signup.html.erb
@@ -92,7 +92,7 @@
         <% else %>
           <div class="crayons-field mt-6">
             <%= f.label :forem_owner_secret, t("views.auth.register.secret.label"), class: "crayons-field__label" %>
-            <div class="relative js-forem_owner_secret-toggle-wrapper">
+            <div class="relative js-forem-owner-secret-toggle-wrapper">
               <%= f.password_field :forem_owner_secret, class: "crayons-textfield js-password", required: ForemInstance.needs_owner_secret?, placeholder: t("views.auth.register.secret.placeholder") %>
               <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--s js-creator-password-visibility h-100 absolute z-elevate right-0" aria-label="<%= t("views.auth.register.secret.show") %>" aria-pressed="false">
                 <%= crayons_icon_tag(:eye, class: "js-eye", data: { testid: "mask-icon" }, aria_hidden: true, title: t("views.auth.register.secret.show")) %>

--- a/app/views/shared/authentication/_forem_creator_signup.html.erb
+++ b/app/views/shared/authentication/_forem_creator_signup.html.erb
@@ -94,9 +94,9 @@
             <%= f.label :forem_owner_secret, t("views.auth.register.secret.label"), class: "crayons-field__label" %>
             <div class="relative js-forem_owner_secret-toggle-wrapper">
               <%= f.password_field :forem_owner_secret, class: "crayons-textfield js-password", required: ForemInstance.needs_owner_secret?, placeholder: t("views.auth.register.secret.placeholder") %>
-              <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--s js-creator-password-visibility h-100 absolute z-elevate right-0" aria-label="<%= t("views.auth.register.field.password.show") %>" aria-pressed="false">
-                <%= crayons_icon_tag(:eye, class: "js-eye", data: { testid: "mask-icon" }, aria_hidden: true, title: t("views.auth.register.field.password.show")) %>
-                <%= crayons_icon_tag("eye-off", class: "hidden js-eye-off", data: { testid: "unmask-icon" }, aria_hidden: true, title: t("views.auth.register.field.password.hide")) %>
+              <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--s js-creator-password-visibility h-100 absolute z-elevate right-0" aria-label="<%= t("views.auth.register.secret.show") %>" aria-pressed="false">
+                <%= crayons_icon_tag(:eye, class: "js-eye", data: { testid: "mask-icon" }, aria_hidden: true, title: t("views.auth.register.secret.show")) %>
+                <%= crayons_icon_tag("eye-off", class: "hidden js-eye-off", data: { testid: "unmask-icon" }, aria_hidden: true, title: t("views.auth.register.secret.hide")) %>
               </button>
             </div>
           </div>

--- a/app/views/shared/authentication/_forem_creator_signup.html.erb
+++ b/app/views/shared/authentication/_forem_creator_signup.html.erb
@@ -76,7 +76,7 @@
 
       <div class="crayons-field mt-6">
         <%= f.label :password, t("views.auth.register.field.password.label"), class: "crayons-field__label" %>
-        <div class="relative">
+        <div class="relative js-password-toggle-wrapper">
           <%= f.password_field :password, minlength: "8", class: "crayons-textfield js-password", placeholder: t("views.auth.register.field.password.placeholder"), required: true, aria: { describedby: "password-helper-text" } %>
           <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--s js-creator-password-visibility h-100 absolute z-elevate right-0" aria-label="<%= t("views.auth.register.field.password.show") %>" aria-pressed="false">
             <%= crayons_icon_tag(:eye, class: "js-eye", data: { testid: "mask-icon" }, aria_hidden: true, title: t("views.auth.register.field.password.show")) %>
@@ -92,7 +92,13 @@
         <% else %>
           <div class="crayons-field mt-6">
             <%= f.label :forem_owner_secret, t("views.auth.register.secret.label"), class: "crayons-field__label" %>
-            <%= f.password_field :forem_owner_secret, class: "crayons-textfield", required: ForemInstance.needs_owner_secret?, placeholder: t("views.auth.register.secret.placeholder") %>
+            <div class="relative js-forem_owner_secret-toggle-wrapper">
+              <%= f.password_field :forem_owner_secret, class: "crayons-textfield js-password", required: ForemInstance.needs_owner_secret?, placeholder: t("views.auth.register.secret.placeholder") %>
+              <button type="button" class="crayons-btn crayons-btn--ghost crayons-btn--s js-creator-password-visibility h-100 absolute z-elevate right-0" aria-label="<%= t("views.auth.register.field.password.show") %>" aria-pressed="false">
+                <%= crayons_icon_tag(:eye, class: "js-eye", data: { testid: "mask-icon" }, aria_hidden: true, title: t("views.auth.register.field.password.show")) %>
+                <%= crayons_icon_tag("eye-off", class: "hidden js-eye-off", data: { testid: "unmask-icon" }, aria_hidden: true, title: t("views.auth.register.field.password.hide")) %>
+              </button>
+            </div>
           </div>
         <% end %>
       <% end %>

--- a/config/locales/views/auth/en.yml
+++ b/config/locales/views/auth/en.yml
@@ -61,6 +61,8 @@ en:
         secret:
           label: New Forem Secret
           placeholder: As provided by your Forem host
+          hide: Hide new Forem secret
+          show: Show new Forem secret
         submit: Sign up
       wizard:
         meta:

--- a/config/locales/views/auth/fr.yml
+++ b/config/locales/views/auth/fr.yml
@@ -61,6 +61,8 @@ fr:
         secret:
           label: New Forem Secret
           placeholder: As provided by your Forem host
+          hide: Hide new Forem secret
+          show: Show new Forem secret
         submit: Sign up
       wizard:
         meta:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

The "New Forem Secret" form can now be toggled as well as the password field.

## Related Tickets & Documents

- Closes #16756

## QA Instructions, Screenshots, Recordings

https://user-images.githubusercontent.com/47295890/160245480-4b0eac46-5b1e-4d7a-8b88-78a3f90a0834.mov

### UI accessibility concerns?

None

## Added/updated tests?

- [x] I need help with writing tests
