### PR TITLE
Instrument `ActiveSupport::Cache#fetch_multi` in Honeycomb

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -9,6 +9,7 @@ else
   # Honeycomb automatic Rails integration
   notification_events = %w[
     cache_read.active_support
+    cache_read_multi.active_support
     sql.active_record
     render_template.action_view
     render_partial.action_view


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Instrumentation
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The particular cache fetching that we do with [rendering comments for an article](https://github.com/forem/forem/blob/d9a5c204e11ff01944f0e1ab395a23848f1cadf2/app/views/articles/_full_comment_area.html.erb#L31) doesn't end up getting picked up by `cache_read.active_support`. After some experimentation, I discovered that it does get picked up via `cache_read_multi.active_support`.

See:

- https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch_multi
- https://guides.rubyonrails.org/v6.1.4.7/active_support_instrumentation.html#cache-fetch-hit-active-support

## QA Instructions, Screenshots, Recordings

In a Rails console:

- Create an `ActiveSupport::Notifications` subscription
  - `ActiveSupport::Notifications.subscribe(/cache_.*\.active_support/) { |*args| pp args: args }`
- Render a tree of comments, as in an article's `show` page
  - `ApplicationController.renderer.render partial: "articles/comment_tree", collection: {}, as: :comment_node, cached: proc { |c, _| c }`
  - You do not need any comments in your DB to do this and this will actually ignore any you do have since all we care about is instrumenting the cache call
- You should see the cache call args from your `AS::Notifications` subscription render into the console

Honeycomb uses [`ActiveSupport::Notifications`](https://guides.rubyonrails.org/v6.1.4.7/active_support_instrumentation.html) to instrument Rails apps, so all we're doing is making sure we capture the one that fires here. Note that the subscription in the QA instructions above use a regex to capture *any* cache operations so we can identify what's being used here. We are not passing that regex to Honeycomb in this PR, but instead using the value returned in that subscription.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Just adding instrumentation
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_