### PR TITLE
Avoid using robohash for factory generated article cover images

### DIFF
--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -23,7 +23,11 @@ FactoryBot.define do
     co_author_ids { [] }
     association :user, factory: :user, strategy: :create
     description { Faker::Hipster.paragraph(sentence_count: 1)[0..100] }
-    main_image    { with_main_image ? Faker::Avatar.image : nil }
+    main_image    do
+      if with_main_image
+        URL.url(ActionController::Base.helpers.asset_path("#{rand(1..40)}.png"))
+      end
+    end
     experience_level_rating { rand(4..6) }
     body_markdown do
       <<~HEREDOC

--- a/spec/view_objects/cloud_cover_url_spec.rb
+++ b/spec/view_objects/cloud_cover_url_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CloudCoverUrl, type: :view_object, cloudinary: true do
-  let(:article) { create(:article) }
+  let(:article) { create(:article, main_image: "https://robohash.org/articlefactory.png") }
   let(:cloudinary_prefix) { "https://res.cloudinary.com/#{Cloudinary.config.cloud_name}/image/fetch/" }
 
   it "returns proper url" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

`Faker::Avatar.image` uses [robohash.org](https://robohash.org/) to generate a unique image from sample text on each request. This provides a nice diverse set of cover images for articles (and is pretty cool). However, if their service slows down (due to load, availability, denial of service, cloudflare defense enabled), loading the cover image times out in system tests, and causes unrelated test failures.

Use a locally served image file instead (these are the animal art images in app/assets/images/)

We do stub out robohash in unit tests (for user agent = Ruby) but headless chrome was having issues with it.

## QA Instructions, Screenshots, Recordings

Test only concern. Tests should pass (but they might anyway). Ideally, the system tests pass with the network disconnected. Maybe you could test this locally by adding a 30-60s delay to any request to that site? 

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes (sort of - this impacts a lot of tests by changing the defaults for the factory).

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: test optimization, already discussed internally

## [optional] What gif best describes this PR or how it makes you feel?

![whatisgoingon](https://user-images.githubusercontent.com/1237369/160454471-7e88f20d-5366-4ad5-b9ca-e2d146f2b3ab.png)
