### PR TITLE
Revert ERB comment tag work-around

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -57,7 +57,7 @@
         </div>
 
         <%# new or less active users that don't have a page worth of notifications
-          # won't be shown the "load more" button %>
+            won't be shown the "load more" button %>
         <% if @notifications.size >= @initial_page_size %>
           <button id="load-more-button" type="button" class="crayons-btn crayons-btn--secondary crayons-btn--l my-6 w-100">
             <%= t("views.notifications.load") %>

--- a/app/views/organizations/_sidebar_additional.html.erb
+++ b/app/views/organizations/_sidebar_additional.html.erb
@@ -8,8 +8,8 @@
     <% end %>
 
     <%# given the probability that organizations can have lots of users,
-      # here we're using the any?/find_each pattern to avoid loading possibly
-      # too many objects in memory %>
+        here we're using the any?/find_each pattern to avoid loading possibly
+        too many objects in memory %>
     <% if @organization.users.any? %>
       <div class="widget">
         <div class="widget-suggested-follows-container">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Since i18n-tasks resolved the issue in 1.0.5, and we've upgraded, the
erb comment tags can use the original (natural) syntax, reverting the work-around from #17012

## Related Tickets & Documents


- Related Issue #17012 

## QA Instructions, Screenshots, Recordings

This was an issue with the task run in rspec, but is no longer an issue:

```
bundle exec rspec spec/i18n_spec.rb

Finished in 6.49 seconds (files took 0.6829 seconds to load)
4 examples, 0 failures, 2 pending
```

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: behavior neutral change (formatting of comment tags in views)
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: comment formatting
