### PR TITLE
Bust cache when changing spaces

### DIFF
--- a/app/controllers/admin/spaces_controller.rb
+++ b/app/controllers/admin/spaces_controller.rb
@@ -9,6 +9,13 @@ module Admin
       Audit::Logger.log(:internal, current_user, params.dup)
     end
 
+    # When we change the settings of a Space, this can impact what user's see.  Thus, we need to
+    # ensure we are busting the cache.
+    #
+    # @see ApplicationHelper#release_adjusted_cache_key ApplicationHelper#release_adjusted_cache_key
+    #      produces the cache key we use for caching the homepage's top bar.
+    after_action :bust_content_change_caches, only: %i[update]
+
     # @note I'm instantiating the @space because in the index view I'm rendering a form that then
     # PUTs to the update action.
     def index


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

In the [app/views/layouts/application.html.erb][1] we use
[ApplicationHelper#release_adjusted_cache_key][2] to define a cache
key.  That cache key includes the
`Settings::General.admin_action_taken_at` time field.

The [ApplicationController#bust_content_change_caches][3] method is
responsible for updating the `Settings::General.admin_action_taken_at` column.

[1]:https://github.com/forem/forem/blob/f5ae2900b5a91d16dac98b9429384c39386163fa/app/views/layouts/application.html.erb#L48
[2]:https://github.com/forem/forem/blob/f5ae2900b5a91d16dac98b9429384c39386163fa/app/helpers/application_helper.rb#L193-L198
[3]:https://github.com/forem/forem/blob/f5ae2900b5a91d16dac98b9429384c39386163fa/app/controllers/application_controller.rb#L255-L258


## Related Tickets & Documents

This relates to forem/forem#16606 and may be necessary for the
following:

- forem/forem#16783
- forem/forem#16836
- forem/forem#16837
- forem/forem#16965
- forem/forem#17008

## QA Instructions, Screenshots, Recordings

For this to be meaningfully tested, you'll need to spin up community.benhalpernc.com.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: I'm waiting on the finalization of the UI behavior
      for the `/admin/content_manager/spaces` before writing a more robust
      spec.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
