### PR TITLE
Extracting article cache invalidation for generalization

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -497,17 +497,6 @@ class User < ApplicationRecord
     monthly_dues.positive?
   end
 
-  def resave_articles
-    articles.find_each do |article|
-      if article.path
-        cache_bust = EdgeCache::Bust.new
-        cache_bust.call(article.path)
-        cache_bust.call("#{article.path}?i=i")
-      end
-      article.save
-    end
-  end
-
   def profile_image_90
     profile_image_url_for(length: 90)
   end

--- a/app/services/users/update.rb
+++ b/app/services/users/update.rb
@@ -117,7 +117,7 @@ module Users
     def conditionally_resave_articles
       return unless resave_articles? && !@user.suspended?
 
-      Users::ResaveArticlesWorker.perform_async(@user.id)
+      Articles::ResaveForAssociationWorker.perform_async(@user.model_name.name, @user.id)
     end
 
     def resave_articles?

--- a/app/workers/articles/resave_for_association_worker.rb
+++ b/app/workers/articles/resave_for_association_worker.rb
@@ -1,0 +1,16 @@
+module Articles
+  class ResaveForAssociationWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :medium_priority, retry: 10, lock: :until_executing
+
+    # @param klass_name [#constantize, String] the name of the class
+    # @param id [Object, Integer] the ID of the record for the given class
+    def perform(klass_name, id)
+      object = klass_name.constantize.find_by(id: id)
+      return unless object
+
+      object.articles.find_each(&:save)
+    end
+  end
+end

--- a/app/workers/users/resave_articles_worker.rb
+++ b/app/workers/users/resave_articles_worker.rb
@@ -1,4 +1,10 @@
 module Users
+  # @deprecated
+  #
+  # @todo Remove this class on or after <2022-05-02 Mon> once all enqueued jobs have had a chance to
+  #       clear.  See the conversation at https://github.com/forem/forem/pull/17049
+  #
+  # @see Articles::ResaveForAssociationWorker other implementation
   class ResaveArticlesWorker
     include Sidekiq::Worker
 
@@ -8,7 +14,7 @@ module Users
       user = User.find_by(id: user_id)
       return unless user
 
-      user.resave_articles
+      user.articles.find_each(&:save)
     end
   end
 end

--- a/spec/services/users/update_spec.rb
+++ b/spec/services/users/update_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe Users::Update, type: :service do
   def sidekiq_assert_resave_article_worker(user, &block)
     sidekiq_assert_enqueued_with(
-      job: Users::ResaveArticlesWorker,
-      args: [user.id],
+      job: Articles::ResaveForAssociationWorker,
+      args: ["User", user.id],
       queue: "medium_priority",
       &block
     )
@@ -162,7 +162,7 @@ RSpec.describe Users::Update, type: :service do
 
         expect do
           described_class.call(suspended_user, user: { username_field => "greatnewusername" })
-        end.not_to change(Users::ResaveArticlesWorker.jobs, :size)
+        end.not_to change(Articles::ResaveForAssociationWorker.jobs, :size)
       end
     end
   end

--- a/spec/workers/articles/resave_for_association_worker_spec.rb
+++ b/spec/workers/articles/resave_for_association_worker_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Articles::ResaveForAssociationWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "medium_priority", 1
+
+  describe "#perform" do
+    let(:worker) { subject }
+
+    context "with user" do
+      it "resave articles" do
+        user = create(:user)
+        article = create(:article, user: user)
+
+        old_updated_at = article.updated_at
+
+        Timecop.travel(1.minute.from_now) do
+          worker.perform(user.class.model_name.name, user.id)
+        end
+
+        expect(article.reload.updated_at).to be > old_updated_at
+      end
+    end
+
+    context "with an organization" do
+      it "resaves articles" do
+        org = create(:organization)
+        article = create(:article, organization: org)
+
+        old_updated_at = article.updated_at
+
+        Timecop.travel(1.minute.from_now) do
+          worker.perform(org.class.model_name.name, org.id)
+        end
+
+        expect(article.reload.updated_at).to be > old_updated_at
+      end
+    end
+
+    context "without user" do
+      it "does not break" do
+        expect { worker.perform("User", nil) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Prior to this commit, when we change attributes for a user we might
resave each article.  The purpose of the resave was to handle some of
the cached attributes of an article.

We need to extend this behavior into organizations.  When an
organization changes it's icon, we want to update each article
associated with the organization.

While this change doesn't do that, it does make it easier for this
update to happen.


## Related Tickets & Documents

Related to forem/forem#17041

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

No.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
