### PR TITLE
Fixed hiding 'Click to edit' link for drafts

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -69,7 +69,7 @@
         <div class="crayons-notice crayons-notice--danger mb-4" aria-live="polite">
           <strong><%= t("views.articles.unpublished.subtitle") %></strong><%= t("views.articles.unpublished.text") %>
           <% if user_signed_in? %>
-            <a id="author-click-to-edit" href="<%= @article.path %>/edit" class="fw-bold" display="none"><%= t("views.articles.unpublished.edit") %></a>
+            <a id="author-click-to-edit" href="<%= @article.path %>/edit" class="fw-bold" style="display: none;"><%= t("views.articles.unpublished.edit") %></a>
           <% end %>
         </div>
       <% end %>

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -161,6 +161,7 @@ RSpec.describe "Views an article", type: :system do
       it "does not the article edit link" do
         visit article_path
         expect(page.body).not_to include('display: inline-block;">Click to edit</a>')
+        expect(page.body).to include('display: none;">Click to edit</a>')
       end
     end
 
@@ -171,7 +172,7 @@ RSpec.describe "Views an article", type: :system do
       it "does not the article edit link" do
         sign_out user
         visit article_path
-        expect(page.body).not_to include('display: inline-block;">Click to edit</a>')
+        expect(page.body).not_to include("Click to edit")
       end
     end
 

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -158,9 +158,8 @@ RSpec.describe "Views an article", type: :system do
       let(:query_params) { "?preview=#{article.password}" }
       let(:article_user) { create(:user) }
 
-      it "does not the article edit link" do
+      it "renders the article edit link" do
         visit article_path
-        expect(page.body).not_to include('display: inline-block;">Click to edit</a>')
         expect(page.body).to include('display: none;">Click to edit</a>')
       end
     end

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe "Views an article", type: :system do
       let(:query_params) { "?preview=#{article.password}" }
       let(:article_user) { user }
 
-      it "does not the article edit link" do
+      it "does not render the article edit link" do
         sign_out user
         visit article_path
         expect(page.body).not_to include("Click to edit")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
While adding a similar notice for scheduled articles, I found out that "Click to edit" link was displayed in the draft notice for the users that are not authorized to edit the article. The test was passing because it was checking for the `'display: inline-block;">Click to edit</a>'` not to exist while actually there was `display="none">Click to edit</a>` (which had no effect) on a page.

![изображение](https://user-images.githubusercontent.com/30115/160835013-bd1a235b-7a80-4257-8dae-ac96fdbf5fab.png)

You should be able to see the incorrect behaviour by visiting [the link](https://dev.to/annaboo/test-draft-2dog-temp-slug-2514949?preview=d10444ef6f58470bc2a55bc97270c8e0bdf8e1170644c192a30e190b4b494e5000ad46c1408db5ad5249da73681a8edff0fcaff3684d128ffad8e034) as a signed in user. 

## QA Instructions, Screenshots, Recordings
- Create a draft article
- On the article page you should see the notice and a link "Click to edit"
- (Save the article preview url)
- Sign in a different user (not admin)
- Go to the article preview url
- You should be able to see the red notice, but no link "Click to edit"

## Added/updated tests?
- [x] Yes


## [Forem core team only] How will this change be communicated?
- [ ] This change does not need to be communicated, and this is why not: a small bug fix, not a big deal
