### PR TITLE
Ensuring article's cache updates on org image update

### DIFF
--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -249,6 +249,41 @@ RSpec.describe Organization, type: :model do
         expect(article.path).to include(new_slug)
       end
 
+      it "updates article's cached_organization profile image", :aggregate_failures do
+        # What is going on with this spec? Follow the comments.
+        #
+        # tl;dr - verifying fix for https://github.com/forem/forem/issues/17041
+
+        # Create an organization and article, verify the article has cached the initial profile
+        # image of the organization.
+        original_org = create(:organization, profile_image: File.open(Rails.root.join("app/assets/images/1.png")))
+        article = create(:article, organization: original_org)
+        expect(article.cached_organization.profile_image_url).to eq(original_org.profile_image_url)
+
+        # For good measure let's have two of these articles
+        create(:article, organization: original_org)
+
+        # A foible of CarrierWave is that I can't re-upload for the same model in memory.  I need to
+        # refind the record.  #reload does not work either.  (I lost sleep on this portion of the
+        # test)
+        organization = described_class.find(original_org.id)
+
+        # Verify that the organization's image changes.  See the above CarrierWave foible
+        expect do
+          organization.profile_image = File.open(Rails.root.join("app/assets/images/2.png"))
+          organization.save!
+        end.to change { organization.reload.profile_image_url }
+
+        # I want to collect reloaded versions of the organization's articles so I can see their
+        # cached organization profile image
+        articles_profile_image_urls = organization.articles
+          .map { |art| art.reload.cached_organization.profile_image_url }.uniq
+
+        # Because of the change `{ organization.reload... }` the organization's profile_image_url is
+        # the most recent change.
+        expect(articles_profile_image_urls).to eq([organization.profile_image_url])
+      end
+
       it "updates article cached_organizations" do
         new_slug = "slug_#{rand(10_000)}"
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix
- [x] Optimization
- [x] Documentation Update

## Description

There are three major things occurring in this pull request:

1. Renaming `Article#update_cached_user` to `Article#set_cached_entities`.
2. Reducing an organization's direct knowledge of which of the org's
   attributes an article caches.
3. Removing duplicate calls to update the article associated with the
   organization.

For renaming to `Article#set_cached_entities`, the prior method implied
we were updating the persistence layer.  However, we were not making any
save nor update calls.  This rename should clarify intention.

For reducing knowledge, the comments for
`Article::ATTRIBUTES_CACHED_FOR_RELATED_ENTITY` should explain the details.

And last, removing the duplicate calls; we had three methods that were
attempting to build and update the `Article#cached_organization`'s
value.

## Related Tickets & Documents

Closes forem/forem#17041

## QA Instructions, Screenshots, Recordings

My hope is that the tests cover this.  To test via the UI, I leave the
following gherkin as guide:

Go to `/` and make sure that there's an article with an organization.

```gherkin
Given an article A that is associated with organization B.
When I update the organization B's image.
Then article A's organization image reflects the new image for B.
```

Now, after the change, look on the dashboard for that article's organization
image.  It should have changed.


### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
