### PR TITLE
WIP - Conditional rendering of "Create Post" link

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -108,6 +108,21 @@ function setCurrentUserToNavBar(user) {
       .getElementsByClassName('js-header-menu-admin-link')[0]
       .classList.remove('hidden');
   }
+
+  // If the user has policies in their data, let's iterate through them and start
+  if (user.policies) {
+    user.policies.forEach(function (policy) {
+      if (
+        policy.resource_type == 'Article' &&
+        policy.action == 'create' &&
+        !policy.allowed
+      ) {
+        document
+          .getElementsByClassName('js-policy-Article-create')[0]
+          .classList.add('hidden');
+      }
+    });
+  }
 }
 
 function initializeBaseUserData() {

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -58,6 +58,9 @@ class AsyncInfoController < ApplicationController
         feed_style: feed_style_preference,
         created_at: @user.created_at,
         admin: @user.any_admin?,
+        policies: [
+          { resource_type: "Article", action: "create", allowed: policy(Article).create? },
+        ],
         apple_auth: @user.email.to_s.end_with?("@privaterelay.appleid.com")
       }
     end.to_json

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -18,7 +18,7 @@
     <li>
       <a href="<%= mod_path %>" class="c-link c-link--block trusted-visible-block"><%= t("views.main.nav.moderator_center") %></a>
     </li>
-    <li>
+    <li class="js-policy-Article-create">
       <a href="<%= new_path %>" class="c-link c-link--block"><%= t("views.main.create_post") %></a>
     </li>
     <li>


### PR DESCRIPTION
This PR is to be a conversation and discussion around the approach.

First, the ability to actually create a post is enforced on the server.
If the "Create Post" button were to be visible but the user couldn't
create a post when they clicked the button, they would get an
authorization error (or some such response).

Things to consider:

1.  How do we invalidate the cache for a group of users when the
    policies change?  Is that vitally important?  After all, we're
    enforcing permissions on the server side.
2.  Is the async_info the right place to put this?  I like the idea of
    piggy-backing on the data.
3.  Does this approach make sense?  If not what else?
4.  I'm not overly proficient in JS, and with one hour of work, I was
    able to get this working.  However, I'd love guidance on how to
    organize this if we proceed.

This also runs a bit contrary to the Turbo task I set forward for
Dwight (see forem/forem#16606).  If would also mean we might be able to
remove Turbo.

If we go forward with this pattern, I think we should make sure to have
a canonical place for rendering conformant asyn info data and HTML on
the server side.  I'll work through that, but below is an example of the
interface for ERB rendering:

```html.erb
<%= policy_element("li", resource: Article, action: "create", default:
:hidden) do %>
  <a href=/new">Create Post</a>
<% end %>
```

This is a place where documentation and consistent application will
matter most.
