### PR TITLE
Ensuring that established tags don't respond 404

### DIFF
--- a/spec/requests/stories/tagged_articles_spec.rb
+++ b/spec/requests/stories/tagged_articles_spec.rb
@@ -63,16 +63,20 @@ RSpec.describe "Stories::TaggedArticlesIndex", type: :request do
 
         it "renders page when tag is not supported but has at least one approved article" do
           unsupported_tag = create(:tag, supported: false)
-          create(:article, published: true, approved: true, tags: unsupported_tag)
+          create(:article, published: true, approved: true, tags: unsupported_tag, published_at: 5.years.ago)
 
           get "/t/#{unsupported_tag.name}/top/week"
-          expect(response.body).to include(unsupported_tag.name)
+
+          expect(response).to be_successful
+
           get "/t/#{unsupported_tag.name}/top/month"
-          expect(response.body).to include(unsupported_tag.name)
+          expect(response).to be_successful
+
           get "/t/#{unsupported_tag.name}/top/year"
-          expect(response.body).to include(unsupported_tag.name)
+          expect(response).to be_successful
+
           get "/t/#{unsupported_tag.name}/top/infinity"
-          expect(response.body).to include(unsupported_tag.name)
+          expect(response).to be_successful
         end
 
         it "returns not found if no published posts and tag not supported" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this commit, we determined the 404 status based on the final
scoped query of the articles.  That scoped query would limit to a
timeframe.

However, what we want is to not render a 404 status if we have an
"established" tag.  An established tag means that we have at least one
published article (regardless of when we published).


## Related Tickets & Documents

Fixes forem/forem#16932

## QA Instructions, Screenshots, Recordings

With our given test data this might be a bit obnoxious to test.

### UI accessibility concerns?

We _might_ want to consider informing the user that there are no articles for the given timeframe.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
