### PR TITLE
Remove the connect feature flag

### DIFF
--- a/lib/data_update_scripts/20220330191441_remove_connect_feature_flag.rb
+++ b/lib/data_update_scripts/20220330191441_remove_connect_feature_flag.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class RemoveConnectFeatureFlag
+    def run
+      FeatureFlag.remove(:connect)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/remove_connect_feature_flag_spec.rb
+++ b/spec/lib/data_update_scripts/remove_connect_feature_flag_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220330191441_remove_connect_feature_flag.rb",
+)
+
+describe DataUpdateScripts::RemoveConnectFeatureFlag do
+  it "removes the connect feature flag" do
+    FeatureFlag.add(:connect)
+
+    described_class.new.run
+
+    expect(FeatureFlag.exist?(:connect)).to be false
+  end
+end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

There's an existing data update to introduce the connect feature flag,
and it's been disabled. However, since all the code relying on this is
now gone, it makes sense to remove the flag.

My main use case is after resetting the db, in a new environment, I don't need or expect to see connect on the http://localhost:3000/admin/feature_flags/features page


## Related Issues

https://github.com/forem/forem/pull/14734 removed all the code dependent on this flag

## QA Instructions, Screenshots, Recordings

Ensure there's a connect feature flag (or add it from the ui http://localhost:3000/admin/feature_flags/features)

![Screenshot from 2022-03-30 14-25-43](https://user-images.githubusercontent.com/1237369/160915346-dc254d6f-72cc-4778-8cf2-cc5ce04fcaa4.png)


Run the data update scripts

```
bundle exec rake data_updates:run
```

Refresh the admin feature flag page, connect should be gone.

![Screenshot from 2022-03-30 14-26-33](https://user-images.githubusercontent.com/1237369/160915316-5aa3aa52-2e8c-4054-b950-5a57c51c5590.png)



### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

