### PR TITLE
Display analytics up to yesterday instead of today

### DIFF
--- a/app/controllers/admin/overview_controller.rb
+++ b/app/controllers/admin/overview_controller.rb
@@ -3,7 +3,7 @@ module Admin
     layout "admin"
     def index
       @length = (params[:period] || 7).to_i
-      @labels = (0..@length - 1).map { |n| n.days.ago.strftime("%b %d") }.reverse
+      @labels = (1..@length).map { |n| n.days.ago.strftime("%b %d") }.reverse
       @analytics = Admin::ChartsData.new(@length).call
       @data_counts = Admin::DataCounts.call
     end

--- a/app/services/admin/charts_data.rb
+++ b/app/services/admin/charts_data.rb
@@ -5,7 +5,7 @@ module Admin
     end
 
     def call
-      period = @length.days.ago..Time.current
+      period = (@length + 1).days.ago..1.day.ago
       previous_period = (@length * 2).days.ago..@length.days.ago
 
       grouped_posts = Article.where(published_at: period).group("DATE(published_at)").size
@@ -13,7 +13,7 @@ module Admin
       grouped_reactions = Reaction.where(created_at: period).group("DATE(created_at)").size
       grouped_users = User.where(registered_at: period).group("DATE(registered_at)").size
 
-      days_range = (@length - 1).downto(0)
+      days_range = @length.downto(1)
       posts_values = days_range.map { |n| grouped_posts[n.days.ago.to_date] || 0 }
       comments_values = days_range.map { |n| grouped_comments[n.days.ago.to_date] || 0 }
       reactions_values = days_range.map { |n| grouped_reactions[n.days.ago.to_date] || 0 }

--- a/app/views/admin/overview/_analytics.html.erb
+++ b/app/views/admin/overview/_analytics.html.erb
@@ -61,7 +61,7 @@
           data-values="<%= values.join(",") %>"></canvas>
         <footer class="flex justify-between items-center fs-xs color-secondary">
           <span><%= @labels[0] %></span>
-          <span>Today</span>
+          <span>Yesterday</span>
         </footer>
       </div>
     <% end %>

--- a/spec/requests/admin/overview_spec.rb
+++ b/spec/requests/admin/overview_spec.rb
@@ -25,4 +25,82 @@ RSpec.describe "/admin", type: :request do
       expect(response.body).to include(ENV["HEROKU_RELEASE_CREATED_AT"])
     end
   end
+
+  describe "analytics" do
+    subject(:body) { response.body }
+
+    before do
+      Timecop.freeze("2019-04-30T12:00:00Z")
+      get admin_path
+    end
+
+    after { Timecop.return }
+
+    it { is_expected.to include("Analytics and trends") }
+    it { is_expected.to include("Yesterday") }
+    it { is_expected.to include("Apr 23") }
+
+    it "displays correct number of posts from past week" do
+      create(:article, published_at: Time.zone.today)
+      create(:article, published_at: 1.day.ago)
+      create(:article, published_at: 7.days.ago)
+      create(:article, published_at: 8.days.ago)
+      get admin_path
+
+      expect(body).to include "2</span> Posts"
+    end
+
+    it "displays correct number of comments from past week" do
+      create(:comment, created_at: Time.zone.today)
+      create(:comment, created_at: 1.day.ago)
+      create(:comment, created_at: 8.days.ago)
+      get admin_path
+
+      expect(body).to include "1</span> Comments"
+    end
+
+    it "displays correct number of reactions from past week" do
+      create(:reaction, created_at: Time.zone.today)
+      create(:reaction, created_at: 3.days.ago)
+      create(:reaction, created_at: 2.weeks.ago)
+      get admin_path
+
+      expect(body).to include "1</span> Reaction"
+    end
+
+    it "displays correct number of new members from past week" do
+      create(:user, registered_at: Time.zone.today)
+      create(:user, registered_at: 2.days.ago)
+      create(:user, registered_at: 10.days.ago)
+      get admin_path
+
+      expect(body).to include "1</span> New members"
+    end
+
+    it "does not display data from previous weeks", :aggregate_failures do
+      create(:article, published_at: 8.days.ago)
+      create(:comment, created_at: 2.weeks.ago)
+      create(:reaction, created_at: 1.month.ago)
+      create(:user, registered_at: 10.days.ago)
+      get admin_path
+
+      expect(body).to include "0</span> Posts"
+      expect(body).to include "0</span> Comments"
+      expect(body).to include "0</span> Reactions"
+      expect(body).to include "0</span> New members"
+    end
+
+    it "does not display data from today", :aggregate_failures do
+      create(:article, published_at: Time.zone.today)
+      create(:comment, created_at: Time.zone.today)
+      create(:reaction, created_at: Time.zone.today)
+      create(:user, registered_at: Time.zone.today)
+      get admin_path
+
+      expect(body).to include "0</span> Posts"
+      expect(body).to include "0</span> Comments"
+      expect(body).to include "0</span> Reactions"
+      expect(body).to include "0</span> New members"
+    end
+  end
 end

--- a/spec/services/admin/charts_data_spec.rb
+++ b/spec/services/admin/charts_data_spec.rb
@@ -9,13 +9,8 @@ RSpec.describe Admin::ChartsData, type: :service do
     expect(described_class.new.call.map(&:first)).to eq(["Posts", "Comments", "Reactions", "New members"])
   end
 
-  it "returns proper current period number" do
-    create_list(:article, 3, published_at: 4.days.ago)
-    expect(described_class.new.call.first.second).to eq(3)
-  end
-
   it "returns proper previous period number" do
-    create_list(:article, 2, published_at: 9.days.ago)
+    create_list(:article, 2, published_at: 8.days.ago)
     expect(described_class.new.call.first.third).to eq(2)
   end
 
@@ -23,4 +18,27 @@ RSpec.describe Admin::ChartsData, type: :service do
     expect(described_class.new(20).call.first.fourth.size).to eq(20)
   end
 
+  describe "current period" do
+    it "returns proper number of items" do
+      create(:article, published_at: Time.zone.today)
+      create_list(:article, 3, published_at: 4.days.ago)
+      create_list(:article, 2, published_at: 7.days.ago)
+      create(:article, published_at: 8.days.ago)
+
+      expect(described_class.new.call.first.second).to eq(5)
+    end
+
+    it "ignores today" do
+      create(:article, published_at: Time.zone.today)
+
+      expect(described_class.new.call.first.second).to eq(0)
+    end
+
+    it "goes back seven days by default" do
+      create(:article, published_at: 7.days.ago)
+      create(:article, published_at: 8.days.ago)
+
+      expect(described_class.new.call.first.second).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Stop displaying admin analytics for current day, as the data is incomplete. Instead, show analytics for any given period up to yesterday

## QA Instructions, Screenshots, Recordings
To QA this:
- go to `/admin`
- verify that analytics are displayed for a 7-day period leading up to "Yesterday"
- verify that the correct number of total Posts, Comments, Reactions and New Members are displayed
- verify that the chart displays the correct number of Posts, Comments, Reactions and New Members for each day

_Chart data_


https://user-images.githubusercontent.com/22390758/161431648-4be13b58-3330-4984-aa1b-cb2da8774dfb.mov


_Update post `published_at` date to show chart does not display data from today_

https://user-images.githubusercontent.com/22390758/161431611-9b316c8c-b96f-408f-80cf-de758cdc47d0.mov


### UI accessibility concerns?
This is a backend change with no impact on accessibility

## Added/updated tests?
- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?
![An empty circle described by comedian Demetri Martin as "a pie chart about procrastination"](https://25.media.tumblr.com/b25d1699b923d149c32b926c8f74a770/tumblr_mg2ncqe2GH1s2szdvo1_500.gif)
