### PR TITLE
Ensuring confirmation and flash message for spaces

### DIFF
--- a/app/controllers/admin/spaces_controller.rb
+++ b/app/controllers/admin/spaces_controller.rb
@@ -38,10 +38,10 @@ module Admin
 
       respond_to do |wants|
         wants.html do
-          redirect_to admin_spaces_path
+          redirect_to admin_spaces_path, notice: t("admin.spaces_controller.update_success")
         end
         wants.json do
-          render json: @space, status: :ok
+          render json: { message: t("admin.spaces_controller.update_success") }, status: :ok
         end
       end
     end

--- a/app/views/admin/spaces/index.html.erb
+++ b/app/views/admin/spaces/index.html.erb
@@ -27,7 +27,7 @@
     <div class="flex justify-between gap-8 items-start">
       <label for="space_limit_post_creation_to_admins">
         <p class="fw-medium">Make this space comment-only for members</p>
-        <p class="fs-s color-secondary">Only admins can publish posts.  Other members can only react to and comment on posts. Only admins will be able to post on behalf of organizations.</p>
+        <p class="fs-s color-secondary">Only admins can publish posts. Other members can only react to and comment on posts. Only admins will be able to post on behalf of organizations.</p>
       </label>
 
       <label class="c-toggle">

--- a/app/views/admin/spaces/index.html.erb
+++ b/app/views/admin/spaces/index.html.erb
@@ -12,8 +12,8 @@
     <p class="color-secondary fs-l">Configure permissions for your different types of posts.</p>
   </header>
 
-  <%# Note: there is javascript in play that is capturing the submission of the form and sending via XHR.  That will impact behavior. %>
-  <%= form_with model: @space, url: admin_space_path(@space), method: :put, class: "crayons-card p-6 flex flex-col gap-6" do |form| %>
+  <%# Note: With data remote false, we submit the form via a non-XHR request (e.g. boring old web). %>
+  <%= form_with model: @space, url: admin_space_path(@space), method: :put, data: { remote: false, confirm: "Are you sure?" }, class: "crayons-card p-6 flex flex-col gap-6" do |form| %>
     <div class="flex items-center gap-4">
       <span class="p-3 crayons-card shrink-0">
         <%= crayons_icon_tag(:folder) %>
@@ -27,7 +27,7 @@
     <div class="flex justify-between gap-8 items-start">
       <label for="space_limit_post_creation_to_admins">
         <p class="fw-medium">Make this space comment-only for members</p>
-        <p class="fs-s color-secondary">Once turned on, only admins can publish posts.  Other members can only react to and comment on posts. Only admins will be able to post on behalf of organizations.</p>
+        <p class="fs-s color-secondary">Only admins can publish posts.  Other members can only react to and comment on posts. Only admins will be able to post on behalf of organizations.</p>
       </label>
 
       <label class="c-toggle">

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -3,3 +3,5 @@ en:
   admin:
     extensions_controller:
       update_success: Extensions have been updated.
+    spaces_controller:
+      update_success: Space has been updated.

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -3,3 +3,5 @@ fr:
   admin:
     extensions_controller:
       update_success: Les extensions ont été mises à jour.
+    spaces_controller:
+      update_success: Space has been updated.

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -4,4 +4,4 @@ fr:
     extensions_controller:
       update_success: Les extensions ont été mises à jour.
     spaces_controller:
-      update_success: Space has been updated.
+      update_success: L'espace a été mis à jour.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix

## Description

This change delivers an accessible form, and while it doesn't remove the
Save button nor produce a modal it does deliver the minimum viable
functionality.

In conversations with Suzanne, we spent an hour looking at how we might
make an accessible modal with the checkbox and state management
required as we as removing save buttons.

There are two paths:

1. Extend the current, yet deprecated, stimulus modal controller.
2. Extend the Preact modal work done for the Members Detail View.

We spent about 15 minutes pursuing the stimulus modal controller route,
and realized how much cruft it added to the system.  Not ideal and very
opaque in it's interaction.

The second one we talked about, but for our alloted time was inadequate
to begin further work.  To deliver on that generalized preact modal will
require at least an afternoon of work.


## Related Tickets & Documents

Closes forem/forem#17032

## QA Instructions, Screenshots, Recordings

On this branch, spin up an instance.

1. `bin/rails runner "FeatureFlag.enable(:limit_post_creation_to_admins)"`. 
2. Login as Admin. 
3. Go to the Admin section.
4. Click on "Content Manager"
5. On the "Spaces" section, toggle the setting "Make this space comment-only for members".
6. Click "Save"

You should be prompted with a confirmation.  Confirm and you should see a flash message "Space has been updated."

### UI accessibility concerns?

This change improves accessibility by adding a browser based confirmation to an "impactful" action.

## Added/updated tests?

- [x] No, and this is why: adjusting how we render this

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
