### PR TITLE
Conditional rendering of "Create Post" link

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -130,10 +130,10 @@ function applyPolicyToggles(user) {
       const elements = document.getElementsByClassName(policy.dom_class);
       for (let i = 0; i < elements.length; i++) {
         const element = elements[i];
-        if (policy.forbidden) {
-          element.classList.add('hidden');
-        } else {
+        if (policy.visible) {
           element.classList.remove('hidden');
+        } else {
+          element.classList.add('hidden');
         }
       }
     });

--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -117,8 +117,8 @@ function setCurrentUserToNavBar(user) {
  * elements that present functionality available or not available to the given
  * user.
  *
- * @param {Object} user with a policies properties that is an array of objects.
- *        Each of those policy objects has a dom_class and forbidden property.
+ * @param {Object} user with a policies property that is an array of objects.
+ *        Each of those policy objects has a dom_class and visible property.
  *
  * A critical assumption is that we are not employing "security through
  * obscurity".  That is to say, if we accidentally show the link, the server

--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -110,9 +110,40 @@ function setCurrentUserToNavBar(user) {
   }
 }
 
+/**
+ * Responsible for hiding or showing elements that match each of the given user
+ * policies.  While this function is "oblivious" to what it's hiding, it
+ * coordinates between the rendered HTML and the user data to show or hide
+ * elements that present functionality available or not available to the given
+ * user.
+ *
+ * @param {Object} user with a policies properties that is an array of objects.
+ *        Each of those policy objects has a dom_class and forbidden property.
+ *
+ * A critical assumption is that we are not employing "security through
+ * obscurity".  That is to say, if we accidentally show the link, the server
+ * will enforce the correct policy.
+ */
+function applyPolicyToggles(user) {
+  if (user.policies) {
+    user.policies.forEach(function (policy) {
+      const elements = document.getElementsByClassName(policy.dom_class);
+      for (let i = 0; i < elements.length; i++) {
+        const element = elements[i];
+        if (policy.forbidden) {
+          element.classList.add('hidden');
+        } else {
+          element.classList.remove('hidden');
+        }
+      }
+    });
+  }
+}
+
 function initializeBaseUserData() {
   const user = userData();
   setCurrentUserToNavBar(user);
+  applyPolicyToggles(user);
   initializeProfileImage(user);
   addRelevantButtonsToArticle(user);
   addRelevantButtonsToComments(user);

--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -110,40 +110,9 @@ function setCurrentUserToNavBar(user) {
   }
 }
 
-/**
- * Responsible for hiding or showing elements that match each of the given user
- * policies.  While this function is "oblivious" to what it's hiding, it
- * coordinates between the rendered HTML and the user data to show or hide
- * elements that present functionality available or not available to the given
- * user.
- *
- * @param {Object} user with a policies property that is an array of objects.
- *        Each of those policy objects has a dom_class and visible property.
- *
- * A critical assumption is that we are not employing "security through
- * obscurity".  That is to say, if we accidentally show the link, the server
- * will enforce the correct policy.
- */
-function applyPolicyToggles(user) {
-  if (user.policies) {
-    user.policies.forEach(function (policy) {
-      const elements = document.getElementsByClassName(policy.dom_class);
-      for (let i = 0; i < elements.length; i++) {
-        const element = elements[i];
-        if (policy.visible) {
-          element.classList.remove('hidden');
-        } else {
-          element.classList.add('hidden');
-        }
-      }
-    });
-  }
-}
-
 function initializeBaseUserData() {
   const user = userData();
   setCurrentUserToNavBar(user);
-  applyPolicyToggles(user);
   initializeProfileImage(user);
   addRelevantButtonsToArticle(user);
   addRelevantButtonsToComments(user);

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -39,43 +39,11 @@ class AsyncInfoController < ApplicationController
   # @note The `user_cache_key` uses `current_user` and this method assumes `@user` which is a
   #       decorated version of the user.  It would be nice if we were using the same "variable" for
   #       the cache key and for that which we cache.
-  # rubocop:disable Metrics/BlockLength
   def user_data
     Rails.cache.fetch(user_cache_key, expires_in: 15.minutes) do
-      {
-        id: @user.id,
-        name: @user.name,
-        username: @user.username,
-        profile_image_90: @user.profile_image_url_for(length: 90),
-        followed_tags: @user.cached_followed_tags.to_json,
-        followed_podcast_ids: @user.cached_following_podcasts_ids,
-        reading_list_ids: @user.cached_reading_list_article_ids,
-        blocked_user_ids: UserBlock.cached_blocked_ids_for_blocker(@user.id),
-        saw_onboarding: @user.saw_onboarding,
-        checked_code_of_conduct: @user.checked_code_of_conduct,
-        checked_terms_and_conditions: @user.checked_terms_and_conditions,
-        display_sponsors: @user.display_sponsors,
-        display_announcements: @user.display_announcements,
-        trusted: @user.trusted?,
-        moderator_for_tags: @user.moderator_for_tags,
-        config_body_class: @user.config_body_class,
-        feed_style: feed_style_preference,
-        created_at: @user.created_at,
-        admin: @user.any_admin?,
-        policies: [
-          {
-            dom_class: ApplicationPolicy.dom_class_for(record: Article, query: :create?),
-            # Why forbidden and not authorized?  I want to "default" to optimistic rendering.  And
-            # the javascript is just a bit more tolerant if we "hide" a button when it's forbidden
-            # ELSE we show it.
-            forbidden: !policy(Article).create?
-          },
-        ],
-        apple_auth: @user.email.to_s.end_with?("@privaterelay.appleid.com")
-      }
+      AsyncInfo.to_hash(user: @user, context: self)
     end.to_json
   end
-  # rubocop:enable Metrics/BlockLength
 
   def user_is_a_creator
     @user.creator?

--- a/app/javascript/packs/applyApplicationPolicyToggles.js
+++ b/app/javascript/packs/applyApplicationPolicyToggles.js
@@ -1,0 +1,27 @@
+import { getUserDataAndCsrfToken } from '@utilities/getUserDataAndCsrfToken';
+/**
+ * Responsible for hiding or showing elements that match each of the given user
+ * policies.  While this function is "oblivious" to what it's hiding, it
+ * coordinates between the rendered HTML and the user data to show or hide
+ * elements that present functionality available or not available to the given
+ * user.
+ *
+ * A critical assumption is that we are not employing "security through
+ * obscurity".  That is to say, if we accidentally show the link, the server
+ * will enforce the correct policy.
+ */
+getUserDataAndCsrfToken().then(({ currentUser }) => {
+  if (currentUser.policies) {
+    currentUser.policies.forEach((policy) => {
+      const elements = document.getElementsByClassName(policy.dom_class);
+      for (let i = 0; i < elements.length; i++) {
+        const element = elements[i];
+        if (policy.visible) {
+          element.classList.remove('hidden');
+        } else {
+          element.classList.add('hidden');
+        }
+      }
+    });
+  }
+});

--- a/app/javascript/packs/applyApplicationPolicyToggles.js
+++ b/app/javascript/packs/applyApplicationPolicyToggles.js
@@ -14,8 +14,7 @@ getUserDataAndCsrfToken().then(({ currentUser }) => {
   if (currentUser.policies) {
     currentUser.policies.forEach((policy) => {
       const elements = document.getElementsByClassName(policy.dom_class);
-      for (let i = 0; i < elements.length; i++) {
-        const element = elements[i];
+      for (const element of elements) {
         if (policy.visible) {
           element.classList.remove('hidden');
         } else {

--- a/app/models/async_info.rb
+++ b/app/models/async_info.rb
@@ -52,10 +52,7 @@ class AsyncInfo
       policies: [
         {
           dom_class: ApplicationPolicy.dom_class_for(record: Article, query: :create?),
-          # Why forbidden and not authorized?  I want to "default" to optimistic rendering.  And
-          # the javascript is just a bit more tolerant if we "hide" a button when it's forbidden
-          # ELSE we show it.
-          forbidden: !allow(record: Article, query: :create?)
+          visible: visible?(record: Article, query: :create?)
         },
       ],
       apple_auth: user.email.to_s.end_with?("@privaterelay.appleid.com")
@@ -69,7 +66,7 @@ class AsyncInfo
   # @return [TrueClass] if policy allows the given query on the given record
   # @return [FalseClass] if policy raises Pundit::NotAuthorizedError
   # @return [FalseClass] if policy does not allow the given query on the given record
-  def allow(record:, query:)
+  def visible?(record:, query:)
     context.__send__(:policy, record).public_send(query)
   rescue Pundit::NotAuthorizedError
     false

--- a/app/models/async_info.rb
+++ b/app/models/async_info.rb
@@ -1,0 +1,77 @@
+# Responsible for generating the asynchronus data of a user.  This is data that we send on the wire
+# to the application for much of its user specific client-side rendering.
+#
+# @see AsyncInfoController#user_data
+# @see UserDecorator
+# @see ApplicationPolicy
+class AsyncInfo
+  # @api public
+  #
+  # Generate a Hash of the relevant user data.
+  #
+  # @param user [User, UserDecorator]
+  # @param context [ApplicationController]
+  # @return [Hash<Symbol,Object>]
+  #
+  # @see ApplicationController#feed_style_preference
+  #
+  # @todo The given feed_style_prefernce could be extracted to the user decorator.  We would need to
+  #       account for a nil current user in our view logic.
+  def self.to_hash(user:, context:)
+    new(user: user, context: context).to_hash
+  end
+
+  def initialize(user:, context:)
+    @user = user.decorate
+    @context = context
+  end
+
+  attr_reader :user, :context
+
+  def to_hash
+    {
+      id: user.id,
+      name: user.name,
+      username: user.username,
+      profile_image_90: user.profile_image_url_for(length: 90),
+      followed_tags: user.cached_followed_tags.to_json,
+      followed_podcast_ids: user.cached_following_podcasts_ids,
+      reading_list_ids: user.cached_reading_list_article_ids,
+      blocked_user_ids: UserBlock.cached_blocked_ids_for_blocker(user.id),
+      saw_onboarding: user.saw_onboarding,
+      checked_code_of_conduct: user.checked_code_of_conduct,
+      checked_terms_and_conditions: user.checked_terms_and_conditions,
+      display_sponsors: user.display_sponsors,
+      display_announcements: user.display_announcements,
+      trusted: user.trusted?,
+      moderator_for_tags: user.moderator_for_tags,
+      config_body_class: user.config_body_class,
+      feed_style: feed_style_preference,
+      created_at: user.created_at,
+      admin: user.any_admin?,
+      policies: [
+        {
+          dom_class: ApplicationPolicy.dom_class_for(record: Article, query: :create?),
+          # Why forbidden and not authorized?  I want to "default" to optimistic rendering.  And
+          # the javascript is just a bit more tolerant if we "hide" a button when it's forbidden
+          # ELSE we show it.
+          forbidden: !allow(record: Article, query: :create?)
+        },
+      ],
+      apple_auth: user.email.to_s.end_with?("@privaterelay.appleid.com")
+    }
+  end
+
+  private
+
+  delegate :feed_style_preference, to: :context
+
+  # @return [TrueClass] if policy allows the given query on the given record
+  # @return [FalseClass] if policy raises Pundit::NotAuthorizedError
+  # @return [FalseClass] if policy does not allow the given query on the given record
+  def allow(record:, query:)
+    context.__send__(:policy, record).public_send(query)
+  rescue Pundit::NotAuthorizedError
+    false
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -91,6 +91,32 @@ class ApplicationPolicy
     raise ApplicationPolicy::UserRequiredError, I18n.t("policies.application_policy.you_must_be_logged_in")
   end
 
+  # This method provides a means for creating a consistent DOM class for "policy" related HTML elements.
+  #
+  # @param record [Object] what object are we testing our policy?
+  # @param query [String,Symbol] what query are we asking of the object's corresponding policy?
+  #
+  # @note This method's signature maps to pundit's `policy` helper method and the implicit chained
+  #       call (e.g. `policy(Article).create?`)
+  #
+  # @see Pundit::Authorization.policy pundit's #policy helper method
+  #
+  # @return [String] a dom class compliant string, see the corresponding specs for expected values.
+  def self.dom_class_for(record:, query:)
+    fragments = %w[js policy]
+    case record
+    when Symbol
+      fragments << record.to_s.underscore
+    when Class
+      fragments << record.model_name.name.underscore
+    when ActiveRecord::Base
+      fragments << record.model_name.name.underscore
+      fragments << (record.id.presence || "new")
+    end
+    fragments << query.to_s.underscore.delete("?").to_s
+    fragments.join("-")
+  end
+
   # @param user [User] who's the one taking the action?
   #
   # @param record [Class, Object] what is the user acting on?  This could be a model (e.g. Article)

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -18,7 +18,7 @@
     <li>
       <a href="<%= mod_path %>" class="c-link c-link--block trusted-visible-block"><%= t("views.main.nav.moderator_center") %></a>
     </li>
-    <li>
+    <li class="<%= ApplicationPolicy.dom_class_for(record: Article, query: :create?) %>">
       <a href="<%= new_path %>" class="c-link c-link--block"><%= t("views.main.create_post") %></a>
     </li>
     <li>

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -18,7 +18,7 @@
     <li>
       <a href="<%= mod_path %>" class="c-link c-link--block trusted-visible-block"><%= t("views.main.nav.moderator_center") %></a>
     </li>
-    <li class="<%= ApplicationPolicy.dom_class_for(record: Article, query: :create?) %>">
+    <li class="<%= ApplicationPolicy.dom_class_for(record: Article, query: :create?) %> hidden">
       <a href="<%= new_path %>" class="c-link c-link--block"><%= t("views.main.create_post") %></a>
     </li>
     <li>

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -33,3 +33,4 @@
     </li>
   </ul>
 </div>
+<%= javascript_packs_with_chunks_tag "applyApplicationPolicyToggles", defer: true %>.

--- a/cypress/integration/seededFlows/policyFlows/limitPostCreationToAdmins.spec.js
+++ b/cypress/integration/seededFlows/policyFlows/limitPostCreationToAdmins.spec.js
@@ -1,0 +1,27 @@
+/**
+   This is to verify visibility of buttons.  The authorization tests are
+   asserted in their corresponding policy tests.
+  */
+describe('Limit Post Creation to Admins', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.fixture('users/articleEditorV1User.json').as('user');
+    cy.enableFeatureFlag('limit_post_creation_to_admins');
+    cy.get('@user').then((user) => {
+      cy.loginAndVisit(user, '/');
+    });
+  });
+
+  it('clicking on User Avatar should open User Dropdown menu and no Create Post is visible', () => {
+    // TODO: If we go with the approach in this commit, then we should test the
+    // "Create Button" that's on the nav bar but not in the drop down.
+
+    cy.findByRole('button', { name: 'Navigation menu' }).as('menuButton');
+    cy.get('@menuButton')
+      .should('have.attr', 'aria-expanded', 'false')
+      .click()
+      .should('have.attr', 'aria-expanded', 'true');
+
+    cy.findByRole('link', { name: 'Create Post' }).should('not.exist');
+  });
+});

--- a/cypress/integration/seededFlows/policyFlows/limitPostCreationToAdmins.spec.js
+++ b/cypress/integration/seededFlows/policyFlows/limitPostCreationToAdmins.spec.js
@@ -17,10 +17,16 @@ describe('Limit Post Creation to Admins', () => {
     // "Create Button" that's on the nav bar but not in the drop down.
 
     cy.findByRole('button', { name: 'Navigation menu' }).as('menuButton');
-    cy.get('@menuButton')
+  cy.get('@menuButton')
       .should('have.attr', 'aria-expanded', 'false')
       .click()
       .should('have.attr', 'aria-expanded', 'true');
+
+    cy.findByRole('link', {
+      name: 'Article Editor v1 User @article_editor_v1_user',
+    }).should('exist');
+
+    cy.findByRole('link', { name: 'Create Post' }).should('not.exist');
 
     cy.findByRole('link', { name: 'Create Post' }).should('not.exist');
   });

--- a/spec/models/async_info_spec.rb
+++ b/spec/models/async_info_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe AsyncInfo do
+  describe "#to_hash_for" do
+    subject(:async_info) { described_class.to_hash(user: user, context: context) }
+
+    let(:user) { create(:user) }
+    let(:feed_style_preference) { Settings::UserExperience.feed_style }
+    let(:context) { AsyncInfoController.new }
+
+    # Because of edge caching considerations, I'm short-circuiting that check.  For the applicable
+    # controller, we should always have an authenticated user and it is not edge cached.
+    before { allow(context).to receive(:current_user).and_return(user) }
+
+    it "has a policies key with an array of policies" do
+      policies = async_info.fetch(:policies)
+      expect(policies.length).to be > 0
+
+      # All policy keys will have dom_class and forbidden
+      expect(policies.map(&:keys).uniq).to eq([%i[dom_class forbidden]])
+    end
+  end
+end

--- a/spec/models/async_info_spec.rb
+++ b/spec/models/async_info_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AsyncInfo do
       expect(policies.length).to be > 0
 
       # All policy keys will have dom_class and forbidden
-      expect(policies.map(&:keys).uniq).to eq([%i[dom_class forbidden]])
+      expect(policies.map(&:keys).uniq).to eq([%i[dom_class visible]])
     end
   end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe ApplicationPolicy do
   end
   # rubocop:enable RSpec/DescribedClass
 
+  describe ".dom_class_for" do
+    [
+      [Article, :create?, "js-policy-article-create"],
+      [:Article, :create?, "js-policy-article-create"],
+      # Note the underscore for WorkerBee
+      [:WorkerBee, :create?, "js-policy-worker_bee-create"],
+      [Article.new(id: 5), :create, "js-policy-article-5-create"],
+      [Article.new, :create, "js-policy-article-new-create"],
+    ].each do |record, query, expected|
+      context "when record=#{record.inspect} and query=#{query.inspect}" do
+        subject { described_class.dom_class_for(record: record, query: query) }
+
+        let(:record) { record }
+        let(:query) { query }
+
+        it { is_expected.to eq(expected) }
+      end
+    end
+  end
+
   describe "require_user_in_good_standing!" do
     subject(:method_call) { described_class.require_user_in_good_standing!(user: user) }
 


### PR DESCRIPTION
This PR builds on the conversation from forem/forem#17056 and moves in a
slightly different direction.

Important in all of this is that the ability to create a post is
enforced on the server.  If the "Create Post" button were to be visible
but the user couldn't create a post when they clicked the button, they
would get an authorization error (or some such response).

This PR posits a different and perhaps competing approach to
forem/forem#16606.  This PR provides a general approach in which we add
class attributes in our HTML erb files.

Note: I have not included Cypress tests as I don't want to yet commit
that time.  I'm also wondering if this is the "right" thing to do.  I
definitely think we want to add some JS tests.  But could we do JS and
unit tests?  (How do we reach consensus regarding our test approach?)

Again, thank you for the conversation and expect an even more "complete"
PR after we have our discussion.
