### PR TITLE
Reducing subtle duplication of effort/logic

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -497,17 +497,6 @@ class User < ApplicationRecord
     monthly_dues.positive?
   end
 
-  def resave_articles
-    articles.find_each do |article|
-      if article.path
-        cache_bust = EdgeCache::Bust.new
-        cache_bust.call(article.path)
-        cache_bust.call("#{article.path}?i=i")
-      end
-      article.save
-    end
-  end
-
   def profile_image_90
     profile_image_url_for(length: 90)
   end

--- a/app/workers/users/resave_articles_worker.rb
+++ b/app/workers/users/resave_articles_worker.rb
@@ -8,7 +8,7 @@ module Users
       user = User.find_by(id: user_id)
       return unless user
 
-      user.resave_articles
+      user.articles.find_each(&:save)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

Prior to this commit, when we change attributes for a user we might
resave each article.  The purpose of the resave is to update some of the
cached attributes of an article.

This removes some redundant code.  The following removed code has
an `article.save` call.  Which, the callbacks in the article (see below)
already clear the cache.

```ruby
def resave_articles
  articles.find_each do |article|
    if article.path
      cache_bust = EdgeCache::Bust.new
      cache_bust.call(article.path)
      cache_bust.call("#{article.path}?i=i")
    end
    article.save
  end
end
```

https://github.com/forem/forem/blob/8e6981aac59e86a9a2c69db1e50fb1119f509c8d/app/models/article.rb#L164

https://github.com/forem/forem/blob/8e6981aac59e86a9a2c69db1e50fb1119f509c8d/app/models/article.rb#L881-L888


## Related Tickets & Documents

This was discovered in triaging forem/forem#17041

## QA Instructions, Screenshots, Recordings

None, our tests cover this.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: existing tests cover the behavior

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
