### PR TITLE
Removing unused instance_variable

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,7 +11,6 @@ class CommentsController < ApplicationController
   # GET /comments.json
   def index
     skip_authorization
-    @on_comments_page = true
     @comment = Comment.new
     @podcast = Podcast.find_by(slug: params[:username])
 
@@ -143,7 +142,6 @@ class CommentsController < ApplicationController
       # cache.
       #
       # https://github.com/forem/forem/issues/10338#issuecomment-693401481
-      @on_comments_page = true
       @root_comment = @comment
       @commentable = @comment.commentable
       @commentable_type = @comment.commentable_type


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

While reviewing the authorization system, I saw a curious instance
variable and wanted to know more about it.  Turns out, it's no longer
referenced.

`$ rg "on_comments_page"` exits status 1 (e.g. no matches)

## Related Tickets & Documents

None.

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: Removing code.

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Removing unused variable
