### PR TITLE
Favoring explicit declaration over inferrence

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -7,6 +7,10 @@ module Api
 
       respond_to :json
 
+      # Informs the application that all actions taking by this controller (and it's subclasses) are
+      # considered an api_action.
+      self.api_action = true
+
       rescue_from ActionController::ParameterMissing do |exc|
         error_unprocessable_entity(exc.message)
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,6 +51,25 @@ class ApplicationController < ActionController::Base
   ].freeze
   private_constant :CONTENT_CHANGE_PATHS
 
+  # @!scope class
+  # @!attribute [w] api_action
+  #   If set to true, all actions on the class (and subclasses) will be considered "api_actions"
+  #
+  #   @param input [Boolean]
+  #   @see ApplicationController#api_action?
+  #   @see ApplicationController#verify_private_forem
+  #   @see https://api.rubyonrails.org/classes/Class.html#method-i-class_attribute Class.class_attribute
+  class_attribute :api_action, default: false, instance_writer: false
+
+  # @!scope instance
+  # @!attribute [r] api_action?
+  #   By default, all actions are *not* an `api_action?`
+  #   @return [TrueClass] if the current requested action is for the API
+  #   @return [FalseClass] if the current requested action is not part of the API
+  #   @see Api::V0::ApiController
+  #   @see ApplicationController.api_action
+  #   @see ApplicationController#verify_private_forem
+
   def verify_private_forem
     return if controller_name.in?(PUBLIC_CONTROLLERS)
     return if self.class.module_parent.to_s == "Admin"
@@ -209,10 +228,6 @@ class ApplicationController < ActionController::Base
 
   def anonymous_user
     User.new(ip_address: request.env["HTTP_FASTLY_CLIENT_IP"] || request.env["HTTP_X_FORWARDED_FOR"])
-  end
-
-  def api_action?
-    self.class.to_s.start_with?("Api::")
   end
 
   def initialize_stripe


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Documentation Update

## Description

This commit does three things:

1. Documents a method
3. Implies the question: "Do we want to use class_attribute in Forem's codebase?"
2. Switches from an inferrence to an explicit (and configurable)

In my experience, I want to favor "explicit" declarations instead of
inferring what they should be.  In this case, the inferrence is perhaps
adequate.  But as I look to `ApplicationController::PUBLIC_CONTROLLERS`,
I think that is a prime case for a `class_attribute`.  (The `api_action`
happened to be the lowest hanging fruit to begin the conversation.)

We still need some clarity into the `verify_private_forem` method as it
looks like it's doing a few different things.

There is precedence for using `class_attribute` found in
[`UniqueCrossModelSlugValidator.model_and_attribute_name_for_uniqueness_test`][1] (also
introduced by me).

[1]:https://github.com/forem/forem/blob/main/app/validators/unique_cross_model_slug_validator.rb

## Related Tickets & Documents

None.

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: this is a no-op change.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
