### PR TITLE
Removing uncalled method ✂✂✂

### DIFF
--- a/app/liquid_tags/poll_tag.rb
+++ b/app/liquid_tags/poll_tag.rb
@@ -120,12 +120,6 @@ class PollTag < LiquidTagBase
     )
   end
 
-  def find_poll(id_code)
-    Poll.find(id_code.to_i(26))
-  rescue ActiveRecord::RecordNotFound
-    raise StandardError, I18n.t("liquid_tags.poll_tag.invalid_poll_id")
-  end
-
   def self.script
     SCRIPT
   end

--- a/config/locales/liquid_tags/en.yml
+++ b/config/locales/liquid_tags/en.yml
@@ -64,8 +64,6 @@ en:
       invalid_parler_url: Invalid Parler URL
     podcast_tag:
       invalid_podcast_link: Invalid podcast link
-    poll_tag:
-      invalid_poll_id: Invalid poll ID
     reddit_tag:
       invalid_reddit_link: 'Invalid Reddit link: %{url}'
     replit_tag:

--- a/config/locales/liquid_tags/fr.yml
+++ b/config/locales/liquid_tags/fr.yml
@@ -64,8 +64,6 @@ fr:
       invalid_parler_url: Invalid Parler URL
     podcast_tag:
       invalid_podcast_link: Invalid podcast link
-    poll_tag:
-      invalid_poll_id: Invalid poll ID
     reddit_tag:
       invalid_reddit_link: 'Invalid Reddit link: %{url}'
     replit_tag:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Introduced in forem/forem#3176, it appears that this method has been
along for the ride.

How did I find this?  I saw an exception and realized that we cast our
comment IDs from base-26 integer format to base-10.  I decided to look
through our code for `/\.to_\w\(26\)/` and stumbled upon the now removed
instance.

Quickly looking at the code, it appeared that this method was never
called.

So ✂✂✂

## Related Tickets & Documents

Barely related to forem/forem#3176

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [X] No, and this is why: removing an uncalled method.

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Removing an uncalled method.
