### PR TITLE
Conditionally rendering "Search > My Posts" by policy

### DIFF
--- a/app/views/stories/articles_search/_nav_menu.html.erb
+++ b/app/views/stories/articles_search/_nav_menu.html.erb
@@ -14,7 +14,9 @@
   <li><a class="query-filter-button crayons-navigation__item" data-filter="class_name:Comment" href="javascript:;">
     <%= t("views.search.nav.comments") %>
   </a></li>
+  <% if policy(Article).has_existing_articles_or_can_create_new_ones? %>
   <li><a class="query-filter-button my-posts-query-button crayons-navigation__item" data-filter="MY_POSTS" href="javascript:;">
     <%= t("views.search.nav.my_posts") %>
   </a></li>
+  <% end %>
 </ul>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

When a user does not have any posts NOR can they create posts, we are to
hide the "Search > My Posts" section.

I have chosen not to write a test for this as it's exercising a well
tested policy and we don't have a unit test for this view.  As part of
forem/forem#17076 I introduced some cypress tests.  But that feels like
quite a bit of overkill for this feature.


## Related Tickets & Documents

Closes forem/forem#16837
Related to forem/forem#16821

## QA Instructions, Screenshots, Recordings

To verify this behavior, I:

1. Enabled ran `bin/rails runner "FeatureFlag.enable(:limit_post_creation_to_admins)"`
2. Found a non-admin user in my local instance (e.g. `bin/rails console` and kept this open)
3. Launched the application (via `bin/startup`)
4. Went to `http://localhost:3000` and logged in as the above mentioned user.
5. I filled in the "Search" section, submitting the search.
6. On the left navigation there was a "My Posts" section.
7. Now back in the console, destroy all of the user's published articles (e.g. `user.articles.published.destroy_all`)
8. Refresh the page, the "My Posts" left nav is gone.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: See inline notes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
