### PR TITLE
Deleting matched async info when space updates

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -1,6 +1,8 @@
 class AsyncInfoController < ApplicationController
   # No pundit policy. All actions are unrestricted.
 
+  ASYNC_INFO_CACHE_KEY_PREFIX = "user-info".freeze
+
   def base_data
     flash.discard(:notice)
     unless user_signed_in?
@@ -68,7 +70,7 @@ class AsyncInfoController < ApplicationController
   end
 
   def user_cache_key
-    "user-info-#{current_user&.id}__
+    "#{ASYNC_INFO_CACHE_KEY_PREFIX}-#{current_user&.id}__
     #{current_user&.last_sign_in_at}__
     #{current_user&.following_tags_count}__
     #{current_user&.last_followed_at}__

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -6,6 +6,8 @@
 #
 # @note This class exists to assist with authorization and exposing an "ActiveModel" compliant
 #       interface for form work.
+#
+# @see AsyncInfoController#base_data for impact.
 class Space
   # ...the final frontier.
   include ActiveModel::Model
@@ -31,6 +33,8 @@ class Space
     else
       FeatureFlag.disable(:limit_post_creation_to_admins)
     end
+
+    Users::BustCacheForSpaceChangeWorker.perform
 
     # I want to ensure that we're returning true, to communicate that the "save" was successful.
     true

--- a/app/workers/users/bust_cache_for_space_change_worker.rb
+++ b/app/workers/users/bust_cache_for_space_change_worker.rb
@@ -1,0 +1,14 @@
+module Users
+  # Conditionally delete the async cache when a Space changes
+  #
+  # @note Good news for those of you using Redis as your cache store, you have access to `Rails.cache.delete_matched`
+  #
+  # @see https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html#method-i-delete_matched
+  class BustCacheForSpaceChangeWorker < BustCacheBaseWorker
+    def perform
+      return unless Rails.cache.respond_to?(:delete_matched)
+
+      Rails.cache.delete_matched("^#{AsyncInfoController::ASYNC_INFO_CACHE_KEY_PREFIX}-")
+    end
+  end
+end

--- a/app/workers/users/bust_cache_for_space_change_worker.rb
+++ b/app/workers/users/bust_cache_for_space_change_worker.rb
@@ -8,7 +8,7 @@ module Users
     def perform
       return unless Rails.cache.respond_to?(:delete_matched)
 
-      Rails.cache.delete_matched("^#{AsyncInfoController::ASYNC_INFO_CACHE_KEY_PREFIX}-")
+      Rails.cache.delete_matched("#{AsyncInfoController::ASYNC_INFO_CACHE_KEY_PREFIX}-*")
     end
   end
 end

--- a/spec/workers/users/bust_cache_for_space_change_worker_spec.rb
+++ b/spec/workers/users/bust_cache_for_space_change_worker_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Users::BustCacheForSpaceChangeWorker, type: :worker do
+  let(:worker) { subject }
+
+  before { allow(Rails.cache).to receive(:delete_matched).and_call_original }
+
+  include_examples "#enqueues_on_correct_queue", "high_priority", 1
+
+  it "deletes matched cache keys" do
+    worker.perform
+    expect(Rails.cache).to have_received(:delete_matched)
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

I don't know if this is a good idea, but I'm relying on those with more
knowledge about such things to give this a thumbs-up or thumbs-down.

Assuming we merge forem/forem#17113, without deleting the user async
info cache, we would have a 15 minute (or less) interval when the site's
client-side rendered links would not reflect the server-sides non-cached
state.

## Related Tickets & Documents

- Related Issue forem/forem#17113

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
