### PR TITLE
Tweak crayons layout for admin section

### DIFF
--- a/app/assets/stylesheets/base/layout.scss
+++ b/app/assets/stylesheets/base/layout.scss
@@ -192,6 +192,17 @@
   }
 }
 
+// Unlike the main app, in the admin area we only break into 2 side-by-side columns at large breakpoint,
+// to allow more real estate for data tables
+.crayons-layout--admin-2-cols {
+  @media (min-width: $breakpoint-l) {
+    --layout: var(--layout-sidebar-left-width) var(--layout-content-width);
+    --layout-sidebar-left-width: 240px;
+    --layout-content-width: 1fr;
+    --layout-gap: var(--su-4);
+  }
+}
+
 // Temporary solution for sidebar on mobile
 .crayons-layout__sidebar-left,
 .crayons-layout__sidebar-right {

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -59,7 +59,7 @@
     </div>
   </header>
 
-  <div class="crayons-layout crayons-layout--2-cols">
+  <div class="crayons-layout crayons-layout--admin-2-cols">
     <div class="admin__left-sidebar crayons-layout__left-sidebar" data-controller="sidebar" data-action="load@window->sidebar#disableCurrentNavItem">
       <%= render "admin/shared/nested_sidebar", menu_items: AdminMenu.navigation_items %>
     </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature


## Description

We had [a discussion in the Admin Experience pod](https://forem-team.slack.com/archives/C01S4QZUDNC/p1648562796522479) around our layout breakpoints for the admin area. This PR implements the agreed change - we now only enter the 2 column view at the **large** breakpoint (before this happened at 'medium', same as the user-facing section of the app). This gives us more UI space for the data-centric views we present in the admin area.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

Discussion on this was prompted by https://github.com/forem/forem/issues/16935

## QA Instructions, Screenshots, Recordings

- On the home page (`/`), adjust your browser size from smallest to larger, just enough to enter the 2 column layout , e.g.

![home page with two columns](https://user-images.githubusercontent.com/20773163/161730571-e6ce6da6-20c4-41cd-8223-3100d528211f.png)

- Now visit the admin area, keeping your browser the same size. The admin overview page should appear in a single column layout, e.g.

![admin overview page with 1 column](https://user-images.githubusercontent.com/20773163/161730694-c4a53252-289c-44a6-987a-fec4084757a6.png)

- If you continue to increase your window size, you should eventually see the 2 column layout

### UI accessibility concerns?

This change is to help users more easily consume the data-heavy content in the admin area, so it's more of a general UX benefit

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: cosmetic only
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [X] This change does not need to be communicated, and this is why not: it's very minor, especially given most of our admin views are not yet optimised for smaller screens


