### PR TITLE
Ensuring users can preview already published posts

### DIFF
--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -168,10 +168,10 @@ class ArticlePolicy < ApplicationPolicy
 
   alias edit? update?
 
-  # [@jeremyf] I made a decision to compress preview? into create?  However, someone editing a post
-  # should also be able to preview?  Perhaps it would make sense to be "preview? is create? ||
-  # update?".
-  alias preview? create?
+  # The ArticlesController#preview method is very complicated but aspirationally, we want to ensure
+  # that someone can preview an article of their if they already have a published article or they
+  # can create new ones.
+  alias preview? has_existing_articles_or_can_create_new_ones?
 
   def permitted_attributes
     %i[title body_html body_markdown main_image published canonical_url

--- a/spec/policies/article_policy_spec.rb
+++ b/spec/policies/article_policy_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ArticlePolicy do
     it { is_expected.to be_truthy }
   end
 
-  %i[create? new? preview?].each do |method_name|
+  %i[create? new?].each do |method_name|
     describe "##{method_name}" do
       let(:policy_method) { method_name }
 
@@ -63,32 +63,34 @@ RSpec.describe ArticlePolicy do
     end
   end
 
-  describe "#has_existing_articles_or_can_create_new_ones?" do
-    let(:policy_method) { :has_existing_articles_or_can_create_new_ones? }
+  %i[preview? has_existing_articles_or_can_create_new_ones?].each do |method_name|
+    describe method_name.to_s do
+      let(:policy_method) { method_name }
 
-    it_behaves_like "permitted roles", to: %i[anyone], limit_post_creation_to_admins?: false
-    it_behaves_like "permitted roles", to: %i[super_admin admin], limit_post_creation_to_admins?: true
-    it_behaves_like "disallowed roles", to: %i[anyone], limit_post_creation_to_admins?: true
+      it_behaves_like "permitted roles", to: %i[anyone], limit_post_creation_to_admins?: false
+      it_behaves_like "permitted roles", to: %i[super_admin admin], limit_post_creation_to_admins?: true
+      it_behaves_like "disallowed roles", to: %i[anyone], limit_post_creation_to_admins?: true
 
-    context "when user has published articles" do
-      before do
-        create(:article, published: true, user: user)
+      context "when user has published articles" do
+        before do
+          create(:article, published: true, user: user)
+        end
+
+        # Below are two scenarios: one with limit_post_creation_to_admins? as true and the other as
+        # limit_post_creation_to_admins? as false.  In both cases, when the user has published
+        # articles, it doesn't matter if they can create an article or not, the
+        # `has_existing_articles_or_can_create_new_ones?` should return true (which is what the
+        # "permitted roles" shared spec verifies).
+        it_behaves_like "permitted roles", to: %i[anyone], limit_post_creation_to_admins?: false
+        it_behaves_like "permitted roles", to: %i[anyone], limit_post_creation_to_admins?: true
       end
 
-      # Below are two scenarios: one with limit_post_creation_to_admins? as true and the other as
-      # limit_post_creation_to_admins? as false.  In both cases, when the user has published
-      # articles, it doesn't matter if they can create an article or not, the
-      # `has_existing_articles_or_can_create_new_ones?` should return true (which is what the
-      # "permitted roles" shared spec verifies).
-      it_behaves_like "permitted roles", to: %i[anyone], limit_post_creation_to_admins?: false
-      it_behaves_like "permitted roles", to: %i[anyone], limit_post_creation_to_admins?: true
-    end
+      context "when user has no published articles" do
+        before { user.articles.delete_all }
 
-    context "when user has no published articles" do
-      before { user.articles.delete_all }
-
-      it_behaves_like "permitted roles", to: %i[anyone], limit_post_creation_to_admins?: false
-      it_behaves_like "disallowed roles", to: %i[anyone], limit_post_creation_to_admins?: true
+        it_behaves_like "permitted roles", to: %i[anyone], limit_post_creation_to_admins?: false
+        it_behaves_like "disallowed roles", to: %i[anyone], limit_post_creation_to_admins?: true
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Pre-emptive Bug Fix

## Description

Prior to this commit

This would have been a bug, if someone had:

1. Toggled on the :limit_post_creation_to_admins feature flag
2. Wasn't an admin
3. Already had a published post
4. Went to edit the post and attempted to preview it

## Related Tickets & Documents

Related to the following issues:

- forem/forem#16908
- forem/forem#16944
- forem/forem#16837
- forem/forem#16942

## QA Instructions, Screenshots, Recordings

None, though I suppose you could try to create this bug with the above steps.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
