### PR TITLE
Expect to raise error should use a block

### DIFF
--- a/spec/requests/admin/reactions_spec.rb
+++ b/spec/requests/admin/reactions_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "/admin/reactions", type: :request do
         put admin_reaction_path(reaction.id), params: { id: reaction.id, status: "confirmed" }
       end
 
-      expect(invalid_request).to raise_error(Pundit::NotAuthorizedError)
+      expect { invalid_request.call }.to raise_error(Pundit::NotAuthorizedError)
     end
   end
 end

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -27,17 +27,17 @@ RSpec.describe AnalyticsService, type: :service do
 
   describe "initialization" do
     it "raises an error if start date is invalid" do
-      expect(-> { described_class.new(user, start_date: "2000-") }).to raise_error(ArgumentError)
+      expect { described_class.new(user, start_date: "2000-") }.to raise_error(ArgumentError)
     end
 
     it "raises an error if end date is invalid" do
-      expect(-> { described_class.new(user, end_date: "2000-") }).to raise_error(ArgumentError)
+      expect { described_class.new(user, end_date: "2000-") }.to raise_error(ArgumentError)
     end
 
     it "raises an error if an article does not belong to the user" do
       other_user = create(:user)
       article = create(:article, user: other_user)
-      expect(-> { described_class.new(user, article_id: article.id) }).to raise_error(ArgumentError)
+      expect { described_class.new(user, article_id: article.id) }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is kind of pedantic, since we _had_ been using a lambda, and
calling as a value. Now explicitly call the proc in a block and expect
the block to raise error.


## QA Instructions, Screenshots, Recordings

On main the request example produces the following warning:

```
The implicit block expectation syntax is deprecated, you should pass a block rather 
than an argument to `expect` to use the provided block expectation matcher or the 
matcher must implement `supports_value_expectations?`. e.g  
`expect { value }.to raise Pundit::NotAuthorizedError` 
not `expect(value).to raise Pundit::NotAuthorizedError`


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total
```

Running the same test on this branch should pass, and show no deprecation warnings.

A similar warning was seen 3 times for the analytics service spec and now should be silenced.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: cleanup

