### PR TITLE
Conditionally hide Create Post from Tag page

### DIFF
--- a/app/views/stories/tagged_articles/_sidebar.html.erb
+++ b/app/views/stories/tagged_articles/_sidebar.html.erb
@@ -3,7 +3,7 @@
     <div class="sidebar-bg" id="sidebar-bg-left"></div>
     <aside class="side-bar">
       <% if @tag && @tag.rules_html.present? %>
-        <div class="widget">
+        <div class="widget <%= ApplicationPolicy.dom_class_for(record: Article, query: :create?) %> hidden">
           <header>
             <h4><%= t("views.tags.sidebar.guidelines") %></h4>
           </header>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Some tags allow for folks to Create a Post from that tag.  This will
conditionally hide that section.

The first line of `app/views/stories/tagged_articles/_sidebar.html.erb`
shows that we're caching the fragment based on the user being signed
in.  So we need to use server side "hide/show" of this section.

```html
<% cache "tag-sidebar-#{@tag.name}-#{@tag&.updated_at}-#{@tag&.taggings_count}-#{user_signed_in?}-#{@page}", expires_in: 5.hours do %>
```

This does create what I suspect will be a "Cumulative Layout
Shift (CLS)".  To visually test, we need to modify our data.

In the Rails console:

```ruby
tag = Tag.first
tag.update(rules_markdown: "Some Rule")
tag.name
```

Then, with the app running for this branch, go to `https://localhost:3000/t/<tag-name>`.


## Related Tickets & Documents

Closes forem/forem#16836

## QA Instructions, Screenshots, Recordings

See above for remediating the CLS.

### UI accessibility concerns?

Gonna need some help with CLS.

## Added/updated tests?

- [x] No, and this is why:

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
