### PR TITLE
Narrowing when we apply "hidden" by policy attributes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -372,4 +372,32 @@ module ApplicationHelper
     creator = User.with_role(:creator).first
     !creator.checked_code_of_conduct && !creator.checked_terms_and_conditions
   end
+
+  # This function is responsible for adding a policy class (and possibly the hidden class).  It's
+  # applying some shortcuts to reduce the likelihood of any Cumulative Layout Shift.
+  #
+  # @param name [String,Symbol] the HTML element name (e.g. "li", "div", "a")
+  # @param record [Object] the record for which we're testing a policy
+  # @param query [Symbol, String] the query we're running on the policy
+  # @param feature_flag [Symbol] the named feature flag that when enabled will add the "hidden"
+  #        class to the dom element.
+  # @param kwargs [Hash] The arguments pass, with modifications to the given :class (see
+  #        implementation details).
+  #
+  # @yield the body of the HTML element
+  #
+  # @see ApplicationPolicy.dom_class_for
+  # @see https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag
+  # @see ./app/javascript/packs/applyApplicationPolicyToggles.js
+  #
+  # @note This assumes that for the given feature flag, when enabled, we will add the "hidden"
+  #       class.
+  # @note I hope you are correctly busting the cache for this feature_flag
+  def application_policy_content_tag(name, record:, query:, feature_flag:, **kwargs, &block)
+    dom_class = kwargs.delete(:class) || kwargs.delete("class") || ""
+    dom_class += " #{ApplicationPolicy.dom_class_for(record: record, query: query)}"
+    dom_class += " hidden" if FeatureFlag.enabled?(feature_flag)
+
+    content_tag(name, class: dom_class, **kwargs, &block)
+  end
 end

--- a/app/views/stories/tagged_articles/_sidebar.html.erb
+++ b/app/views/stories/tagged_articles/_sidebar.html.erb
@@ -4,6 +4,7 @@
     <aside class="side-bar">
       <% if @tag && @tag.rules_html.present? %>
         <div class="widget">
+        <%= application_policy_content_tag("div", record: Article, query: :create?, feature_flag: :limit_post_creation_to_admins, class: "widget") do %>
           <header>
             <h4><%= t("views.tags.sidebar.guidelines") %></h4>
           </header>
@@ -13,7 +14,7 @@
               <%= t("views.tags.sidebar.new") %>
             </a>
           </div>
-        </div>
+        <% end %>
       <% end %>
       <% if @tag && @tag.wiki_body_html.present? %>
         <div class="widget">

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -317,4 +317,32 @@ RSpec.describe ApplicationHelper, type: :helper do
       expect(optimized_helper).to eq(cloudinary_image_tag)
     end
   end
+
+  describe "#application_policy_content_tag" do
+    subject(:content) do
+      application_policy_content_tag(html_tag_type, record: Article, query: :create?, feature_flag: given_feature_flag,
+                                                    class: "something") do
+        "My Content"
+      end
+    end
+
+    let(:given_feature_flag) { :hello_world }
+    let(:html_tag_type) { "p" }
+
+    it "has a policy class based on record and query" do
+      expect(content).to include(%(<p class="something js-policy-article-create">My Content</p>))
+    end
+
+    context "when the given flag is enabled" do
+      around do |example|
+        FeatureFlag.enable(given_feature_flag)
+        example.call
+        FeatureFlag.remove(given_feature_flag)
+      end
+
+      it "adds the 'hidden' to the HTML element's class list" do
+        expect(content).to include(%(<p class="something js-policy-article-create hidden">My Content</p>))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Prior to this commit, we always assumed a policy based attribute would
have the "hidden" class and then we'd rely on JavaScript to toggle the
visibility.

With this approach, we are "cheating" a bit by specifically referencing
a feature flag that is the driver for the visibility behavior.

This mirrors the one-off behavior of forem/forem#16606.  Namely, when
the flag is off, we render without default hiding.  And when it's on, we
include the "hidden" attribute.

In both cases, we will still leveraged the [applyApplicationPolicyToggles.js][1]
introduced in forem/forem#17076.

An impact could be that if multiple flags are fiddling with the policy,
we could see an area disappear or wrongly remain present.  This would be
a warning to fix (the server would still enforce correct policies so
this would be a bit of a "heads up we have a mismatch in understanding
that happens to impact UI behavior").

[1]:https://github.com/forem/forem/blob/main/app/javascript/packs/applyApplicationPolicyToggles.js

## Related Tickets & Documents

Related to:

- forem/forem#16606
- forem/forem#17076

## QA Instructions, Screenshots, Recordings

None, this is a minor change in place.

### UI accessibility concerns?

This positions us to remove some of the times we might see an "and it appears" behavior.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
