### PR TITLE
Adding conditional Create Post path

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -70,6 +70,41 @@ class ApplicationController < ActionController::Base
   #   @see ApplicationController.api_action
   #   @see ApplicationController#verify_private_forem
 
+  # @!scope class
+  # @!attribute [r|w] create_new_post_path
+  #   By default, this is "/new" but sometimes we want a different path based on the handling controller's context.
+  #
+  #   @param path [String]
+  #   @return [String] the relative path to render in the "Create Post" button.
+  #
+  #   @see Stories::TaggedArticlesController#index
+  #   @see https://api.rubyonrails.org/classes/Class.html#method-i-class_attribute Class.class_attribute
+  #   @example
+  #     class CustomController < ApplicationController
+  #       def show
+  #         self.create_new_post_path = "/new/custom/path"
+  #       end
+  #     end
+  class_attribute :create_new_post_path, default: "/new", instance_writer: true
+  helper_method :create_new_post_path
+
+  # @!scope instance
+  # @!attribute [r|w] create_new_post_path
+  #
+  #   During the execution of a controller action, you can override the path for the "Create Post" button.
+  #
+  #   @param path [String]
+  #   @return [String] the relative path to render in the "Create Post" button.
+  #
+  #   @see Stories::TaggedArticlesController#index
+  #   @see ApplicationController.create_new_post_path
+  #   @example
+  #     class CustomController < ApplicationController
+  #       def show
+  #         self.create_new_post_path = "/new/custom/path"
+  #       end
+  #     end
+
   def verify_private_forem
     return if controller_name.in?(PUBLIC_CONTROLLERS)
     return if self.class.module_parent.to_s == "Admin"

--- a/app/controllers/stories/tagged_articles_controller.rb
+++ b/app/controllers/stories/tagged_articles_controller.rb
@@ -6,8 +6,12 @@ module Stories
 
     rescue_from ArgumentError, with: :bad_request
 
+    # @see ApplicationController.create_new_post_path
     def index
       @tag = Tag.find_by(name: params[:tag].downcase) || not_found
+      # In the context of a tag's "homepage", we want to have the "Create Post" prepopulate with the
+      # current tag's template.
+      self.create_new_post_path = "/new/#{@tag}"
 
       if @tag.alias_for.present?
         redirect_permanently_to("/t/#{@tag.alias_for}")

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,6 +1,6 @@
 <% title t("views.editor.heading.new") %>
 <%= content_for :page_meta do %>
-    <link rel="canonical" href="<%= app_url("/new") %>" />
+    <link rel="canonical" href="<%= app_url(create_new_post_path) %>" />
 <% end %>
 
 <% if user_signed_in? %>

--- a/app/views/authorization/articles/create_post_button.html.erb
+++ b/app/views/authorization/articles/create_post_button.html.erb
@@ -1,3 +1,3 @@
 <turbo-frame id="authorization-articles-create-post-button">
-  <a href="<%= new_path %>" class="c-cta c-cta--branded mr-2 whitespace-nowrap"><%= t("views.main.create_post") %></a>
+  <a href="<%= create_new_post_path %>" class="c-cta c-cta--branded mr-2 whitespace-nowrap"><%= t("views.main.create_post") %></a>
 </turbo-frame>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -59,7 +59,7 @@
             <%= image_tag(image_url, class: "sloan mb-7", alt: "Mascot image") %>
           <% end %>
           <p class="mb-6"><%= t("views.dashboard.posts.empty.desc") %></p>
-          <p><a href="/new" class="crayons-btn crayons-btn--l"><%= t("views.dashboard.posts.empty.new") %></a></p>
+          <p><a href="<%= respond_to?(:create_new_post_path) ? create_new_post_path : "/new" %>" class="crayons-btn crayons-btn--l"><%= t("views.dashboard.posts.empty.new") %></a></p>
         </div>
       </div>
     <% end %>

--- a/app/views/layouts/_nav_menu.html.erb
+++ b/app/views/layouts/_nav_menu.html.erb
@@ -19,7 +19,7 @@
       <a href="<%= mod_path %>" class="c-link c-link--block trusted-visible-block"><%= t("views.main.nav.moderator_center") %></a>
     </li>
     <li class="<%= ApplicationPolicy.dom_class_for(record: Article, query: :create?) %> hidden">
-      <a href="<%= new_path %>" class="c-link c-link--block"><%= t("views.main.create_post") %></a>
+      <a href="<%= create_new_post_path %>" class="c-link c-link--block"><%= t("views.main.create_post") %></a>
     </li>
     <li>
       <a href="<%= readinglist_path %>" class="c-link c-link--block"><%= t("views.main.nav.list") %></a>

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -33,7 +33,7 @@
             <turbo-frame id="authorization-articles-create-post-button" src="<%= authorization_create_post_button_path %>">
             </turbo-frame>
           <% else %>
-            <a href="<%= new_path %>" class="c-cta c-cta--branded mr-2 whitespace-nowrap"><%= t("views.main.create_post") %></a>
+            <a href="<%= create_new_post_path %>" class="c-cta c-cta--branded mr-2 whitespace-nowrap"><%= t("views.main.create_post") %></a>
           <% end %>
 
           <span class="trusted-visible-block">

--- a/app/views/onboardings/_task_card.html.erb
+++ b/app/views/onboardings/_task_card.html.erb
@@ -38,7 +38,7 @@
     </li>
 
     <li class="task-card-action">
-      <a class="task-card-link" href="/new">
+      <a class="task-card-link" href="<%= create_new_post_path %>">
         <p><%= t("views.onboardings.write_html", community: community_name) %></p>
         <svg width="8" height="14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5.172 7L.222 2.05 1.636.636 8 7l-6.364 6.364L.222 11.95 5.172 7z" fill="#fff" /></svg>
       </a>

--- a/app/views/stories/tagged_articles/_sidebar.html.erb
+++ b/app/views/stories/tagged_articles/_sidebar.html.erb
@@ -9,9 +9,6 @@
           </header>
           <div class="widget-body">
             <%= sanitize @tag.rules_html %>
-            <a class="crayons-btn crayons-btn--s" href="/new/<%= @tag.name %>">
-              <%= t("views.tags.sidebar.new") %>
-            </a>
           </div>
         </div>
       <% end %>

--- a/cypress/integration/seededFlows/tagsFlows/tagIndexNavigation.spec.js
+++ b/cypress/integration/seededFlows/tagsFlows/tagIndexNavigation.spec.js
@@ -9,6 +9,13 @@ describe('Tag index page navigation', () => {
   });
 
   it('shows Relevant by default', () => {
+    // Verify that the "Create Post" is for the given tag.
+    cy.findByRole('link', { name: 'Create Post' }).should(
+      'have.attr',
+      'href',
+      '/new/tag1',
+    );
+
     cy.findByRole('navigation', { name: 'View tagged posts by' }).within(() => {
       cy.findByRole('link', { name: 'Relevant' }).as('relevant');
       cy.findByRole('link', { name: 'Top' }).as('top');
@@ -37,6 +44,13 @@ describe('Tag index page navigation', () => {
       cy.get('@week').click(); // should not change the page
       cy.url().should('contain', '/top/week'); // so the url stays the same
     });
+
+    // Verify that the "Create Post" is for the given tag.
+    cy.findByRole('link', { name: 'Create Post' }).should(
+      'have.attr',
+      'href',
+      '/new/tag1',
+    );
   });
 
   it('should navigate to Month view', () => {
@@ -63,6 +77,13 @@ describe('Tag index page navigation', () => {
         'page',
       );
     });
+
+    // Verify that the "Create Post" is for the given tag.
+    cy.findByRole('link', { name: 'Create Post' }).should(
+      'have.attr',
+      'href',
+      '/new/tag1',
+    );
   });
 
   it('should navigate to Year view', () => {
@@ -89,6 +110,13 @@ describe('Tag index page navigation', () => {
         'page',
       );
     });
+
+    // Verify that the "Create Post" is for the given tag.
+    cy.findByRole('link', { name: 'Create Post' }).should(
+      'have.attr',
+      'href',
+      '/new/tag1',
+    );
   });
 
   it('should navigate to Infinity view', () => {
@@ -115,5 +143,12 @@ describe('Tag index page navigation', () => {
         'page',
       );
     });
+
+    // Verify that the "Create Post" is for the given tag.
+    cy.findByRole('link', { name: 'Create Post' }).should(
+      'have.attr',
+      'href',
+      '/new/tag1',
+    );
   });
 });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] A11y Bug Fix

## Description

This commit does two things:

1. Removes the "Create Post" button from the `/t/:tag` page
2. Adds a means of setting on an action by action level the "Create
   Post"'s HREF.

In removing the "Create Post" button from the `/t/:tag` we are
addressing forem/forem#16836.  Further we are removing an a11y
violation: namely we had two links on the page with the name "Create
Post" but they had different URLs.

By adding a means of setting the path during the controller's action
handling, we can contextually render the appropriate URL and avoid
application helper case logic.


## Related Tickets & Documents

Closes forem/forem#16836
Replaces forem/forem#17137

## QA Instructions, Screenshots, Recordings

Our Cypress tests should cover us quite well with this change.

### UI accessibility concerns?

Improving our A11y-ship.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
