### PR TITLE
Adding copy to assist with space toggle decision

### DIFF
--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -1,5 +1,6 @@
+# @note No pundit policy. All actions are unrestricted.
 class AsyncInfoController < ApplicationController
-  # No pundit policy. All actions are unrestricted.
+  NUMBER_OF_MINUTES_FOR_CACHE_EXPIRY = 15
 
   def base_data
     flash.discard(:notice)
@@ -40,7 +41,7 @@ class AsyncInfoController < ApplicationController
   #       decorated version of the user.  It would be nice if we were using the same "variable" for
   #       the cache key and for that which we cache.
   def user_data
-    Rails.cache.fetch(user_cache_key, expires_in: 15.minutes) do
+    Rails.cache.fetch(user_cache_key, expires_in: NUMBER_OF_MINUTES_FOR_CACHE_EXPIRY.minutes) do
       AsyncInfo.to_hash(user: @user, context: self)
     end.to_json
   end

--- a/app/views/admin/spaces/index.html.erb
+++ b/app/views/admin/spaces/index.html.erb
@@ -36,6 +36,14 @@
       </label>
     </div>
 
+    <div class="fs-s color-secondary">
+      <p><%= crayons_icon_tag("info") %> When you turn on comment-only for this space, it also means that for the time being…</p>
+      <ul>
+        <li>Active campaigns will be hidden.  <a href="https://admin.forem.com/docs/advanced-customization/config/campaigns">Learn more about Campaigns</a>.</li>
+        <li>Only admins who are part of an organization will be able to post on behalf of that organization.  <a href="https://admin.forem.com/docs/managing-your-community/organization-pages#overview.">Learn more about Organizations</a>.</li>
+        <li>It will take about <%= pluralize(AsyncInfoController::NUMBER_OF_MINUTES_FOR_CACHE_EXPIRY, "minute") %> to propagate <abbr title="User Interface">UI</abbr> changes for all members. <a href="https://developers.forem.com/technical-overview/caching">Learn more about Caching.</a></li>
+      </ul>
+    </div>
     <div>
       <%= form.button "Save", type: "submit", class: "c-btn c-btn--primary" %>
     </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Documentation Update

## Description

This commit adds instruction as to what's happening when a person
toggles on this feature.  So as to not repeat knowlege, I added a
`NUMBER_OF_MINUTES_FOR_CACHE_EXPIRY` constant so the UI can reference that
instead of dropping a hard-coded 15 in the UI.

## Related Tickets & Documents

- Closes forem/forem#17097

## QA Instructions, Screenshots, Recordings

See screen shot


<img width="1007" alt="Screen Shot 2022-04-06 at 9 59 58 AM" src="https://user-images.githubusercontent.com/2130/161997663-ebef5ae0-e30b-4956-a3f8-fcc07f1058d8.png">

### UI accessibility concerns?

More help text improves a11y-ship.

## Added/updated tests?

- [x] No, and this is why: Added copy

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
