### PR TITLE
Adding logic to hide Create Post on empty dashboard

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -59,7 +59,9 @@
             <%= image_tag(image_url, class: "sloan mb-7", alt: "Mascot image") %>
           <% end %>
           <p class="mb-6"><%= t("views.dashboard.posts.empty.desc") %></p>
-          <p><a href="/new" class="crayons-btn crayons-btn--l"><%= t("views.dashboard.posts.empty.new") %></a></p>
+          <% if policy(Article).create? %>
+            <p><a href="/new" class="crayons-btn crayons-btn--l"><%= t("views.dashboard.posts.empty.new") %></a></p>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/spec/views/dashboards/show.html.erb_spec.rb
+++ b/spec/views/dashboards/show.html.erb_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe "dashboards/show", type: :view do
 
     allow(Images::Optimizer).to receive(:imgproxy_enabled?).and_return(true)
     allow(Settings::General).to receive(:mascot_image_url).and_return("https://i.imgur.com/fKYKgo4.png")
+
+    # These three lines are required for assisting the view in handling a policy.
+    # This issue highlights a continued problem: https://github.com/varvet/pundit/issues/163
+    view.extend(Pundit::Authorization)
+    policy = instance_double(ArticlePolicy, create?: true)
+    allow(view).to receive(:policy).and_return(policy)
   end
 
   context "when using Imgproxy" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

As implemented, folks won't see this page if they can't create a post.
However, as our implementation drifts, we should continue to apply the
same policy.

See forem/forem#16999 for the conditional logic that redirects users.

## Related Tickets & Documents

Indirectly to forem/forem#16913

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why:

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
