### PR TITLE
Add Oauth check to AwardContributorFromGithub

### DIFF
--- a/app/services/badges/award_contributor_from_github.rb
+++ b/app/services/badges/award_contributor_from_github.rb
@@ -25,6 +25,8 @@ module Badges
     end
 
     def call
+      return unless Settings::Authentication.providers.include?(:github)
+
       REPOSITORIES.each do |repo|
         award_single_commit_contributors(repo)
         award_multi_commit_contributors(repo)

--- a/spec/services/badges/award_contributor_from_github_spec.rb
+++ b/spec/services/badges/award_contributor_from_github_spec.rb
@@ -14,13 +14,7 @@ RSpec.describe Badges::AwardContributorFromGithub, type: :service, vcr: true do
     allow(Settings::Authentication).to receive(:providers).and_return([])
     user = create(:user, :with_identity, identities: ["github"], uid: "389169")
 
-    Timecop.freeze("2021-08-16T13:49:20Z") do
-      expect do
-        VCR.use_cassette("github_client_commits_contributor_badge") do
-          described_class.call
-        end
-      end.to change(user.badge_achievements, :count).by(0)
-    end
+    expect { described_class.call }.not_to change(user.badge_achievements, :count)
   end
 
   it "awards contributor badge" do

--- a/spec/services/badges/award_contributor_from_github_spec.rb
+++ b/spec/services/badges/award_contributor_from_github_spec.rb
@@ -6,7 +6,21 @@ RSpec.describe Badges::AwardContributorFromGithub, type: :service, vcr: true do
   before do
     badge
     omniauth_mock_github_payload
+    allow(Settings::Authentication).to receive(:providers).and_return([:github])
     stub_const("#{described_class}::REPOSITORIES", ["forem/DEV-Android"])
+  end
+
+  it "won't work without Github oauth configured" do
+    allow(Settings::Authentication).to receive(:providers).and_return([])
+    user = create(:user, :with_identity, identities: ["github"], uid: "389169")
+
+    Timecop.freeze("2021-08-16T13:49:20Z") do
+      expect do
+        VCR.use_cassette("github_client_commits_contributor_badge") do
+          described_class.call
+        end
+      end.to change(user.badge_achievements, :count).by(0)
+    end
   end
 
   it "awards contributor badge" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug fix

## Description
Resolve the following error https://app.honeybadger.io/projects/72638/faults/84843802

This is happening to the Forem fleet that doesn't have Github OAuth configured.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
Spec should be enough

## Added tests?
- [x] yes

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a