### PR TITLE
Adding link to Spaces admin guide

### DIFF
--- a/app/views/admin/spaces/index.html.erb
+++ b/app/views/admin/spaces/index.html.erb
@@ -49,5 +49,5 @@
     </div>
   <% end %>
   <hr />
-  <p>Learn <a href="https://admin.forem.com/docs/advanced-customization/content-manager/spaces">more about Spaces in the Admin Guide</a>.</p>
+  <p>Learn <a href="https://admin.forem.com/docs/advanced-customization/content-manager/spaces" target="_blank" rel="noopener">more about Spaces in the Admin Guide</a>.</p>
 </div>

--- a/app/views/admin/spaces/index.html.erb
+++ b/app/views/admin/spaces/index.html.erb
@@ -49,5 +49,5 @@
     </div>
   <% end %>
   <hr />
-  <p>Learn <a href="https://admin.forem.com/docs/advanced-customization/content-manager/spaces" target="_blank" rel="noopener">more about Spaces in the Admin Guide</a>.</p>
+  <p><a href="https://admin.forem.com/docs/advanced-customization/content-manager/spaces" target="_blank" rel="noopener">Learn more about Spaces in the Admin Guide</a>.</p>
 </div>

--- a/app/views/admin/spaces/index.html.erb
+++ b/app/views/admin/spaces/index.html.erb
@@ -48,5 +48,6 @@
       <%= form.button "Save", type: "submit", class: "c-btn c-btn--primary" %>
     </div>
   <% end %>
-
+  <hr />
+  <p>Learn <a href="https://admin.forem.com/docs/advanced-customization/content-manager/spaces">more about Spaces in the Admin Guide</a>.</p>
 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Documentation Update

## Description

This commit presently links to a missing page, but in consultation with
Ella, she'll be putting the page at the linked URL.

The original copy was:

> Want to learn more about spaces? Check [Admin Guide]

I chose to go with the following, as assistive technology will announce
the link's text as "more about Spaces in the Admin Guide", which I find
more a11y oriented.

> Learn [more about Spaces in the Admin Guide]

See Screenshot

<img width="1049" alt="Screen Shot 2022-04-06 at 2 36 56 PM" src="https://user-images.githubusercontent.com/2130/162045693-64f6474f-9329-4db6-abdd-14fcfde76b23.png">


## Related Tickets & Documents

Closes forem/forem#17148

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: it's inline help text

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
