### PR TITLE
fix: 🐛 Fix Color displaying over button in settings

### DIFF
--- a/app/javascript/packs/stickySaveFooter.js
+++ b/app/javascript/packs/stickySaveFooter.js
@@ -3,6 +3,6 @@ const form = document.getElementsByClassName('sticky-footer-form')[0];
 form.addEventListener('change', () => {
   const saveFooter = document.getElementsByClassName('save-footer')[0];
   if (saveFooter) {
-    saveFooter.classList.add('sticky', 'bottom-0');
+    saveFooter.classList.add('sticky', 'z-sticky', 'bottom-0');
   }
 });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
This PR adds the `z-sticky` class generated at:
https://github.com/forem/forem/blob/d6421923be6f0a41edf4afec404891c2bae2cec0/app/assets/stylesheets/config/_generator.scss#L245
https://github.com/forem/forem/blob/d6421923be6f0a41edf4afec404891c2bae2cec0/app/assets/stylesheets/config/_import.scss#L87-L95

Because `sticky` class only set sticky position:
https://github.com/forem/forem/blob/d6421923be6f0a41edf4afec404891c2bae2cec0/app/assets/stylesheets/config/_generator.scss#L460-L473

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #17160

## QA Instructions, Screenshots, Recordings
![image](https://user-images.githubusercontent.com/39246879/162303995-fd7cb14f-1315-4b4a-951d-3304996f372b.png)


### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _no needed_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/gKCh5SiWhid0X9CmyU/giphy.gif)
