### PR TITLE
Admin member index: stop capitalizing table headers

### DIFF
--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -65,6 +65,12 @@
     }
   }
 
+  &__lowercase {
+    th {
+      text-transform: none;
+    }
+  }
+
   tbody {
     tr {
       &:first-child {

--- a/app/views/admin/users/_member_index.html.erb
+++ b/app/views/admin/users/_member_index.html.erb
@@ -96,7 +96,7 @@
     <!-- Responsive screen (breakpoints below XL) data view end -->
 
     <!-- XL screen data view start -->
-    <table class="crayons-table hidden xl:block" width="100%">
+    <table class="crayons-table crayons-table__lowercase hidden xl:block" width="100%">
       <thead>
         <tr>
           <th scope="col" class="normal-case">Member</th>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor


## Description

Our `crayons-table` CSS transforms table headers into 100% uppercase characters, whereas the designs for the member index view calls for title casing. Since we're likely to be repeating this styling around new admin views, I've added a class variant for the `crayons-table` to achieve the desired effect. Eventually, as we work through admin refactors, we might want to flip the default behaviour to `text-transform: none`; keeping everything together in `tables.scss` will help make that straightforward as/when we want to.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/16911

## QA Instructions, Screenshots, Recordings

Not much to see here - the table headers (in largest view) should be title cased:


![headers title cased](https://user-images.githubusercontent.com/20773163/162412050-5a4edb75-9fc1-4535-b090-d4ea79e06a34.png)

NB: the text size looks a bit small to me, but I've triple checked this matches the designs at 12px.

### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: purely a presentational change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] This change does not need to be communicated, and this is why not: part of a larger issue & behind a feature flag

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![why are you yelling at me?](https://media.giphy.com/media/3ohhwr2FHK5u2TZFcI/giphy-downsized-large.gif)
