### PR TITLE
Remove profile admin feature flag

### DIFF
--- a/lib/data_update_scripts/20220408203135_remove_profile_admin_flag.rb
+++ b/lib/data_update_scripts/20220408203135_remove_profile_admin_flag.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class RemoveProfileAdminFlag
+    def run
+      FeatureFlag.remove(:profile_admin)
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/remove_profile_admin_flag_spec.rb
+++ b/spec/lib/data_update_scripts/remove_profile_admin_flag_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220408203135_remove_profile_admin_flag.rb",
+)
+
+describe DataUpdateScripts::RemoveProfileAdminFlag do
+  it "causes enabled? to be false" do
+    FeatureFlag.enable(:profile_admin)
+
+    described_class.new.run
+
+    expect(FeatureFlag.enabled?(:profile_admin)).to be false
+  end
+
+  it "removes the profile_admin flag" do
+    FeatureFlag.enable(:profile_admin)
+
+    described_class.new.run
+
+    expect(FeatureFlag.exist?(:profile_admin)).to be false
+  end
+
+  it "works if the flag does not exist" do
+    FeatureFlag.remove(:profile_admin)
+
+    described_class.new.run
+
+    expect(FeatureFlag.exist?(:profile_admin)).to be false
+  end
+end

--- a/spec/models/admin_menu_spec.rb
+++ b/spec/models/admin_menu_spec.rb
@@ -89,12 +89,5 @@ RSpec.describe AdminMenu do
 
     it { is_expected.to be_a(Menu::Item) }
     it { is_expected.to be_visible }
-
-    context "when :profile_field FeatureFlag is not enabled" do
-      # leaving this in place to make sure item is visible even if flag not enabled
-      before { allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(false) }
-
-      it { is_expected.to be_visible }
-    end
   end
 end

--- a/spec/requests/admin/nested_sidebar_spec.rb
+++ b/spec/requests/admin/nested_sidebar_spec.rb
@@ -27,14 +27,6 @@ RSpec.describe "admin sidebar", type: :request do
   end
 
   describe "profile admin feature flag" do
-    it "shows the option in the sidebar even when the feature flag is disabled" do
-      allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(false)
-
-      get admin_articles_path
-
-      expect(response.body).to include("Profile Fields")
-    end
-
     it "shows the option in the sidebar" do
       get admin_articles_path
 

--- a/spec/routing/profile_admin_routes_spec.rb
+++ b/spec/routing/profile_admin_routes_spec.rb
@@ -1,17 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Profile admin routes", type: :routing do
-  it "renders the profile admin route if the feature flag is enabled" do
-    expect(get: admin_profile_fields_path).to route_to(
-      controller: "admin/profile_fields",
-      action: "index",
-      locale: nil,
-    )
-  end
-
-  it "renders the profile admin route even if the feature flag is disabled" do
-    allow(FeatureFlag).to receive(:enabled?).with(:profile_admin).and_return(false)
-
+  it "renders the profile admin route" do
     expect(get: admin_profile_fields_path).to route_to(
       controller: "admin/profile_fields",
       action: "index",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update 

## Description

Remove profile admin feature flag, since it does nothing now.

Remove test cases built around it (modified when the guards were removed).

This flag had been enabled, and all conditional code removed, so removing the flag should be a no-op. The test cases removed were asserting the flag was a no-op where behavior had depended on it previously.

## Related Tickets & Documents

- Related Issue #12159 and https://github.com/forem/forem-internal-eng/issues/352

## QA Instructions, Screenshots, Recordings

After running the data update script, no profile_admin feature flag should be present (this is created/enabled in a recent PR so it may enabled, then remove, the flag during the migration).


### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [x] This change does not need to be communicated, and this is why not: This is a no-op removal of dead code in the tests, and a removal of an ineffective feature flag in production.

## [optional] Are there any post deployment tasks we need to perform?

Verify the data update runs successfully. This flag is enabled on DEV and should not show afterward.
