### PR TITLE
Use the latest repo URLs in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/thepracticaldev/dev.to.git"
+    "url": "https://github.com/forem/forem.git"
   },
   "author": "",
   "license": "AGPL-3.0-or-later",
   "bugs": {
-    "url": "https://github.com/thepracticaldev/dev.to/issues"
+    "url": "https://github.com/forem/forem/issues"
   },
-  "homepage": "https://github.com/thepracticaldev/dev.to#readme",
+  "homepage": "https://github.com/forem/forem#readme",
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",
     "@faker-js/faker": "^6.0.0",


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
Use the latest repo URLs (i.e., `https://github.com/forem/forem`) in `package.json`.

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added/updated tests?

- [x] No, and this is why: nothing can be tested