### PR TITLE
Update jQuery from 3.3.1 to 3.6.0 on /videos/new

### DIFF
--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -37,8 +37,8 @@
     </p>
   </div>
 </center>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"
-  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+  integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <%= javascript_include_tag "s3_direct_upload" %>
 <script>
   setTimeout(function () {


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Updates jQuery from 3.3.1 to 3.6.0 (latest) on `/videos/new`.

## Related Tickets & Documents
- Related Issue #17204

## QA Instructions, Screenshots, Recordings

### UI accessibility concerns?


## Added/updated tests?

- [x] No, and this is why: tests are already included.

## [optional] Are there any post deployment tasks we need to perform?
No.