### PR TITLE
Member index (phase 2) - Search invitations

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -3,7 +3,10 @@ module Admin
     layout "admin"
 
     def index
-      @invitations = User.where(registered: false).page(params[:page]).per(50)
+      @invitations = Admin::UsersQuery.call(relation: User.where(registered: false),
+                                            options: params.permit(
+                                              :search,
+                                            )).page(params[:page]).per(50)
     end
 
     def new; end

--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -3,7 +3,7 @@ module Admin
     layout "admin"
 
     def index
-      @invitations = Admin::UsersQuery.call(relation: User.where(registered: false),
+      @invitations = Admin::UsersQuery.call(relation: User.invited,
                                             options: params.permit(
                                               :search,
                                             )).page(params[:page]).per(50)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -170,6 +170,7 @@ class User < ApplicationRecord
 
   scope :eager_load_serialized_data, -> { includes(:roles) }
   scope :registered, -> { where(registered: true) }
+  scope :invited, -> { where(registered: false) }
   # Unfortunately pg_search's default SQL query is not performant enough in this
   # particular case (~ 500ms). There are multiple reasons:
   # => creates a complex query like `SELECT FROM users INNER JOIN users` to compute ranking.

--- a/app/views/admin/invitations/index.html.erb
+++ b/app/views/admin/invitations/index.html.erb
@@ -5,7 +5,16 @@
         <h1 class="crayons-title ml-3 l:ml-0">Members<span class="screen-reader-only"> (Invitations)</span></h1>
         <%= render "admin/users/index/tabs" %>
       </div>
-      <%= render "admin/users/index/controls" %>
+      <div class="flex justify-content-between py-3">
+        <%= form_with url: admin_invitations_path, method: :get, local: true, class:"grow-1" do |f| %>
+          <% render "admin/users/index/search_field", f: f, placeholder: "Search invited members...", aria_label: "Search invited members by name, username, or email" %>
+        <% end %>
+        <div class="flex grow-1 justify-content-end">
+          <%= paginate @invitations, theme: "admin", scope: @invitations, label: "Paginate invitations" %>
+          <%= link_to "Invite member", new_admin_invitation_path, class: "c-cta c-cta--branded self-end" %>
+        </div>
+      </div>
+     
     </header>
     <table class="crayons-table" width="100%">
       <thead>

--- a/app/views/admin/users/index/_controls.html.erb
+++ b/app/views/admin/users/index/_controls.html.erb
@@ -18,8 +18,8 @@
         <%= paginate @users, theme: "admin", scope: @users, label: "Paginate users" %>
       </div>
       <div>
-        <div id="search-users" class="hidden relative">
-          <%= render "admin/users/index/search_field", f: f %>
+        <div id="search-users" class="hidden">
+          <%= render "admin/users/index/search_field", f: f, placeholder: "Search member...", aria_label: "Search member by name, username, email, or Twitter/GitHub usernames" %>
         </div>
         <div id="filter-users" class="hidden crayons-field flex-row items-center gap-2">
           <%= render "admin/users/index/filter_role_field", f: f %>
@@ -30,8 +30,8 @@
     <!-- Larger screen layout -->
     <div class="hidden m:flex justify-between">
       <%= form_with url: admin_users_path, method: :get, local: true, class: "flex flex-col m:flex-row gap-3 m:items-center py-3" do |f| %>
-        <div class="crayons-field flex-1 flex-row items-center gap-2 relative">
-          <%= render "admin/users/index/search_field", f: f %>
+        <div class="crayons-field flex-1 flex-row items-center gap-2">
+          <%= render "admin/users/index/search_field", f: f, placeholder: "Search member...", aria_label: "Search member by name, username, email, or Twitter/GitHub usernames" %>
         </div>
         <div class="crayons-field flex-row items-center gap-2">
           <%= render "admin/users/index/filter_role_field", f: f %>

--- a/app/views/admin/users/index/_search_field.html.erb
+++ b/app/views/admin/users/index/_search_field.html.erb
@@ -1,4 +1,6 @@
-<%= f.text_field :search, value: params[:search], class: "crayons-textfield mt-0", placeholder: "Search member...", aria: { label: "Search member by name, username, email, or Twitter/GitHub usernames" } %>
-<button type="submit" aria-label="Search" class="crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon-rounded absolute right-2 bottom-0 top-0 m-1">
-  <%= crayons_icon_tag(:search, aria_hidden: true) %>
-</button>
+<div class="relative">
+  <%= f.text_field :search, value: params[:search], class: "crayons-textfield mt-0", placeholder: placeholder, aria: { label: aria_label } %>
+  <button type="submit" aria-label="Search" class="crayons-btn crayons-btn--ghost crayons-btn--s crayons-btn--icon-rounded absolute right-2 bottom-0 top-0 m-1">
+    <%= crayons_icon_tag(:search, aria_hidden: true) %>
+  </button>
+</div>

--- a/cypress/integration/seededFlows/adminFlows/users/invitedUsers.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/invitedUsers.spec.js
@@ -1,0 +1,40 @@
+describe('Invited users', () => {
+  beforeEach(() => {
+    cy.testSetup();
+    cy.fixture('users/adminUser.json').as('user');
+    cy.get('@user').then((user) => {
+      cy.loginUser(user)
+        .then(() => cy.enableFeatureFlag('member_index_view'))
+        .then(() =>
+          cy.inviteUser({
+            name: 'Test user',
+            email: 'test@test.com',
+          }),
+        )
+        .then(() => cy.visitAndWaitForUserSideEffects('/admin/invitations'));
+    });
+  });
+
+  it('searches for an invited user', () => {
+    // The single invited user should be visible on the page
+    cy.findByText('test@test.com').should('exist');
+
+    // Search for a term that should match the entry
+    cy.findByRole('textbox', {
+      name: 'Search invited members by name, username, or email',
+    }).type('test');
+    cy.findByRole('button', { name: 'Search' }).click();
+    cy.url().should('contain', 'search=test');
+    cy.findByText('test@test.com').should('exist');
+
+    // Search for a term that shouldn't match the entry
+    cy.findByRole('textbox', {
+      name: 'Search invited members by name, username, or email',
+    })
+      .clear()
+      .type('something');
+    cy.findByRole('button', { name: 'Search' }).click();
+    cy.url().should('contain', 'search=something');
+    cy.findByText('test@test.com').should('not.exist');
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -391,3 +391,11 @@ Cypress.Commands.add(
     return cy.wrap(subject).invoke('val', color).trigger('input');
   },
 );
+
+Cypress.Commands.add('inviteUser', ({ name, email }) => {
+  return cy.request(
+    'POST',
+    '/admin/invitations',
+    `utf8=%E2%9C%93&user%5Bemail%5D=${email}&user%5Bname%5D=${name}&commit=Invite+User`,
+  );
+});


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds the search functionality to the new member invitations view. Following this PR, invitations can be searched by: username, name, or email address.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/16960
- Closes https://github.com/forem/forem/issues/17209

## QA Instructions, Screenshots, Recordings

- When the `member_index_view` feature flag is disabled, there should be no change to the current UI, and no searchability

With the `member_index_view` feature flag enabled:

- Make sure you have some users invited! You can do this in the console e.g. `User.invite!(email: "test@something.com", name: "test user", username: "test-user", registered: false)`
- You should see a "Search invited members" field
- If you enter text and click the search button (or press enter), the page should reload with the query param `search=something`, and the invitations list should reflect your search term (i.e. have filtered to users which match your term)

https://user-images.githubusercontent.com/20773163/162724156-e27b6f87-ccad-4fb5-bd89-2fe62a1eb6c2.mp4


### UI accessibility concerns?

- The `search_field` partial is now being used in `/invitations` as well as `/users`. I've updated it to require a string to be passed for the `aria-label` and `placeholder` so that it's tailored to the context

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [X] This change does not need to be communicated, and this is why not: part of a larger issue, hidden behind a feature flag

