### PR TITLE
Replace #to_s(:format) with #to_fs

### DIFF
--- a/app/views/articles/feed.rss.builder
+++ b/app/views/articles/feed.rss.builder
@@ -41,7 +41,7 @@ xml.rss(:version => "2.0",
       xml.item do
         xml.title article.title
         xml.tag!("dc:creator", user.instance_of?(User) ? user.name : article.user.name)
-        xml.pubDate article.published_at.to_s(:rfc822) if article.published_at
+        xml.pubDate article.published_at.to_fs(:rfc822) if article.published_at
         xml.link app_url(article.path)
         xml.guid app_url(article.path)
         xml.description sanitize(article.plain_html,


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Replaces `TimeWithZone#to_s(:format)` with `TimeWithZone#to_fs`.

## Related Tickets & Documents

Rails 7 deprecated `TimeWithZone#to_s(:format)` in favor of `TimeWithZone#to_fs`.

- https://github.com/rails/rails/pull/43772
- https://github.com/rails/rails/pull/44354

```
DEPRECATION WARNING: TimeWithZone#to_s(:rfc822) is deprecated. Please use TimeWithZone#to_fs(:rfc822) instead. (called from block (4 levels) in _app_views_articles_feed_rss_builder__990977305614084656_3900980 at /home/travis/build/forem/forem/app/views/articles/feed.rss.builder:44)
```
from https://app.travis-ci.com/github/forem/forem/jobs/566636747

## Added/updated tests?

- [x] No, and this is why: no logic changed.

## [optional] Are there any post deployment tasks we need to perform?

No.