### PR TITLE
Wait for articleForm component to mount before editing title

### DIFF
--- a/spec/system/user_uses_the_editor_spec.rb
+++ b/spec/system/user_uses_the_editor_spec.rb
@@ -98,11 +98,12 @@ RSpec.describe "Using the editor", type: :system do
   describe "using v2 editor", js: true do
     it "fill out form with rich content and click publish" do
       visit "/new"
-      fill_in "article-form-title", with: "This is a <span> test"
-      fill_in "tag-input", with: "What, Yo"
-      fill_in "article_body_markdown", with: "Hello"
+      within "form#article-form" do
+        fill_in "article-form-title", with: "This is a <span> test"
+        fill_in "tag-input", with: "What, Yo"
+        fill_in "article_body_markdown", with: "Hello"
+      end
       find("button", text: /\APublish\z/).click
-
       expect(page).to have_xpath("//div[@class='crayons-article__header__meta']//h1")
       expect(page).to have_text("Hello")
       expect(page).to have_link("what", href: "/t/what")


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This test had been failing with "title can't be blank" a few times
recently. Looking for a difference between the v2 form template (in
app/views/articles) and the ArticleForm component (in
app/javascript/article-form/) showed there is an id on the js form but
not the erb/html form we respond with first.

The test had been sometimes typing the title into the text area before
the component mounts, and trying to view the article gives a
validation error rather than the expected response.

## QA Instructions, Screenshots, Recordings

Hmm... I had to run the test a number of times locally before I saw this error. I'm not going to recommend running this test on a tight loop waiting for failures to return, but that would be evidence.

I'm relying on my deductive skills, if you specify within an id, and start typing, that id had to be present. Allthis breaks if we add that same id to the form element in the template. 

### UI accessibility concerns?

I don't think so (this is a test only, the only thing that could be better for accessibility is if I leveraged a test-id data element instead). Happy to see feedback if that approach was obvious and helpful.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![billboard with the word wait on it](https://user-images.githubusercontent.com/1237369/162835228-81c50c62-3f7a-4ee9-82b1-4622c42ff997.png)
