### PR TITLE
Context Notifications

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -95,6 +95,7 @@ class Article < ApplicationRecord
 
   has_many :mentions, as: :mentionable, inverse_of: :mentionable, dependent: :delete_all
   has_many :comments, as: :commentable, inverse_of: :commentable, dependent: :nullify
+  has_many :context_notifications, as: :context, inverse_of: :context, dependent: :delete_all
   has_many :html_variant_successes, dependent: :nullify
   has_many :html_variant_trials, dependent: :nullify
   has_many :notification_subscriptions, as: :notifiable, inverse_of: :notifiable, dependent: :delete_all

--- a/app/models/context_notification.rb
+++ b/app/models/context_notification.rb
@@ -1,7 +1,7 @@
 class ContextNotification < ApplicationRecord
   belongs_to :context, polymorphic: true
 
-  validates :action, presence: true, inclusion: { in: %w[published] }
+  validates :action, presence: true, inclusion: { in: %w[Published] }
   validates :context_type, presence: true, inclusion: { in: %w[Article] }
   validates :context_id, uniqueness: { scope: %i[context_type action] }
 end

--- a/app/models/context_notification.rb
+++ b/app/models/context_notification.rb
@@ -1,0 +1,7 @@
+class ContextNotification < ApplicationRecord
+  belongs_to :context, polymorphic: true
+
+  validates :action, presence: true, inclusion: { in: %w[published] }
+  validates :context_type, presence: true, inclusion: { in: %w[Article] }
+  validates :context_id, uniqueness: { scope: %i[context_type action] }
+end

--- a/app/models/context_notification.rb
+++ b/app/models/context_notification.rb
@@ -1,3 +1,8 @@
+# This model was created to track notifications for which events have been sent already.
+# E.g. when a notification about a published article is sent (a Notification record is created),
+# we create a ContextNotification record where context_id is the article id,
+# context_type is "Article", and action is "Published".
+# Currently, context notifications are created only for notifications about published articles.
 class ContextNotification < ApplicationRecord
   belongs_to :context, polymorphic: true
 

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -38,6 +38,8 @@ module Articles
         if article.saved_changes["published"] == [true, false]
           Notification.remove_all_by_action_without_delay(notifiable_ids: article.id, notifiable_type: "Article",
                                                           action: "Published")
+          ContextNotification.delete_by(context_id: article.id, context_type: "Article",
+                                        action: "Published")
 
           if article.comments.exists?
             Notification.remove_all(notifiable_ids: article.comments.ids,

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -59,6 +59,17 @@ module Notifications
           unique_by: upsert_index,
           returning: %i[id],
         )
+
+        return unless action == "Published" && notifiable.is_a?(Article)
+
+        context_notification_attributes = {
+          context_id: notifiable.id,
+          context_type: notifiable.class.name,
+          action: action
+        }
+
+        ContextNotification.upsert(context_notification_attributes,
+                                   unique_by: :index_context_notification_on_context_and_action)
       end
 
       private

--- a/db/migrate/20220401071321_create_context_notifications.rb
+++ b/db/migrate/20220401071321_create_context_notifications.rb
@@ -1,0 +1,13 @@
+class CreateContextNotifications < ActiveRecord::Migration[7.0]
+  def change
+    create_table :context_notifications do |t|
+      t.string :action
+      t.integer :context_id
+      t.string :context_type
+
+      t.timestamps
+    end
+    add_index :context_notifications, %i[context_id context_type action],
+              unique: true, name: "index_context_notification_on_context_and_action"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_23_185428) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_01_071321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -386,6 +386,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_23_185428) do
     t.string "team_id"
     t.datetime "updated_at", null: false
     t.index ["app_bundle", "platform"], name: "index_consumer_apps_on_app_bundle_and_platform", unique: true
+  end
+
+  create_table "context_notifications", force: :cascade do |t|
+    t.string "action"
+    t.integer "context_id"
+    t.string "context_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["context_id", "context_type", "action"], name: "index_context_notification_on_context_and_action", unique: true
   end
 
   create_table "credits", force: :cascade do |t|

--- a/spec/factories/context_notifications.rb
+++ b/spec/factories/context_notifications.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :context_notification do
-    action { "published" }
+    action { "Published" }
     association :context, factory: :article
   end
 end

--- a/spec/factories/context_notifications.rb
+++ b/spec/factories/context_notifications.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :context_notification do
+    action { "published" }
+    association :context, factory: :article
+  end
+end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_one(:discussion_lock).dependent(:delete) }
 
     it { is_expected.to have_many(:comments).dependent(:nullify) }
+    it { is_expected.to have_many(:context_notifications).dependent(:delete_all) }
     it { is_expected.to have_many(:mentions).dependent(:delete_all) }
     it { is_expected.to have_many(:html_variant_successes).dependent(:nullify) }
     it { is_expected.to have_many(:html_variant_trials).dependent(:nullify) }

--- a/spec/models/context_notification_spec.rb
+++ b/spec/models/context_notification_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe ContextNotification, type: :model do
+  let(:context_notification) { create(:context_notification) }
+
+  describe "validations" do
+    describe "builtin validations" do
+      subject { context_notification }
+
+      it { is_expected.to be_valid }
+      it { is_expected.to belong_to(:context) }
+      it { is_expected.to validate_presence_of(:action) }
+      it { is_expected.to validate_presence_of(:context_type) }
+
+      it { is_expected.to validate_uniqueness_of(:context_id).scoped_to(%i[context_type action]) }
+    end
+
+    it "is invalid with a Comment as context" do
+      context_notification.context_type = "Comment"
+      expect(context_notification.valid?).to be false
+    end
+  end
+end

--- a/spec/services/notifications/notifiable_action/send_spec.rb
+++ b/spec/services/notifications/notifiable_action/send_spec.rb
@@ -43,18 +43,47 @@ RSpec.describe Notifications::NotifiableAction::Send, type: :service do
       expect(notification.json_data["organization"]["name"]).to eq(organization.name)
     end
 
+    it "creates a context notification" do
+      expect do
+        described_class.call(article, "Published")
+      end.to change(ContextNotification, :count).by(1)
+    end
+
+    it "creates a correct context notification" do
+      described_class.call(article, "Published")
+      context_notifications = article.context_notifications
+      expect(context_notifications.pluck(:action)).to eq(["Published"])
+    end
+
     it "does not create a notification if the follower has muted the user" do
       user2.follows.first.update(subscription_status: "none")
       user3.stop_following(organization)
       described_class.call(article, "Published")
       expect(Notification.count).to eq(0)
+      expect(ContextNotification.count).to eq(0)
     end
 
     it "doesn't fail if the notification already exists" do
+      create(:notification, user: user2, action: "Published", notifiable: article)
+      expect do
+        described_class.call(article, "Published")
+      end.not_to raise_error
+    end
+
+    it "upserts the existing notification" do
+      time = Date.yesterday
       notification = create(:notification, user: user2, action: "Published", notifiable: article)
-      result = described_class.call(article, "Published")
-      ids = result.to_a.map { |r| r["id"] }
-      expect(ids).to include(notification.id)
+      notification.update_columns(updated_at: time, created_at: time)
+      described_class.call(article, "Published")
+      notification.reload
+      expect(notification.created_at).to be > time
+    end
+
+    it "doesn't fail if the context notification already exists" do
+      create(:context_notification, action: "Published", context: article)
+      expect do
+        described_class.call(article, "Published")
+      end.not_to raise_error
     end
   end
 
@@ -65,6 +94,7 @@ RSpec.describe Notifications::NotifiableAction::Send, type: :service do
 
       described_class.call(article, "Published")
       expect(Notification.count).to eq(0)
+      expect(ContextNotification.count).to eq(0)
     end
 
     it "does not create a notification when following an organization" do
@@ -73,6 +103,7 @@ RSpec.describe Notifications::NotifiableAction::Send, type: :service do
 
       described_class.call(article, "Published")
       expect(Notification.count).to eq(0)
+      expect(ContextNotification.count).to eq(0)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description 
Added a `ContextNotification` model to track that the notifications for a certain article were sent.
The idea of Context Notifications was described by Jeremy [here](https://forem.team/jeremy/comment/85m)

When "Scheduling Posts" will be deployed, notifications about published articles will be sent in a worker which will be working independently (https://forem.team/jamie/comment/860), so we will need a way to find out which notifications have been sent already and which not. So I think that we need to deploy `ContextNotification`s before deploying "Scheduling Posts" to make it easier, that's why I created this pr.

## Related Tickets & Documents
#15858  

## QA Instructions, Screenshots, Recordings
When an article is published, and the corresponding notifications are created (asynchronously via `Notifications::NotifiableActionWorker` and `Notifications::NotifiableAction::Send`), a corresponding `ContextNotification` should be created.
When an article is unpublished, and the notifications are deleted, the corresponding `ContextNotification` should be deleted too.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I'm not sure how best to communicate this change and need help
Do we have docs for the notifications? The feature doesn't change a lot but would worth mentioning if we have docs.
