### PR TITLE
Show a "Unable to login" message in browser when a user is unable to login.

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -8,10 +8,10 @@ en:
     failure:
       already_authenticated: You are already signed in.
       inactive: Your account is not activated yet.
-      invalid: Invalid %{authentication_keys} or password.
+      invalid: Unable to login.
       last_attempt: You have one more attempt before your account is locked.
-      locked: Your account is locked.
-      not_found_in_database: Invalid %{authentication_keys} or password.
+      locked: Unable to login.
+      not_found_in_database: Unable to login.
       timeout: Your session expired. Please sign in again to continue.
       unauthenticated: You need to sign in or sign up before continuing.
       unconfirmed: You have to confirm your email address before continuing.
@@ -61,4 +61,4 @@ en:
       not_locked: was not locked
       not_saved:
         one: '1 error prohibited this %{resource} from being saved:'
-        other: "%{count} errors prohibited this %{resource} from being saved:"
+        other: '%{count} errors prohibited this %{resource} from being saved:'

--- a/spec/system/authentication/user_logs_in_with_email_spec.rb
+++ b/spec/system/authentication/user_logs_in_with_email_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Authenticating with Email" do
         click_button("Continue", match: :first)
 
         expect(page).to have_current_path("/users/sign_in")
-        expect(page).to have_text("Invalid Email or password.")
+        expect(page).to have_text("Unable to login.")
       end
     end
   end

--- a/spec/system/user_logs_in_with_password_spec.rb
+++ b/spec/system/user_logs_in_with_password_spec.rb
@@ -20,16 +20,16 @@ RSpec.describe "Authenticating with a password" do
     it "displays an error when the email address is wrong" do
       submit_login_form("wrong@example.com", password)
 
-      expect(page).to have_text("Invalid Email or password.")
+      expect(page).to have_text("Unable to login.")
     end
 
     it "displays an error when the password is wrong" do
       submit_login_form(user.email, "wr0ng")
-      expect(page).to have_text("Invalid Email or password.")
+      expect(page).to have_text("Unable to login.")
     end
 
-    it "sends an email with the unlock link if the uset gets locked out", :aggregate_failures do
-      allow(User).to receive(:maximum_attempts).and_return(1)
+    it "sends an email with the unlock link if the user gets locked out", :aggregate_failures do
+      allow(User).to receive(:maximum_attempts).and_return(0)
 
       assert_enqueued_with(job: Devise.mailer.delivery_job) do
         submit_login_form(user.email, "wr0ng")

--- a/spec/system/user_logs_in_with_password_spec.rb
+++ b/spec/system/user_logs_in_with_password_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Authenticating with a password" do
     end
 
     it "sends an email with the unlock link if the user gets locked out", :aggregate_failures do
-      allow(User).to receive(:maximum_attempts).and_return(0)
+      allow(User).to receive(:maximum_attempts).and_return(1)
 
       assert_enqueued_with(job: Devise.mailer.delivery_job) do
         submit_login_form(user.email, "wr0ng")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Implements language for invalid email/passwords or account lockouts that do not leak security details.

## Related Tickets & Documents
- Closes https://github.com/forem/forem/issues/16736

## QA Instructions, Screenshots, Recordings
Sign out of your localhost Forem and sign-in with invalid email and then invalid password. An error message should appear at the top with the words `Unable to login`.
To simulate a lockout, in Rails console, search for the user you are using: `user = User.find_by(email: "email-you-are-using")`. Then attempt to login in the UI; you should see the error `Unable to login`. After testing, unlock your local user by running `user.unlock_access!` in the console.

### UI accessibility concerns?
None; only backend changes.

## Added/updated tests?
- [X] Yes

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
