### PR TITLE
Move showModal/closeModal helpers into their own pack file

### DIFF
--- a/app/javascript/packs/base.jsx
+++ b/app/javascript/packs/base.jsx
@@ -5,10 +5,8 @@ import {
   initializeMemberMenu,
 } from '../topNavigation/utilities';
 import { waitOnBaseData } from '../utilities/waitOnBaseData';
+import { showWindowModal, closeWindowModal } from '@utilities/showModal';
 import * as Runtime from '@utilities/runtime';
-
-// Unique ID applied to modals created using window.Forem.showModal
-const WINDOW_MODAL_ID = 'window-modal';
 
 // Namespace for functions which need to be accessed in plain JS initializers
 window.Forem = {
@@ -53,54 +51,8 @@ window.Forem = {
       originalTextArea,
     );
   },
-  modalImports: undefined,
-  getModalImports() {
-    if (!this.modalImports) {
-      this.modalImports = [import('@crayons/Modal'), this.getPreactImport()];
-    }
-    return Promise.all(this.modalImports);
-  },
-  showModal: async ({ title, contentSelector, size = 'small', onOpen }) => {
-    const [{ Modal }, { render, h }] = await window.Forem.getModalImports();
-
-    // Guard against two modals being opened at once
-    let currentModalContainer = document.getElementById(WINDOW_MODAL_ID);
-    if (currentModalContainer) {
-      render(null, currentModalContainer);
-    } else {
-      currentModalContainer = document.createElement('div');
-      currentModalContainer.setAttribute('id', WINDOW_MODAL_ID);
-      document.body.appendChild(currentModalContainer);
-    }
-
-    render(
-      <Modal
-        title={title}
-        onClose={() => {
-          render(null, currentModalContainer);
-        }}
-        size={size}
-        focusTrapSelector={`#${WINDOW_MODAL_ID}`}
-      >
-        <div
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{
-            __html: document.querySelector(contentSelector).innerHTML,
-          }}
-        />
-      </Modal>,
-      currentModalContainer,
-    );
-
-    onOpen?.();
-  },
-  closeModal: async () => {
-    const currentModalContainer = document.getElementById(WINDOW_MODAL_ID);
-    if (currentModalContainer) {
-      const { render } = await window.Forem.getPreactImport();
-      render(null, currentModalContainer);
-    }
-  },
+  showModal: showWindowModal,
+  closeModal: closeWindowModal,
   Runtime,
 };
 

--- a/app/javascript/utilities/showModal.jsx
+++ b/app/javascript/utilities/showModal.jsx
@@ -1,0 +1,81 @@
+// Unique ID applied to modals created using the showWindowModal function
+const WINDOW_MODAL_ID = 'window-modal';
+
+// We only import these modules if a user actually triggers a modal. Here we cache them so they are only imported once.
+let preactImport;
+let modalImports;
+
+const getPreactImport = () => {
+  if (!preactImport) {
+    preactImport = import('preact');
+  }
+  return preactImport;
+};
+
+const getModalImports = () => {
+  if (!modalImports) {
+    modalImports = [import('@crayons/Modal'), getPreactImport()];
+  }
+  return Promise.all(modalImports);
+};
+
+/**
+ * This helper function finds the HTML with the given contentSelector, and presents it inside a Preact modal.
+ * Only one modal will be presented at any given time.
+ *
+ * @param {Object} args
+ * @param {string} args.title The title of the modal (presented at the top of the modal dialog)
+ * @param {string} args.contentSelector The CSS query to locate the HTML to be presented in the modal (e.g. '#my-modal-content')
+ * @param {string} args.size The size prop for the modal ('small', 'medium', or 'large')
+ * @param {Function} args.onOpen A callback function to run when the modal opens. This can be useful, for example, to attach any event listeners to items inside the modal.
+ */
+export const showWindowModal = async ({
+  title,
+  contentSelector,
+  size = 'small',
+  onOpen,
+}) => {
+  const [{ Modal }, { render, h }] = await getModalImports();
+
+  // Guard against two modals being opened at once
+  let currentModalContainer = document.getElementById(WINDOW_MODAL_ID);
+  if (currentModalContainer) {
+    render(null, currentModalContainer);
+  } else {
+    currentModalContainer = document.createElement('div');
+    currentModalContainer.setAttribute('id', WINDOW_MODAL_ID);
+    document.body.appendChild(currentModalContainer);
+  }
+
+  render(
+    <Modal
+      title={title}
+      onClose={() => {
+        render(null, currentModalContainer);
+      }}
+      size={size}
+      focusTrapSelector={`#${WINDOW_MODAL_ID}`}
+    >
+      <div
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: document.querySelector(contentSelector).innerHTML,
+        }}
+      />
+    </Modal>,
+    currentModalContainer,
+  );
+
+  onOpen?.();
+};
+
+/**
+ * This helper function closes any currently open window modal. This can be useful, for example, if your modal contains a "cancel" button.
+ */
+export const closeWindowModal = async () => {
+  const currentModalContainer = document.getElementById(WINDOW_MODAL_ID);
+  if (currentModalContainer) {
+    const { render } = await getPreactImport();
+    render(null, currentModalContainer);
+  }
+};


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The current generic `showModal`/`closeModal` helpers are only available in `base.jsx`, meaning they are not currently available in the app's admin area. Increasingly we are finding use cases for this minimal show/hide modal functionality in the admin area, and we want to move away from Stimulus (which we currently use to control some modals there).

This PR extracts the modal code from `base.jsx` into its own utility file. This means that older code can still access it in the current way (e.g. `window.Forem.showModal()`), but we can now also call these functions from any admin pack files (or indeed any pack files generally).

This refactor also allows us to add some clearer JSDoc comments to the code.

**Follow up task:**

Once this is merged I will push up a quick follow up task to refactor the modal usage in `packs/admin/editUser` to utilise these helpers. I wanted to keep this PR small so that we can get using these helpers 😄 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

Will be used in https://github.com/forem/forem/pull/17259

## QA Instructions, Screenshots, Recordings

Our Cypress specs should catch any regression, but for manual testing purposes, here are the locations where we currently use this helper:

- the login modal - when you are a logged out user, clicking a reading list save button, a follow button, an article reaction button, should all trigger a login modal
- the user alert modal - for example, if you post more comments than the configured rate limit
- the hide comment modal - when viewing a comment on your own post, you can click "Hide" in the 'three dots' dropdown menu, and it will trigger a modal
- the user subscription liquid tag 'confirm' modal - using liquid tag `{% user_subscription some example text %}` - the 'signed in' version of this liquid tag should have a "Subscribe" button which triggers a pop up confirmation modal
- the confirm email "click here if you didn't receive the email" modal

I've tested each area, and modals are working as expected 🙂 

### UI accessibility concerns?

The Preact modal component has a lot of accessibility features baked-in (e.g. a focus trap), so the ability to use it more widely helps us keep things consistently accessible.

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: Existing tests should cover all functionality
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [X] I will share this change internally with the appropriate teams



