### PR TITLE
Correcting public_reactions_count

### DIFF
--- a/app/services/articles/feeds/weighted_query_strategy.rb
+++ b/app/services/articles/feeds/weighted_query_strategy.rb
@@ -219,14 +219,14 @@ module Articles
         },
         # Weight to give for the number of reactions on the article.
         reactions_factor: {
-          clause: "articles.reactions_count",
+          clause: "articles.public_reactions_count",
           cases: [
             [0, 0.9988], [1, 0.9988], [2, 0.9988],
             [3, 0.9988]
           ],
           fallback: 1,
           requires_user: false,
-          group_by: "articles.reactions_count"
+          group_by: "articles.public_reactions_count"
         },
         # Weight to give based on spaminess of the article.
         spaminess_factor: {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this commit, we were looking at trusted user's reaction
counts.  This is not the desired column to be testing.

See
https://github.com/forem/forem/blob/f1d6291d0038f4e7131e750c73f31d155ddc6a1f/app/models/reaction.rb#L25-L28

```ruby
  counter_culture :reactable,
                  column_name: proc { |model|
                    PUBLIC_CATEGORIES.include?(model.category) ? "public_reactions_count" : "reactions_count"
                  }
```

In the above code, all public reactions (hearts, unicorns, reading
list) go to public_reactions_count.  Other things go to the
`reactions_count`; which is the thumbs up and thumbs down.


## Related Tickets & Documents

- Closes forem/forem#17260

## QA Instructions, Screenshots, Recordings

None

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: the SQL is already tested

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
