### PR TITLE
Fix broken favicons in embeds of other Forem URLs

### DIFF
--- a/app/assets/stylesheets/base/typography.scss
+++ b/app/assets/stylesheets/base/typography.scss
@@ -348,4 +348,9 @@ body {
     margin: 0;
     margin-bottom: var(--su-2);
   }
+
+  &__favicon {
+    width: 32px;
+    height: auto;
+  }
 }

--- a/app/views/liquids/_open_graph.html.erb
+++ b/app/views/liquids/_open_graph.html.erb
@@ -22,9 +22,9 @@
         <% if page.images.favicon %>
           <img
             alt="favicon"
-            class="m-0 mr-2 radius-0"
-            src="<%= Images::Optimizer.call(page.images.favicon, width: 48) %>"
-            width="24" height="24" loading="lazy" />
+            class="c-embed__favicon m-0 mr-2 radius-0"
+            src="<%= page.images.favicon %>"
+            loading="lazy" />
         <% end %>
         <%= url_domain %>
       </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fix bug where embed favicons were broken when embedding other Forem URLs.

## Related Tickets & Documents
- Closes https://github.com/forem/forem/issues/17238

## QA Instructions, Screenshots, Recordings
Create an embed to another Forem URL. The embeds favicon should render correctly (if it exists).

### UI accessibility concerns?
No significant frontend changes

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: _unnecessary_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
