### PR TITLE
Update builder spec variable names

### DIFF
--- a/spec/services/articles/builder_spec.rb
+++ b/spec/services/articles/builder_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes and does not store location" do
-      subject, store_location = described_class.call(user, tag, prefill)
+    it "initializes an article with the correct attributes" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
       expect(subject).to have_attributes(correct_attributes)
-      expect(store_location).to be true
+      expect(needs_authorization).to be true
     end
   end
 
@@ -38,12 +38,12 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes and does not store location" do
-      subject, store_location = described_class.call(user, tag, prefill)
+    it "initializes an article with the correct attributes" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
       expect(subject).to have_attributes(correct_attributes)
-      expect(store_location).to be true
+      expect(needs_authorization).to be true
     end
   end
 
@@ -60,12 +60,12 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes and does not store location" do
-      subject, store_location = described_class.call(user, tag, prefill)
+    it "initializes an article with the correct attributes" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
       expect(subject).to have_attributes(correct_attributes)
-      expect(store_location).to be true
+      expect(needs_authorization).to be true
     end
   end
 
@@ -79,12 +79,12 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes and does not store location" do
-      subject, store_location = described_class.call(user, tag, prefill)
+    it "initializes an article with the correct attributes" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
       expect(subject).to have_attributes(correct_attributes)
-      expect(store_location).to be true
+      expect(needs_authorization).to be true
     end
   end
 
@@ -99,13 +99,13 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes and stores location" do
+    it "initializes an article with the correct attributes and does not need authorization" do
       user.setting.update(editor_version: "v1")
-      subject, store_location = described_class.call(user, tag, prefill)
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
       expect(subject).to have_attributes(correct_attributes)
-      expect(store_location).to be false
+      expect(needs_authorization).to be false
     end
   end
 
@@ -117,12 +117,12 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes and does stores location" do
-      subject, store_location = described_class.call(user, tag, prefill)
+    it "initializes an article with the correct attributes" do
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
       expect(subject).to have_attributes(correct_attributes)
-      expect(store_location).to be false
+      expect(needs_authorization).to be false
     end
   end
 
@@ -139,13 +139,13 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes and does stores location" do
+    it "initializes an article with the correct attributes" do
       user.setting.update(editor_version: "v1")
-      subject, store_location = described_class.call(user, tag, prefill)
+      subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
       expect(subject).to have_attributes(correct_attributes)
-      expect(store_location).to be false
+      expect(needs_authorization).to be false
     end
   end
 end

--- a/spec/services/articles/builder_spec.rb
+++ b/spec/services/articles/builder_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes" do
+    it "initializes an article with the correct attributes and needs authorization" do
       subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
@@ -38,7 +38,7 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes" do
+    it "initializes an article with the correct attributes and needs authorization" do
       subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
@@ -60,7 +60,7 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes" do
+    it "initializes an article with the correct attributes and needs authorization" do
       subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
@@ -79,7 +79,7 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes" do
+    it "initializes an article with the correct attributes and needs authorization" do
       subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
@@ -117,7 +117,7 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes" do
+    it "initializes an article with the correct attributes and does not need authorization" do
       subject, needs_authorization = described_class.call(user, tag, prefill)
 
       expect(subject).to be_an_instance_of(Article)
@@ -139,7 +139,7 @@ RSpec.describe Articles::Builder, type: :service do
       }
     end
 
-    it "initializes an article with the correct attributes" do
+    it "initializes an article with the correct attributes and does not need authorization" do
       user.setting.update(editor_version: "v1")
       subject, needs_authorization = described_class.call(user, tag, prefill)
 


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description


In #16536 the tests were updated to match a change in the
logic (rather than "needs authorization" the response was "store
location", and we checked for those values).

In #17294 we re-adjusted the meaning of the second returned value from
Articles::Builder.call, and the call sites now label the second value
as "needs_authorization" again.

Restore consistent naming in the spec as in the service object, and clarify 
the spec description text to match the meaning. 

## Related Tickets & Documents

- Related Issue #17294 follow up

## QA Instructions, Screenshots, Recordings

Test only change. Should be green.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes (variable name substitution only)

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] This change does not need to be communicated, and this is why not: cleanup

## [optional] What gif best describes this PR or how it makes you feel?
![better than you found it](https://user-images.githubusercontent.com/1237369/163471299-bd228f19-0ddd-4d4a-af74-8d1fd1e1d8dc.png)
