### PR TITLE
Enable string uuid as namespace

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,10 +49,6 @@ module PracticalDeveloper
     config.active_support.hash_digest_class = ::Digest::MD5 # New default is ::Digest::SHA1
     ### END FRAMEWORK DEFAULT OVERIDES
 
-    # permit using a string uuid as namespace
-    # see https://github.com/rails/rails/pull/37682
-    config.active_support.use_rfc4122_namespaced_uuids = true
-
     # Disable auto adding of default load paths to $LOAD_PATH
     # Setting this to false saves Ruby from checking these directories when
     # resolving require calls with relative paths, and saves Bootsnap work and

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,10 @@ module PracticalDeveloper
     config.active_support.hash_digest_class = ::Digest::MD5 # New default is ::Digest::SHA1
     ### END FRAMEWORK DEFAULT OVERIDES
 
+    # permit using a string uuid as namespace
+    # see https://github.com/rails/rails/pull/37682
+    config.active_support.use_rfc4122_namespaced_uuids = true
+
     # Disable auto adding of default load paths to $LOAD_PATH
     # Setting this to false saves Ruby from checking these directories when
     # resolving require calls with relative paths, and saves Bootsnap work and

--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -104,7 +104,7 @@
 #
 # See https://guides.rubyonrails.org/configuring.html#config-active-support-use-rfc4122-namespaced-uuids for
 # more information.
-# Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
+Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
 
 # Change the default headers to disable browsers' flawed legacy XSS protection.
 # Rails.application.config.action_dispatch.default_headers = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adopt the rails 7 default for generated  namespaced UUIDs.

This addresses a noisy deprecation warning showing in specs (it points
to our re-implementation of warden's [login_as helper](https://github.com/forem/forem/blob/main/spec/support/initializers/warden.rb#L8-L13), but I suspect
the issue is within warden since our initializer seems to match the
implementation in the upstream gem).

My understanding of this is that the prior default had been to pass
the provided uuid namespace as-is if it didn't match one of a few
named constants. New behavior is to validate that any string provided
as a namespace looks like a uuid representation or fail).

If nothing breaks, the further assumption is that warden is passing a uuid as a string in the namespace method.

The comment in the new_framework_defaults_7_0.rb file has 

> See https://guides.rubyonrails.org/configuring.html#config-active-support-use-rfc4122-namespaced-uuids for more information.

## Related Tickets & Documents


## QA Instructions, Screenshots, Recordings

Since this is related to a test setup issue, I assume nothing bad happens in dev/prod.

Looking for places we might directly call a uuid (or pass a namespace) didn't show anything obvious.


### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: config change

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams
