### PR TITLE
Renaming WeightedQueryStrategy to VariantQuery

### DIFF
--- a/app/controllers/stories/feeds_controller.rb
+++ b/app/controllers/stories/feeds_controller.rb
@@ -43,7 +43,7 @@ module Stories
                  controller: self, user: current_user,
                  default_value: AbExperiment::ORIGINAL_VARIANT
                )
-               Articles::Feeds::WeightedQueryStrategy.new(
+               Articles::Feeds::VariantQuery.new(
                  user: current_user,
                  number_of_articles: 25,
                  page: @page,
@@ -68,7 +68,7 @@ module Stories
       strategy = AbExperiment.get(experiment: AbExperiment::CURRENT_FEED_STRATEGY_EXPERIMENT, controller: self,
                                   user: current_user, default_value: AbExperiment::ORIGINAL_VARIANT)
       feed = if strategy.weighted_query_strategy?
-               Articles::Feeds::WeightedQueryStrategy.new(user: current_user, page: @page, tags: params[:tag])
+               Articles::Feeds::VariantQuery.new(user: current_user, page: @page, tags: params[:tag])
              elsif Settings::UserExperience.feed_strategy == "basic"
                # I'm a bit uncertain why we're skipping the user on this call.
                Articles::Feeds::Basic.new(user: nil, page: @page, tag: params[:tag])

--- a/app/services/articles/feeds/find_featured_story.rb
+++ b/app/services/articles/feeds/find_featured_story.rb
@@ -15,7 +15,7 @@ module Articles
       #       consideration for `featured == true`.  Perhaps that
       #       should change?  This has been reported in
       #       https://github.com/forem/forem/issues/15613 and impacts
-      #       Articles::Feeds::WeightedQueryStrategy.
+      #       Articles::Feeds::VariantQuery.
       def self.call(stories, must_have_main_image: true)
         featured_story =
           if must_have_main_image

--- a/app/services/articles/feeds/variant_query.rb
+++ b/app/services/articles/feeds/variant_query.rb
@@ -30,7 +30,7 @@ module Articles
     #       account for the Forem's administrators.
     # @note For those considering extending this, be very mindful of
     #       SQL injection.
-    class WeightedQueryStrategy
+    class VariantQuery
       # This constant defines the allowable relevance scoring methods.
       #
       # A scoring method should be a SQL fragment that produces a
@@ -310,7 +310,7 @@ module Articles
       # @example
       #
       #    user = User.first
-      #    strategy = Articles::Feed::WeightedQueryStrategy.new(user: user)
+      #    strategy = Articles::Feed::VariantQuery.new(user: user)
       #    puts strategy.call.to_sql
       #
       # rubocop:disable Layout/LineLength

--- a/config/feed/README.md
+++ b/config/feed/README.md
@@ -8,7 +8,7 @@ constraints.
 ## Historical Documents
 
 - The
-  [Articles::Feeds::WeightedQueryStrategy](https://github.com/forem/forem/blob/de2edee07d824a34e5c5445d455b1f8086bd127d/app/services/articles/feeds/weighted_query_strategy.rb)
+  [Articles::Feeds::VariantQuery](https://github.com/forem/forem/blob/main/app/services/articles/feeds/variant_query.rb)
   is the precursor to the more robust feed configuration. It provides hints as
   to how we'll structure the feed configuration.
 - [These Are the [Feed] Levers I Know I Know - Forem Team 🌱](https://dev.to/devteam/these-are-the-feed-levers-i-know-i-know-3jj7)
@@ -20,8 +20,8 @@ constraints.
 
 - **_Feed Experiment_:** A _feed experiment_ is the currently implemented set of
   _feed strategies_ - current configurations we're using to generate feeds
-- **_Feed Strategy_:** a configuration of _levers_ and _relevancy factors_,
-  which can be used to generate the _relevancy feed_.
+- **_Feed Variant_:** a configuration of _levers_ and _relevancy factors_, which
+  can be used to generate the _relevancy feed_.
 - **_Lever_:** A _lever_ is a specific attribute we're querying from the
   database.
 - **_Lever Range_:** The _lever range_ is the potential range of values that the
@@ -32,9 +32,9 @@ constraints.
 - **_Relevancy Feed_:** The _relevancy feed_ (or for this document the _feed_)
   builds the list of articles a user sees on the homepage of a Forem.
 - **_Relevancy Score_:** Each article is assigned a _relevancy score_ based on
-  the _lever_ configuration of the current _feed strategy_. It is the product of
+  the _lever_ configuration of the current _feed variant_. It is the product of
   all applicable _relevancy factors_ for each of the _levers_ in the _feed
-  strategy_.
+  variant_.
 
 At a future point, we might allow for the site creators to pick one or more feed
 strategies for the _relevancy feed_ and even allow a member to specify their
@@ -47,7 +47,7 @@ other emergent _feed strategies_.
 There are three layers of configuration, presented working from the inside out.
 
 1.  Lever
-2.  Feed Strategy
+2.  Feed Variant
 3.  Feed Experiment
 
 ### Lever Configuration
@@ -68,15 +68,15 @@ I believe the goal is to avoid changing the SQL implementation details of a
 lever; we would instead create a new lever. This way we can have consistent
 documentation for a given lever.
 
-### Feed Strategy
+### Feed Variant
 
-Each _feed strategy_ need not require engineering time to create and define.
-This involves:
+Each _feed variant_ need not require engineering time to create and define. This
+involves:
 
-- Defining the programmatic key for the _feed strategy_.
+- Defining the programmatic key for the _feed variant_.
 - Writing the human readable label.
-- Writing any notes around the _feed strategy_.
-- Defining which _lever_ this _feed strategy_ incorporates.
+- Writing any notes around the _feed variant_.
+- Defining which _lever_ this _feed variant_ incorporates.
 - For each _lever_,
   - Mapping the elements within the _lever range_ to the desired _relevancy
     factor_.
@@ -84,7 +84,7 @@ This involves:
   - Describing the intention of this mapping and fallback.
 
 From an application stand-point we want to run the queries for each _feed
-strategy_ (to ensure valid SQL).
+variant_ (to ensure valid SQL).
 
 ### Feed Experiment
 
@@ -104,15 +104,15 @@ While the application is running, either in _production_ or under a request or
 integration test, we should only load _feed strategies_ that are part of a _feed
 experiment_ and/or available for a Creator to select.
 
-To expose a new _feed strategy_ to a production instance will require a deploy
-of that instance. At a future point, we may look to allowing uploads of _feed
+To expose a new _feed variant_ to a production instance will require a deploy of
+that instance. At a future point, we may look to allowing uploads of _feed
 strategies_ but that is not the current path.
 
 Changing from one _feed experiment_ to another will require a new deploy. At a
 future point we might allow for live changes of the _feed experiment_ but that
 is outside the scope of present considerations.
 
-Each _feed strategy_ will be tested as part of unit testing; to ensure it
+Each _feed variant_ will be tested as part of unit testing; to ensure it
 generates valid SQL.
 
 Each _feed lever_ will be tested as part of unit testing to ensure it is well

--- a/spec/services/articles/feeds/variant_query_spec.rb
+++ b/spec/services/articles/feeds/variant_query_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
-RSpec.describe Articles::Feeds::WeightedQueryStrategy, type: :service do
+RSpec.describe Articles::Feeds::VariantQuery, type: :service do
   subject(:feed_strategy) { described_class.new(user: user) }
 
   let(:user) { nil }
 
   describe "#default_home_feed" do
     # This test helps test the common interface between the
-    # WeightedQueryStrategy and the LargeForemExperimental
+    # VariantQuery and the LargeForemExperimental
     it "receives `user_signed_in: false` and behaves" do
       response = feed_strategy.default_home_feed(user_signed_in: false)
       expect(response).to be_a(ActiveRecord::Relation)
@@ -53,7 +53,7 @@ RSpec.describe Articles::Feeds::WeightedQueryStrategy, type: :service do
         articles = create_list(:article, 3)
 
         # This scenario can happen with
-        # `Articles::Feeds::WeightedQueryStrategy#featured_story_and_default_home_feed`
+        # `Articles::Feeds::VariantQuery#featured_story_and_default_home_feed`
         # when we look for a "featured" article and don't find any.
         # So let's make sure we get back the articles we were
         # expecting instead of none of them.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Documentation Update

## Description

Given that we're moving forward with the approach of the
"WeightedQueryStrategy", I wanted to better align the class name.

I'm choosing "VariantQuery" to align with the FieldTest gem in which we run an
`experiment` and each `experiment` has one or more `variants`.  (See
[./config/field_test.yml][1])
In other words, I'm working to align the terms we already have in our domain.

When I first wrote this class, I was looking for the appropriate term to
describe it; and it has served well but it is time to bring a more
general name to this class.

[1]:https://github.com/forem/forem/blob/01d04ae7f3dc72a0684b2545f212a5cb7ad368ad/config/field_test.yml

## Related Tickets & Documents

Closes forem/forem#17312

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
