### PR TITLE
Replace links to the repo with newer URLs

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -313,7 +313,7 @@ class ArticlesController < ApplicationController
                      end
 
     # NOTE: the organization logic is still a little counter intuitive but this should
-    # fix the bug <https://github.com/thepracticaldev/dev.to/issues/2871>
+    # fix the bug <https://github.com/forem/forem/issues/2871>
     if params["article"]["user_id"] && org_admin_user_change_privilege
       allowed_params << :user_id
     elsif params["article"]["organization_id"] && allowed_to_change_org_id?

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -81,7 +81,7 @@ class CommentsController < ApplicationController
       message = @comment.errors_as_sentence
       render json: { error: message }, status: :unprocessable_entity
     end
-  # See https://github.com/thepracticaldev/dev.to/pull/5485#discussion_r366056925
+  # See https://github.com/forem/forem/pull/5485#discussion_r366056925
   # for details as to why this is necessary
   rescue ModerationUnauthorizedError => e
     render json: { error: e.message }, status: :unprocessable_entity

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -68,7 +68,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect(@user, event: :authentication)
     # NOTE: I can't find a way to test this path
     # as `User` will assign a temporary username if the username already exists
-    # see https://github.com/thepracticaldev/dev.to/blob/27131f6f420df347a467f8e9afc84a6af2fcb13a/app/models/user.rb#L532-L555
+    # see https://github.com/forem/forem/blob/27131f6f420df347a467f8e9afc84a6af2fcb13a/app/models/user.rb#L532-L555
     elsif user_persisted_but_username_taken?
       redirect_to "/settings?state=previous-registration"
     # NOTE: I can't find a way to test this path
@@ -76,7 +76,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # raise errors for a validation error.
     # In the past we had 1 path (update_user) which would have ended up
     # here in case of validation errors, see:
-    # https://github.com/thepracticaldev/dev.to/blob/80737b540453afe8775128cb37bd379b7c09c7e8/app/services/authorization_service.rb#L77
+    # https://github.com/forem/forem/blob/80737b540453afe8775128cb37bd379b7c09c7e8/app/services/authorization_service.rb#L77
     else
       # Devise will clean this data when the user is not persisted
       session["devise.#{provider}_data"] = request.env["omniauth.auth"]

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe Article, type: :model do
     describe "tag validation" do
       let(:article) { build(:article, user: user) }
 
-      # See https://github.com/thepracticaldev/dev.to/pull/6302
+      # See https://github.com/forem/forem/pull/6302
       # rubocop:disable RSpec/VerifiedDoubles
       it "does not modify the tag list if there are no adjustments" do
         allow(TagAdjustment).to receive(:where).and_return(TagAdjustment.none)


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

Replace links to the repo in Ruby code comments with newer URLs to avoid useless redirections.

## Related Tickets & Documents

- Related Issue #17208

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added/updated tests?

- [x] No, and this is why: changes only comments