### PR TITLE
Replace Git URL with the new one

### DIFF
--- a/scripts/clean_fork.sh
+++ b/scripts/clean_fork.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 # clean up the fork and restart from upstream
-git remote add upstream https://github.com/thepracticaldev/dev.to
+git remote add upstream https://github.com/forem/forem.git
 git fetch upstream
 git checkout main
-git reset --hard upstream/main  
-git push origin main --force 
+git reset --hard upstream/main
+git push origin main --force

--- a/scripts/sync_fork.sh
+++ b/scripts/sync_fork.sh
@@ -2,7 +2,7 @@
 set -e
 
 # sync this fork with upstream to get the latest changes
-URL="https://github.com/thepracticaldev/dev.to";
+URL="https://github.com/forem/forem.git";
 if ! git config remote.upstream.url > /dev/null; then
   echo "Adding remote ${URL}"
   git remote add upstream $URL


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

Replaces Git URL `https://github.com/thepracticaldev/dev.to` with the new one `https://github.com/forem/forem.git`.

## Related Tickets & Documents

- Related Issue #17208

## QA Instructions, Screenshots, Recordings

Run `scripts/clean_fork.sh` and `scripts/sync_fork.sh` on the forked repo.

### UI accessibility concerns?

n/a

## Added/updated tests?

- [x] No, and this is why: it is hard to prepare forked repos in tests.