### PR TITLE
Enable error tracking on sendFollowUser

### DIFF
--- a/app/javascript/utilities/sendFollowUser.js
+++ b/app/javascript/utilities/sendFollowUser.js
@@ -20,8 +20,6 @@ export function sendFollowUser(user, successCb) {
       // json is followed or unfollowed
     })
     .catch((error) => {
-      // TODO: Add client-side error tracking. See https://github.com/thepracticaldev/dev.to/issues/2501
-      // for the discussion.
-      console.log(error); // eslint-disable-line no-console
+      Honeybadger.notify(error);
     });
 }


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization
- [x] Documentation Update

## Description

Enables error tracking on `sendFollowUser` in client-side. Also removes links to #2501 from the comments.

## Related Tickets & Documents

- Related Issue #2501
- Part of #17208

## QA Instructions, Screenshots, Recordings

1. Setup Honeybadger on your local
1. Access to `/t/discuss`
1. Click "Follow" in `who to follow` on sidebar.
1. You can use the following a patch to generate an error on `POST /follows`:

```diff
diff --git a/app/controllers/follows_controller.rb b/app/controllers/follows_controller.rb
index b463758fd..87945858d 100644
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -75,7 +75,8 @@ def create
                 follow(followable, need_notification: need_notification)
               end
 
-    render json: { outcome: @result }
+    # render json: { outcome: @result }
+    render text: "hello honeybadger from follows#create"
   end
 
   def bulk_update
```

![3000-forem-forem-7madp5en847 ws-us40 gitpod io_t_discuss](https://user-images.githubusercontent.com/10229505/163794991-c322a61d-d42a-413d-9489-6bc5de2a315e.png)

### UI accessibility concerns?

No UI changed.

## Added/updated tests?

- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_