### PR TITLE
Fix bug in search and filter indicators (admin member index)

### DIFF
--- a/app/javascript/packs/admin/users/controls.js
+++ b/app/javascript/packs/admin/users/controls.js
@@ -73,13 +73,13 @@ const sendFocusToFirstInteractiveItem = (element) => {
 };
 
 /**
- * Ensures that search/filter button indicators stay in sync with the user's current selections.
+ * Ensures that search/filter button indicators in mobile view stay in sync with the user's current selections.
  * Indicators may become visible when a search term or filter option is input (although they are only displayed via CSS
  * when the section is collapsed).
  */
 const initializeSectionIndicators = () => {
   document
-    .getElementById('search')
+    .getElementById('search-small')
     ?.addEventListener('change', ({ target: { value } }) => {
       toggleIndicator({
         indicator: expandSearchButton?.querySelector('.search-indicator'),
@@ -88,7 +88,7 @@ const initializeSectionIndicators = () => {
     });
 
   document
-    .getElementById('role')
+    .getElementById('filter-small')
     ?.addEventListener('change', ({ target: { value } }) => {
       toggleIndicator({
         indicator: expandFilterButton?.querySelector('.search-indicator'),

--- a/app/views/admin/users/index/_controls.html.erb
+++ b/app/views/admin/users/index/_controls.html.erb
@@ -9,7 +9,7 @@
           <%= render "admin/users/index/expand_search_button" %>
           <button type="button" id="expand-filter-btn" class="c-btn c-btn--icon-alone indicator-btn" aria-label="Expand filter" aria-expanded="false" aria-controls="filter-users">
             <%= crayons_icon_tag("filter", aria_hidden: true) %>
-            <span class="search-indicator absolute top-1 right-1 c-indicator c-indicator--info <%= params[:role].blank? ? "hidden" : "" %>"></span>
+            <span data-testid="search-indicator" class="search-indicator absolute top-1 right-1 c-indicator c-indicator--info <%= params[:role].blank? ? "hidden" : "" %>"></span>
           </button>
         </div>
         <div class="flex">

--- a/app/views/admin/users/index/_expand_search_button.html.erb
+++ b/app/views/admin/users/index/_expand_search_button.html.erb
@@ -1,4 +1,4 @@
 <button type="button" id="expand-search-btn" class="relative c-btn c-btn--icon-alone indicator-btn" aria-label="Expand search" aria-expanded="false" aria-controls="search-users">
     <%= crayons_icon_tag("search", aria_hidden: true) %>
-    <span class="search-indicator absolute top-1 right-1 c-indicator c-indicator--info <%= params[:search].blank? ? "hidden" : "" %>"></span>
+    <span data-testid="search-indicator" class="search-indicator absolute top-1 right-1 c-indicator c-indicator--info <%= params[:search].blank? ? "hidden" : "" %>"></span>
 </button>

--- a/cypress/integration/seededFlows/adminFlows/users/userIndexView.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/userIndexView.spec.js
@@ -73,6 +73,54 @@ describe('User index view', () => {
         cy.findByRole('button', { name: 'Search' }).should('not.exist');
       });
 
+      it('indicates filter is applied if filter options are collapsed', () => {
+        // Choose a filter
+        cy.findByRole('button', { name: 'Expand filter' })
+          .as('filterButton')
+          .should('have.attr', 'aria-expanded', 'false')
+          .pipe(click)
+          .should('have.attr', 'aria-expanded', 'true');
+        cy.findByRole('combobox').select('trusted');
+        // Indicator should not be shown while open
+        cy.get('@filterButton')
+          .findByTestId('search-indicator')
+          .should('not.be.visible');
+
+        // Collapse the filter field; indicator should now be shown
+        cy.get('@filterButton')
+          .click()
+          .should('have.attr', 'aria-expanded', 'false');
+        cy.get('@filterButton')
+          .findByTestId('search-indicator')
+          .should('be.visible');
+      });
+
+      it('indicates a search term is applied if search options are collapsed', () => {
+        // Enter some text in search term
+        cy.findByRole('button', { name: 'Expand search' })
+          .as('searchButton')
+          .should('have.attr', 'aria-expanded', 'false')
+          .pipe(click)
+          .should('have.attr', 'aria-expanded', 'true');
+        cy.findByRole('textbox', {
+          name: 'Search member by name, username, email, or Twitter/GitHub usernames',
+        })
+          .clear()
+          .type('something');
+        // Indicator should not be shown while open
+        cy.get('@searchButton')
+          .findByTestId('search-indicator')
+          .should('not.be.visible');
+
+        // Collapse the filter field; indicator should now be shown
+        cy.get('@searchButton')
+          .click()
+          .should('have.attr', 'aria-expanded', 'false');
+        cy.get('@searchButton')
+          .findByTestId('search-indicator')
+          .should('be.visible');
+      });
+
       it(`Clicks through to the Member Detail View`, () => {
         cy.findAllByRole('link', { name: 'Admin McAdmin' }).first().click();
         cy.url().should('contain', '/admin/users/1');


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

(this bug isn't live anywhere as it's still behind a feature flag)

My changes to the member index layouts which made sure all inputs have unique IDs had a side effect of breaking the "dot" indicator over the mobile search/filter buttons, which let users know if they have a current search term or filter input. This PR restores that functionality and adds test to make sure it doesn't regress again.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

Introduced in https://github.com/forem/forem/pull/17246

## QA Instructions, Screenshots, Recordings

- Make sure you have `member_index_view` feature flag enabled and visit `admin/users`
- Reduce your viewport to a mobile screen size
- Click the search button and enter some text
- Click the filter button
- Search button should now have a small dot over it
- Select a role to filter by
- Click the search button
- Filter button should now have a small dot over it, and no dot over the search button
- Check that whenever the relevant section is expanded, no dot appears
- And whenever the relevant section is collapsed, a dot does appear


https://user-images.githubusercontent.com/20773163/164023870-cd32ec5e-3c16-4944-ac45-d810dbc8d57e.mp4


### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] This change does not need to be communicated, and this is why not: The bug never reached production

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![whoopsies](https://media.giphy.com/media/3ohzdYJK1wAdPWVk88/giphy.gif)
