### PR TITLE
Removing unclosed div tag

### DIFF
--- a/app/views/stories/tagged_articles/_sidebar.html.erb
+++ b/app/views/stories/tagged_articles/_sidebar.html.erb
@@ -3,7 +3,6 @@
     <div class="sidebar-bg" id="sidebar-bg-left"></div>
     <aside class="side-bar">
       <% if @tag && @tag.rules_html.present? %>
-        <div class="widget">
         <%= application_policy_content_tag("div", record: Article, query: :create?, class: "widget") do %>
           <header>
             <h4><%= t("views.tags.sidebar.guidelines") %></h4>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

This div tag is subsumed by the line below (e.g. `<%=
application_policy_content_tag("div"...`).  When the unclosed div is
present there is some undesirable layout offset.  When it's removed,
things line up a bit nicer.

Discovered while attempting to reproduce forem/forem#17324

## Related Tickets & Documents

- Related Issue forem/forem#17324

## QA Instructions, Screenshots, Recordings

Before Screenshot

<img width="304" alt="Screen Shot 2022-04-19 at 12 15 30 PM" src="https://user-images.githubusercontent.com/2130/164050287-b8f1b757-14c5-43a0-9ef8-5ae86aeaa200.png">

After Screenshot

<img width="320" alt="Screen Shot 2022-04-19 at 12 15 12 PM" src="https://user-images.githubusercontent.com/2130/164050321-afdbcd8a-fd21-4f20-adb6-e5af225b00fe.png">




### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: to low level to require a test

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
