### PR TITLE
change the object-fit to scale down to retain ratio on cover images

### DIFF
--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -23,7 +23,7 @@
       border-radius: var(--radius-auto);
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      object-fit: cover;
+      object-fit: scale-down;
       width: 100%;
       height: 100%;
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

The corresponding issue #16455 proposes resizing the image to retain correct aspect ratio via image manipulation done server side. While this can certainly be done, it comes at a slight cost of maintenance and perhaps performance. The cover image is something that is higher touch than setting a company logo or profile picture. Given that, I wanted to propose this css first solution that accomplishes the goal of maintaining the aspect ratio WITHOUT further image manipulation done server side. To me, this gets us moving in the right direction while allowing us to take a half step back and explore if there is a true need to "hard" scale the cover image. This approach also avoids the cumulative layout shift that Pawel mentioned as we are not changing the image height and width inline. Welcoming any input especially if my thinking here is just way off base.

## Related Tickets & Documents

#16455. 

## QA Instructions, Screenshots, Recordings

<img width="1000" alt="mona-before-after" src="https://user-images.githubusercontent.com/720055/164054358-79601a9e-b410-478f-9b0a-a61962d5a5d9.png">
<img width="1000" alt="starry-before-after" src="https://user-images.githubusercontent.com/720055/164054366-a5eadb37-b99a-4e79-b30d-861620353042.png">


### UI accessibility concerns?

none

## Added/updated tests?

- [x] No, and this is why: just a scaling change to the CSS

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
