### PR TITLE
Remove DISABLE_SPRING variables after PR#16848

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,8 +13,6 @@ ports:
 
 tasks:
   - name: Forem Server
-    env:
-      DISABLE_SPRING: 1
     before: >
       redis-server &
       gp await-port 5432 &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ env:
     - KNAPSACK_PRO_CI_NODE_TOTAL=3
     - COVERAGE_REPORTS_TOTAL=4
     - FOREM_OWNER_SECRET="secret" # test secret so e2e tests can run properly.
-    - DISABLE_SPRING=true
 before_install:
   - sudo apt-get update
   - sudo apt-get -y install gsfonts


### PR DESCRIPTION
## Description
Removes `DISABLE_SPRING` variables from tests (Travis CI) and dev (Gitpod) after PR #16848.

## What type of PR is this? (check all applicable)
- [x] Refactor

## Related Tickets & Documents
- Follows up #16848

## QA Instructions, Screenshots, Recordings
See the results on Gitpod and Travis CI logs.

### UI accessibility concerns?
n/a

## Added/updated tests?
- [x] No, and this is why: dependency update

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>