### PR TITLE
Enable active_support.use_rfc4122_namespaced_uuid

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -104,7 +104,7 @@
 #
 # See https://guides.rubyonrails.org/configuring.html#config-active-support-use-rfc4122-namespaced-uuids for
 # more information.
-# Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
+Rails.application.config.active_support.use_rfc4122_namespaced_uuids = true
 
 # Change the default headers to disable browsers' flawed legacy XSS protection.
 # Rails.application.config.action_dispatch.default_headers = {


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description
Enables `active_support.use_rfc4122_namespaced_uuid = true` config introduced in Rails 7.0 to suppress warnings as follows:

```
DEPRECATION WARNING: Providing a namespace ID that is not one of the constants defined on Digest::UUID generates an incorrect UUID value according to RFC 4122. To enable the correct behavior, set the Rails.application.config.active_support.use_rfc4122_namespaced_uuids configuration option to true. (called from current_user at {{PATH}}/app/controllers/concerns/edge_cache_safety_check.rb:12)
```

## Related Tickets & Documents
Follows up #15908

## QA Instructions, Screenshots, Recordings
See CI.

### UI accessibility concerns?
n/a

## Added/updated tests?

- [x] No, and this is why: just the configuration is changed.