### PR TITLE
Skip rescoring draft articles

### DIFF
--- a/app/workers/moderator/sink_articles_worker.rb
+++ b/app/workers/moderator/sink_articles_worker.rb
@@ -8,7 +8,7 @@ module Moderator
       user = User.find_by(id: user_id)
       return unless user
 
-      Article.where(user: user).each(&:update_score)
+      Article.published.where(user: user).each(&:update_score)
     rescue StandardError => e
       ForemStatsClient.count("moderators.sink", 1, tags: ["action:failed", "user_id:#{user.id}"])
       Honeybadger.notify(e)

--- a/spec/workers/moderator/sink_articles_worker_spec.rb
+++ b/spec/workers/moderator/sink_articles_worker_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Moderator::SinkArticlesWorker, type: :worker do
+  include_examples "#enqueues_on_correct_queue", "medium_priority", 1
+
+  describe "#perform" do
+    it "returns early when user not found" do
+      expect { described_class.new.perform(nil) }.not_to raise_error
+      expect(described_class.new.perform(nil)).to be_nil
+    end
+
+    it "updates score for user's articles" do
+      article = create(:article, score: 20.0)
+      # flagging a user is the normal route to sink articles,
+      # and ensures score changes in an observable manner
+      create(:vomit_reaction, reactable: article.user)
+      allow(BlackBox).to receive(:article_hotness_score).and_call_original
+
+      described_class.new.perform(article.user_id)
+
+      expect(BlackBox).to have_received(:article_hotness_score)
+      expect(article.reload.score).not_to eq(20)
+    end
+
+    it "skips draft articles" do
+      article = create(:article, published: false)
+      allow(BlackBox).to receive(:article_hotness_score).and_call_original
+
+      described_class.new.perform(article.user_id)
+
+      expect(BlackBox).not_to have_received(:article_hotness_score)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When a moderator flags a user, we attempt to rescore all of their articles (to make them less visible). However, the published timestamp is factored into scoring as `usable_date` in the black box, and draft articles don't have a published timestamp (so a no method error was raised).

When we rescore articles, skip the ones which have not been published (publishing a draft will cause the score calculation, it's fine to defer until then).



## Related Tickets & Documents

https://app.honeybadger.io/projects/66984/faults/83632362

## QA Instructions, Screenshots, Recordings


### UI accessibility concerns?

None, background job.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._


- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

