### PR TITLE
Prevent chrome tab crashes due to memory issues

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "numTestsKeptInMemory": 1,
   "screenshotsFolder": "tmp/cypress_screenshots",
   "trashAssetsBeforeRuns": false,
   "video": false,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When cypress is running in CI, we save snapshots for each step
executed. As the size of the test suite grows, we're seeing an
increase in the number of times we have hung processes. Travis reports
"no output from this job in 10 minutes" and stops/fails the job.

Testing locally, this is consistent with running many examples (for me
it was about 60-80) and having the render process reach about 4.5GB
RSS, then an Aw Snap error page is loaded in chrome, and no
status (error or otherwise) is reported by cypress.

This change won't impact users interacting with the bin/e2e
script (which loads the cypress.dev.json default config), but may
cause problems if you normally use `cypress open` directly to run tests.

I think this won't impact CI reporting, as each test prints the status/results 
to stdout during exexcution (so the logs will show progress) - the in browser
copy is really more intended for interactive inspection and makes no sense in 
a headless context.


## Related Tickets & Documents


## QA Instructions, Screenshots, Recordings

This is a CI configuration change, so there's limited local testing.

You could replay the steps travis does (and run cypress via bin/knapsack_pro_cypress), or when I tested this locally I added the same option to the cypress.dev.json (which is loaded by bin/e2e) and ran a test many times in a loop to observe the memory use. When I did this without the config change I would exhaust the tab memory (about 4.5GB), when I enabled the config change here I saw memory grow, but GC restored the render process memory to about 1.5GB (it got as high as 3.5GB before collecting garbage/releasing allocated memory).

### UI accessibility concerns?

None, test only change. 

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: test config change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams
