### PR TITLE
Busting tag cache when space changes

### DIFF
--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -32,6 +32,8 @@ class Space
       FeatureFlag.disable(:limit_post_creation_to_admins)
     end
 
+    Spaces::BustCachesForSpaceChangeWorker.perform_async
+
     # I want to ensure that we're returning true, to communicate that the "save" was successful.
     true
   end

--- a/app/workers/spaces/bust_caches_for_space_change_worker.rb
+++ b/app/workers/spaces/bust_caches_for_space_change_worker.rb
@@ -1,0 +1,16 @@
+module Spaces
+  # Conditionally delete the async cache when a Space changes
+  #
+  # @note Good news for those of you using Redis as your cache store, you have access to `Rails.cache.delete_matched`
+  #
+  # @see https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html#method-i-delete_matched
+  class BustCachesForSpaceChangeWorker < BustCacheBaseWorker
+    def perform
+      return unless Rails.cache.respond_to?(:delete_matched)
+
+      # Addresses the cache in: app/views/stories/tagged_articles/_sidebar.html, which has
+      # conditional rendering of buttons based on the state of the space.
+      Rails.cache.delete_matched("tag-sidebar-*")
+    end
+  end
+end

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Space do
   describe "#save" do
     subject(:save) { space.save }
 
+    before do
+      allow(Spaces::BustCachesForSpaceChangeWorker).to receive(:perform_async)
+    end
+
     it { is_expected.to be_truthy }
 
     context "when limit_post_creation_to_admins is true" do
@@ -31,6 +35,12 @@ RSpec.describe Space do
         save
         expect(FeatureFlag.enabled?(:limit_post_creation_to_admins)).to be(false)
       end
+    end
+
+    it "busts the caches that impact the space" do
+      save
+
+      expect(Spaces::BustCachesForSpaceChangeWorker).to have_received(:perform_async)
     end
   end
 end

--- a/spec/workers/spaces/bust_caches_for_space_change_worker_spec.rb
+++ b/spec/workers/spaces/bust_caches_for_space_change_worker_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe Spaces::BustCachesForSpaceChangeWorker, type: :worker do
+  let(:worker) { subject }
+
+  before { allow(Rails.cache).to receive(:delete_matched).and_call_original }
+
+  include_examples "#enqueues_on_correct_queue", "high_priority", 1
+
+  it "deletes matched cache keys" do
+    worker.perform
+    expect(Rails.cache).to have_received(:delete_matched)
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

We avoid busting a user cache for 15 minutes but the tag cache is 5
hours.  So we want to "nudge things along".

What this is trying to solve is the server side rendering of whether we
hide or show a button.


## Related Tickets & Documents

Related to forem/forem#17324
Related to forem/forem#17119

## QA Instructions, Screenshots, Recordings

This is part of the UAT we're performing on Canary 1.

### UI accessibility concerns?

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
