### PR TITLE
Wait for pin article to complete (flaky pinArticles e2e test)

### DIFF
--- a/cypress/integration/seededFlows/adminFlows/articles/pinArticle.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/articles/pinArticle.spec.js
@@ -97,6 +97,7 @@ describe('Pin an article from the admin area', () => {
   it('should show the pinned post to a logged out user', () => {
     cy.findAllByRole('button', { name: 'Pin post' }).first().click();
 
+    cy.findByRole('link', { name: 'Unpin post' }).should('exist');
     cy.signOutUser();
 
     cy.findByRole('main').findByTestId('pinned-article').should('be.visible');


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description


We had seen an increase in CI timeouts (no output received for 10
minutes).

Running this example (signed out user sees the pinned article)
repeatedly I was able to reproduce the failure seen in Travis, and
checking the last few times this occurred it appears to be linked to
the pinArticle.spec.js last test, which fails with an
ApplicationPolicy when pinning.

The likeliest source of this issue is the POST (pin the article) is
received concurrently with the session delete (logging the admin user
out), resulting in a race. If/when the signout occurs before the
article policy is checked (does the current user have permission to
pin an article), the cypress running stalls.

This occurred both interactively (bin/e2e or cypress open) and
headless (cypress run/CI). The error went away reliably after
inserting this guard to check for the "Unpin post" link on the page,
which forces the POST to have completed and redirected back to the
admin page before logging out.

My understanding of this problem is borne out in the local test logs,
where the signout and pin requests arrive concurrently and process out
of order (and the POST gives a 404 instead of a 302).

    Started DELETE "/users/sign_out" for 127.0.0.1 at 2022-04-20 12:09:23 -0500
    Started POST "/admin/content_manager/articles/1/pin" for 127.0.0.1 at 2022-04-20 12:09:23 -0500
    Completed 204 No Content in 42ms (ActiveRecord: 6.2ms | Allocations: 6323)
    Completed 404 Not Found in 4ms (ActiveRecord: 0.4ms | Allocations: 833)


@aitchiss commented internally when I pointed to this spec's behavior:

> hmm well I definitely think we want to refactor should show the pinned post to a logged out user so it can be in its own describe block and avoid having to sign in, then immediately sign out. We've had so many problems with test flows that do this in the past. Definitely eyeing this spec with some suspicion - we pin a post and then immediately sign out without waiting for any confirmation of success :face_with_raised_eyebrow:  could be causing weird issues

The change here is the smallest possible fix - but the above suggestion (refactor how we position a pinned article for signed out users to see) might be a better long term decision.

## QA Instructions, Screenshots, Recordings

Hard to test in a clean manner. In main and in this branch I repeated the last two tests in the pinArticles.spec.js 100 times, it didnt' take long to observe the failure locally

```
  Pin an article from the admin area
    ✓ should pin an article when no other article is currently pinned (4641ms)
    ✓ should display a warning modal when pinning an article, and one is already pinned (3523ms)
    ✓ should change the pinned article when choosing to pin a new article (3435ms)
    ✓ should show the pinned post to a logged out user (3154ms)
    ✓ should change the pinned article when choosing to pin a new article (3392ms)
    ✓ should show the pinned post to a logged out user (3434ms)
    ✓ should change the pinned article when choosing to pin a new article (3265ms)
    ✓ should show the pinned post to a logged out user (3166ms)
    ✓ should change the pinned article when choosing to pin a new article (3219ms)
    ✓ should show the pinned post to a logged out user (3413ms)
    ✓ should change the pinned article when choosing to pin a new article (3417ms)
    ✓ should show the pinned post to a logged out user (3404ms)
    ✓ should change the pinned article when choosing to pin a new article (4597ms)
    ✓ should show the pinned post to a logged out user (3129ms)
    ✓ should change the pinned article when choosing to pin a new article (3294ms)
    ✓ should show the pinned post to a logged out user (3223ms)
    ✓ should change the pinned article when choosing to pin a new article (3537ms)
2022-04-20 12:36:58 -0500 Rack app ("GET /admin/content_manager/articles/1" - (127.0.0.1)): #<ApplicationPolicy::UserRequiredError: You must be logged in>
    (Attempt 1 of 4) should show the pinned post to a logged out user
    (Attempt 1 of 4) should show the pinned post to a logged out user
```

After this Attempt 1 of 4 is printed the process stalls (cypress neither fails nor recovers). 

On this branch, similar setup, the pinArticles spec runs these examples over and over without failing.

```
    ✓ should change the pinned article when choosing to pin a new article (3116ms)
    ✓ should show the pinned post to a logged out user (3337ms)
    ✓ should change the pinned article when choosing to pin a new article (3283ms)
    ✓ should show the pinned post to a logged out user (3093ms)
    ✓ should change the pinned article when choosing to pin a new article (3196ms)
    ✓ should show the pinned post to a logged out user (3101ms)
    ✓ should change the pinned article when choosing to pin a new article (3199ms)
    ✓ should show the pinned post to a logged out user (3381ms)
    ✓ should change the pinned article when choosing to pin a new article (3323ms)
    ✓ should show the pinned post to a logged out user (3067ms)


  210 passing (12m)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        210                                                                              │
  │ Passing:      210                                                                              │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        false                                                                            │
  │ Duration:     11 minutes, 46 seconds                                                           │
  │ Spec Ran:     seededFlows/adminFlows/articles/pinArticle.spec.js                               │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
```


### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams


