### PR TITLE
e2e: Reload the page after changing authentication

### DIFF
--- a/cypress/integration/seededFlows/adminFlows/config/authenticationSection.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/config/authenticationSection.spec.js
@@ -41,7 +41,9 @@ describe('Authentication Section', () => {
             );
           });
 
-          cy.url().should('contains', '/admin/customization/config');
+          // The next comment suggests this had reloaded the page
+          // instead of just showing the snackbar before.
+          cy.visit('/admin/customization/config');
 
           // Page reloaded so need to get a new reference to the form.
           cy.findByTestId('authSectionForm').as('authSectionForm');

--- a/cypress/integration/seededFlows/adminFlows/config/authenticationSection.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/config/authenticationSection.spec.js
@@ -41,9 +41,9 @@ describe('Authentication Section', () => {
             );
           });
 
-          // The next comment suggests this had reloaded the page
-          // instead of just showing the snackbar before.
-          cy.visit('/admin/customization/config');
+          // The page doesn't automatically reload on submission, 
+          // so we reload manually to check the settings have been persisted
+          cy.reload();
 
           // Page reloaded so need to get a new reference to the form.
           cy.findByTestId('authSectionForm').as('authSectionForm');


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The customization submission no longer reloads the page (did it once? it looks like it might have from the test comments), and clicking Authentication after submitting changes collapses the Authentication section (if the page had reloaded after a POST, clicking would have shown the section). 

When the section was hidden, the tests for labels not to be visible pass (for the wrong reason) in Firefox and Electron (CI runs travis's bundled electron version), but the findByLabelText times out in when this is run in Chrome. Moreover, because we don't reload the page after update, the behavior being checked is not happening (for example, the "Email enabled" label is still present if you show the Authentication section, it seems like it's only been passing because we click to hide the section before making assertions about its content).

I tried removing the second click, to not hide the auth section after submission, and confirmed the Email enabled failure, so opted instead to reload the page (change the cy.url() check to cy.visit()).

Since the checkbox wasn't tested to be visible (only to be checked), and all the other form labels were checked not to be visible, we missed this change. I don't know if Chrome also changed its behavior or if this would never have passed in chrome if run in the foreground after the page reloading stopped.

## QA Instructions, Screenshots, Recordings

run bin/e2e. Select Chrome as the test browser if available. Run the authenticationSection tests (filtering helps). Test should pass. If you have another browser available and care to test that, great. I tried with Firefox and Electron as well, all three work with this manual page refresh.

In CI (running electron), test should also still pass.

### UI accessibility concerns?

Test only change.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._
- [x] I will share this change internally with the appropriate teams

