### PR TITLE
Update Bootstrap from 4.4.1 to 4.5.3

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -14,10 +14,10 @@
   <!-- StimulusJS -->
   <%= javascript_packs_with_chunks_tag "admin", defer: true %>
 
-  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
 
   <!-- Bootstrap -->
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
 
   <%= stylesheet_link_tag "admin" %>
 
@@ -96,6 +96,6 @@
   <div data-snackbar-target="snackZone"></div>
 
   <!-- Bootstrap Dependencies -->
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.min.js" integrity="sha384-w1Q4orYjBQndcko6MimVbzY0tgp4pWB4lZ7lr30WKz0vr/aWKhXdBNmNb5D92v7s" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description
Updates Bootstrap from 4.4.1 to 4.5.3 on `/admin` to update jQuery from 3.4.1 to 3.5.1.

## Related Tickets & Documents

- Bootstrap 4.5 docs: https://getbootstrap.com/docs/4.5/getting-started/introduction/
- jquery@3.4.1 vulnerabilities (snyk): https://snyk.io/vuln/npm:jquery@3.4.1
- Related Issue #17337
- Closes #17204

## QA Instructions, Screenshots, Recordings

Access to `/admin` on a test instance to confirm if there is no regression.

### UI accessibility concerns?

No regression should be confirmed.

## Added/updated tests?

- [x] No, and this is why: dependency update