### PR TITLE
Confirm signout happened by looking for Log in link

### DIFF
--- a/cypress/integration/seededFlows/adminFlows/articles/pinArticle.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/articles/pinArticle.spec.js
@@ -96,9 +96,10 @@ describe('Pin an article from the admin area', () => {
 
   it('should show the pinned post to a logged out user', () => {
     cy.findAllByRole('button', { name: 'Pin post' }).first().click();
-
     cy.findByRole('link', { name: 'Unpin post' }).should('exist');
+
     cy.signOutUser();
+    cy.findAllByRole('link', { name: 'Log in' }).first().should('exist');
 
     cy.findByRole('main').findByTestId('pinned-article').should('be.visible');
   });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

Similar to checking that "Unpin post" is shown after pinning a post, 
wait for "Log in" to show after signing out before checking that signed 
out users can see a pinned post.

Recommended by @aitchiss in a comment on #17385 as a way to limit
false negatives (where we mistakenly check the previously signed in user's view)


## Related Tickets & Documents


- Related Issue #17385 

## QA Instructions, Screenshots, Recordings

Since this  is a change to an e2e test, launch cypress and run the test.


### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: tiny test update
