### PR TITLE
Permanently delete users from Mailchimp automatically

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -213,7 +213,7 @@ class User < ApplicationRecord
   before_validation :set_username
   before_validation :strip_payment_pointer
   before_create :create_users_settings_and_notification_settings_records
-  before_destroy :unsubscribe_from_newsletters, prepend: true
+  before_destroy :remove_from_mailchimp_newsletters, prepend: true
   before_destroy :destroy_follows, prepend: true
 
   after_create_commit :send_welcome_notification
@@ -502,11 +502,11 @@ class User < ApplicationRecord
     profile_image_url_for(length: 90)
   end
 
-  def unsubscribe_from_newsletters
+  def remove_from_mailchimp_newsletters
     return if email.blank?
     return if Settings::General.mailchimp_api_key.blank?
 
-    Mailchimp::Bot.new(self).unsubscribe_all_newsletters
+    Mailchimp::Bot.new(self).permanent_delete_from_mailchimp
   end
 
   def enough_credits?(num_credits_needed)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -506,7 +506,7 @@ class User < ApplicationRecord
     return if email.blank?
     return if Settings::General.mailchimp_api_key.blank?
 
-    Mailchimp::Bot.new(self).permanent_delete_from_mailchimp
+    Mailchimp::Bot.new(self).remove_from_mailchimp
   end
 
   def enough_credits?(num_credits_needed)

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -179,9 +179,11 @@ module Mailchimp
     end
 
     def permanent_delete_from_mailchimp(list_id)
-      gibbon.lists(list_id).mebers(target_md5_email).actions.delete_permanent.create
+      gibbon.lists(list_id).members(target_md5_email).actions.delete_permanent.create
     rescue Gibbon::MailChimpError => e
       return if e.status_code == 404
+
+      report_error(e)
     end
 
     def previously_subscribed?(error)

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -199,7 +199,7 @@ module Mailchimp
     end
 
     def previously_subscribed?(error)
-      error.title.include?(I18n.t("services.mailchimp.bot.member_in_compliance_state"))
+      error.title.include?("Member In Compliance State")
     end
   end
 end

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -44,15 +44,14 @@ module Mailchimp
       rescue Gibbon::GibbonError => e
         report_error(e)
       rescue Gibbon::MailChimpError => e
-        # If user was previously subscribed, set their status to "pending"
-        return resubscribe_to_newsletter if previously_subscribed?(e)
+        return resubscribe_as_pending if previously_subscribed?(e)
 
         report_error(e)
       end
       success
     end
 
-    def resubscribe_to_newsletter
+    def resubscribe_as_pending
       success = false
 
       begin

--- a/app/services/moderator/banish_user.rb
+++ b/app/services/moderator/banish_user.rb
@@ -15,7 +15,7 @@ module Moderator
 
     def banish
       BanishedUser.create(username: user.username, banished_by: admin)
-      user.unsubscribe_from_newsletters if user.email?
+      user.remove_from_mailchimp_newsletters if user.email?
       remove_profile_info
       handle_user_status("Suspend", I18n.t("services.moderator.banish_user.spam_account"))
       delete_user_activity

--- a/app/services/users/delete.rb
+++ b/app/services/users/delete.rb
@@ -8,7 +8,7 @@ module Users
       delete_comments
       delete_articles
       delete_user_activity
-      user.unsubscribe_from_newsletters
+      user.remove_from_mailchimp_newsletters
       EdgeCache::Bust.call("/#{user.username}")
       Users::SuspendedUsername.create_from_user(user) if user.suspended?
       user.destroy

--- a/config/locales/services/en.yml
+++ b/config/locales/services/en.yml
@@ -38,9 +38,6 @@ en:
       parser:
         enter_fullscreen_mode: Enter fullscreen mode
         exit_fullscreen_mode: Exit fullscreen mode
-    mailchimp:
-      bot:
-        member_in_compliance_state: Member In Compliance State
     markdown_processor:
       parser:
         invalid_markdown_detected: Invalid markdown detected!

--- a/config/locales/services/fr.yml
+++ b/config/locales/services/fr.yml
@@ -38,9 +38,6 @@ fr:
       parser:
         enter_fullscreen_mode: Enter fullscreen mode
         exit_fullscreen_mode: Exit fullscreen mode
-    mailchimp:
-      bot:
-        member_in_compliance_state: Member In Compliance State
     markdown_processor:
       parser:
         invalid_markdown_detected: Invalid markdown detected!

--- a/spec/services/mailchimp/bot_spec.rb
+++ b/spec/services/mailchimp/bot_spec.rb
@@ -84,11 +84,11 @@ RSpec.describe Mailchimp::Bot, type: :service do
       mc_error =
         Gibbon::MailChimpError.new("Error", status_code: 400, title: "Member In Compliance State")
       allow(mailchimp_bot.gibbon).to receive(:upsert).and_raise(mc_error)
-      allow(mailchimp_bot).to receive(:resubscribe_to_newsletter)
+      allow(mailchimp_bot).to receive(:resubscribe_as_pending)
 
       mailchimp_bot.upsert_to_newsletter
 
-      expect(mailchimp_bot).to have_received(:resubscribe_to_newsletter)
+      expect(mailchimp_bot).to have_received(:resubscribe_as_pending)
     end
 
     it "handles GibbonError" do

--- a/spec/services/mailchimp/bot_spec.rb
+++ b/spec/services/mailchimp/bot_spec.rb
@@ -145,16 +145,4 @@ RSpec.describe Mailchimp::Bot, type: :service do
               ))
     end
   end
-
-  describe "#unsubscribe_all_newsletters" do
-    context "when called" do
-      before { allow(my_gibbon_client).to receive(:update).and_return(true) }
-
-      it "unsubscribes the user from the weekly newsletter" do
-        described_class.new(user).unsubscribe_all_newsletters
-        expect(my_gibbon_client).to have_received(:update)
-          .with(hash_including(body: hash_including(status: "unsubscribed")))
-      end
-    end
-  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Bug Fix

## Description
Right now, Forem admins on Forems that use Mailchimp have to manually delete users from Mailchimp. This builds that process into our app by sending the request via API.

There are some product decisions to consider, which I've shared in our internal Slack: https://forem-team.slack.com/archives/CAA200SH5/p1650557891042839

## Related Tickets & Documents

- https://github.com/forem/internalCommunity/issues/328

## QA Instructions, Screenshots, Recordings
QAing this is a bit of a hassle. That said, I'd really appreciate it if someone would go through with it! 🙏 

1. DM me on Slack for the necessary ENV variables
2. Run this setup script in `rails console`:
```ruby
Settings::General.mailchimp_api_key = "api_key_that_I_give_you"
Settings::General.mailchimp_newsletter_id = "list_id_that_I_give_you"
gibbon = Gibbon::Request.new(api_key: Settings::General.mailchimp_api_key)
# add a user to Mailchimp newsletter/list
body = { email_address: User.first.email, status: "subscribed" }
gibbon.lists(Settings::General.mailchimp_newsletter_id).members(User.first.email).upsert(body: body)
``
3. While in Rails console, test permanently deleting a user:
```ruby
Mailchimp::Bot.new(User.first).remove_from_mailchimp
#=> true
```
4. Try to add the user back to the newsletter, and you should get an error response with status code 400, and a title of "Forgotten Email Not Subscribed":
```ruby
gibbon.lists(Settings::General.mailchimp_newsletter_id).members(User.first.email).upsert(body: body)
#=> Gibbon::MailChimpError: the server responded with status 400 @title="Forgotten Email Not Subscribed" etc etc
```

### UI accessibility concerns?
Nope, backend change

## Added/updated tests?
- [x] No, because the tests should be refactored into VCR cassettes. Out of scope for this PR.

## [Forem core team only] How will this change be communicated?
- [x] Will share with internal team involved with this since we use Mailchimp