### PR TITLE
Update @testing-library/cypress from 7.0.7 to 8.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@storybook/builder-webpack5": "^6.4.22",
     "@storybook/manager-webpack5": "^6.4.22",
     "@storybook/preact": "^6.4.22",
-    "@testing-library/cypress": "^7.0.7",
+    "@testing-library/cypress": "^8.0.2",
     "@testing-library/dom": "^8.13.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/preact": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.14.6":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.7", "@babel/template@^7.16.0", "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -3148,15 +3155,15 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
-"@testing-library/cypress@^7.0.7":
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-7.0.7.tgz#b3e8696e707bcaa1664f5f9452f96f87cb90f438"
-  integrity sha512-4yavolmN9o4Lmtrff6sbOTNFW9VqRRqDrP6gS2hkqLri4+lKURRYblg8kjOlcni/5h/qctFych+gkUOkpgypxw==
+"@testing-library/cypress@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-8.0.2.tgz#b13f0ff2424dec4368b6670dfbfb7e43af8eefc9"
+  integrity sha512-KVdm7n37sg/A4e3wKMD4zUl0NpzzVhx06V9Tf0hZHZ7nrZ4yFva6Zwg2EFF1VzHkEfN/ahUzRtT1qiW+vuWnJw==
   dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^7.29.6"
+    "@babel/runtime" "^7.14.6"
+    "@testing-library/dom" "^8.1.0"
 
-"@testing-library/dom@^7.16.2", "@testing-library/dom@^7.29.6":
+"@testing-library/dom@^7.16.2":
   version "7.31.2"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
   integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
@@ -3170,7 +3177,7 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
-"@testing-library/dom@^8.13.0":
+"@testing-library/dom@^8.1.0", "@testing-library/dom@^8.13.0":
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
   integrity sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Optimization

## Description
Revisits upgrading `@testing-library/cypress` npm package from 7.x to 8.x, @rhymes stopped in https://github.com/forem/forem/pull/14403#issuecomment-891674975 .

> The PR https://github.com/forem/forem/pull/14324 contained a version bump to pretty-format@27.0.6 which required a later version of node than our buildkite builds can currently use. As a result, all of our latest buildkite builds are failing with the error:
> ```
> error pretty-format@27.0.6: The engine "node" is incompatible with this module. Expected version "^10.13.0 \|\| ^12.13.0 \|\| ^14.15.0 \|\| >=15.0.0". Got "14.14.0"
> --
>   | error Found incompatible module.
> ```
> This PR reverts the change until we are able to upgrade the node version in buildkite (this is a work in progress with systems team)

Cited from #14353

This update avoids to use `@testing-library/dom` 7.x, which depends on `pretty-format` 26.x. After this patch, only `@testing-library/preact` depends on `@testing-library/dom` 7.x, which will be resolved in https://github.com/testing-library/preact-testing-library/pull/49.

## Related Tickets & Documents
- Related PRs: #14353, #14403
   - #14324
- Breaking changes on upstream: https://github.com/testing-library/cypress-testing-library/releases/tag/v8.0.0
   - including https://github.com/testing-library/cypress-testing-library/issues/188
- testing-library/preact-testing-library#49

## QA Instructions, Screenshots, Recordings
n/a

### UI accessibility concerns?
n/a

## Added/updated tests?
- [x] No, and this is why: dep (npm) updated