### PR TITLE
Only accept suggestions in multi select autocomplete

### DIFF
--- a/app/javascript/crayons/MultiSelectAutocomplete/__stories__/MultiSelectAutocomplete.mdx
+++ b/app/javascript/crayons/MultiSelectAutocomplete/__stories__/MultiSelectAutocomplete.mdx
@@ -2,7 +2,7 @@
 
 The MultiSelectAutocomplete component can be used in situations where a user can search for matching options, and select multiple values.
 
-When the user starts typing, an async search will be triggered, and any fetched suggestions displayed in the dropdown. If no suggestions are available, the currently entered search term will be displayed as an option.
+When the user starts typing, an async search will be triggered, and any fetched suggestions displayed in the dropdown.
 
 ## Browsing and selecting an option
 
@@ -29,6 +29,8 @@ A `fetchSuggestions` prop **must** be passed in props to the component. This cal
 ```
 
 i.e. suggestions and selections are expected as `object`s with a `name` attribute.
+
+**NB: By default, the MultiSelectAutocomplete component will only allow suggested items to be selected (i.e. will not accept user's own text). If you would like to allow user-entered text to be selected, be sure to return it as an option in `fetchSuggestions`**
 
 ### Static suggestions
 

--- a/app/javascript/hooks/useTagsField.js
+++ b/app/javascript/hooks/useTagsField.js
@@ -49,15 +49,19 @@ export const useTagsField = ({ defaultValue, onInput }) => {
   };
 
   /**
-   * Fetches tags for a given search term
+   * Fetches tags for a given search term.
+   * If no matching tags are found, the user's own entry is suggested instead
    *
    * @param {string} searchTerm The text to search for
    * @returns {Promise} Promise which resolves to the tag search results
    */
   const fetchSuggestions = (searchTerm) =>
-    fetchSearch('tags', { name: searchTerm }).then(
-      (response) => response.result,
-    );
+    fetchSearch('tags', { name: searchTerm }).then(({ result }) => {
+      if (result.length === 0) {
+        return [{ name: searchTerm }];
+      }
+      return result;
+    });
 
   return {
     defaultSelections,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [X] Feature

## Description

This follows on from the work started in https://github.com/forem/forem/pull/16980. I ended up creating a new PR and closing the old one, as there had been quite a few changes to the tags field in the meantime and it just seemed easier 😄 

This PR updates the `MultiSelectAutocomplete` component so that it only accepts suggestions returned by the `fetchSuggestions` prop, and not any other user-generated input. This allows the implementing component to decide whether or not to allow user-generated input, and therefore makes the core component more versatile.

The `useTagsField` hook has been updated to return the user's search term if no matching tags are found, meaning there's no functional change in the app at the moment, and existing tests for the article tags field should continue to test this feature.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Supersedes https://github.com/forem/forem/pull/16980/files 
- Unblocks https://github.com/forem/forem/pull/16604

## QA Instructions, Screenshots, Recordings

**To test the core component:**

- run `yarn storybook` and visit the `MultiSelectAutocomplete` entry
- try typing a word that isn't a number between one and ten
- type a comma, or a space, and check that your text isn't selected
- now trying clicking away from the input and check that your text isn't selected _and_ the input is cleared
- go back to the input and type a word that _is_ a number between one and ten
- try typing a comma or a space, or clicking away from the input, and check that your text _is_ selected

https://user-images.githubusercontent.com/20773163/164702592-94746e4c-52fb-4be6-9560-aed666d2f816.mp4


**To test the tags field currently using this component:**

- Spin up the app and go to create a new post
- In the tags field, try typing existing tags and selecting them by either clicking, typing space or comma, or clicking away from the input
- Try typing a word that _isn't_ a supported tag, make sure that if there are no other matching suggestions it's still shown as an option
- Make sure you can select that option
- Make sure that the selection works by click, space, comma, or clicking away from the input
- Keep in mind there's a little bug if you type too fast 😄  - https://github.com/forem/forem/issues/16966

https://user-images.githubusercontent.com/20773163/164702694-4dea9f08-0e23-4d0c-a67d-93790c010446.mp4

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

