### PR TITLE
Remove redundant feat flag setup in spec

### DIFF
--- a/spec/system/user_views_logo_spec.rb
+++ b/spec/system/user_views_logo_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Logo behaviour with creator_onboarding Feature Flag", type: :system do
+RSpec.describe "Logo behaviour", type: :system do
   let!(:user) { create(:user) }
   let(:resized_logo) { "default.png" }
 
@@ -8,34 +8,28 @@ RSpec.describe "Logo behaviour with creator_onboarding Feature Flag", type: :sys
     sign_in user
   end
 
-  context "when Feature flag creator_onboarding is enabled" do
+  context "with an image set" do
     before do
-      allow(FeatureFlag).to receive(:enabled?).with(:creator_onboarding).and_return(true)
+      allow(Settings::General).to receive(:resized_logo).and_return(resized_logo)
     end
 
-    context "with an image set" do
-      before do
-        allow(Settings::General).to receive(:resized_logo).and_return(resized_logo)
-      end
-
-      it "renders the resized_logo" do
-        visit root_path
-        within(".site-logo") do
-          expect(page.find(".site-logo__img")["src"]).to have_content(resized_logo)
-        end
+    it "renders the resized_logo" do
+      visit root_path
+      within(".site-logo") do
+        expect(page.find(".site-logo__img")["src"]).to have_content(resized_logo)
       end
     end
+  end
 
-    context "without an image set" do
-      before do
-        allow(Settings::General).to receive(:resized_logo).and_return(nil)
-      end
+  context "without an image set" do
+    before do
+      allow(Settings::General).to receive(:resized_logo).and_return(nil)
+    end
 
-      it "renders the the community name" do
-        visit root_path
-        within(".truncate-at-2") do
-          expect(page).to have_text("DEV(local)")
-        end
+    it "renders the the community name" do
+      visit root_path
+      within(".truncate-at-2") do
+        expect(page).to have_text("DEV(local)")
       end
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a small follow up to https://github.com/forem/forem/pull/17404 where we made sure the `creator_onboarding` feature flag was disabled via DUS. @djuber noticed we still had references to the feature flag in this rspec test, even though the code it's testing doesn't vary its logic based on the feature flag anymore.

This PR removes that setup and updates the description to be more generic.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/16188
- Related Issue https://github.com/forem/forem/pull/17404

## QA Instructions, Screenshots, Recordings

I think it's enough to check the build passes 😄 

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: teeny tiny change 


