### PR TITLE
Removing unused instance variable

### DIFF
--- a/app/controllers/stories/articles_search_controller.rb
+++ b/app/controllers/stories/articles_search_controller.rb
@@ -4,7 +4,7 @@ module Stories
 
     def index
       @query = I18n.t("stories_controller.searching")
-      @article_index = true
+
       @current_ordering = current_search_results_ordering
       set_surrogate_key_header "articles-page-with-query"
     end

--- a/app/controllers/stories/tagged_articles_controller.rb
+++ b/app/controllers/stories/tagged_articles_controller.rb
@@ -15,7 +15,7 @@ module Stories
       end
 
       @page = (params[:page] || 1).to_i
-      @article_index = true
+
       @moderators = User.with_role(:tag_moderator, @tag).select(:username, :profile_image, :id)
 
       set_number_of_articles(tag: @tag)

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -25,7 +25,6 @@ class StoriesController < ApplicationController
 
   def index
     @page = (params[:page] || 1).to_i
-    @article_index = true
 
     return handle_user_or_organization_or_podcast_or_page_index if params[:username]
 
@@ -128,7 +127,7 @@ class StoriesController < ApplicationController
     assign_hero_html
     assign_podcasts
     get_latest_campaign_articles if Campaign.current.show_in_sidebar?
-    @article_index = true
+
     set_surrogate_key_header "main_app_home_page"
     set_cache_control_headers(600,
                               stale_while_revalidate: 30,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

As I was looking into the implementation details of the `/t/:tag_name`
relevancy feed I noticed an instance variable that we do not need.

Below are the results of looking for the instance_variable
`@article_index` or a potential `article_index` local variable or method name.

```shell
❯ rg "@?article_index"
app/controllers/stories_controller.rb
28:    @article_index = true
131:    @article_index = true
162:    @organization_article_index = true

app/controllers/stories/tagged_articles_controller.rb
18:      @article_index = true

app/controllers/stories/articles_search_controller.rb
7:      @article_index = true

app/views/articles/_single_story.html.erb
26:          <% if story.cached_organization && !@organization_article_index %>
32:          <a href="/<%= story.cached_user.username %>" class="crayons-avatar <% if story.cached_organization && !@organization_article_index %> crayons-avatar--s absolute -right-2 -bottom-2 border-solid border-2 border-base-inverted <% else %> crayons-avatar--l <% end %> ">
79:            <% if story.cached_organization && !@organization_article_index %>
```

## Related Tickets & Documents

None.

## QA Instructions, Screenshots, Recordings

Our test suite will cover it.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: testing for the absence of this variable does not make sense.

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: it's a noop change
