### PR TITLE
Multi-select autocomplete - ignore fetched suggestions if input already cleared

### DIFF
--- a/app/javascript/crayons/MultiSelectAutocomplete/MultiSelectAutocomplete.jsx
+++ b/app/javascript/crayons/MultiSelectAutocomplete/MultiSelectAutocomplete.jsx
@@ -303,6 +303,12 @@ export const MultiSelectAutocomplete = ({
     }
 
     const results = await fetchSuggestions(value);
+
+    // It could be that while waiting on the network fetch, the user has already made a selection or otherwise cleared the input
+    if (inputRef.current.value === '') {
+      return;
+    }
+
     // If no results, display current search term as an option
     if (results.length === 0 && value !== '') {
       results.push({ name: value });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The MultiSelectAutocomplete component (as used in the editor tags field) allows users to free-type their selection and 'select' it automatically by typing a space or a comma. When typing quickly, we were seeing a bug this resulted in fetched suggestions being displayed when the input had already cleared/reset (see reproduction in https://github.com/forem/forem/issues/16966).

[A previous PR](https://github.com/forem/forem/pull/17120) attempted to fix this issue by cancelling any in progress suggestions fetch when the user made their selection. Unfortunately, this wasn't robust enough (I suspect because there is a short time when the network request _has_ completed, but Preact is still processing what it returned).

This PR instead adds a quick check once suggestions have been fetched, checking if these suggestions are still relevant or not before rendering them.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/forem/forem/issues/16966

## QA Instructions, Screenshots, Recordings

- Create a new post
- With speed (😄 ) type any tagname followed by a space or comma
- Verify that your tag is "selected" and the "Top tags" resume showing


https://user-images.githubusercontent.com/20773163/165080451-e6a016da-c0ba-410e-90d2-980d445d8f90.mp4


### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: The existing tests should ensure there's no regression in this behaviour, and because this small bug is _very_ dependent on timing it's difficult to truly test in Cypress or other tools. 
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: it's quite a minor fix to an edge case


