### PR TITLE
Pass options correctly to chart.js on articles#stats

### DIFF
--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -45,15 +45,23 @@ function writeCards(data, timeRangeLabel) {
 }
 
 function drawChart({ id, showPoints = true, title, labels, datasets }) {
-  const chartOptions = showPoints
-    ? {}
-    : {
-        elements: {
-          point: {
-            radius: 0,
-          },
+  const chartOptions = {
+    elements: {
+      point: {
+        // The default is 3: https://www.chartjs.org/docs/latest/configuration/elements.html#point-configuration
+        radius: showPoints ? 3 : 0,
+      },
+    },
+    scales: {
+      y: {
+        type: 'linear',
+        suggestedMin: 0,
+        ticks: {
+          precision: 0,
         },
-      };
+      },
+    },
+  };
   const dataOptions = {
     plugins: {
       legend: {
@@ -64,16 +72,6 @@ function drawChart({ id, showPoints = true, title, labels, datasets }) {
     title: {
       display: true,
       text: title,
-    },
-    scales: {
-      y: {
-        type: 'linear',
-        suggestedMin: 0,
-
-        ticks: {
-          precision: 0,
-        },
-      },
     },
   };
 


### PR DESCRIPTION
Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Bug Fix

## Description
Pass options correctly to chart.js on (frontend of) `articles#stats` to remove unnecessary ticks (after the decimal point) and grid lines on y-axis to revert #2037's intention after #3102.

This would lead changes mainly on stats for articles with less 10 pageview per day in specific spans (in 7 days or 30 days).

## Related Tickets & Documents

- Closes #17433
- Relates to #3102 (cause of regression)
- Original implementation: #2037
- Docs on upstream (chart.js 3.7.1)
   - Axes: https://chartjs.org/docs/3.7.1/axes/
   - Point configuration: https://www.chartjs.org/docs/3.7.1/configuration/elements.html#point-configuration

## QA Instructions, Screenshots, Recordings

| before | after |
|-|-|
| ![](https://user-images.githubusercontent.com/10229505/165303114-124e4f12-12a8-4884-a299-fcfb6219069d.png) | ![user_slug_stats_after](https://user-images.githubusercontent.com/10229505/165307891-a2df1612-2558-4665-85ac-17007c45fe3b.png) |

### UI accessibility concerns?


## Added/updated tests?

- [x] I need help with writing tests