### PR TITLE
Remove Facebook Pixel language from default privacy policy 

### DIFF
--- a/app/views/pages/_privacy_text.html.erb
+++ b/app/views/pages/_privacy_text.html.erb
@@ -1,4 +1,4 @@
-<p>Effective May 25, 2018</p>
+<p>Effective Dec 20, 2018</p>
 <p>This policy covers <%= community_name %>.</p>
 <h3> What information <%= community_name %> collects and Why </h3>
 <p>In order to give you the best possible experience using <%= community_name %>, we collect information from your interactions with our network. We use common internet technologies, such as cookies and web server logs. We collect this basic information from everybody, whether they have an account or not.</p>
@@ -86,14 +86,6 @@
   data third parties collect in cases like this, or what they will do with it. Third-party embeds on <%= community_name %>
    are not covered by this privacy policy; they are covered by the privacy policy of the third-party service. Be mindful
    when interacting with these services.
-</p>
-<p><strong>Facebook (visitor action pixel)</strong>
-  <br>
-  We use the “visitor action pixels” from Facebook Inc on our website.
-  <br>
-  <br>
-  This allows user behavior to be tracked after they have been redirected to our website by clicking on a Facebook ad. This enables us to measure the effectiveness of Facebook ads. The data collected in this way is anonymous to us, i.e. we do not see the personal data of individual users. However, this data is stored and processed by Facebook, which is why we are informing you, based on our knowledge of the situation. Facebook may link this information to your Facebook account and also use it for its own promotional purposes, in accordance with
-  <a href="https://www.facebook.com/about/privacy">Facebook’s Data Usage Policy</a>. You can object to the collection of your data by Facebook pixel, or to the use of your data for the purpose of displaying Facebook ads by contacting the following address: https://www.facebook.com/settings?tab=ads.
 </p>
 <p><strong>Tracking & Cookies</strong>
   <br>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Documentation Update

## Description
This removes the language about using Facebook Pixel since we haven't used it since December 20, 2018 via #1380.

## Related Tickets & Documents
#1380

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams