### PR TITLE
validate sort direction

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -196,6 +196,6 @@ class SearchController < ApplicationController
   # nil differently. This is a helper method to remove any params that are
   # blank before passing it to Elasticsearch.
   def sanitize_params
-    params.delete_if { |_k, v| v.blank? }
+    params.compact_blank!
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -50,6 +50,8 @@ class SearchController < ApplicationController
     },
   ].freeze
 
+  VALID_SORT_DIRECTIONS = %i[asc desc].freeze
+
   def tags
     result = Search::Tag.search_documents(term: params[:name])
     render json: { result: result }
@@ -197,5 +199,13 @@ class SearchController < ApplicationController
   # blank before passing it to Elasticsearch.
   def sanitize_params
     params.compact_blank!
+    remove_invalid_sort_directions
+  end
+
+  def remove_invalid_sort_directions
+    return unless params.key?(:sort_direction)
+
+    direction = params[:sort_direction].downcase.to_sym
+    params.delete(:sort_direction) unless direction.in?(VALID_SORT_DIRECTIONS)
   end
 end

--- a/app/queries/homepage/articles_query.rb
+++ b/app/queries/homepage/articles_query.rb
@@ -17,7 +17,9 @@ module Homepage
     ].freeze
     DEFAULT_PER_PAGE = 60
     MAX_PER_PAGE = 100
+
     SORT_PARAMS = %i[hotness_score public_reactions_count published_at].freeze
+    DEFAULT_SORT_DIRECTION = :desc
 
     def self.call(...)
       new(...).call
@@ -44,7 +46,7 @@ module Homepage
       @tags = tags.presence || []
 
       @sort_by = sort_by
-      @sort_direction = sort_direction
+      @sort_direction = sort_direction || DEFAULT_SORT_DIRECTION
 
       @page = page.to_i + 1
       @per_page = [(per_page || DEFAULT_PER_PAGE).to_i, MAX_PER_PAGE].min

--- a/app/services/search/article.rb
+++ b/app/services/search/article.rb
@@ -23,7 +23,7 @@ module Search
       # By skipping ordering, we rely on the custom ranking defined in the article's tsvector document
       return relation if term.present? && sort_by.blank?
 
-      return relation.reorder(sort_by => sort_direction) if sort_by&.to_sym == :published_at
+      return relation.reorder(sort_by => sort_direction) if sort_by&.to_sym == :published_at && sort_direction
 
       relation.reorder(DEFAULT_SORT_BY)
     end

--- a/spec/requests/search_spec.rb
+++ b/spec/requests/search_spec.rb
@@ -157,6 +157,21 @@ RSpec.describe "Search", type: :request, proper_status: true do
 
         expect(Search::Article).to have_received(:search_documents)
       end
+
+      it "nullifies invalid sort directions" do
+        allow(Search::Article).to receive(:search_documents).and_call_original
+        article = create(:article)
+
+        get search_feed_content_path(
+          class_name: "Article", page: 0, per_page: 1, search_fields: article.title,
+          sort_by: :published_at, sort_direction: :invalid
+        )
+
+        expect(response.parsed_body["result"].first["id"]).to eq(article.id)
+        expect(Search::Article)
+          .to have_received(:search_documents)
+          .with(hash_including(sort_direction: nil))
+      end
     end
 
     context "when searching for comments" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A pentester (or curious user) might send an invalid sort direction in the url params.

We previously passed the provided parameter from the url to the AR query, and would see an error raised if invalid data were passed (like `sort_direction=hhg`).

Remove invalid data, which relies on the default sort direction in each query class overriding a provided nil value, for example in [Search::Comment](https://github.com/forem/forem/blob/main/app/services/search/comment.rb#L41).

Update a few of the search classes to ensure we only sort with a valid direction.


## Related Tickets & Documents

https://app.honeybadger.io/projects/66984/faults/85115617

## QA Instructions, Screenshots, Recordings

1. all existing specs should pass
2. when sending an invalid sort direction like "invalid", a default order should be used instead (or sorting skipped) - request spec added should pass

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: backend bugfix
