### PR TITLE
Sharpen RegEx that matches Forem-specific links

### DIFF
--- a/app/liquid_tags/forem_tag.rb
+++ b/app/liquid_tags/forem_tag.rb
@@ -1,5 +1,5 @@
 module ForemTag
-  REGISTRY_REGEXP = %r{#{URL.protocol}\.#{URL.domain}/\b([\w-]+)?}
+  REGISTRY_REGEXP = %r{#{URL.url.gsub("\.", "\\.")}/\b([\w-]+)?}
   USER_ORG_REGEXP = %r{#{URL.url}/(?<name>[\w-]+)/?$}
   POST_PODCAST_REGEXP = %r{#{URL.url}/(?<podcast>[\w-]+)/[\w-]+/?}
   COMBINED_REGEXP = [USER_ORG_REGEXP, POST_PODCAST_REGEXP].freeze

--- a/app/liquid_tags/forem_tag.rb
+++ b/app/liquid_tags/forem_tag.rb
@@ -1,5 +1,5 @@
 module ForemTag
-  REGISTRY_REGEXP = %r{#{URL.url}/?}
+  REGISTRY_REGEXP = %r{#{URL.protocol}\.#{URL.domain}/\b([\w-]+)?}
   USER_ORG_REGEXP = %r{#{URL.url}/(?<name>[\w-]+)/?$}
   POST_PODCAST_REGEXP = %r{#{URL.url}/(?<podcast>[\w-]+)/[\w-]+/?}
   COMBINED_REGEXP = [USER_ORG_REGEXP, POST_PODCAST_REGEXP].freeze

--- a/app/liquid_tags/forem_tag.rb
+++ b/app/liquid_tags/forem_tag.rb
@@ -1,5 +1,5 @@
 module ForemTag
-  REGISTRY_REGEXP = %r{#{URL.url.gsub("\.", "\\.")}/\b([\w-]+)?}
+  REGISTRY_REGEXP = %r{#{Regexp.escape(URL.url)}/\b([\w\-]+)?}
   USER_ORG_REGEXP = %r{#{URL.url}/(?<name>[\w-]+)/?$}
   POST_PODCAST_REGEXP = %r{#{URL.url}/(?<podcast>[\w-]+)/[\w-]+/?}
   COMBINED_REGEXP = [USER_ORG_REGEXP, POST_PODCAST_REGEXP].freeze

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -161,6 +161,20 @@ RSpec.describe UnifiedEmbed::Registry do
       end
     end
 
+    it "returns OpenGraphTag for pathless or invalid Forem url", :aggregate_failures do
+      # for localhost, the first 2 cases are identical, due to no dots in URL.url
+      invalid_forem_links = [
+        URL.url, # pathless domain
+        URL.url.tr(".", "n"),
+        "#{URL.url}something",
+      ]
+
+      invalid_forem_links.each do |url|
+        expect(described_class.find_liquid_tag_for(link: url))
+          .to eq(OpenGraphTag)
+      end
+    end
+
     it "returns GistTag for a gist url" do
       expect(described_class.find_liquid_tag_for(link: "https://gist.github.com/jeremyf/662585f5c4d22184a6ae133a71bf891a"))
         .to eq(GistTag)

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -164,8 +164,10 @@ RSpec.describe UnifiedEmbed::Registry do
     it "returns OpenGraphTag for pathless or invalid Forem url", :aggregate_failures do
       # for localhost, the first 2 cases are identical, due to no dots in URL.url
       invalid_forem_links = [
-        URL.url, # pathless domain
+        URL.url,
         URL.url.tr(".", "n"),
+        "#{URL.url}/",
+        "#{URL.url}////",
         "#{URL.url}something",
       ]
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR sharpens the regular expression that matches Forem-specific links when embedded.
This is my first solution iteration; PR review may reveal more robust regex options. 😅

## Related Tickets & Documents
- Closes https://github.com/forem/forem/issues/16922

## QA Instructions, Screenshots, Recordings
Forem-specific embeds should work as expected; embeds of the naked Forem URL (e.g. `https://dev.to` or `https://dev.to/`) will trigger the fallback embed (to avoid validating URLs like `https://dev.to//`).

### UI accessibility concerns?
None; no frontend changes

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: _existing tests provide coverage_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
