### PR TITLE
apply same `scale-down` property to preview cover image

### DIFF
--- a/app/assets/stylesheets/views/article-form.scss
+++ b/app/assets/stylesheets/views/article-form.scss
@@ -198,7 +198,7 @@
       width: 250px;
       height: 105px;
       border-radius: var(--radius);
-      object-fit: cover;
+      object-fit: scale-down;
       margin-bottom: var(--su-2);
 
       @media (min-width: $breakpoint-s) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

When uploading a cover image the preview could sometimes be cut off if the ratio is incorrect. So this applies the same `scale-down` css property that we're using on the actual cover image for consistency.

## Related Tickets & Documents

- closes #17448 
- related PR for cover image #17347 

## QA Instructions, Screenshots, Recordings

Upload a cover image and verify that the preview isn't be cut off

### Before
<img width="642" alt="Screen Shot 2022-04-28 at 9 58 27 AM" src="https://user-images.githubusercontent.com/720055/165771325-45dae283-8fea-4c82-b252-696e7baa53cc.png">

### After
<img width="597" alt="Screen Shot 2022-04-28 at 9 57 57 AM" src="https://user-images.githubusercontent.com/720055/165771321-b5d8ea63-0274-40aa-868e-e1aea3a1f95a.png">


### UI accessibility concerns?

no

## Added/updated tests?

- [x] No, and this is why: just a css change

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
