### PR TITLE
make feed image consistent with cover image

### DIFF
--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -30,6 +30,10 @@
       &__feed {
         padding-top: 0;
         padding-bottom: 0;
+        height: 100%;
+        width: 100%;
+        aspect-ratio: auto 650 / 275;
+        object-fit: scale-down;
       }
     }
   }

--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -23,9 +23,14 @@
       border-radius: var(--radius-auto);
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      object-fit: cover;
+      object-fit: scale-down;
       width: 100%;
       height: 100%;
+
+      &__feed {
+        padding-top: 0;
+        padding-bottom: 0;
+      }
     }
   }
 

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -35,11 +35,6 @@ Object {
                 src="/images/10.png"
                 width="650"
               />
-              <span
-                class="hidden"
-              >
-                Unbranded Home Loan Account
-              </span>
             </a>
           </div>
           <div
@@ -295,11 +290,6 @@ Object {
               src="/images/10.png"
               width="650"
             />
-            <span
-              class="hidden"
-            >
-              Unbranded Home Loan Account
-            </span>
           </a>
         </div>
         <div

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -20,18 +20,28 @@ Object {
         <div
           role="presentation"
         >
-          <a
-            class="crayons-story__cover"
-            href="/some-post/path"
-            style="background-image: url(/images/10.png);"
-            title="Unbranded Home Loan Account"
+          <div
+            class="crayons-article__cover crayons-article__cover__image__feed"
           >
-            <span
-              class="hidden"
+            <a
+              class="crayons-article__cover__image__feed crayons-story__cover__image"
+              href="/some-post/path"
+              title="Unbranded Home Loan Account"
             >
-              Unbranded Home Loan Account
-            </span>
-          </a>
+              <img
+                alt="Cover for Unbranded Home Loan Account"
+                class="crayons-article__cover__image__feed"
+                height="275"
+                src="/images/10.png"
+                width="650"
+              />
+              <span
+                class="hidden"
+              >
+                Unbranded Home Loan Account
+              </span>
+            </a>
+          </div>
           <div
             class="crayons-story__body"
           >
@@ -270,18 +280,28 @@ Object {
       <div
         role="presentation"
       >
-        <a
-          class="crayons-story__cover"
-          href="/some-post/path"
-          style="background-image: url(/images/10.png);"
-          title="Unbranded Home Loan Account"
+        <div
+          class="crayons-article__cover crayons-article__cover__image__feed"
         >
-          <span
-            class="hidden"
+          <a
+            class="crayons-article__cover__image__feed crayons-story__cover__image"
+            href="/some-post/path"
+            title="Unbranded Home Loan Account"
           >
-            Unbranded Home Loan Account
-          </span>
-        </a>
+            <img
+              alt="Cover for Unbranded Home Loan Account"
+              class="crayons-article__cover__image__feed"
+              height="275"
+              src="/images/10.png"
+              width="650"
+            />
+            <span
+              class="hidden"
+            >
+              Unbranded Home Loan Account
+            </span>
+          </a>
+        </div>
         <div
           class="crayons-story__body"
         >

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -29,7 +29,7 @@ Object {
               title="Unbranded Home Loan Account"
             >
               <img
-                alt="Cover for Unbranded Home Loan Account"
+                alt="Unbranded Home Loan Account"
                 class="crayons-article__cover__image__feed"
                 height="275"
                 src="/images/10.png"
@@ -289,7 +289,7 @@ Object {
             title="Unbranded Home Loan Account"
           >
             <img
-              alt="Cover for Unbranded Home Loan Account"
+              alt="Unbranded Home Loan Account"
               class="crayons-article__cover__image__feed"
               height="275"
               src="/images/10.png"

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -20,18 +20,21 @@ Object {
         <div
           role="presentation"
         >
-          <a
-            class="crayons-story__cover"
-            href="/some-post/path"
-            style="background-image: url(/images/10.png);"
-            title="Unbranded Home Loan Account"
-          >
-            <span
-              class="hidden"
+          <div className="crayons-article__cover crayons-article__cover__image__feed">
+            <a
+              href="/some-post/path"
+              class="crayons-article__cover__image__feed crayons-story__cover__image"
+              title="Unbranded Home Loan Account"
             >
-              Unbranded Home Loan Account
-            </span>
-          </a>
+              <img
+                className="crayons-article__cover__image__feed"
+                src="/images/10.png"
+                width="650"
+                height="275"
+                alt="Cover for Unbranded Home Loan Account" />
+              <span class="hidden">Unbranded Home Loan Account</span>
+            </a>
+          </div>
           <div
             class="crayons-story__body"
           >

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -20,21 +20,18 @@ Object {
         <div
           role="presentation"
         >
-          <div className="crayons-article__cover crayons-article__cover__image__feed">
-            <a
-              href="/some-post/path"
-              class="crayons-article__cover__image__feed crayons-story__cover__image"
-              title="Unbranded Home Loan Account"
+          <a
+            class="crayons-story__cover"
+            href="/some-post/path"
+            style="background-image: url(/images/10.png);"
+            title="Unbranded Home Loan Account"
+          >
+            <span
+              class="hidden"
             >
-              <img
-                className="crayons-article__cover__image__feed"
-                src="/images/10.png"
-                width="650"
-                height="275"
-                alt="Cover for Unbranded Home Loan Account" />
-              <span class="hidden">Unbranded Home Loan Account</span>
-            </a>
-          </div>
+              Unbranded Home Loan Account
+            </span>
+          </a>
           <div
             class="crayons-story__body"
           >

--- a/app/javascript/articles/components/ArticleCoverImage.jsx
+++ b/app/javascript/articles/components/ArticleCoverImage.jsx
@@ -14,7 +14,7 @@ export const ArticleCoverImage = ({ article }) => {
           src={article.main_image}
           width="650"
           height="275"
-          alt={`Cover for ${article.title}`}
+          alt={article.title}
           style={{ backgroundColor: `${article.main_image_background_hex_color}` }} />
         <span class="hidden">{article.title}</span>
       </a>

--- a/app/javascript/articles/components/ArticleCoverImage.jsx
+++ b/app/javascript/articles/components/ArticleCoverImage.jsx
@@ -3,14 +3,22 @@ import { articlePropTypes } from '../../common-prop-types';
 
 export const ArticleCoverImage = ({ article }) => {
   return (
-    <a
-      href={article.path}
-      className="crayons-story__cover"
-      title={article.title}
-      style={{ backgroundImage: `url(${article.main_image})` }}
-    >
-      <span class="hidden">{article.title}</span>
-    </a>
+    <div className="crayons-article__cover crayons-article__cover__image__feed">
+      <a
+        href={article.path}
+        className="crayons-article__cover__image__feed crayons-story__cover__image"
+        title={article.title}
+      >
+        <img
+          className="crayons-article__cover__image__feed"
+          src={article.main_image}
+          width="650"
+          height="275"
+          alt={`Cover for ${article.title}`}
+          style={{ backgroundColor: `${article.main_image_background_hex_color}` }} />
+        <span class="hidden">{article.title}</span>
+      </a>
+    </div>
   );
 };
 

--- a/app/javascript/articles/components/ArticleCoverImage.jsx
+++ b/app/javascript/articles/components/ArticleCoverImage.jsx
@@ -15,8 +15,10 @@ export const ArticleCoverImage = ({ article }) => {
           width="650"
           height="275"
           alt={article.title}
-          style={{ backgroundColor: `${article.main_image_background_hex_color}` }} />
-        <span class="hidden">{article.title}</span>
+          style={{
+            backgroundColor: `${article.main_image_background_hex_color}`,
+          }}
+        />
       </a>
     </div>
   );

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -5,10 +5,8 @@
   <% end %>
   <% if featured == true || (feed_style_preference == "rich" && story.main_image.present?) %>
     <div class="crayons-article__cover crayons-article__cover__image__feed">
-      <a href="<%= story.path %>" title="<%= story.title %>"
-        style="background-color: <%= story.main_image_background_hex_color %>;"
-        class="crayons-article__cover__image__feed crayons-story__cover__image">
-        <img src="<%= cloud_cover_url(story.main_image) %>" width="650" height="275" style="background-color:<%= story.main_image_background_hex_color %>;" class="crayons-article__cover__image__feed" alt="<%= story.title %>">
+      <a href="<%= story.path %>" title="<%= story.title %>" aria-label="article" class="crayons-article__cover__image__feed crayons-story__cover__image">
+        <img src="<%= cloud_cover_url(story.main_image) %>" width="650" height="275" style="background-color:<%= story.main_image_background_hex_color %>;" class="crayons-article__cover__image__feed" alt="Cover image for <%= story.title %>">
       </a>
     </div>
   <% end %>

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -8,7 +8,7 @@
       <a href="<%= story.path %>" title="<%= story.title %>" aria-label="article"
         style="background-color: <%= story.main_image_background_hex_color %>;"
         class="crayons-article__cover__image__feed crayons-story__cover__image">
-        <img src="<%= cloud_cover_url(story.main_image) %>" width="650" height="275" style="background-color:<%= story.main_image_background_hex_color %>;" class="crayons-article__cover__image__feed" alt="Cover image for <%= story.title %>">
+        <img src="<%= cloud_cover_url(story.main_image) %>" width="650" height="275" style="background-color:<%= story.main_image_background_hex_color %>;" class="crayons-article__cover__image__feed" alt="<%= story.title %>">
       </a>
     </div>
   <% end %>

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -5,7 +5,7 @@
   <% end %>
   <% if featured == true || (feed_style_preference == "rich" && story.main_image.present?) %>
     <div class="crayons-article__cover crayons-article__cover__image__feed">
-      <a href="<%= story.path %>" title="<%= story.title %>" aria-label="article"
+      <a href="<%= story.path %>" title="<%= story.title %>"
         style="background-color: <%= story.main_image_background_hex_color %>;"
         class="crayons-article__cover__image__feed crayons-story__cover__image">
         <img src="<%= cloud_cover_url(story.main_image) %>" width="650" height="275" style="background-color:<%= story.main_image_background_hex_color %>;" class="crayons-article__cover__image__feed" alt="<%= story.title %>">

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -4,11 +4,13 @@
     <div id="featured-story-marker" data-featured-article="articles-<%= story.id %>"></div>
   <% end %>
   <% if featured == true || (feed_style_preference == "rich" && story.main_image.present?) %>
-    <a href="<%= story.path %>" title="<%= story.title %>" aria-label="article"
-      style="background-color: <%= story.main_image_background_hex_color %>; background-image: url(<%= cloud_cover_url(story.main_image) %>);"
-      class="crayons-story__cover crayons-story__cover__image">
-      <span class="hidden"><%= story.title %></span>
-    </a>
+    <div class="crayons-article__cover crayons-article__cover__image__feed">
+      <a href="<%= story.path %>" title="<%= story.title %>" aria-label="article"
+        style="background-color: <%= story.main_image_background_hex_color %>;"
+        class="crayons-article__cover__image__feed crayons-story__cover__image">
+        <img src="<%= cloud_cover_url(story.main_image) %>" width="650" height="275" style="background-color:<%= story.main_image_background_hex_color %>;" class="crayons-article__cover__image__feed" alt="Cover image for <%= story.title %>">
+      </a>
+    </div>
   <% end %>
 
   <% if story.video.present? && story.video_thumbnail_url.present? %>

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -6,7 +6,7 @@ article_attributes_to_include = %i[
 article_methods_to_include = %i[
   readable_publish_date flare_tag class_name
   cloudinary_video_url video_duration_in_minutes published_at_int
-  published_timestamp
+  published_timestamp main_image_background_hex_color
 ]
 
 json.array!(@stories) do |article|

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -182,7 +182,9 @@ RSpec.describe "StoriesIndex", type: :request do
 
       allow(Settings::UserExperience).to receive(:feed_style).and_return("rich")
       get "/"
+      # rubocop:disable Layout/LineLength
       expect(response.body.scan(/(?=class="crayons-article__cover crayons-article__cover__image__feed)/).count).to be > 1
+      # rubocop:enable Layout/LineLength
     end
 
     context "with campaign hero" do

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe "StoriesIndex", type: :request do
 
       allow(Settings::UserExperience).to receive(:feed_style).and_return("basic")
       get "/"
-      expect(response.body.scan(/(?=class="crayons-story__cover crayons-story__cover__image)/).count).to be 1
+      expect(response.body.scan(/(?=class="crayons-article__cover crayons-article__cover__image__feed)/).count).to be 1
     end
 
     it "shows multiple cover images if rich feed style" do
@@ -182,7 +182,7 @@ RSpec.describe "StoriesIndex", type: :request do
 
       allow(Settings::UserExperience).to receive(:feed_style).and_return("rich")
       get "/"
-      expect(response.body.scan(/(?=class="crayons-story__cover crayons-story__cover__image)/).count).to be > 1
+      expect(response.body.scan(/(?=class="crayons-article__cover crayons-article__cover__image__feed)/).count).to be > 1
     end
 
     context "with campaign hero" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

This PR makes the feed image to be more consistent with the cover image by maintaining the correct aspect ratio. You'll notice in the before/after screenshots that it has a gray background now. This is how we treat cover images. I continued this here.

## Related Tickets & Documents

- Related Issue #16455
- Closes #17447 

## QA Instructions, Screenshots, Recordings

### before
<img width="712" alt="Screen Shot 2022-04-29 at 9 22 40 AM" src="https://user-images.githubusercontent.com/720055/165952931-3eca71b3-9557-4cbf-a934-311d646bb277.png">

### after
<img width="693" alt="Screen Shot 2022-04-29 at 9 23 01 AM" src="https://user-images.githubusercontent.com/720055/165952941-ec3ba950-1dd0-4287-ba65-17ce47ccd41a.png">


### UI accessibility concerns?

No

## Added/updated tests?

- [x] No, and this is why: css change

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
