### PR TITLE
Show Series counts on all Dashboard Tabs

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -51,27 +51,32 @@ class DashboardsController < ApplicationController
   def following_tags
     fetch_and_authorize_user
     @followed_tags = follows_for(user: @user, type: "ActsAsTaggableOn::Tag", order_by: :points)
+    @collections_count = collections_count(@user)
   end
 
   def following_users
     fetch_and_authorize_user
     @follows = follows_for(user: @user, type: "User")
+    @collections_count = collections_count(@user)
   end
 
   def following_organizations
     fetch_and_authorize_user
     @followed_organizations = follows_for(user: @user, type: "Organization")
+    @collections_count = collections_count(@user)
   end
 
   def following_podcasts
     fetch_and_authorize_user
     @followed_podcasts = follows_for(user: @user, type: "Podcast")
+    @collections_count = collections_count(@user)
   end
 
   def followers
     fetch_and_authorize_user
     @follows = Follow.followable_user(@user.id)
       .includes(:follower).order(created_at: :desc).limit(follows_limit)
+    @collections_count = collections_count(@user)
   end
 
   def analytics
@@ -124,5 +129,9 @@ class DashboardsController < ApplicationController
     return max if per_page > max
 
     per_page
+  end
+
+  def collections_count(user)
+    user.collections.non_empty.count
   end
 end

--- a/spec/system/dashboards/user_visits_dashboard_spec.rb
+++ b/spec/system/dashboards/user_visits_dashboard_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe "Dashboard", type: :system, js: true do
   let(:collection) { create(:collection, :with_articles) }
   let(:collection_user) { collection.user }
 
-  before do
-    sign_in user
-  end
-
   context "when looking at analytics counters" do
+    before do
+      sign_in user
+    end
+
     it "shows the count of unspent credits" do
       Credit.add_to(user, 2)
 
@@ -35,51 +35,22 @@ RSpec.describe "Dashboard", type: :system, js: true do
       sign_in collection_user
     end
 
-    it "shows the user-collections count on dashboard tab" do
-      visit dashboard_path
+    it "shows the user-collections count on current dashboard tab", :aggregate_failures do
+      dashboard_paths = [
+        dashboard_path,
+        dashboard_following_path,
+        dashboard_following_tags_path,
+        dashboard_following_users_path,
+        dashboard_following_organizations_path,
+        dashboard_following_podcasts_path,
+      ]
 
-      within "main#main-content nav" do
-        expect(page).to have_text(/Series\n1/)
-      end
-    end
+      dashboard_paths.each do |path|
+        visit path
 
-    it "shows the user-collections count on following tab" do
-      visit dashboard_following_path
-
-      within "main#main-content nav" do
-        expect(page).to have_text(/Series\n1/)
-      end
-    end
-
-    it "shows the user-collections count on following-tags tab" do
-      visit dashboard_following_tags_path
-
-      within "main#main-content nav" do
-        expect(page).to have_text(/Series\n1/)
-      end
-    end
-
-    it "shows the user-collections count on following-users tab" do
-      visit dashboard_following_users_path
-
-      within "main#main-content nav" do
-        expect(page).to have_text(/Series\n1/)
-      end
-    end
-
-    it "shows the user-collections count on following-orgs tab" do
-      visit dashboard_following_organizations_path
-
-      within "main#main-content nav" do
-        expect(page).to have_text(/Series\n1/)
-      end
-    end
-
-    it "shows the user-collections count on following-podcasts tab" do
-      visit dashboard_following_podcasts_path
-
-      within "main#main-content nav" do
-        expect(page).to have_text(/Series\n1/)
+        within "main#main-content nav" do
+          expect(page).to have_text(/Series\n1/)
+        end
       end
     end
   end

--- a/spec/system/dashboards/user_visits_dashboard_spec.rb
+++ b/spec/system/dashboards/user_visits_dashboard_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe "Dashboard", type: :system, js: true do
   let(:user) { create(:user) }
   let(:listing) { create(:listing) }
+  let(:collection) { create(:collection, :with_articles) }
+  let(:collection_user) { collection.user }
 
   before do
     sign_in user
@@ -24,6 +26,60 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
       within "main#main-content > header" do
         expect(page).to have_text(/1\nCredits available/)
+      end
+    end
+  end
+
+  context "when looking at actions panel" do
+    before do
+      sign_in collection_user
+    end
+
+    it "shows the user-collections count on dashboard tab" do
+      visit dashboard_path
+
+      within "main#main-content nav" do
+        expect(page).to have_text(/Series\n1/)
+      end
+    end
+
+    it "shows the user-collections count on following tab" do
+      visit dashboard_following_path
+
+      within "main#main-content nav" do
+        expect(page).to have_text(/Series\n1/)
+      end
+    end
+
+    it "shows the user-collections count on following-tags tab" do
+      visit dashboard_following_tags_path
+
+      within "main#main-content nav" do
+        expect(page).to have_text(/Series\n1/)
+      end
+    end
+
+    it "shows the user-collections count on following-users tab" do
+      visit dashboard_following_users_path
+
+      within "main#main-content nav" do
+        expect(page).to have_text(/Series\n1/)
+      end
+    end
+
+    it "shows the user-collections count on following-orgs tab" do
+      visit dashboard_following_organizations_path
+
+      within "main#main-content nav" do
+        expect(page).to have_text(/Series\n1/)
+      end
+    end
+
+    it "shows the user-collections count on following-podcasts tab" do
+      visit dashboard_following_podcasts_path
+
+      within "main#main-content nav" do
+        expect(page).to have_text(/Series\n1/)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR ensures that counts for the user's series (collections) show on every Dashboard Tab.

## Related Tickets & Documents
- Closes https://github.com/forem/forem/issues/16914

## QA Instructions, Screenshots, Recordings
Visit `/dashboard`, click through all the Dashboard views (Following Users, Following Organizations, etc) and ensure that the Series count shows in each view.

### UI accessibility concerns?
None

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
