### PR TITLE
Remove sustaining member newsletter, and its settings

### DIFF
--- a/app/controllers/incoming_webhooks/mailchimp_unsubscribes_controller.rb
+++ b/app/controllers/incoming_webhooks/mailchimp_unsubscribes_controller.rb
@@ -6,7 +6,6 @@ module IncomingWebhooks
 
     LIST_MAPPINGS = {
       mailchimp_newsletter_id: :email_newsletter,
-      mailchimp_sustaining_members_id: :email_membership_newsletter,
       mailchimp_tag_moderators_id: :email_tag_mod_newsletter,
       mailchimp_community_moderators_id: :email_community_mod_newsletter
     }.freeze

--- a/app/lib/constants/settings/general.rb
+++ b/app/lib/constants/settings/general.rb
@@ -57,10 +57,6 @@ module Constants
           description: "Main Newsletter ID, also known as Audience ID",
           placeholder: ""
         },
-        mailchimp_sustaining_members_id: {
-          description: "Sustaining Members Newsletter ID",
-          placeholder: ""
-        },
         mailchimp_tag_moderators_id: {
           description: "Tag Moderators Newsletter ID",
           placeholder: ""

--- a/app/models/settings/general.rb
+++ b/app/models/settings/general.rb
@@ -70,7 +70,6 @@ module Settings
     # <https://mailchimp.com/developer/>
     setting :mailchimp_api_key, type: :string, default: ApplicationConfig["MAILCHIMP_API_KEY"]
     setting :mailchimp_newsletter_id, type: :string, default: ""
-    setting :mailchimp_sustaining_members_id, type: :string, default: ""
     setting :mailchimp_tag_moderators_id, type: :string, default: ""
     setting :mailchimp_community_moderators_id, type: :string, default: ""
     # Mailchimp webhook secret. Part of the callback URL in the Mailchimp settings.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -494,10 +494,6 @@ class User < ApplicationRecord
     Users::SubscribeToMailchimpNewsletterWorker.perform_async(id)
   end
 
-  def a_sustaining_member?
-    monthly_dues.positive?
-  end
-
   def profile_image_90
     profile_image_url_for(length: 90)
   end

--- a/app/services/mailchimp/bot.rb
+++ b/app/services/mailchimp/bot.rb
@@ -122,12 +122,6 @@ module Mailchimp
       success
     end
 
-    def remove_sustaining_member
-      return unless Settings::General.mailchimp_sustaining_members_id.present? && a_sustaining_member?
-
-      permanent_delete_from_mailchimp(Settings::General.mailchimp_sustaining_members_id)
-    end
-
     def remove_community_mod
       return unless Settings::General.mailchimp_community_moderators_id.present? && user.trusted?
 
@@ -145,7 +139,6 @@ module Mailchimp
       begin
         permanent_delete_from_mailchimp(Settings::General.mailchimp_newsletter_id)
         remove_tag_mod
-        remove_sustaining_member
         remove_community_mod
         success = true
       rescue Gibbon::MailChimpError => e
@@ -155,13 +148,6 @@ module Mailchimp
     end
 
     private
-
-    def a_sustaining_member?
-      # Reasoning for including => saved_changes["monthly_dues"]
-      # Is that mailchimp should be updated if a user decides to
-      # unsubscribes
-      user.monthly_dues.positive? || saved_changes["monthly_dues"]
-    end
 
     def md5_email(email)
       Digest::MD5.hexdigest(email.downcase)

--- a/app/views/admin/settings/forms/_newsletter.html.erb
+++ b/app/views/admin/settings/forms/_newsletter.html.erb
@@ -22,14 +22,6 @@
         </div>
 
         <div class="crayons-field">
-          <%= admin_config_label :mailchimp_sustaining_members_id, "Sustaining Members Newsletter" %>
-          <%= admin_config_description Constants::Settings::General::DETAILS[:mailchimp_sustaining_members_id][:description] %>
-          <%= f.text_field :mailchimp_sustaining_members_id,
-                           class: "crayons-textfield",
-                           value: Settings::General.mailchimp_sustaining_members_id %>
-        </div>
-
-        <div class="crayons-field">
           <%= admin_config_label :mailchimp_tag_moderators_id, "Tag Moderators Newsletter" %>
           <%= admin_config_description Constants::Settings::General::DETAILS[:mailchimp_tag_moderators_id][:description] %>
           <%= f.text_field :mailchimp_tag_moderators_id,

--- a/app/views/users/_notifications.html.erb
+++ b/app/views/users/_notifications.html.erb
@@ -13,12 +13,6 @@
       <%= f.check_box :email_digest_periodic, class: "crayons-checkbox" %>
       <%= f.label :email_digest_periodic, "Send me a periodic digest of top posts from my tags", class: "crayons-field__label" %>
     </div>
-    <% if current_user.a_sustaining_member? %>
-      <div class="crayons-field crayons-field--checkbox">
-        <%= f.check_box :email_membership_newsletter, class: "crayons-checkbox" %>
-        <%= f.label :email_membership_newsletter, "Send me sustaining membership newsletter emails", class: "crayons-field__label" %>
-      </div>
-    <% end %>
     <% if current_user.tag_moderator? %>
       <div class="crayons-field crayons-field--checkbox">
         <%= f.check_box :email_tag_mod_newsletter, class: "crayons-checkbox" %>

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -54,7 +54,6 @@ en:
       users_notification_setting:
         email_newsletter: Send me weekly newsletter emails
         email_digest_periodic: Send me a periodic digest of top posts from my tags
-        email_membership_newsletter: Send me sustaining membership newsletter emails
         email_tag_mod_newsletter: Send me tag moderator newsletter emails
         email_community_mod_newsletter: Send me community moderator newsletter emails
         email_comment_notifications: Send me an email when someone replies to me in a comment thread

--- a/config/locales/helpers/fr.yml
+++ b/config/locales/helpers/fr.yml
@@ -54,7 +54,6 @@ fr:
       users_notification_setting:
         email_newsletter: Send me weekly newsletter emails
         email_digest_periodic: Send me a periodic digest of top posts from my tags
-        email_membership_newsletter: Send me sustaining membership newsletter emails
         email_tag_mod_newsletter: Send me tag moderator newsletter emails
         email_community_mod_newsletter: Send me community moderator newsletter emails
         email_comment_notifications: Send me an email when someone replies to me in a comment thread

--- a/lib/data_update_scripts/20220429142653_remove_mailchimp_sustaining_members_newsletter.rb
+++ b/lib/data_update_scripts/20220429142653_remove_mailchimp_sustaining_members_newsletter.rb
@@ -1,7 +1,7 @@
 module DataUpdateScripts
   class RemoveMailchimpSustainingMembersNewsletter
     def run
-      Settings::General.where(var: "mailchimp_sustaining_members_id").delete_all
+      Settings::General.where(var: "mailchimp_sustaining_members_id").destroy_all
     end
   end
 end

--- a/lib/data_update_scripts/20220429142653_remove_mailchimp_sustaining_members_newsletter.rb
+++ b/lib/data_update_scripts/20220429142653_remove_mailchimp_sustaining_members_newsletter.rb
@@ -1,0 +1,7 @@
+module DataUpdateScripts
+  class RemoveMailchimpSustainingMembersNewsletter
+    def run
+      Settings::General.where(var: "mailchimp_sustaining_members_id").delete_all
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/remove_mailchimp_sustaining_members_newsletter_spec.rb
+++ b/spec/lib/data_update_scripts/remove_mailchimp_sustaining_members_newsletter_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220429142653_remove_mailchimp_sustaining_members_newsletter.rb",
+)
+
+describe DataUpdateScripts::RemoveMailchimpSustainingMembersNewsletter do
+  it "does nothing when setting not present" do
+    expect { described_class.new.run }.not_to change(Settings::General, :count)
+  end
+
+  context "when there is a newsletter setting" do
+    before do
+      # since it's been removed from the code, define it here in test
+      Settings::General.setting(:mailchimp_sustaining_members_id)
+      # setting the value changes count to 1
+      Settings::General.mailchimp_sustaining_members_id = "abcdefgh"
+    end
+
+    it "removes mailchimp_sustaining_members_id setting" do
+      expect { described_class.new.run }.to change(Settings::General, :count).by(-1)
+    end
+  end
+end

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -399,13 +399,6 @@ RSpec.describe "/admin/customization/config", type: :request do
           expect(Settings::General.mailchimp_newsletter_id).to eq("abc")
         end
 
-        it "updates mailchimp_sustaining_members_id" do
-          post admin_settings_general_settings_path, params: {
-            settings_general: { mailchimp_sustaining_members_id: "abc" }
-          }
-          expect(Settings::General.mailchimp_sustaining_members_id).to eq("abc")
-        end
-
         it "updates mailchimp_tag_moderators_id" do
           post admin_settings_general_settings_path, params: {
             settings_general: { mailchimp_tag_moderators_id: "abc" }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature (removal)
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This removes the concept of sustaining memberships from the system,
and logic related to or dependent on it.

This does not remove the monthly_dues column from the users table (todo).


## Related Tickets & Documents

- Closes #17498

## QA Instructions, Screenshots, Recordings

Please let nothing break. Specifically forms in the admin area around mailchimp newsletters were touched and should be spot checked.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: removing old behavior, nothing to test

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: almost nobody knew this was even here, they won't miss it.

## [optional] Are there any post deployment tasks we need to perform?

I think a mailchimp administrator could remove the newsletter if it exists?
