### PR TITLE
drop monthly dues from users

### DIFF
--- a/db/migrate/20220429150448_drop_monthly_dues_from_users.rb
+++ b/db/migrate/20220429150448_drop_monthly_dues_from_users.rb
@@ -1,0 +1,7 @@
+class DropMonthlyDuesFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    safety_assured do
+      remove_column :users, :monthly_dues, :integer, default: 0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_01_071321) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_29_150448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -1242,7 +1242,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_01_071321) do
     t.inet "last_sign_in_ip"
     t.datetime "latest_article_updated_at", precision: nil
     t.datetime "locked_at", precision: nil
-    t.integer "monthly_dues", default: 0
     t.string "name"
     t.string "old_old_username"
     t.string "old_username"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Database Cleanup

## Description

After #17514 was merged, there are no users of the monthly_dues column. It may be removed.

## Related Tickets & Documents

- Related Issue #17514 and #17498

## QA Instructions, Screenshots, Recordings

Running `rails db:migrate` (drop), `db:rollback` (add column back), and `db:migrate` (drop once more)should work without any errors.

And nothing should break.

### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: Removing something is hard to test.

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams

