### PR TITLE
Use Sidekiq::Job module alias for Sidekiq::Worker

### DIFF
--- a/app/workers/articles/bust_multiple_caches_worker.rb
+++ b/app/workers/articles/bust_multiple_caches_worker.rb
@@ -1,6 +1,6 @@
 module Articles
   class BustMultipleCachesWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform(article_ids)

--- a/app/workers/articles/enrich_image_attributes_worker.rb
+++ b/app/workers/articles/enrich_image_attributes_worker.rb
@@ -1,6 +1,6 @@
 module Articles
   class EnrichImageAttributesWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 5, lock: :until_executing
 

--- a/app/workers/articles/score_calc_worker.rb
+++ b/app/workers/articles/score_calc_worker.rb
@@ -1,6 +1,6 @@
 module Articles
   class ScoreCalcWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, lock: :until_executing
 

--- a/app/workers/articles/update_organic_page_views_worker.rb
+++ b/app/workers/articles/update_organic_page_views_worker.rb
@@ -1,6 +1,6 @@
 module Articles
   class UpdateOrganicPageViewsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority,
                     lock: :until_executing,

--- a/app/workers/articles/update_page_views_worker.rb
+++ b/app/workers/articles/update_page_views_worker.rb
@@ -1,6 +1,6 @@
 module Articles
   class UpdatePageViewsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority,
                     lock: :until_executing,

--- a/app/workers/badge_achievements/badge_award_worker.rb
+++ b/app/workers/badge_achievements/badge_award_worker.rb
@@ -1,6 +1,6 @@
 module BadgeAchievements
   class BadgeAwardWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority, retry: 10
 

--- a/app/workers/badge_achievements/send_email_notification_worker.rb
+++ b/app/workers/badge_achievements/send_email_notification_worker.rb
@@ -1,6 +1,6 @@
 module BadgeAchievements
   class SendEmailNotificationWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 10
 

--- a/app/workers/broadcasts/send_welcome_notifications_worker.rb
+++ b/app/workers/broadcasts/send_welcome_notifications_worker.rb
@@ -1,6 +1,6 @@
 module Broadcasts
   class SendWelcomeNotificationsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 15
 

--- a/app/workers/bust_cache_base_worker.rb
+++ b/app/workers/bust_cache_base_worker.rb
@@ -1,5 +1,5 @@
 class BustCacheBaseWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   sidekiq_options queue: :high_priority, retry: 15, lock: :until_executing
 end

--- a/app/workers/capture_query_stats_worker.rb
+++ b/app/workers/capture_query_stats_worker.rb
@@ -1,5 +1,5 @@
 class CaptureQueryStatsWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   def perform
     return unless ENV["PG_HERO_CAPTURE_QUERY_STATS"] == "true"

--- a/app/workers/comments/calculate_score_worker.rb
+++ b/app/workers/comments/calculate_score_worker.rb
@@ -1,6 +1,6 @@
 module Comments
   class CalculateScoreWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, lock: :until_executing
 

--- a/app/workers/comments/create_first_reaction_worker.rb
+++ b/app/workers/comments/create_first_reaction_worker.rb
@@ -1,6 +1,6 @@
 module Comments
   class CreateFirstReactionWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority, retry: 10
 

--- a/app/workers/comments/send_email_notification_worker.rb
+++ b/app/workers/comments/send_email_notification_worker.rb
@@ -1,6 +1,6 @@
 module Comments
   class SendEmailNotificationWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :mailers
 

--- a/app/workers/credits/sync_counter_cache.rb
+++ b/app/workers/credits/sync_counter_cache.rb
@@ -1,6 +1,6 @@
 module Credits
   class SyncCounterCache
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 10
 

--- a/app/workers/data_update_worker.rb
+++ b/app/workers/data_update_worker.rb
@@ -1,5 +1,5 @@
 class DataUpdateWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
   sidekiq_options queue: :high_priority, retry: 5
 
   def perform(id = nil)

--- a/app/workers/discover/register_worker.rb
+++ b/app/workers/discover/register_worker.rb
@@ -1,6 +1,6 @@
 module Discover
   class RegisterWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 3
 

--- a/app/workers/emails/enqueue_digest_worker.rb
+++ b/app/workers/emails/enqueue_digest_worker.rb
@@ -1,6 +1,6 @@
 module Emails
   class EnqueueDigestWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 15
 

--- a/app/workers/emails/remove_old_emails_worker.rb
+++ b/app/workers/emails/remove_old_emails_worker.rb
@@ -1,6 +1,6 @@
 module Emails
   class RemoveOldEmailsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 10
 

--- a/app/workers/emails/send_user_digest_worker.rb
+++ b/app/workers/emails/send_user_digest_worker.rb
@@ -1,6 +1,6 @@
 module Emails
   class SendUserDigestWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 15, lock: :until_executing
 

--- a/app/workers/export_content_worker.rb
+++ b/app/workers/export_content_worker.rb
@@ -1,5 +1,5 @@
 class ExportContentWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   sidekiq_options queue: :medium_priority, retry: 10, lock: :until_executed
 

--- a/app/workers/feeds/import_articles_worker.rb
+++ b/app/workers/feeds/import_articles_worker.rb
@@ -1,6 +1,6 @@
 module Feeds
   class ImportArticlesWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10, lock: :until_and_while_executing
 
@@ -34,7 +34,7 @@ module Feeds
     end
 
     class ForUser
-      include Sidekiq::Worker
+      include Sidekiq::Job
 
       def perform(user_ids, earlier_than)
         users_scope = User.where(id: user_ids)

--- a/app/workers/follows/send_email_notification_worker.rb
+++ b/app/workers/follows/send_email_notification_worker.rb
@@ -1,6 +1,6 @@
 module Follows
   class SendEmailNotificationWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :mailers, retry: 10
 
     def perform(follow_id, mailer = NotifyMailer.name)

--- a/app/workers/follows/update_points_worker.rb
+++ b/app/workers/follows/update_points_worker.rb
@@ -1,6 +1,6 @@
 module Follows
   class UpdatePointsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :low_priority, retry: 10, lock: :until_executing
 
     def perform(article_id, user_id)

--- a/app/workers/github_repos/repo_sync_worker.rb
+++ b/app/workers/github_repos/repo_sync_worker.rb
@@ -1,6 +1,6 @@
 module GithubRepos
   class RepoSyncWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 10, lock: :until_executing
 

--- a/app/workers/github_repos/update_latest_worker.rb
+++ b/app/workers/github_repos/update_latest_worker.rb
@@ -1,6 +1,6 @@
 module GithubRepos
   class UpdateLatestWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10
 

--- a/app/workers/html_variants/remove_old_data_worker.rb
+++ b/app/workers/html_variants/remove_old_data_worker.rb
@@ -1,6 +1,6 @@
 module HtmlVariants
   class RemoveOldDataWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 15
 

--- a/app/workers/listings/expire_old_listings_worker.rb
+++ b/app/workers/listings/expire_old_listings_worker.rb
@@ -1,6 +1,6 @@
 module Listings
   class ExpireOldListingsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 5
 

--- a/app/workers/mentions/create_all_worker.rb
+++ b/app/workers/mentions/create_all_worker.rb
@@ -1,7 +1,7 @@
 module Mentions
   # This worker is currently only used to create mentions on comments.
   class CreateAllWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :default, retry: 10
 
     def perform(notifiable_id, notifiable_type)

--- a/app/workers/mentions/send_email_notification_worker.rb
+++ b/app/workers/mentions/send_email_notification_worker.rb
@@ -1,6 +1,6 @@
 module Mentions
   class SendEmailNotificationWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :default, retry: 10
 
     def perform(mention_id)

--- a/app/workers/metrics/check_data_update_script_statuses.rb
+++ b/app/workers/metrics/check_data_update_script_statuses.rb
@@ -1,6 +1,6 @@
 module Metrics
   class CheckDataUpdateScriptStatuses
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform

--- a/app/workers/metrics/record_background_queue_stats_worker.rb
+++ b/app/workers/metrics/record_background_queue_stats_worker.rb
@@ -1,6 +1,6 @@
 module Metrics
   class RecordBackgroundQueueStatsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :high_priority, retry: 10
 
     def perform

--- a/app/workers/metrics/record_daily_notifications_worker.rb
+++ b/app/workers/metrics/record_daily_notifications_worker.rb
@@ -1,6 +1,6 @@
 module Metrics
   class RecordDailyNotificationsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :low_priority, retry: 10
 
     EVENT_TITLES = %w[

--- a/app/workers/metrics/record_daily_usage_worker.rb
+++ b/app/workers/metrics/record_daily_usage_worker.rb
@@ -1,6 +1,6 @@
 module Metrics
   class RecordDailyUsageWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform

--- a/app/workers/metrics/record_data_counts_worker.rb
+++ b/app/workers/metrics/record_data_counts_worker.rb
@@ -1,6 +1,6 @@
 module Metrics
   class RecordDataCountsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform

--- a/app/workers/migrate_data_to_work_field_worker.rb
+++ b/app/workers/migrate_data_to_work_field_worker.rb
@@ -2,7 +2,7 @@
 # and we gave self-hosters some time to run it to we should be able to remove
 # this.
 class MigrateDataToWorkFieldWorker
-  include Sidekiq::Worker
+  include Sidekiq::Job
 
   def perform(profile_id)
     profile = Profile.find_by(id: profile_id)

--- a/app/workers/moderator/banish_user_worker.rb
+++ b/app/workers/moderator/banish_user_worker.rb
@@ -1,6 +1,6 @@
 module Moderator
   class BanishUserWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority, retry: 10
 

--- a/app/workers/moderator/sink_articles_worker.rb
+++ b/app/workers/moderator/sink_articles_worker.rb
@@ -1,6 +1,6 @@
 module Moderator
   class SinkArticlesWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10
 

--- a/app/workers/moderator/unpublish_all_articles_worker.rb
+++ b/app/workers/moderator/unpublish_all_articles_worker.rb
@@ -1,6 +1,6 @@
 module Moderator
   class UnpublishAllArticlesWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10
 

--- a/app/workers/notification_subscriptions/update_worker.rb
+++ b/app/workers/notification_subscriptions/update_worker.rb
@@ -1,6 +1,6 @@
 module NotificationSubscriptions
   class UpdateWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10, lock: :until_executing
 

--- a/app/workers/notifications/mention_worker.rb
+++ b/app/workers/notifications/mention_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class MentionWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform(mention_id)

--- a/app/workers/notifications/milestone_worker.rb
+++ b/app/workers/notifications/milestone_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class MilestoneWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 10
 

--- a/app/workers/notifications/moderation_notification_worker.rb
+++ b/app/workers/notifications/moderation_notification_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class ModerationNotificationWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10
 

--- a/app/workers/notifications/new_badge_achievement_worker.rb
+++ b/app/workers/notifications/new_badge_achievement_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class NewBadgeAchievementWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform(badge_achievement_id)

--- a/app/workers/notifications/new_follower_worker.rb
+++ b/app/workers/notifications/new_follower_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class NewFollowerWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10
 

--- a/app/workers/notifications/new_reaction_worker.rb
+++ b/app/workers/notifications/new_reaction_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class NewReactionWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10
 

--- a/app/workers/notifications/notifiable_action_worker.rb
+++ b/app/workers/notifications/notifiable_action_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class NotifiableActionWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 10
     def perform(notifiable_id, notifiable_type, action)

--- a/app/workers/notifications/remove_all_worker.rb
+++ b/app/workers/notifications/remove_all_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class RemoveAllWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 10
 

--- a/app/workers/notifications/remove_old_notifications_worker.rb
+++ b/app/workers/notifications/remove_old_notifications_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class RemoveOldNotificationsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 10
 

--- a/app/workers/notifications/tag_adjustment_notification_worker.rb
+++ b/app/workers/notifications/tag_adjustment_notification_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class TagAdjustmentNotificationWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10
 

--- a/app/workers/notifications/update_worker.rb
+++ b/app/workers/notifications/update_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class UpdateWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10, lock: :until_executing
 

--- a/app/workers/notifications/welcome_notification_worker.rb
+++ b/app/workers/notifications/welcome_notification_worker.rb
@@ -1,6 +1,6 @@
 module Notifications
   class WelcomeNotificationWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform(receiver_id, broadcast_id)

--- a/app/workers/organizations/delete_worker.rb
+++ b/app/workers/organizations/delete_worker.rb
@@ -1,6 +1,6 @@
 module Organizations
   class DeleteWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority, retry: 10
 

--- a/app/workers/organizations/update_organization_articles_paths_worker.rb
+++ b/app/workers/organizations/update_organization_articles_paths_worker.rb
@@ -1,6 +1,6 @@
 module Organizations
   class UpdateOrganizationArticlesPathsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority
 

--- a/app/workers/podcast_episodes/create_worker.rb
+++ b/app/workers/podcast_episodes/create_worker.rb
@@ -1,6 +1,6 @@
 module PodcastEpisodes
   class CreateWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority
 

--- a/app/workers/podcast_episodes/update_media_url_worker.rb
+++ b/app/workers/podcast_episodes/update_media_url_worker.rb
@@ -1,6 +1,6 @@
 module PodcastEpisodes
   class UpdateMediaUrlWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority
 

--- a/app/workers/podcasts/enqueue_get_episodes_worker.rb
+++ b/app/workers/podcasts/enqueue_get_episodes_worker.rb
@@ -1,6 +1,6 @@
 module Podcasts
   class EnqueueGetEpisodesWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10
 

--- a/app/workers/podcasts/get_episodes_worker.rb
+++ b/app/workers/podcasts/get_episodes_worker.rb
@@ -1,6 +1,6 @@
 module Podcasts
   class GetEpisodesWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority, retry: 10
 

--- a/app/workers/push_notifications/cleanup_worker.rb
+++ b/app/workers/push_notifications/cleanup_worker.rb
@@ -1,6 +1,6 @@
 module PushNotifications
   class CleanupWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 10, lock: :until_and_while_executing
 

--- a/app/workers/push_notifications/deliver_worker.rb
+++ b/app/workers/push_notifications/deliver_worker.rb
@@ -1,6 +1,6 @@
 module PushNotifications
   class DeliverWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority,
                     retry: 10,

--- a/app/workers/rating_votes/assign_rating_worker.rb
+++ b/app/workers/rating_votes/assign_rating_worker.rb
@@ -1,6 +1,6 @@
 module RatingVotes
   class AssignRatingWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 10, lock: :until_executing
 

--- a/app/workers/reactions/bust_homepage_cache_worker.rb
+++ b/app/workers/reactions/bust_homepage_cache_worker.rb
@@ -1,6 +1,6 @@
 module Reactions
   class BustHomepageCacheWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority, retry: 10
 

--- a/app/workers/reactions/bust_reactable_cache_worker.rb
+++ b/app/workers/reactions/bust_reactable_cache_worker.rb
@@ -1,6 +1,6 @@
 module Reactions
   class BustReactableCacheWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority, retry: 10
 

--- a/app/workers/reactions/update_relevant_scores_worker.rb
+++ b/app/workers/reactions/update_relevant_scores_worker.rb
@@ -1,6 +1,6 @@
 module Reactions
   class UpdateRelevantScoresWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority, retry: 10
 

--- a/app/workers/slack/messengers/worker.rb
+++ b/app/workers/slack/messengers/worker.rb
@@ -1,7 +1,7 @@
 module Slack
   module Messengers
     class Worker
-      include Sidekiq::Worker
+      include Sidekiq::Job
 
       sidekiq_options queue: :default, retry: 10
 

--- a/app/workers/tags/alias_retag_worker.rb
+++ b/app/workers/tags/alias_retag_worker.rb
@@ -1,6 +1,6 @@
 module Tags
   class AliasRetagWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 5
 

--- a/app/workers/tags/resave_supported_tags_worker.rb
+++ b/app/workers/tags/resave_supported_tags_worker.rb
@@ -1,6 +1,6 @@
 module Tags
   class ResaveSupportedTagsWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :low_priority, retry: 5
 

--- a/app/workers/users/delete_worker.rb
+++ b/app/workers/users/delete_worker.rb
@@ -1,6 +1,6 @@
 module Users
   class DeleteWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority, retry: 10
 

--- a/app/workers/users/follow_worker.rb
+++ b/app/workers/users/follow_worker.rb
@@ -1,6 +1,6 @@
 module Users
   class FollowWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :high_priority, retry: 10, lock: :until_executed
 
     def perform(user_id, followable_id, followable_type)

--- a/app/workers/users/merge_sync_worker.rb
+++ b/app/workers/users/merge_sync_worker.rb
@@ -1,6 +1,6 @@
 module Users
   class MergeSyncWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :high_priority, retry: 10
 

--- a/app/workers/users/record_field_test_event_worker.rb
+++ b/app/workers/users/record_field_test_event_worker.rb
@@ -1,6 +1,6 @@
 module Users
   class RecordFieldTestEventWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     include FieldTest::Helpers
 
     sidekiq_options queue: :low_priority, retry: 10

--- a/app/workers/users/resave_articles_worker.rb
+++ b/app/workers/users/resave_articles_worker.rb
@@ -1,6 +1,6 @@
 module Users
   class ResaveArticlesWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 10, lock: :until_executing
 

--- a/app/workers/users/subscribe_to_mailchimp_newsletter_worker.rb
+++ b/app/workers/users/subscribe_to_mailchimp_newsletter_worker.rb
@@ -1,6 +1,6 @@
 module Users
   class SubscribeToMailchimpNewsletterWorker
-    include Sidekiq::Worker
+    include Sidekiq::Job
     sidekiq_options queue: :low_priority, retry: 10, lock: :until_executed
 
     def perform(user_id)


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Sidekiq is in the process of moving from the term Worker to Job, to
better align with other projects. Worker is deprecated and will be
removed in Sidekiq 7.0.


## QA Instructions, Screenshots, Recordings

Nothing here should break (in this pass, no paths or constants are changing, only changing the name of the included module in worker classes).

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Nothing changing
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] This change does not need to be communicated, and this is why not: behavior neutral change