### PR TITLE
Adding a field test option for post publishing goals

### DIFF
--- a/app/models/ab_experiment/goal_conversion_handler.rb
+++ b/app/models/ab_experiment/goal_conversion_handler.rb
@@ -7,6 +7,9 @@ class AbExperiment
   class GoalConversionHandler
     include FieldTest::Helpers
 
+    # The constant says "publishes post"; we're not actually concerned with the state change (from
+    # unpublished to published) but instead counting the number of published articles.
+    USER_PUBLISHES_POST_GOAL = "user_publishes_post".freeze
     USER_CREATES_PAGEVIEW_GOAL = "user_creates_pageview".freeze
     USER_CREATES_COMMENT_GOAL = "user_creates_comment".freeze
 
@@ -40,36 +43,58 @@ class AbExperiment
         # We have special conditional goals for some where we look for past events for cummulative wins
         # Otherwise we convert the goal as given.
       when USER_CREATES_PAGEVIEW_GOAL
-        pageview_goal(experiment,
-                      [7.days.ago, experiment_start_date].max,
-                      "DATE(created_at)",
-                      4,
-                      "user_views_pages_on_at_least_four_different_days_within_a_week")
-        pageview_goal(experiment,
-                      [24.hours.ago, experiment_start_date].max,
-                      "DATE_PART('hour', created_at)",
-                      4,
-                      "user_views_pages_on_at_least_four_different_hours_within_a_day")
-        pageview_goal(experiment,
-                      [14.days.ago, experiment_start_date].max,
-                      "DATE(created_at)",
-                      9,
-                      "user_views_pages_on_at_least_nine_different_days_within_two_weeks")
-        pageview_goal(experiment,
-                      [5.days.ago, experiment_start_date].max,
-                      "DATE_PART('hour', created_at)",
-                      12,
-                      "user_views_pages_on_at_least_twelve_different_hours_within_five_days")
+        convert_pageview_goal(experiment: experiment, experiment_start_date: experiment_start_date)
       when USER_CREATES_COMMENT_GOAL # comments goal. Only page views and comments are currently active.
-        field_test_converted(experiment, participant: user, goal: goal) # base single comment goal.
-        comment_goal(experiment,
-                     [7.days.ago, experiment_start_date].max,
-                     "DATE(created_at)",
-                     4,
-                     "user_creates_comment_on_at_least_four_different_days_within_a_week")
+        convert_comment_goal(experiment: experiment, experiment_start_date: experiment_start_date)
+      when USER_PUBLISHES_POST_GOAL
+        convert_post_goal(experiment: experiment, experiment_start_date: experiment_start_date)
       else
         field_test_converted(experiment, participant: user, goal: goal) # base single comment goal.
       end
+    end
+
+    def convert_pageview_goal(experiment:, experiment_start_date:)
+      pageview_goal(experiment,
+                    [7.days.ago, experiment_start_date].max,
+                    "DATE(created_at)",
+                    4,
+                    "user_views_pages_on_at_least_four_different_days_within_a_week")
+      pageview_goal(experiment,
+                    [24.hours.ago, experiment_start_date].max,
+                    "DATE_PART('hour', created_at)",
+                    4,
+                    "user_views_pages_on_at_least_four_different_hours_within_a_day")
+      pageview_goal(experiment,
+                    [14.days.ago, experiment_start_date].max,
+                    "DATE(created_at)",
+                    9,
+                    "user_views_pages_on_at_least_nine_different_days_within_two_weeks")
+      pageview_goal(experiment,
+                    [5.days.ago, experiment_start_date].max,
+                    "DATE_PART('hour', created_at)",
+                    12,
+                    "user_views_pages_on_at_least_twelve_different_hours_within_five_days")
+    end
+
+    def convert_comment_goal(experiment:, experiment_start_date:)
+      field_test_converted(experiment, participant: user, goal: goal) # base single comment goal.
+      comment_goal(experiment,
+                   [7.days.ago, experiment_start_date].max,
+                   "DATE(created_at)",
+                   4,
+                   "user_creates_comment_on_at_least_four_different_days_within_a_week")
+    end
+
+    def convert_post_goal(experiment:, experiment_start_date:)
+      field_test_converted(experiment, participant: user, goal: goal) # base is we created a post
+      post_goal(experiment,
+                [7.days.ago, experiment_start_date].max,
+                2,
+                "user_publishes_post_at_least_two_times_within_week")
+      post_goal(experiment,
+                [14.days.ago, experiment_start_date].max,
+                2,
+                "user_publishes_post_at_least_two_times_within_two_weeks")
     end
 
     def pageview_goal(experiment, time_start, group_value, min_count, goal)
@@ -77,6 +102,12 @@ class AbExperiment
         .group(group_value).count.values
       page_view_counts.delete(0)
       return unless page_view_counts.size >= min_count
+
+      field_test_converted(experiment, participant: user, goal: goal)
+    end
+
+    def post_goal(experiment, time_start, min_count, goal)
+      return unless user.articles.published.where("published_at > ?", time_start).count >= min_count
 
       field_test_converted(experiment, participant: user, goal: goal)
     end

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -18,6 +18,9 @@ experiments:
       - user_views_pages_on_at_least_four_different_hours_within_a_day
       - user_views_pages_on_at_least_nine_different_days_within_two_weeks
       - user_views_pages_on_at_least_twelve_different_hours_within_five_days
+      - user_publishes_post
+      - user_publishes_post_at_least_two_times_within_week
+      - user_publishes_post_at_least_two_times_within_two_weeks
 exclude:
   bots: true
 

--- a/spec/models/ab_experiment/goal_conversion_handler_spec.rb
+++ b/spec/models/ab_experiment/goal_conversion_handler_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe AbExperiment::GoalConversionHandler do
         expect(FieldTest::Event.all.pluck(:name).sort)
           .to match_array([
             goal,
-            "publishes_post_at_least_two_times_within_two_weeks",
+            "user_publishes_post_at_least_two_times_within_two_weeks",
             "user_publishes_post_at_least_two_times_within_week",
           ].sort)
       end

--- a/spec/models/ab_experiment/goal_conversion_handler_spec.rb
+++ b/spec/models/ab_experiment/goal_conversion_handler_spec.rb
@@ -42,6 +42,37 @@ RSpec.describe AbExperiment::GoalConversionHandler do
       end
     end
 
+    context "with user who is part of field test and user_publishes_post goal" do
+      let(:goal) { described_class::USER_PUBLISHES_POST_GOAL }
+
+      before do
+        field_test(AbExperiment::CURRENT_FEED_STRATEGY_EXPERIMENT, participant: user)
+      end
+
+      it "records a conversion", :aggregate_failures do
+        create(:article, published_at: 2.days.ago, user_id: user.id)
+        handler.call
+        expect(FieldTest::Event.last.field_test_membership.participant_id).to eq(user.id.to_s)
+        expect(FieldTest::Event.last.name).to eq(goal)
+      end
+
+      it "records weekly post publishing conversions", :aggregate_failures do
+        create(:article, published_at: 2.days.ago, user_id: user.id)
+        create(:article, published_at: 3.days.ago, user_id: user.id)
+        create(:article, published_at: 13.days.ago, user_id: user.id)
+
+        handler.call
+
+        expect(FieldTest::Event.last.field_test_membership.participant_id).to eq(user.id.to_s)
+        expect(FieldTest::Event.all.pluck(:name).sort)
+          .to match_array([
+            goal,
+            "publishes_post_at_least_two_times_within_two_weeks",
+            "user_publishes_post_at_least_two_times_within_week",
+          ].sort)
+      end
+    end
+
     context "with user who is part of field test and user_creates_comment goal" do
       let(:goal) { described_class::USER_CREATES_COMMENT_GOAL }
 
@@ -55,7 +86,8 @@ RSpec.describe AbExperiment::GoalConversionHandler do
         expect(FieldTest::Event.last.name).to eq(goal)
       end
 
-      it "records user_creates_comment_on_at_least_four_different_days_within_a_week field test conversion", :aggregate_failures do
+      it "records user_creates_comment_on_at_least_four_different_days_within_a_week field test conversion",
+         :aggregate_failures do
         7.times do |n|
           create(:comment, user_id: user.id, created_at: n.days.ago)
         end
@@ -73,7 +105,8 @@ RSpec.describe AbExperiment::GoalConversionHandler do
         field_test(AbExperiment::CURRENT_FEED_STRATEGY_EXPERIMENT, participant: user)
       end
 
-      it "records user_views_pages_on_at_least_four_different_days_within_a_week field test conversion", :aggregate_failures do
+      it "records user_views_pages_on_at_least_four_different_days_within_a_week field test conversion",
+         :aggregate_failures do
         7.times do |n|
           create(:page_view, user_id: user.id, created_at: n.days.ago)
         end
@@ -83,7 +116,8 @@ RSpec.describe AbExperiment::GoalConversionHandler do
           .to include("user_views_pages_on_at_least_four_different_days_within_a_week")
       end
 
-      it "records user_views_pages_on_at_least_nine_different_days_within_two_weeks field test conversionn", :aggregate_failures do
+      it "records user_views_pages_on_at_least_nine_different_days_within_two_weeks field test conversionn",
+         :aggregate_failures do
         10.times do |n|
           create(:page_view, user_id: user.id, created_at: n.days.ago)
         end
@@ -93,7 +127,8 @@ RSpec.describe AbExperiment::GoalConversionHandler do
           .to include("user_views_pages_on_at_least_nine_different_days_within_two_weeks")
       end
 
-      it "records user_views_pages_on_at_least_twelve_different_hours_within_five_days field test conversion", :aggregate_failures do
+      it "records user_views_pages_on_at_least_twelve_different_hours_within_five_days field test conversion",
+         :aggregate_failures do
         15.times do |n|
           create(:page_view, user_id: user.id, created_at: n.hours.ago)
         end
@@ -112,7 +147,8 @@ RSpec.describe AbExperiment::GoalConversionHandler do
         expect(FieldTest::Event.all.size).to be(0)
       end
 
-      it "records user_views_pages_on_at_least_four_different_hours_within_a_day field test conversionn", :aggregate_failures do
+      it "records user_views_pages_on_at_least_four_different_hours_within_a_day field test conversionn",
+         :aggregate_failures do
         7.times do |n|
           create(:page_view, user_id: user.id, created_at: n.hours.ago)
         end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1121,6 +1121,17 @@ RSpec.describe Article, type: :model do
       end
     end
 
+    describe "record field test event" do
+      it "enqueues Users::RecordFieldTestEventWorker" do
+        sidekiq_assert_enqueued_with(
+          job: Users::RecordFieldTestEventWorker,
+          args: [article.user_id, AbExperiment::GoalConversionHandler::USER_PUBLISHES_POST_GOAL],
+        ) do
+          article.save
+        end
+      end
+    end
+
     describe "async score calc" do
       it "enqueues Articles::ScoreCalcWorker if published" do
         sidekiq_assert_enqueued_with(job: Articles::ScoreCalcWorker, args: [article.id]) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -211,7 +211,10 @@ RSpec.configure do |config|
                                  user_views_article_four_days_in_week
                                  user_views_article_four_hours_in_day
                                  user_views_article_nine_days_in_two_week
-                                 user_views_article_twelve_hours_in_five_days] } },
+                                 user_views_article_twelve_hours_in_five_days
+                                 user_publishes_post
+                                 user_publishes_post_at_least_two_times_within_week
+                                 user_publishes_post_at_least_two_times_within_two_weeks] } },
                  "exclude" => { "bots" => true },
                  "cache" => true,
                  "cookies" => false }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

We have page view and comment view "goals" but have not looked at
publication "goals".  We're using these "goals" to help us refine the
feed towards sustainable engagement and community health.

The conjecture on publication goals is that the content on the feed
itself can nudge folks in their decision to publish posts.


## Related Tickets & Documents

Closes forem/forem#17585

## QA Instructions, Screenshots, Recordings

The new (and existing) tests cover the changes.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
