### PR TITLE
Improves UI unit tests by correcting wrong use of queries

### DIFF
--- a/app/javascript/article-form/components/ArticleCoverImage.jsx
+++ b/app/javascript/article-form/components/ArticleCoverImage.jsx
@@ -37,6 +37,7 @@ const StandardImageUpload = ({
       <label className="cursor-pointer crayons-btn crayons-btn--outlined">
         {uploadLabel}
         <input
+          data-testid="cover-image-input"
           id="cover-image-input"
           type="file"
           onChange={handleImageUpload}

--- a/app/javascript/article-form/components/__tests__/Close.test.jsx
+++ b/app/javascript/article-form/components/__tests__/Close.test.jsx
@@ -1,6 +1,7 @@
 import { h } from 'preact';
 import { render } from '@testing-library/preact';
 import { axe } from 'jest-axe';
+import '@testing-library/jest-dom';
 import { Close } from '../Close';
 
 describe('<Close />', () => {
@@ -12,9 +13,8 @@ describe('<Close />', () => {
   });
 
   it('renders the close button', () => {
-    const { getByTitle } = render(<Close />);
-    const icon = getByTitle(/Close the editor/i);
-
-    expect(icon).toBeDefined();
+    const { getByRole } = render(<Close />);
+    const icon = getByRole('button', { name: /Close the editor/i });
+    expect(icon).toBeInTheDocument();
   });
 });

--- a/app/javascript/article-form/components/__tests__/Form.test.jsx
+++ b/app/javascript/article-form/components/__tests__/Form.test.jsx
@@ -71,28 +71,28 @@ describe('<Form />', () => {
     });
 
     it('renders the v1 form', () => {
-      const { queryByTestId, queryByLabelText, queryByAltText } = render(
-        <Form
-          titleDefaultValue="Test Title v1"
-          titleOnChange={null}
-          tagsDefaultValue="javascript, career"
-          tagsOnInput={null}
-          bodyDefaultValue={bodyMarkdown}
-          bodyOnChange={null}
-          bodyHasFocus={false}
-          version="v1"
-          mainImage={mainImage}
-          onMainImageUrlChange={null}
-          errors={null}
-          switchHelpContext={null}
-        />,
-      );
+      const { queryByTestId, queryByLabelText, queryByAltText, getByTestId } =
+        render(
+          <Form
+            titleDefaultValue="Test Title v1"
+            titleOnChange={null}
+            tagsDefaultValue="javascript, career"
+            tagsOnInput={null}
+            bodyDefaultValue={bodyMarkdown}
+            bodyOnChange={null}
+            bodyHasFocus={false}
+            version="v1"
+            mainImage={mainImage}
+            onMainImageUrlChange={null}
+            errors={null}
+            switchHelpContext={null}
+          />,
+        );
 
-      queryByTestId('article-form__body');
-
-      expect(queryByAltText(/post cover/i)).toBeNull();
-      expect(queryByTestId('article-form__title')).toBeNull();
-      expect(queryByLabelText('Post Tags')).toBeNull();
+      expect(getByTestId('article-form__body')).toBeInTheDocument();
+      expect(queryByAltText(/post cover/i)).not.toBeInTheDocument();
+      expect(queryByTestId('article-form__title')).not.toBeInTheDocument();
+      expect(queryByLabelText('Post Tags')).not.toBeInTheDocument();
     });
   });
 
@@ -142,7 +142,7 @@ describe('<Form />', () => {
     });
 
     it('renders the v2 form', () => {
-      const { queryByTestId, getByLabelText, getByAltText } = render(
+      const { getByTestId, getByRole, getByLabelText } = render(
         <Form
           titleDefaultValue="Test Title v2"
           titleOnChange={null}
@@ -159,10 +159,12 @@ describe('<Form />', () => {
         />,
       );
 
-      getByAltText(/post cover/i);
-      queryByTestId('article-form__title');
-      getByLabelText('Add up to 4 tags');
-      queryByTestId('article-form__body');
+      expect(getByRole('img', { name: /post cover/i })).toBeInTheDocument();
+      expect(getByRole('textbox', { name: /post title/i })).toBeInTheDocument();
+      expect(
+        getByRole('textbox', { name: 'Add up to 4 tags' }),
+      ).toBeInTheDocument();
+      expect(getByTestId('article-form__body')).toBeInTheDocument();
 
       const coverImageInput = getByLabelText('Change');
 
@@ -174,7 +176,7 @@ describe('<Form />', () => {
     });
 
     it('renders a toolbar of markdown formatters', () => {
-      const { getByRole, getByLabelText } = render(
+      const { getByRole } = render(
         <Form
           titleDefaultValue="Test Title v2"
           titleOnChange={null}
@@ -191,7 +193,7 @@ describe('<Form />', () => {
         />,
       );
 
-      const textArea = getByLabelText('Post Content');
+      const textArea = getByRole('textbox', { name: /Post Content/ });
 
       getByRole('button', { name: 'Bold' }).click();
       expect(textArea.value).toEqual('****');
@@ -231,7 +233,7 @@ describe('<Form />', () => {
     });
 
     it('renders an overflow menu of markdown formatters', async () => {
-      const { getByRole, getByLabelText } = render(
+      const { getByRole } = render(
         <Form
           titleDefaultValue="Test Title v2"
           titleOnChange={null}
@@ -248,7 +250,7 @@ describe('<Form />', () => {
         />,
       );
 
-      const textArea = getByLabelText('Post Content');
+      const textArea = getByRole('textbox', { name: 'Post Content' });
       const overflowMenuButton = getByRole('button', { name: 'More options' });
 
       overflowMenuButton.click();
@@ -317,8 +319,8 @@ describe('<Form />', () => {
       />,
     );
 
-    getByTestId('error-message');
-    expect(getByTestId('error-message').textContent).toContain('title');
-    expect(getByTestId('error-message').textContent).toContain('main_image');
+    const errorMsg = getByTestId('error-message');
+    expect(errorMsg.textContent).toContain('title');
+    expect(errorMsg.textContent).toContain('main_image');
   });
 });

--- a/app/javascript/article-form/components/__tests__/Help.test.jsx
+++ b/app/javascript/article-form/components/__tests__/Help.test.jsx
@@ -1,5 +1,6 @@
 import { h } from 'preact';
-import { render } from '@testing-library/preact';
+import { render, within } from '@testing-library/preact';
+import '@testing-library/jest-dom';
 import { axe } from 'jest-axe';
 import { Help } from '../Help';
 
@@ -22,11 +23,11 @@ describe('<Help />', () => {
     const { queryByTestId } = render(
       <Help previewShowing helpFor={null} helpPosition={null} version="v1" />,
     );
-    expect(queryByTestId('article-form__help-section')).toBeNull();
+    expect(queryByTestId('article-form__help-section')).not.toBeInTheDocument();
   });
 
   it('shows help for the given section when in edit mode', () => {
-    const { getByTestId, getByText } = render(
+    const { getByTestId, getByRole } = render(
       <Help
         previewShowing={false}
         helpFor="article-form-title"
@@ -34,26 +35,28 @@ describe('<Help />', () => {
         version="v1"
       />,
     );
-    const titleHelp = getByTestId('title-help');
+    const articleTitle = within(getByTestId('title-help'));
 
-    getByTestId('article-form__help-section');
-    getByText(/writing a great post title/i);
+    expect(getByTestId('article-form__help-section')).toBeInTheDocument();
+    expect(
+      getByRole('heading', { name: /writing a great post title/i }),
+    ).toBeInTheDocument();
 
     expect(
-      titleHelp.textContent.includes(
+      articleTitle.getByText(
         'Think of your post title as a super short (but compelling!) description — like an overview of the actual post in one short sentence.',
       ),
-    ).toEqual(true);
+    ).toBeInTheDocument();
 
     expect(
-      titleHelp.textContent.includes(
+      articleTitle.getByText(
         'Use keywords where appropriate to help ensure people can find your post by search.',
       ),
-    ).toEqual(true);
+    ).toBeInTheDocument();
   });
 
   it('shows the correct help for v1', () => {
-    const { queryByTestId } = render(
+    const { queryByTestId, getByTestId } = render(
       <Help
         previewShowing={false}
         helpFor={null}
@@ -62,16 +65,17 @@ describe('<Help />', () => {
       />,
     );
 
-    queryByTestId('article-form__help-section');
-    queryByTestId('basic-editor-help');
-    queryByTestId('format-help');
-    expect(queryByTestId('title-help')).toBeNull();
-    expect(queryByTestId('basic-tag-input-help')).toBeNull();
+    expect(getByTestId('article-form__help-section')).toBeInTheDocument();
+    expect(getByTestId('basic-editor-help')).toBeInTheDocument();
+    expect(getByTestId('format-help')).toBeInTheDocument();
+
+    expect(queryByTestId('title-help')).not.toBeInTheDocument();
+    expect(queryByTestId('basic-tag-input-help')).not.toBeInTheDocument();
   });
 
   describe('with the appropriate v2 help sections', () => {
     it('shows the article-form-title', () => {
-      const { queryByTestId } = render(
+      const { queryByTestId, getByTestId } = render(
         <Help
           previewShowing={false}
           helpFor="article-form-title"
@@ -80,15 +84,16 @@ describe('<Help />', () => {
         />,
       );
 
-      queryByTestId('article-form__help-section');
-      expect(queryByTestId('basic-editor-help')).toBeNull();
-      expect(queryByTestId('format-help')).toBeNull();
-      queryByTestId('title-help');
-      expect(queryByTestId('basic-tag-input-help')).toBeNull();
+      expect(getByTestId('article-form__help-section')).toBeInTheDocument();
+      expect(getByTestId('title-help')).toBeInTheDocument();
+
+      expect(queryByTestId('basic-editor-help')).not.toBeInTheDocument();
+      expect(queryByTestId('format-help')).not.toBeInTheDocument();
+      expect(queryByTestId('basic-tag-input-help')).not.toBeInTheDocument();
     });
 
     it('shows the article_body_markdown', () => {
-      const { queryByTestId } = render(
+      const { queryByTestId, getByTestId } = render(
         <Help
           previewShowing={false}
           helpFor="article_body_markdown"
@@ -97,15 +102,16 @@ describe('<Help />', () => {
         />,
       );
 
-      queryByTestId('article-form__help-section');
-      expect(queryByTestId('basic-editor-help')).toBeNull();
-      queryByTestId('format-help');
-      expect(queryByTestId('title-help')).toBeNull();
-      expect(queryByTestId('basic-tag-input-help')).toBeNull();
+      expect(getByTestId('article-form__help-section')).toBeInTheDocument();
+      expect(getByTestId('format-help')).toBeInTheDocument();
+
+      expect(queryByTestId('basic-editor-help')).not.toBeInTheDocument();
+      expect(queryByTestId('title-help')).not.toBeInTheDocument();
+      expect(queryByTestId('basic-tag-input-help')).not.toBeInTheDocument();
     });
 
     it('shows the tag-input', () => {
-      const { queryByTestId } = render(
+      const { queryByTestId, getByTestId } = render(
         <Help
           previewShowing={false}
           helpFor="tag-input"
@@ -114,11 +120,12 @@ describe('<Help />', () => {
         />,
       );
 
-      queryByTestId('article-form__help-section');
-      expect(queryByTestId('basic-editor-help')).toBeNull();
-      expect(queryByTestId('format-help')).toBeNull();
-      expect(queryByTestId('title-help')).toBeNull();
-      queryByTestId('basic-tag-input-help');
+      expect(queryByTestId('article-form__help-section')).toBeInTheDocument();
+      expect(getByTestId('basic-tag-input-help')).toBeInTheDocument();
+
+      expect(queryByTestId('basic-editor-help')).not.toBeInTheDocument();
+      expect(queryByTestId('format-help')).not.toBeInTheDocument();
+      expect(queryByTestId('title-help')).not.toBeInTheDocument();
     });
   });
 

--- a/app/javascript/article-form/components/__tests__/ImageUploader.test.jsx
+++ b/app/javascript/article-form/components/__tests__/ImageUploader.test.jsx
@@ -62,7 +62,7 @@ describe('<ImageUploader />', () => {
         }),
       );
 
-      const { getByLabelText, queryByText } = render(
+      const { getByLabelText, getByText } = render(
         <ImageUploader editorVersion="v1" />,
       );
 
@@ -73,9 +73,9 @@ describe('<ImageUploader />', () => {
 
       fireEvent.change(inputEl, { target: { files: [file] } });
 
-      const uploadingImage = queryByText(/uploading.../i);
+      const uploadingImage = getByText(/uploading.../i);
 
-      expect(uploadingImage).toBeDefined();
+      expect(uploadingImage).toBeInTheDocument();
     });
 
     it('displays text to copy after upload', async () => {
@@ -85,8 +85,13 @@ describe('<ImageUploader />', () => {
         }),
       );
 
-      const { findByTitle, getByDisplayValue, getByLabelText, queryByText } =
-        render(<ImageUploader editorVersion="v1" />);
+      const {
+        findByTitle,
+        getByDisplayValue,
+        getByLabelText,
+        queryByText,
+        getByText,
+      } = render(<ImageUploader editorVersion="v1" />);
       const inputEl = getByLabelText(/Upload image/i);
 
       const file = new File(['(⌐□_□)'], 'chucknorris.png', {
@@ -94,18 +99,18 @@ describe('<ImageUploader />', () => {
       });
 
       fireEvent.change(inputEl, { target: { files: [file] } });
-      const uploadingImage = queryByText(/uploading.../i);
+      const uploadingImage = getByText(/uploading.../i);
 
-      expect(uploadingImage).toBeDefined();
+      expect(uploadingImage).toBeInTheDocument();
 
       expect(inputEl.files[0]).toEqual(file);
       expect(inputEl.files).toHaveLength(1);
 
       waitForElementToBeRemoved(() => queryByText(/uploading.../i));
 
-      expect(await findByTitle(/copy markdown for image/i)).toBeDefined();
+      expect(await findByTitle(/copy markdown for image/i)).toBeInTheDocument();
 
-      getByDisplayValue(/fake-link.jpg/i);
+      expect(getByDisplayValue(/fake-link.jpg/i)).toBeInTheDocument();
     });
 
     // TODO: 'Copied!' is always in the DOM, and so we cannot test that the visual implications of the copy when clicking on the copy icon
@@ -115,7 +120,7 @@ describe('<ImageUploader />', () => {
         message: 'Some Fake Error',
       });
 
-      const { getByLabelText, findByText, queryByText } = render(
+      const { getByLabelText, findByText, queryByText, getByText } = render(
         <ImageUploader editorVersion="v1" />,
       );
       const inputEl = getByLabelText(/Upload image/i);
@@ -134,12 +139,12 @@ describe('<ImageUploader />', () => {
         },
       });
 
-      expect(await findByText(/uploading.../i)).not.toBeNull();
-
       // Upload is finished, so the message has disappeared.
-      expect(queryByText(/uploading.../i)).toBeNull();
+      await waitForElementToBeRemoved(() => getByText(/uploading.../i));
+      expect(queryByText(/uploading.../i)).not.toBeInTheDocument();
 
-      await findByText(/some fake error/i);
+      const errorMsg = await findByText(/some fake error/i);
+      expect(errorMsg).toBeInTheDocument();
     });
   });
 
@@ -184,7 +189,7 @@ describe('<ImageUploader />', () => {
       );
       fireEvent(document, event);
 
-      expect(await findByTitle(/copy markdown for image/i)).toBeDefined();
+      expect(await findByTitle(/copy markdown for image/i)).toBeInTheDocument();
     });
   });
 
@@ -212,11 +217,11 @@ describe('<ImageUploader />', () => {
         }),
       );
 
-      const { getAllByLabelText, queryByText } = render(
+      const { getAllByLabelText, queryByText, getByRole } = render(
         <ImageUploader editorVersion="v2" />,
       );
 
-      expect(queryByText('Cancel upload')).toBeNull();
+      expect(queryByText('Cancel upload')).not.toBeInTheDocument();
 
       const inputEl = getAllByLabelText(/Upload image/i)[0];
       const file = new File(['(⌐□_□)'], 'chucknorris.png', {
@@ -224,7 +229,10 @@ describe('<ImageUploader />', () => {
       });
 
       fireEvent.change(inputEl, { target: { files: [file] } });
-      expect(queryByText('Cancel upload')).toBeInTheDocument();
+
+      expect(
+        getByRole('button', { name: /Cancel image upload/i }),
+      ).toBeInTheDocument();
     });
 
     it('invokes upload start and success callbacks when image is uploaded', async () => {
@@ -237,7 +245,7 @@ describe('<ImageUploader />', () => {
       const uploadStartCallback = jest.fn();
       const uploadSuccessCallback = jest.fn();
 
-      const { getAllByLabelText, queryByText } = render(
+      const { getAllByLabelText, queryByRole, getByRole } = render(
         <ImageUploader
           editorVersion="v2"
           onImageUploadStart={uploadStartCallback}
@@ -254,7 +262,12 @@ describe('<ImageUploader />', () => {
 
       expect(uploadStartCallback).toHaveBeenCalled();
 
-      await waitFor(() => expect(queryByText('Cancel upload')).toBeNull());
+      await waitForElementToBeRemoved(() =>
+        getByRole('button', { name: /Cancel image upload/i }),
+      );
+      expect(
+        queryByRole('button', { name: /Cancel image upload/i }),
+      ).not.toBeInTheDocument();
 
       expect(uploadSuccessCallback).toHaveBeenCalledWith(
         '![Image description](/i/fake-link.jpg)',
@@ -268,7 +281,7 @@ describe('<ImageUploader />', () => {
 
       const uploadErrorCallback = jest.fn();
 
-      const { getAllByLabelText, queryByText } = render(
+      const { getAllByLabelText, getByRole, queryByRole } = render(
         <ImageUploader
           editorVersion="v2"
           onImageUploadError={uploadErrorCallback}
@@ -290,7 +303,13 @@ describe('<ImageUploader />', () => {
         },
       });
 
-      await waitFor(() => expect(queryByText('Cancel upload')).toBeNull());
+      await waitForElementToBeRemoved(() =>
+        getByRole('button', { name: /Cancel image upload/i }),
+      );
+      expect(
+        queryByRole('button', { name: /Cancel image upload/i }),
+      ).not.toBeInTheDocument();
+
       expect(uploadErrorCallback).toHaveBeenCalled();
     });
   });

--- a/app/javascript/article-form/components/__tests__/Options.test.jsx
+++ b/app/javascript/article-form/components/__tests__/Options.test.jsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import { render } from '@testing-library/preact';
 import { axe } from 'jest-axe';
 import { Options } from '../Options';
+import '@testing-library/jest-dom';
 
 function getPassedData() {
   return {
@@ -60,7 +61,7 @@ describe('<Options />', () => {
     const passedData = getPassedData();
     passedData.published = true;
 
-    const { queryByTestId, getByText } = render(
+    const { getByText, getByTestId } = render(
       <Options
         passedData={passedData}
         onConfigChange={null}
@@ -70,10 +71,10 @@ describe('<Options />', () => {
       />,
     );
 
-    expect(queryByTestId('options__danger-zone')).toBeDefined();
-    expect(getByText(/danger zone/i)).toBeDefined();
-    expect(getByText(/unpublish post/i)).toBeDefined();
-    expect(getByText(/done/i)).toBeDefined();
+    expect(getByTestId('options__danger-zone')).toBeInTheDocument();
+    expect(getByText(/danger zone/i)).toBeInTheDocument();
+    expect(getByText(/unpublish post/i)).toBeInTheDocument();
+    expect(getByText(/done/i)).toBeInTheDocument();
   });
 
   it('unpublishes an article when the unpublish post button is clicked', () => {

--- a/app/javascript/article-form/components/__tests__/PageTitle.test.jsx
+++ b/app/javascript/article-form/components/__tests__/PageTitle.test.jsx
@@ -1,7 +1,8 @@
 import { h } from 'preact';
-import { render, queryByAttribute } from '@testing-library/preact';
+import { render } from '@testing-library/preact';
 import { axe } from 'jest-axe';
 import { PageTitle } from '../PageTitle';
+import '@testing-library/jest-dom';
 
 let organizations, organizationId, onToggle;
 
@@ -36,8 +37,7 @@ describe('<PageTitle/>', () => {
   });
 
   it('shows the picker if there is more than one organisation', () => {
-    const getById = queryByAttribute.bind(null, 'id');
-    const dom = render(
+    const { getByRole } = render(
       <PageTitle
         organizations={organizations}
         organizationId={organizationId}
@@ -45,16 +45,13 @@ describe('<PageTitle/>', () => {
       />,
     );
 
-    const organizationPicker = getById(
-      dom.container,
-      'article_publish_under_org',
-    );
-    expect(organizationPicker).toBeTruthy();
+    expect(
+      getByRole('combobox', { name: /select an organization/i }),
+    ).toBeInTheDocument();
   });
 
   it('does not show the picker if there is no organisations', () => {
-    const getById = queryByAttribute.bind(null, 'id');
-    const dom = render(
+    const { queryByRole } = render(
       <PageTitle
         organizations={[]}
         organizationId={organizationId}
@@ -62,10 +59,8 @@ describe('<PageTitle/>', () => {
       />,
     );
 
-    const organizationPicker = getById(
-      dom.container,
-      'article_publish_under_org',
-    );
-    expect(organizationPicker).toBeNull();
+    expect(
+      queryByRole('combobox', { name: /select an organization/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/javascript/article-form/components/__tests__/Preview.test.jsx
+++ b/app/javascript/article-form/components/__tests__/Preview.test.jsx
@@ -3,6 +3,7 @@ import { JSDOM } from 'jsdom';
 import { render } from '@testing-library/preact';
 import { axe } from 'jest-axe';
 import { Preview } from '../Preview';
+import '@testing-library/jest-dom';
 
 const doc = new JSDOM('<!doctype html><html><body></body></html>');
 global.document = doc;
@@ -81,7 +82,7 @@ describe('<Preview />', () => {
 
   it('shows the correct title', () => {
     const previewResponse = getPreviewResponse();
-    const { queryByText } = render(
+    const { getByText } = render(
       <Preview
         previewResponse={previewResponse}
         articleState={getArticleState()}
@@ -89,11 +90,11 @@ describe('<Preview />', () => {
       />,
     );
 
-    expect(queryByText(previewResponse.title)).toBeDefined();
+    expect(getByText(previewResponse.title)).toBeInTheDocument();
   });
 
   it('shows the correct tags', () => {
-    const { queryByText } = render(
+    const { getByText } = render(
       <Preview
         previewResponse={getPreviewResponse()}
         articleState={getArticleState()}
@@ -101,8 +102,8 @@ describe('<Preview />', () => {
       />,
     );
 
-    expect(queryByText(`javascript`)).toBeDefined();
-    expect(queryByText(`career`)).toBeDefined();
+    expect(getByText(`javascript`)).toBeInTheDocument();
+    expect(getByText(`career`)).toBeInTheDocument();
   });
 
   it('shows a cover image in the preview if one exists', () => {
@@ -116,7 +117,7 @@ describe('<Preview />', () => {
     );
     const coverImage = getByAltText(/post preview cover/i);
 
-    getByTestId('article-form__cover');
+    expect(getByTestId('article-form__cover')).toBeInTheDocument();
 
     expect(coverImage.src).toEqual('http://lorempixel.com/400/200/');
   });
@@ -132,7 +133,7 @@ describe('<Preview />', () => {
       />,
     );
 
-    expect(queryByTestId('article-form__cover')).toBeNull();
+    expect(queryByTestId('article-form__cover')).not.toBeInTheDocument();
   });
 
   // TODO: need to write a test for the cover image for v1

--- a/app/javascript/article-form/components/__tests__/Tabs.test.jsx
+++ b/app/javascript/article-form/components/__tests__/Tabs.test.jsx
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import { render } from '@testing-library/preact';
 import { axe } from 'jest-axe';
 import { Tabs } from '../Tabs';
+import '@testing-library/jest-dom';
 
 describe('<Tabs />', () => {
   it('should have no a11y violations', async () => {
@@ -14,61 +15,61 @@ describe('<Tabs />', () => {
   });
 
   it('renders two buttons', () => {
-    const { queryByText } = render(
+    const { getByRole } = render(
       <Tabs onPreview={null} previewShowing={false} />,
     );
 
-    expect(queryByText(/preview/i, { selector: 'button' })).toBeDefined();
-    expect(queryByText(/edit/i, { selector: 'button' })).toBeDefined();
+    expect(getByRole('button', { name: /preview/i })).toBeInTheDocument();
+    expect(getByRole('button', { name: /edit/i })).toBeInTheDocument();
   });
 
   describe('highlights the current tab', () => {
     it('when preview is selected', () => {
-      const { getByText } = render(
+      const { getByRole } = render(
         <Tabs onPreview={null} previewShowing={true} />,
       );
 
       expect(
-        getByText(/preview/i, { selector: 'button' }).classList.contains(
+        getByRole('button', { name: /preview/i }).classList.contains(
           `crayons-tabs__item--current`,
         ),
       ).toEqual(true);
       expect(
-        getByText(/edit/i, { selector: 'button' }).classList.contains(
+        getByRole('button', { name: /edit/i }).classList.contains(
           `crayons-tabs__item--current`,
         ),
       ).toEqual(false);
     });
 
     it('should make the edit button the current button when not in preview mode', () => {
-      const { getByText } = render(
+      const { getByRole } = render(
         <Tabs onPreview={null} previewShowing={false} />,
       );
 
       expect(
-        getByText(/edit/i, { selector: 'button' }).classList.contains(
+        getByRole('button', { name: /edit/i }).classList.contains(
           `crayons-tabs__item--current`,
         ),
       ).toEqual(true);
       expect(
-        getByText(/preview/i, { selector: 'button' }).classList.contains(
+        getByRole('button', { name: /preview/i }).classList.contains(
           `crayons-tabs__item--current`,
         ),
       ).toEqual(false);
     });
 
     it('should make the preview button the current button when in preview mode', () => {
-      const { getByText } = render(
+      const { getByRole } = render(
         <Tabs onPreview={null} previewShowing={true} />,
       );
 
       expect(
-        getByText(/edit/i, { selector: 'button' }).classList.contains(
+        getByRole('button', { name: /edit/i }).classList.contains(
           `crayons-tabs__item--current`,
         ),
       ).toEqual(false);
       expect(
-        getByText(/preview/i, { selector: 'button' }).classList.contains(
+        getByRole('button', { name: /preview/i }).classList.contains(
           `crayons-tabs__item--current`,
         ),
       ).toEqual(true);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Some of the UI unit tests using the `testing-library` lib are misusing queries and not applying best practices. This can cause flaky tests, i.e. not catching bugs because we're not looking at the correct elements. This PR aims to improve tests in that regard. 

I used this [blog post](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library) by Kent C. Dodds to base my changes. I didn't refactor all of the tests files because then the PR would get too big. 

My biggest concern here was the use of `.toBeDefined()` paired together with the `queryBy*` queries. This query returns `null` or the element. Whereas the `.toBeDefined()` matcher checks for `undefined` or a truthy value. This can lead to a false positive scenario, where the query returns `null` and the matcher will check for defined/undefined values, so the test will pass.

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## What gif best describes this PR or how it makes you feel?

![cat typing quickly](https://media.giphy.com/media/l2Sq72gPlwox4o2n6/giphy.gif)
