### PR TITLE
Adding ID to API organization response document

### DIFF
--- a/app/views/api/v0/organizations/show.json.jbuilder
+++ b/app/views/api/v0/organizations/show.json.jbuilder
@@ -2,6 +2,7 @@ json.type_of "organization"
 
 json.extract!(
   @organization,
+  :id,
   :username,
   :name,
   :summary,

--- a/spec/requests/api/v0/organizations_spec.rb
+++ b/spec/requests/api/v0/organizations_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Api::V0::Organizations", type: :request do
       )
 
       %w[
-        username name summary twitter_username github_username url location tech_stack tag_line story
+        id username name summary twitter_username github_username url location tech_stack tag_line story
       ].each do |attr|
         expect(response_organization[attr]).to eq(organization.public_send(attr))
       end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Ensuring that the `GET /api/organizations/:username` has the organization ID.


## Related Tickets & Documents

Closes forem/forem#17590

## QA Instructions, Screenshots, Recordings

None.  The tests cover this behavior.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
