### PR TITLE
Replacing a potentially expensive query

### DIFF
--- a/app/policies/article_policy.rb
+++ b/app/policies/article_policy.rb
@@ -200,11 +200,10 @@ class ArticlePolicy < ApplicationPolicy
   private
 
   def user_author?
-    if record.instance_of?(Article)
-      record.user_id == user.id
-    else
-      record.pluck(:user_id).uniq == [user.id]
-    end
+    # We might have the Article class (instead of the Article instance), so let's short circuit
+    return false unless record.respond_to?(:user_id)
+
+    record.user_id == user.id
   end
 
   def user_org_admin?


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

Prior to this commit, if we didn't have an instance of `Article` we
likely had the class `Article`; we would then run a potentially VERY
expensive query (`SELECT user_id FROM articles;`) to provide an
answer; namely if all of the articles are written by the same user then
yes this user is the author.

With this commit, when you're authorizing the `Article` class, let's
just say "Nope, this user isn't the author".


## Related Tickets & Documents

Related to forem/forem#630
Closes forem/forem#17604

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: the tests adequately cover this behavior

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
