### PR TITLE
Display "Create Post" button on tag page, regardless of submission template presence

### DIFF
--- a/app/views/stories/tagged_articles/_sidebar.html.erb
+++ b/app/views/stories/tagged_articles/_sidebar.html.erb
@@ -2,28 +2,32 @@
   <div id="sidebar-wrapper-left" class="sidebar-wrapper sidebar-wrapper-left">
     <div class="sidebar-bg" id="sidebar-bg-left"></div>
     <aside class="side-bar">
-      <% if @tag && @tag.rules_html.present? %>
+      <% if @tag %>
         <%= application_policy_content_tag("div", record: Article, query: :create?, class: "widget") do %>
-          <header>
-            <h4><%= t("views.tags.sidebar.guidelines") %></h4>
-          </header>
-          <div class="widget-body">
-            <%= sanitize @tag.rules_html %>
-            <a class="crayons-btn crayons-btn--s" href="/new/<%= @tag.name %>">
-              <%= t("views.tags.sidebar.new") %>
-            </a>
+          <a class="crayons-btn crayons-btn--s" href="/new/<%= @tag.name %>">
+            <%= t("views.tags.sidebar.new") %>
+          </a>
+        <% end %>
+        <% if @tag.rules_html.present? %>
+          <div class="widget">
+            <header>
+              <h4><%= t("views.tags.sidebar.guidelines") %></h4>
+            </header>
+            <div class="widget-body">
+              <%= sanitize @tag.rules_html %>
+            </div>
           </div>
         <% end %>
-      <% end %>
-      <% if @tag && @tag.wiki_body_html.present? %>
-        <div class="widget">
-          <header>
-            <h4><%= t("views.tags.sidebar.about", tag: @tag.name) %></h4>
-          </header>
-          <div class="widget-body">
-            <%= sanitize @tag.wiki_body_html %>
+        <% if @tag.wiki_body_html.present? %>
+          <div class="widget">
+            <header>
+              <h4><%= t("views.tags.sidebar.about", tag: @tag.name) %></h4>
+            </header>
+            <div class="widget-body">
+              <%= sanitize @tag.wiki_body_html %>
+            </div>
           </div>
-        </div>
+        <% end %>
       <% end %>
       <% if @tag.sponsorship && @tag.sponsorship.status == "live" && @tag.sponsorship.expires_at > Time.current %>
         <div class="widget">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR displays the Create Post button on tag pages, whether or not a submission template exists for the tag. If a submission template exists, the New Post body displays the template.
In addition, this button is hidden for non-admin members in comment-only Spaces.

## Related Tickets & Documents
- Closes https://github.com/forem/forem/issues/16978

## QA Instructions, Screenshots, Recordings
For spaces that allow everyone to post:
(1) As as admin, navigate to `Admin >> Content Manager >> Tags`, and choose the tag you wish to test. Under `Submission template`, enter some text and save.
(2) In the Forem, navigate to your chosen tag's page. You should see the `Create Post` button. Click the button to create a post. Your new post should be populated with the content you entered in `Submission template`.

For spaces that are comments-only:
(1) As an admin, navigate to `Admin >> Content Manager >> Spaces`. In the Space named "Uncategorized Posts", toggle the comments-only setting ON then save.
(2) Sign into the Forem as a non-admin member, then navigate to your chosen tag page. You should NOT see the `Create Post` button.
(3) As an admin, navigate to your chosen tag page. You should STILL see the `Create Post` button, since admins are allowed to post in comment-only Spaces.

### UI accessibility concerns?
None

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: _not sure if/how to test_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
