### PR TITLE
Ensuring only privileged users may give certain reactions

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -13,6 +13,8 @@ class Reaction < ApplicationRecord
 
   # These are categories of reactions that administrators can select
   PRIVILEGED_CATEGORIES = %w[thumbsup thumbsdown vomit].freeze
+  NEGATIVE_PRIVILEGED_CATEGORIES = %w[thumbsdown vomit].freeze
+
   REACTABLE_TYPES = %w[Comment Article User].freeze
   STATUSES = %w[valid invalid confirmed archived].freeze
 
@@ -126,7 +128,7 @@ class Reaction < ApplicationRecord
   end
 
   def negative?
-    category == "vomit" || category == "thumbsdown"
+    NEGATIVE_PRIVILEGED_CATEGORIES.include?(category)
   end
 
   private

--- a/app/policies/reaction_policy.rb
+++ b/app/policies/reaction_policy.rb
@@ -1,9 +1,25 @@
+# This policy assumes that we apply the same logic regardless of the reactable.
 class ReactionPolicy < ApplicationPolicy
+  # We don't have a robust concept of a Privileged Reaction class, but instead must switch the
+  # reaction permissions based on the given category.
+  def self.policy_query_for(category:)
+    return :privileged_create? if Reaction::PRIVILEGED_CATEGORIES.include?(category)
+
+    :create?
+  end
+
   def index?
     true
   end
 
   def create?
     true
+  end
+
+  def privileged_create?
+    return true if user_any_admin?
+    return true if user_trusted?
+
+    false
   end
 end

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -249,6 +249,23 @@ RSpec.describe "Reactions", type: :request do
       end
     end
 
+    context "when attempting to create thumbsup as regular user" do
+      before do
+        sign_in user
+      end
+
+      it "does not permit the action" do
+        expect do
+          post "/reactions", params: {
+            reactable_id: article.id,
+            reactable_type: "Article",
+            category: "thumbsup"
+          }
+        end.to raise_error(Pundit::NotAuthorizedError)
+        expect(Reaction.where(category: "thumbsup").count).to eq(0)
+      end
+    end
+
     context "when creating thumbsup" do
       before do
         user.add_role(:trusted)
@@ -263,9 +280,9 @@ RSpec.describe "Reactions", type: :request do
           reactable_type: "Article",
           category: "thumbsup"
         }
-        expect(Reaction.where(category: "thumbsup").size).to be 1
-        expect(Reaction.where(category: "thumbsdown").size).to be 0
-        expect(Reaction.where(category: "like").size).to be 1
+        expect(Reaction.where(category: "thumbsup").count).to eq(1)
+        expect(Reaction.where(category: "thumbsdown").count).to eq(0)
+        expect(Reaction.where(category: "like").count).to eq(1)
       end
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

There are 2 things going on in this pull request:

1. Reducing duplication of knowledge, by favoring constants found in
   Reaction.
2. Creating and enforcing the policies regarding the different
   categories of reactions.

I chose to conflate these two as I was working on developing the
ReactionPolicy's finder method.


## Related Tickets & Documents

- Closes forem/forem-internal-eng#454
- Related to forem/forem#17628

## QA Instructions, Screenshots, Recordings

Let's rely on the tests for this one.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
