### PR TITLE
Passing --passWithNoTests to jest linter

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -7,7 +7,11 @@ module.exports = {
   ],
   '*.scss': ['prettier --write'],
   '*.svg': ['svgo --pretty'],
-  '*.{js,jsx}': ['prettier --write', 'eslint --fix', 'jest --findRelatedTests'],
+  '*.{js,jsx}': [
+    'prettier --write',
+    'eslint --fix',
+    'jest --findRelatedTests --passWithNoTests',
+  ],
   './Gemfile': [
     'bundle exec rubocop --require rubocop-rspec --auto-correct --enable-pending-cops',
   ],


### PR DESCRIPTION
Related to forem/forem#17612
Related to forem/forem#17634

Looking at the following error, I *think* this might address the
observed issue.

```shell
✖ jest --findRelatedTests:
No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
Make sure Jest's configuration does not exclude this directory.
To set up Jest, make sure a package.json file exists.
Jest Documentation: https://jestjs.io/docs/configuration
```
