### PR TITLE
Ensuring we don't render call to action when unauthorized

### DIFF
--- a/app/views/users/onboardings/_task_card.html.erb
+++ b/app/views/users/onboardings/_task_card.html.erb
@@ -37,12 +37,12 @@
       </a>
     </li>
 
-    <li class="task-card-action">
+    <%= application_policy_content_tag("li", record: Article, query: :create?, class: "task-card-action") do %>
       <a class="task-card-link" href="/new">
         <p><%= t("views.onboardings.write_html", community: community_name) %></p>
         <svg width="8" height="14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5.172 7L.222 2.05 1.636.636 8 7l-6.364 6.364L.222 11.95 5.172 7z" fill="#fff" /></svg>
       </a>
-    </li>
+    <% end %>
 
     <li class="task-card-action">
       <a class="task-card-link" href="/settings">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this commit, if the Forem limitted article creation only to
admins, when a new user would sign-up their call to action was to
"Create a Post".  If that new user clicked on the button, they would get
an action unauthorized error.

With this commit, the call to action for Creating a Post is hidden to
that user.

The `users/onboardings/_task_card.html.erb` is rendered as part of the
home page.  The home page, due to our [EdgeCacheSafetyCheck][1], does not
allow us to access attributes of the current user (e.g. are they an
admin); which means we can't add a `if policy(Article).create` to the
HTML erb.  We must instead use the [`application_policy_content_tag`][2]
as well as the [AsyncInfo][3] to help inform the
[applyApplicationPolicyToggles.js pack][4] of the conditional rendering.

[1]:https://github.com/forem/forem/blob/8160089f3d1f719026b6d001586061ac838c3601/app/controllers/concerns/edge_cache_safety_check.rb
[2]:https://github.com/forem/forem/blob/8160089f3d1f719026b6d001586061ac838c3601/app/helpers/application_helper.rb#L390
[3]:https://github.com/forem/forem/blob/8160089f3d1f719026b6d001586061ac838c3601/app/models/async_info.rb#L52-L61
[4]:https://github.com/forem/forem/blob/8160089f3d1f719026b6d001586061ac838c3601/app/javascript/packs/applyApplicationPolicyToggles.js

## Related Tickets & Documents

Closes forem/forem#17638
Related to forem/forem-internal-eng#347

## QA Instructions, Screenshots, Recordings

The attached screenshot demonstrates that the call to action for Articles is hidden.

<img width="1251" aria-hidden="true" src="https://user-images.githubusercontent.com/2130/167921603-233ed177-b82d-4920-a174-bd75725b3894.png">

To test this, I:

1. Checked out this PR's branch
2. Run bin/startup
3. `bin/rails runner "FeatureFlag.enable(:limit_post_creation_to_admins?)"`
4. Login as a non-admin user.
5. In the JS console call `localStorage.setItem("task-card-closed", undefined)`
6. Refresh the page; the button to create a post should not be visible.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
