### PR TITLE
Hide mod panel shield for moderator's own article

### DIFF
--- a/app/javascript/packs/articleModerationTools.js
+++ b/app/javascript/packs/articleModerationTools.js
@@ -24,11 +24,10 @@ getCsrfToken().then(() => {
 
       // article show page
       if (canModerateArticles) {
-        // <2022-05-09 Mon> [@jeremyf] the user.id is an integer and
-        // articleAuthorId is a string so our logic is such that we always
-        // initializeActionsPanel and initializeFlagUserModal; I'm asking
-        // product to clarify if we want mods to boost their own posts.
-        if (user?.id !== articleAuthorId && !isModerationPage()) {
+        if (
+          parseInt(user?.id) !== parseInt(articleAuthorId) &&
+          !isModerationPage()
+        ) {
           initializeActionsPanel(user, path);
           initializeFlagUserModal(articleAuthorId);
           // "/mod" page

--- a/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
@@ -41,10 +41,22 @@ describe('Moderation Tools for Posts', () => {
     });
   });
 
-  it('should not alter tags from a post if a reason is not specified', () => {
+  it("should not show moderation badge for a person's own posts", () => {
     cy.fixture('users/adminUser.json').as('user');
     cy.get('@user').then((user) => {
       cy.loginAndVisit(user, '/admin_mcadmin/tag-test-article').then(() => {
+        cy.findByRole('button', { name: 'Moderation' }).should('not.exist');
+      });
+    });
+  });
+
+  it('should not alter tags from a post if a reason is not specified', () => {
+    cy.fixture('users/adminUser.json').as('user');
+    cy.get('@user').then((user) => {
+      cy.loginAndVisit(
+        user,
+        '/notifications_user/notification-article-slug',
+      ).then(() => {
         cy.findByRole('button', { name: 'Moderation' }).click();
 
         // Helper function for pipe command

--- a/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
@@ -69,7 +69,9 @@ describe('Moderation Tools for Posts', () => {
             .pipe(click)
             .should('have.attr', 'aria-expanded', 'true');
 
-          cy.findByRole('button', { name: '#tag1 Remove tag' }).click();
+          cy.findByRole('button', {
+            name: '#tagtomoderate Remove tag',
+          }).click();
           cy.findByRole('button', { name: 'Submit' }).click();
         });
 

--- a/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
@@ -55,7 +55,7 @@ describe('Moderation Tools for Posts', () => {
     cy.get('@user').then((user) => {
       cy.loginAndVisit(
         user,
-        '/notifications_user/notification-article-slug',
+        '/to_be_moderated_user/moderate-article-slug',
       ).then(() => {
         cy.findByRole('button', { name: 'Moderation' }).click();
 

--- a/cypress/integration/seededFlows/moderationFlows/adjustPostTags.spec.js
+++ b/cypress/integration/seededFlows/moderationFlows/adjustPostTags.spec.js
@@ -124,7 +124,7 @@ describe('Adjust post tags', () => {
       cy.fixture('users/adminUser.json').as('user');
 
       cy.get('@user').then((user) => {
-        cy.loginAndVisit(user, '/admin_mcadmin/tag-test-article');
+        cy.loginAndVisit(user, '/to_be_moderated_user/tag-test-article');
       });
     });
 

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -392,7 +392,6 @@ seeder.create_if_doesnt_exist(User, "email", "notifications-user@forem.local") d
     markdown = <<~MARKDOWN
       ---
       title:  Notification article
-      tags: tag1
       published: true
       ---
       #{Faker::Hipster.paragraph(sentence_count: 2)}
@@ -428,6 +427,54 @@ seeder.create_if_doesnt_exist(User, "email", "notifications-user@forem.local") d
     reply = Comment.create!(reply_comment_attributes)
 
     Notification.send_new_comment_notifications_without_delay(reply)
+  end
+end
+
+##############################################################################
+
+seeder.create_if_doesnt_exist(User, "email", "to_be_moderated_user@forem.local") do
+  user = User.create!(
+    name: "Tobi M. Oderated \\:/",
+    email: "to_be_moderated_user@forem.local",
+    username: "to_be_moderated_user",
+    profile_image: File.open(Rails.root.join("app/assets/images/#{rand(1..40)}.png")),
+    confirmed_at: Time.current,
+    registered_at: Time.current,
+    password: "password",
+    password_confirmation: "password",
+    saw_onboarding: true,
+    checked_code_of_conduct: true,
+    checked_terms_and_conditions: true,
+  )
+
+  user.notification_setting.update(
+    email_comment_notifications: false,
+    email_follower_notifications: false,
+  )
+  user.profile.update(
+    summary: Faker::Lorem.paragraph_by_chars(number: 199, supplemental: false),
+    website_url: Faker::Internet.url,
+  )
+
+  # Create an article for moderation testing
+  seeder.create_if_doesnt_exist(Article, "slug", "moderate-article-slug") do
+    markdown = <<~MARKDOWN
+      ---
+      title:  Moderate article
+      tags: tag1
+      published: true
+      ---
+      #{Faker::Hipster.paragraph(sentence_count: 2)}
+      #{Faker::Markdown.random}
+      #{Faker::Hipster.paragraph(sentence_count: 2)}
+    MARKDOWN
+    Article.create!(
+      body_markdown: markdown,
+      featured: true,
+      show_comments: true,
+      user_id: user.id,
+      slug: "moderate-article-slug",
+    )
   end
 end
 

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -392,6 +392,7 @@ seeder.create_if_doesnt_exist(User, "email", "notifications-user@forem.local") d
     markdown = <<~MARKDOWN
       ---
       title:  Notification article
+      tags: tag1
       published: true
       ---
       #{Faker::Hipster.paragraph(sentence_count: 2)}

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -497,8 +497,6 @@ seeder.create_if_doesnt_exist(User, "email", "to_be_moderated_user@forem.local")
   end
 end
 
-to_be_moderated_user = User.find_by(email: "to_be_moderated_user@forem.local")
-
 ##############################################################################
 
 seeder.create_if_doesnt_exist(User, "email", "liquid-tags-user@forem.local") do
@@ -790,7 +788,7 @@ seeder.create_if_doesnt_exist(Article, "title", "Tag test article") do
     body_markdown: markdown,
     featured: true,
     show_comments: true,
-    user_id: to_be_moderated_user.id,
+    user_id: admin_user.id,
     slug: "tag-test-article",
   )
 end

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -497,6 +497,8 @@ seeder.create_if_doesnt_exist(User, "email", "to_be_moderated_user@forem.local")
   end
 end
 
+to_be_moderated_user = User.find_by(email: "to_be_moderated_user@forem.local")
+
 ##############################################################################
 
 seeder.create_if_doesnt_exist(User, "email", "liquid-tags-user@forem.local") do
@@ -788,7 +790,7 @@ seeder.create_if_doesnt_exist(Article, "title", "Tag test article") do
     body_markdown: markdown,
     featured: true,
     show_comments: true,
-    user_id: admin_user.id,
+    user_id: to_be_moderated_user.id,
     slug: "tag-test-article",
   )
 end

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -461,7 +461,7 @@ seeder.create_if_doesnt_exist(User, "email", "to_be_moderated_user@forem.local")
     markdown = <<~MARKDOWN
       ---
       title:  Moderate article
-      tags: tag1
+      tags: tagtomoderate
       published: true
       ---
       #{Faker::Hipster.paragraph(sentence_count: 2)}

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -32,6 +32,7 @@ Profile.refresh_attributes!
 # extract generated attribute names
 work_attr = ProfileField.find_by(label: "Work").attribute_name
 education_attr = ProfileField.find_by(label: "Education").attribute_name
+
 ##############################################################################
 
 seeder.create_if_doesnt_exist(User, "email", "admin@forem.local") do
@@ -68,6 +69,24 @@ seeder.create_if_doesnt_exist(User, "email", "admin@forem.local") do
 end
 
 admin_user = User.find_by(email: "admin@forem.local")
+
+##############################################################################
+
+seeder.create_if_none(Tag) do
+  tags = %w[tag1 tag2]
+
+  tags.each do |tagname|
+    Tag.create!(
+      name: tagname,
+      bg_color_hex: "#672c99",
+      text_color_hex: Faker::Color.hex_color,
+      supported: true,
+    )
+  end
+end
+
+# Show the tag in the sidebar
+Settings::General.sidebar_tags = %i[tag1]
 
 ##############################################################################
 
@@ -750,26 +769,6 @@ seeder.create_if_none(Listing) do
     tag_list: Tag.order(Arel.sql("RANDOM()")).first(2).pluck(:name),
   )
 end
-
-##############################################################################
-
-seeder.create_if_none(Tag) do
-  tags = %w[tag1 tag2]
-
-  tags.each do |tagname|
-    tag = Tag.create!(
-      name: tagname,
-      bg_color_hex: "#672c99",
-      text_color_hex: Faker::Color.hex_color,
-      supported: true,
-    )
-
-    admin_user.add_role(:tag_moderator, tag)
-  end
-end
-
-# Show the tag in the sidebar
-Settings::General.sidebar_tags = %i[tag1]
 
 ##############################################################################
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this commit, the `articleAuthorId` was a string and the
`user.id` was an integer.  These were never equal.  So, we would render
the moderator shield for a "moderator"'s own article.

With this commit, we're comparing integer to integer.

## Related Tickets & Documents

Closes forem/forem#17628

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

