### PR TITLE
Adding more goals to feed experiments

### DIFF
--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -21,6 +21,9 @@ experiments:
       - user_publishes_post
       - user_publishes_post_at_least_two_times_within_week
       - user_publishes_post_at_least_two_times_within_two_weeks
+      - user_publishes_post_on_four_different_days_within_a_week
+      - user_creates_article_reaction
+      - user_creates_article_reaction_on_four_different_days_within_a_week
 exclude:
   bots: true
 

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -193,6 +193,36 @@ RSpec.describe Reaction, type: :model do
   end
 
   context "when callbacks are called after create" do
+    describe "field tests" do
+      let!(:user) { create(:user, :trusted) }
+
+      before do
+        # making sure there are no other enqueued jobs from other tests
+        sidekiq_perform_enqueued_jobs(only: Users::RecordFieldTestEventWorker)
+      end
+
+      it "enqueues a Users::RecordFieldTestEventWorker for giving a like to an article" do
+        article = create(:article, user: user)
+        sidekiq_assert_enqueued_jobs(1, only: Users::RecordFieldTestEventWorker) do
+          create(:reaction, reactable: article, user: user, category: "like")
+        end
+      end
+
+      it "does not enqueue a Users::RecordFieldTestEventWorker for giving a privileged reaction to an article" do
+        article = create(:article, user: user)
+        sidekiq_assert_enqueued_jobs(0, only: Users::RecordFieldTestEventWorker) do
+          create(:reaction, reactable: article, user: user, category: "thumbsdown")
+        end
+      end
+
+      it "does not enqueue a Users::RecordFieldTestEventWorker for giving a like to a comment" do
+        comment = create(:comment, user: user)
+        sidekiq_assert_enqueued_jobs(0, only: Users::RecordFieldTestEventWorker) do
+          create(:reaction, reactable: comment, user: user, category: "like")
+        end
+      end
+    end
+
     describe "slack messages" do
       let!(:user) { create(:user, :trusted) }
       let!(:article) { create(:article, user: user) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

This commit adds three new feed experiment goals:

* user publishes four posts within a week
* user reacts with a "heart", "unicorn", or "reading list" to an article
* user reacts with a "heart", "unicorn", or "reading list" to an article
  four times in a week

In addition it adds it to the existing experiment.  Adding it to the
existing experiment is acceptable because:

1. We can ignore the results
2. The experiments are structured such that these new goals could be met
   with prior data.
3. Both variants are playing by the same rules, so the results relative
   to each other are valid.

**There is a nuanced assumption in how we handle reactions:**

This implementation does not count by unique article reactions. However,
most folks will :heart: , :unicorn: , and :bookmark: in one swoop; thus
those 3 reactions are all grouped into happening on one day.

Further, it's a reflection of the person taking an action after reading
a post, not how much action on that particular post.

**Rollback considerations:**

This also includes a feature flag that we can explicitly disable if we
overload the application with workers handling reaction goals.  Using
`FeatureFlag.accessible?(:field_test_event_for_reactions)` returns
`true` unless we explicitly disable this flag.


## Related Tickets & Documents

Closes forem/forem#17669

## QA Instructions, Screenshots, Recordings

None, the tests cover the cases.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
