### PR TITLE
Ensuring that embed fallback renders URL

### DIFF
--- a/app/liquid_tags/open_graph_tag.rb
+++ b/app/liquid_tags/open_graph_tag.rb
@@ -6,6 +6,7 @@ class OpenGraphTag < LiquidTagBase
   def initialize(_tag_name, url, _parse_context)
     super
 
+    @url = url
     @page = OpenGraph.new url
     @url_domain = URI.parse(url).host.delete_prefix("www.")
   end
@@ -15,6 +16,7 @@ class OpenGraphTag < LiquidTagBase
       partial: PARTIAL,
       locals: {
         page: @page,
+        url: @url,
         url_domain: @url_domain
       },
     )

--- a/app/services/open_graph.rb
+++ b/app/services/open_graph.rb
@@ -48,6 +48,7 @@ class OpenGraph
   end
 
   def main_properties
+    # QUESTION: If we don't have `og:url` could we infer the url based on what was passed?
     %w[og:title og:url]
   end
 

--- a/app/views/liquids/_open_graph.html.erb
+++ b/app/views/liquids/_open_graph.html.erb
@@ -30,7 +30,7 @@
       </div>
     </div>
   <% else %>
-    <a href="<%= url_domain %>" target="_blank" rel="noopener noreferrer">
+    <a href="<%= url %>" target="_blank" rel="noopener noreferrer">
       <%= url_domain %>
     </a>
   <% end %>

--- a/spec/fixtures/files/guides.rubyonrails.org-routing.html
+++ b/spec/fixtures/files/guides.rubyonrails.org-routing.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Rails Routing from the Outside In — Ruby on Rails Guides</title>
+  <meta property="og:title" content="Rails Routing from the Outside In — Ruby on Rails Guides" />
+  <meta name="description" content="Rails Routing from the Outside InThis guide covers the user-facing features of Rails routing.After reading this guide, you will know: How to interpret the code in config/routes.rb. How to construct your own routes, using either the preferred resourceful style or the match method. How to declare route parameters, which are passed onto controller actions. How to automatically create paths and URLs using route helpers. Advanced techniques such as creating constraints and mounting Rack endpoints." />
+  <meta property="og:description" content="Rails Routing from the Outside InThis guide covers the user-facing features of Rails routing.After reading this guide, you will know: How to interpret the code in config/routes.rb. How to construct your own routes, using either the preferred resourceful style or the match method. How to declare route parameters, which are passed onto controller actions. How to automatically create paths and URLs using route helpers. Advanced techniques such as creating constraints and mounting Rack endpoints." />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:site_name" content="Ruby on Rails Guides" />
+  <meta property="og:image" content="https://avatars.githubusercontent.com/u/4223" />
+  <meta property="og:type" content="website" />
+</head>
+<body class="guide">
+  <h1>The Guide</h1>
+</body>
+</html>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this commit, our fallback HREF was using only the URL's
domain (e.g. `guides.rubyonrails.org/routing.html`) instead of the
provided URL (e.g. `https://guides.rubyonrails.org/routing.html`).  This
resulted in the link resolving to
`<url-of-article>/guides.rubyonrails.org/routing.html`)

With this commit, we're using the given URL for the HREF.

An interesting side note, the Ruby on Rails guides includes an
`og:title` but not an `og:url` so we hit the fallback condition.  Could
we use the given URL if `og:url` does not exist?


## Related Tickets & Documents

Fixes forem/forem#17679
Related to forem/forem#17001

## QA Instructions, Screenshots, Recordings

Spin up a local instance:

- go to `/new`
- In the new post's body add `{% embed https://guides.rubyonrails.org/routing.html %}`
- Click Preview
- Then click the embed link; you should be taken to https://guides.rubyonrails.org/routing.html 

This assumes that the above URL still does not have an `og:url` meta data entry.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
