### PR TITLE
Fix spec calc that checks date filter expectation

### DIFF
--- a/spec/queries/comments/community_wellness_query_spec.rb
+++ b/spec/queries/comments/community_wellness_query_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Comments::CommunityWellnessQuery, type: :query do
       weeks_ago_array = result[index6]["serialized_weeks_ago"].split(",")
       comment_counts_array = result[index6]["serialized_comment_counts"].split(",")
 
-      oldest_comment_date_post_rollout = user6.comments.where("created_at > ?",
-                                                              "2022-05-01").order(created_at: :asc).first.created_at
+      post_rollout_comments = user6.comments.where("created_at > ?", "2022-05-01").order(created_at: :asc)
+      oldest_comment_date_post_rollout = post_rollout_comments.first.created_at
 
       # If `1.34` weeks have passed we should get no more than 2 weeks in the
       # result arrays because of the `limit_release_date_sql_query`. That's what

--- a/spec/queries/comments/community_wellness_query_spec.rb
+++ b/spec/queries/comments/community_wellness_query_spec.rb
@@ -49,10 +49,14 @@ RSpec.describe Comments::CommunityWellnessQuery, type: :query do
       weeks_ago_array = result[index6]["serialized_weeks_ago"].split(",")
       comment_counts_array = result[index6]["serialized_comment_counts"].split(",")
 
+      oldest_comment_date_post_rollout = user6.comments.where("created_at > ?",
+                                                              "2022-05-01").order(created_at: :asc).first.created_at
+
       # If `1.34` weeks have passed we should get no more than 2 weeks in the
       # result arrays because of the `limit_release_date_sql_query`. That's what
       # is being calculated here and stored in `expected_weeks`
-      expected_weeks = ((Time.current - Time.zone.parse("2022-05-01")) / 7.days).ceil
+      expected_weeks = ((Time.current - oldest_comment_date_post_rollout) / 7.days).ceil
+
       expect(weeks_ago_array.count).to eq(expected_weeks)
       expect(comment_counts_array.count).to eq(expected_weeks)
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

There was a problem with the way we are generating the comments for the users in the query spec. The easiest way AFAICT is the way we do it now, which loops from 0 to 33 and calculates `(2+ (i * 7))`. This makes it so 2 comments are created 2 days ago (week 0), then 9 days ago (week 1), then 16 days ago (week 2), and so on.

This comment creation won't match perfectly with the "number of weeks ago since rollout date" (`2022-05-01`) throughout the week (because of the _rigidness_ of creating the days with the formula above). Making the calculation with the oldest comment date post the rollout date (`oldest_comment_date_post_rollout`) will continue to ensure we're restricting the date here (original the purpose of the spec).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #17310

## QA Instructions, Screenshots, Recordings

Spec fix only

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

None

## [optional] What gif best describes this PR or how it makes you feel?

![woman checking dates in a calendar](https://media.giphy.com/media/l2YWxPbinlJYX5zMc/giphy.gif)
