### PR TITLE
Adding page view goal for experiments

### DIFF
--- a/app/models/ab_experiment/goal_conversion_handler.rb
+++ b/app/models/ab_experiment/goal_conversion_handler.rb
@@ -58,6 +58,11 @@ class AbExperiment
     end
 
     def convert_pageview_goal(experiment:, experiment_start_date:)
+      # TODO: Remove once we know that this test is not over-heating the application.  That would be a
+      # few days after the deploy to DEV of this change.
+      if FeatureFlag.accessible?(:field_test_event_single_create_pageview)
+        field_test_converted(experiment, participant: user, goal: goal) # base is someone viewed a page
+      end
       pageview_goal(experiment,
                     [7.days.ago, experiment_start_date].max,
                     "DATE(created_at)",

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -12,18 +12,20 @@ experiments:
       - 80
       - 20
     goals:
+      - user_creates_pageview
+      - user_creates_article_reaction
       - user_creates_comment
-      - user_creates_comment_on_at_least_four_different_days_within_a_week
-      - user_views_pages_on_at_least_four_different_days_within_a_week
-      - user_views_pages_on_at_least_four_different_hours_within_a_day
-      - user_views_pages_on_at_least_nine_different_days_within_two_weeks
-      - user_views_pages_on_at_least_twelve_different_hours_within_five_days
       - user_publishes_post
+      - user_views_pages_on_at_least_four_different_days_within_a_week
+      - user_creates_article_reaction_on_four_different_days_within_a_week
+      - user_creates_comment_on_at_least_four_different_days_within_a_week
+      - user_publishes_post_on_four_different_days_within_a_week
+      # These are historical and may be userful
+      - user_views_pages_on_at_least_four_different_hours_within_a_day
+      - user_views_pages_on_at_least_twelve_different_hours_within_five_days
+      - user_views_pages_on_at_least_nine_different_days_within_two_weeks
       - user_publishes_post_at_least_two_times_within_week
       - user_publishes_post_at_least_two_times_within_two_weeks
-      - user_publishes_post_on_four_different_days_within_a_week
-      - user_creates_article_reaction
-      - user_creates_article_reaction_on_four_different_days_within_a_week
 exclude:
   bots: true
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

With comments, publishing articles, and reactions we had symmetry on two
goals:

- Create a _subject_ (e.g. Comment, Published Article, Reaction)
- Create four _subjects_ within a week.

For page views we only had "Create four _subjects_ within a week."  This
PR addes the "Create a _subject_".

To do this required adjusting some tests as they were too specific in
nature (looking at an expected count).

In addition, in consultation with Jennie, I've updated the experiment
order to better reflect some hierarchical importance.

**Rollback considerations:**

This also includes a feature flag that we can explicitly disable if we
overload the application with workers handling reaction goals.  Using
`FeatureFlag.accessible?(:field_test_event_single_create_pageview)`
returns `true` unless we explicitly disable this flag.

## Related Tickets & Documents

Related to forem/forem#17673
Related to forem/forem#17669
Closes forem/forem#17691

## QA Instructions, Screenshots, Recordings

The tests should be adequate coverage.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
