### PR TITLE
Reposition 'Feature Post' button on Mod Panel

### DIFF
--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -51,7 +51,7 @@
     <% if current_user.any_admin? && @moderatable.published %>
       <% @recent_featured_count = Article.where(featured: true).where("published_at > ?", 1.day.ago).size %>
       <button
-        class="c-btn c-btn--primary w-100 <%= "crayons-btn--destructive" if @moderatable.featured %>"
+        class="c-btn c-btn--primary w-100 <%= "c-btn--destructive" if @moderatable.featured %>"
         id="feature-article-btn"
         data-article-featured="<%= @moderatable.featured %>"
         data-article-id="<%= @moderatable.id %>"

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -192,22 +192,6 @@
       </button>
 
       <div id="admin-action-options" class="admin-action-options dropdown-options hidden">
-        <% @recent_featured_count = Article.where(featured: true).where("published_at > ?", 1.day.ago).size %>
-        <div class="article-admin-action mt-2">
-          <button
-            class="c-btn c-btn--primary w-100 <%= "crayons-btn--destructive" if @moderatable.featured %>"
-            id="feature-article-btn"
-            data-article-featured="<%= @moderatable.featured %>"
-            data-article-id="<%= @moderatable.id %>"
-            data-article-author="<%= @moderatable.username %>"
-            data-article-slug="<%= @moderatable.slug %>">
-            <%= @moderatable.featured ? t("views.moderations.actions.unfeature") : t("views.moderations.actions.feature") %>
-          </button>
-          <div class="block additional-subtext-section py-4 pt-2">
-            <%= t("views.moderations.actions.featured_past_day", count: @recent_featured_count) %>
-          </div>
-
-        </div>
         <div class="article-admin-action">
           <button
             class="c-btn c-btn--primary c-btn--destructive w-100"

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -51,7 +51,7 @@
     <% if current_user.any_admin? && @moderatable.published %>
       <% @recent_featured_count = Article.where(featured: true).where("published_at > ?", 1.day.ago).size %>
       <button
-        class="c-btn c-btn--primary w-100 <%= "c-btn--destructive" if @moderatable.featured %>"
+        class="c-btn c-btn--primary w-100"
         id="feature-article-btn"
         data-article-featured="<%= @moderatable.featured %>"
         data-article-id="<%= @moderatable.id %>"

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -48,6 +48,21 @@
       <span></span>
       <%= crayons_icon_tag(:checkmark, class: "vomit-checkmark", title: t("views.moderations.actions.checkmark")) %>
     </button>
+    <% if current_user.any_admin? && @moderatable.published %>
+      <% @recent_featured_count = Article.where(featured: true).where("published_at > ?", 1.day.ago).size %>
+      <button
+        class="c-btn c-btn--primary w-100 <%= "crayons-btn--destructive" if @moderatable.featured %>"
+        id="feature-article-btn"
+        data-article-featured="<%= @moderatable.featured %>"
+        data-article-id="<%= @moderatable.id %>"
+        data-article-author="<%= @moderatable.username %>"
+        data-article-slug="<%= @moderatable.slug %>">
+        <%= @moderatable.featured ? t("views.moderations.actions.unfeature") : t("views.moderations.actions.feature") %>
+      </button>
+      <div class="additional-subtext-section py-4 pt-2">
+        <%= t("views.moderations.actions.featured_past_day", count: @recent_featured_count) %>
+      </div>
+    <% end %>
     <a href="<%= URL.url %>/community-moderation#using-the-quick-reactions-to-moderate-content" target="_blank" rel="noopener">
       <span class="additional-subtext-section py-3">
         <%= t("views.moderations.actions.how") %>

--- a/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
+++ b/cypress/integration/seededFlows/articleFlows/postModerationTools.spec.js
@@ -3,18 +3,6 @@ describe('Moderation Tools for Posts', () => {
     cy.testSetup();
   });
 
-  it('should load moderation tools on a post for a trusted user', () => {
-    cy.fixture('users/trustedUser.json').as('user');
-    cy.get('@user').then((user) => {
-      cy.loginAndVisit(user, '/').then(() => {
-        cy.findAllByRole('link', { name: 'Test article' })
-          .first()
-          .click({ force: true });
-        cy.findByRole('button', { name: 'Moderation' }).should('exist');
-      });
-    });
-  });
-
   it('should not load moderation tools for a post when the logged on user is not a trusted user', () => {
     cy.fixture('users/articleEditorV1User.json').as('user');
 
@@ -42,8 +30,8 @@ describe('Moderation Tools for Posts', () => {
   });
 
   it('should not alter tags from a post if a reason is not specified', () => {
-    cy.fixture('users/adminUser.json').as('user');
-    cy.get('@user').then((user) => {
+    cy.fixture('users/adminUser.json').as('adminUser');
+    cy.get('@adminUser').then((user) => {
       cy.loginAndVisit(user, '/admin_mcadmin/tag-test-article').then(() => {
         cy.findByRole('button', { name: 'Moderation' }).click();
 
@@ -62,6 +50,72 @@ describe('Moderation Tools for Posts', () => {
         });
 
         cy.findByTestId('snackbar').should('not.exist');
+      });
+    });
+  });
+
+  it('should show Feature Post button on an unfeatured post for an admin user', () => {
+    cy.fixture('users/adminUser.json').as('adminUser');
+    cy.get('@adminUser').then((user) => {
+      cy.loginAndVisit(user, '/').then(() => {
+        cy.findAllByRole('link', { name: 'Unfeatured article' })
+          .first()
+          .click({ force: true });
+        cy.findByRole('button', { name: 'Moderation' }).click();
+
+        cy.getIframeBody('[title="Moderation panel actions"]').within(() => {
+          cy.findByRole('button', { name: 'Feature Post' }).should('exist');
+        });
+      });
+    });
+  });
+
+  it('should show Unfeature Post button on a featured post for an admin user', () => {
+    cy.fixture('users/adminUser.json').as('adminUser');
+    cy.get('@adminUser').then((user) => {
+      cy.loginAndVisit(user, '/').then(() => {
+        cy.findAllByRole('link', { name: 'Test article' })
+          .first()
+          .click({ force: true });
+        cy.findByRole('button', { name: 'Moderation' }).click();
+
+        cy.getIframeBody('[title="Moderation panel actions"]').within(() => {
+          cy.findByRole('button', { name: 'Unfeature Post' }).should('exist');
+        });
+      });
+    });
+  });
+
+  context('as trusted user', () => {
+    beforeEach(() => {
+      cy.fixture('users/trustedUser.json').as('trustedUser');
+    });
+
+    it('should load moderation tools on a post for a trusted user', () => {
+      cy.get('@trustedUser').then((user) => {
+        cy.loginAndVisit(user, '/').then(() => {
+          cy.findAllByRole('link', { name: 'Test article' })
+            .first()
+            .click({ force: true });
+          cy.findByRole('button', { name: 'Moderation' }).should('exist');
+        });
+      });
+    });
+
+    it('should not show Feature Post button on a post for a trusted user', () => {
+      cy.get('@trustedUser').then((user) => {
+        cy.loginAndVisit(user, '/').then(() => {
+          cy.findAllByRole('link', { name: 'Unfeatured article' })
+            .first()
+            .click({ force: true });
+          cy.findByRole('button', { name: 'Moderation' }).click();
+
+          cy.getIframeBody('[title="Moderation panel actions"]').within(() => {
+            cy.findByRole('button', { name: 'Feature Post' }).should(
+              'not.exist',
+            );
+          });
+        });
       });
     });
   });

--- a/spec/support/seeds/seeds_e2e.rb
+++ b/spec/support/seeds/seeds_e2e.rb
@@ -93,6 +93,24 @@ seeder.create_if_doesnt_exist(User, "email", "trusted-user-1@forem.local") do
   user.profile.update(website_url: Faker::Internet.url)
 
   user.add_role(:trusted)
+
+  seeder.create_if_doesnt_exist(Article, "slug", "unfeatured-article-slug") do
+    markdown = <<~MARKDOWN
+      ---
+      title:  Unfeatured article
+      published: true
+      ---
+      #{Faker::Hipster.paragraph(sentence_count: 2)}
+      #{Faker::Markdown.random}
+      #{Faker::Hipster.paragraph(sentence_count: 2)}
+    MARKDOWN
+    Article.create!(
+      body_markdown: markdown,
+      featured: false,
+      user_id: user.id,
+      slug: "unfeatured-article-slug",
+    )
+  end
 end
 
 trusted_user = User.find_by(email: "trusted-user-1@forem.local")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
As part of the Moderator Role project, this PR relocates the `Feature Post` button from the Admin Actions dropdown to the Moderate Post section.

## Related Tickets & Documents
- Closes https://github.com/forem/forem/issues/17710

## QA Instructions, Screenshots, Recordings
As an admin, ensure the Feature/Unfeature Post button is where it should be, and that it works (it features or unfeatures a post; verify in `/admin`)

### UI accessibility concerns?
Will correct errors or omissions as flagged by frontend 

## Added/updated tests?

- [X] Yes

## [Forem core team only] How will this change be communicated?
- [X] I will share this change internally with the appropriate teams
