### PR TITLE
create helper for roles and add FF for moderator role

### DIFF
--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,5 +1,17 @@
 module Admin
   module UsersHelper
+    def role_options(logged_in_user)
+      options = { "Base Roles" => Constants::Role::BASE_ROLES }
+      if logged_in_user.super_admin?
+        special_roles = Constants::Role::SPECIAL_ROLES
+        if FeatureFlag.enabled?(:moderator_role)
+          special_roles = special_roles.dup << "Moderator"
+        end
+        options["Special Roles"] = special_roles
+      end
+      options
+    end
+
     def format_last_activity_timestamp(timestamp)
       return if timestamp.blank?
 

--- a/app/views/admin/users/show/overview/_roles.html.erb
+++ b/app/views/admin/users/show/overview/_roles.html.erb
@@ -48,9 +48,7 @@
   <%= form_for(@user, url: user_status_admin_user_path(@user), html: { class: "flex flex-col gap-4", id: nil }) do |f| %>
     <div class="crayons-field">
       <%= f.label :user_status, "Role", class: "crayons-field__label" %>
-      <% options = { "Base Roles" => Constants::Role::BASE_ROLES } %>
-      <% options["Special Roles"] = Constants::Role::SPECIAL_ROLES if current_user.super_admin? %>
-      <%= f.select(:user_status, grouped_options_for_select(options), { include_blank: "Select role" }, class: "crayons-select") %>
+      <%= f.select(:user_status, grouped_options_for_select(role_options(current_user)), { include_blank: "Select role" }, class: "crayons-select") %>
     </div>
     <div class="crayons-field">
       <%= f.label :note_for_current_role, "Add a note to this action:", class: "crayons-field__label" %>

--- a/spec/helpers/admin/users_helper_spec.rb
+++ b/spec/helpers/admin/users_helper_spec.rb
@@ -1,6 +1,33 @@
 require "rails_helper"
 
 describe Admin::UsersHelper do
+  describe "#role_options" do
+    let(:user) { create(:user) }
+
+    it "returns base roles" do
+      user.add_role(:admin)
+      roles = helper.role_options(user)
+      expect(roles).to have_key("Base Roles")
+      expect(roles["Base Roles"]).to eq Constants::Role::BASE_ROLES
+    end
+
+    it "returns special roles" do
+      user.add_role(:super_admin)
+      roles = helper.role_options(user)
+      expect(roles).to have_key("Special Roles")
+      expect(roles["Special Roles"]).to eq Constants::Role::SPECIAL_ROLES
+    end
+
+    it "adds moderator role when feature flag enabled" do
+      user.add_role(:super_admin)
+      FeatureFlag.enable(:moderator_role)
+
+      roles = helper.role_options(user)
+      expect(roles).to have_key("Special Roles")
+      expect(roles["Special Roles"]).to include "Moderator"
+    end
+  end
+
   describe "#format_last_activity_timestamp" do
     it "renders the proper 'Last activity' date for a user that was active today" do
       timestamp = Time.zone.today


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature

## Description

This PR adds the `Moderator` role to the `Special Roles` drop down as well as moved the logic to build those dropdown options to the admin user helper

## Related Tickets & Documents

- Closes #17706 

## QA Instructions, Screenshots, Recordings

Enable/add the feature flag of `moderator_role` and verify that the role is selectable in the roles drop down.

- Log in as super admin
- manage members (`/admin/member_manager/users`)
- click on a user then `Assign Role`
- verify `Moderator` is an option. should be very last option

### UI accessibility concerns?

No -- adding a dropdown element to an existing interface

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

