### PR TITLE
DateRangePicker component: localize US vs non-US date format

### DIFF
--- a/app/javascript/crayons/formElements/DateRangePicker/DateRangePicker.jsx
+++ b/app/javascript/crayons/formElements/DateRangePicker/DateRangePicker.jsx
@@ -10,6 +10,7 @@ import { Icon } from '@crayons';
 import ChevronLeft from '@images/chevron-left.svg';
 import ChevronRight from '@images/chevron-right.svg';
 import Calendar from '@images/calendar.svg';
+import { getCurrentLocale } from '@utilities/runtime';
 
 const PICKER_PHRASES = {
   ...defaultPhrases,
@@ -117,6 +118,8 @@ export const DateRangePicker = ({
     relevantDate.month() === latestMoment.month();
 
   const today = moment();
+  const dateFormat =
+    getCurrentLocale().toLowerCase() === 'en-us' ? 'MM/DD/YYYY' : 'DD/MM/YYYY';
 
   return (
     // We wrap in a span to assist with scoping CSS selectors & overriding styles from react-dates
@@ -126,6 +129,9 @@ export const DateRangePicker = ({
         startDate={startMoment}
         endDate={endMoment}
         endDateId={endDateId}
+        startDatePlaceholderText={dateFormat}
+        endDatePlaceholderText={dateFormat}
+        displayFormat={dateFormat}
         focusedInput={focusedInput}
         // It is strange to add a tabindex to an icon, but react-dates renders these inside a role="button" which does not have a tabindex
         // This is a workaround to make sure keyboard users can reach and interact with the nav buttons
@@ -134,7 +140,11 @@ export const DateRangePicker = ({
         minDate={earliestMoment}
         maxDate={latestMoment}
         initialVisibleMonth={() => {
-          const relevantDate = startMoment ? startMoment : today;
+          let relevantDate = startMoment;
+
+          if (!relevantDate) {
+            relevantDate = latestMoment ? latestMoment : today;
+          }
 
           return isMonthSameAsLatestMonth(relevantDate)
             ? relevantDate.clone().subtract(1, 'month')

--- a/app/javascript/crayons/formElements/DateRangePicker/__stories__/DateRangePicker.test.jsx
+++ b/app/javascript/crayons/formElements/DateRangePicker/__stories__/DateRangePicker.test.jsx
@@ -1,0 +1,78 @@
+import { h } from 'preact';
+import { render, waitFor } from '@testing-library/preact';
+import { DateRangePicker } from '@crayons';
+import '@testing-library/jest-dom';
+
+const windowNavigator = window.navigator;
+
+describe('<DateRangePicker />', () => {
+  describe('Localization', () => {
+    afterAll(() => {
+      Object.defineProperty(window, 'navigator', {
+        value: windowNavigator,
+        writable: true,
+      });
+    });
+
+    it('localizes for en-US date format', async () => {
+      Object.defineProperty(window, 'navigator', {
+        value: { language: 'en-US' },
+        writable: true,
+      });
+
+      const { getAllByPlaceholderText, getByRole, getByDisplayValue } = render(
+        <DateRangePicker
+          startDateId="start-date"
+          endDateId="end-date"
+          minStartDate={new Date(2020, 0, 1)}
+          maxEndDate={new Date(2020, 0, 31)}
+        />,
+      );
+
+      const inputs = getAllByPlaceholderText('MM/DD/YYYY');
+      expect(inputs).toHaveLength(2);
+
+      getByRole('button', {
+        name: 'Interact with the calendar and add your start date',
+      }).click();
+
+      getByRole('button', {
+        name: 'Choose Wednesday, January 22, 2020 as start date',
+      }).click();
+
+      await waitFor(() =>
+        expect(getByDisplayValue('01/22/2020')).toBeInTheDocument(),
+      );
+    });
+
+    it('localizes for non en-US format', async () => {
+      Object.defineProperty(window, 'navigator', {
+        value: { language: 'en' },
+        writable: true,
+      });
+
+      const { getAllByPlaceholderText, getByRole, getByDisplayValue } = render(
+        <DateRangePicker
+          startDateId="start-date"
+          endDateId="end-date"
+          minStartDate={new Date(2020, 0, 1)}
+          maxEndDate={new Date(2020, 0, 31)}
+        />,
+      );
+
+      expect(getAllByPlaceholderText('DD/MM/YYYY')).toHaveLength(2);
+
+      getByRole('button', {
+        name: 'Interact with the calendar and add your start date',
+      }).click();
+
+      getByRole('button', {
+        name: 'Choose Wednesday, January 22, 2020 as start date',
+      }).click();
+
+      await waitFor(() =>
+        expect(getByDisplayValue('22/01/2020')).toBeInTheDocument(),
+      );
+    });
+  });
+});

--- a/app/javascript/utilities/runtime.js
+++ b/app/javascript/utilities/runtime.js
@@ -145,3 +145,8 @@ export const hasOSSpecificModifier = (event) => {
  */
 export const getOSKeyboardModifierKeyString = () =>
   currentOS() === 'macOS' ? 'cmd' : 'ctrl';
+
+/**
+ * @returns {string} A string representing the locale as per the user's browser settings
+ */
+export const getCurrentLocale = () => navigator.language;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR enhances the DateRangePicker component to display dates in format "MM/DD/YYYY" when the user's browser locale is "en-US" and "DD/MM/YYYY" in all other cases.

(The DateRangePicker component is still in "BETA" in Storybook and is not live anywhere in the app)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/17493

## QA Instructions, Screenshots, Recordings

- Run `yarn install && yarn storybook` locally and navigate to the `BETA>DateRangePicker` story
- Check your browser preferences, and set your language so that "en-US" (US English) is your preferred language
- Refresh the storybook window to make sure the component picks up your changes
- Check that placeholder text reads "MM/DD/YYYY"
- Try selecting a date from the picker, and check it populates in the input in the correct format
- Now change your browser language preferences to any other locale (e.g. British English)
- Refresh storybook and check the placeholders are now "DD/MM/YYYY"
- Try selecting a date and make sure it populates in the correct format

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: component is still in beta, only in storybook

