### PR TITLE
Add missing explicit scopes to Omniauth adapters

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -13,25 +13,27 @@ TWITTER_OMNIAUTH_SETUP = lambda do |env|
 end
 
 GITHUB_OMNIAUTH_SETUP = lambda do |env|
+  env["omniauth.strategy"].options[:scope] = "user:email"
   env["omniauth.strategy"].options[:client_id] = Settings::Authentication.github_key
   env["omniauth.strategy"].options[:client_secret] = Settings::Authentication.github_secret
-  env["omniauth.strategy"].options[:scope] = "user:email"
 end
 
 GOOGLE_OAUTH2_OMNIAUTH_SETUP = lambda do |env|
+  env["omniauth.strategy"].options[:scope] = "email,profile"
   env["omniauth.strategy"].options[:client_id] = Settings::Authentication.google_oauth2_key
   env["omniauth.strategy"].options[:client_secret] = Settings::Authentication.google_oauth2_secret
 end
 
 FACEBOOK_OMNIAUTH_SETUP = lambda do |env|
+  env["omniauth.strategy"].options[:scope] = "email"
   env["omniauth.strategy"].options[:client_id] = Settings::Authentication.facebook_key
   env["omniauth.strategy"].options[:client_secret] = Settings::Authentication.facebook_secret
   env["omniauth.strategy"].options[:token_params][:parse] = :json
 end
 
 APPLE_OMNIAUTH_SETUP = lambda do |env|
-  env["omniauth.strategy"].options[:client_id] = Settings::Authentication.apple_client_id
   env["omniauth.strategy"].options[:scope] = "email name"
+  env["omniauth.strategy"].options[:client_id] = Settings::Authentication.apple_client_id
   env["omniauth.strategy"].options[:key_id] = Settings::Authentication.apple_key_id
   env["omniauth.strategy"].options[:pem] = Settings::Authentication.apple_pem.to_s.gsub("\\n", "\n")
   env["omniauth.strategy"].options[:provider_ignores_state] = true
@@ -49,7 +51,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "#{ENV['COMMUNITY_NAME']} <#{ENV['DEFAULT_EMAIL']}>"
+  config.mailer_sender = "#{ENV.fetch('COMMUNITY_NAME', nil)} <#{ENV.fetch('DEFAULT_EMAIL', nil)}>"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

In our OAuth providers we didn't specify all of their scopes explicitly. This wasn't an issue because the underlying Omniauth gems provide a default scope, but it was brought up to our attention that it's better to explicitly specify our scopes for security reasons.

There shouldn't be any real differences in how the code will work, we're just explicitly requesting the scopes we need instead of relying in the upstream gem default scopes.

## Related Tickets & Documents

- Closes https://github.com/forem/forem-internal-eng/issues/459

## QA Instructions, Screenshots, Recordings

I ran through the updated providers and didn't find any issues

1. Enable [Google](https://developers.forem.com/backend/auth-google)/[Facebook](https://developers.forem.com/backend/auth-facebook) OAuth flows
2. Sign in/up using those providers
3. Shouldn't find any problems with step 2


https://user-images.githubusercontent.com/6045239/170286790-d1e6358c-ecc0-4e5c-9d7d-c81b1251ce49.mov


### UI accessibility concerns?

None

## Added/updated tests?

- [x] No, and this is why: We didn't test the exact scopes requested to OAuth providers before and I don't think we need to IMO

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] What gif best describes this PR or how it makes you feel?

![man saying: put it in writing](https://media.giphy.com/media/qlnqDO6nkw8iae2G2s/giphy.gif)
