### PR TITLE
 "Empty State" for Result-less Search and Filter

### DIFF
--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -100,6 +100,13 @@
         <% end %>
       </tbody>
     </table>
+
+    <% if @users.empty? %>
+      <div class="align-center flex flex-col my-auto py-7" id="empty-state-message-id">
+        <p class="fs-xl fw-normal mb-2">No members found under these filters.</p>
+        <p class="color-secondary">Try broadening or removing the filters.</p>
+      </div>
+    <% end %>
     <!-- XL screen data view end -->
 
     <div class="flex justify-end xl:p-7">

--- a/cypress/integration/seededFlows/adminFlows/users/userIndexView.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/userIndexView.spec.js
@@ -172,10 +172,19 @@ describe('User index view', () => {
     });
 
     describe('Empty state', () => {
+      // Search and filter controls are initialized async.
+      // This helper function allows us to use `pipe` to retry commands in case the test runner clicks before the JS has run
+      const click = (el) => el.click();
+
       it('Displays an empty state when no results are returned when searching for a user', () => {
+        cy.findByRole('button', { name: 'Expand search' })
+          .should('have.attr', 'aria-expanded', 'false')
+          .pipe(click)
+          .should('have.attr', 'aria-expanded', 'true');
+
         cy.findByRole('textbox', {
           name: 'Search member by name, username or email',
-        }).type('Not a User');
+        }).type('Not a member');
 
         cy.findByRole('button', { name: 'Search' }).click();
 
@@ -184,6 +193,11 @@ describe('User index view', () => {
       });
 
       it('Displays an empty state when no results are returned when filtering for a user', () => {
+        cy.findByRole('button', { name: 'Expand filter' })
+          .should('have.attr', 'aria-expanded', 'false')
+          .pipe(click)
+          .should('have.attr', 'aria-expanded', 'true');
+
         cy.findByRole('combobox', { name: 'User role' }).select(
           'codeland_admin',
         );
@@ -260,7 +274,7 @@ describe('User index view', () => {
       it('Displays an empty state when no results are returned when searching for a user', () => {
         cy.findByRole('textbox', {
           name: 'Search member by name, username or email',
-        }).type('Not a User');
+        }).type('Not a member');
 
         cy.findByRole('button', { name: 'Search' }).click();
 

--- a/cypress/integration/seededFlows/adminFlows/users/userIndexView.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/users/userIndexView.spec.js
@@ -170,6 +170,29 @@ describe('User index view', () => {
           .should('equal', 'admin@forem.local');
       });
     });
+
+    describe('Empty state', () => {
+      it('Displays an empty state when no results are returned when searching for a user', () => {
+        cy.findByRole('textbox', {
+          name: 'Search member by name, username or email',
+        }).type('Not a User');
+
+        cy.findByRole('button', { name: 'Search' }).click();
+
+        // Since there aren't any results, the following message should be displayed
+        cy.findByText('No members found under these filters.').should('exist');
+      });
+
+      it('Displays an empty state when no results are returned when filtering for a user', () => {
+        cy.findByRole('combobox', { name: 'User role' }).select(
+          'codeland_admin',
+        );
+        cy.findByRole('button', { name: 'Filter' }).click();
+
+        // Since there aren't any results, the following message should be displayed
+        cy.findByText('No members found under these filters.').should('exist');
+      });
+    });
   });
 
   describe('large screens', () => {
@@ -230,6 +253,29 @@ describe('User index view', () => {
       it(`Clicks through to the Member Detail View`, () => {
         cy.findAllByRole('link', { name: 'Admin McAdmin' }).first().click();
         cy.url().should('contain', '/admin/member_manager/users/1');
+      });
+    });
+
+    describe('Empty state', () => {
+      it('Displays an empty state when no results are returned when searching for a user', () => {
+        cy.findByRole('textbox', {
+          name: 'Search member by name, username or email',
+        }).type('Not a User');
+
+        cy.findByRole('button', { name: 'Search' }).click();
+
+        // Since there aren't any results, the following message should be displayed
+        cy.findByText('No members found under these filters.').should('exist');
+      });
+
+      it('Displays an empty state when no results are returned when filtering for a user', () => {
+        cy.findByRole('combobox', { name: 'User role' }).select(
+          'codeland_admin',
+        );
+        cy.findByRole('button', { name: 'Filter' }).click();
+
+        // Since there aren't any results, the following message should be displayed
+        cy.findByText('No members found under these filters.').should('exist');
       });
     });
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds an "empty state" to the Member Index View table, which is shown when no results are returned when searching or filtering for a user.

## Related Tickets & Documents
- Closes #17490 

## QA Instructions, Screenshots, Recordings
To QA this PR, navigate to `/admin/member_manager/users` and ensure that when there are no search or filtered results, that you are shown the "empty state":

### Before:
![Screen Shot 2022-05-26 at 12 53 54 PM](https://user-images.githubusercontent.com/32834804/170557093-17f7f07d-5e56-4a46-8dac-bdc02ece913d.png)

### After (Desktop):
![Screen Shot 2022-05-26 at 12 52 40 PM](https://user-images.githubusercontent.com/32834804/170556857-8c973ef0-fbf1-4b13-b5ed-1d3fdb018940.png)

### After (Mobile):
![Screen Shot 2022-05-26 at 12 53 16 PM](https://user-images.githubusercontent.com/32834804/170556967-5acfc26b-3c46-456e-ac82-c5a1d8a51c4a.png)

### UI accessibility concerns?
There shouldn't be!

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Binoculars with the text "searching" in the lens](https://media.giphy.com/media/HdkzWcDvoRmLmkrWOt/giphy.gif)
