### PR TITLE
Allow Moderator Role to Unpublish Single Post

### DIFF
--- a/app/javascript/actionsPanel/actionsPanel.js
+++ b/app/javascript/actionsPanel/actionsPanel.js
@@ -1,4 +1,5 @@
 import { toggleFlagUserModal } from '../packs/flagUserModal';
+import { toggleUnpublishPostModal } from '../packs/unpublishPostModal';
 import { request } from '@utilities/http';
 
 export function addCloseListener() {
@@ -148,33 +149,6 @@ export async function updateExperienceLevel(
     alert(error);
   }
 }
-
-const adminUnpublishArticle = async (id, username, slug) => {
-  try {
-    const response = await request(`/articles/${id}/admin_unpublish`, {
-      method: 'PATCH',
-      body: JSON.stringify({ id, username, slug }),
-      credentials: 'same-origin',
-    });
-
-    const outcome = await response.json();
-
-    /* eslint-disable no-restricted-globals */
-    if (outcome.message == 'success') {
-      window.top.location.assign(`${window.location.origin}${outcome.path}`);
-    } else {
-      top.addSnackbarItem({
-        message: `Error: ${outcome.message}`,
-        addCloseButton: true,
-      });
-    }
-  } catch (error) {
-    top.addSnackbarItem({
-      message: `Error: ${error}`,
-      addCloseButton: true,
-    });
-  }
-};
 
 const adminFeatureArticle = async (id, featured) => {
   try {
@@ -415,17 +389,7 @@ export function addBottomActionsListeners() {
 
   const unpublishArticleBtn = document.getElementById('unpublish-article-btn');
   if (unpublishArticleBtn) {
-    unpublishArticleBtn.addEventListener('click', () => {
-      const {
-        articleId: id,
-        articleAuthor: username,
-        articleSlug: slug,
-      } = unpublishArticleBtn.dataset;
-
-      if (confirm('You are unpublishing this post; are you sure?')) {
-        adminUnpublishArticle(id, username, slug);
-      }
-    });
+    unpublishArticleBtn.addEventListener('click', toggleUnpublishPostModal);
   }
 
   document

--- a/app/javascript/packs/articleModerationTools.js
+++ b/app/javascript/packs/articleModerationTools.js
@@ -6,13 +6,22 @@ getCsrfToken().then(() => {
 
   if (articleContainer) {
     const user = userData();
-    const { authorId: articleAuthorId, path } = articleContainer.dataset;
+    const {
+      articleId,
+      articleSlug,
+      authorId: articleAuthorId,
+      authorUsername,
+      path,
+    } = articleContainer.dataset;
 
     const initializeModerationsTools = async () => {
       const { initializeActionsPanel } = await import(
         '../actionsPanel/initializeActionsPanelToggle'
       );
       const { initializeFlagUserModal } = await import('./flagUserModal');
+      const { initializeUnpublishPostModal } = await import(
+        './unpublishPostModal.jsx'
+      );
 
       // If the user can moderate an article give them access to this panel.
       // Note: this assumes we're within the article context (which is the case
@@ -31,10 +40,12 @@ getCsrfToken().then(() => {
         if (user?.id !== articleAuthorId && !isModerationPage()) {
           initializeActionsPanel(user, path);
           initializeFlagUserModal(articleAuthorId);
+          initializeUnpublishPostModal(articleId, authorUsername, articleSlug);
           // "/mod" page
         } else if (isModerationPage()) {
           initializeActionsPanel(user, path);
           initializeFlagUserModal(articleAuthorId);
+          initializeUnpublishPostModal(articleId, authorUsername, articleSlug);
         }
       }
     };

--- a/app/javascript/packs/unpublishPostModal.jsx
+++ b/app/javascript/packs/unpublishPostModal.jsx
@@ -1,5 +1,4 @@
 import { h, render } from 'preact';
-// import { useState, useRef } from 'preact/hooks';
 import PropTypes from 'prop-types';
 import { request } from '../utilities/http';
 import { ButtonNew as Button } from '@crayons';
@@ -91,9 +90,6 @@ export function initializeUnpublishPostModal(
  * @param {string} props.articleSlug Slug of the article to be unpublished.
  */
 export function UnpublishPostModal({ articleId, authorUsername, articleSlug }) {
-  // const [isConfirmButtonEnabled, enableConfirmButton] = useState(false);
-  // const vomitAllRef = useRef(null);
-
   return (
     <div
       data-testid="unpublish-post-modal"
@@ -122,18 +118,12 @@ export function UnpublishPostModal({ articleId, authorUsername, articleSlug }) {
                 className="mr-2"
                 id="confirm-unpublish-post-action"
                 onClick={(_event) => {
-                  // const {
-                  //   current: { dataset: adminVomitReaction },
-                  // } = vomitAllRef;
-
                   confirmAdminUnpublishPost(
                     articleId,
                     authorUsername,
                     articleSlug,
                   );
-                  // enableConfirmButton(false);
                 }}
-                // disabled={!isConfirmButtonEnabled}
               >
                 Unpublish post
               </Button>

--- a/app/javascript/packs/unpublishPostModal.jsx
+++ b/app/javascript/packs/unpublishPostModal.jsx
@@ -1,0 +1,159 @@
+import { h, render } from 'preact';
+// import { useState, useRef } from 'preact/hooks';
+import PropTypes from 'prop-types';
+import { request } from '../utilities/http';
+import { ButtonNew as Button } from '@crayons';
+import RemoveIcon from '@images/x.svg';
+
+async function confirmAdminUnpublishPost(id, username, slug) {
+  try {
+    const response = await request(`/articles/${id}/admin_unpublish`, {
+      method: 'PATCH',
+      body: JSON.stringify({ id, username, slug }),
+      credentials: 'same-origin',
+    });
+
+    const outcome = await response.json();
+
+    /* eslint-disable no-restricted-globals */
+    if (outcome.message == 'success') {
+      window.top.location.assign(`${window.location.origin}${outcome.path}`);
+    } else {
+      top.addSnackbarItem({
+        message: `Error: ${outcome.message}`,
+        addCloseButton: true,
+      });
+    }
+  } catch (error) {
+    top.addSnackbarItem({
+      message: `Error: ${error}`,
+      addCloseButton: true,
+    });
+  }
+
+  toggleUnpublishPostModal();
+}
+
+/**
+ * Shows or hides the flag user modal.
+ */
+export function toggleUnpublishPostModal() {
+  const modalContainer = top.document.getElementsByClassName(
+    'unpublish-post-modal-container',
+  )[0];
+  modalContainer.classList.toggle('hidden');
+
+  if (!modalContainer.classList.contains('hidden')) {
+    top.window.scrollTo(0, 0);
+    top.document.body.style.height = '100vh';
+    top.document.body.style.overflowY = 'hidden';
+  } else {
+    top.document.body.style.height = 'inherit';
+    top.document.body.style.overflowY = 'inherit';
+  }
+}
+
+/**
+ * Initializes the Unpublish Post modal for the given article ID, author username and article slug.
+ *
+ * @param {number} articleId
+ * @param {string} authorUsername
+ * @param {string} articleSlug
+ */
+export function initializeUnpublishPostModal(
+  articleId,
+  authorUsername,
+  articleSlug,
+) {
+  // Check whether context is ModCenter or Friday-Night-Mode
+  const modContainer = document.getElementById('mod-container');
+
+  if (!modContainer) {
+    return;
+  }
+
+  render(
+    <UnpublishPostModal
+      articleId={articleId}
+      authorUsername={authorUsername}
+      articleSlug={articleSlug}
+    />,
+    document.getElementsByClassName('unpublish-post-modal-container')[0],
+  );
+}
+
+/**
+ * A modal for unpublishing a post. This can be used in the moderation center
+ * or on an article page.
+ *
+ * @param {number} props.articleId ID of the article to be unpublished.
+ * @param {string} props.authorUsername Username of the article's author.
+ * @param {string} props.articleSlug Slug of the article to be unpublished.
+ */
+export function UnpublishPostModal({ articleId, authorUsername, articleSlug }) {
+  // const [isConfirmButtonEnabled, enableConfirmButton] = useState(false);
+  // const vomitAllRef = useRef(null);
+
+  return (
+    <div
+      data-testid="unpublish-post-modal"
+      class="crayons-modal crayons-modal--small absolute unpublish-post-modal"
+    >
+      <div class="crayons-modal__box">
+        <header class="crayons-modal__box__header unpublish-post-modal-header">
+          <h2 class="crayons-modal__box__header__title">Unpublish post</h2>
+          <Button
+            icon={RemoveIcon}
+            className="inline-flex"
+            onClick={toggleUnpublishPostModal}
+          />
+        </header>
+        <div class="crayons-modal__box__body">
+          <div class="grid gap-4">
+            <p>
+              Once unpublished, this post will become invisible to the public
+              and only accessible to Anuj.
+            </p>
+            <p>They can still re-publish the post if they are not suspended.</p>
+            <div>
+              <Button
+                destructive
+                variant="primary"
+                className="mr-2"
+                id="confirm-unpublish-post-action"
+                onClick={(_event) => {
+                  // const {
+                  //   current: { dataset: adminVomitReaction },
+                  // } = vomitAllRef;
+
+                  confirmAdminUnpublishPost(
+                    articleId,
+                    authorUsername,
+                    articleSlug,
+                  );
+                  // enableConfirmButton(false);
+                }}
+                // disabled={!isConfirmButtonEnabled}
+              >
+                Unpublish post
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        role="presentation"
+        class="crayons-modal__overlay"
+        onClick={toggleUnpublishPostModal}
+        onKeyUp={toggleUnpublishPostModal}
+      />
+    </div>
+  );
+}
+
+UnpublishPostModal.displayName = 'UnpublishPostModal';
+UnpublishPostModal.propTypes = {
+  articleId: PropTypes.number.isRequired,
+  authorUsername: PropTypes.string.isRequired,
+  articleSlug: PropTypes.string.isRequired,
+};

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -81,12 +81,14 @@
       <article class="crayons-card crayons-article mb-4"
         id="article-show-container"
         data-article-id="<%= @article.id %>"
+        data-article-slug="<%= @article.slug %>"
         data-author-id="<%= @article.user_id %>"
+        data-author-username="<%= @article.username %>"
         data-co-author-ids="<%= @article.co_author_ids.join(",") %>"
         data-path="<%= @article.path %>"
-        data-published="<%= @article.published? %>"
         data-pin-path="<%= stories_feed_pinned_article_path %>"
         data-pinned-article-id="<%= @pinned_article_id %>"
+        data-published="<%= @article.published? %>"
         <%= @article.pinned? ? "data-pinned" : " " %>>
         <header class="crayons-article__header" id="main-title">
           <% if @article.video.present? %>
@@ -216,6 +218,7 @@
 
 <div class="mod-actions-menu print-hidden"></div>
 <div data-testid="flag-user-modal-container" class="flag-user-modal-container hidden"></div>
+<div data-testid="unpublish-post-modal-container" class="unpublish-post-modal-container hidden"></div>
 
 <div class="fullscreen-code js-fullscreen-code"></div>
 <%= javascript_packs_with_chunks_tag "followButtons", defer: true %>

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -180,8 +180,9 @@
       </a>
     </div>
 
+    <%# Hiding this Admin Actions panel until Flag User, Unpublish All Posts and Suspend User are moved into it  %>
     <% if current_user.any_admin? && @moderatable.published %>
-      <button aria-haspopup="true" aria-expanded="false" aria-controls="admin-action-options" class="other-things-btn admin-action" type="button" data-other-things-type="admin-action" aria-label="<%= t("views.moderations.actions.admin.aria_label") %>">
+      <button aria-haspopup="true" aria-expanded="false" aria-controls="admin-action-options" class="other-things-btn admin-action hidden" type="button" data-other-things-type="admin-action" aria-label="<%= t("views.moderations.actions.admin.aria_label") %>">
         <div class="label-wrapper">
           <div class="icon circle centered-icon">
             <%= inline_svg_tag("admin.svg", aria_hidden: true, title: t("views.moderations.actions.admin.icon")) %>

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -49,6 +49,11 @@
       <%= crayons_icon_tag(:checkmark, class: "vomit-checkmark", title: t("views.moderations.actions.checkmark")) %>
     </button>
     <% if current_user.any_admin? && @moderatable.published %>
+      <button
+        class="c-btn c-btn--primary c-btn--destructive w-100 my-4"
+        id="unpublish-article-btn">
+        <%= t("views.moderations.actions.unpublish") %>
+      </button>
       <% @recent_featured_count = Article.where(featured: true).where("published_at > ?", 1.day.ago).size %>
       <button
         class="c-btn c-btn--primary w-100"
@@ -190,19 +195,6 @@
           <%= inline_svg_tag("arrow-down-fill.svg", aria: true, title: t("views.moderations.actions.toggle")) %>
         </div>
       </button>
-
-      <div id="admin-action-options" class="admin-action-options dropdown-options hidden">
-        <div class="article-admin-action">
-          <button
-            class="c-btn c-btn--primary c-btn--destructive w-100"
-            id="unpublish-article-btn"
-            data-article-id="<%= @moderatable.id %>"
-            data-article-author="<%= @moderatable.username %>"
-            data-article-slug="<%= @moderatable.slug %>">
-            <%= t("views.moderations.actions.unpublish") %>
-          </button>
-        </div>
-      </div>
     <% end %>
   </div>
 

--- a/app/views/moderations/actions_panel.html.erb
+++ b/app/views/moderations/actions_panel.html.erb
@@ -181,7 +181,7 @@
     </div>
 
     <%# Hiding this Admin Actions panel until Flag User, Unpublish All Posts and Suspend User are moved into it  %>
-    <% if current_user.any_admin? && @moderatable.published %>
+    <% if current_user.any_admin? %>
       <button aria-haspopup="true" aria-expanded="false" aria-controls="admin-action-options" class="other-things-btn admin-action hidden" type="button" data-other-things-type="admin-action" aria-label="<%= t("views.moderations.actions.admin.aria_label") %>">
         <div class="label-wrapper">
           <div class="icon circle centered-icon">

--- a/app/views/moderations/index.html.erb
+++ b/app/views/moderations/index.html.erb
@@ -26,8 +26,8 @@
         </div>
       </section>
     </div>
-    <div data-testid="flag-user-modal-container" class="flag-user-modal-container hidden">
-    </div>
+    <div data-testid="flag-user-modal-container" class="flag-user-modal-container hidden"></div>
+    <div data-testid="unpublish-post-modal-container" class="unpublish-post-modal-container hidden"></div>
   </main>
 <% else %>
   <div class="container" style="margin-top: 90px;">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR does two tings:
- Allows the Moderator Role to unpublish a single post from the Mod Actions Panel.
- Relocates the "Unpublish Post" button from Admin Actions dropdown to the Moderate Post section.

## Related Tickets & Documents

- Closes https://github.com/forem/forem/issues/17444

## QA Instructions, Screenshots, Recordings
_(work still in progress)_

### UI accessibility concerns?
Will be addressed as they are flagged

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
- [X] Not yet

## [Forem core team only] How will this change be communicated?

- [X] I will share this change internally with the appropriate teams
