### PR TITLE
Unpin article should behave more like Pin article

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -55,7 +55,7 @@ module Admin
 
       respond_to do |format|
         format.html do
-          flash[:success] = I18n.t("admin.articles_controller.pinned")
+          flash[:danger] = I18n.t("admin.articles_controller.unpinned")
           redirect_to admin_article_path(article.id)
         end
         format.js do

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -18,8 +18,6 @@ module Admin
                                  published_at].freeze
 
     def index
-      @pinned_article = PinnedArticle.get
-
       case params[:state]
       when /top-/
         months_ago = params[:state].split("-")[1].to_i.months.ago
@@ -30,6 +28,9 @@ module Admin
         @articles = articles_mixed
         @featured_articles = articles_featured
       end
+
+      @pinned_article = PinnedArticle.get
+      @articles = @articles.where.not(id: @pinned_article) if @pinned_article
     end
 
     def show

--- a/app/javascript/admin/controllers/article_controller.js
+++ b/app/javascript/admin/controllers/article_controller.js
@@ -6,7 +6,6 @@ export default class ArticleController extends Controller {
     'featuredNumber',
     'cardBody',
     'pinnedCheckbox',
-    'unpinButton',
   ];
   static values = { id: Number, pinPath: String };
 
@@ -74,11 +73,15 @@ export default class ArticleController extends Controller {
     }
   }
 
-  ajaxSuccess(event) {
-    if (event.target !== this.unpinButtonTarget) {
-      return;
-    }
+  async unpinArticle(event) {
+    const unpinArticleForm = event.target;
+    // We dont want to submit the pin form here.
+    event.preventDefault();
 
+    unpinArticleForm.submit();
+  }
+
+  ajaxSuccess(event) {
     // Replace the current Article HTML with the HTML sent by the server
     const newArticle = document.createElement('div');
 

--- a/app/views/admin/articles/_individual_article.html.erb
+++ b/app/views/admin/articles/_individual_article.html.erb
@@ -73,14 +73,14 @@
 
       <div class="flex gap-1">
         <% if decorated_article.pinned? %>
-          <%= link_to(
-                "Unpin post",
-                unpin_admin_article_path(decorated_article.id),
-                method: :delete,
-                remote: true,
-                class: "c-link c-link--block",
-                data: { "article-target": "unpinButton" },
-              ) %>
+          <form method="post" action="<%= unpin_admin_article_path(decorated_article.id) %>" class="inline"
+            data-action="submit->article#unpinArticle">
+            <input type="hidden" name="_method" value="delete" />
+            <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>" />
+            <button type="submit" class="c-btn">
+              Unpin post
+            </button>
+          </form>
         <% else %>
           <form method="post" action="<%= pin_admin_article_path(decorated_article.id) %>" class="inline"
             data-action="submit->article#pinArticle">

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -4,6 +4,7 @@ en:
     articles_controller:
       saved: Article saved!
       pinned: Article Pinned!
+      unpinned: Article Unpinned!
     badge_achievements_controller:
       deleted: Badge achievement has been deleted!
       rewarded: Badges are being rewarded. The task will finish shortly.

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -4,6 +4,7 @@ fr:
     articles_controller:
       saved: Article saved!
       pinned: Article Pinned!
+      unpinned: Article Unpinned!
     badge_achievements_controller:
       deleted: Badge achievement has been deleted!
       rewarded: Badges are being rewarded. The task will finish shortly.

--- a/cypress/integration/seededFlows/adminFlows/articles/pinArticle.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/articles/pinArticle.spec.js
@@ -36,7 +36,7 @@ describe('Pin an article from the admin area', () => {
     cy.url().should('contain', '/content_manager/articles/');
 
     cy.findByRole('button', { name: 'Pin post' }).should('not.exist');
-    cy.findByRole('link', { name: 'Unpin post' }).should('exist');
+    cy.findByRole('button', { name: 'Unpin post' }).should('exist');
     cy.findByTestId('pinned-indicator').should('exist');
   });
 
@@ -96,7 +96,7 @@ describe('Pin an article from the admin area', () => {
 
   it('should show the pinned post to a logged out user', () => {
     cy.findAllByRole('button', { name: 'Pin post' }).first().click();
-    cy.findByRole('link', { name: 'Unpin post' }).should('exist');
+    cy.findByRole('button', { name: 'Unpin post' }).should('exist');
 
     cy.signOutUser();
     cy.findAllByRole('link', { name: 'Log in' }).first().should('exist');

--- a/cypress/integration/seededFlows/adminFlows/articles/unpinArticle.spec.js
+++ b/cypress/integration/seededFlows/adminFlows/articles/unpinArticle.spec.js
@@ -25,15 +25,15 @@ describe('Unpin an article from the admin area', () => {
   });
 
   it('should not display the "Unpin post" button by default', () => {
-    cy.findByRole('link', { name: 'Unpin post' }).should('not.exist');
+    cy.findByRole('button', { name: 'Unpin post' }).should('not.exist');
   });
 
   it('should unpin the pinned article', () => {
     cy.findAllByRole('button', { name: 'Pin post' }).first().click();
 
-    cy.findAllByRole('link', { name: 'Unpin post' }).first().click();
+    cy.findAllByRole('button', { name: 'Unpin post' }).first().click();
 
-    cy.findAllByRole('link', { name: 'Unpin post' }).should('not.exist');
+    cy.findAllByRole('button', { name: 'Unpin post' }).should('not.exist');
     cy.findByTestId('pinned-indicator').should('not.exist');
   });
 });


### PR DESCRIPTION
Before: Was a link, did not use flash as expected
After: Now a button, uses flash as expected

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://github.com/forem/forem/blob/main/CONTRIBUTING.md#create-a-pull-request.
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md.
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Unpinning an article did not show a confirmation message. While investigating, I noticed that there was a related issue -- the "Unpin" button was implemented as a `link` not a `button`, and thus an background/ajax request, not a form.

This PR changes the "Unpin" button to be a `button` and updates the `flash` confirmation message for "unpinning". (It seems we're using `flash[:danger]` for delete-type actions?) 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #17417 
- 💬 https://github.com/forem/forem/pull/15090#issuecomment-954957033 for additional background.

## QA Instructions, Screenshots, Recordings

* Log in as an admin
* Navigate to Content Manager > Posts
* Pin a post, "Article Pinned!" green banner
* Unpin that post, "Article Unpinned!" red banner

### UI accessibility concerns?

As I understand the comments on #15090, we prefer having the "Unpin button" be an actual `button` element.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: minor change to confirmation message and markup, underlying behavior is not changing

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media0.giphy.com/media/xT5LMPj8P20jjOqZ5C/giphy.gif)
