### PR TITLE
Adding ability to "seed" feed's SQL randomization

### DIFF
--- a/app/models/articles/feeds.rb
+++ b/app/models/articles/feeds.rb
@@ -87,7 +87,8 @@ module Articles
 
       order_by_lever(:final_order_by_random_weighted_to_score,
                      label: "Order by conflating a random number and the score (see forem/forem#16128)",
-                     order_by_fragment: "RANDOM() ^ (1.0 / greatest(articles.score, 0.1)) DESC")
+                     order_by_fragment: "article_relevancies.randomized_value " \
+                                        "^ (1.0 / greatest(articles.score, 0.1)) DESC")
 
       relevancy_lever(:comments_count_by_those_followed,
                       label: "Weight to give for the number of comments on the article from other users" \


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

The commit includes three changes that work to allow us to "seed" the randomization.  When using the same seed, and randomizer should/must return the same sequence of numbers.

First, I added the "seed" parameter to the variant query.  If you want the same sequence of random numbers from query to query, pass the same seed.  Otherwise, we'll use a Ruby generated random seed.

Second, I added a virtual column to the virtual `article_relevancies` table.  If you provide a seed, and call the query twice, the first row in each of `article_relevancies` will have the same `randomized_value`, likewise the second row, etc.

Third, I amended the existing `order_by_lever` that had a `RANDOM()` postgresql function call.  I replaced that with the `randomized_value` which is computed based on the provided seed.

Fundamentally the idea is to allow for randomness but introduce possible repeatability; a hard thing considering that some of the inner selection criteria is not fixed (e.g. number of reactions can change from moment to moment).

I wrote a [complimentary DEV.to post][1] to further explain what's happening.


[1]:https://dev.to/devteam/adding-reproducible-randomization-to-sql-queries-3dnb

## Related Tickets & Documents

Related to forem/forem#17826

## QA Instructions, Screenshots, Recordings

Please read the above description and [complimentary blog post][1] and ask clarifying questions.

### UI accessibility concerns?

## Added/updated tests?

- [x] No, and this is why: the tests already verify the changed behavior.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams
