### PR TITLE
Enable/remove some Rails 6.1 framework default

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -7,10 +7,10 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 # Support for inversing belongs_to -> has_many Active Record associations.
-# Rails.application.config.active_record.has_many_inversing = true
+Rails.application.config.active_record.has_many_inversing = true
 
 # Track Active Storage variants in the database.
-# Rails.application.config.active_storage.track_variants = true
+Rails.application.config.active_storage.track_variants = true
 
 # Apply random variation to the delay when retrying failed jobs.
 Rails.application.config.active_job.retry_jitter = 0.15
@@ -48,10 +48,10 @@ Rails.application.config.active_record.legacy_connection_handling = false
 # Rails.application.config.action_view.form_with_generates_remote_forms = false
 
 # Set the default queue name for the analysis job to the queue adapter default.
-# Rails.application.config.active_storage.queues.analysis = nil
+Rails.application.config.active_storage.queues.analysis = nil
 
 # Set the default queue name for the purge job to the queue adapter default.
-# Rails.application.config.active_storage.queues.purge = nil
+Rails.application.config.active_storage.queues.purge = nil
 
 # Set the default queue name for the incineration job to the queue adapter default.
 # Rails.application.config.action_mailbox.queues.incineration = nil

--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -9,9 +9,6 @@
 # Support for inversing belongs_to -> has_many Active Record associations.
 Rails.application.config.active_record.has_many_inversing = true
 
-# Track Active Storage variants in the database.
-Rails.application.config.active_storage.track_variants = true
-
 # Apply random variation to the delay when retrying failed jobs.
 Rails.application.config.active_job.retry_jitter = 0.15
 
@@ -46,18 +43,6 @@ Rails.application.config.active_record.legacy_connection_handling = false
 
 # Make `form_with` generate non-remote forms by default.
 # Rails.application.config.action_view.form_with_generates_remote_forms = false
-
-# Set the default queue name for the analysis job to the queue adapter default.
-Rails.application.config.active_storage.queues.analysis = nil
-
-# Set the default queue name for the purge job to the queue adapter default.
-Rails.application.config.active_storage.queues.purge = nil
-
-# Set the default queue name for the incineration job to the queue adapter default.
-# Rails.application.config.action_mailbox.queues.incineration = nil
-
-# Set the default queue name for the routing job to the queue adapter default.
-# Rails.application.config.action_mailbox.queues.routing = nil
 
 # Set the default queue name for the mail deliver job to the queue adapter default.
 # Rails.application.config.action_mailer.deliver_later_queue_name = nil


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Chore

## Description
Slowly updating our rails framework. 

- Enable `has_many_inversing` as a useful feature
- All `active_storage` and `action_mailbox` updates are moot because we don't use them.

## Related Tickets & Documents
https://github.com/forem/forem-internal-eng/issues/463

## QA Instructions, Screenshots, Recordings
Boot up the rails app normally and things should work as expected

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a