### PR TITLE
Fixes `sort_link` specs warning

### DIFF
--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -33,10 +33,10 @@
 <table class="crayons-table" width="100%">
   <thead>
     <tr>
-      <th scope="col"><%= sort_link(@q, :name, {}, { aria: { label: "Sort by Name" } }) %></th>
-      <th scope="col"><%= sort_link(@q, :id, {}, { aria: { label: "Sort by ID" } }) %></th>
-      <th scope="col"><%= sort_link(@q, :alias_for, {}, { aria: { label: "Sort by Alias For" } }) %></th>
-      <th scope="col"><%= sort_link(@q, :taggings_count, {}, { aria: { label: "Sort by Taggings Count" } }) %></th>
+      <th scope="col"><%= sort_link(@q, :name, { aria: { label: "Sort by Name" } }) %></th>
+      <th scope="col"><%= sort_link(@q, :id, { aria: { label: "Sort by ID" } }) %></th>
+      <th scope="col"><%= sort_link(@q, :alias_for, { aria: { label: "Sort by Alias For" } }) %></th>
+      <th scope="col"><%= sort_link(@q, :taggings_count, { aria: { label: "Sort by Taggings Count" } }) %></th>
       <th scope="col">Is Moderated?</th>
     </tr>
   </thead>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Fixed spec warnings like this 
> Passing two trailing hashes to `sort_link` is deprecated, merge the trailing hashes into a single one.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why:  the tests are fine
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: no logic changes

