### PR TITLE
ignore spaminess rating to safely remove database column

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -401,6 +401,8 @@ class Article < ApplicationRecord
 
   scope :eager_load_serialized_data, -> { includes(:user, :organization, :tags) }
 
+  self.ignored_columns = ["spaminess_rating"]
+
   def self.seo_boostable(tag = nil, time_ago = 18.days.ago)
     # Time ago sometimes returns this phrase instead of a date
     time_ago = 5.days.ago if time_ago == "latest"

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Article, type: :model do
   include_examples "#sync_reactions_count", :article
   it_behaves_like "UserSubscriptionSourceable"
 
+  describe "ignored columns" do
+    it "ignores spaminess rating" do
+      expect(described_class.ignored_columns).to eq ["spaminess_rating"]
+    end
+  end
+
   describe "validations" do
     it { is_expected.to belong_to(:collection).optional }
     it { is_expected.to belong_to(:organization).optional }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Active Record caches attributes, which would cause problems when removing the `spaminess_rating` column. The recommended fix is to first ignore it in the model, deploy this change, then wrap the migration in a `safety_assured { ... } block`.

## Related Tickets & Documents

- Related Issue #17222 

## QA Instructions, Screenshots, Recordings
N/A

### UI accessibility concerns?
N/A

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: not needed for this step
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)

