### PR TITLE
Enable cookies_same_site_protection :lax

### DIFF
--- a/config/initializers/new_framework_defaults_6_1.rb
+++ b/config/initializers/new_framework_defaults_6_1.rb
@@ -20,7 +20,7 @@ Rails.application.config.active_job.skip_after_callbacks_if_terminated = true
 #
 # This change is not backwards compatible with earlier Rails versions.
 # It's best enabled when your entire app is migrated and stable on 6.1.
-# Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
+Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
 
 # Generate CSRF tokens that are encoded in URL-safe Base64.
 #


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Dependency upgrade

## Description
The last default of 6.1

This is safe because we are already using :lax as the session store default

https://github.com/forem/forem/blob/77a00d242af81e2f68df2744203dde0115010140/config/initializers/session_store.rb#L21

## Related Tickets & Documents

https://github.com/forem/forem-internal-eng/issues/463


## QA Instructions, Screenshots, Recordings
- Users should not be logged out upon boot.
## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
n/a