### PR TITLE
Fix email confirmation logic when registering via Omniauth

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -5,7 +5,7 @@ class ConfirmationsController < Devise::ConfirmationsController
     yield resource if block_given?
 
     if resource.errors.empty?
-      set_flash_message!(:global_notice, :confirmed)
+      set_flash_message!(:notice, :confirmed)
       sign_in(resource)
 
       if resource.creator?

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -5,9 +5,10 @@ class ConfirmationsController < Devise::ConfirmationsController
     yield resource if block_given?
 
     if resource.errors.empty?
-      set_flash_message!(:notice, :confirmed)
+      set_flash_message!(:global_notice, :confirmed)
+      sign_in(resource)
+
       if resource.creator?
-        sign_in(resource)
         redirect_to new_admin_creator_setting_path
       else
         respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -56,11 +56,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       cta_variant: cta_variant,
     )
 
-    if user_persisted_and_valid? && ForemInstance.smtp_enabled?
-      redirect_to confirm_email_path(email: @user.email)
-    elsif user_persisted_and_valid?
-      # User is allowed to start onboarding without email confirmation because
-      # SMTP isn't enabled
+    if user_persisted_and_valid? && @user.confirmed?
+      # User is allowed to start onboarding
       set_flash_message(:notice, :success, kind: provider.to_s.titleize) if is_navigational_format?
 
       # Devise's Omniauthable does not automatically remember users
@@ -68,6 +65,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       remember_me(@user)
 
       sign_in_and_redirect(@user, event: :authentication)
+    elsif user_persisted_and_valid?
+      redirect_to confirm_email_path(email: @user.email)
     else
       # Devise will clean this data when the user is not persisted
       session["devise.#{provider}_data"] = request.env["omniauth.auth"]

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -56,27 +56,18 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       cta_variant: cta_variant,
     )
 
-    if user_persisted_and_valid?
+    if user_persisted_and_valid? && ForemInstance.smtp_enabled?
+      redirect_to confirm_email_path(email: @user.email)
+    elsif user_persisted_and_valid?
+      # User is allowed to start onboarding without email confirmation because
+      # SMTP isn't enabled
+      set_flash_message(:notice, :success, kind: provider.to_s.titleize) if is_navigational_format?
+
       # Devise's Omniauthable does not automatically remember users
       # see <https://github.com/heartcombo/devise/wiki/Omniauthable,-sign-out-action-and-rememberable>
       remember_me(@user)
 
-      set_flash_message(:notice, :success, kind: provider.to_s.titleize) if is_navigational_format?
-
-      # `event: authentication` is only needed for Warden callbacks
-      # see <config/initializers/persistent_csrf_token_cookie.rb>
       sign_in_and_redirect(@user, event: :authentication)
-    # NOTE: I can't find a way to test this path
-    # as `User` will assign a temporary username if the username already exists
-    # see https://github.com/forem/forem/blob/27131f6f420df347a467f8e9afc84a6af2fcb13a/app/models/user.rb#L532-L555
-    elsif user_persisted_but_username_taken?
-      redirect_to "/settings?state=previous-registration"
-    # NOTE: I can't find a way to test this path
-    # as `Authentication::Authenticator.call` invokes `User.save!` which will
-    # raise errors for a validation error.
-    # In the past we had 1 path (update_user) which would have ended up
-    # here in case of validation errors, see:
-    # https://github.com/forem/forem/blob/80737b540453afe8775128cb37bd379b7c09c7e8/app/services/authorization_service.rb#L77
     else
       # Devise will clean this data when the user is not persisted
       session["devise.#{provider}_data"] = request.env["omniauth.auth"]
@@ -107,10 +98,6 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def user_persisted_and_valid?
     @user.persisted? && @user.valid?
-  end
-
-  def user_persisted_but_username_taken?
-    @user.persisted? && @user.errors_as_sentence.include?(I18n.t("omniauth_callbacks_controller.username_taken"))
   end
 
   # We only bypass CSRF checks on Apple callback path & Apple trusted ORIGIN

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -59,8 +59,6 @@ module Authentication
         log_to_datadog = new_identity && successful_save
         id_provider = identity.provider
 
-        user.skip_confirmation!
-
         flag_spam_user(user) if account_less_than_a_week_old?(user, identity)
 
         user.save!
@@ -130,6 +128,7 @@ module Authentication
         user.assign_attributes(default_user_fields)
 
         user.set_remember_fields
+        user.skip_confirmation!
 
         # The user must be saved in the database before
         # we assign the user to a new identity.

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -59,8 +59,6 @@ module Authentication
         log_to_datadog = new_identity && successful_save
         id_provider = identity.provider
 
-        user.skip_confirmation!
-
         flag_spam_user(user) if account_less_than_a_week_old?(user, identity)
 
         user.save!
@@ -130,7 +128,10 @@ module Authentication
         user.assign_attributes(default_user_fields)
 
         user.set_remember_fields
-        user.skip_confirmation!
+
+        # If SMTP is enabled we require email confirmation to start onboarding.
+        # Otherwise we skip this required step because we can't confirm them.
+        user.skip_confirmation! unless ForemInstance.smtp_enabled?
 
         # The user must be saved in the database before
         # we assign the user to a new identity.

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -131,7 +131,7 @@ module Authentication
 
         # If SMTP is enabled we require email confirmation to start onboarding.
         # Otherwise we skip this required step because we can't confirm them.
-        user.skip_confirmation! unless ForemInstance.smtp_enabled?
+        user.skip_confirmation! unless requires_email_confirmation?
 
         # The user must be saved in the database before
         # we assign the user to a new identity.
@@ -195,6 +195,10 @@ module Authentication
       else
         Time.current
       end
+    end
+
+    def requires_email_confirmation?
+      ForemInstance.smtp_enabled? && provider.class.name != "Authentication::Providers::Forem"
     end
 
     def flag_spam_user(user)

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -59,6 +59,8 @@ module Authentication
         log_to_datadog = new_identity && successful_save
         id_provider = identity.provider
 
+        user.skip_confirmation!
+
         flag_spam_user(user) if account_less_than_a_week_old?(user, identity)
 
         user.save!

--- a/app/services/authentication/authenticator.rb
+++ b/app/services/authentication/authenticator.rb
@@ -128,9 +128,6 @@ module Authentication
         user.assign_attributes(default_user_fields)
 
         user.set_remember_fields
-
-        # If SMTP is enabled we require email confirmation to start onboarding.
-        # Otherwise we skip this required step because we can't confirm them.
         user.skip_confirmation! unless requires_email_confirmation?
 
         # The user must be saved in the database before
@@ -197,6 +194,9 @@ module Authentication
       end
     end
 
+    # If SMTP is enabled we require email confirmation to start onboarding,
+    # otherwise we skip this required step because we can't confirm them.
+    # Forem Account auth doesn't require email confirmation (already confirmed)
     def requires_email_confirmation?
       ForemInstance.smtp_enabled? && provider.class.name != "Authentication::Providers::Forem"
     end

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.apple_username).to match(/#{info.first_name.downcase}_\w+/)
       end
 
+      it "persists the user as confirmed when SMTP isn't enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(false)
+        user = service.call
+        expect(user.confirmed?).to be(true)
+      end
+
+      it "persists the user as unconfirmed when SMTP is enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+        user = service.call
+        expect(user.confirmed?).to be(false)
+      end
+
       it "sets default fields" do
         user = service.call
 
@@ -181,19 +193,6 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.remember_created_at).to be_present
       end
 
-      it "updates confirmed_at with the current UTC time" do
-        original_confirmed_at = user.confirmed_at
-
-        Timecop.travel(1.minute.from_now) do
-          service.call
-        end
-
-        user.reload
-        expect(
-          user.confirmed_at.utc.to_i > original_confirmed_at.utc.to_i,
-        ).to be(true)
-      end
-
       it "updates the username when it is changed on the provider" do
         new_username = "new_username#{rand(1000)}"
         auth_payload.info.first_name = new_username
@@ -261,6 +260,18 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect do
           service.call
         end.to change(Identity, :count).by(1)
+      end
+
+      it "persists the user as confirmed when SMTP isn't enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(false)
+        user = service.call
+        expect(user.confirmed?).to be(true)
+      end
+
+      it "persists the user as unconfirmed when SMTP is enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+        user = service.call
+        expect(user.confirmed?).to be(false)
       end
 
       it "extracts the proper data from the auth payload" do
@@ -383,19 +394,6 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.remember_created_at).to be_present
       end
 
-      it "updates confirmed_at with the current UTC time" do
-        original_confirmed_at = user.confirmed_at
-
-        Timecop.travel(1.minute.from_now) do
-          service.call
-        end
-
-        user.reload
-        expect(
-          user.confirmed_at.utc.to_i > original_confirmed_at.utc.to_i,
-        ).to be(true)
-      end
-
       it "updates the username when it is changed on the provider" do
         new_username = "new_username#{rand(1000)}"
         auth_payload.info.nickname = new_username
@@ -475,6 +473,18 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect do
           service.call
         end.to change(Identity, :count).by(1)
+      end
+
+      it "persists the user as confirmed when SMTP isn't enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(false)
+        user = service.call
+        expect(user.confirmed?).to be(true)
+      end
+
+      it "persists the user as unconfirmed when SMTP is enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+        user = service.call
+        expect(user.confirmed?).to be(false)
       end
 
       it "extracts the proper data from the auth payload" do
@@ -568,6 +578,18 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect do
           service.call
         end.to change(Identity, :count).by(1)
+      end
+
+      it "persists the user as confirmed when SMTP isn't enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(false)
+        user = service.call
+        expect(user.confirmed?).to be(true)
+      end
+
+      it "persists the user as unconfirmed when SMTP is enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+        user = service.call
+        expect(user.confirmed?).to be(false)
       end
 
       it "extracts the proper data from the auth payload" do
@@ -685,19 +707,6 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.remember_me).to be(true)
         expect(user.remember_token).to be_present
         expect(user.remember_created_at).to be_present
-      end
-
-      it "updates confirmed_at with the current UTC time" do
-        original_confirmed_at = user.confirmed_at
-
-        Timecop.travel(1.minute.from_now) do
-          service.call
-        end
-
-        user.reload
-        expect(
-          user.confirmed_at.utc.to_i > original_confirmed_at.utc.to_i,
-        ).to be(true)
       end
 
       it "updates the username when it is changed on the provider" do

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -82,9 +82,11 @@ RSpec.describe Authentication::Authenticator, type: :service do
       end
 
       it "sets confirmed_at" do
-        user = service.call
+        expect do
+          user = service.call
 
-        expect(user.confirmed_at).to be_present
+          expect(user.confirmed_at).to be_present
+        end.not_to change(ActionMailer::Base.deliveries, :count)
       end
 
       it "queues a slack message to be sent for a user whose identity is brand new" do
@@ -297,9 +299,11 @@ RSpec.describe Authentication::Authenticator, type: :service do
       end
 
       it "sets confirmed_at" do
-        user = service.call
+        expect do
+          user = service.call
 
-        expect(user.confirmed_at).to be_present
+          expect(user.confirmed_at).to be_present
+        end.not_to change(ActionMailer::Base.deliveries, :count)
       end
 
       it "queues a slack message to be sent for a user whose identity is brand new" do
@@ -509,9 +513,11 @@ RSpec.describe Authentication::Authenticator, type: :service do
       end
 
       it "sets confirmed_at" do
-        user = service.call
+        expect do
+          user = service.call
 
-        expect(user.confirmed_at).to be_present
+          expect(user.confirmed_at).to be_present
+        end.not_to change(ActionMailer::Base.deliveries, :count)
       end
 
       it "queues a slack message to be sent for a user whose identity is brand new" do
@@ -600,9 +606,11 @@ RSpec.describe Authentication::Authenticator, type: :service do
       end
 
       it "sets confirmed_at" do
-        user = service.call
+        expect do
+          user = service.call
 
-        expect(user.confirmed_at).to be_present
+          expect(user.confirmed_at).to be_present
+        end.not_to change(ActionMailer::Base.deliveries, :count)
       end
 
       it "queues a slack message to be sent for a user whose identity is brand new" do

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -93,12 +93,20 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.remember_created_at).to be_present
       end
 
-      it "sets confirmed_at" do
-        expect do
+      it "sets confirmed_at and doesn't deliver email without SMTP enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(false)
+
+        sidekiq_assert_no_enqueued_jobs(only: Devise.mailer.delivery_job) do
           user = service.call
 
           expect(user.confirmed_at).to be_present
-        end.not_to change(ActionMailer::Base.deliveries, :count)
+        end
+      end
+
+      it "sets confirmed_at as nil when SMTP is enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+        user = service.call
+        expect(user.confirmed_at).to be_nil
       end
 
       it "queues a slack message to be sent for a user whose identity is brand new" do
@@ -309,12 +317,20 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.remember_created_at).to be_present
       end
 
-      it "sets confirmed_at" do
-        expect do
+      it "sets confirmed_at and doesn't deliver email without SMTP enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(false)
+
+        sidekiq_assert_no_enqueued_jobs(only: Devise.mailer.delivery_job) do
           user = service.call
 
           expect(user.confirmed_at).to be_present
-        end.not_to change(ActionMailer::Base.deliveries, :count)
+        end
+      end
+
+      it "sets confirmed_at as nil when SMTP is enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+        user = service.call
+        expect(user.confirmed_at).to be_nil
       end
 
       it "queues a slack message to be sent for a user whose identity is brand new" do
@@ -522,12 +538,20 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.remember_created_at).to be_present
       end
 
-      it "sets confirmed_at" do
-        expect do
+      it "sets confirmed_at and doesn't deliver email without SMTP enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(false)
+
+        sidekiq_assert_no_enqueued_jobs(only: Devise.mailer.delivery_job) do
           user = service.call
 
           expect(user.confirmed_at).to be_present
-        end.not_to change(ActionMailer::Base.deliveries, :count)
+        end
+      end
+
+      it "sets confirmed_at as nil when SMTP is enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+        user = service.call
+        expect(user.confirmed_at).to be_nil
       end
 
       it "queues a slack message to be sent for a user whose identity is brand new" do
@@ -627,12 +651,20 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.remember_created_at).to be_present
       end
 
-      it "sets confirmed_at" do
-        expect do
+      it "sets confirmed_at and doesn't deliver email without SMTP enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(false)
+
+        sidekiq_assert_no_enqueued_jobs(only: Devise.mailer.delivery_job) do
           user = service.call
 
           expect(user.confirmed_at).to be_present
-        end.not_to change(ActionMailer::Base.deliveries, :count)
+        end
+      end
+
+      it "sets confirmed_at as nil when SMTP is enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+        user = service.call
+        expect(user.confirmed_at).to be_nil
       end
 
       it "queues a slack message to be sent for a user whose identity is brand new" do

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -790,4 +790,225 @@ RSpec.describe Authentication::Authenticator, type: :service do
       end
     end
   end
+
+  context "when authenticating through Forem Account" do
+    let!(:auth_payload) { OmniAuth.config.mock_auth[:forem] }
+    let!(:service) { described_class.new(auth_payload) }
+
+    include_context "spam handling"
+
+    describe "new user" do
+      it "creates a new user" do
+        expect do
+          service.call
+        end.to change(User, :count).by(1)
+      end
+
+      it "creates a new identity" do
+        expect do
+          service.call
+        end.to change(Identity, :count).by(1)
+      end
+
+      it "persists the user as confirmed when SMTP isn't enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(false)
+        user = service.call
+        expect(user.confirmed?).to be(true)
+      end
+
+      it "persists the user as confirmed (special provider provider) when SMTP is enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+        user = service.call
+        expect(user.confirmed?).to be(true)
+      end
+
+      it "extracts the proper data from the auth payload" do
+        user = service.call
+
+        info = auth_payload.info
+        raw_info = auth_payload.extra.raw_info
+
+        expect(user.email).to eq(info.email)
+        expect(user.name).to eq(raw_info.name)
+        expect(user.remote_profile_image_url).to eq(info.image)
+        expect(user.forem_username).to eq(info.user_nickname)
+      end
+
+      it "sets default fields" do
+        user = service.call
+
+        expect(user.password).to be_present
+        expect(user.signup_cta_variant).to be_nil
+        expect(user.saw_onboarding).to be(false)
+        expect(user.setting.editor_version).to eq("v2")
+      end
+
+      it "sets the correct sign up cta variant" do
+        user = described_class.call(auth_payload, cta_variant: "awesome")
+
+        expect(user.signup_cta_variant).to eq("awesome")
+      end
+
+      it "sets remember_me for the new user" do
+        user = service.call
+
+        expect(user.remember_me).to be(true)
+        expect(user.remember_token).to be_present
+        expect(user.remember_created_at).to be_present
+      end
+
+      it "sets confirmed_at and doesn't deliver email without SMTP enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(false)
+
+        sidekiq_assert_no_enqueued_jobs(only: Devise.mailer.delivery_job) do
+          user = service.call
+
+          expect(user.confirmed_at).to be_present
+        end
+      end
+
+      it "sets confirmed_at (special provider) when SMTP is enabled" do
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+        user = service.call
+        expect(user.confirmed_at).to be_present
+      end
+
+      it "queues a slack message to be sent for a user whose identity is brand new" do
+        auth_payload.extra.raw_info.created_at = 1.minute.ago.rfc3339
+
+        sidekiq_assert_enqueued_with(job: Slack::Messengers::Worker) do
+          described_class.call(auth_payload)
+        end
+      end
+
+      it "records successful identity creation metric" do
+        allow(ForemStatsClient).to receive(:increment)
+        service.call
+
+        expect(ForemStatsClient).to have_received(:increment).with(
+          "identity.created", tags: ["provider:forem"]
+        )
+      end
+
+      it "increments identity.errors if any errors occur in the transaction" do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Identity).to receive(:save!).and_raise(StandardError)
+        # rubocop:enable RSpec/AnyInstance
+        allow(ForemStatsClient).to receive(:increment)
+
+        expect { described_class.call(auth_payload) }.to raise_error(StandardError)
+
+        tags = hash_including(tags: array_including("error:StandardError"))
+        expect(ForemStatsClient).to have_received(:increment).with("identity.errors", tags)
+      end
+    end
+
+    describe "existing user" do
+      let(:user) { create(:user, :with_identity, identities: [:forem]) }
+
+      before do
+        auth_payload.info.email = user.email
+      end
+
+      it "doesn't create a new user" do
+        expect do
+          service.call
+        end.not_to change(User, :count)
+      end
+
+      it "creates a new identity if the user doesn't have one" do
+        user = create(:user)
+        auth_payload.info.email = user.email
+        auth_payload.uid = "#{user.email}-#{rand(10_000)}"
+
+        expect do
+          described_class.call(auth_payload)
+        end.to change(Identity, :count).by(1)
+      end
+
+      it "does not create a new identity if the user has one" do
+        expect do
+          service.call
+        end.not_to change(Identity, :count)
+      end
+
+      it "does not record an identity creation metric" do
+        allow(ForemStatsClient).to receive(:increment)
+        service.call
+
+        expect(ForemStatsClient).not_to have_received(:increment)
+      end
+
+      it "sets remember_me for the existing user" do
+        user.update_columns(remember_token: nil, remember_created_at: nil)
+
+        service.call
+        user.reload
+
+        expect(user.remember_me).to be(true)
+        expect(user.remember_token).to be_present
+        expect(user.remember_created_at).to be_present
+      end
+
+      it "updates the username when it is changed on the provider" do
+        new_username = "new_username#{rand(1000)}"
+        auth_payload.info.user_nickname = new_username
+
+        user = described_class.call(auth_payload)
+
+        expect(user.forem_username).to eq(new_username)
+      end
+
+      it "updates profile_updated_at when the username is changed" do
+        original_profile_updated_at = user.profile_updated_at
+
+        new_username = "new_username#{rand(1000)}"
+        auth_payload.info.user_nickname = new_username
+
+        Timecop.travel(1.minute.from_now) do
+          described_class.call(auth_payload)
+        end
+
+        user.reload
+        expect(
+          user.profile_updated_at.to_i > original_profile_updated_at.to_i,
+        ).to be(true)
+      end
+
+      it "increments identity.errors if any errors occur in the transaction" do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Identity).to receive(:save!).and_raise(StandardError)
+        # rubocop:enable RSpec/AnyInstance
+        allow(ForemStatsClient).to receive(:increment)
+
+        expect { described_class.call(auth_payload) }.to raise_error(StandardError)
+
+        tags = hash_including(tags: array_including("error:StandardError"))
+        expect(ForemStatsClient).to have_received(:increment).with("identity.errors", tags)
+      end
+
+      it "does not update their forem_username if the user is suspended" do
+        new_username = "new_username#{rand(1000)}"
+        auth_payload.info.nickname = new_username
+        user.add_role :suspended
+
+        user = described_class.call(auth_payload)
+        expect(user.forem_username).not_to eq(new_username)
+      end
+    end
+
+    describe "user already logged in" do
+      it "returns the current user if the identity exists" do
+        user = create(:user, :with_identity, identities: [:forem])
+        expect(described_class.call(auth_payload, current_user: user)).to eq(user)
+      end
+
+      it "creates the identity if for any reason it does not exist" do
+        user = create(:user)
+        expect do
+          described_class.call(auth_payload, current_user: user)
+        end.to change(Identity, :count).by(1)
+      end
+    end
+  end
 end

--- a/spec/services/authentication/authenticator_spec.rb
+++ b/spec/services/authentication/authenticator_spec.rb
@@ -822,7 +822,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.confirmed?).to be(true)
       end
 
-      it "extracts the proper data from the auth payload" do
+      it "extracts the proper data from the auth payload", :aggregate_failures do
         user = service.call
 
         info = auth_payload.info
@@ -834,7 +834,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.forem_username).to eq(info.user_nickname)
       end
 
-      it "sets default fields" do
+      it "sets default fields", :aggregate_failures do
         user = service.call
 
         expect(user.password).to be_present
@@ -849,7 +849,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(user.signup_cta_variant).to eq("awesome")
       end
 
-      it "sets remember_me for the new user" do
+      it "sets remember_me for the new user", :aggregate_failures do
         user = service.call
 
         expect(user.remember_me).to be(true)
@@ -890,7 +890,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
         )
       end
 
-      it "increments identity.errors if any errors occur in the transaction" do
+      it "increments identity.errors if any errors occur in the transaction", :aggregate_failures do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(Identity).to receive(:save!).and_raise(StandardError)
         # rubocop:enable RSpec/AnyInstance
@@ -939,7 +939,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
         expect(ForemStatsClient).not_to have_received(:increment)
       end
 
-      it "sets remember_me for the existing user" do
+      it "sets remember_me for the existing user", :aggregate_failures do
         user.update_columns(remember_token: nil, remember_created_at: nil)
 
         service.call
@@ -975,7 +975,7 @@ RSpec.describe Authentication::Authenticator, type: :service do
         ).to be(true)
       end
 
-      it "increments identity.errors if any errors occur in the transaction" do
+      it "increments identity.errors if any errors occur in the transaction", :aggregate_failures do
         # rubocop:disable RSpec/AnyInstance
         allow_any_instance_of(Identity).to receive(:save!).and_raise(StandardError)
         # rubocop:enable RSpec/AnyInstance


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

This PR ensures email confirmation is required when authenticating via 3rd party auth service providers. The only reason email confirmation isn't required is when SMTP isn't configured (can't confirm the email in that case).

## Related Tickets & Documents

- Closes #17865

## QA Instructions, Screenshots, Recordings

1. Boot app locally
   - Make sure it's configured to work with an OAuth service provider (Twitter, Facebook, etc)
   - Also make sure emails can be sent from your local environment
2. Register a new account
3. Confirmation email should be delivered if SMTP is enabled

Tests for this situation were modified/included and can be tested locally with:

`bundle exec rspec spec/services/authentication/authenticator_spec.rb`

**Complete flow using GitHub**
https://user-images.githubusercontent.com/6045239/174094827-17b67df9-1806-4219-a112-407c616c9a41.mov

**Same flow as above but with duplicated (already existing) username:**
https://user-images.githubusercontent.com/6045239/174095411-170bdb8d-5646-46d6-aab6-4d475f96a5b7.mov

**Forem Authentication registration doesn't require email confirmation:**
https://user-images.githubusercontent.com/6045239/174116995-3f2a8212-7136-4c0a-b69c-fcbac77f5869.mov

### UI accessibility concerns?

None - backend change only

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: It's a bug fix for future (new) registrations

## [optional] What gif best describes this PR or how it makes you feel?

![confirm?](https://media.giphy.com/media/rENopoYGHYif6cc6mC/giphy.gif)

