### PR TITLE
Enable clickOutsideDeactivates on Onboarding FocusTrap

### DIFF
--- a/app/javascript/onboarding/Onboarding.jsx
+++ b/app/javascript/onboarding/Onboarding.jsx
@@ -81,7 +81,10 @@ export class Onboarding extends Component {
             : null
         }
       >
-        <FocusTrap key={`onboarding-${currentSlide}`}>
+        <FocusTrap
+          key={`onboarding-${currentSlide}`}
+          clickOutsideDeactivates="true"
+        >
           {this.slides[currentSlide]}
         </FocusTrap>
       </main>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Fixes a bug where the FocusTrap was stopping users from interacting with the RuntimeBanner (mobile devices) during onboarding.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #17876

## QA Instructions, Screenshots, Recordings

To test this manually:

1. Boot app locally
2. Go through onboarding on a mobile device (or simulate it)
3. The runtime banner should be able to be dismissed or clicked through into the mobile apps
Here's a video of it working on my local environment:

https://user-images.githubusercontent.com/6045239/173097594-e7646a9e-95c2-4ab5-aa84-c3c6552fc344.MP4

### UI accessibility concerns?

I believe there are no accessibility concerns here as the Focus trap isn't quite necessary here compared to a modal

## Added/updated tests?

- [x] No, and this is why: FocusTrap component and Onboarding flow seem thoroughly tested and this is just using a built-in feature of FocusTrap in this scenario

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Small user facing bug fix during onboarding

## [optional] What gif best describes this PR or how it makes you feel?

![You need to let me go](https://media.giphy.com/media/nKb1gBFN1GTqdtH2yy/giphy-downsized-large.gif)

