### PR TITLE
Adjusting field_test index and show page

### DIFF
--- a/app/controllers/field_test/experiments_controller.rb
+++ b/app/controllers/field_test/experiments_controller.rb
@@ -1,0 +1,16 @@
+# This controller originally came from
+# https://github.com/ankane/field_test/blob/master/app/controllers/field_test/experiments_controller.rb
+module FieldTest
+  class ExperimentsController < BaseController
+    def index
+      # More recently started experiments at the top
+      @experiments = FieldTest::Experiment.all.sort_by(&:started_at).reverse
+    end
+
+    def show
+      @experiment = FieldTest::Experiment.find(params[:id])
+    rescue FieldTest::ExperimentNotFound
+      raise ActionController::RoutingError, "Experiment not found"
+    end
+  end
+end

--- a/app/models/ab_experiment/goal_conversion_handler.rb
+++ b/app/models/ab_experiment/goal_conversion_handler.rb
@@ -32,7 +32,10 @@ class AbExperiment
       return if experiments.nil?
 
       experiments.each do |key, data|
-        experiment_start_date = @start_date || data.fetch("start_date").beginning_of_day
+        # We've already declared a winner, let's not do any of the processing
+        next if data.key?("winner")
+
+        experiment_start_date = @start_date || data.fetch("started_at").beginning_of_day
         experiment = key.to_sym
         convert(experiment: experiment, experiment_start_date: experiment_start_date)
       end

--- a/app/views/field_test/experiments/index.html.erb
+++ b/app/views/field_test/experiments/index.html.erb
@@ -1,0 +1,32 @@
+<h1>Experiments</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Experiment</th>
+      <th>Status</th>
+      <th>Started</th>
+      <th>Ended</th>
+      <th>Variants</th>
+      <tr>
+  </thead>
+  <tbody>
+    <% @experiments.each do |experiment| %>
+      <tr>
+        <td><%= link_to experiment.name, experiment_path(experiment.id) %></td>
+        <td><%= experiment.active? ? "Active" : "Completed" %></td>
+        <td><% if experiment.started_at %><time datetime="<%= experiment.started_at.to_date.to_fs(:iso8601) %>"><%= experiment.started_at.to_date.to_fs(:iso8601) %></time><% end %></td>
+        <td><% if experiment.ended_at %><time datetime="<%= experiment.ended_at.to_date.to_fs(:iso8601) %>"><%= experiment.ended_at.to_date.to_fs(:iso8601) %></time><% end %></td>
+        <td>
+          <ul>
+            <% experiment.variants.each do |variant| %>
+              <li>
+                <%= variant %><% if variant == experiment.winner %> <span class="check" aria-label="Winner">✓</span><% end %>
+              </li>
+            <% end %>
+          </ul>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/field_test/experiments/show.html.erb
+++ b/app/views/field_test/experiments/show.html.erb
@@ -1,0 +1,117 @@
+<style>
+  details details { padding: 1em 0 0 1.5em; }
+</style>
+<% experiment = @experiment %>
+<h1><%= experiment.name %><% unless experiment.active? %> <small class="closed">Completed</small><% end %></h1>
+<%# NOTE: The root_path is the Rails's engine root path, not the application's root path (e.g. "/") %>
+<p><%= link_to "Back to Experiments", root_path %></p>
+<details<%= " open" if experiment.active? %>>
+  <summary>Experiment Details</summary>
+
+  <% if experiment.description %>
+    <p class="description"><%= experiment.description %></p>
+  <% end %>
+
+  <details<%= " open" if experiment.active? %>>
+    <summary>Goals for <%= experiment.name %></summary>
+    <% experiment.goals.each do |goal| %>
+      <% results = experiment.results(goal: goal) %>
+
+      <% if experiment.multiple_goals? %>
+        <h2><%= goal.titleize %></h2>
+      <% end %>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Variant</th>
+            <th style="width: 20%;">Participants</th>
+            <th style="width: 20%;">Conversions</th>
+            <th style="width: 20%;">Conversion Rate</th>
+            <th style="width: 20%;">Prob Winning</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% results.each do |variant, result| %>
+            <tr>
+              <td>
+                <%= variant %>
+                <% if variant == experiment.winner %>
+                  <span class="check">✓</span>
+                <% end %>
+              </td>
+              <td><%= result[:participated] %></td>
+              <td><%= result[:converted] %></td>
+              <td>
+                <% if result[:conversion_rate] %>
+                  <%= (100.0 * result[:conversion_rate]).round(FieldTest.precision) %>%
+                <% else %>
+                  -
+                <% end %>
+              </td>
+              <td>
+                <% if result[:prob_winning] %>
+                  <% if result[:prob_winning] < 0.01 %>
+                    &lt; 1%
+                  <% else %>
+                    <%= (100.0 * result[:prob_winning]).round(FieldTest.precision) %>%
+                  <% end %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  </details>
+
+  <% if experiment.id.start_with?("feed_strategy") %>
+    <% experiment.variants.each do |variant| %>
+      <details>
+        <summary>Config for <%= variant %> <% if variant == experiment.winner %><span class="check">✓</span><% end %></summary>
+        <% config = Articles::Feeds::VariantAssembler.user_config_hash_for(variant: variant) %>
+        <dl>
+          <dt>Description</dt>
+          <dd><%= config["description"] || "n/a" %></dd>
+          <dt>Weight</dt>
+          <dd><%= experiment.weights[experiment.variants.index(variant)] %></dd>
+          <dt>Order Lever</dt>
+          <dd><%= config["order_by"] %></dd>
+          <% config["levers"].each do |lever_key, lever| %>
+            <% next unless lever.key?("query_parameters") %>
+            <dt>Parameters for <strong><%= lever_key %></strong> relevancy lever</dt>
+            <% lever["query_parameters"].each do |key, value| %>
+              <dd><strong><%= key %>:</strong> <%= value %></dd>
+            <% end %>
+          <% end %>
+        </dl>
+
+        <table>
+          <% lever_range = config["levers"].map { |_, lever| lever["cases"].map(&:first) }.flatten.uniq.sort %>
+          <caption>Relevency Lever(s): Fallback and Range Factors</caption>
+          <thead>
+            <tr>
+              <th>Lever</th>
+              <th>Fallback</th>
+              <% lever_range.each do |i| %>
+                <th><%= i %></th>
+              <% end %>
+            </tr>
+          </thead>
+          <tbody>
+            <% config["levers"].each do |lever_key, lever| %>
+              <% cases = lever["cases"].each_with_object({}) { |(key, value), mem| mem[key] = value } %>
+              <tr>
+                <th><%= lever_key %></th>
+                <td><%= lever["fallback"] %></th>
+                  <% lever_range.each do |i| %>
+                    <td><%= cases.fetch(i, "&nbsp;".html_safe) %></td>
+                  <% end %>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </details>
+    <% end %>
+  <% end %>
+</details>

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -6,11 +6,12 @@
 # Checklist for creating a new feed experiment:
 #
 # - [ ] Create and/or reference the forem/forem issue with desired configuration
-# - [ ] Identifyer the winner for the past experiment by adding the `winner:
+# - [ ] Identify the winner for the past experiment by adding the `winner:
 #       <variant-name>` attribute to the past experiment.
+# - [ ] Set the past experiments `ended_at` to the new experiments started_at.
 # - [ ] Copy the previous experiment and prepend and rename to
 #       `feed_strategy_starting_CCYYMMDD`
-# - [ ] Update the `start_date` to `CCYY-MM-DD`
+# - [ ] Update the `started_at` to `CCYY-MM-DD`
 # - [ ] Assign the variants; the winner of the previous experiment SHOULD be in
 #       this array.
 # - [ ] Remove the winner from the newly copied `feed_strategy_starting_CCYYMMDD`
@@ -29,7 +30,7 @@ experiments:
   feed_strategy_starting_20220603:
     # NOTE: Required as we want only want to consider for conversion events that
     #       occurred on or after the given start_date.
-    start_date: 2022-06-03
+    started_at: 2022-06-03
     variants:
       - 20220518-variant
       - 20220603-variant-a
@@ -57,7 +58,8 @@ experiments:
     winner: 20220518-variant
     # NOTE: Required as we want only want to consider for conversion events that
     #       occurred on or after the given start_date.
-    start_date: 2022-05-09
+    started_at: 2022-05-26
+    ended_at: 2022-06-03
     variants:
       - 20220518-variant
       - 20220525-variant
@@ -83,7 +85,8 @@ experiments:
     winner: 20220518-variant
     # NOTE: Required as we want only want to consider for conversion events that
     #       occurred on or after the given start_date.
-    start_date: 2022-05-09
+    started_at: 2022-05-18
+    ended_at: 2022-06-26
     variants:
       - 20220422-variant
       - 20220518-variant
@@ -108,7 +111,8 @@ experiments:
     winner: 20220422-variant
     # NOTE: Required as we want only want to consider for conversion events that
     #       occurred on or after the given start_date.
-    start_date: 2022-05-09
+    started_at: 2022-05-09
+    ended_at: 2022-05-18
     variants:
       - 20220422-variant
       - 20220509-variant
@@ -130,10 +134,11 @@ experiments:
       - user_views_pages_on_at_least_nine_different_days_within_two_weeks
       - user_publishes_post_at_least_two_times_within_week
   feed_strategy_starting_20220422:
-    winner: 20220422-variant
+    winner: 20220422-jennie-variant
     # NOTE: Required as we want only want to consider for conversion events that
     #       occurred on or after the given start_date.
-    start_date: 2022-04-22
+    started_at: 2022-04-22
+    ended_at: 2022-05-09
     variants:
       - 20220415-incumbent
       - 20220422-jennie-variant


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description

This change introduces several things things:

1. Fixes the performance of the `/admin/abtests` page; instead of rendering all of the experiment results, just render the overview.
2. Adjust the show page for an experiment to show the summary of results.
3. Favor the existing "started_at" and "ended_at" attributes of FieldTest (see https://github.com/ankane/field_test#config)
4. Update the field test experiments to include the `started_at` and `ended_at` attributes.
5. Skip processing all non-active experiments in our conversion handler.

Why are there no tests?  This is a page that is Admin only and is only visible for reporting purposes.  So, it's not quite worth writing tests as you'd need lots of data.  So we'll assume the logic from the upstream [field_test gem][1] is adequate.

[1]:https://github.com/ankane/field_test

### Screenshots of Local Instance

<img width="1290" alt="Screen Shot 2022-06-13 at 9 31 26 AM" src="https://user-images.githubusercontent.com/2130/173365274-ab42dd5f-0479-4328-aab2-2f83bf4b7565.png">

<img width="1332" alt="Screen Shot 2022-06-13 at 9 31 35 AM" src="https://user-images.githubusercontent.com/2130/173365297-69d7b05e-061f-421a-ae01-630351e4018b.png">


## Related Tickets & Documents

Closes forem/forem#17869

## QA Instructions, Screenshots, Recordings

Spin up your local instance, login as the admin, and go to `/admin/abtests` click around.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: to low of value for the effort required.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

