### PR TITLE
Allowing UserQuery to filter on multiple roles

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -3,10 +3,12 @@ module Admin
     layout "admin"
 
     def index
-      @invitations = Admin::UsersQuery.call(relation: User.invited,
-                                            options: params.permit(
-                                              :search,
-                                            )).page(params[:page]).per(50)
+      @invitations = Admin::UsersQuery.call(
+        relation: User.invited,
+        search: params[:search],
+        role: params[:role],
+        roles: params[:roles],
+      ).page(params[:page]).per(50)
     end
 
     def new; end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,7 +32,9 @@ module Admin
     def index
       @users = Admin::UsersQuery.call(
         relation: User.registered,
-        options: params.permit(:role, :search),
+        search: params[:search],
+        role: params[:role],
+        roles: params[:roles],
       ).page(params[:page]).per(50)
 
       @organization_limit = 3

--- a/app/lib/constants/role.rb
+++ b/app/lib/constants/role.rb
@@ -8,23 +8,25 @@ module Constants
       "Trusted",
     ].freeze
 
-    SPECIAL_ROLES = [
-      "Admin",
-      "Tech Admin",
-      "Super Admin",
-      "Resource Admin: Article",
-      "Resource Admin: Badge",
-      "Resource Admin: BadgeAchievement",
-      "Resource Admin: Broadcast",
-      "Resource Admin: Comment",
-      "Resource Admin: Config",
-      "Resource Admin: DisplayAd",
-      "Resource Admin: DataUpdateScript",
-      "Resource Admin: FeedbackMessage",
-      "Resource Admin: HtmlVariant",
-      "Resource Admin: ListingCategory",
-      "Resource Admin: Page",
-      "Resource Admin: Tag",
-    ].freeze
+    SPECIAL_ROLES_LABELS_TO_WHERE_CLAUSE = {
+      "Admin" => { name: "admin", resource_type: nil },
+      "Tech Admin" => { name: "tech_admin", resource_type: nil },
+      "Super Admin" => { name: "super_admin", resource_type: nil },
+      "Resource Admin: Article" => { name: "single_resource_admin", resource_type: "Article" },
+      "Resource Admin: Badge" => { name: "single_resource_admin", resource_type: "Badge" },
+      "Resource Admin: BadgeAchievement" => { name: "single_resource_admin", resource_type: "BadgeAchievement" },
+      "Resource Admin: Broadcast" => { name: "single_resource_admin", resource_type: "Broadcast" },
+      "Resource Admin: Comment" => { name: "single_resource_admin", resource_type: "Comment" },
+      "Resource Admin: Config" => { name: "single_resource_admin", resource_type: "Config" },
+      "Resource Admin: DisplayAd" => { name: "single_resource_admin", resource_type: "DisplayAd" },
+      "Resource Admin: DataUpdateScript" => { name: "single_resource_admin", resource_type: "DataUpdateScript" },
+      "Resource Admin: FeedbackMessage" => { name: "single_resource_admin", resource_type: "FeedbackMessage" },
+      "Resource Admin: HtmlVariant" => { name: "single_resource_admin", resource_type: "HtmlVariant" },
+      "Resource Admin: ListingCategory" => { name: "single_resource_admin", resource_type: "ListingCategory" },
+      "Resource Admin: Page" => { name: "single_resource_admin", resource_type: "Page" },
+      "Resource Admin: Tag" => { name: "single_resource_admin", resource_type: "Tag" }
+    }.freeze
+
+    SPECIAL_ROLES = SPECIAL_ROLES_LABELS_TO_WHERE_CLAUSE.keys.freeze
   end
 end

--- a/app/queries/admin/users_query.rb
+++ b/app/queries/admin/users_query.rb
@@ -4,17 +4,62 @@ module Admin
                    "users.email ILIKE :search OR " \
                    "users.username ILIKE :search".freeze
 
-    def self.call(relation: User.registered, options: {})
-      role, search = options.values_at(:role, :search)
+    # @api public
+    # @param relation [ActiveRecord::Relation<User>]
+    # @param role [String, nil]
+    # @param search [String, nil]
+    # @param roles [Array<String>, nil]
+    def self.call(relation: User.registered, role: nil, search: nil, roles: [])
+      # We are at an interstitial moment where we are exposing both the role and roles param.  We
+      # need to favor one or the other.
+      if role.presence
+        relation = relation.with_role(role, :any)
+      elsif roles.presence
+        relation = filter_roles(relation: relation, roles: roles)
+      end
 
-      relation = relation.with_role(role, :any) if role.presence
       relation = search_relation(relation, search) if search.presence
-
       relation.order(created_at: :desc)
     end
 
     def self.search_relation(relation, search)
       relation.where(QUERY_CLAUSE, search: "%#{search.strip}%")
     end
+
+    # Apply the "where" scope to the given relation for the given roles.
+    #
+    # @param relation [ActiveRecord::Relation<User>]
+    # @param roles [Array<String>]
+    #
+    # @note Why not use `relation.with_roles`; As implemented in Rolify's `.with_any_role` performs
+    #       one User query per role passed.  Given that we intend to use pagination, the one User
+    #       query per role is inadequate.
+    #
+    # @see https://github.com/RolifyCommunity/rolify/blob/0c883f4173f409766338b9c6dfc64b0fc8ec8a52/lib/rolify/finders.rb#L26-L32
+    def self.filter_roles(relation:, roles:, role_map: Constants::Role::SPECIAL_ROLES_LABELS_TO_WHERE_CLAUSE)
+      conditions = []
+      values = []
+
+      # Assemble the conditions and positional parameter values
+      roles.each do |role|
+        where_clause = role_map.fetch(role)
+        resource_type = where_clause.fetch(:resource_type, nil)
+        condition = "(#{Role.table_name}.name = ? AND #{Role.table_name}.resource_id IS NULL"
+        values << where_clause.fetch(:name)
+
+        # We need to use `IS NULL` instead of `= NULL` as those are different meanings.
+        if resource_type.nil?
+          condition += " AND #{Role.table_name}.resource_type IS NULL"
+        else
+          condition += " AND #{Role.table_name}.resource_type = ?"
+          values << resource_type
+        end
+        condition += ")"
+        conditions << condition
+      end
+
+      relation.joins(:roles).where(%((#{conditions.join(') OR (')})), *values)
+    end
+    private_class_method :filter_roles
   end
 end

--- a/spec/queries/admin/users_query_spec.rb
+++ b/spec/queries/admin/users_query_spec.rb
@@ -1,7 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Admin::UsersQuery, type: :query do
-  subject { described_class.call(options: options) }
+  subject { described_class.call(search: search, role: role, roles: roles) }
+
+  let(:role) { nil }
+  let(:roles) { [] }
+  let(:search) { [] }
 
   let!(:user)  { create(:user, :trusted, name: "Greg") }
   let!(:user2) { create(:user, :trusted, name: "Gregory") }
@@ -9,42 +13,56 @@ RSpec.describe Admin::UsersQuery, type: :query do
   let!(:user4) { create(:user, :admin, name: "Susi") }
   let!(:user5) { create(:user, :trusted, :admin, name: "Beth") }
   let!(:user6) { create(:user, :super_admin, name: "Jean") }
+  let!(:user7) { create(:user).tap { |u| u.add_role(:single_resource_admin, DataUpdateScript) } }
 
   describe ".call" do
     context "when no arguments are given" do
       it "returns all users" do
-        expect(described_class.call).to eq([user6, user5, user4, user3, user2, user])
+        expect(described_class.call).to eq([user7, user6, user5, user4, user3, user2, user])
       end
     end
 
     context "when search is set" do
-      let(:options) { { search: "greg" } }
+      let(:search) { "greg" }
 
       it { is_expected.to eq([user2, user]) }
     end
 
     context "when role is tag_moderator" do
-      let(:options) { { role: "tag_moderator" } }
+      let(:role) { "tag_moderator" }
 
       it { is_expected.to eq([user3]) }
     end
 
     context "when role is super_admin" do
-      let(:options) { { role: "super_admin" } }
+      let(:role) { "super_admin" }
 
       it { is_expected.to eq([user6]) }
     end
 
     context "when role is trusted" do
-      let(:options) { { role: "trusted" } }
+      let(:role) { "trusted" }
 
       it { is_expected.to eq([user5, user2, user]) }
     end
 
     context "when role is admin" do
-      let(:options) { { role: "admin" } }
+      let(:role) { "admin" }
 
       it { is_expected.to eq([user5, user4]) }
+    end
+
+    context "when roles is multiple" do
+      let(:roles) { ["Admin", "Tech Admin", "Resource Admin: DataUpdateScript"] }
+
+      it { is_expected.to eq([user7, user5, user4]) }
+    end
+
+    context "when given multiple single_resource_admin roles" do
+      let(:roles) { ["Admin", "Super Admin", "Resource Admin: DataUpdateScript", "Resource Admin: DisplayAd"] }
+      let!(:user8) { create(:user).tap { |u| u.add_role(:single_resource_admin, DisplayAd) } }
+
+      it { is_expected.to eq([user8, user7, user6, user5, user4]) }
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

I had looked at using `User.with_any_roles` but that creates one User query per role passed.  Which is not ideal, given that we want to have an ActiveRecord::Relation object on which we'd paginate.

This adjustment does it's best to mimic Forem's role structure and adhear to how Rolify builds the underlying query.

An astute reader will notice that in these specs we use `role: "admin"` and `roles: ["Admin"]`; the primary reason relates the user interface being worked on in forem/forem#17884.  It is my understanding that the `role` approach and `roles` approach will be separated by a feature flag (we're rolling out the `roles` approach).

On adjustment I made was to move from an :options hash to keywords.  By favoring keywords, out Language Server Protocol (LSP) prompts will provide more useful hover tips.

## Related Tickets & Documents

- forem/forem#17491
- forem/forem#17884

## QA Instructions, Screenshots, Recordings

The specs provide the tests.

### UI accessibility concerns?

None, though I don't like having `role` search use the underlying `name` and the `roles` search use the label.

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

