### PR TITLE
Adding VariantQuery reseed randomization option

### DIFF
--- a/app/models/articles/feeds/variant_assembler.rb
+++ b/app/models/articles/feeds/variant_assembler.rb
@@ -85,6 +85,7 @@ module Articles
           description: config.fetch("description", ""),
           order_by: catalog.fetch_order_by(config.fetch("order_by")),
           max_days_since_published: config.fetch("max_days_since_published"),
+          reseed_randomizer_on_each_request: config.fetch("reseed_randomizer_on_each_request"),
         )
       end
       private_class_method :build_with

--- a/config/feed-variants/20220415-incumbent.json
+++ b/config/feed-variants/20220415-incumbent.json
@@ -1,5 +1,6 @@
 {
   "max_days_since_published": 15,
+  "reseed_randomizer_on_each_request": false,
   "order_by": "relevancy_score_and_publication_date",
   "levers": {
     "daily_decay": {

--- a/config/feed-variants/20220422-variant.json
+++ b/config/feed-variants/20220422-variant.json
@@ -1,5 +1,6 @@
 {
   "max_days_since_published": 15,
+  "reseed_randomizer_on_each_request": false,
   "order_by": "relevancy_score_and_publication_date",
   "levers": {
     "daily_decay": {

--- a/config/feed-variants/20220509-variant.json
+++ b/config/feed-variants/20220509-variant.json
@@ -1,5 +1,6 @@
 {
   "max_days_since_published": 15,
+  "reseed_randomizer_on_each_request": false,
   "order_by": "relevancy_score_and_publication_date",
   "levers": {
     "daily_decay": {

--- a/config/feed-variants/20220518-variant.json
+++ b/config/feed-variants/20220518-variant.json
@@ -1,5 +1,6 @@
 {
   "max_days_since_published": 15,
+  "reseed_randomizer_on_each_request": false,
   "order_by": "relevancy_score_and_publication_date",
   "levers": {
     "daily_decay": {

--- a/config/feed-variants/20220525-variant.json
+++ b/config/feed-variants/20220525-variant.json
@@ -1,5 +1,6 @@
 {
   "max_days_since_published": 15,
+  "reseed_randomizer_on_each_request": false,
   "order_by": "relevancy_score_and_publication_date",
   "levers": {
     "featured_article": { "cases": [[1, 1]], "fallback": 0.85 },

--- a/config/feed-variants/20220603-variant-a.json
+++ b/config/feed-variants/20220603-variant-a.json
@@ -1,5 +1,6 @@
 {
   "max_days_since_published": 15,
+  "reseed_randomizer_on_each_request": false,
   "description": "As 202205518-variant but with modificiation to `matching_positive_tags_intersection_count`.",
   "order_by": "relevancy_score_and_publication_date",
   "levers": {

--- a/config/feed-variants/20220603-variant-b.json
+++ b/config/feed-variants/20220603-variant-b.json
@@ -1,5 +1,6 @@
 {
   "max_days_since_published": 15,
+  "reseed_randomizer_on_each_request": false,
   "description": "As 202205518-variant but with modificiation to `order_by` lever.",
   "order_by": "final_order_by_random_weighted_to_score",
   "levers": {

--- a/config/feed-variants/README.md
+++ b/config/feed-variants/README.md
@@ -40,3 +40,7 @@ and as of <2022-05-06 Fri> are:
 
 - **_max_days_since_published_:** only consider articles that were published no
   more than the _max_days_since_published_.
+
+- **_reseed_randomizer_on_each_request_:** when true, each time you call the
+  query you will get different randomized numbers; when false, the resulting
+  randomized numbers will be the same within a window of time.

--- a/config/feed-variants/original.json
+++ b/config/feed-variants/original.json
@@ -1,5 +1,6 @@
 {
   "max_days_since_published": 15,
+  "reseed_randomizer_on_each_request": false,
   "order_by": "relevancy_score_and_publication_date",
   "levers": {
     "daily_decay": {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Prior to this change, we setup our feed variant query to have a cached randomization seed.  For a given user this seed is cached for 15 minutes.  The goal of this is to provide mostly consistent sort orders on the feed articles during that 15 minute window.

With this change, we allow for a feed variant to say ignore the cached seed and generate a new one for this call.

I have also added explicit settings to each of the feed variants to reflect our desired intentions for those features.

## Related Tickets & Documents

Relates to
- forem/forem#17833
- forem/forem#17826

Closes forem/forem#17940

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why: the tests cover this configuration.

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

