### PR TITLE
Adding 2022-06-17 feed variant

### DIFF
--- a/config/feed-variants/20220617-variant-a.json
+++ b/config/feed-variants/20220617-variant-a.json
@@ -1,0 +1,97 @@
+{
+  "max_days_since_published": 15,
+  "description": "Blend of 20220603-variant-b and 20220603-variant-a",
+  "order_by": "final_order_by_random_weighted_to_score",
+  "reseed_randomizer_on_each_request": false,
+  "levers": {
+    "daily_decay": {
+      "cases": [
+        [0, 1],
+        [1, 0.99],
+        [2, 0.985],
+        [3, 0.98],
+        [4, 0.975],
+        [5, 0.97],
+        [6, 0.965],
+        [7, 0.96],
+        [8, 0.955],
+        [9, 0.95],
+        [10, 0.945],
+        [11, 0.94],
+        [12, 0.935],
+        [13, 0.93],
+        [14, 0.925]
+      ],
+      "fallback": 0.9
+    },
+    "comments_count_by_those_followed": {
+      "cases": [
+        [0, 0.95],
+        [1, 0.98],
+        [2, 0.99]
+      ],
+      "fallback": 0.93
+    },
+    "comments_count": {
+      "cases": [
+        [0, 0.8],
+        [1, 0.82],
+        [2, 0.84],
+        [3, 0.86],
+        [4, 0.88],
+        [5, 0.9],
+        [6, 0.92],
+        [7, 0.94],
+        [8, 0.96],
+        [9, 0.98]
+      ],
+      "fallback": 1
+    },
+    "featured_article": { "cases": [[1, 1]], "fallback": 0.85 },
+    "latest_comment": {
+      "cases": [
+        [0, 1],
+        [1, 0.9988]
+      ],
+      "fallback": 0.988
+    },
+    "matching_negative_tags_intersection_count": {
+      "cases": [
+        [0, 1],
+        [1, 0.5],
+        [2, 0.4],
+        [3, 0.3],
+        [4, 0.2]
+      ],
+      "fallback": 0
+    },
+    "matching_positive_tags_intersection_count": {
+      "cases": [
+        [0, 0.5],
+        [1, 0.85],
+        [2, 0.9],
+        [3, 0.95],
+        [4, 1]
+      ],
+      "fallback": 1
+    },
+    "privileged_user_reaction": {
+      "cases": [
+        [-1, 0.2],
+        [1, 1]
+      ],
+      "fallback": 0.95,
+      "negative_reaction_threshold": -10,
+      "positive_reaction_threshold": 10
+    },
+    "public_reactions": {
+      "cases": [
+        [0, 0.9988],
+        [1, 0.9988],
+        [2, 0.9988],
+        [3, 0.9988]
+      ],
+      "fallback": 1
+    }
+  }
+}

--- a/config/feed-variants/20220617-variant-b.json
+++ b/config/feed-variants/20220617-variant-b.json
@@ -1,0 +1,98 @@
+
+{
+  "max_days_since_published": 15,
+  "description": "Derived from 20220617-variant-a but with re-seeding every request",
+  "order_by": "final_order_by_random_weighted_to_score",
+  "reseed_randomizer_on_each_request": true,
+  "levers": {
+    "daily_decay": {
+      "cases": [
+        [0, 1],
+        [1, 0.99],
+        [2, 0.985],
+        [3, 0.98],
+        [4, 0.975],
+        [5, 0.97],
+        [6, 0.965],
+        [7, 0.96],
+        [8, 0.955],
+        [9, 0.95],
+        [10, 0.945],
+        [11, 0.94],
+        [12, 0.935],
+        [13, 0.93],
+        [14, 0.925]
+      ],
+      "fallback": 0.9
+    },
+    "comments_count_by_those_followed": {
+      "cases": [
+        [0, 0.95],
+        [1, 0.98],
+        [2, 0.99]
+      ],
+      "fallback": 0.93
+    },
+    "comments_count": {
+      "cases": [
+        [0, 0.8],
+        [1, 0.82],
+        [2, 0.84],
+        [3, 0.86],
+        [4, 0.88],
+        [5, 0.9],
+        [6, 0.92],
+        [7, 0.94],
+        [8, 0.96],
+        [9, 0.98]
+      ],
+      "fallback": 1
+    },
+    "featured_article": { "cases": [[1, 1]], "fallback": 0.85 },
+    "latest_comment": {
+      "cases": [
+        [0, 1],
+        [1, 0.9988]
+      ],
+      "fallback": 0.988
+    },
+    "matching_negative_tags_intersection_count": {
+      "cases": [
+        [0, 1],
+        [1, 0.5],
+        [2, 0.4],
+        [3, 0.3],
+        [4, 0.2]
+      ],
+      "fallback": 0
+    },
+    "matching_positive_tags_intersection_count": {
+      "cases": [
+        [0, 0.5],
+        [1, 0.85],
+        [2, 0.9],
+        [3, 0.95],
+        [4, 1]
+      ],
+      "fallback": 1
+    },
+    "privileged_user_reaction": {
+      "cases": [
+        [-1, 0.2],
+        [1, 1]
+      ],
+      "fallback": 0.95,
+      "negative_reaction_threshold": -10,
+      "positive_reaction_threshold": 10
+    },
+    "public_reactions": {
+      "cases": [
+        [0, 0.9988],
+        [1, 0.9988],
+        [2, 0.9988],
+        [3, 0.9988]
+      ],
+      "fallback": 1
+    }
+  }
+}

--- a/config/feed-variants/20220617-variant-c.json
+++ b/config/feed-variants/20220617-variant-c.json
@@ -1,0 +1,98 @@
+
+{
+  "max_days_since_published": 15,
+  "description": "Derived from 20220617-variant-a but with alternate order by",
+  "order_by": "random_pick_of_which_date_to_use_with_randomization_favoring_public_reactions",
+  "reseed_randomizer_on_each_request": false,
+  "levers": {
+    "daily_decay": {
+      "cases": [
+        [0, 1],
+        [1, 0.99],
+        [2, 0.985],
+        [3, 0.98],
+        [4, 0.975],
+        [5, 0.97],
+        [6, 0.965],
+        [7, 0.96],
+        [8, 0.955],
+        [9, 0.95],
+        [10, 0.945],
+        [11, 0.94],
+        [12, 0.935],
+        [13, 0.93],
+        [14, 0.925]
+      ],
+      "fallback": 0.9
+    },
+    "comments_count_by_those_followed": {
+      "cases": [
+        [0, 0.95],
+        [1, 0.98],
+        [2, 0.99]
+      ],
+      "fallback": 0.93
+    },
+    "comments_count": {
+      "cases": [
+        [0, 0.8],
+        [1, 0.82],
+        [2, 0.84],
+        [3, 0.86],
+        [4, 0.88],
+        [5, 0.9],
+        [6, 0.92],
+        [7, 0.94],
+        [8, 0.96],
+        [9, 0.98]
+      ],
+      "fallback": 1
+    },
+    "featured_article": { "cases": [[1, 1]], "fallback": 0.85 },
+    "latest_comment": {
+      "cases": [
+        [0, 1],
+        [1, 0.9988]
+      ],
+      "fallback": 0.988
+    },
+    "matching_negative_tags_intersection_count": {
+      "cases": [
+        [0, 1],
+        [1, 0.5],
+        [2, 0.4],
+        [3, 0.3],
+        [4, 0.2]
+      ],
+      "fallback": 0
+    },
+    "matching_positive_tags_intersection_count": {
+      "cases": [
+        [0, 0.5],
+        [1, 0.85],
+        [2, 0.9],
+        [3, 0.95],
+        [4, 1]
+      ],
+      "fallback": 1
+    },
+    "privileged_user_reaction": {
+      "cases": [
+        [-1, 0.2],
+        [1, 1]
+      ],
+      "fallback": 0.95,
+      "negative_reaction_threshold": -10,
+      "positive_reaction_threshold": 10
+    },
+    "public_reactions": {
+      "cases": [
+        [0, 0.9988],
+        [1, 0.9988],
+        [2, 0.9988],
+        [3, 0.9988]
+      ],
+      "fallback": 1
+    }
+  }
+}

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -14,7 +14,8 @@
 # - [ ] Update the `started_at` to `CCYY-MM-DD`
 # - [ ] Assign the variants; the winner of the previous experiment SHOULD be in
 #       this array.
-# - [ ] Remove the winner from the newly copied `feed_strategy_starting_CCYYMMDD`
+# - [ ] Remove the winner attribute from the newly copied
+#       `feed_strategy_starting_CCYYMMDD`
 # - [ ] Assign weights and make the corresponding
 #       `./config/feed-variants/*.json` files where * is the new named variants.
 # - [ ] Each newly named variant should have a description; typically briefly
@@ -27,10 +28,35 @@
 ################################################################################
 experiments:
   # NOTE: Our feed strategy testing experiment must begin with "feed_strategy"
+  feed_strategy_starting_20220617:
+    # NOTE: Required as we want only want to consider for conversion events that
+    #       occurred on or after the given start_date.
+    started_at: 2022-06-17
+    variants:
+      - 20220617-variant-a
+      - 20220617-variant-b
+      - 20220617-variant-c
+    weights:
+      - 50
+      - 25
+      - 25
+    goals:
+      - user_creates_pageview
+      - user_creates_article_reaction
+      - user_creates_comment
+      - user_publishes_post
+      - user_views_pages_on_at_least_four_different_days_within_a_week
+      - user_creates_article_reaction_on_four_different_days_within_a_week
+      - user_creates_comment_on_at_least_four_different_days_within_a_week
+      - user_publishes_post_on_four_different_days_within_a_week
   feed_strategy_starting_20220603:
+    # B won with some statistical signficance but A had a strong showing as
+    # well.  So we're melding those two together.
+    winner: 20220603-variant-b
     # NOTE: Required as we want only want to consider for conversion events that
     #       occurred on or after the given start_date.
     started_at: 2022-06-03
+    ended_at: 2022-06-17
     variants:
       - 20220518-variant
       - 20220603-variant-a


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description

New experiment based on conversations:

```
❯ diff config/feed-variants/20220617-variant-a.json config/feed-variants/20220617-variant-b.json
0a1
>
3c4
<   "description": "Blend of 20220603-variant-b and 20220603-variant-a",
---
>   "description": "Derived from 20220617-variant-a but with re-seeding every request",
5c6
<   "reseed_randomizer_on_each_request": false,
---
>   "reseed_randomizer_on_each_request": true,
```

```
❯ diff config/feed-variants/20220617-variant-a.json config/feed-variants/20220617-variant-c.json
0a1
>
3,4c4,5
<   "description": "Blend of 20220603-variant-b and 20220603-variant-a",
<   "order_by": "final_order_by_random_weighted_to_score",
---
>   "description": "Derived from 20220617-variant-a but with alternate order by",
>   "order_by": "random_pick_of_which_date_to_use_with_randomization_favoring_public_reactions",
```


```
❯ diff config/feed-variants/20220617-variant-b.json config/feed-variants/20220617-variant-c.json
4,6c4,6
<   "description": "Derived from 20220617-variant-a but with re-seeding every request",
<   "order_by": "final_order_by_random_weighted_to_score",
<   "reseed_randomizer_on_each_request": true,
---
>   "description": "Derived from 20220617-variant-a but with alternate order by",
>   "order_by": "random_pick_of_which_date_to_use_with_randomization_favoring_public_reactions",
>   "reseed_randomizer_on_each_request": false,
```

## Related Tickets & Documents

Dependent on forem/forem#17942
Closes forem/forem#17949

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No, and this is why:

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

