### PR TITLE
Add service_name scope to Datadog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "carrierwave", "~> 2.2" # Upload files in your Ruby applications, map them t
 gem "carrierwave-bombshelter", "~> 0.2" # Protect your carrierwave from image bombs
 gem "cloudinary", "~> 1.23" # Client library for easily using the Cloudinary service
 gem "counter_culture", "~> 3.2" # counter_culture provides turbo-charged counter caches that are kept up-to-date
-gem "ddtrace", "~> 1.1.0", require: "ddtrace/auto_instrument" # ddtrace is Datadog’s tracing client for Ruby.
+gem "ddtrace", "~> 1.1.0" # ddtrace is Datadog’s tracing client for Ruby.
 gem "devise", "~> 4.8" # Flexible authentication solution for Rails
 gem "devise_invitable", "~> 2.0.6" # Allows invitations to be sent for joining
 gem "dogstatsd-ruby", "~> 4.8" # A client for DogStatsD, an extension of the StatsD metric server for Datadog

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -2,22 +2,34 @@ Datadog.configure do |c|
   c.env = Rails.env
   c.tracing.enabled = ENV["DD_API_KEY"].present?
   c.tracing.partial_flush.enabled = true
+  service_name = ENV.fetch("DD_SERVICE") { "rails-#{Rails.env}" }
+
+  c.tracing.instrument :rails, service_name: service_name
+  c.tracing.instrument :sidekiq, service_name: "#{service_name}-sidekiq"
+  c.tracing.instrument :concurrent_ruby
+  c.tracing.instrument :excon, service_name: "#{service_name}-excon"
+  c.tracing.instrument :httprb, service_name: "#{service_name}-httprb"
+  c.tracing.instrument :net_http, service_name: "#{service_name}-net_http"
+  c.tracing.instrument :faraday, service_name: "#{service_name}-faraday"
+
+  # sidekiq-client
 
   # Multiple Redis integrations to split Redis usage per-instance to
   # accommodate having a different Redis instance for each use case.
-  c.tracing.instrument :redis, service_name: "redis-rpush", describes: { url: ENV.fetch("REDIS_RPUSH_URL", nil) }
-  c.tracing.instrument :redis, service_name: "redis-sessions", describes: { url: ENV.fetch("REDIS_SESSIONS_URL", nil) }
-
+  c.tracing.instrument :redis, service_name: "#{service_name}-redis-rpush",
+                               describes: { url: ENV.fetch("REDIS_RPUSH_URL", nil) }
+  c.tracing.instrument :redis, service_name: "#{service_name}-redis-sessions",
+                               describes: { url: ENV.fetch("REDIS_SESSIONS_URL", nil) }
   # Sidekiq jobs that spin up thousands of other jobs end up consuming a
   # *lot* of memory on instrumentation alone. This env var allows us to
   # enable it only when needed.
   if ENV["DD_ENABLE_REDIS_SIDEKIQ"] == "true"
-    c.tracing.strument :redis, service_name: "redis-sidekiq", describes: { url: ENV.fetch("REDIS_SIDEKIQ_URL", nil) }
+    c.tracing.strument :redis, service_name: "#{service_name}-redis-sidekiq",
+                               describes: { url: ENV.fetch("REDIS_SIDEKIQ_URL", nil) }
   end
-
   # Generic REDIS_URL comes last, allowing it to overwrite any of the
   # above when multiple Redis use cases are backed by the same Redis URL.
-  c.tracing.instrument :redis, service_name: "redis", describes: { url: ENV.fetch("REDIS_URL", nil) }
+  c.tracing.instrument :redis, service_name: "#{service_name}-redis", describes: { url: ENV.fetch("REDIS_URL", nil) }
 end
 
 ForemStatsClient = Datadog::Statsd.new

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -12,8 +12,6 @@ Datadog.configure do |c|
   c.tracing.instrument :http, service_name: "#{service_name}-net_http"
   c.tracing.instrument :faraday, service_name: "#{service_name}-faraday"
 
-  # sidekiq-client
-
   # Multiple Redis integrations to split Redis usage per-instance to
   # accommodate having a different Redis instance for each use case.
   c.tracing.instrument :redis, service_name: "#{service_name}-redis-rpush",

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -9,7 +9,7 @@ Datadog.configure do |c|
   c.tracing.instrument :concurrent_ruby
   c.tracing.instrument :excon, service_name: "#{service_name}-excon"
   c.tracing.instrument :httprb, service_name: "#{service_name}-httprb"
-  c.tracing.instrument :net_http, service_name: "#{service_name}-net_http"
+  c.tracing.instrument :http, service_name: "#{service_name}-net_http"
   c.tracing.instrument :faraday, service_name: "#{service_name}-faraday"
 
   # sidekiq-client


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Telemetry

## Description
- Disable Datadog's auto_instrument because we don't need all the APM it provides us.
- Add back the old instrumentation we use in the new Datadog syntax.
- Give them all proper `service_name` so we can distinguish them.
## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a