### PR TITLE
Validate date format and min/max in date range picker component

### DIFF
--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -318,6 +318,12 @@ textarea.crayons-textfield.crayons-textfield--ghost {
     }
   }
 
+  &--error {
+    .DateRangePickerInput {
+      border-color: var(--accent-danger);
+    }
+  }
+
   .DateRangePicker:focus-within {
     .DateRangePickerInput {
       border-color: var(--focus);
@@ -429,5 +435,9 @@ textarea.crayons-textfield.crayons-textfield--ghost {
         cursor: not-allowed;
       }
     }
+  }
+
+  &__errors {
+    color: var(--accent-danger);
   }
 }

--- a/app/javascript/crayons/formElements/DateRangePicker/DateRangePicker.jsx
+++ b/app/javascript/crayons/formElements/DateRangePicker/DateRangePicker.jsx
@@ -236,7 +236,7 @@ export const DateRangePicker = ({
       if (valueMoment.isAfter(latestMoment)) {
         setError(
           PICKER_PHRASES.dateTooLate(
-            earliestMoment.format(dateFormat),
+            latestMoment.format(dateFormat),
             errorPrefix,
           ),
           inputId,

--- a/app/javascript/crayons/formElements/DateRangePicker/__tests__/DateRangePicker.test.jsx
+++ b/app/javascript/crayons/formElements/DateRangePicker/__tests__/DateRangePicker.test.jsx
@@ -148,6 +148,133 @@ describe('<DateRangePicker />', () => {
     expect(endDate.getFullYear()).toEqual(2022);
   });
 
+  it('displays errors on blur if an invalid date is typed', async () => {
+    const { getByRole } = render(
+      <DateRangePicker
+        startDateId="start-date"
+        endDateId="end-date"
+        todaysDate={todayMock}
+        minStartDate={new Date('2022-01-01')}
+        maxEndDate={new Date('2022-01-31')}
+      />,
+    );
+
+    const startDateInput = getByRole('textbox', {
+      name: 'Start date (MM/DD/YYYY)',
+    });
+
+    const endDateInput = getByRole('textbox', {
+      name: 'End date (MM/DD/YYYY)',
+    });
+
+    userEvent.type(startDateInput, 'something');
+    await waitFor(() => expect(startDateInput).toHaveDisplayValue('something'));
+    // Move away from the input to trigger the blur event
+    userEvent.tab();
+
+    await waitFor(() =>
+      expect(startDateInput).toHaveAccessibleDescription(
+        'Start date must be in the format MM/DD/YYYY',
+      ),
+    );
+
+    userEvent.type(endDateInput, '12345');
+    await waitFor(() => expect(endDateInput).toHaveDisplayValue('12345'));
+    userEvent.tab();
+
+    await waitFor(() =>
+      expect(endDateInput).toHaveAccessibleDescription(
+        'End date must be in the format MM/DD/YYYY',
+      ),
+    );
+  });
+
+  it('displays errors on blur if date is before minimum date', async () => {
+    const { getByRole } = render(
+      <DateRangePicker
+        startDateId="start-date"
+        endDateId="end-date"
+        todaysDate={todayMock}
+        minStartDate={new Date('2022-01-01')}
+        maxEndDate={new Date('2022-01-31')}
+      />,
+    );
+
+    const startDateInput = getByRole('textbox', {
+      name: 'Start date (MM/DD/YYYY)',
+    });
+
+    const endDateInput = getByRole('textbox', {
+      name: 'End date (MM/DD/YYYY)',
+    });
+
+    userEvent.type(startDateInput, '01/22/2020');
+    await waitFor(() =>
+      expect(startDateInput).toHaveDisplayValue('01/22/2020'),
+    );
+    // Move away from the input to trigger the blur event
+    userEvent.tab();
+
+    await waitFor(() =>
+      expect(startDateInput).toHaveAccessibleDescription(
+        'Start date must be on or after 01/01/2022',
+      ),
+    );
+
+    userEvent.type(endDateInput, '01/22/2020');
+    await waitFor(() => expect(endDateInput).toHaveDisplayValue('01/22/2020'));
+    userEvent.tab();
+
+    await waitFor(() =>
+      expect(endDateInput).toHaveAccessibleDescription(
+        'End date must be on or after 01/01/2022',
+      ),
+    );
+  });
+
+  it('displays errors on blur if date is after maximum date', async () => {
+    const { getByRole } = render(
+      <DateRangePicker
+        startDateId="start-date"
+        endDateId="end-date"
+        todaysDate={todayMock}
+        minStartDate={new Date('2022-01-01')}
+        maxEndDate={new Date('2022-01-31')}
+      />,
+    );
+
+    const startDateInput = getByRole('textbox', {
+      name: 'Start date (MM/DD/YYYY)',
+    });
+
+    const endDateInput = getByRole('textbox', {
+      name: 'End date (MM/DD/YYYY)',
+    });
+
+    userEvent.type(startDateInput, '05/22/2022');
+    await waitFor(() =>
+      expect(startDateInput).toHaveDisplayValue('05/22/2022'),
+    );
+    // Move away from the input to trigger the blur event
+    userEvent.tab();
+
+    await waitFor(() =>
+      expect(startDateInput).toHaveAccessibleDescription(
+        'Start date must be on or before 01/31/2022',
+      ),
+    );
+
+    userEvent.type(endDateInput, '05/22/2022');
+    await waitFor(() => expect(endDateInput).toHaveDisplayValue('05/22/2022'));
+    userEvent.tab();
+
+    await waitFor(() =>
+      expect(endDateInput).toHaveAccessibleDescription(
+        'End date must be on or before 01/31/2022',
+      ),
+    );
+  });
+
   it('skips to a selected year', async () => {
     const { getByRole, getAllByRole } = render(
       <DateRangePicker


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The date picker from `react-dates` allows us to pass an 'earliest' and 'latest' valid date to limit user selections, and it blocks these dates from the calendar picker. However, it doesn't execute any validation on dates typed directly into the inputs. 

This PR adds that validation behaviour into our wrapping DateRangePicker class.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes https://github.com/forem/forem/issues/17959

## QA Instructions, Screenshots, Recordings

- Locally run `yarn install && yarn storybook` and navigate to the DateRangePicker story
- Use the storybook controls to configure max and min dates
- Experiment with typing values into the inputs directly (rather than using the calendar popup) 
- Check that when you move away from the input, an error is shown if the date is invalid (either for being too early, too late, or just by not being a date at all)
- Check for both start and end dates



### UI accessibility concerns?

- The error messages are linked to their inputs with `aria-describedby`
- The error messages are wrapped in `aria-live="assertive"` to immediately announce errors to screen reader users as they appear on the screen

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: change to design system component only, not currently used in the app



