### PR TITLE
Truncation long text on profile screen

### DIFF
--- a/app/assets/stylesheets/views/profile.scss
+++ b/app/assets/stylesheets/views/profile.scss
@@ -73,6 +73,14 @@
       flex-wrap: nowrap;
       white-space: nowrap;
       padding: var(--su-2) var(--su-2);
+      max-width: 100%;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      
+      & > span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
 
       @media (min-width: $breakpoint-m) {
         padding: var(--su-1) var(--su-3);

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -37,13 +37,17 @@
           <% if @organization.location.present? %>
             <span class="profile-header__meta__item">
               <%= crayons_icon_tag(:location, class: "mr-2 shrink-0", title: t("views.organizations.location.icon")) %>
-              <%= sanitize @organization.location %>
+              <span>
+                <%= sanitize @organization.location %>
+              </span>
             </span>
           <% end %>
 
           <span class="profile-header__meta__item">
             <%= crayons_icon_tag(:cake, class: "mr-2 shrink-0", title: t("views.organizations.joined.icon")) %>
-            <%= t("views.organizations.joined.text_html", date: local_date(@user.created_at)) %>
+            <span>
+              <%= t("views.organizations.joined.text_html", date: local_date(@user.created_at)) %>
+            </span>
           </span>
 
           <span class="profile-header__meta__item -ml-1">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -65,26 +65,34 @@
             <% if @user.profile.location.present? %>
               <span class="profile-header__meta__item">
                 <%= crayons_icon_tag(:location, class: "mr-2 shrink-0", title: t("views.users.location_icon")) %>
-                <%= @user.profile.location %>
+                <span>
+                  <%= @user.profile.location %>
+                <span>
               </span>
             <% end %>
 
             <span class="profile-header__meta__item">
               <%= crayons_icon_tag(:cake, class: "mr-2 shrink-0", title: t("views.users.joined.icon")) %>
-              <%= t("views.users.joined.text_html", date: local_date(@user.created_at)) %>
+              <span>
+                <%= t("views.users.joined.text_html", date: local_date(@user.created_at)) %>
+              </span>
             </span>
 
             <% if @user.setting.display_email_on_profile %>
               <a href="mailto:<%= @user.email %>" class="profile-header__meta__item">
                 <%= crayons_icon_tag(:email, class: "mr-2 shrink-0", title: t("views.users.email_icon")) %>
-                <%= @user.email %>
+                <span>
+                  <%= @user.email %>
+                </span>
               </a>
             <% end %>
 
             <% if @user.profile.website_url.present? %>
               <a href="<%= @user.profile.website_url %>" target="_blank" rel="noopener me <%= "ugc" unless @user.trusted? %>" class="profile-header__meta__item">
                 <%= crayons_icon_tag("external-link", class: "mr-2 shrink-0", title: t("views.users.website")) %>
-                <%= @user.profile.website_url %>
+                <span>
+                  <%= @user.profile.website_url %>
+                </span>
               </a>
             <% end %>
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When a string becomes too long for the screen truncate it with ellipse rather than breaking the site

## Related Tickets & Documents
https://dev.to/wjplatformer/whats-wrong-foremdev-2-e89

## QA Instructions, Screenshots, Recordings
**Before:**
![Before truncation](https://user-images.githubusercontent.com/3534427/177325216-8d8e077b-f63d-417c-8ce4-b6f2bcb7e14a.gif)

**After:**
![after truncation](https://user-images.githubusercontent.com/3534427/177325264-ff701d48-b3df-4022-8ed4-b9ac9f9f7515.gif)

### UI accessibility concerns?
N/A

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: visual change only
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![encanto bruno with bucket on head](https://user-images.githubusercontent.com/3534427/177325522-ab52bd42-8882-4a2d-8cad-b6066509fb5b.gif)


