### PR TITLE
Fixed removing notifications on admin unpublishing

### DIFF
--- a/spec/requests/articles/articles_admin_unpublish_spec.rb
+++ b/spec/requests/articles/articles_admin_unpublish_spec.rb
@@ -20,4 +20,16 @@ RSpec.describe "ArticlesAdminUnpublish", type: :request do
     article.reload
     expect(article.published).to be false
   end
+
+  it "removes the related notifications when unpublishing" do
+    expect(article.published).to be true
+    create(:notification, notifiable: article, action: "Published")
+    expect do
+      patch "/articles/#{article.id}/admin_unpublish", params: {
+        id: article.id,
+        username: user.username,
+        slug: article.slug
+      }
+    end.to change(Notification, :count).by(-1)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Use `Articles::Updater` for unpublishing an article from the "Moderate Post" side panel, so that the related notifications would be deleted in that case.

## Related Tickets & Documents
#15675 #18031

## QA Instructions, Screenshots, Recordings
- find(create) an article that has notifications
- unpublish the article from the "Moderate Post" side panel
- the related notifications should be deleted

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
