### PR TITLE
Fix style injection with user mentions

### DIFF
--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -226,7 +226,7 @@ module Html
 
         # only focus on portion of text with "@"
         node.xpath("text()[contains(.,'@')]").each do |el|
-          el.replace(el.text.gsub(/\B@[a-z0-9_-]+/i) { |text| user_link_if_exists(text) })
+          el.replace(el.to_s.gsub(/\B@[a-z0-9_-]+/i) { |text| user_link_if_exists(text) })
         end
 
         # enqueue children that has @ in it's text

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -272,6 +272,30 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
   end
 
   context "when provided with an @username" do
+    context "when html has injected styles" do
+      before do
+        create :user, username: "User1"
+      end
+
+      let(:suspicious) do
+        <<~HTML.strip
+          <style>x{animation:s}@User1 s{}
+          <style>{transition:color 1s}:hover{color:red}
+        HTML
+      end
+
+      it "strips the styles as expected" do
+        linked_user = %(<a class=\"mentioned-user\" href=\"http://localhost:3000/user1\">@user1</a>)
+        expected_result = <<~HTML.strip
+          <p>x{animation:s}#{linked_user} s{}&lt;br&gt;
+          &lt;style&gt;{transition:color 1s}:hover{color:red}&lt;/p&gt;
+          </p>
+        HTML
+        parsed = generate_and_parse_markdown(suspicious)
+        expect(parsed.strip).to eq(expected_result)
+      end
+    end
+
     it "links to a user if user exist" do
       username = create(:user).username
       with_user = "@#{username}"


### PR DESCRIPTION
See https://github.com/forem/forem-internal-eng/issues/480

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We seem to be emitting tags we don't want to be, creating the potential for cross-site scripting. Our sanitizer escapes `<` and `>` into `&lt;` and `&gt;`, but later Nokogiri/libxml inflates those "HTML entities" into their respective ASCII characters, which we then emit. @aitchiss and @maestromac traced this to the `wrap_mentions_with_links` block. It turns out that Nokogiri has two _very_ similar methods -- `text` and `to_s` -- that differ with respect to entities.

## Related Tickets & Documents

Reported in https://github.com/forem/forem-internal-eng/issues/480

## QA Instructions, Screenshots, Recordings

This text snippet is enough to trigger the behavior:

```
<style>x{animation:s}@Keyframes s{}
<style>{transition:color 1s}:hover{color:red}
```

## Added/updated tests?

- [x] Yes -- added a test covering the vulnerability
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

Nope

## [optional] What gif best describes this PR or how it makes you feel?

![trenches](https://user-images.githubusercontent.com/2077/177749832-12726ad4-f7c8-4a8f-ad5e-8042fb52c629.gif)

