### PR TITLE
Add exclude rule to rubocop's Style/TopLevelMethodDefinition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -676,6 +676,7 @@ Style/TopLevelMethodDefinition:
   Exclude:
     - scripts/release
     - scripts/stage_release
+    - spec
 
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in argument lists.'


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

Rubocop started complaining about `require "rails_helper"` at the top of files in specs. I'm not sure if this was introduced in a recent rubocop update, but it feels that way because we've had these for a long time. 

<img width="1126" alt="Screen Shot 2022-07-08 at 10 46 38" src="https://user-images.githubusercontent.com/6045239/178035456-59a33249-876f-4405-bece-8357a831188a.png">

This PR adds an `exclude` rule on the `spec` directory. The alternative would be to always require `rails_helper`, for all specs (during initial load of rspec).

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Run rubocop on spec files

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] No, and this is why: Rubocop update

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Rubocop fix

## [optional] What gif best describes this PR or how it makes you feel?

![simspons cops: we'd better lay low](https://media.giphy.com/media/3o6MbjbnedjFgKbcze/giphy.gif)

