### PR TITLE
Enable framework 7's cache_format_version

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -39,7 +39,7 @@ Rails.application.config.active_support.remove_deprecated_time_with_zone_name = 
 # will have a different format that is not supported by Rails 6.1 applications.
 # Only change this value after your application is fully deployed to Rails 7.0
 # and you have no plans to rollback.
-# Rails.application.config.active_support.cache_format_version = 7.0
+Rails.application.config.active_support.cache_format_version = 7.0
 
 # Calls `Rails.application.executor.wrap` around test cases.
 # This makes test cases behave closer to an actual request or job.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Chore

## Description
Use the new cache format version that is supposed to be faster.
 
## Related Tickets & Documents
https://github.com/forem/forem-internal-eng/issues/468
## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a