### PR TITLE
Fix Honeybadger typo in Rpush reflection callback

### DIFF
--- a/config/initializers/rpush.rb
+++ b/config/initializers/rpush.rb
@@ -73,7 +73,7 @@ Rpush.reflect do |on|
       Device.ios.where(token: notification.device_token).destroy_all
     end
 
-    HoneyBadger.notify(error_message:
+    Honeybadger.notify(error_message:
       "error_description: #{notification.error_description}, error_code: #{notification.error_code}")
 
     ForemStatsClient.increment(


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Fixes a typo 🤦🏼‍♂️ in Rpush reflection callback. This caused us to never be notified when PN deliveries failed. Noticed this by running the Rpush delivery directly on the console in a production environment (BHC) with `Rpush.push`.

```
E, [2022-07-11T18:05:33.570078 #4] ERROR -- : [2022-07-11 18:05:33][ERROR] NameError, uninitialized constant HoneyBadger
Did you mean?  Honeybadger
/app/config/initializers/rpush.rb:76:in `block (2 levels) in <main>'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/reflection_collection.rb:33:in `__dispatch'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/reflectable.rb:6:in `block in reflect'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/reflectable.rb:4:in `each'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/reflectable.rb:4:in `reflect'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:130:in `block (2 levels) in complete_failed'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:129:in `each'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:129:in `block in complete_failed'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:127:in `each'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:127:in `complete_failed'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:109:in `block in complete'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:107:in `each'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:107:in `complete'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:98:in `block in all_processed'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:96:in `synchronize'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/batch.rb:96:in `all_processed'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/apns2/delivery.rb:36:in `perform'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/dispatcher/apns_http2.rb:24:in `dispatch'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/dispatcher_loop.rb:66:in `dispatch'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/dispatcher_loop.rb:35:in `block (2 levels) in start'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/dispatcher_loop.rb:25:in `loop'
/app/vendor/bundle/ruby/3.0.0/gems/rpush-7.0.1/lib/rpush/daemon/dispatcher_loop.rb:25:in `block in start'
```

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

Got this working again on BHC. We still need to update the certificates on DEV + other instances, but this fix will help us monitor errors.

![IMG_1981](https://user-images.githubusercontent.com/6045239/178330294-6ae46235-f436-42f6-abe4-2c076d154d38.jpg)

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] No, and this is why: Testing the Rpush reflection callbacks is tricky and our test coverage tests when the delivery is successful

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Bug fix

## [optional] Are there any post deployment tasks we need to perform?

Follow up with internal team to ensure PNs are being delivered correctly

## [optional] What gif best describes this PR or how it makes you feel?

![proofread fail](https://media.giphy.com/media/FaMmrCXe5zx2QZfkh6/giphy.gif)

