### PR TITLE
Remove filter by last activity, fix close modal bug

### DIFF
--- a/app/javascript/packs/admin/users/filtersModal.js
+++ b/app/javascript/packs/admin/users/filtersModal.js
@@ -105,7 +105,7 @@ const clearAllCheckboxesInFieldset = (fieldset) => {
 const initializeModalCloseButton = () =>
   document
     .querySelector(`#${WINDOW_MODAL_ID} .js-filter-modal-cancel-btn`)
-    .addEventListener('click', closeWindowModal);
+    .addEventListener('click', () => closeWindowModal());
 
 /**
  * Roles list is dynamically expanded and collapsed by this toggle button

--- a/app/views/admin/users/index/_filters_modal.html.erb
+++ b/app/views/admin/users/index/_filters_modal.html.erb
@@ -45,10 +45,6 @@
                 <summary class="py-4 flex justify-between text-uppercase color-base-60 fs-s">Joining date<%= crayons_icon_tag("chevron-down", aria_hidden: true, class: "summary-icon") %></summary>
                 Joining date options
             </details>
-            <details data-section="last-activity" class="admin-details">
-                <summary class="py-4 flex justify-between text-uppercase color-base-60 fs-s">Last activity<%= crayons_icon_tag("chevron-down", aria_hidden: true, class: "summary-icon") %></summary>
-                Last activity options
-            </details>
             <details data-section="organizations" class="admin-details">
                 <summary class="py-4 flex justify-between text-uppercase color-base-60 fs-s">
                     <span class="flex">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We're no longer going to implement "filter by last activity" as part of this phase of member index work. This PR removes it from the filter modal UI.

This PR also fixes a small bug I found in the filter modal cancel button, following some changes to the `closeWindowModal` code.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

Relates to https://github.com/forem/forem/issues/17477

## QA Instructions, Screenshots, Recordings

The filters modal should no longer include a "Last activity" section:

![modal without the specified section](https://user-images.githubusercontent.com/20773163/178471719-8f33efdf-b426-4cc8-9c90-49f293bed8fa.png)



### UI accessibility concerns?

N/A

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: just placeholder code
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: not released yet



