### PR TITLE
Add 299 warning messages for V0 api requests when v1 is enabled

### DIFF
--- a/spec/requests/api/v0/api_controller_spec.rb
+++ b/spec/requests/api/v0/api_controller_spec.rb
@@ -1,0 +1,120 @@
+require "rails_helper"
+
+# Subclass of v0::ApiController for testing
+module Api
+  module V0
+    class TestsController < ApiController
+      def index; end
+    end
+  end
+end
+
+RSpec.describe "Api::V0::ApiController", type: :request do
+  let(:path) { "/api/tests" }
+
+  before do
+    # Dynamically add a route to our testing V0::ApiController subclass
+    Rails.application.routes.draw do
+      namespace :api, defaults: { format: "json" } do
+        scope module: :v0 do
+          resources :tests
+        end
+      end
+    end
+  end
+
+  after do
+    # Clean up the route we added!
+    Rails.application.reload_routes!
+  end
+
+  context "when API V1 is enabled" do
+    before do
+      allow(FeatureFlag).to receive(:enabled?).with(:api_v1).and_return(true)
+    end
+
+    context "when request header is v0 and does not include an api key" do
+      let(:headers) { { Accept: "application/v0+json" } }
+
+      it "responds with a Warning header with code 299" do
+        get path, headers: headers
+
+        expect(response).to have_http_status(:success)
+        # rubocop:disable Layout/LineLength
+        expect(response.headers["Warning"])
+          .to eq("299 - This endpoint will require the `api-key` header and the `Accept` header to be set to `application/vnd.forem.api-v1+json` in future.")
+        # rubocop:enable Layout/LineLength
+      end
+    end
+
+    context "when request header is v0 and includes an empty api key" do
+      let(:headers) { { Accept: "application/v0+json", "api-key": nil } }
+
+      it "responds with a Warning header with code 299" do
+        get path, headers: headers
+
+        expect(response).to have_http_status(:success)
+        # rubocop:disable Layout/LineLength
+        expect(response.headers["Warning"])
+          .to eq("299 - This endpoint will require the `api-key` header and the `Accept` header to be set to `application/vnd.forem.api-v1+json` in future.")
+        # rubocop:enable Layout/LineLength
+      end
+    end
+
+    context "when request header is v0 and includes an api key" do
+      let(:headers) { { Accept: "application/v0+json", "api-key": "abc123" } }
+
+      it "responds with a Warning header with code 299" do
+        get path, headers: headers
+
+        expect(response).to have_http_status(:success)
+        # rubocop:disable Layout/LineLength
+        expect(response.headers["Warning"])
+          .to eq("299 - This endpoint will require the `api-key` header and the `Accept` header to be set to `application/vnd.forem.api-v1+json` in future.")
+        # rubocop:enable Layout/LineLength
+      end
+    end
+
+    context "when request header is missing" do
+      let(:headers) { {} }
+
+      it "responds with a Success code and no warning header" do
+        get path, headers: headers
+
+        expect(response).to have_http_status(:success)
+        # rubocop:disable Layout/LineLength
+        expect(response.headers["Warning"])
+          .to eq("299 - This endpoint will require the `api-key` header and the `Accept` header to be set to `application/vnd.forem.api-v1+json` in future.")
+        # rubocop:enable Layout/LineLength
+      end
+    end
+  end
+
+  context "when API V1 is NOT enabled" do
+    before do
+      allow(FeatureFlag).to receive(:enabled?).with(:api_v1).and_return(false)
+    end
+
+    context "when request header is v0" do
+      let(:headers) { { Accept: "application/v0+json" } }
+
+      it "responds with a Success code and no warning header" do
+        get path, headers: headers
+
+        expect(response).to have_http_status(:success)
+        expect(response.headers["Warning"]).to be_nil
+      end
+    end
+
+    context "when request header is missing" do
+      let(:headers) { {} }
+
+      it "responds with a Success code and no warning header" do
+        get path, headers: headers
+
+        expect(response).to have_http_status(:success)
+        expect(response.headers["Warning"]).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a 299 Warning message to the response header when a user access an V0 API endpoint and the V1 API is enabled. This is our way of communicating that these API V0 endpoints are deprecated and will be going away at some point in the future. This method is based on https://datatracker.ietf.org/doc/html/rfc7234#section-5.5

## Related Tickets & Documents

- Closes https://github.com/forem/forem/issues/17830

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [x] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post **(once v1 is released publically**)
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] What gif best describes this PR or how it makes you feel?

![Closing](https://media.giphy.com/media/l3q2Kgm3KOBUE6wF2/giphy-downsized-large.gif)

