### PR TITLE
Improve DateRangePickerSpec that was flaking in CI

### DIFF
--- a/app/javascript/crayons/formElements/DateRangePicker/__tests__/DateRangePicker.test.jsx
+++ b/app/javascript/crayons/formElements/DateRangePicker/__tests__/DateRangePicker.test.jsx
@@ -275,10 +275,8 @@ describe('<DateRangePicker />', () => {
     );
   });
 
-  // TODO: Flaking in CI
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('skips to a selected year', async () => {
-    const { getByRole, getAllByRole } = render(
+  it('skips to a selected year', async () => {
+    const { getByRole, queryByRole, getAllByRole } = render(
       <DateRangePicker
         startDateId="start-date"
         endDateId="end-date"
@@ -288,16 +286,23 @@ describe('<DateRangePicker />', () => {
       />,
     );
 
+    expect(
+      queryByRole('button', {
+        name: 'Choose Monday, January 25, 2021 as start date',
+      }),
+    ).not.toBeInTheDocument();
+
     // react-dates renders a hidden (by CSS) month/year picker for off screen previous and next month views
-    // testing library doesn't load the CSS, so we have to "skip over" the first matching select to get the correct visible one
+    // testing library doesn't load the CSS, so we need to skip the first "hidden" select
     const startYearPicker = getAllByRole('combobox', {
       name: 'Navigate to year',
     })[1];
-    expect(startYearPicker).toHaveDisplayValue('2022');
     userEvent.selectOptions(
       startYearPicker,
       within(startYearPicker).getByRole('option', { name: '2021' }),
     );
+
+    await waitFor(() => expect(startYearPicker).toHaveDisplayValue('2021'));
 
     await waitFor(() =>
       expect(
@@ -309,7 +314,7 @@ describe('<DateRangePicker />', () => {
   });
 
   it('skips to a selected month', async () => {
-    const { getByRole, getAllByRole } = render(
+    const { queryByRole, getByRole, getByDisplayValue } = render(
       <DateRangePicker
         startDateId="start-date"
         endDateId="end-date"
@@ -319,18 +324,23 @@ describe('<DateRangePicker />', () => {
       />,
     );
 
+    expect(
+      queryByRole('button', {
+        name: 'Choose Wednesday, April 6, 2022 as start date',
+      }),
+    ).not.toBeInTheDocument();
+
     // react-dates renders a hidden (by CSS) month/year picker for off screen previous and next month views
-    // testing library doesn't load the CSS, so we have to "skip over" the first matching select to get the correct visible one
-    const startMonthPicker = getAllByRole('combobox', {
-      name: 'Navigate to month',
-    })[1];
-    expect(startMonthPicker).toHaveDisplayValue('January');
-    userEvent.selectOptions(startMonthPicker, 'February');
+    // testing library doesn't load the CSS, so we grab the correct picker by displayValue rather than role/name
+    const startMonthPicker = getByDisplayValue('January');
+
+    userEvent.selectOptions(startMonthPicker, 'April');
+    await waitFor(() => expect(startMonthPicker).toHaveDisplayValue('April'));
 
     await waitFor(() =>
       expect(
         getByRole('button', {
-          name: 'Choose Wednesday, February 2, 2022 as start date',
+          name: 'Choose Wednesday, April 6, 2022 as start date',
         }),
       ).toBeInTheDocument(),
     );


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I've tested locally and not seeing this flake with these changes, and I've re-run the frontend tests job in CI 5 times with no issue, so I think this is a step in the right direction at least.

Testing this particular part of the date range picker is tricky because `react-dates` renders hidden copies that a component-level test can get confused by.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

N/A

## QA Instructions, Screenshots, Recordings

Just that the test passes 😄 

### UI accessibility concerns?

N/A

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [X] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_



