### PR TITLE
Ensuring home feed uses minimum score threshold

### DIFF
--- a/app/services/articles/feeds/basic.rb
+++ b/app/services/articles/feeds/basic.rb
@@ -12,7 +12,7 @@ module Articles
       def default_home_feed(**_kwargs)
         articles = Article.published
           .order(hotness_score: :desc)
-          .where(score: 0..)
+          .with_at_least_home_feed_minimum_score
           .limit(@number_of_articles)
           .limited_column_select.includes(top_comments: :user)
         return articles unless @user


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Prior to this commit we had a hard-coded 0; there are other hard-coded
score ranges throughout the code-base.  These are unexplained magic
numbers.  The hope with this change is to provide a mechanism for Forem
owners to adjust a configuration and see a change in behavior.

## Related Tickets & Documents

Related to forem/forem-internal-eng#484

## QA Instructions, Screenshots, Recordings

None.

### UI accessibility concerns?

None.

## Added/updated tests?

- [x] No

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

