### PR TITLE
API V1 skip authenticity token validation

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -6,6 +6,8 @@ module Api
 
       self.api_action = true
 
+      skip_before_action :verify_authenticity_token
+
       rescue_from ActionController::ParameterMissing do |exc|
         error_unprocessable_entity(exc.message)
       end

--- a/app/controllers/api/v1/listings_controller.rb
+++ b/app/controllers/api/v1/listings_controller.rb
@@ -8,7 +8,6 @@ module Api
       before_action :authenticate!
       before_action :set_cache_control_headers, only: %i[index show]
       before_action :set_and_authorize_listing, only: %i[update]
-      skip_before_action :verify_authenticity_token, only: %i[create update]
     end
   end
 end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe "Api::V0::Users", type: :request do
           expect(response).to have_http_status(:ok)
           expect(target_user.reload.suspended?).to be true
           expect(Note.last.content).to eq(payload[:note])
-        end.to change(Note, :count).by(1)
+        end.to change(Note, :count).by(2)
       end
     end
   end

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe "Api::V0::Users", type: :request do
           expect(response).to have_http_status(:ok)
           expect(target_user.reload.suspended?).to be true
           expect(Note.last.content).to eq(payload[:note])
-        end.to change(Note, :count).by(2)
+        end.to change(Note, :count).by(1)
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

API requests on V1 don't need authenticity token validation because it only uses API Key authentication.

This validation is required if we're allowing the use of the API from browsers to avoid CSRF attacks, but we are not going to support this anymore.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

Before un-feature flagging (#17655) I've been running some tests and we need this fix

## QA Instructions, Screenshots, Recordings

1. Enable :api_v1 Feature Flag
2. Create an API Key in /settings/extensions
3. Send in a PUT request to `/api/users/:id/unpublish` with the API Key and `application/vnd.forem.api-v1+json` in the Accept header

I've been testing some stuff [using this Postman collection](https://www.getpostman.com/collections/426f4c6a7f6db55affa8), in case it's helpful for anyone.

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] No

## [Forem core team only] How will this change be communicated?

- [x]  This change does not need to be communicated, and this is why not: WIP project that is still behind FeatureFlag

## [optional] Are there any post deployment tasks we need to perform?

Test again on BHC or another forem instance

## [optional] What gif best describes this PR or how it makes you feel?

![huh](https://media.giphy.com/media/xTiQyBOIQe5cgiyUPS/giphy.gif)

