### PR TITLE
Adding conditional spam handling for user profile

### DIFF
--- a/spec/services/spam/handler_spec.rb
+++ b/spec/services/spam/handler_spec.rb
@@ -104,12 +104,24 @@ RSpec.describe Spam::Handler, type: :service do
       allow(Settings::General).to receive(:mascot_user_id).and_return(mascot_user.id)
     end
 
-    context "when using :more_rigorous_user_profile_spam_checking" do
+    context "when using :more_rigorous_user_profile_spam_checking but there's no spam" do
       before do
         allow(FeatureFlag).to receive(:enabled?).with(:more_rigorous_user_profile_spam_checking).and_return(true)
       end
 
       it { is_expected.to eq(:not_spam) }
+    end
+
+    context "when using :more_rigorous_user_profile_spam_checking but there spam in the website_url" do
+      before do
+        user.profile.update(summary: "Please Not This")
+        allow(FeatureFlag).to receive(:enabled?).with(:more_rigorous_user_profile_spam_checking).and_return(true)
+        allow(Settings::RateLimit).to receive(:spam_trigger_terms).and_return(["Please Not This"])
+      end
+
+      it "creates a reaction but does not suspend the user" do
+        expect { handler }.to change { Reaction.where(reactable: user, category: "vomit").count }.by(1)
+      end
     end
 
     context "when non-spammy content" do

--- a/spec/services/spam/handler_spec.rb
+++ b/spec/services/spam/handler_spec.rb
@@ -104,6 +104,14 @@ RSpec.describe Spam::Handler, type: :service do
       allow(Settings::General).to receive(:mascot_user_id).and_return(mascot_user.id)
     end
 
+    context "when using :more_rigorous_user_profile_spam_checking" do
+      before do
+        allow(FeatureFlag).to receive(:enabled?).with(:more_rigorous_user_profile_spam_checking).and_return(true)
+      end
+
+      it { is_expected.to eq(:not_spam) }
+    end
+
     context "when non-spammy content" do
       before do
         allow(Settings::RateLimit).to receive(:trigger_spam_for?).and_return(false)

--- a/spec/services/spam/handler_spec.rb
+++ b/spec/services/spam/handler_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Spam::Handler, type: :service do
       it { is_expected.to eq(:not_spam) }
     end
 
-    context "when using :more_rigorous_user_profile_spam_checking but there spam in the website_url" do
+    context "when using :more_rigorous_user_profile_spam_checking but there spam in the summary" do
       before do
         user.profile.update(summary: "Please Not This")
         allow(FeatureFlag).to receive(:enabled?).with(:more_rigorous_user_profile_spam_checking).and_return(true)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [x] Optimization

## Description

Prior to this commit, we always checked the user's name for spam matching criteria.  With this change, we're allowing a site administrator to toggle on a feature flag for more rigorous profile checking.

The reason for the increased rigor is that there could be unexpected consequences (e.g. marking a user as spam who was previously not caught as a spammer).  If you want the feature, enable the `:more_rigorous_user_profile_spam_checking` flag.

## Related Tickets & Documents

Closes forem/forem#18157
Related to forem/forem-internal-eng#453

## QA Instructions, Screenshots, Recordings

Given that this is running against users whenever the user record saves, there could be unintended consequences (e.g. marking a user as a spammer).  That is why this feature is behind a feature flag.

### UI accessibility concerns?

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

