### PR TITLE
Change "posted on" to "scheduled for" on the scheduled articles preview page

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -124,7 +124,7 @@
                   <% end %>
                   <p class="fs-xs color-base-60">
                     <% if @article.published_timestamp.present? %>
-                      <%= t("views.articles.posted_html", date: local_date(@article.published_timestamp, show_year: @article.displayable_published_at.year != Time.current.year)) %>
+                      <%= t("views.articles.#{@article.current_state}_html", date: local_date(@article.published_timestamp, show_year: @article.displayable_published_at.year != Time.current.year)) %>
                     <% end %>
                     <% if @article.co_author_ids.present? %>
                       <%= t("views.articles.co_authors_html", names: @article.co_author_name_and_path.html_safe) %>

--- a/config/locales/views/articles/en.yml
+++ b/config/locales/views/articles/en.yml
@@ -85,7 +85,8 @@ en:
       edited_html: Updated on %{date}
       for_org_html: "%{start} for %{end}%{org}"
       missing: Article No Longer Available
-      posted_html: Posted on %{date}
+      published_html: Posted on %{date}
+      scheduled_html: Scheduled to %{date}
       read_next: Read next
       reading_time:
         one: "1 min read"

--- a/config/locales/views/articles/en.yml
+++ b/config/locales/views/articles/en.yml
@@ -86,7 +86,7 @@ en:
       for_org_html: "%{start} for %{end}%{org}"
       missing: Article No Longer Available
       published_html: Posted on %{date}
-      scheduled_html: Scheduled to %{date}
+      scheduled_html: Scheduled for %{date}
       read_next: Read next
       reading_time:
         one: "1 min read"

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -57,6 +57,12 @@ RSpec.describe "ArticlesShow", type: :request do
         "dateModified" => article.published_timestamp,
       )
     end
+
+    it "renders 'posted on' information" do
+      get article.path
+      expect(response.body).to include("Posted on")
+      expect(response.body).not_to include("Scheduled to")
+    end
   end
 
   describe "GET /:username/:slug (scheduled)" do
@@ -68,6 +74,12 @@ RSpec.describe "ArticlesShow", type: :request do
       get scheduled_article_path
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(scheduled_article.title)
+    end
+
+    it "renders 'scheduled to' information" do
+      get scheduled_article_path
+      expect(response.body).to include("Scheduled to")
+      expect(response.body).not_to include("Posted on")
     end
 
     it "doesn't show edit link when user is not signed in" do

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "ArticlesShow", type: :request do
     it "renders 'posted on' information" do
       get article.path
       expect(response.body).to include("Posted on")
-      expect(response.body).not_to include("Scheduled to")
+      expect(response.body).not_to include("Scheduled for")
     end
   end
 
@@ -76,9 +76,9 @@ RSpec.describe "ArticlesShow", type: :request do
       expect(response.body).to include(scheduled_article.title)
     end
 
-    it "renders 'scheduled to' information" do
+    it "renders 'scheduled for' information" do
       get scheduled_article_path
-      expect(response.body).to include("Scheduled to")
+      expect(response.body).to include("Scheduled for")
       expect(response.body).not_to include("Posted on")
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix

## Description
Change "posted on" to "scheduled for" on the scheduled articles preview page

## Related Tickets & Documents
- Related Issue #17939 

## QA Instructions, Screenshots, Recordings
- enable the feature flag `FeatureFlag.enable(:schedule_articles)`
- create an article scheduled to the future
- the preview page should include "Scheduled for {published_at}" instead of "Posted on {published_at}"
- for articles, published in the past, the page should include "Posted on {published_at}" (as before the changes)

![изображение](https://user-images.githubusercontent.com/30115/179935391-27f1071d-16a6-46fe-8992-04e43e4e804b.png)

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

