### PR TITLE
Add crayon styles to c-color-picker

### DIFF
--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -275,6 +275,43 @@ textarea.crayons-textfield.crayons-textfield--ghost {
 
   &__popover {
     min-width: min-content;
+    
+    & .react-colorful {
+      padding: var(--su-2);
+      border-radius: var(--radius);
+      background: var(--card-bg);
+      box-shadow: var(--shadow-1);
+      width: 220px;
+      height: 160px;
+      
+      &__pointer {
+        cursor: pointer;
+      }
+
+      &__saturation {
+        margin: 0 0 var(--su-2) 0;
+        border-radius: var(--radius);
+      }
+
+      &__saturation-pointer {
+        width: var(--fs-s);
+        height: var(--fs-s);
+        border: 2px solid var(--card-bg);
+        border-radius: 50%;
+      }
+
+      &__hue {
+        height: var(--fs-xs);
+        border-radius: var(--radius);
+      }
+
+      &__hue-pointer {
+        border: 2px solid var(--card-bg);
+        border-radius: 1px;
+        width: var(--fs-s);
+        height: calc(100% + 8px);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature (maybe?)
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Update the colour picker styles to bring them inline with crayons

## Related Tickets & Documents
closes #18130 

## QA Instructions, Screenshots, Recordings

The colour picker should now look like this

![new colour picker](https://user-images.githubusercontent.com/3534427/179946209-7d586b3a-e7fa-4849-a5a8-3c8c9cb50b44.png)

You can find it in settings under branding

### UI accessibility concerns?
Don't think so

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: not a functionality change
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
N/A

## [optional] What gif best describes this PR or how it makes you feel?

![Fairy magic](https://user-images.githubusercontent.com/3534427/179946443-54e98481-d61e-4ab6-ab2f-2163552c15e8.gif)

