### PR TITLE
Use --radius-auto for top of article images

### DIFF
--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -34,7 +34,7 @@
         width: 100%;
         aspect-ratio: auto 650 / 273;
         object-fit: scale-down;
-        border-radius: var(--radius) var(--radius) 0 0;
+        border-radius: var(--radius-auto) var(--radius) 0 0;
       }
     }
   }


### PR DESCRIPTION
Setting the first variable of border-radius to var(--radius-auto) fixed the issue.

Attempting to set the first and second variables of border-radius to var(--radius-auto) resulted in no border radius ever showing.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Using var(--radius-auto) will remove the radius on the article image when it shouldn't have a radius.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

closes #18197 

## QA Instructions, Screenshots, Recordings

This should only affect mobile renderings of the page.

Old:
![image](https://user-images.githubusercontent.com/13600696/180341223-5a08ed1f-fcb9-4644-a5f8-f9d12954906c.png)

New:
![image](https://user-images.githubusercontent.com/13600696/180341161-d18c1900-343b-4650-aca9-f999079041a4.png)


### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: small CSS issue
- [ ] I need help with writing tests

### Other Notes

I would have preferred to set "overflow: hidden" on the article element itself, to prevent anything from overflowing. But I saw the Dev's fix my previous issue using the radius on the image itself, so I followed their lead to stick with that.