### PR TITLE
Сleared up the message when a comment is hidden 

### DIFF
--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -7,7 +7,9 @@
     <div class="comment__content crayons-card">
       <% if comment.deleted %>
         <div class="p-6 align-center opacity-50 fs-s">
-          <span class="js-comment-username">Comment deleted</span>
+          <span class="js-comment-username">
+            <%= t("views.comments.delete.text_html_comment") %>
+          </span>
         </div>
       <% else %>
         <%= render partial: "comments/comment_quality_marker", locals: {
@@ -35,7 +37,7 @@
 
         <% if should_be_hidden?(comment, @root_comment) %>
           <div class="p-6 align-center opacity-50 fs-s hidden comment-hidden-by-author-text">
-            Comment hidden by author
+            <%= t("views.comments.hidden.text_html_comment") %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -8,7 +8,7 @@
       <% if comment.deleted %>
         <div class="p-6 align-center opacity-50 fs-s">
           <span class="js-comment-username">
-            <%= t("views.comments.delete.text_html_comment") %>
+            <%= t("views.comments.delete.comment_deleted") %>
           </span>
         </div>
       <% else %>
@@ -37,7 +37,7 @@
 
         <% if should_be_hidden?(comment, @root_comment) %>
           <div class="p-6 align-center opacity-50 fs-s hidden comment-hidden-by-author-text">
-            <%= t("views.comments.hidden.text_html_comment") %>
+            <%= t("views.comments.hidden.comment_hidden") %>
           </div>
         <% end %>
       <% end %>

--- a/config/locales/views/comments/en.yml
+++ b/config/locales/views/comments/en.yml
@@ -28,7 +28,7 @@ en:
         submit: Delete
         edit: Edit
         cancel: Dismiss
-        text_html_comment: Comment deleted
+        comment_deleted: Comment deleted
       collapse: Collapse
       edit: Editing comment
       edited:
@@ -38,7 +38,7 @@ en:
       hidden:
         text_html: Some comments have been hidden by the post's author - %{info}
         info: find out more
-        text_html_comment: Comment hidden by post author
+        comment_hidden: Comment hidden by post author
       hider:
         description_html: Are you sure you want to hide this comment? It will become hidden in your post, but will still be visible via the comment's %{permalink}.
         hide_child: Hide child comments as well

--- a/config/locales/views/comments/en.yml
+++ b/config/locales/views/comments/en.yml
@@ -28,6 +28,7 @@ en:
         submit: Delete
         edit: Edit
         cancel: Dismiss
+        text_html_comment: Comment deleted
       collapse: Collapse
       edit: Editing comment
       edited:
@@ -37,6 +38,7 @@ en:
       hidden:
         text_html: Some comments have been hidden by the post's author - %{info}
         info: find out more
+        text_html_comment: Comment hidden by post author
       hider:
         description_html: Are you sure you want to hide this comment? It will become hidden in your post, but will still be visible via the comment's %{permalink}.
         hide_child: Hide child comments as well

--- a/config/locales/views/comments/fr.yml
+++ b/config/locales/views/comments/fr.yml
@@ -28,7 +28,7 @@ fr:
         submit: Delete
         edit: Edit
         cancel: Dismiss
-        text_html_comment: Comment deleted
+        comment_deleted: Comment deleted
       collapse: Collapse
       edit: Editing comment
       edited:
@@ -38,7 +38,7 @@ fr:
       hidden:
         text_html: Some comments have been hidden by the post's author - %{info}
         info: find out more
-        text_html_comment: Comment hidden by post author
+        comment_hidden: Comment hidden by post author
       hider:
         description_html: Are you sure you want to hide this comment? It will become hidden in your post, but will still be visible via the comment's %{permalink}.
         hide_child: Hide child comments as well

--- a/config/locales/views/comments/fr.yml
+++ b/config/locales/views/comments/fr.yml
@@ -28,6 +28,7 @@ fr:
         submit: Delete
         edit: Edit
         cancel: Dismiss
+        text_html_comment: Comment deleted
       collapse: Collapse
       edit: Editing comment
       edited:
@@ -37,6 +38,7 @@ fr:
       hidden:
         text_html: Some comments have been hidden by the post's author - %{info}
         info: find out more
+        text_html_comment: Comment hidden by post author
       hider:
         description_html: Are you sure you want to hide this comment? It will become hidden in your post, but will still be visible via the comment's %{permalink}.
         hide_child: Hide child comments as well


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- Сleared up the message when a comment is hidden 
- Adds i18n for "_comment_proper.html.erb" file

## Related Tickets & Documents

- Related Issue #14888
- Closes #17832

## QA Instructions, Screenshots, Recordings

### Before 
![alt text](https://user-images.githubusercontent.com/45401242/172206747-e09eefc4-2c8b-4dae-9aad-cb455ac0e1a9.png)

### After
![Screenshot from 2022-07-21 15-34-25](https://user-images.githubusercontent.com/82709517/180430735-2b8f8d70-e0fd-4c6d-8ac5-fcf5c61a9a36.png)

### UI accessibility concerns?

Change is consistent with the interface.
![Screenshot from 2022-07-21 15-36-46](https://user-images.githubusercontent.com/82709517/180431033-a2055796-e6e5-4e28-ac6e-ae23f40c3f6e.png)


## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: There is no change in logic.
- [ ] I need help with writing tests
