### PR TITLE
Try for inline T&C links on small screens

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -644,6 +644,10 @@ $onboarding-user-selected-hover: rgba(71, 85, 235, 0.2);
         align-items: center;
       }
 
+      @media screen and (max-width: $breakpoint-xs) {
+        display: inline;
+      }
+
       &:hover {
         background: var(--body-bg);
         cursor: pointer;

--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -637,16 +637,10 @@ $onboarding-user-selected-hover: rgba(71, 85, 235, 0.2);
       border-radius: var(--radius);
       display: flex;
       flex-direction: row;
+      flex-wrap: wrap;
+      align-items: center;
       padding: 0 var(--su-1);
       width: 100%;
-
-      @media screen and (min-width: $breakpoint-s) {
-        align-items: center;
-      }
-
-      @media screen and (max-width: $breakpoint-xs) {
-        display: inline;
-      }
 
       &:hover {
         background: var(--body-bg);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

On small screens (below our xs breakpoint), links to terms & conditions on the onboarding screen break in a visually odd way:

<img width="551" alt="179087472-eaf51440-e9f8-48da-8d3f-8ad8495ad34d" src="https://user-images.githubusercontent.com/2077/180451106-336ca2b7-cb96-418e-872b-f6d03079a37f.png">

It seems that at a small enough screen dimension, the `label` container becomes a two-column layout, with links and text in separate columns. This feels like a bug in the grid layout -- it doesn't seem to be something we've _asked for_ -- but I might be missing something?

Anyway, after:

<img width="412" alt="Screen Shot 2022-07-22 at 15 35 56" src="https://user-images.githubusercontent.com/2077/180452269-a02e6d56-e572-4962-958f-a6be9b221966.png">



## Related Tickets & Documents

- Closes https://github.com/forem/forem-internal-eng/issues/487

## QA Instructions, Screenshots, Recordings

To replicate the issue on a desktop browser, I needed to use device emulation mode -- otherwise, the browser's minimum width was wider than the width at which the bug would occur. Depending on browsers, odd wrapping happens somewhere around 400±25px wide.

### UI accessibility concerns?

The links were functional all along, just wrapping in an odd way. 

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: surface-level visual change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: surface-level visual change

## [optional] Are there any post deployment tasks we need to perform?

Nope, just a visual tweak.

## [optional] What gif best describes this PR or how it makes you feel?

![giphy](https://user-images.githubusercontent.com/2077/180452127-b843cbbe-ece2-4ae6-a18c-5184571f6b46.gif)


