### PR TITLE
Add missing action of comment deletion in unpublish API endpoint

### DIFF
--- a/app/controllers/concerns/api/users_controller.rb
+++ b/app/controllers/concerns/api/users_controller.rb
@@ -43,7 +43,11 @@ module Api
 
     def unpublish
       authorize(@user, :unpublish_all_articles?)
-      Moderator::UnpublishAllArticlesWorker.perform_async(params[:id].to_i)
+
+      target_user = User.find(params[:id].to_i)
+      Moderator::UnpublishAllArticlesWorker.perform_async(target_user.id)
+      target_user.comments.update_all(deleted: true)
+
       render head: :ok
     end
   end

--- a/app/controllers/concerns/api/users_controller.rb
+++ b/app/controllers/concerns/api/users_controller.rb
@@ -49,19 +49,21 @@ module Api
       authorize(@user, :unpublish_all_articles?)
 
       target_user = User.find(params[:id].to_i)
-      target_articles = Article.published.where(user_id: target_user.id)
-      Moderator::UnpublishAllArticlesWorker.perform_async(target_user.id)
-
       target_comments = target_user.comments.where(deleted: false)
-      # Keep track of the ids that will be affected for the AuditLog later
-      target_comment_ids = target_comments.ids
+
+      # Keep track of affected ids for AuditLog trail
+      article_ids = Article.published.where(user_id: target_user.id).ids
+      comment_ids = target_comments.ids
+
+      # Unpublish posts and delete comments w/ boolean attr to allow revert
+      Moderator::UnpublishAllArticlesWorker.perform_async(target_user.id)
       target_comments.update(deleted: true)
 
       payload = {
         action: "api_user_unpublish",
         target_user_id: target_user.id,
-        target_article_ids: target_articles.ids,
-        target_comment_ids: target_comment_ids
+        target_article_ids: article_ids,
+        target_comment_ids: comment_ids
       }
       Audit::Logger.log(:admin_api, @user, payload)
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Fixes the `/api/users/:id/unpublish` endpoint. When implemented I missed taking in consideration the deletion of comments along with the unpublishing of posts.

The reasoning of using the `deleted` boolean on the comments instead of completely destroying them is so they can be re-created if needed (`AuditLog` trail implemented in #18167). In contrast, the core app logic is that comments are completely destroyed [if they are childless](https://github.com/forem/forem/blob/main/app/controllers/comments_controller.rb#L175-L180).

## Related Tickets & Documents

- Related Issue #18058

## QA Instructions, Screenshots, Recordings

1. Enable :api_v1 Feature Flag
2. Create an API Key in /settings/extensions
3. Send in a PUT request to /api/users/:id/unpublish with the API Key and `application/vnd.forem.api-v1+json` in the `Accept` header

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] What gif best describes this PR or how it makes you feel?

![whoopsies](https://media.giphy.com/media/3ohzdYJK1wAdPWVk88/giphy.gif)

