### PR TITLE
Command update for gp cli in gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,13 +15,13 @@ tasks:
   - name: Forem Server
     before: >
       redis-server &
-      gp await-port 5432 &&
+      gp ports await 5432 &&
       sleep 1
     init: ./gitpod-init.sh
     command: bin/startup
   - name: Open Site
     command: >
-      gp await-port 3000 &&
+      gp ports await 3000 &&
       printf "Waiting for local Forem development environment to load in the browser..." &&
       gp preview $(gp url 3000)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

Replaces `gp await-port` with `gp ports await` in `.gitpod.yml`.

This will remove the following deprecation warnings:
```
Command "await-port" is deprecated, please use `ports await` instead.
```

## Related Tickets & Documents

n/a

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility concerns?

n/a

## Added/updated tests?

- [x] No, and this is why: it looks hard to test a Gitpod environment.

Signed-off-by: Takuya Noguchi [takninnovationresearch@gmail.com](https://github.com/sponsors/tnir)
