### PR TITLE
Member index view: add clear all functionality to filters modal

### DIFF
--- a/app/javascript/packs/admin/users/filtersModal.js
+++ b/app/javascript/packs/admin/users/filtersModal.js
@@ -98,13 +98,34 @@ const initializeFilterDetailsToggles = () => {
 
 /**
  * Each filter section has a "Clear filter" button, visible only if one of its values is currently selected.
- * Here we initialize the show/hide behaviour, as well as the "clear" behaviour.
+ * There is also a "Clear all filters" button.
+ * We use a single listener on the modal to handle all clear button clicks.
  */
 const initializeFilterClearButtons = () => {
-  // Handle clicks on clear filter buttons with a single listener on the modal
   document
     .getElementById(WINDOW_MODAL_ID)
     .addEventListener('click', ({ target }) => {
+      if (target.classList.contains('js-clear-all-filters-btn')) {
+        // Execute the related "clear" action for all checkbox groups
+        document
+          .querySelectorAll(`#${WINDOW_MODAL_ID} .js-clear-filter-btn`)
+          .forEach((button) => {
+            const {
+              dataset: { checkboxFieldsetSelector },
+            } = button;
+
+            clearAllCheckboxesInFieldset(
+              document.querySelector(
+                `#${WINDOW_MODAL_ID} ${checkboxFieldsetSelector}`,
+              ),
+            );
+          });
+
+        // Clear the date range picker
+        document.querySelector(`#${WINDOW_MODAL_ID} #joining_start`).value = '';
+        document.querySelector(`#${WINDOW_MODAL_ID} #joining_end`).value = '';
+      }
+
       if (!target.classList.contains('js-clear-filter-btn')) {
         return;
       }
@@ -122,8 +143,7 @@ const initializeFilterClearButtons = () => {
       }
     });
 
-  // Set up change listeners on each form group so we can toggle the button/status indicator visibility
-  // TODO: The current setup assumes checkbox groups, but as we develop this modal we will need to consider the date picker ranges too
+  // Set up change listeners on each checkbox group so we can toggle the button/status indicator visibility
   document.querySelectorAll('.js-clear-filter-btn').forEach((button) => {
     const { checkboxFieldsetSelector, filterIndicatorSelector } =
       button.dataset;

--- a/app/views/admin/users/index/_filters_modal.html.erb
+++ b/app/views/admin/users/index/_filters_modal.html.erb
@@ -2,7 +2,7 @@
     <%= form_with url: admin_users_path, method: :get, local: true, class: "flex flex-col h-100" do |f| %>
         <div class="flex justify-between items-center border-0 border-b-1 border-base-10 border-solid -mx-7 px-7 pb-2">
             <h2 class="crayons-subtitle-2">Filters</h2>
-            <button type="button" class="c-btn">Clear filters</button>
+            <button type="button" class="js-clear-all-filters-btn c-btn">Clear filters</button>
         </div>
         <p id="filters-description" class="mt-4 crayons-field__description">Members who match any of the selected filters will be displayed</p>
         <div class="py-4">

--- a/cypress/e2e/seededFlows/adminFlows/users/filterUserIndex.spec.js
+++ b/cypress/e2e/seededFlows/adminFlows/users/filterUserIndex.spec.js
@@ -72,6 +72,42 @@ describe('Filter user index', () => {
     );
   });
 
+  it('Clears all filters', () => {
+    openFiltersModal();
+    cy.getModal().within(() => {
+      cy.findAllByText('Joining date').first().click();
+      cy.findByRole('textbox', { name: /Joined after/ })
+        .as('joinStart')
+        .type('01/01/2020');
+      cy.findByRole('textbox', { name: /Joined before/ })
+        .as('joinEnd')
+        .type('01/01/2020');
+
+      cy.findAllByText('Member roles').first().click();
+      cy.findByRole('group', { name: 'Member roles' }).should('be.visible');
+      cy.findByRole('checkbox', { name: 'Super Admin' }).as('role').check();
+
+      cy.findAllByText('Status').first().click();
+      cy.findByRole('group', { name: 'Status' }).should('be.visible');
+      cy.findByRole('checkbox', { name: 'Trusted' }).as('status').check();
+
+      cy.findAllByText('Organizations').first().click();
+      cy.findByRole('group', { name: 'Organizations' }).should('be.visible');
+      cy.findByRole('checkbox', { name: 'Bachmanity' })
+        .as('organization')
+        .check();
+
+      cy.findByRole('button', { name: 'Clear filters' }).click();
+
+      // Check the selected filters are no longer applied
+      cy.get('@joinStart').should('have.value', '');
+      cy.get('@joinEnd').should('have.value', '');
+      cy.get('@role').should('not.be.checked');
+      cy.get('@status').should('not.be.checked');
+      cy.get('@organization').should('not.be.checked');
+    });
+  });
+
   describe('Member roles', () => {
     it('Expands and collapses list of roles', () => {
       openFiltersModal();


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR adds the "Clear filters" functionality to the new filters modal - when clicked, it clears all current checkbox selections and date picker values.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/17477

## QA Instructions, Screenshots, Recordings

- Make sure you have the `member_index_view` feature flag enabled
- Visit `/admin/member_manager/users`
- Click the filter button
- Inside the modal, select some checkboxes and set some dates in the joining date section
- Click the "Clear filters" button at the top right
- Check all values have cleared 


https://user-images.githubusercontent.com/20773163/180730940-ce3e4e6e-c06b-493f-9307-405cb89b4016.mp4


### UI accessibility concerns?

I don't think so. There's not any immediate feedback on the button press, but the intention of the button (I think) is pretty clear, and a user can validate the fields have been successfully cleared by inspecting them. So I think on balance this is OK.

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: it will be released and communicated with the rest of the member index view project



