### PR TITLE
Dynamically change number of formatter buttons in md toolbar overflow menu

### DIFF
--- a/app/assets/stylesheets/views/article-form.scss
+++ b/app/assets/stylesheets/views/article-form.scss
@@ -158,31 +158,25 @@
     top: 0;
     background: var(--base-0);
     padding: var(--su-2) var(--content-padding-x);
-    padding-right: var(--toolbar-padding-right, 0);
-    overflow-x: auto;
+    padding-right: var(--content-padding-x, 0);
     flex-shrink: 0;
     margin: calc(var(--content-padding-y) * -1)
       calc(var(--content-padding-x) * -1) var(--su-6)
       calc(var(--content-padding-x) * -1);
 
     .editor-toolbar {
-      position: relative;
+      overflow-x: auto;
+
+      @media (min-width: $breakpoint-xs) {
+        overflow-x: unset;
+        position: relative;
+      }
     }
 
     > :first-child {
       @media (min-width: $breakpoint-m) {
         margin-left: calc(var(--su-2) * -1);
       }
-    }
-
-    &::-webkit-scrollbar {
-      background: transparent;
-      height: 0;
-    }
-
-    @media (min-width: $breakpoint-m) {
-      --toolbar-padding-right: var(--content-padding-x);
-      overflow: visible;
     }
   }
 

--- a/app/assets/stylesheets/views/comments.scss
+++ b/app/assets/stylesheets/views/comments.scss
@@ -28,14 +28,9 @@
     .editor-toolbar {
       border-top: 1px solid var(--form-border);
       overflow-x: auto;
-
-      &::-webkit-scrollbar {
-        background: transparent;
-        height: 0;
-      }
     }
 
-    @media (min-width: $breakpoint-m) {
+    @media (min-width: $breakpoint-xs) {
       .editor-toolbar {
         overflow-x: unset;
       }

--- a/app/javascript/crayons/MarkdownToolbar/__tests__/MarkdownToolbar.test.jsx
+++ b/app/javascript/crayons/MarkdownToolbar/__tests__/MarkdownToolbar.test.jsx
@@ -3,6 +3,7 @@ import { render, waitFor } from '@testing-library/preact';
 import { axe } from 'jest-axe';
 import '@testing-library/jest-dom';
 import { MarkdownToolbar } from '../MarkdownToolbar';
+import { BREAKPOINTS } from '@components/useMediaQuery';
 
 describe('<MarkdownToolbar />', () => {
   beforeEach(() => {
@@ -30,30 +31,149 @@ describe('<MarkdownToolbar />', () => {
     expect(results).toHaveNoViolations();
   });
 
-  it('should render core syntax formatters in main toolbar', () => {
-    const { getByLabelText } = render(<MarkdownToolbar />);
+  describe('small screen layout', () => {
+    const smallScreenMediaQuery = `(max-width: ${BREAKPOINTS.Medium - 1}px)`;
+    beforeEach(() => {
+      global.window.matchMedia = jest.fn((query) => {
+        return {
+          matches: query === smallScreenMediaQuery,
+          media: query,
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+        };
+      });
+    });
 
-    expect(getByLabelText('Bold')).toBeInTheDocument();
-    expect(getByLabelText('Italic')).toBeInTheDocument();
-    expect(getByLabelText('Ordered list')).toBeInTheDocument();
-    expect(getByLabelText('Unordered list')).toBeInTheDocument();
-    expect(getByLabelText('Heading')).toBeInTheDocument();
-    expect(getByLabelText('Quote')).toBeInTheDocument();
-    expect(getByLabelText('Code')).toBeInTheDocument();
-    expect(getByLabelText('Code block')).toBeInTheDocument();
-    expect(getByLabelText('Embed')).toBeInTheDocument();
+    it('should render only 5 formatters in main toolbar', () => {
+      const { getByLabelText, queryByLabelText } = render(<MarkdownToolbar />);
+
+      expect(getByLabelText('Bold')).toBeInTheDocument();
+      expect(getByLabelText('Italic')).toBeInTheDocument();
+      expect(getByLabelText('Ordered list')).toBeInTheDocument();
+      expect(getByLabelText('Unordered list')).toBeInTheDocument();
+      expect(getByLabelText('Link')).toBeInTheDocument();
+
+      expect(queryByLabelText('Heading')).not.toBeInTheDocument();
+      expect(queryByLabelText('Quote')).not.toBeInTheDocument();
+      expect(queryByLabelText('Code')).not.toBeInTheDocument();
+      expect(queryByLabelText('Code block')).not.toBeInTheDocument();
+      expect(queryByLabelText('Embed')).not.toBeInTheDocument();
+      expect(queryByLabelText('Underline')).not.toBeInTheDocument();
+      expect(queryByLabelText('Strikethrough')).not.toBeInTheDocument();
+      expect(queryByLabelText('Line divider')).not.toBeInTheDocument();
+    });
+
+    it('should render remaining formatters in overflow menu', async () => {
+      const { getByLabelText } = render(<MarkdownToolbar />);
+
+      getByLabelText('More options').click();
+
+      await waitFor(() =>
+        expect(getByLabelText('Heading')).toBeInTheDocument(),
+      );
+
+      expect(getByLabelText('Quote')).toBeInTheDocument();
+      expect(getByLabelText('Code')).toBeInTheDocument();
+      expect(getByLabelText('Code block')).toBeInTheDocument();
+      expect(getByLabelText('Embed')).toBeInTheDocument();
+      expect(getByLabelText('Underline')).toBeInTheDocument();
+      expect(getByLabelText('Strikethrough')).toBeInTheDocument();
+      expect(getByLabelText('Line divider')).toBeInTheDocument();
+    });
   });
 
-  it('should render an overflow menu with secondary formatters', async () => {
-    const { getByLabelText } = render(<MarkdownToolbar />);
+  describe('large screen layout', () => {
+    const largeScreenMediaQuery = `(min-width: ${
+      BREAKPOINTS.Large
+    }px) and (max-width: ${BREAKPOINTS.ExtraLarge - 1}px)`;
+    beforeEach(() => {
+      global.window.matchMedia = jest.fn((query) => {
+        return {
+          matches: query === largeScreenMediaQuery,
+          media: query,
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+        };
+      });
+    });
 
-    getByLabelText('More options').click();
+    it('should render only 7 formatters in the main toolbar', () => {
+      const { getByLabelText, queryByLabelText } = render(<MarkdownToolbar />);
 
-    await waitFor(() =>
-      expect(getByLabelText('Underline')).toBeInTheDocument(),
-    );
-    expect(getByLabelText('Strikethrough')).toBeInTheDocument();
-    expect(getByLabelText('Line divider')).toBeInTheDocument();
+      expect(getByLabelText('Bold')).toBeInTheDocument();
+      expect(getByLabelText('Italic')).toBeInTheDocument();
+      expect(getByLabelText('Ordered list')).toBeInTheDocument();
+      expect(getByLabelText('Unordered list')).toBeInTheDocument();
+      expect(getByLabelText('Link')).toBeInTheDocument();
+      expect(getByLabelText('Heading')).toBeInTheDocument();
+      expect(getByLabelText('Quote')).toBeInTheDocument();
+
+      expect(queryByLabelText('Code')).not.toBeInTheDocument();
+      expect(queryByLabelText('Code block')).not.toBeInTheDocument();
+      expect(queryByLabelText('Embed')).not.toBeInTheDocument();
+      expect(queryByLabelText('Underline')).not.toBeInTheDocument();
+      expect(queryByLabelText('Strikethrough')).not.toBeInTheDocument();
+      expect(queryByLabelText('Line divider')).not.toBeInTheDocument();
+    });
+
+    it('should render remaining formatters in overflow menu', async () => {
+      const { getByLabelText } = render(<MarkdownToolbar />);
+
+      getByLabelText('More options').click();
+
+      await waitFor(() => expect(getByLabelText('Code')).toBeInTheDocument());
+
+      expect(getByLabelText('Code block')).toBeInTheDocument();
+      expect(getByLabelText('Embed')).toBeInTheDocument();
+      expect(getByLabelText('Underline')).toBeInTheDocument();
+      expect(getByLabelText('Strikethrough')).toBeInTheDocument();
+      expect(getByLabelText('Line divider')).toBeInTheDocument();
+    });
+  });
+
+  describe('extra large screen layout', () => {
+    beforeEach(() => {
+      global.window.matchMedia = jest.fn((query) => {
+        return {
+          matches: false,
+          media: query,
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+        };
+      });
+    });
+
+    it('should render 10 formatters in the main toolbar', () => {
+      const { getByLabelText, queryByLabelText } = render(<MarkdownToolbar />);
+
+      expect(getByLabelText('Bold')).toBeInTheDocument();
+      expect(getByLabelText('Italic')).toBeInTheDocument();
+      expect(getByLabelText('Ordered list')).toBeInTheDocument();
+      expect(getByLabelText('Unordered list')).toBeInTheDocument();
+      expect(getByLabelText('Link')).toBeInTheDocument();
+      expect(getByLabelText('Heading')).toBeInTheDocument();
+      expect(getByLabelText('Quote')).toBeInTheDocument();
+      expect(getByLabelText('Code')).toBeInTheDocument();
+      expect(getByLabelText('Code block')).toBeInTheDocument();
+      expect(getByLabelText('Embed')).toBeInTheDocument();
+
+      expect(queryByLabelText('Underline')).not.toBeInTheDocument();
+      expect(queryByLabelText('Strikethrough')).not.toBeInTheDocument();
+      expect(queryByLabelText('Line divider')).not.toBeInTheDocument();
+    });
+
+    it('should render remaining formatters in overflow menu', async () => {
+      const { getByLabelText } = render(<MarkdownToolbar />);
+
+      getByLabelText('More options').click();
+
+      await waitFor(() =>
+        expect(getByLabelText('Underline')).toBeInTheDocument(),
+      );
+
+      expect(getByLabelText('Strikethrough')).toBeInTheDocument();
+      expect(getByLabelText('Line divider')).toBeInTheDocument();
+    });
   });
 
   it('should render any custom secondary toolbar elements', async () => {

--- a/app/javascript/crayons/MarkdownToolbar/__tests__/markdownSyntaxFormatters.test.js
+++ b/app/javascript/crayons/MarkdownToolbar/__tests__/markdownSyntaxFormatters.test.js
@@ -1,6 +1,5 @@
 import {
-  coreSyntaxFormatters,
-  secondarySyntaxFormatters,
+  markdownSyntaxFormatters,
   getNewTextAreaValueWithEdits,
 } from '../markdownSyntaxFormatters';
 
@@ -17,7 +16,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['bold'].getFormatting({
+        } = markdownSyntaxFormatters['bold'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -46,7 +45,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['bold'].getFormatting({
+        } = markdownSyntaxFormatters['bold'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -74,7 +73,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['bold'].getFormatting({
+        } = markdownSyntaxFormatters['bold'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 11,
@@ -103,7 +102,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['bold'].getFormatting({
+        } = markdownSyntaxFormatters['bold'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 9,
@@ -132,7 +131,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['bold'].getFormatting({
+        } = markdownSyntaxFormatters['bold'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 9,
@@ -161,7 +160,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['bold'].getFormatting({
+        } = markdownSyntaxFormatters['bold'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 11,
@@ -190,7 +189,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['bold'].getFormatting({
+        } = markdownSyntaxFormatters['bold'].getFormatting({
           value: textAreaValue,
           selectionStart: 6,
           selectionEnd: 9,
@@ -219,7 +218,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['bold'].getFormatting({
+        } = markdownSyntaxFormatters['bold'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -250,7 +249,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['italic'].getFormatting({
+        } = markdownSyntaxFormatters['italic'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -279,7 +278,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['italic'].getFormatting({
+        } = markdownSyntaxFormatters['italic'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -307,7 +306,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['italic'].getFormatting({
+        } = markdownSyntaxFormatters['italic'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 9,
@@ -336,7 +335,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['italic'].getFormatting({
+        } = markdownSyntaxFormatters['italic'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 8,
@@ -365,7 +364,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['italic'].getFormatting({
+        } = markdownSyntaxFormatters['italic'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 8,
@@ -394,7 +393,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['italic'].getFormatting({
+        } = markdownSyntaxFormatters['italic'].getFormatting({
           value: textAreaValue,
           selectionStart: 5,
           selectionEnd: 8,
@@ -423,7 +422,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['italic'].getFormatting({
+        } = markdownSyntaxFormatters['italic'].getFormatting({
           value: textAreaValue,
           selectionStart: 5,
           selectionEnd: 8,
@@ -452,7 +451,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['italic'].getFormatting({
+        } = markdownSyntaxFormatters['italic'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -483,7 +482,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['code'].getFormatting({
+        } = markdownSyntaxFormatters['code'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -512,7 +511,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['code'].getFormatting({
+        } = markdownSyntaxFormatters['code'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -540,7 +539,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['code'].getFormatting({
+        } = markdownSyntaxFormatters['code'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 9,
@@ -569,7 +568,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['code'].getFormatting({
+        } = markdownSyntaxFormatters['code'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 8,
@@ -598,7 +597,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['code'].getFormatting({
+        } = markdownSyntaxFormatters['code'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 8,
@@ -627,7 +626,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['code'].getFormatting({
+        } = markdownSyntaxFormatters['code'].getFormatting({
           value: textAreaValue,
           selectionStart: 5,
           selectionEnd: 8,
@@ -656,7 +655,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['code'].getFormatting({
+        } = markdownSyntaxFormatters['code'].getFormatting({
           value: textAreaValue,
           selectionStart: 5,
           selectionEnd: 8,
@@ -685,7 +684,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['code'].getFormatting({
+        } = markdownSyntaxFormatters['code'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -716,7 +715,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['underline'].getFormatting({
+        } = markdownSyntaxFormatters['underline'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -745,7 +744,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['underline'].getFormatting({
+        } = markdownSyntaxFormatters['underline'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -773,7 +772,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['underline'].getFormatting({
+        } = markdownSyntaxFormatters['underline'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 14,
@@ -802,7 +801,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['underline'].getFormatting({
+        } = markdownSyntaxFormatters['underline'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 10,
@@ -831,7 +830,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['underline'].getFormatting({
+        } = markdownSyntaxFormatters['underline'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 11,
@@ -860,7 +859,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['underline'].getFormatting({
+        } = markdownSyntaxFormatters['underline'].getFormatting({
           value: textAreaValue,
           selectionStart: 7,
           selectionEnd: 10,
@@ -889,7 +888,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['underline'].getFormatting({
+        } = markdownSyntaxFormatters['underline'].getFormatting({
           value: textAreaValue,
           selectionStart: 7,
           selectionEnd: 10,
@@ -918,7 +917,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['underline'].getFormatting({
+        } = markdownSyntaxFormatters['underline'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -949,7 +948,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['strikethrough'].getFormatting({
+        } = markdownSyntaxFormatters['strikethrough'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -978,7 +977,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['strikethrough'].getFormatting({
+        } = markdownSyntaxFormatters['strikethrough'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -1006,7 +1005,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['strikethrough'].getFormatting({
+        } = markdownSyntaxFormatters['strikethrough'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 11,
@@ -1035,7 +1034,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['strikethrough'].getFormatting({
+        } = markdownSyntaxFormatters['strikethrough'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 9,
@@ -1064,7 +1063,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['strikethrough'].getFormatting({
+        } = markdownSyntaxFormatters['strikethrough'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 9,
@@ -1093,7 +1092,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['strikethrough'].getFormatting({
+        } = markdownSyntaxFormatters['strikethrough'].getFormatting({
           value: textAreaValue,
           selectionStart: 6,
           selectionEnd: 9,
@@ -1122,7 +1121,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['strikethrough'].getFormatting({
+        } = markdownSyntaxFormatters['strikethrough'].getFormatting({
           value: textAreaValue,
           selectionStart: 6,
           selectionEnd: 9,
@@ -1151,7 +1150,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['strikethrough'].getFormatting({
+        } = markdownSyntaxFormatters['strikethrough'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -1182,7 +1181,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 8,
           selectionEnd: 8,
@@ -1211,7 +1210,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -1240,7 +1239,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 24,
@@ -1268,7 +1267,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 25,
@@ -1296,7 +1295,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 5,
           selectionEnd: 5,
@@ -1324,7 +1323,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 7,
           selectionEnd: 10,
@@ -1352,7 +1351,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 16,
           selectionEnd: 19,
@@ -1381,7 +1380,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 7,
           selectionEnd: 25,
@@ -1410,7 +1409,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 16,
           selectionEnd: 34,
@@ -1440,7 +1439,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 42,
@@ -1469,7 +1468,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 26,
@@ -1498,7 +1497,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['link'].getFormatting({
+        } = markdownSyntaxFormatters['link'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 11,
@@ -1528,7 +1527,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['embed'].getFormatting({
+        } = markdownSyntaxFormatters['embed'].getFormatting({
           value: textAreaValue,
           selectionStart: 8,
           selectionEnd: 8,
@@ -1557,7 +1556,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['embed'].getFormatting({
+        } = markdownSyntaxFormatters['embed'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -1585,7 +1584,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['embed'].getFormatting({
+        } = markdownSyntaxFormatters['embed'].getFormatting({
           value: textAreaValue,
           selectionStart: 13,
           selectionEnd: 13,
@@ -1613,7 +1612,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['embed'].getFormatting({
+        } = markdownSyntaxFormatters['embed'].getFormatting({
           value: textAreaValue,
           selectionStart: 13,
           selectionEnd: 33,
@@ -1642,7 +1641,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['embed'].getFormatting({
+        } = markdownSyntaxFormatters['embed'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 35,
@@ -1675,7 +1674,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -1704,7 +1703,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 13,
@@ -1733,7 +1732,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -1762,7 +1761,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 10,
@@ -1791,7 +1790,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 9,
           selectionEnd: 9,
@@ -1819,7 +1818,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 22,
@@ -1848,7 +1847,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 19,
@@ -1877,7 +1876,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -1906,7 +1905,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 1,
           selectionEnd: 4,
@@ -1935,7 +1934,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -1964,7 +1963,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -1993,7 +1992,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['orderedList'].getFormatting({
+        } = markdownSyntaxFormatters['orderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -2024,7 +2023,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -2053,7 +2052,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 13,
@@ -2082,7 +2081,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -2111,7 +2110,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 9,
@@ -2140,7 +2139,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 7,
           selectionEnd: 7,
@@ -2168,7 +2167,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 20,
@@ -2197,7 +2196,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 17,
@@ -2226,7 +2225,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -2255,7 +2254,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 1,
           selectionEnd: 4,
@@ -2284,7 +2283,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -2313,7 +2312,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -2342,7 +2341,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['unorderedList'].getFormatting({
+        } = markdownSyntaxFormatters['unorderedList'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -2373,7 +2372,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -2401,7 +2400,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -2429,7 +2428,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 11,
           selectionEnd: 11,
@@ -2457,7 +2456,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 8,
           selectionEnd: 11,
@@ -2485,7 +2484,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 12,
           selectionEnd: 12,
@@ -2513,7 +2512,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 9,
           selectionEnd: 12,
@@ -2541,7 +2540,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 13,
           selectionEnd: 13,
@@ -2569,7 +2568,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 10,
           selectionEnd: 13,
@@ -2597,7 +2596,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -2626,7 +2625,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 1,
           selectionEnd: 4,
@@ -2655,7 +2654,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -2684,7 +2683,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -2713,7 +2712,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['heading'].getFormatting({
+        } = markdownSyntaxFormatters['heading'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -2744,7 +2743,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -2773,7 +2772,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 13,
@@ -2802,7 +2801,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -2831,7 +2830,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 9,
@@ -2860,7 +2859,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 7,
           selectionEnd: 7,
@@ -2888,7 +2887,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 20,
@@ -2917,7 +2916,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 17,
@@ -2946,7 +2945,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -2975,7 +2974,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 1,
           selectionEnd: 4,
@@ -3004,7 +3003,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -3033,7 +3032,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -3062,7 +3061,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['quote'].getFormatting({
+        } = markdownSyntaxFormatters['quote'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -3093,7 +3092,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -3122,7 +3121,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 13,
@@ -3151,7 +3150,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -3180,7 +3179,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 9,
           selectionEnd: 12,
@@ -3209,7 +3208,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 9,
           selectionEnd: 18,
@@ -3238,7 +3237,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 9,
           selectionEnd: 9,
@@ -3267,7 +3266,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 5,
           selectionEnd: 16,
@@ -3296,7 +3295,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -3325,7 +3324,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 1,
           selectionEnd: 4,
@@ -3354,7 +3353,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -3383,7 +3382,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -3412,7 +3411,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = coreSyntaxFormatters['codeBlock'].getFormatting({
+        } = markdownSyntaxFormatters['codeBlock'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -3443,7 +3442,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['divider'].getFormatting({
+        } = markdownSyntaxFormatters['divider'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 4,
@@ -3472,7 +3471,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['divider'].getFormatting({
+        } = markdownSyntaxFormatters['divider'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -3500,7 +3499,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['divider'].getFormatting({
+        } = markdownSyntaxFormatters['divider'].getFormatting({
           value: textAreaValue,
           selectionStart: 9,
           selectionEnd: 9,
@@ -3528,7 +3527,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['divider'].getFormatting({
+        } = markdownSyntaxFormatters['divider'].getFormatting({
           value: textAreaValue,
           selectionStart: 9,
           selectionEnd: 12,
@@ -3557,7 +3556,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['divider'].getFormatting({
+        } = markdownSyntaxFormatters['divider'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,
@@ -3586,7 +3585,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['divider'].getFormatting({
+        } = markdownSyntaxFormatters['divider'].getFormatting({
           value: textAreaValue,
           selectionStart: 1,
           selectionEnd: 4,
@@ -3615,7 +3614,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['divider'].getFormatting({
+        } = markdownSyntaxFormatters['divider'].getFormatting({
           value: textAreaValue,
           selectionStart: 4,
           selectionEnd: 7,
@@ -3644,7 +3643,7 @@ describe('markdownSyntaxFormatters', () => {
           editSelectionStart,
           editSelectionEnd,
           replaceSelectionWith,
-        } = secondarySyntaxFormatters['divider'].getFormatting({
+        } = markdownSyntaxFormatters['divider'].getFormatting({
           value: textAreaValue,
           selectionStart: 0,
           selectionEnd: 3,

--- a/app/javascript/crayons/MarkdownToolbar/markdownSyntaxFormatters.jsx
+++ b/app/javascript/crayons/MarkdownToolbar/markdownSyntaxFormatters.jsx
@@ -404,7 +404,7 @@ export const getNewTextAreaValueWithEdits = ({
     editSelectionStart,
   )}${replaceSelectionWith}${textAreaValue.substring(editSelectionEnd)}`;
 
-export const coreSyntaxFormatters = {
+export const markdownSyntaxFormatters = {
   bold: {
     icon: () => <Icon src={BoldIcon} />,
     label: 'Bold',
@@ -734,9 +734,6 @@ export const coreSyntaxFormatters = {
         suffix: ' %}',
       }),
   },
-};
-
-export const secondarySyntaxFormatters = {
   underline: {
     icon: () => <Icon src={UnderlineIcon} />,
     label: 'Underline',


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We had a couple of issues relating to the approach we took to make the toolbar responsive on smaller screens - previously it scrolled horizontally, but there were issues of discoverability and also usability when the scrolling behaviour was triggered on non-touch devices (e.g. in the moderator centre where we render inside a smaller iframe, but also if a user zoomed their viewport for a11y).

Instead of scrolling in small viewports, we now dynamically detect how many items we place in the overflow (3 dots) menu. See the [figma mockups](https://www.figma.com/file/PIPeiiVSADmcpCbiZTdJm9/Editor?node-id=2185%3A8563).

**A small implementation detail:** 

In extremely small screens (super-narrow smartphones like galaxy fold, or mobile devices where a user is choosing to zoom the screen), I've kept the scrolling behaviour as before. I've done this purely as a fall-back for edge cases like screen zooming for a11y, or those rarer width smartphones. 

The solution we have at the moment is fairly lightweight/understandable, and I didn't want to introduce a ton of complexity just for these less-likely scenarios (but also didn't want things to look terrible for those users).

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/forem/forem/issues/17714
- Closes https://github.com/forem/forem/issues/18131

## QA Instructions, Screenshots, Recordings

This needs tested in 3 locations:
- The editor
- Comments on a post
- In the mod centre, commenting on a post

In each case, experiment with resizing your screen and check that everything looks sensible 😄  Please also check some things that gave us headaches before:

- In larger screen sizes, tooltips appear on hover
- Regardless of the overflow menu being open, or the bar being horizontally scrollable, there is never a vertical scroll


https://user-images.githubusercontent.com/20773163/181026057-58a36a2c-c72b-401a-a965-7acdcf9ab687.mp4


### UI accessibility concerns?

I think this will make things a bit more usable for all.

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [X] This change does not need to be communicated, and this is why not: small tweak, no new functionality


