### PR TITLE
add github action for mayhem for api

### DIFF
--- a/.github/workflows/mapi.yml
+++ b/.github/workflows/mapi.yml
@@ -1,0 +1,38 @@
+name: mapi
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Start the service
+        run: docker-compose up -d
+
+      - name: Wait for service to be started
+        run: while ! curl -s http://localhost:3000; do echo "waiting for api server"; sleep 1; done
+
+      - name: Run Mayhem for API
+        uses: ForAllSecure/mapi-action@v1
+        continue-on-error: true
+        with:
+          mapi-token: ${{ secrets.MAPI_TOKEN }}
+          api-url: http://localhost:3000
+          api-spec: swagger/v1/swagger.json
+          target: mayhemheroes/forem
+          duration: auto
+          sarif-report: mapi.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: mapi.sarif

--- a/.github/workflows/mapi.yml
+++ b/.github/workflows/mapi.yml
@@ -1,9 +1,7 @@
 name: mapi
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  schedule:
+    - cron: '0 8 * * *'
 
 jobs:
   test:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add a github action to run [Mayhem for API](https://mayhem4api.forallsecure.com/) (which is a free automated testing tool for http APIs) against the api: given the openapi spec and api server, it generates and runs random test payloads, looking for exceptional behavior.

Disclosure: working on this tool is my day job!

As with any github workflow, test results can be consumed through github. Alternatively, Mayhem for API also has a dashboard, over here: https://mayhem4api.forallsecure.com/mayhemheroes/forem.

The currently checked-in spec only documents `GET /api/articles`, so that's all that's currently tested. Still, in a few seconds' testing, it finds an Internal Server Error that *probably* just boils down to data validation, but might be more serious.

To make it work in the upstream repo, there's a bit of out-of-PR effort to integrate:

- sign up for a free mapi account, creating a forem organization
- create a mapi service account within the forem organization
- modify the mapi.yaml action in this PR to point at your mapi organization
- add the service account's API token to github as a repository secret named MAPI_TOKEN

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

This is strictly a build change.

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests