### PR TITLE
Improved editing scheduled articles

### DIFF
--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -97,12 +97,14 @@ export class ArticleForm extends Component {
           }
         : {};
 
-    this.publishedAtTime, (this.publishedAtDate = '');
+    this.publishedAtTime = '';
+    this.publishedAtDate = '';
+    this.publishedAtWas = '';
 
     if (this.article.published_at) {
-      const publishedAt = moment(this.article.published_at);
-      this.publishedAtTime = publishedAt.format('HH:mm');
-      this.publishedAtDate = publishedAt.format('YYYY-MM-DD');
+      this.publishedAtWas = moment(this.article.published_at);
+      this.publishedAtTime = this.publishedAtWas.format('HH:mm');
+      this.publishedAtDate = this.publishedAtWas.format('YYYY-MM-DD');
     }
 
     this.state = {
@@ -114,6 +116,7 @@ export class ArticleForm extends Component {
       canonicalUrl: this.article.canonical_url || '', // eslint-disable-line react/no-unused-state
       publishedAtTime: this.publishedAtTime,
       publishedAtDate: this.publishedAtDate,
+      publishedAtWas: this.publishedAtWas,
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || '', // eslint-disable-line react/no-unused-state
       series: this.article.series || '', // eslint-disable-line react/no-unused-state
       allSeries: this.article.all_series || [], // eslint-disable-line react/no-unused-state
@@ -347,6 +350,7 @@ export class ArticleForm extends Component {
       canonicalUrl: this.article.canonical_url || '', // eslint-disable-line react/no-unused-state
       publishedAtTime: this.publishedAtTime,
       publishedAtDate: this.publishedAtDate,
+      publishedAtWas: this.publishedAtWas,
       series: this.article.series || '', // eslint-disable-line react/no-unused-state
       allSeries: this.article.all_series || [], // eslint-disable-line react/no-unused-state
       bodyMarkdown: this.article.body_markdown || '',
@@ -410,6 +414,7 @@ export class ArticleForm extends Component {
       published,
       publishedAtTime,
       publishedAtDate,
+      publishedAtWas,
       previewShowing,
       previewLoading,
       previewResponse,
@@ -512,6 +517,7 @@ export class ArticleForm extends Component {
           published={published}
           publishedAtTime={publishedAtTime}
           publishedAtDate={publishedAtDate}
+          publishedAtWas={publishedAtWas}
           schedulingEnabled={schedulingEnabled}
           version={version}
           onPublish={this.onPublish}

--- a/app/javascript/article-form/components/EditorActions.jsx
+++ b/app/javascript/article-form/components/EditorActions.jsx
@@ -44,12 +44,19 @@ export const EditorActions = ({
     ? moment(`${publishedAtDate} ${publishedAtTime || '00:00'}`)
     : now;
   const schedule = publishedAtObj > now;
+  const wasScheduled = passedData.publishedAtWas > now;
 
-  const saveButtonText = schedule
-    ? 'Schedule'
-    : published || isVersion1
-    ? 'Save changes'
-    : 'Publish';
+  // if the article was saved as scheduled, and the user clears publishedAt in the post options, the save button text is changed to "Publish"
+  // to make it clear that the article is going to be published right away
+
+  let saveButtonText;
+  if (schedule) {
+    saveButtonText = 'Schedule';
+  } else if (wasScheduled || (!published && !isVersion1)) {
+    saveButtonText = 'Publish';
+  } else {
+    saveButtonText = 'Save changes';
+  }
 
   return (
     <div className="crayons-article-form__footer">

--- a/app/javascript/article-form/components/Options.jsx
+++ b/app/javascript/article-form/components/Options.jsx
@@ -18,6 +18,7 @@ export const Options = ({
     published = false,
     publishedAtDate = '',
     publishedAtTime = '',
+    publishedAtWas = '',
     timezone = Intl.DateTimeFormat().resolvedOptions().timeZone,
     allSeries = [],
     canonicalUrl = '',
@@ -32,8 +33,8 @@ export const Options = ({
   let existingSeries = '';
   let publishedAtField = '';
 
-  const readonlyPublishedAt =
-    published && moment(`${publishedAtDate} ${publishedAtTime}`) < moment();
+  const wasScheduled = moment(publishedAtWas) > moment();
+  const readonlyPublishedAt = published && !wasScheduled;
 
   if (allSeries.length > 0) {
     const seriesNames = allSeries.map((name, index) => {
@@ -65,16 +66,30 @@ export const Options = ({
   }
 
   if (published) {
-    publishedField = (
-      <div data-testid="options__danger-zone" className="crayons-field mb-6">
-        <div className="crayons-field__label color-accent-danger">
-          Danger Zone
+    if (wasScheduled) {
+      publishedField = (
+        <div data-testid="options__danger-zone" className="crayons-field mb-6">
+          <Button
+            className="c-btn c-btn--secondary w-100"
+            variant="primary"
+            onClick={onSaveDraft}
+          >
+            Convert to a Draft
+          </Button>
         </div>
-        <Button variant="primary" destructive onClick={onSaveDraft}>
-          Unpublish post
-        </Button>
-      </div>
-    );
+      );
+    } else {
+      publishedField = (
+        <div data-testid="options__danger-zone" className="crayons-field mb-6">
+          <div className="crayons-field__label color-accent-danger">
+            Danger Zone
+          </div>
+          <Button variant="primary" destructive onClick={onSaveDraft}>
+            Unpublish post
+          </Button>
+        </div>
+      );
+    }
   }
 
   if (schedulingEnabled && !readonlyPublishedAt) {
@@ -194,6 +209,7 @@ Options.propTypes = {
     published: PropTypes.bool.isRequired,
     publishedAtDate: PropTypes.string.isRequired,
     publishedAtTime: PropTypes.string.isRequired,
+    publishedAtWas: PropTypes.string.isRequired,
     timezone: PropTypes.string.isRequired,
     allSeries: PropTypes.array.isRequired,
     canonicalUrl: PropTypes.string.isRequired,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This pr contains impromevents and a bug fix related to editing a scheduled article:
When removing date from the datepicker in Post Options:
- fixed an error in the console
- change save button text from "Save changes" to "Publish" to make it clear that the article will be published right away
Post Options:
- changed "dangerous" "unpublish post" button to a regular one
![изображение](https://user-images.githubusercontent.com/30115/182110238-22cf3346-1f51-4f8b-bef6-920c366c0e19.png)

Maybe the "design" in questionable, but imo red button is misleading in this case (a scheduled post has not been published yet so it shouldn't be dangerous to unpublish it). I tried the blue button, but it draws too much attention and makes the user (me) want to press it when meaning to press "Done". Any suggestions appreciated.

## Related Tickets & Documents
- Related Issue #15858 

## QA Instructions, Screenshots, Recordings
- enable the feature flag `FeatureFlag.enable(:schedule_articles)`
- create a scheduled article (published at in the future)
- click "edit" from the article preview page
- try to remove date from the datepicker in post options.
There should be no errors in the console. The save button text should be changed to "Publish".
If you choose the date again, it should change back to "Schedule"

The unpublishing button in the "Post Options" on the edit page should look like on a screenshot.
If you visit an edit page of a published article, an unpublish button in the "Post Options" should be red, as it was before the changes.

## Added/updated tests?
- [x] I need help with writing tests - again, would be nice to add tests, but I didn't succeed in enabling feature flag for front-end tests.

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams