### PR TITLE
Tweak prefix image size for DisplayAds on articles

### DIFF
--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -7,6 +7,9 @@ class DisplayAd < ApplicationRecord
                                             "Sidebar Right",
                                             "Below the comment section"].freeze
 
+  POST_WIDTH = 775
+  SIDEBAR_WIDTH = 350
+
   belongs_to :organization, optional: true
   has_many :display_ad_events, dependent: :destroy
 
@@ -41,6 +44,11 @@ class DisplayAd < ApplicationRecord
                                                             tags: MarkdownProcessor::AllowedTags::DISPLAY_AD,
                                                             attributes: MarkdownProcessor::AllowedAttributes::DISPLAY_AD
     html = stripped_html.delete("\n")
-    self.processed_html = Html::Parser.new(html).prefix_all_images(350, synchronous_detail_detection: true).html
+    self.processed_html = Html::Parser.new(html)
+      .prefix_all_images(prefix_width, synchronous_detail_detection: true).html
+  end
+
+  def prefix_width
+    placement_area.to_s == "post_comments" ? POST_WIDTH : SIDEBAR_WIDTH
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Previously (#18141) we added the ability to show DisplayAds in a new placement area, below individual articles. This area is wider than the right sidebar, but code in the DisplayAds model resizes images to maximum 350px wide. That fits in the sidebar, but is too small on the articles view. (Even if one uses CSS/HTML to embiggen them, there's only 350 width of pixels, so it looks bad.)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/18241

## QA Instructions, Screenshots, Recordings

It may be necessary to edit any DisplayAds to trigger re-processing their images.

### UI accessibility concerns?

No.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: minor visual tweak
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?


- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![gorgeous](https://user-images.githubusercontent.com/2077/182347628-e3ee3cf8-3270-454d-bd68-9b1bd8127b55.gif)


