### PR TITLE
Fixed sending slack notifications for published articles

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -180,7 +180,6 @@ class Article < ApplicationRecord
   before_save :fetch_video_duration
   before_save :set_caches
   before_create :create_password
-  after_update :notify_slack_channel_about_publication, if: -> { published && saved_change_to_published? }
   before_destroy :before_destroy_actions, prepend: true
 
   after_save :create_conditional_autovomits
@@ -944,10 +943,6 @@ class Article < ApplicationRecord
 
   def touch_collection
     collection.touch if collection && previous_changes.present?
-  end
-
-  def notify_slack_channel_about_publication
-    Slack::Messengers::ArticlePublished.call(article: self)
   end
 
   def enrich_image_attributes

--- a/app/services/slack/messengers/article_published.rb
+++ b/app/services/slack/messengers/article_published.rb
@@ -10,7 +10,7 @@ module Slack
       end
 
       def call
-        return unless article.published && article.published_at > 30.seconds.ago
+        return unless article.published && article.published_at > 10.minutes.ago
 
         message = I18n.t(
           "services.slack.messengers.article_published.body",

--- a/spec/services/slack/messengers/article_published_spec.rb
+++ b/spec/services/slack/messengers/article_published_spec.rb
@@ -22,7 +22,17 @@ RSpec.describe Slack::Messengers::ArticlePublished, type: :service do
     sidekiq_assert_no_enqueued_jobs(only: Slack::Messengers::Worker) do
       article = build(:article).tap do |art|
         art.published = true
-        art.published_at = 1.minute.ago
+        art.published_at = 15.minutes.ago
+      end
+      described_class.call(article: article)
+    end
+  end
+
+  it "messages slack for an article that was published a few minutes ago" do
+    sidekiq_assert_enqueued_jobs(1, only: Slack::Messengers::Worker) do
+      article = build(:article).tap do |art|
+        art.published = true
+        art.published_at = 5.minutes.ago
       end
       described_class.call(article: article)
     end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description

Previously, slack notifications for published articles were sent in a callback, right after publishing. So there was a check in the `Slack::Messengers::ArticlePublished` which filtered out all articles older than 30 seconds, and notifications were not sent for them.
Currently, the notifications are sent separately from the publication process, in the `Articles::PublishWorker` which runs every 5 minutes. When the worker calls `Slack::Messengers::ArticlePublished` some articles may be older than 30 seconds, so sending notifications was skipped for them. 
In this pr I increased the time for sending slack notifications to 10 minutes. I also removed the `notify_slack_channel_about_publication` because notifications for updated articles should be handled by the worker too.

## Related Tickets & Documents
- Related Issue #15858 (sort of)

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
