### PR TITLE
Don't show manage link in the action-space for a scheduled article

### DIFF
--- a/app/assets/javascripts/initializers/initializeBaseUserData.js
+++ b/app/assets/javascripts/initializers/initializeBaseUserData.js
@@ -13,7 +13,9 @@ function addRelevantButtonsToArticle(user) {
     articleContainer.dataset.buttonsInitialized !== 'true'
   ) {
     let actions = [];
+
     const published = JSON.parse(articleContainer.dataset.published);
+    const scheduled = JSON.parse(articleContainer.dataset.scheduled);
 
     if (parseInt(articleContainer.dataset.authorId, 10) === user.id) {
       actions.push(
@@ -25,9 +27,9 @@ function addRelevantButtonsToArticle(user) {
         clickToEditButton.style.display = 'inline-block';
       }
 
-      if (published === true) {
+      if (published === true && !scheduled) {
         actions.push(
-          `<a class="crayons-btn crayons-btn--s crayons-btn--ghost px-2" href="${articleContainer.dataset.path}/manage" rel="nofollow">Manage</a>`,
+          `<a class="crayons-btn crayons-btn--s crayons-btn--ghost px-2" id ="article-action-space-manage" href="${articleContainer.dataset.path}/manage" rel="nofollow">Manage</a>`,
         );
       }
 

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -90,6 +90,7 @@
         data-pin-path="<%= stories_feed_pinned_article_path %>"
         data-pinned-article-id="<%= @pinned_article_id %>"
         data-published="<%= @article.published? %>"
+        data-scheduled="<%= @article.scheduled? %>"
         <%= @article.pinned? ? "data-pinned" : " " %>>
         <header class="crayons-article__header" id="main-title">
           <% if @article.video.present? %>

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -150,6 +150,11 @@ RSpec.describe "Views an article", type: :system do
       expect(edit_link.matches_style?(display: "inline-block")).to be true
     end
 
+    it "doesn't show the article manage link, even for the author", js: true do
+      visit scheduled_article_path
+      expect(page).to have_no_link("article-action-space-manage")
+    end
+
     it "doesn't show an article edit link for the non-authorized user" do
       sign_out user
       sign_in create(:user)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Hide "manage" button from the action space on the preview page of a scheduled article.

## Related Tickets & Documents
- Related Issue #15858 

## QA Instructions, Screenshots, Recordings
- enable the feature flag `FeatureFlag.enable(:schedule_articles)`
- create a scheduled article (choose a future published at)
- you will be redirected to a preview page
- there should be no "manage" button

Published article:
![изображение](https://user-images.githubusercontent.com/30115/183091678-7fbd61f4-0fde-4f58-b26f-2f99be7caa76.png)

Scheduled article:
![изображение](https://user-images.githubusercontent.com/30115/183091750-735f5a29-35fb-448c-9fa2-f4ad7526f0c4.png)

## Added/updated tests?
- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] This change does not need to be communicated, and this is why not: it's a small bug fix



