### PR TITLE
Remove context_notifications when unpublishing all posts

### DIFF
--- a/app/workers/moderator/unpublish_all_articles_worker.rb
+++ b/app/workers/moderator/unpublish_all_articles_worker.rb
@@ -22,6 +22,9 @@ module Moderator
       Notification.remove_all_by_action_without_delay(notifiable_ids: article.id,
                                                       notifiable_type: "Article",
                                                       action: "Published")
+
+      ContextNotification.delete_by(context_id: article.id, context_type: "Article", action: "Published")
+
       return unless article.comments.exists?
 
       Notification.remove_all(notifiable_ids: article.comments.ids, notifiable_type: "Comment")

--- a/spec/workers/moderator/unpublish_all_articles_worker_spec.rb
+++ b/spec/workers/moderator/unpublish_all_articles_worker_spec.rb
@@ -2,17 +2,37 @@ require "rails_helper"
 
 RSpec.describe Moderator::UnpublishAllArticlesWorker, type: :worker do
   include_examples "#enqueues_on_correct_queue", "medium_priority", 1
-  it "unpublishes all articles" do
-    user = create(:user)
-    create_list(:article, 3, user: user)
-    expect { described_class.new.perform(user.id) }.to change { user.articles.published.size }.from(3).to(0)
-  end
 
-  it "applies proper frontmatter", :aggregate_failures do
-    user = create(:user)
-    create_list(:article, 3, user: user)
-    described_class.new.perform(user.id)
-    expect(Article.last.body_markdown).to include("published: false")
-    expect(Article.last.body_markdown).not_to include("published: true")
+  context "when unpublishing" do
+    let!(:user) { create(:user) }
+    let!(:articles) { create_list(:article, 3, user: user) }
+
+    it "unpublishes all articles" do
+      expect { described_class.new.perform(user.id) }.to change { user.articles.published.size }.from(3).to(0)
+    end
+
+    it "applies proper frontmatter", :aggregate_failures do
+      described_class.new.perform(user.id)
+      expect(Article.last.body_markdown).to include("published: false")
+      expect(Article.last.body_markdown).not_to include("published: true")
+    end
+
+    it "destroys the prexexisting notifications" do
+      allow(Notification).to receive(:remove_all_by_action_without_delay).and_call_original
+      described_class.new.perform(user.id)
+      articles.map(&:id).each do |id|
+        attrs = { notifiable_ids: id, notifiable_type: "Article", action: "Published" }
+        expect(Notification).to have_received(:remove_all_by_action_without_delay).with(attrs)
+      end
+    end
+
+    it "destroys the prexexisting context notifications" do
+      articles.each do |article|
+        create(:context_notification, context: article, action: "Published")
+      end
+      expect do
+        described_class.new.perform(user.id)
+      end.to change(ContextNotification, :count).by(-3)
+    end
   end
 end

--- a/spec/workers/moderator/unpublish_all_articles_worker_spec.rb
+++ b/spec/workers/moderator/unpublish_all_articles_worker_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Moderator::UnpublishAllArticlesWorker, type: :worker do
       end
     end
 
-    it "destroys the prexexisting context notifications" do
+    it "destroys the pre-existing context notifications" do
       articles.each do |article|
         create(:context_notification, context: article, action: "Published")
       end

--- a/spec/workers/moderator/unpublish_all_articles_worker_spec.rb
+++ b/spec/workers/moderator/unpublish_all_articles_worker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Moderator::UnpublishAllArticlesWorker, type: :worker do
       expect(Article.last.body_markdown).not_to include("published: true")
     end
 
-    it "destroys the prexexisting notifications" do
+    it "destroys the pre-existing notifications" do
       allow(Notification).to receive(:remove_all_by_action_without_delay).and_call_original
       described_class.new.perform(user.id)
       articles.map(&:id).each do |id|


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
Remove context notifications when unpublishing all posts from user by admin, similarly as it's done in `Articles::Updater`.
Context notifications are used to track wether we have sent notifications about an article publication, so when the article is being unpublished, context notifications should be removed along with notifications.
I also added tests for removing notifications and context notifications for `Moderator::UnpublishAllArticlesWorker`

## Related Tickets & Documents
- Related Issue #15858 (tangentially, as it's related to changing sending notifications logic)

## QA Instructions, Screenshots, Recordings
- find a user that has articles, notifications for those articles, and context_notifications for those notifications (or create them manually from console)
- visit admin user manage page http://localhost:3000/admin/member_manager/users/%user_id%
- press 3 dots => unpublish all posts from a user
- wait while sidekiq workers finish
- notifications and context notifications for the unpublished articles should be destroyed

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: not a big deal



