### PR TITLE
Nullify published_at when unpublishing an article

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -824,6 +824,8 @@ class Article < ApplicationRecord
 
   def has_correct_published_at?
     return unless published_at_was && published
+    # nullifying published_at when unpublishing is valid
+    return if changes["published"] == [true, false] && !published_at
     # don't allow editing published_at if an article has already been published
     # allow changes within one minute in case of editing via frontmatter w/o specifying seconds
     return unless published_was && published_at_was < Time.current &&

--- a/app/services/articles/attributes.rb
+++ b/app/services/articles/attributes.rb
@@ -11,7 +11,8 @@ module Articles
       @article_user = article_user
     end
 
-    def for_update(update_edited_at: false, update_published_at: false)
+    def for_update(update_edited_at: false, update_published_at: false,
+                   nullify_published_at: false)
       hash = attributes.slice(*ATTRIBUTES)
       # don't reset the collection when no series was passed
       hash[:collection] = collection if attributes.key?(:series)
@@ -19,6 +20,8 @@ module Articles
       hash[:edited_at] = Time.current if update_edited_at
       if update_published_at
         hash[:published_at] = Time.current
+      elsif nullify_published_at
+        hash[:published_at] = nil
       elsif hash[:published_at]
         hash[:published_at] = hash[:published_at].to_datetime
       end

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -23,9 +23,15 @@ module Articles
       publishing = !article.published && article_params[:published]
       past_published_at = !article_params[:published_at] || article_params[:published_at] < Time.current
       update_published_at = publishing && !article.published_from_feed && past_published_at
+
+      # nullify published_at on unpublishing to avoid having drafts with various published_at values
+      # because it may be misleading
+      unpublishing = article.published && !article_params[:published]
+
       attrs = Articles::Attributes.new(article_params, article.user)
         .for_update(update_edited_at: update_edited_at,
-                    update_published_at: update_published_at)
+                    update_published_at: update_published_at,
+                    nullify_published_at: unpublishing)
 
       success = article.update(attrs)
       if success

--- a/app/workers/moderator/unpublish_all_articles_worker.rb
+++ b/app/workers/moderator/unpublish_all_articles_worker.rb
@@ -11,6 +11,9 @@ module Moderator
       user.articles.published.find_each do |article|
         if article.has_frontmatter?
           article.body_markdown.sub!(/^published:\s*true\s*$/, "published: false")
+        else
+          # nullify published_at when unpublishing for the articles published in a rich markdown editor
+          article.published_at = nil
         end
         article.published = false
         article.save(validate: false)

--- a/spec/services/articles/attributes_spec.rb
+++ b/spec/services/articles/attributes_spec.rb
@@ -78,6 +78,12 @@ RSpec.describe Articles::Attributes, type: :service do
       expect(attrs[:published_at]).to be_falsey
     end
 
+    it "nullifies published_at if nullify_publlished_at is passed" do
+      attrs = described_class.new({ title: "title", published_at: Time.current }, user)
+        .for_update(nullify_published_at: true)
+      expect(attrs[:published_at]).to be_nil
+    end
+
     it "sets published_at correctly" do
       attrs = described_class.new({ title: "title", published_at: "2022-04-25" }, user).for_update
       expect(attrs[:published_at]).to eq(DateTime.new(2022, 4, 25))

--- a/spec/services/articles/updater_spec.rb
+++ b/spec/services/articles/updater_spec.rb
@@ -124,12 +124,12 @@ RSpec.describe Articles::Updater, type: :service do
     context "when an article is unpublished" do
       before { attributes[:published] = false }
 
-      it "doesn't update published_at" do
+      it "nullifies published_at" do
         published_at = 1.day.ago
         article.update_column(:published_at, published_at)
         described_class.call(user, article, attributes)
         article.reload
-        expect(article.published_at).to be_within(1.second).of(published_at)
+        expect(article.published_at).to be_nil
       end
 
       it "doesn't send any notifications" do

--- a/spec/services/articles/updater_spec.rb
+++ b/spec/services/articles/updater_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Articles::Updater, type: :service do
         expect(Mentions::CreateAll).not_to have_received(:call).with(article)
       end
 
-      it "destroys the preexisting notifications" do
+      it "destroys the pre-existing notifications" do
         allow(Notification).to receive(:remove_all_by_action_without_delay).and_call_original
         described_class.call(user, article, attributes)
         attrs = { notifiable_ids: article.id, notifiable_type: "Article", action: "Published" }
@@ -152,7 +152,7 @@ RSpec.describe Articles::Updater, type: :service do
         # expect(ContextNotification).to have_received(:delete_all)
       end
 
-      it "destroys the prexexisting context notifications" do
+      it "destroys the pre-existing context notifications" do
         create(:context_notification, context: article, action: "Published")
         expect do
           described_class.call(user, article, attributes)
@@ -180,7 +180,7 @@ RSpec.describe Articles::Updater, type: :service do
         allow(Notification).to receive(:remove_all).and_call_original
       end
 
-      it "removes any preexisting comment notifications but does not delete the comment" do
+      it "removes any pre-existing comment notifications but does not delete the comment" do
         described_class.call(user, article, attributes)
 
         expect(Notification).to have_received(:remove_all).with(
@@ -201,7 +201,7 @@ RSpec.describe Articles::Updater, type: :service do
         allow(Notification).to receive(:remove_all).and_call_original
       end
 
-      it "removes any preexisting mention notifications but does not delete the mention" do
+      it "removes any pre-existing mention notifications but does not delete the mention" do
         described_class.call(user, article, attributes)
 
         expect(Notification).to have_received(:remove_all).with(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor
- [x] Feature

## Description
Nullify published_at when unpublishing an article to avoid situations when we have a draft with `published_at` displayed in the "Post options" which can be misleading, especially if published_at is already in the past by the time of editing.

Editing an unpublished draft (that was scheduled before) before the changes:
![изображение](https://user-images.githubusercontent.com/30115/183593021-4b56c67c-86ca-4397-9e34-65f47aa985ea.png)

Keeping `published_at` for unpublished drafts doesn't make a lot of sense, but also doesn't make a lot of harm. There can be potential problems with re-publishing when a draft has `published_at` in the past, but we have the logic to avoid such problems [(we update `published_at` to current in such cases)](https://github.com/forem/forem/blob/d942fa87eb05bb8424a9c0fd7f9f96affc1f3020/app/services/articles/updater.rb#L21-L25)

### Concerns
I haven't added nullifying `published_at` for the articles created in the editor v1, which is questionable.
The reason is that I wanted to avoid manipulating `frontmatter` when the user edits it manually, and expects it to look as they left it.

## Related Tickets & Documents

- Related Issue #15858 

## QA Instructions, Screenshots, Recordings
- enable the feature flag `FeatureFlag.enable(:schedule_articles)`
- create a scheduled article
- unpublish a scheduled article (edit => post options => convert to a draft)
- go to edit => post options
- there should be no published_at set in "schedule publication"

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
