### PR TITLE
Changed save article button text to be always 'Save changes' when using editor v1

### DIFF
--- a/app/javascript/article-form/components/EditorActions.jsx
+++ b/app/javascript/article-form/components/EditorActions.jsx
@@ -46,13 +46,14 @@ export const EditorActions = ({
   const schedule = publishedAtObj > now;
   const wasScheduled = passedData.publishedAtWas > now;
 
-  // if the article was saved as scheduled, and the user clears publishedAt in the post options, the save button text is changed to "Publish"
-  // to make it clear that the article is going to be published right away
-
   let saveButtonText;
-  if (schedule) {
+  if (isVersion1) {
+    saveButtonText = 'Save changes';
+  } else if (schedule) {
     saveButtonText = 'Schedule';
-  } else if (wasScheduled || (!published && !isVersion1)) {
+  } else if (wasScheduled || !published) {
+    // if the article was saved as scheduled, and the user clears publishedAt in the post options, the save button text is changed to "Publish"
+    // to make it clear that the article is going to be published right away
     saveButtonText = 'Publish';
   } else {
     saveButtonText = 'Save changes';

--- a/app/workers/articles/publish_worker.rb
+++ b/app/workers/articles/publish_worker.rb
@@ -6,7 +6,7 @@ module Articles
 
     def perform
       # find published articles for which notifications were not set yet (so the context notifications were not created)
-      published_articles =  Article.where(published: true, published_at: 30.minutes.ago..Time.current)
+      published_articles = Article.where(published: true, published_at: 30.minutes.ago..Time.current)
         .where.missing(:context_notifications_published)
       published_articles.each do |article|
         # send slack notifications


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
When using rich markdown editor, we change save button text according to the `published_at` and `published` values, but when using basic markdown editor, the text should always be "Save changes" (as it was before adding scheduling posts feature) 

## Related Tickets & Documents
- Related Issue #15858 

## QA Instructions, Screenshots, Recordings
Check button text in situations like:
- creating a post from editor v1
- editing scheduled post from editor v1
- editing published post from editor v1
The save button text should be "Save changes".

## [Forem core team only] How will this change be communicated?

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: tiny change by itself