### PR TITLE
Try context-based sorting for username search

### DIFF
--- a/app/services/search/username.rb
+++ b/app/services/search/username.rb
@@ -9,10 +9,41 @@ module Search
       username
     ].freeze
 
-    def self.search_documents(term)
-      results = ::User.search_by_name_and_username(term).limit(MAX_RESULTS).select(*ATTRIBUTES)
+    JOIN_COMMENTS = <<-JOIN_SQL.freeze
+    LEFT OUTER JOIN comments on (
+      comments.user_id = users.id AND
+      comments.commentable_type = '%<commentable_type>s' AND
+      comments.commentable_id = %<commentable_id>s
+    )
+    JOIN_SQL
 
-      serialize(results)
+    JOIN_COMMENT_CONTEXT = lambda { |context|
+      commentable_type = context.class.polymorphic_name
+      commentable_id = context.id
+      format(JOIN_COMMENTS, commentable_type: commentable_type, commentable_id: commentable_id)
+    }
+
+    def self.search_documents(term, context: nil)
+      results = context ? search_with_context(term, context) : search_without_context(term)
+      serialize results.limit(MAX_RESULTS)
+    end
+
+    def self.search_without_context(term)
+      ::User.search_by_name_and_username(term).select(*ATTRIBUTES)
+    end
+
+    def self.search_with_context(_term, context)
+      join_sql = JOIN_COMMENT_CONTEXT[context]
+      selects = ATTRIBUTES.map { |sym| "users.#{sym}".to_sym }
+      selects << "(users.id = #{context.user_id}) as is_author"
+      selects << "COUNT(comments.id) as comments_count"
+      selects << "MAX(comments.created_at) as comment_at"
+      # (users.id = 1) as is_author, count(comments.id) as comments_count, MAX(comments.created_at) as comment_at
+
+      ::User.joins(join_sql)
+        .group("users.id")
+        .select(*selects)
+        .order("is_author DESC, comments_count DESC, comment_at ASC")
     end
 
     def self.serialize(results)

--- a/app/services/search/username.rb
+++ b/app/services/search/username.rb
@@ -32,7 +32,7 @@ module Search
       ::User.search_by_name_and_username(term).select(*ATTRIBUTES)
     end
 
-    def self.search_with_context(_term, context)
+    def self.search_with_context(term, context)
       join_sql = JOIN_COMMENT_CONTEXT[context]
       selects = ATTRIBUTES.map { |sym| "users.#{sym}".to_sym }
       selects << "(users.id = #{context.user_id}) as is_author"
@@ -41,6 +41,7 @@ module Search
       # (users.id = 1) as is_author, count(comments.id) as comments_count, MAX(comments.created_at) as comment_at
 
       ::User.joins(join_sql)
+        .search_by_name_and_username(term)
         .group("users.id")
         .select(*selects)
         .order("is_author DESC, comments_count DESC, comment_at ASC")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

When we autocomplete @-mentions, the list is not sorted. If there are lots of matching users, this is nearly useless. It'd be nice if the autocomplete could be contextual: we'd like users who have been active on the post to appear before users who aren't very active. (We might also look at the `current_user`'s mutuals, but that will come later.) 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem-internal-eng/issues/489

## QA Instructions, Screenshots, Recordings

WIP


## Added/updated tests?

- [ ] I need to finish tests for the new behavior

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

I'm concerned about impacting the performance of this query, as I imagine it's one that runs pretty often. It'd be useful if we could monitor performance on this query? (I'm still figuring out what our monitoring situation looks like.)

## [optional] What gif best describes this PR or how it makes you feel?

![gandalf](https://user-images.githubusercontent.com/2077/183698643-352ec4a7-4b37-4b90-8519-fb900d3ae404.gif)


