### PR TITLE
Rubocop Update: Change auto-correct to autocorrect

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -3,7 +3,7 @@ module.exports = {
   '*.json': ['prettier --write'],
   '*.md': ['prettier --write --prose-wrap always'],
   '*.rake': [
-    'bundle exec rubocop --require rubocop-rspec --auto-correct --enable-pending-cops',
+    'bundle exec rubocop --require rubocop-rspec --autocorrect --enable-pending-cops',
   ],
   '*.scss': ['prettier --write'],
   '*.svg': ['svgo --pretty'],
@@ -13,7 +13,7 @@ module.exports = {
     'jest --findRelatedTests --passWithNoTests',
   ],
   './Gemfile': [
-    'bundle exec rubocop --require rubocop-rspec --auto-correct --enable-pending-cops',
+    'bundle exec rubocop --require rubocop-rspec --autocorrect --enable-pending-cops',
   ],
   'app/**/*.html.erb': ['bundle exec erblint --autocorrect'],
   'app/assets/config/manifest.js': [
@@ -21,13 +21,13 @@ module.exports = {
     'eslint --fix -c app/assets/javascripts/.eslintrc.js',
   ],
   'app/views/**/*.jbuilder': [
-    'bundle exec rubocop --require rubocop-rspec --auto-correct --enable-pending-cops',
+    'bundle exec rubocop --require rubocop-rspec --autocorrect --enable-pending-cops',
   ],
   // 'config/locales/*': () => 'bundle exec i18n-tasks normalize',
   'scripts/{release,stage_release}': [
-    'bundle exec rubocop --require rubocop-rspec --auto-correct --enable-pending-cops',
+    'bundle exec rubocop --require rubocop-rspec --autocorrect --enable-pending-cops',
   ],
   '{app,spec,config,lib}/**/*.rb': [
-    'bundle exec rubocop --require rubocop-rspec --auto-correct --enable-pending-cops',
+    'bundle exec rubocop --require rubocop-rspec --autocorrect --enable-pending-cops',
   ],
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When the git commit hooks are being run, we are getting the following warning: 
```
✖ bundle exec rubocop --require rubocop-rspec --auto-correct --enable-pending-cops:
--auto-correct is deprecated; use --autocorrect instead.
```

In [this PR ](https://github.com/rubocop/rubocop/pull/10547) rubocop changed auto-correct to autocorrect whilst still ensuring there is a deprecated alias.

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

The git commit hooks should run without any errors and the warning should disappear. 

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, this is an external tool
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)

