### PR TITLE
 Fix updating articles from scheduled to published (immediately)

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -328,6 +328,8 @@ class ArticlesController < ApplicationController
       time_zone = Time.find_zone(time_zone_str)
       time_zone ||= Time.find_zone("UTC")
       params["article"]["published_at"] = time_zone.parse("#{date} #{time}")
+    else
+      params["article"]["published_at"] = nil
     end
 
     @article_params_json = params.require(:article).permit(allowed_params)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -328,7 +328,7 @@ class ArticlesController < ApplicationController
       time_zone = Time.find_zone(time_zone_str)
       time_zone ||= Time.find_zone("UTC")
       params["article"]["published_at"] = time_zone.parse("#{date} #{time}")
-    else
+    elsif params["article"]["version"] != "v1"
       params["article"]["published_at"] = nil
     end
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -823,7 +823,7 @@ class Article < ApplicationRecord
   end
 
   def has_correct_published_at?
-    return unless published_at_was
+    return unless published_at_was && published
     # don't allow editing published_at if an article has already been published
     # allow changes within one minute in case of editing via frontmatter w/o specifying seconds
     return unless published_was && published_at_was < Time.current &&

--- a/spec/requests/articles/articles_update_spec.rb
+++ b/spec/requests/articles/articles_update_spec.rb
@@ -180,6 +180,17 @@ RSpec.describe "ArticlesUpdate", type: :request do
       expect(published_at_utc).to eq("#{tomorrow.strftime('%m/%d/%Y')} 15:00")
     end
 
+    # scheduled => published immediately
+    it "udpates published_at to current when removing published_at date" do
+      article.update_column(:published_at, 3.days.from_now)
+      attributes.delete :published_at_date
+      attributes[:published] = true
+      now = Time.current
+      put "/articles/#{article.id}", params: { article: attributes }
+      article.reload
+      expect(article.published_at).to be_within(1.minute).of(now)
+    end
+
     # draft => scheduled
     it "sets published_at according to the timezone when updating draft => scheduled" do
       draft = create(:article, published: false, user_id: user.id)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixed publishing a scheduled article:
When a user removes published at date from "Post Options", passed `params` didn't have the corresponding keys, so `published_at` was not updated and kept the future value. After the fix, `published_at` will be set to `nil` explicitly. It will be updated to current time when publising.

## Related Tickets & Documents
- Related Issue #15858 

## QA Instructions, Screenshots, Recordings
- edit a scheduled article
- remove published at date
- click "Publish"
- you should be redirected to the article page (not preview page), and see that the article was published.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: it's a small fix for the big feature

