### PR TITLE
Allow published_at to be within 15 minutes, not 15 hours

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -817,7 +817,7 @@ class Article < ApplicationRecord
 
   def future_or_current_published_at
     # allow published_at in the future or within 15 minutes in the past
-    return if !published || published_at > Time.current - (15 * 60 * 60)
+    return if !published || published_at > Time.current - (15 * 60)
 
     errors.add(:published_at, I18n.t("models.article.future_or_current_published_at"))
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -817,7 +817,7 @@ class Article < ApplicationRecord
 
   def future_or_current_published_at
     # allow published_at in the future or within 15 minutes in the past
-    return if !published || published_at > Time.current - (15 * 60)
+    return if !published || published_at > 15.minutes.ago
 
     errors.add(:published_at, I18n.t("models.article.future_or_current_published_at"))
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -801,15 +801,15 @@ RSpec.describe Article, type: :model do
 
   describe ".active_help" do
     it "returns properly filtered articles under the 'help' tag" do
-      filtered_article = create(:article, user: user, tags: "help",
-                                          published_at: 13.hours.ago, comments_count: 5, score: -3)
+      filtered_article = create(:article, :past, user: user, tags: "help",
+                                                 past_published_at: 13.hours.ago, comments_count: 5, score: -3)
       articles = described_class.active_help
       expect(articles).to include(filtered_article)
     end
 
     it "returns any published articles tagged with 'help' when there are no articles that fit the criteria" do
-      unfiltered_article = create(:article, user: user, tags: "help",
-                                            published_at: 10.hours.ago, comments_count: 8, score: -5)
+      unfiltered_article = create(:article, :past, user: user, tags: "help",
+                                                   past_published_at: 10.hours.ago, comments_count: 8, score: -5)
       articles = described_class.active_help
       expect(articles).to include(unfiltered_article)
     end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -500,6 +500,18 @@ RSpec.describe Article, type: :model do
         .to include("only future or current published_at allowed when publishing an article")
     end
 
+    it "doesn't allow recent published_at when publishing on create" do
+      article2 = build(:article, published_at: 1.hour.ago, published: true)
+      expect(article2.valid?).to be false
+      expect(article2.errors[:published_at])
+        .to include("only future or current published_at allowed when publishing an article")
+    end
+
+    it "allows recent published_at when publishing on create" do
+      article2 = build(:article, published_at: 5.minutes.ago, published: true)
+      expect(article2.valid?).to be true
+    end
+
     it "doesn't allow updating published_at if an article has already been published" do
       article.published_at = (Date.current + 10.days).strftime("%d/%m/%Y %H:%M")
       expect(article.valid?).to be false

--- a/spec/services/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/services/articles/feeds/large_forem_experimental_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
   end
 
   describe ".globally_hot_articles" do
-    let!(:recently_published_article) { create(:article, published_at: 3.hours.ago) }
+    let!(:recently_published_article) { create(:article, :past, past_published_at: 3.hours.ago) }
     let(:globally_hot_articles) { feed.globally_hot_articles(true).second }
 
     it "returns hot recent stories" do
@@ -157,7 +157,7 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :service do
     context "when low number of hot stories and no recently published articles" do
       before do
         Article.delete_all
-        create(:article, hotness_score: 1000, score: 1000, published_at: 3.hours.ago)
+        create(:article, :past, hotness_score: 1000, score: 1000, past_published_at: 3.hours.ago)
       end
 
       # This test handles a situation in which there are a low number of hot or new stories, and the user is logged in.

--- a/spec/system/articles/feeds/large_forem_experimental_spec.rb
+++ b/spec/system/articles/feeds/large_forem_experimental_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Articles::Feeds::LargeForemExperimental, type: :system, js: true 
   let(:user) { create(:user) }
   let(:second_user) { create(:user) }
   let!(:hot_story) do
-    create(:article, hotness_score: 1000, score: 1000, published_at: 3.hours.ago, user_id: second_user.id)
+    create(:article, :past, hotness_score: 1000, score: 1000, past_published_at: 3.hours.ago, user_id: second_user.id)
   end
 
   before do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
We only allow future or current published_at for the new articles, but we allow a 15-minute gap, just in case and for convinience when using editor v1 and the user chooses to specify `published_at`.
This pr allows `published_at` to be within 15 minutes in the past (as intended), not 15 hours

## Related Tickets & Documents

- Related Issue #15858 

## QA Instructions, Screenshots, Recordings
- enable the feature flag `FeatureFlag.enable(:schedule_articles)`
You can use both editors for the next steps:
- try create an article with `published_at` set to 1 hour ago, press `save` - an article should't be saved, an error message should be displayed
- try create an article with `published_at` set to 10 minutes ago, press `save` - an article should be saved

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: a small bug fix


