### PR TITLE
WIP: Fix jest datetime tests

### DIFF
--- a/app/javascript/listings/__tests__/ListingDashboard.test.jsx
+++ b/app/javascript/listings/__tests__/ListingDashboard.test.jsx
@@ -224,7 +224,7 @@ describe('<ListingDashboard />', () => {
         name: 'asdfasdf (expired)',
         level: 2,
       });
-      const timer = screen.getByTitle('Tuesday, June 11, 2019, 4:45:37 PM');
+      const timer = screen.getByTitle('Tuesday, June 11, 2019 at 4:45:37 PM');
 
       expect(title).toBeInTheDocument();
       expect(timer).toBeInTheDocument();
@@ -286,7 +286,7 @@ describe('<ListingDashboard />', () => {
         name: 'YOYOYOYOYOOOOOOOO (expired)',
         level: 2,
       });
-      const timer = screen.getByTitle('Tuesday, June 11, 2019, 4:45:37 PM');
+      const timer = screen.getByTitle('Tuesday, June 11, 2019 at 4:45:37 PM');
 
       expect(title).toBeInTheDocument();
       expect(timer).toBeInTheDocument();

--- a/app/javascript/shared/components/__tests__/dateTime.test.jsx
+++ b/app/javascript/shared/components/__tests__/dateTime.test.jsx
@@ -36,7 +36,7 @@ describe('<DateTime />', () => {
     );
 
     const dateTime = getByText('Sep 10, 2019');
-    expect(dateTime.title).toBe('Tuesday, September 10, 2019, 5:26:20 PM');
+    expect(dateTime.title).toBe('Tuesday, September 10, 2019 at 5:26:20 PM');
     expect(dateTime).toHaveClass('date-time');
   });
 });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)

