### PR TITLE
Revert "Nullify published_at when unpublishing an article (#18298)"

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -824,8 +824,6 @@ class Article < ApplicationRecord
 
   def has_correct_published_at?
     return unless published_at_was && published
-    # nullifying published_at when unpublishing is valid
-    return if changes["published"] == [true, false] && !published_at
     # don't allow editing published_at if an article has already been published
     # allow changes within one minute in case of editing via frontmatter w/o specifying seconds
     return unless published_was && published_at_was < Time.current &&

--- a/app/services/articles/attributes.rb
+++ b/app/services/articles/attributes.rb
@@ -11,8 +11,7 @@ module Articles
       @article_user = article_user
     end
 
-    def for_update(update_edited_at: false, update_published_at: false,
-                   nullify_published_at: false)
+    def for_update(update_edited_at: false, update_published_at: false)
       hash = attributes.slice(*ATTRIBUTES)
       # don't reset the collection when no series was passed
       hash[:collection] = collection if attributes.key?(:series)
@@ -20,8 +19,6 @@ module Articles
       hash[:edited_at] = Time.current if update_edited_at
       if update_published_at
         hash[:published_at] = Time.current
-      elsif nullify_published_at
-        hash[:published_at] = nil
       elsif hash[:published_at]
         hash[:published_at] = hash[:published_at].to_datetime
       end

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -23,15 +23,9 @@ module Articles
       publishing = !article.published && article_params[:published]
       past_published_at = !article_params[:published_at] || article_params[:published_at] < Time.current
       update_published_at = publishing && !article.published_from_feed && past_published_at
-
-      # nullify published_at on unpublishing to avoid having drafts with various published_at values
-      # because it may be misleading
-      unpublishing = article.published && !article_params[:published]
-
       attrs = Articles::Attributes.new(article_params, article.user)
         .for_update(update_edited_at: update_edited_at,
-                    update_published_at: update_published_at,
-                    nullify_published_at: unpublishing)
+                    update_published_at: update_published_at)
 
       success = article.update(attrs)
       if success

--- a/app/workers/moderator/unpublish_all_articles_worker.rb
+++ b/app/workers/moderator/unpublish_all_articles_worker.rb
@@ -11,9 +11,6 @@ module Moderator
       user.articles.published.find_each do |article|
         if article.has_frontmatter?
           article.body_markdown.sub!(/^published:\s*true\s*$/, "published: false")
-        else
-          # nullify published_at when unpublishing for the articles published in a rich markdown editor
-          article.published_at = nil
         end
         article.published = false
         article.save(validate: false)

--- a/spec/services/articles/attributes_spec.rb
+++ b/spec/services/articles/attributes_spec.rb
@@ -78,12 +78,6 @@ RSpec.describe Articles::Attributes, type: :service do
       expect(attrs[:published_at]).to be_falsey
     end
 
-    it "nullifies published_at if nullify_publlished_at is passed" do
-      attrs = described_class.new({ title: "title", published_at: Time.current }, user)
-        .for_update(nullify_published_at: true)
-      expect(attrs[:published_at]).to be_nil
-    end
-
     it "sets published_at correctly" do
       attrs = described_class.new({ title: "title", published_at: "2022-04-25" }, user).for_update
       expect(attrs[:published_at]).to eq(DateTime.new(2022, 4, 25))

--- a/spec/services/articles/updater_spec.rb
+++ b/spec/services/articles/updater_spec.rb
@@ -124,12 +124,12 @@ RSpec.describe Articles::Updater, type: :service do
     context "when an article is unpublished" do
       before { attributes[:published] = false }
 
-      it "nullifies published_at" do
+      it "doesn't update published_at" do
         published_at = 1.day.ago
         article.update_column(:published_at, published_at)
         described_class.call(user, article, attributes)
         article.reload
-        expect(article.published_at).to be_nil
+        expect(article.published_at).to be_within(1.second).of(published_at)
       end
 
       it "doesn't send any notifications" do
@@ -144,7 +144,7 @@ RSpec.describe Articles::Updater, type: :service do
         expect(Mentions::CreateAll).not_to have_received(:call).with(article)
       end
 
-      it "destroys the pre-existing notifications" do
+      it "destroys the preexisting notifications" do
         allow(Notification).to receive(:remove_all_by_action_without_delay).and_call_original
         described_class.call(user, article, attributes)
         attrs = { notifiable_ids: article.id, notifiable_type: "Article", action: "Published" }
@@ -152,7 +152,7 @@ RSpec.describe Articles::Updater, type: :service do
         # expect(ContextNotification).to have_received(:delete_all)
       end
 
-      it "destroys the pre-existing context notifications" do
+      it "destroys the prexexisting context notifications" do
         create(:context_notification, context: article, action: "Published")
         expect do
           described_class.call(user, article, attributes)
@@ -180,7 +180,7 @@ RSpec.describe Articles::Updater, type: :service do
         allow(Notification).to receive(:remove_all).and_call_original
       end
 
-      it "removes any pre-existing comment notifications but does not delete the comment" do
+      it "removes any preexisting comment notifications but does not delete the comment" do
         described_class.call(user, article, attributes)
 
         expect(Notification).to have_received(:remove_all).with(
@@ -201,7 +201,7 @@ RSpec.describe Articles::Updater, type: :service do
         allow(Notification).to receive(:remove_all).and_call_original
       end
 
-      it "removes any pre-existing mention notifications but does not delete the mention" do
+      it "removes any preexisting mention notifications but does not delete the mention" do
         described_class.call(user, article, attributes)
 
         expect(Notification).to have_received(:remove_all).with(


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
This reverts commit 414e17aca62f48e0bdaa908a5ba3ab45902f67c8.

## Related Tickets & Documents
Resolves https://github.com/forem/forem/issues/18341


