### PR TITLE
API for Reactions: Create endpoint

### DIFF
--- a/app/controllers/api/v1/reactions_controller.rb
+++ b/app/controllers/api/v1/reactions_controller.rb
@@ -1,0 +1,28 @@
+module Api
+  module V1
+    class ReactionsController < ApiController
+      before_action :authenticate!
+
+      def create
+        remove_count_cache_key
+
+        result = ReactionToggle.toggle(params, current_user: current_user || @user)
+
+        if result.success?
+          render json: { result: result.action, category: result.category }
+        else
+          render json: { error: result.errors_as_sentence, status: 422 }, status: :unprocessable_entity
+        end
+      end
+    end
+
+    private
+
+    # TODO: should this move to toggle service? refactor?
+    def remove_count_cache_key
+      return unless params[:reactable_type] == "Article"
+
+      Rails.cache.delete "count_for_reactable-Article-#{params[:reactable_id]}"
+    end
+  end
+end

--- a/app/controllers/api/v1/reactions_controller.rb
+++ b/app/controllers/api/v1/reactions_controller.rb
@@ -14,15 +14,15 @@ module Api
           render json: { error: result.errors_as_sentence, status: 422 }, status: :unprocessable_entity
         end
       end
-    end
 
-    private
+      private
 
-    # TODO: should this move to toggle service? refactor?
-    def remove_count_cache_key
-      return unless params[:reactable_type] == "Article"
+      # TODO: should this move to toggle service? refactor?
+      def remove_count_cache_key
+        return unless params[:reactable_type] == "Article"
 
-      Rails.cache.delete "count_for_reactable-Article-#{params[:reactable_id]}"
+        Rails.cache.delete "count_for_reactable-Article-#{params[:reactable_id]}"
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,8 @@ Rails.application.routes.draw do
           put "/articles/:id/unpublish", to: "articles#unpublish", as: :article_unpublish
           put "/users/:id/unpublish", to: "users#unpublish", as: :user_unpublish
 
+          post "/reactions", to: "reactions#create"
+
           draw :api
         end
       end

--- a/spec/requests/api/v1/reactions_spec.rb
+++ b/spec/requests/api/v1/reactions_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Reactions", type: :request do
+  let!(:v1_headers) { { "content-type" => "application/json", "Accept" => "application/vnd.forem.api-v1+json" } }
+  let(:params) do
+    {
+      reactable_type: "Article",
+      reactable_id: "123",
+      category: "like"
+    }
+  end
+
+  before { allow(FeatureFlag).to receive(:enabled?).with(:api_v1).and_return(true) }
+
+  shared_context "when user and post to create is authorized" do
+    let(:api_secret) { create(:api_secret) }
+    let(:user) { api_secret.user }
+    let(:auth_header) { v1_headers.merge({ "api-key" => api_secret.secret }) }
+  end
+
+  context "when unauthenticated and post to create" do
+    it "returns unauthorized" do
+      post api_reactions_path, params: params.to_json, headers: v1_headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context "when unauthorized and post to create" do
+    it "returns unauthorized" do
+      post api_reactions_path, params: params.to_json, headers: v1_headers.merge({ "api-key" => "invalid api key" })
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context "when authorized and post to create" do
+    include_context "when user is authorized"
+
+    before do
+      allow(Rails.cache).to receive(:delete)
+      allow(ReactionToggle).to receive(:toggle).and_return(result)
+    end
+
+    context "when toggled successfully" do
+      let(:result) { ReactionToggle::Result.new reaction: Reaction.new }
+
+      it "responds with success" do
+        post api_reactions_path, params: params.to_json, headers: auth_header
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when toggled unsuccessfully" do
+      let(:result) do
+        ReactionToggle::Result.new.tap do |bad_result|
+          allow(bad_result).to receive(:success?).and_return(false)
+          allow(bad_result).to receive(:errors_as_sentence).and_return("Stuff was bad")
+        end
+      end
+
+      it "responds with success" do
+        post api_reactions_path, params: params.to_json, headers: auth_header
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We intend to support reactions via the V1 API. First step is an endpoint that allows "create" via post.

**However**, this might be a good time to discuss: Forem does not *really* "create" Reactions. It might be more accurate to describe them as being "complicated toggles". 

* In the simplest case, "like"-ing an Article will *indeed* create a new Reaction, however...
* "like"-ing an Article that was previously liked (by the same user) will *remove the like*
* The behavior for "unicorn", "hands", and "thinking" is the same as for "like", however...
* Moderator reactions will clear previous mod-level reactions in the opposite "polarity" (thumbsdown or vomit will destroy previous thumbsup, and vice-versa) 
* The negative moderator reactions on *user* or *organization* reactables causes a ripple effect: sinking all articles belonging to affected users.
* Reacting with "readinglist" will trigger a `RatingVote` for users with an `experience_level` (reacting with a 2nd "readinglist" will clear any previous "readinglist" but ignores the `RatingVote` -- this is almost certainly a :bug:)

This PR assumes we want the API endpoint to mirror this behavior closely, however... it's a little unclear if that's _actually_ our intention. For example, we are elsewhere (#18266) interested in having a `delete` endpoint for an individual reaction, but there currently is *no* equivalent "pure destroy" action for individual reactions in the main app.

One option might be for the API to have "idempotent" creates, instead of toggles -- then, say, repeated calls to "like" the same article would be no-ops. However, in _some_ cases (moderator reactions in particular), this seems like a significant deviation from expected behavior. A moderator "vomit" is a particularly "load-bearing" reaction, in a way that seems difficult to divide from the "toggle" behavior. (The "toggle reaction" logic is also significantly concerned with count caching, in a way that's similarly difficult to unwind from the toggle behavior.)

Because our current primary use-case for the reactions API endpoint is spam mitigation, @Ridhwana and I assume that we're particularly interested in the moderator-vomit behavior, and therefore we want to mirror the "load-bearing vomit" logic in the main app pretty closely, but thought it was something worth pointing out, particularly how it might impact the planned `delete` endpoint.

`cc` @fdocr @joshpuetz @mirie 

## Related Tickets & Documents

- Related Issue #https://github.com/forem/forem/issues/18263
- Related Issue #18266 
- This is built on PR #18350 

## QA Instructions, Screenshots, Recordings
* Enable `api_v1` feature flag
* With an API token and an Article having id ':id', POST to `http://localhost:3000/api/reactions?reactable_type=Article&reactable_id=[:id]&category=like`

Expected result:
```
200 OK
{
    "result": "create",
    "category": "like"
}
```

Or:
```
200 OK
{
    "result": "destroy",
    "category": "like"
}
```

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?


- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media3.giphy.com/media/l2JdUolkmRLmZM9Fu/giphy.gif?cid=ecf05e47rch707bon7jwuvkq59m3pe4lid9cbf09vpf7ees7&rid=giphy.gif&ct=g)

