### PR TITLE
Public reactions score feed lever

### DIFF
--- a/app/models/articles/feeds.rb
+++ b/app/models/articles/feeds.rb
@@ -332,6 +332,14 @@ module Articles
                       user_required: false,
                       select_fragment: "articles.public_reactions_count",
                       group_by_fragment: "articles.public_reactions_count")
+
+      relevancy_lever(:public_reactions_score,
+                      label: "Weight to give based on article.score (see article.update_score for this calculation -
+                      it's a sum of the scores of reactions on an article).",
+                      range: "[0..∞)",
+                      user_required: false,
+                      select_fragment: "articles.score",
+                      group_by_fragment: "articles.score")
     end
     private_constant :LEVER_CATALOG
     # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a feed lever for ranking articles by their public reaction score. This value is already calculated by `article.update_score` and held in the database as `articles.score`. It's represents a sum of the points associated with reactions on an article.

## Related Tickets & Documents

- Closes #18271

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: covered by existing tests
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/bppSFMYWlbmsE/giphy.gif)

