### PR TITLE
Set key_generator_hash_digest_class to SHA256

### DIFF
--- a/config/initializers/new_framework_defaults_7_0.rb
+++ b/config/initializers/new_framework_defaults_7_0.rb
@@ -23,7 +23,7 @@ Rails.application.config.action_view.apply_stylesheet_media_default = false
 #
 # See upgrading guide for more information on how to build a rotator.
 # https://guides.rubyonrails.org/v7.0/upgrading_ruby_on_rails.html
-# Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
+Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA256
 
 # Change the digest class for ActiveSupport::Digest.
 # Changing this default means that for example Etags change and


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Dependency update

## Description
Update to a more secure SHA256 on `key_generator_hash_digest_class`. 

>The default digest class for the key generator is changing from SHA1 to SHA256. This has consequences in any encrypted message generated by Rails, including encrypted cookies. In order to be able to read messages using the old digest class it is necessary to register a rotator. [reference link](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#key-generator-digest-class-changing-to-use-sha256. )



~This is potentially a breaking change, which is why a cookie rotator is necessary to persist user's sessions~

A rotator was initially added, but I realize that it's unnecessary for me. This change was tested on staging and no side effect were detected. My best guess is we digest of choice has always been SHA256 because that's [technically the default](https://github.com/rails/rails/blob/7-0-stable/activesupport/lib/active_support/message_encryptor.rb#L146) because of the default `aed_mode`. I looked far and wide and was only able to see 3 Stack Overflow questions, stating they were an obvious error after applying this change. At this point I am fairly certain this change is safe but we should still keep a an eye for it.

## Related Tickets & Documents
Related to one of the tasks on https://github.com/forem/forem-internal-eng/issues/468

## QA Instructions, Screenshots, Recordings
Tested on canary and heroku staging.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a