### PR TITLE
Update the error message when a user with role "comment_suspended" tries to comment

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -17,7 +17,7 @@ class ArticlesController < ApplicationController
   #
   #              I still want to enable this, but first want to get things mostly conformant with
   #              existing expectations.  Note, in config/application.rb, we're rescuing the below
-  #              excpetion as though it was a Pundit::NotAuthorizedError.
+  #              exception as though it was a Pundit::NotAuthorizedError.
   #
   #              The difference being that rescue_from is an ALWAYS use case.  Whereas the
   #              config/application.rb uses the config.consider_all_requests_local to determine if

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -94,6 +94,7 @@ class CommentsController < ApplicationController
     raise
   rescue StandardError => e
     skip_authorization
+
     message = I18n.t("comments_controller.markdown", error: e)
     render json: { error: message }, status: :unprocessable_entity
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -82,15 +82,18 @@ class CommentsController < ApplicationController
       message = @comment.errors_as_sentence
       render json: { error: message }, status: :unprocessable_entity
     end
+
   # See https://github.com/forem/forem/pull/5485#discussion_r366056925
   # for details as to why this is necessary
   rescue ModerationUnauthorizedError => e
     render json: { error: e.message }, status: :unprocessable_entity
-  rescue Pundit::NotAuthorizedError, RateLimitChecker::LimitReached
+  rescue Pundit::NotAuthorizedError => e
+    message = I18n.t("comments_controller.create.authorization_error", error: e)
+    render json: { error: message }, status: :unauthorized
+  rescue RateLimitChecker::LimitReached
     raise
   rescue StandardError => e
     skip_authorization
-
     message = I18n.t("comments_controller.markdown", error: e)
     render json: { error: message }, status: :unprocessable_entity
   end

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -13,7 +13,7 @@ en:
     create:
       success: created
       failure: comment already exists
-      authorization_error: Your comment could not be posted because your privileges have been suspended.
+      authorization_error: Your privileges have been suspended.
     delete:
       error: Something went wrong; Comment NOT deleted.
       notice: Comment was successfully deleted.

--- a/config/locales/controllers/en.yml
+++ b/config/locales/controllers/en.yml
@@ -13,6 +13,7 @@ en:
     create:
       success: created
       failure: comment already exists
+      authorization_error: Your comment could not be posted because your privileges have been suspended.
     delete:
       error: Something went wrong; Comment NOT deleted.
       notice: Comment was successfully deleted.

--- a/config/locales/controllers/fr.yml
+++ b/config/locales/controllers/fr.yml
@@ -13,6 +13,7 @@ fr:
     create:
       success: created
       failure: comment already exists
+      authorization_error: Your comment could not be posted because your privileges have been suspended.
     delete:
       error: Something went wrong; Comment NOT deleted.
       notice: Comment was successfully deleted.

--- a/config/locales/controllers/fr.yml
+++ b/config/locales/controllers/fr.yml
@@ -13,7 +13,7 @@ fr:
     create:
       success: created
       failure: comment already exists
-      authorization_error: Your comment could not be posted because your privileges have been suspended.
+      authorization_error: Your privileges have been suspended.
     delete:
       error: Something went wrong; Comment NOT deleted.
       notice: Comment was successfully deleted.

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -319,6 +319,18 @@ RSpec.describe "Comments", type: :request do
       }
     end
 
+    context "when a user is coment_suspended" do
+      before do
+        sign_in user
+        user.add_role(:comment_suspended)
+      end
+
+      it "returns not authorized" do
+        post "/comments", params: base_comment_params
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
     context "when part of field test" do
       before do
         sign_in user


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently, when a suspended or comment suspended user tries to take an action that they can't because of their suspension they receive a generic error message "Your comment could not be posted due to a server error". The issue is that users see this error message and think that they're experiencing a bug. They frequently don't realize that they're experiencing this issue because they're suspended.

Hence, in this PR, we change the error message to read "Your comment could not be posted due to an error: Your privileges have been suspended."

<img width="1471" alt="Screenshot 2022-08-23 at 15 22 58" src="https://user-images.githubusercontent.com/2786819/186169903-b0af5d1b-dabe-448e-911e-96f3eaa74f9c.png">

## Related Tickets & Documents

- Related Issue #https://github.com/forem/forem/issues/18336
- Closes #https://github.com/forem/forem/issues/18336

## QA Instructions, Screenshots, Recordings

- Add the role `comment_suspended` to your logged in user. You can do this by finding the user and assigning it to `user` in the console. Thereafter run `user.add_role(:comment_suspended)`. 
- Now navigate to an article and try to comment.
- You should see the following error message:
<img width="1471" alt="Screenshot 2022-08-23 at 15 22 58" src="https://user-images.githubusercontent.com/2786819/186169903-b0af5d1b-dabe-448e-911e-96f3eaa74f9c.png">

Aside:
If you now run `user.remove_role(:comment_suspended)` you will be able to comment again.

### UI accessibility concerns?

No real UI changes.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/dRa1rr45u0s96KqCVC/giphy.gif)

