### PR TITLE
Made published_at immutable after an article has been published once

### DIFF
--- a/app/javascript/article-form/components/Options.jsx
+++ b/app/javascript/article-form/components/Options.jsx
@@ -33,8 +33,9 @@ export const Options = ({
   let existingSeries = '';
   let publishedAtField = '';
 
-  const wasScheduled = moment(publishedAtWas) > moment();
-  const readonlyPublishedAt = published && !wasScheduled;
+  const wasScheduled = publishedAtWas && moment(publishedAtWas) > moment();
+  // allow to edit published at if it was not set earlier or if it's in the future
+  const editablePublishedAt = !publishedAtWas || wasScheduled;
 
   if (allSeries.length > 0) {
     const seriesNames = allSeries.map((name, index) => {
@@ -92,7 +93,7 @@ export const Options = ({
     }
   }
 
-  if (schedulingEnabled && !readonlyPublishedAt) {
+  if (schedulingEnabled && editablePublishedAt) {
     const currentDate = moment().format('YYYY-MM-DD');
     publishedAtField = (
       <div className="crayons-field mb-6">

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -840,16 +840,6 @@ class Article < ApplicationRecord
     end
   end
 
-  # def has_correct_published_at?
-  #   return unless published_at_was && published
-  #   # don't allow editing published_at if an article has already been published
-  #   # allow changes within one minute in case of editing via frontmatter w/o specifying seconds
-  #   return unless published_was && published_at_was < Time.current &&
-  #     changes["published_at"] && !(published_at_was - published_at).between?(-60, 60)
-
-  #   errors.add(:published_at, I18n.t("models.article.immutable_published_at"))
-  # end
-
   def canonical_url_must_not_have_spaces
     return unless canonical_url.to_s.match?(/[[:space:]]/)
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -827,7 +827,8 @@ class Article < ApplicationRecord
 
     # for drafts (that were never published before) or scheduled articles => allow future or current dates
     if !published_at_was || published_at_was > Time.current
-      if !published_at || published_at < 15.minutes.ago
+      # for articles published_from_feed (exported from rss) we allow past published_at
+      if (!published_at || published_at < 15.minutes.ago) && !published_from_feed
         errors.add(:published_at, I18n.t("models.article.future_or_current_published_at"))
       end
     else

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -159,7 +159,7 @@ class Article < ApplicationRecord
   validates :video_state, inclusion: { in: %w[PROGRESSING COMPLETED] }, allow_nil: true
   validates :video_thumbnail_url, url: { allow_blank: true, schemes: %w[https http] }
   validate :future_or_current_published_at, on: :create
-  validate :has_correct_published_at?, on: :update, unless: :admin_update
+  validate :correct_published_at?, on: :update, unless: :admin_update
 
   validate :canonical_url_must_not_have_spaces
   validate :validate_collection_permission
@@ -822,15 +822,32 @@ class Article < ApplicationRecord
     errors.add(:published_at, I18n.t("models.article.future_or_current_published_at"))
   end
 
-  def has_correct_published_at?
-    return unless published_at_was && published
-    # don't allow editing published_at if an article has already been published
-    # allow changes within one minute in case of editing via frontmatter w/o specifying seconds
-    return unless published_was && published_at_was < Time.current &&
-      changes["published_at"] && !(published_at_was - published_at).between?(-60, 60)
+  def correct_published_at?
+    return unless changes["published_at"]
 
-    errors.add(:published_at, I18n.t("models.article.immutable_published_at"))
+    # for drafts (that were never published before) or scheduled articles => allow future or current dates
+    if !published_at_was || published_at_was > Time.current
+      if !published_at || published_at < 15.minutes.ago
+        errors.add(:published_at, I18n.t("models.article.future_or_current_published_at"))
+      end
+    else
+      # for articles that have been published already (published or unpublished drafts) => immutable published_at
+      # allow changes within one minute in case of editing via frontmatter w/o specifying seconds
+      has_nils = changes["published_at"].include?(nil) # changes from nil or to nil
+      close_enough = !has_nils && (published_at_was - published_at).between?(-60, 60)
+      errors.add(:published_at, I18n.t("models.article.immutable_published_at")) if has_nils || !close_enough
+    end
   end
+
+  # def has_correct_published_at?
+  #   return unless published_at_was && published
+  #   # don't allow editing published_at if an article has already been published
+  #   # allow changes within one minute in case of editing via frontmatter w/o specifying seconds
+  #   return unless published_was && published_at_was < Time.current &&
+  #     changes["published_at"] && !(published_at_was - published_at).between?(-60, 60)
+
+  #   errors.add(:published_at, I18n.t("models.article.immutable_published_at"))
+  # end
 
   def canonical_url_must_not_have_spaces
     return unless canonical_url.to_s.match?(/[[:space:]]/)

--- a/app/services/articles/attributes.rb
+++ b/app/services/articles/attributes.rb
@@ -11,17 +11,13 @@ module Articles
       @article_user = article_user
     end
 
-    def for_update(update_edited_at: false, update_published_at: false)
+    def for_update(update_edited_at: false)
       hash = attributes.slice(*ATTRIBUTES)
       # don't reset the collection when no series was passed
       hash[:collection] = collection if attributes.key?(:series)
       hash[:tag_list] = tag_list
       hash[:edited_at] = Time.current if update_edited_at
-      if update_published_at
-        hash[:published_at] = Time.current
-      elsif hash[:published_at]
-        hash[:published_at] = hash[:published_at].to_datetime
-      end
+      hash[:published_at] = hash[:published_at].to_datetime if hash[:published_at]
       hash
     end
 

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -17,17 +17,10 @@ module Articles
 
       # updated edited time only if already published and not edited by an admin
       update_edited_at = article.user == user && article.published
-      # TODO: move setting published_at to Articles::Attributes
-      # when publishing (draft => published), and published_at is nil or is in the past, set it to Time.current
-      # except for exported articles, and the articles that are re-published
-      publishing = !article.published && article_params[:published]
-      past_published_at = !article_params[:published_at] || article_params[:published_at] < Time.current
-      update_published_at = false # publishing && !article.published_at && !article.published_from_feed && past_published_at
       attrs = Articles::Attributes.new(article_params, article.user)
-        .for_update(update_edited_at: update_edited_at,
-                    update_published_at: update_published_at)
+        .for_update(update_edited_at: update_edited_at)
 
-        success = article.update(attrs)
+      success = article.update(attrs)
       if success
         user.rate_limiter.track_limit_by_action(:article_update)
 

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -19,8 +19,8 @@ module Articles
       update_edited_at = article.user == user && article.published
       attrs = Articles::Attributes.new(article_params, article.user)
         .for_update(update_edited_at: update_edited_at)
-
       success = article.update(attrs)
+
       if success
         user.rate_limiter.track_limit_by_action(:article_update)
 

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -17,6 +17,10 @@ module Articles
 
       # updated edited time only if already published and not edited by an admin
       update_edited_at = article.user == user && article.published
+      # remove published_at values received from a user if an articles was published before (has past published_at)
+      # published_at will remain as it was in this case
+      article_params.delete :published_at if article.published_at && !article.scheduled?
+
       attrs = Articles::Attributes.new(article_params, article.user)
         .for_update(update_edited_at: update_edited_at)
       success = article.update(attrs)

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -20,7 +20,6 @@ module Articles
       attrs = Articles::Attributes.new(article_params, article.user)
         .for_update(update_edited_at: update_edited_at)
       success = article.update(attrs)
-
       if success
         user.rate_limiter.track_limit_by_action(:article_update)
 

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -19,15 +19,15 @@ module Articles
       update_edited_at = article.user == user && article.published
       # TODO: move setting published_at to Articles::Attributes
       # when publishing (draft => published), and published_at is nil or is in the past, set it to Time.current
-      # except for exported articles
+      # except for exported articles, and the articles that are re-published
       publishing = !article.published && article_params[:published]
       past_published_at = !article_params[:published_at] || article_params[:published_at] < Time.current
-      update_published_at = publishing && !article.published_from_feed && past_published_at
+      update_published_at = false # publishing && !article.published_at && !article.published_from_feed && past_published_at
       attrs = Articles::Attributes.new(article_params, article.user)
         .for_update(update_edited_at: update_edited_at,
                     update_published_at: update_published_at)
 
-      success = article.update(attrs)
+        success = article.update(attrs)
       if success
         user.rate_limiter.track_limit_by_action(:article_update)
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -484,7 +484,7 @@ RSpec.describe Article, type: :model do
       expect(article_with_date.published_at.strftime("%d/%m/%Y")).to eq(date)
     end
 
-    it "sets published_at from frontmatter" do
+    it "sets future published_at from frontmatter" do
       published_at = (Date.current + 10.days).strftime("%d/%m/%Y %H:%M")
       body_markdown = "---\ntitle: Title\npublished: false\npublished_at: #{published_at}\ndescription:\ntags: heytag
       \n---\n\nHey this is the article"
@@ -493,20 +493,29 @@ RSpec.describe Article, type: :model do
       expect(article_with_published_at.published_at.strftime("%d/%m/%Y %H:%M")).to eq(published_at)
     end
 
+    it "sets published_at when publishing but no published_at passed from frontmatter" do
+      body_markdown = "---\ntitle: Title\npublished: true\ndescription:\ntags: heytag
+      \n---\n\nHey this is the article"
+      article = create(:article, body_markdown: body_markdown)
+      article.reload
+      expect(article.published_at).to be > 10.minutes.ago
+    end
+
+    it "sets published_at when publishing from draft and no published_at passed from frontmatter" do
+      body_markdown = "---\ntitle: Title\npublished: true\ndescription:\ntags: heytag
+      \n---\n\nHey this is the article"
+      draft = create(:article, published: false, published_at: nil)
+      draft.update(body_markdown: body_markdown)
+      draft.reload
+      expect(draft.published).to be true
+      expect(draft.published_at).to be > 10.minutes.ago
+    end
+
     it "doesn't allow past published_at when publishing on create" do
       article2 = build(:article, published_at: 10.days.ago, published: true)
       expect(article2.valid?).to be false
       expect(article2.errors[:published_at])
         .to include("only future or current published_at allowed when publishing an article")
-    end
-
-    it "allows past published_at for published_from_feed articles when publishing on update" do
-      published_at = 10.days.ago
-      article2 = create(:article, published: false, published_at: nil, published_from_feed: true)
-      body_markdown = "---\ntitle: Title\npublished: true\npublished_at: #{published_at.strftime('%d/%m/%Y %H:%M')}
-      \ndescription:\ntags: heytag\n---\n\nHey this is the article"
-      article2.update(body_markdown: body_markdown)
-      expect(article2.published_at).to be_within(1.minute).of(published_at)
     end
 
     it "doesn't allow recent published_at when publishing on create" do
@@ -521,23 +530,114 @@ RSpec.describe Article, type: :model do
       expect(article2.valid?).to be true
     end
 
-    it "doesn't allow updating published_at if an article has already been published" do
-      article.published_at = (Date.current + 10.days).strftime("%d/%m/%Y %H:%M")
-      expect(article.valid?).to be false
-      expect(article.errors[:published_at])
-        .to include("updating published_at for articles that have already been published is not allowed")
+    context "when unpublishing" do
+      let!(:published_at_was) { article.published_at }
+
+      it "keeps published_at" do
+        article.update(published: false)
+        article.reload
+        expect(article.published_at).to be_within(1.second).of(published_at_was)
+      end
+
+      it "keeps published_at if we try to unset it" do
+        article.update(published: false, published_at: nil)
+        article.reload
+        expect(article.published_at).to be_within(1.second).of(published_at_was)
+      end
+
+      it "keeps published_at when unpublising a scheduled article" do
+        scheduled_published_at = 1.day.from_now
+        article.update_columns(published_at: scheduled_published_at)
+        article.update(published: false)
+        article.reload
+        expect(article.published_at).to be_within(1.second).of(scheduled_published_at)
+      end
     end
 
-    it "doesn't allow changing published_at for published_from_feed articles that have been published before" do
-      published_at = Time.current
-      published_at_was = 10.days.ago
-      # has published_at means that the article was published before
-      article2 = create(:article, published: false, published_at: published_at_was, published_from_feed: true)
-      body_markdown = "---\ntitle: Title\npublished: true\npublished_at: #{published_at.strftime('%d/%m/%Y %H:%M')}
-      \ndescription:\ntags: heytag\n---\n\nHey this is the article"
-      success = article2.update(body_markdown: body_markdown)
-      expect(success).to be false
-      expect(article2.errors[:published_at]).to include(I18n.t("models.article.immutable_published_at"))
+    context "when unpublishing a frontmatter article" do
+      let(:published_at) { "2022-05-05 18:00 +0300" }
+      let(:body_markdown) { "---\ntitle: Title\npublished: true\npublished_at: #{published_at}\n---\n\n" }
+      let(:frontmatter_article) do
+        a = create(:article, :past, past_published_at: DateTime.parse(published_at))
+        # if we would set markdown on create, past_published_at would be overriden by body_markdown values
+        # and the validation wouldn't pass
+        a.update_columns(body_markdown: body_markdown)
+        a
+      end
+
+      it "keeps published at" do
+        new_body_markdown = "---\ntitle: Title\npublished: false\n---\n\n"
+        frontmatter_article.update(body_markdown: new_body_markdown)
+        expect(frontmatter_article.published_at).to be_within(1.minute).of(DateTime.parse(published_at))
+      end
+
+      it "keeps published at when trying to set published_at" do
+        new_body_markdown = "---\ntitle: Title\npublished: false\npublished_at:2022-12-05 18:00 +0300---\n\n"
+        frontmatter_article.update(body_markdown: new_body_markdown)
+        expect(frontmatter_article.published_at).to be_within(1.minute).of(DateTime.parse(published_at))
+      end
+
+      it "keeps published_at when unpublishing a scheduled article" do
+        scheduled_time = 1.day.from_now
+        time_str = scheduled_time.strftime("%d/%m/%Y %H:%M %z")
+        scheduled_body_markdown = "---\ntitle: Title\npublished: true\npublished_at: #{time_str}\n---\n\n"
+        frontmatter_scheduled_article = create(:article, body_markdown: scheduled_body_markdown)
+        new_body_markdown = "---\ntitle: Title\npublished: false\npublished_at:2022-12-05 18:00 +0300---\n\n"
+        frontmatter_scheduled_article.update(body_markdown: new_body_markdown)
+        expect(frontmatter_scheduled_article.published_at).to be_within(1.minute).of(scheduled_time)
+      end
+    end
+
+    context "when publishing on update (draft => published)" do
+      # has published_at means that the article was published before (and unpublished later, in this)
+      it "doesn't allow updating published_at if an article has already been published" do
+        article.published_at = (Date.current + 10.days).strftime("%d/%m/%Y %H:%M")
+        expect(article.valid?).to be false
+        expect(article.errors[:published_at])
+          .to include("updating published_at for articles that have already been published is not allowed")
+      end
+
+      it "allows past published_at for published_from_feed articles when publishing on update" do
+        published_at = 10.days.ago
+        article2 = create(:article, published: false, published_at: nil, published_from_feed: true)
+        body_markdown = "---\ntitle: Title\npublished: true\npublished_at: #{published_at.strftime('%d/%m/%Y %H:%M')}
+        \ndescription:\ntags: heytag\n---\n\nHey this is the article"
+        article2.update(body_markdown: body_markdown)
+        expect(article2.published_at).to be_within(1.minute).of(published_at)
+      end
+
+      it "doesn't allow changing published_at for published_from_feed articles that have been published before" do
+        published_at = Time.current
+        published_at_was = 10.days.ago
+        # has published_at means that the article was published before
+        article2 = create(:article, published: false, published_at: published_at_was, published_from_feed: true)
+        body_markdown = "---\ntitle: Title\npublished: true\npublished_at: #{published_at.strftime('%d/%m/%Y %H:%M')}
+        \ndescription:\ntags: heytag\n---\n\nHey this is the article"
+        success = article2.update(body_markdown: body_markdown)
+        expect(success).to be false
+        expect(article2.errors[:published_at]).to include(I18n.t("models.article.immutable_published_at"))
+      end
+    end
+
+    context "when updating a previously published (and unpublished) frontmatter article" do
+      let(:published_at) { "2022-05-05 18:00 +0300" }
+      let(:body_markdown) { "---\ntitle: Title\npublished: false\npublished_at: #{published_at}\n---\n\n" }
+      let(:frontmatter_article) { create(:article, body_markdown: body_markdown) }
+
+      it "doesn't allow updating published_at if specifying published_at" do
+        # expect(frontmatter_article.published_at < 10.days.ago).to be true
+        new_body_markdown = "---\ntitle: Title\npublished: true\npublished_at: 2022-10-05 18:00 +0300\n---\n\n"
+        success = frontmatter_article.update(body_markdown: new_body_markdown)
+        expect(success).to be false
+        expect(frontmatter_article.errors[:published_at]).to include(I18n.t("models.article.immutable_published_at"))
+      end
+
+      it "doesn't allow updating published_at if removing published_at" do
+        new_body_markdown = "---\ntitle: Title\npublished: true\n---\n\n"
+        frontmatter_article.update(body_markdown: new_body_markdown)
+        frontmatter_article.reload
+        expect(frontmatter_article.published_at).to be_within(1.minute).of(DateTime.parse(published_at))
+      end
     end
   end
 

--- a/spec/services/articles/attributes_spec.rb
+++ b/spec/services/articles/attributes_spec.rb
@@ -68,24 +68,9 @@ RSpec.describe Articles::Attributes, type: :service do
       expect(attrs[:edited_at]).to be_falsey
     end
 
-    it "sets published_at if update_published_at is true" do
-      attrs = described_class.new({ title: "title" }, user).for_update(update_published_at: true)
-      expect(attrs[:published_at]).to be_truthy
-    end
-
-    it "doesn't set published_at if update_published_at is false" do
-      attrs = described_class.new({ title: "title" }, user).for_update(update_published_at: false)
-      expect(attrs[:published_at]).to be_falsey
-    end
-
     it "sets published_at correctly" do
       attrs = described_class.new({ title: "title", published_at: "2022-04-25" }, user).for_update
       expect(attrs[:published_at]).to eq(DateTime.new(2022, 4, 25))
-    end
-
-    it "doesn't set published_at if it's nil and update_published_at is false" do
-      attrs = described_class.new({ title: "title", published_at: nil }, user).for_update
-      expect(attrs[:published_at]).to be_nil
     end
   end
 end

--- a/spec/services/articles/updater_spec.rb
+++ b/spec/services/articles/updater_spec.rb
@@ -135,8 +135,7 @@ RSpec.describe Articles::Updater, type: :service do
         attributes[:published_at] = new_published_at
         described_class.call(user, draft, attributes)
         draft.reload
-        # won't be saved because of the validation
-        expect(draft.published).to be false
+        expect(draft.published).to be true
         expect(draft.published_at).to be_within(1.second).of(past_time)
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix
- [x] Optimization

## Description
We don't want to allow users to use unpublishing and republishing as a hack, and bump an old post to have a current published at [Slack thread](https://forem-team.slack.com/archives/C7GE84DEJ/p1660845549633789?thread_ts=1660841521.696969&cid=C7GE84DEJ)
In this pr I:
- removed bumping published_at to current on republishing
- rewrote validation for `published_at` on update, currently it:
  - allows future or current published_at when publishing for the first time (from a draft)
  - allows any published_at for articles that were `published_from_feed` when publishing for the first time (from a draft)
  - doesn't allow changing `published_at` for articles that have already been published (had `published_at` already)
- added more specs for unpublishing, publishing, and republishing, including the tests for the frontmatter

## Related Tickets & Documents
- Related Issue #15858 

## QA Instructions, Screenshots, Recordings
- enable the feature flag `FeatureFlag.enable(:schedule_articles)`
Try from both basic and rich editors:
- publish an article from a draft for the first time => published_at should be set to current time
- publsh an article, unpublish, then republish => published_at should remain as it was on the first publication
- unpublish a published article => published_at should remain as it was
- try changing `published_at` on a published_article => it should not be allowed
- try changing `published_at` of a scheduled article => it shoud be allowed to change it to the future, but not to the past

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams

