### PR TITLE
Add "name" field to Display Ads

### DIFF
--- a/app/controllers/admin/display_ads_controller.rb
+++ b/app/controllers/admin/display_ads_controller.rb
@@ -60,7 +60,7 @@ module Admin
     private
 
     def display_ad_params
-      params.permit(:organization_id, :body_markdown, :placement_area, :published, :approved)
+      params.permit(:organization_id, :body_markdown, :placement_area, :published, :approved, :name)
     end
 
     def authorize_admin

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -17,7 +17,7 @@ class DisplayAd < ApplicationRecord
                              inclusion: { in: ALLOWED_PLACEMENT_AREAS }
   validates :body_markdown, presence: true
   before_save :process_markdown
-  after_create :generate_display_ad_name
+  after_save :generate_display_ad_name
 
   scope :approved_and_published, -> { where(approved: true, published: true) }
 

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -17,6 +17,7 @@ class DisplayAd < ApplicationRecord
                              inclusion: { in: ALLOWED_PLACEMENT_AREAS }
   validates :body_markdown, presence: true
   before_save :process_markdown
+  after_create :generate_display_ad_name
 
   scope :approved_and_published, -> { where(approved: true, published: true) }
 
@@ -35,6 +36,13 @@ class DisplayAd < ApplicationRecord
   end
 
   private
+
+  def generate_display_ad_name
+    return unless name.nil?
+
+    self.name = "Display Ad #{id}"
+    save!
+  end
 
   def process_markdown
     renderer = Redcarpet::Render::HTMLRouge.new(hard_wrap: true, filter_html: false)

--- a/app/views/admin/display_ads/_form.html.erb
+++ b/app/views/admin/display_ads/_form.html.erb
@@ -1,6 +1,11 @@
 <div class="grid l:grid-cols-2 gap-6 mb-4">
   <div class="flex flex-col gap-4">
     <div class="crayons-field">
+      <%= label_tag :name, "Name:", class: "crayons-field__label" %>
+      <%= text_field_tag :name, @display_ad.name, class: "crayons-textfield" %>
+    </div>
+
+    <div class="crayons-field">
       <%= label_tag :organization_id, "Organization ID:", class: "crayons-field__label" %>
       <%= text_field_tag :organization_id, @display_ad.organization_id, class: "crayons-textfield", placeholder: "1234" %>
     </div>

--- a/app/views/admin/display_ads/index.html.erb
+++ b/app/views/admin/display_ads/index.html.erb
@@ -20,7 +20,7 @@
   <table class="crayons-table" width="100%">
     <thead>
       <tr>
-        <th scope="col">ID</th>
+        <th scope="col">Name</th>
         <th scope="col">Placement Area</th>
         <th scope="col">Published</th>
         <th scope="col">Approved</th>
@@ -30,7 +30,7 @@
     <tbody class="crayons-card">
       <% @display_ads.each do |display_ad| %>
           <tr data-row-id="<%= display_ad.id %>">
-            <td><%= link_to display_ad.id, edit_admin_display_ad_path(display_ad) %></td>
+            <td><%= link_to display_ad.name, edit_admin_display_ad_path(display_ad) %></td>
             <td><%= display_ad.human_readable_placement_area %></td>
             <td><%= display_ad.published %></td>
             <td><%= display_ad.approved %></td>

--- a/db/migrate/20220830141143_add_name_to_display_ad.rb
+++ b/db/migrate/20220830141143_add_name_to_display_ad.rb
@@ -1,5 +1,5 @@
 class AddNameToDisplayAd < ActiveRecord::Migration[7.0]
   def change
-    add_column :display_ad, :name, :string
+    add_column :display_ads, :name, :string
   end
 end

--- a/db/migrate/20220830141143_add_name_to_display_ad.rb
+++ b/db/migrate/20220830141143_add_name_to_display_ad.rb
@@ -1,0 +1,5 @@
+class AddNameToDisplayAd < ActiveRecord::Migration[7.0]
+  def change
+    add_column :display_ad, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_04_135751) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_30_141143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_stat_statements"
@@ -460,6 +460,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_04_135751) do
     t.integer "clicks_count", default: 0
     t.datetime "created_at", precision: nil, null: false
     t.integer "impressions_count", default: 0
+    t.string "name"
     t.bigint "organization_id"
     t.string "placement_area"
     t.text "processed_html"

--- a/lib/data_update_scripts/20220830153942_generate_display_ad_names.rb
+++ b/lib/data_update_scripts/20220830153942_generate_display_ad_names.rb
@@ -1,0 +1,9 @@
+module DataUpdateScripts
+  class GenerateDisplayAdNames
+    def run
+      DisplayAd.where(name: nil).find_each do |display_ad|
+        display_ad.update(name: "Display Ad #{display_ad.id}")
+      end
+    end
+  end
+end

--- a/spec/lib/data_update_scripts/generate_display_ad_names_spec.rb
+++ b/spec/lib/data_update_scripts/generate_display_ad_names_spec.rb
@@ -8,9 +8,8 @@ describe DataUpdateScripts::GenerateDisplayAdNames do
     it "generates a name for an existing Display Ad" do
       display_ad = create(:display_ad, name: nil)
 
-      expect do
-        described_class.new.run
-      end.to change { display_ad.reload.name }.to("Display Ad #{display_ad.id}")
+      described_class.new.run
+      expect(display_ad.reload.name).to eq("Display Ad #{display_ad.id}")
     end
   end
 

--- a/spec/lib/data_update_scripts/generate_display_ad_names_spec.rb
+++ b/spec/lib/data_update_scripts/generate_display_ad_names_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+require Rails.root.join(
+  "lib/data_update_scripts/20220830153942_generate_display_ad_names.rb",
+)
+
+describe DataUpdateScripts::GenerateDisplayAdNames do
+  context "when there is no name for a Display Ad" do
+    it "generates a name for an existing Display Ad" do
+      display_ad = create(:display_ad, name: nil)
+
+      expect do
+        described_class.new.run
+      end.to change { display_ad.reload.name }.to("Display Ad #{display_ad.id}")
+    end
+  end
+
+  context "when there is a name for the Display Ad" do
+    it "does not change the name" do
+      display_ad = create(:display_ad, name: "Test")
+
+      expect do
+        described_class.new.run
+      end.not_to change { display_ad.reload.name }
+    end
+  end
+end

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe DisplayAd, type: :model do
     end
   end
 
+  describe "after_create callbacks" do
+    it "generates a name when one does not exist" do
+      display_ad = create(:display_ad, name: nil)
+      display_ad_with_name = create(:display_ad, name: "Test")
+
+      expect(display_ad.name).to eq("Display Ad #{display_ad.id}")
+      expect(display_ad_with_name.name).to eq("Test")
+    end
+  end
+
   describe ".for_display" do
     let!(:display_ad) { create(:display_ad, organization_id: organization.id) }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The following was done in this PR: 

1. Add the name field to the Display Ads page (edit, index and show)
2. The name field is not mandatory so I generate a name based on the "id" if a user does not enter one. This is so that the columns on the index table is more readable. 
3. In relation to the above, I also add a DUS that generates the name for previous Display Ads

## Related Tickets & Documents
- Related Issue #https://github.com/forem/forem/issues/18391
- Closes #https://github.com/forem/forem/issues/18391

## QA Instructions, Screenshots, Recordings

Existing Display Ads:
- Run the Data Update Script `rails data_updates:run`
- Go to http://localhost:3000/admin/customization/display_ads
- You should see a generated name for each Display Ad of the format "Display Ad #{id}"

New Display Ads with a name
- Create a new Display Ad
- Fill out the name and save 
- the name will be the same as you have entered

New Display Ads without a name
- Create a new Display Ad
- Do not fill out the name and save 
- The name will be generated of the format "Display Ad #{id}"

![screencapture-localhost-3000-admin-customization-display-ads-2022-08-30-18_39_22](https://user-images.githubusercontent.com/2786819/187492462-b1057caa-8e09-477b-b4ff-5cc98fcf9dfc.png)

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/ftSuvpSBKl9hwBGWVC/giphy.gif)

