### PR TITLE
Use remote_ip in Rack::Attack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -76,6 +76,7 @@ module PracticalDeveloper
     config.eager_load_paths += Dir["#{config.root}/lib"]
 
     config.middleware.use Rack::Deflater
+    config.middleware.insert_after ActionDispatch::RemoteIp, Rack::Attack
 
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]
 

--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -1,3 +1,9 @@
+Rails.application.reloader.to_prepare do
+  Dir.glob(Rails.root.join("lib/rack/atttack/*.rb")).each do |filename|
+    require_dependency filename
+  end
+end
+
 Rack::Attack.throttled_response_retry_after_header = true
 
 module Rack

--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -4,20 +4,20 @@ module Rack
   class Attack
     throttle("search_throttle", limit: 5, period: 1) do |request|
       if request.path.starts_with?("/search/")
-        track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
+        track_and_return_ip(request)
       end
     end
 
     throttle("api_throttle", limit: 3, period: 1) do |request|
       if request.path.starts_with?("/api/") && request.get?
-        track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
+        track_and_return_ip(request)
       end
     end
 
     throttle("api_write_throttle", limit: 1, period: 1) do |request|
       if request.path.starts_with?("/api/") && (request.put? || request.post? || request.delete?)
         Honeycomb.add_field("user_api_key", request.env["HTTP_API_KEY"])
-        ip_address = track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
+        ip_address = track_and_return_ip(request)
         if request.env["HTTP_API_KEY"].present?
           "#{ip_address}-#{request.env['HTTP_API_KEY']}"
         elsif ip_address.present?
@@ -27,19 +27,25 @@ module Rack
     end
 
     throttle("site_hits", limit: 40, period: 2) do |request|
-      track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
+      track_and_return_ip(request)
     end
 
     throttle("tag_throttle", limit: 2, period: 1) do |request|
       if tag_request?(request)
-        track_and_return_ip(request.env["HTTP_FASTLY_CLIENT_IP"])
+        track_and_return_ip(request)
       end
     end
 
-    def self.track_and_return_ip(ip_address)
+    def self.track_and_return_ip(req)
+      ip_address = if ApplicationConfig["FASTLY_API_KEY"].present?
+                     req.env["HTTP_FASTLY_CLIENT_IP"]
+                   else
+                     req.remote_ip
+                   end
       return if ip_address.blank?
 
-      Honeycomb.add_field("fastly_client_ip", ip_address)
+      Honeycomb.add_field("fastly_client_ip", req.env["HTTP_FASTLY_CLIENT_IP"])
+      Honeycomb.add_field("remote_ip", req.remote_ip)
       ip_address.to_s
     end
 

--- a/config/initializers/rack/attack.rb
+++ b/config/initializers/rack/attack.rb
@@ -1,5 +1,5 @@
 Rails.application.reloader.to_prepare do
-  Dir.glob(Rails.root.join("lib/rack/atttack/*.rb")).each do |filename|
+  Dir.glob(Rails.root.join("lib/rack/attack/*.rb")).each do |filename|
     require_dependency filename
   end
 end

--- a/lib/rack/attack/request.rb
+++ b/lib/rack/attack/request.rb
@@ -1,0 +1,9 @@
+module Rack
+  class Attack
+    class Request < ::Rack::Request
+      def remote_ip
+        @remote_ip ||= ActionDispatch::Request.new(env).remote_ip
+      end
+    end
+  end
+end

--- a/spec/initializers/rack/attack_spec.rb
+++ b/spec/initializers/rack/attack_spec.rb
@@ -6,6 +6,11 @@ describe Rack::Attack, type: :request, throttle: true do
     allow(Rails).to receive(:cache) { cache_db }
     cache_db.redis.flushdb
     allow(Honeycomb).to receive(:add_field)
+    ENV["FASTLY_API_KEY"] = "12345"
+  end
+
+  after do
+    ENV["FASTLY_API_KEY"] = nil
   end
 
   describe "search_throttle" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] bug fix

## Description
Fastly HTTP data is not available when Fastly is not being used. This uses remote_ip as the backup.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
n/a

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
n/a