### PR TITLE
Restrict Reactions API to admins

### DIFF
--- a/app/controllers/api/v1/reactions_controller.rb
+++ b/app/controllers/api/v1/reactions_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V1
     class ReactionsController < ApiController
       before_action :authenticate!
+      before_action :require_admin
 
       def create
         remove_count_cache_key
@@ -42,11 +43,19 @@ module Api
 
       private
 
+      def pundit_user
+        (current_user || @user)
+      end
+
       # TODO: should this move to toggle service? refactor?
       def remove_count_cache_key
         return unless params[:reactable_type] == "Article"
 
         Rails.cache.delete "count_for_reactable-Article-#{params[:reactable_id]}"
+      end
+
+      def require_admin
+        authorize :reaction, :api?
       end
     end
   end

--- a/app/controllers/api/v1/reactions_controller.rb
+++ b/app/controllers/api/v1/reactions_controller.rb
@@ -43,10 +43,6 @@ module Api
 
       private
 
-      def pundit_user
-        (current_user || @user)
-      end
-
       # TODO: should this move to toggle service? refactor?
       def remove_count_cache_key
         return unless params[:reactable_type] == "Article"

--- a/app/policies/reaction_policy.rb
+++ b/app/policies/reaction_policy.rb
@@ -8,6 +8,10 @@ class ReactionPolicy < ApplicationPolicy
     :create?
   end
 
+  def api?
+    return true if user_any_admin?
+  end
+
   def index?
     true
   end

--- a/spec/requests/api/v1/docs/reactions_spec.rb
+++ b/spec/requests/api/v1/docs/reactions_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "api/v1/reactions", type: :request do
   let(:user) { api_secret.user }
 
   before do
+    user.add_role(:admin)
+
     result.category = category
     allow(FeatureFlag).to receive(:enabled?).with(:api_v1).and_return(true)
     allow(ReactionHandler).to receive(:toggle).and_return(result)

--- a/spec/requests/api/v1/reactions_spec.rb
+++ b/spec/requests/api/v1/reactions_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Api::V1::Reactions", type: :request do
     let(:api_secret) { create(:api_secret) }
     let(:user) { api_secret.user }
     let(:auth_header) { v1_headers.merge({ "api-key" => api_secret.secret }) }
+    before { user.add_role(:admin) }
   end
 
   context "when unauthenticated and post to toggle" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We want to limit access to the Reactions API to admins. With the change in this PR, the Reactions API will respond `unauthorized` for non-admins.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #18263 #18355 


### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media2.giphy.com/media/myeDS6IoQrnyqus91Q/giphy.gif?cid=ecf05e47w9yr3xxp5f4cdeolauhet9vra9kmt2o9vyu73isv&rid=giphy.gif&ct=g)

