### PR TITLE
Add STATEMENT_TIMEOUT to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     - DATABASE_NAME=Forem_prod_test
     - DATABASE_URL_TEST=postgres://travis@localhost:5432/Forem_test
     - DATABASE_NAME_TEST=Forem_test
+    - STATEMENT_TIMEOUT=20000
     # Dummy values needed to verify the app boots via "rails runner"
     - APP_PROTOCOL=http://
     - APP_DOMAIN=localhost:3000


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
Instead of keeping `STATEMENT_TIMEOUT` on Travis config UI, it's better to have it visible in `.travis.yml` as a useful context

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a