### PR TITLE
Try front-end hiding ads for user setting

### DIFF
--- a/app/assets/javascripts/.eslintrc.js
+++ b/app/assets/javascripts/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
     handleFollowButtPress: false,
     browserStoreCache: false,
     initializeBaseUserData: false,
+    initializeDisplayAdVisibility: false,
     initializeReadingListIcons: false,
     initializeSponsorshipVisibility: false,
     ActiveXObject: false,

--- a/app/assets/javascripts/initializePage.js
+++ b/app/assets/javascripts/initializePage.js
@@ -11,7 +11,7 @@
   initializeVideoPlayback, initializeDrawerSliders, initializeProfileBadgesToggle,
   initializeHeroBannerClose, initializeOnboardingTaskCard, initScrolling,
   nextPage:writable, fetching:writable, done:writable, adClicked:writable,
-  initializePaymentPointers, initializeBroadcast, initializeDateHelpers,
+  initializePaymentPointers, initializeBroadcast, initializeDateHelpers
 */
 
 function callInitializers() {
@@ -50,6 +50,7 @@ function initializePage() {
       initializeBroadcast();
       initializeReadingListIcons();
       initializeSponsorshipVisibility();
+      initializeDisplayAdVisibility();
       if (document.getElementById('sidebar-additional')) {
         document.getElementById('sidebar-additional').classList.add('showing');
       }

--- a/app/assets/javascripts/initializers/initializeDisplayAdVisibility.js
+++ b/app/assets/javascripts/initializers/initializeDisplayAdVisibility.js
@@ -1,0 +1,19 @@
+function initializeDisplayAdVisibility() {
+  var displayAds = document.querySelectorAll('[data-display-unit]');
+
+  if (displayAds?.length == 0) {
+    return;
+  }
+
+  var user = userData();
+
+  displayAds.forEach((ad) => {
+    if (user && !user.display_sponsors) {
+      ad.classList.add('hidden');
+    } else {
+      ad.classList.remove('hidden');
+    }
+  });
+
+  // for impression & click-tracking, see initializeBaseTracking
+}

--- a/app/assets/javascripts/initializers/initializeDisplayAdVisibility.js
+++ b/app/assets/javascripts/initializers/initializeDisplayAdVisibility.js
@@ -1,7 +1,7 @@
 function initializeDisplayAdVisibility() {
   var displayAds = document.querySelectorAll('[data-display-unit]');
 
-  if (displayAds?.length == 0) {
+  if (displayAds && displayAds.length == 0) {
     return;
   }
 

--- a/app/assets/javascripts/initializers/initializeLocalStorageRender.js
+++ b/app/assets/javascripts/initializers/initializeLocalStorageRender.js
@@ -5,6 +5,7 @@ function initializeLocalStorageRender() {
       document.body.dataset.user = userData;
       initializeBaseUserData();
       initializeReadingListIcons();
+      initializeDisplayAdVisibility();
       initializeSponsorshipVisibility();
     }
   } catch (err) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

User can toggle a setting to turn off sponsorships, either viewing or seeing them adjacent to their posts. We'd like DisplayAds to honor this setting as well, if it is set. I [initially](https://github.com/forem/forem/pull/18399) went about solving this on the back-end, however we cache rendered DisplayAds, so we need to approach hiding these ads on the front-end. There is prior art in the `initializeSponsorshipVisibility` function, so this follows very much in those foot-steps.

## Related Tickets & Documents

- Related #18399 
- Closes #https://github.com/forem/forem-internal-eng/issues/519

## QA Instructions, Screenshots, Recordings

* View an Article, confirm that there's at least one DisplayAd visible (below comments).
* Navigate to `/settings/customization`

<img width="773" alt="Screen Shot 2022-09-13 at 15 20 44" src="https://user-images.githubusercontent.com/2077/189912076-b14b3385-7973-41f7-829e-ab4f6214c9af.png">

* Disable `Display Sponsors (when browsing)`
* Verify that DisplayAd is no longer appearing


### UI accessibility concerns?

Users who have disabled viewing sponsorships but who have also disabled JavaScript will still see sponsorships. This is consistent with what we've done previously (eg, `initializeSponsorshipVisibility`) but I wanted to mention it anyway.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: I'm not sure we have front-end tests for this?
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![invisible](https://i.giphy.com/media/SjJtvObPvnTeE/giphy.webp)

