### PR TITLE
Remove featured number usage from articles

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -12,7 +12,6 @@ module Admin
                                  approved
                                  email_digest_eligible
                                  main_image_background_hex_color
-                                 featured_number
                                  user_id
                                  co_author_ids_list
                                  published_at].freeze
@@ -114,10 +113,10 @@ module Admin
     def articles_featured
       Article.published.or(Article.where(published_from_feed: true))
         .featured
-        .where("featured_number > ?", Time.current.to_i)
+        .where("published_at > ?", Time.current)
         .includes(:user)
         .limited_columns_internal_select
-        .order(featured_number: :desc)
+        .order(published_at: :desc)
     end
 
     def article_params

--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -113,7 +113,7 @@ class ArticleDecorator < ApplicationDecorator
 
   # Used in determining when to bust additional routes for an Article's comments
   def discussion?
-    cached_tag_list_array.include?("discuss") && featured_number.to_i > 35.hours.ago.to_i
+    cached_tag_list_array.include?("discuss") && published_at.to_i > 35.hours.ago.to_i
   end
 
   def pinned?

--- a/app/lib/black_box.rb
+++ b/app/lib/black_box.rb
@@ -44,7 +44,7 @@ class BlackBox
     end
 
     def last_mile_hotness_calc(article)
-      score_from_epoch = article.featured_number.to_i - OUR_EPOCH_NUMBER # Approximate time of publish - epoch time
+      score_from_epoch = article.published_at.to_i - OUR_EPOCH_NUMBER # Approximate time of publish - epoch time
       (score_from_epoch / 1000) +
         ([article.score, 650].min * 2) +
         ([article.comment_score, 650].min * 2)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -353,8 +353,8 @@ class Article < ApplicationRecord
            :main_image, :main_image_background_hex_color, :updated_at,
            :video, :user_id, :organization_id, :video_source_url, :video_code,
            :video_thumbnail_url, :video_closed_caption_track_url, :social_image,
-           :published_from_feed, :crossposted_at, :published_at, :featured_number,
-           :created_at, :body_markdown, :email_digest_eligible, :processed_html, :co_author_ids)
+           :published_from_feed, :crossposted_at, :published_at, :created_at,
+           :body_markdown, :email_digest_eligible, :processed_html, :co_author_ids)
   }
 
   scope :sorting, lambda { |value|
@@ -608,7 +608,7 @@ class Article < ApplicationRecord
       (score < Settings::UserExperience.index_minimum_score &&
        user.comments_count < 1 &&
        !featured) ||
-      featured_number.to_i < 1_500_000_000 ||
+      published_at.to_i < 1_500_000_000 ||
       score < -1
   end
 
@@ -894,7 +894,6 @@ class Article < ApplicationRecord
   end
 
   def set_all_dates
-    set_featured_number
     set_crossposted_at
     set_last_comment_at
     set_nth_published_at
@@ -902,10 +901,6 @@ class Article < ApplicationRecord
 
   def set_published_date
     self.published_at = Time.current if published && published_at.blank?
-  end
-
-  def set_featured_number
-    self.featured_number = Time.current.to_i if featured_number.blank? && published
   end
 
   def set_crossposted_at
@@ -930,7 +925,7 @@ class Article < ApplicationRecord
   end
 
   def title_to_slug
-    "#{Sterile.sluggerize(title)}-#{rand(100_000).to_s(26)}"
+    "#{Sterile.sluggerize(title)}-#{rand(100_000).to_s(26)}" # rubocop:disable Rails/ToSWithArgument
   end
 
   def touch_actor_latest_article_updated_at(destroying: false)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -259,14 +259,14 @@ class Tag < ActsAsTaggableOn::Tag
     #   FROM articles
     #   WHERE
     #     (cached_tag_list ~ '[[:<:]]javascript[[:>:]]')
-    #     AND (articles.featured_number > 1639594999)
+    #     AND (articles.published_at > 7.days.ago)
     #
     # Due to the construction of the query, there will be one entry.
     # Furthermore, we need to first convert to an array then call
     # `.first`.  The ActiveRecord query handler is ill-prepared to
     # call "first" on this.
     score_attributes = Article.cached_tagged_with(name)
-      .where("articles.featured_number > ?", 7.days.ago.to_i)
+      .where("articles.published_at > ?", 7.days.ago)
       .select("(SUM(comments_count) * 14 + SUM(score)) AS partial_score, COUNT(id) AS article_count")
       .to_a
       .first

--- a/app/services/article_api_index_service.rb
+++ b/app/services/article_api_index_service.rb
@@ -70,7 +70,7 @@ class ArticleApiIndexService
     articles = published_articles_with_users_and_organizations.cached_tagged_with(tag)
 
     articles = if Tag.find_by(name: tag)&.requires_approval
-                 articles.approved.order(featured_number: :desc)
+                 articles.approved.order(published_at: :desc)
                elsif top.present?
                  articles.where("published_at > ?", top.to_i.days.ago)
                    .order(public_reactions_count: :desc)
@@ -104,12 +104,12 @@ class ArticleApiIndexService
     articles = case state
                when "fresh"
                  articles.where(
-                   "public_reactions_count < ? AND featured_number > ? AND score > ?", 2, 7.hours.ago.to_i, -2
+                   "public_reactions_count < ? AND published_at > ? AND score > ?", 2, 7.hours.ago, -2
                  )
                when "rising"
                  articles.where(
-                   "public_reactions_count > ? AND public_reactions_count < ? AND featured_number > ?",
-                   19, 33, 3.days.ago.to_i
+                   "public_reactions_count > ? AND public_reactions_count < ? AND published_at > ?",
+                   19, 33, 3.days.ago
                  )
                when "recent"
                  articles.order(published_at: :desc)

--- a/app/services/articles/suggest_stickies.rb
+++ b/app/services/articles/suggest_stickies.rb
@@ -71,7 +71,7 @@ module Articles
         .limited_column_select
         .where.not(id: article.id)
         .not_authored_by(article.user_id)
-        .where("featured_number > ?", 5.days.ago.to_i)
+        .where("published_at > ?", 5.days.ago)
         .order(Arel.sql("RANDOM()"))
     end
   end

--- a/app/services/edge_cache/bust_article.rb
+++ b/app/services/edge_cache/bust_article.rb
@@ -46,12 +46,12 @@ module EdgeCache
     end
 
     def self.bust_home_pages(cache_bust, article)
-      if article.featured_number.to_i > Time.current.to_i
+      if article.published_at.to_i > Time.current.to_i
         cache_bust.call("/")
         cache_bust.call("?i=i")
       end
 
-      if article.video.present? && article.featured_number.to_i > 10.days.ago.to_i
+      if article.video.present? && article.published_at.to_i > 10.days.ago.to_i
         cache_bust.call("/videos")
         cache_bust.call("/videos?i=i")
       end

--- a/app/views/admin/articles/_individual_article.html.erb
+++ b/app/views/admin/articles/_individual_article.html.erb
@@ -124,15 +124,6 @@
     <input type="hidden" name="_method" value="patch" />
     <div class="flex gap-4">
       <div class="crayons-field flex-1">
-        <label for="featured_number_<%= article.id %>" class="crayons-field__label">Featured number</label>
-        <input id="featured_number_<%= article.id %>"
-              class="crayons-textfield"
-              name="article[featured_number]"
-              value="<%= article.featured_number %>"
-              data-article-target="featuredNumber">
-      </div>
-
-      <div class="crayons-field flex-1">
         <label for="author_id_<%= article.id %>" class="crayons-field__label">Author ID</label>
         <input id="author_id_<%= article.id %>" class="crayons-textfield" size="6" name="article[user_id]"
           value="<%= article.user_id %>">

--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -214,17 +214,17 @@ RSpec.describe ArticleDecorator, type: :decorator do
       expect(article.decorate.discussion?).to be false
     end
 
-    it "returns false if featured number is less than 35 hours ago" do
+    it "returns false if published_at is less than 35 hours ago" do
       Timecop.freeze(Time.current) do
-        article.featured_number = 35.hours.ago.to_i - 1
+        article.published_at = 35.hours.ago - 1
         expect(article.decorate.discussion?).to be false
       end
     end
 
-    it "returns true if it's tagged with discuss and has a feature number greater than 35 hours ago" do
+    it "returns true if it's tagged with discuss and has a published_at greater than 35 hours ago" do
       Timecop.freeze(Time.current) do
         article.cached_tag_list = "welcome, discuss"
-        article.featured_number = 35.hours.ago.to_i + 1
+        article.published_at = 35.hours.ago + 1
         expect(article.decorate.discussion?).to be true
       end
     end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -688,19 +688,6 @@ RSpec.describe Article, type: :model do
     end
   end
 
-  describe "#featured_number" do
-    it "is updated if approved when already true" do
-      body = "---\ntitle: Hellohnnnn#{rand(1000)}\npublished: true\ntags: hiring\n---\n\nHello"
-      article.update(body_markdown: body, approved: true)
-
-      Timecop.travel(1.second.from_now) do
-        article.update(body_markdown: "#{body}s")
-      end
-
-      expect(article.featured_number).not_to eq(article.updated_at.to_i)
-    end
-  end
-
   describe "#slug" do
     let(:title) { "hey This' is$ a SLUG" }
     let(:article0) { build(:article, title: title, published: false) }

--- a/spec/requests/api/v0/articles_spec.rb
+++ b/spec/requests/api/v0/articles_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe "Api::V0::Articles", type: :request do
       end
 
       it "returns rising articles" do
-        article.update_columns(public_reactions_count: 32, score: 1, featured_number: 2.days.ago.to_i)
+        article.update_columns(public_reactions_count: 32, score: 1, published_at: 2.days.ago)
 
         get api_articles_path(state: "rising")
         expect(response.parsed_body.size).to eq(1)

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
 
       it "returns rising articles" do
-        article.update_columns(public_reactions_count: 32, score: 1, featured_number: 2.days.ago.to_i)
+        article.update_columns(public_reactions_count: 32, score: 1, published_at: 2.days.ago)
 
         get api_articles_path(state: "rising"), headers: headers
         expect(response.parsed_body.size).to eq(1)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

Perhaps I'm being overly cautious, but I'd rather remove all usage of `featured_number` and replace it with `published_at` first, as mentioned in the issue (#18482). Only after deploying this change and making sure we don't see any unexpected side effects I'll push forward a PR that will remove the column.

The intention behind this approach is to be able to revert the change if needed. If we remove the column along with the logic update (in this same PR) we would've lost the data from the DB and would have to scramble to recover them from backups 🙃 

## Related Tickets & Documents

- #18482

## QA Instructions, Screenshots, Recordings

- App should continue to work as expected locally
   - The feed where featured posts are being fetched
   - `/admin/content_manager/articles` where this value used to be viewed/manipulated

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] Are there any post deployment tasks we need to perform?

Once the PR is deployed we should keep an eye out for any weird behavior related to featured posts (possibly also reach out to our community managers to ensure this). Once things are confirmed to be okay we can move forward with removing the column from the DB

## [optional] What gif best describes this PR or how it makes you feel?

![scissors](https://media.giphy.com/media/8a0Gjt3TmUFGM/giphy.gif)

