### PR TITLE
Restore DisplayAd search

### DIFF
--- a/app/controllers/admin/display_ads_controller.rb
+++ b/app/controllers/admin/display_ads_controller.rb
@@ -10,9 +10,7 @@ module Admin
 
       return if params[:search].blank?
 
-      @display_ads = @display_ads
-        .where("processed_html ILIKE :search OR placement_area ILIKE :search OR organizations.name ILIKE :search",
-               search: "%#{params[:search]}%")
+      @display_ads = @display_ads.search_ads(params[:search])
     end
 
     def new

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -23,6 +23,11 @@ class DisplayAd < ApplicationRecord
 
   scope :approved_and_published, -> { where(approved: true, published: true) }
 
+  scope :search_ads, lambda { |term|
+                       where "name ILIKE :search OR processed_html ILIKE :search OR placement_area ILIKE :search",
+                             search: "%#{term}%"
+                     }
+
   def self.for_display(area, user_signed_in)
     relation = approved_and_published.where(placement_area: area).order(success_rate: :desc)
 

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -113,4 +113,28 @@ RSpec.describe DisplayAd, type: :model do
       end
     end
   end
+
+  describe ".search_ads" do
+    let!(:ad) { create(:display_ad, name: "This is an Ad", body_markdown: "Ad Body", placement_area: "post_comments") }
+
+    it "finds via name" do
+      expect(described_class.search_ads("this").ids).to contain_exactly(ad.id)
+    end
+
+    it "finds via body" do
+      expect(described_class.search_ads("body").ids).to contain_exactly(ad.id)
+    end
+
+    it "finds via placement_area" do
+      expect(described_class.search_ads("comment").ids).to contain_exactly(ad.id)
+    end
+
+    it "finds just one result via multiple criteria" do
+      expect(described_class.search_ads("ad").ids).to contain_exactly(ad.id)
+    end
+
+    it "returns empty when no match" do
+      expect(described_class.search_ads("foo")).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

DisplayAd search was throwing a 500 because of a connection to Organization, which isn't used on modern DisplayAds anyway. I wanted to keep this as a quick bug-fix, but there are potentially interesting things to return to in a future pass:

* It would be nice if this could search the "human-readable" placement areas
* It might be nice to have this use pg_search, but that needs a migration to add the tsvector columns

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #https://github.com/forem/forem/issues/18491

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/dIBLtolI6axTGIGopo/giphy.gif)

