### PR TITLE
Try hiding low-quality comments

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -268,6 +268,7 @@ class StoriesController < ApplicationController
     end
 
     @comments_to_show_count = @article.cached_tag_list_array.include?("discuss") ? 50 : 30
+    @comments_to_show_count = 15 unless user_signed_in?
     set_article_json_ld
     assign_co_authors
     @comment = Comment.new(body_markdown: @article&.comment_template)

--- a/app/decorators/article_decorator.rb
+++ b/app/decorators/article_decorator.rb
@@ -33,10 +33,6 @@ class ArticleDecorator < ApplicationDecorator
     end
   end
 
-  def comments_to_show_count
-    cached_tag_list_array.include?("discuss") ? 75 : 25
-  end
-
   def cached_tag_list_array
     (cached_tag_list || "").split(", ")
   end

--- a/app/decorators/podcast_episode_decorator.rb
+++ b/app/decorators/podcast_episode_decorator.rb
@@ -1,8 +1,4 @@
 class PodcastEpisodeDecorator < ApplicationDecorator
-  def comments_to_show_count
-    cached_tag_list_array.include?("discuss") ? 75 : 25
-  end
-
   # this method exists because podcast episodes are "commentables"
   # and in some parts of the code we assume they have this method,
   # but podcast episodes don't have a cached_tag_list like articles do

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -2,6 +2,22 @@ module CommentsHelper
   MAX_COMMENTS_TO_RENDER = 250
   MIN_COMMENTS_TO_RENDER = 8
 
+  def article_comment_tree(article, count, order)
+    @article_comment_tree ||= begin
+      collection = Comment.tree_for(article, count, order)
+      collection.reject! { |comment| comment.score.negative? } unless user_signed_in?
+      collection
+    end
+  end
+
+  def podcast_comment_tree(episode)
+    @podcast_comment_tree ||= begin
+      collection = Comment.tree_for(episode, 12)
+      collection.reject! { |comment| comment.score.negative? } unless user_signed_in?
+      collection
+    end
+  end
+
   def comment_class(comment, is_view_root: false)
     if comment.root? || is_view_root
       "root"

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -2,6 +2,18 @@ module CommentsHelper
   MAX_COMMENTS_TO_RENDER = 250
   MIN_COMMENTS_TO_RENDER = 8
 
+  def any_negative_comments?(commentable)
+    commentable.comments.where("score < 0").any?
+  end
+
+  def any_hidden_negative_comments?(commentable)
+    !user_signed_in? && any_negative_comments?(commentable)
+  end
+
+  def all_comments_visible?(commentable)
+    !(commentable.any_comments_hidden || any_hidden_negative_comments?(commentable))
+  end
+
   def article_comment_tree(article, count, order)
     @article_comment_tree ||= begin
       collection = Comment.tree_for(article, count, order)

--- a/app/views/articles/_comments_actions.html.erb
+++ b/app/views/articles/_comments_actions.html.erb
@@ -7,9 +7,10 @@
     </div>
   <% end %>
 
-  <% if @article.any_comments_hidden %>
+  <% unless all_comments_visible?(@article) %>
     <p class="fs-s color-base-60 mb-4">
-      <%= t("views.comments.hidden.text_html", info: link_to(t("views.comments.hidden.info"), "/faq")) %>
+      <%= t("views.comments.visible_signed_in.text_html", sign_in: link_to(t("views.comments.visible_signed_in.sign_in"), "/enter")) if any_hidden_negative_comments?(@article) %>
+      <%= t("views.comments.hidden.text_html", info: link_to(t("views.comments.hidden.info"), "/faq")) if @article.any_comments_hidden %>
     </p>
   <% end %>
 

--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -58,7 +58,7 @@
             <%= render partial: "articles/comment_tree",
                        collection: article_comment_tree(@article, @comments_to_show_count, @comments_order),
                        as: :comment_node,
-                       cached: proc { |comment, _sub_comments| [comment, @comments_order] } %>
+                       cached: proc { |comment, _sub_comments| [comment, @comments_order, user_signed_in] } %>
           <% end %>
         </div>
       </div>

--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -55,7 +55,10 @@
 
         <div class="comments" id="comment-trees-container">
           <% if @article.comments_count > 0 %>
-            <%= render partial: "articles/comment_tree", collection: article_comment_tree(@article, @comments_to_show_count, @comments_order), as: :comment_node, cached: proc { |comment, _sub_comments| [comment, @comments_order] } %>
+            <%= render partial: "articles/comment_tree",
+                       collection: article_comment_tree(@article, @comments_to_show_count, @comments_order),
+                       as: :comment_node,
+                       cached: proc { |comment, _sub_comments| [comment, @comments_order] } %>
           <% end %>
         </div>
       </div>

--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -1,4 +1,4 @@
-<% cache("whole-comment-area-#{@article.id}-#{@article.last_comment_at}-#{@article.show_comments}-#{@discussion_lock&.updated_at}-#{@comments_order}", expires_in: 2.hours) do %>
+<% cache("whole-comment-area-#{@article.id}-#{@article.last_comment_at}-#{@article.show_comments}-#{@discussion_lock&.updated_at}-#{@comments_order}-#{user_signed_in?}", expires_in: 2.hours) do %>
   <section id="comments" data-follow-button-container="true" data-updated-at="<%= Time.current %>" class="text-padding mb-4 border-t-1 border-0 border-solid border-base-10">
     <% if @article.show_comments %>
       <header class="relative flex justify-between items-center mb-6">
@@ -55,7 +55,7 @@
 
         <div class="comments" id="comment-trees-container">
           <% if @article.comments_count > 0 %>
-            <%= render partial: "articles/comment_tree", collection: Comment.tree_for(@article, @comments_to_show_count, @comments_order), as: :comment_node, cached: proc { |comment, _sub_comments| [comment, @comments_order] } %>
+            <%= render partial: "articles/comment_tree", collection: article_comment_tree(@article, @comments_to_show_count, @comments_order), as: :comment_node, cached: proc { |comment, _sub_comments| [comment, @comments_order] } %>
           <% end %>
         </div>
       </div>

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -103,7 +103,7 @@
                    commentable: @episode,
                    commentable_type: "PodcastEpisode" %>
         <div class="comment-trees" id="comment-trees-container">
-          <% Comment.tree_for(@episode, 12).each do |comment, sub_comments| %>
+          <% podcast_comment_tree(@episode).each do |comment, sub_comments| %>
             <% cache ["comment_root_#{user_signed_in?}", comment] do %>
               <%= tree_for(comment, sub_comments, @episode) %>
             <% end %>

--- a/config/locales/views/comments/en.yml
+++ b/config/locales/views/comments/en.yml
@@ -35,6 +35,9 @@ en:
         text_html: "&bull; Edited %{on}"
         on_html: on %{date}
       expand: Expand
+      visible_signed_in:
+        text_html: "Some comments may only be visible to logged-in visitors. %{sign_in} to view all comments."
+        sign_in: "Sign in"
       hidden:
         text_html: Some comments have been hidden by the post's author - %{info}
         info: find out more

--- a/config/locales/views/comments/fr.yml
+++ b/config/locales/views/comments/fr.yml
@@ -35,6 +35,9 @@ fr:
         text_html: "&bull; Edited %{on}"
         on_html: on %{date}
       expand: Expand
+      visible_signed_in:
+        text_html: "Some comments may only be visible to logged-in visitors. %{sign_in} to view all comments."
+        sign_in: "Sign in"
       hidden:
         text_html: Some comments have been hidden by the post's author - %{info}
         info: find out more

--- a/spec/decorators/article_decorator_spec.rb
+++ b/spec/decorators/article_decorator_spec.rb
@@ -83,18 +83,6 @@ RSpec.describe ArticleDecorator, type: :decorator do
     end
   end
 
-  describe "#comments_to_show_count" do
-    it "returns 25 if does not have a discuss tag" do
-      article.cached_tag_list = ""
-      expect(article.decorate.comments_to_show_count).to eq(25)
-    end
-
-    it "returns 75 if it does have a discuss tag" do
-      article.cached_tag_list = "discuss, python"
-      expect(article.decorate.comments_to_show_count).to eq(75)
-    end
-  end
-
   describe "#cached_tag_list_array" do
     it "returns no tags if the cached tag list is empty" do
       article.cached_tag_list = ""

--- a/spec/decorators/podcast_episode_decorator_spec.rb
+++ b/spec/decorators/podcast_episode_decorator_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe PodcastEpisodeDecorator, type: :decorator do
 
     it "serializes both the decorated object IDs and decorated methods" do
       expected_result = {
-        "id" => podcast_episode.id, "comments_to_show_count" => podcast_episode.comments_to_show_count
+        "id" => podcast_episode.id, "published_timestamp" => podcast_episode.published_timestamp
       }
-      expect(podcast_episode.as_json(only: [:id], methods: [:comments_to_show_count])).to eq(expected_result)
+      expect(podcast_episode.as_json(only: [:id], methods: [:published_timestamp])).to eq(expected_result)
     end
 
     it "serializes collections of decorated objects" do
@@ -16,21 +16,9 @@ RSpec.describe PodcastEpisodeDecorator, type: :decorator do
 
       decorated_collection = PodcastEpisode.decorate
       expected_result = [
-        { "id" => podcast_episode.id, "comments_to_show_count" => podcast_episode.comments_to_show_count },
+        { "id" => podcast_episode.id, "published_timestamp" => podcast_episode.published_timestamp },
       ]
-      expect(decorated_collection.as_json(only: [:id], methods: [:comments_to_show_count])).to eq(expected_result)
-    end
-  end
-
-  describe "#comments_to_show_count" do
-    it "returns 25 if does not have a discuss tag" do
-      pe = build(:podcast_episode)
-      expect(pe.decorate.comments_to_show_count).to eq(25)
-    end
-
-    it "returns 75 if it does have a discuss tag" do
-      pe = build(:podcast_episode, tag_list: ["discuss"])
-      expect(pe.decorate.comments_to_show_count).to eq(75)
+      expect(decorated_collection.as_json(only: [:id], methods: [:published_timestamp])).to eq(expected_result)
     end
   end
 

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -15,8 +15,9 @@ RSpec.describe "Views an article", type: :system do
     expect(page).to have_content(article.title)
   end
 
-  it "shows comments", js: true do
+  it "shows non-negative comments", js: true do
     create_list(:comment, 3, commentable: article)
+    create :thumbsdown_reaction, reactable: create(:comment, commentable: article)
 
     visit article.path
     expect(page).to have_selector(".single-comment-node", visible: :visible, count: 3)

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -17,8 +17,11 @@ RSpec.describe "Views an article", type: :system do
 
   it "shows non-negative comments", js: true do
     create_list(:comment, 3, commentable: article)
-    create :thumbsdown_reaction, reactable: create(:comment, commentable: article)
-
+    comments = create_list(:comment, 4, commentable: article)
+    admin = create(:user, :admin)
+    create(:thumbsdown_reaction, reactable: comments.last, user: admin)
+    sidekiq_perform_enqueued_jobs
+    sign_out user
     visit article.path
     expect(page).to have_selector(".single-comment-node", visible: :visible, count: 3)
   end

--- a/spec/system/articles/user_visits_an_article_spec.rb
+++ b/spec/system/articles/user_visits_an_article_spec.rb
@@ -16,11 +16,14 @@ RSpec.describe "Views an article", type: :system do
   end
 
   it "shows non-negative comments", js: true do
-    create_list(:comment, 3, commentable: article)
     comments = create_list(:comment, 4, commentable: article)
     admin = create(:user, :admin)
     create(:thumbsdown_reaction, reactable: comments.last, user: admin)
     sidekiq_perform_enqueued_jobs
+
+    visit article.path
+    expect(page).to have_selector(".single-comment-node", visible: :visible, count: 4)
+
     sign_out user
     visit article.path
     expect(page).to have_selector(".single-comment-node", visible: :visible, count: 3)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR combines fixes for two comment-related issues:

1. We want to hide low-quality comments from users who are not logged-in.
2. We want to show fewer comments for logged-out users.

I'm combining them together here because they work similarly. Also both require changes to our cache key (including `user_signed_in?`). 

## Related Tickets & Documents

- Closes https://github.com/forem/forem/issues/18488
- Closes https://github.com/forem/forem/issues/18490

## QA Instructions, Screenshots, Recordings

I found it challenging to create a low-quality comment, maybe there's a method I don't know, but what worked for me:

* Disable sidekiq or at least the `CalculateScoreWorker`
* Set a comment score to negative: `Comment.find(id).update score: -5`

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: I expected changing this would break more tests, but it did not -- someone tell me if I'm wrong, but I think that means we haven't historically been testing this?
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![hiding](https://media.giphy.com/media/xpTi1dngQ74ndHWpca/giphy.gif)

