### PR TITLE
Comment fragment link when signed out

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -64,6 +64,16 @@ module CommentsHelper
     end
   end
 
+  def contextual_comment_url(comment, article: nil)
+    # Liquid tag parsing doesn't have Devise/Warden (request middleware) so we
+    # can't use `user_signed_in?`, this is why guard against it.
+    return URL.comment(comment) if request.env["warden"].present? && !user_signed_in?
+
+    # If `user_signed_in?` is true we can provide the article's path to anchor
+    # the comment URL instead of using the permalink.
+    URL.comment(comment, article_path: article&.path)
+  end
+
   private
 
   def nested_comments(tree:, commentable:, is_view_root: false)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -67,7 +67,8 @@ module CommentsHelper
   def contextual_comment_url(comment, article: nil)
     # Liquid tag parsing doesn't have Devise/Warden (request middleware) so we
     # can't use `user_signed_in?`, this is why guard against it.
-    return URL.comment(comment) if request.env["warden"].present? && !user_signed_in?
+    # binding.break if ENV['WAT'] == comment.id.to_s
+    return URL.comment(comment) if request.env["warden"].nil? || !user_signed_in?
 
     # If `user_signed_in?` is true we can provide the article's path to anchor
     # the comment URL instead of using the permalink.

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -65,14 +65,14 @@ module CommentsHelper
   end
 
   def contextual_comment_url(comment, article: nil)
-    # Liquid tag parsing doesn't have Devise/Warden (request middleware) so we
-    # can't use `user_signed_in?`, this is why guard against it.
-    # binding.break if ENV['WAT'] == comment.id.to_s
-    return URL.comment(comment) if request.env["warden"].nil? || !user_signed_in?
+    # Liquid tag parsing doesn't have Devise/Warden (request middleware)
+    return URL.comment(comment) if request.env["warden"].nil?
 
-    # If `user_signed_in?` is true we can provide the article's path to anchor
-    # the comment URL instead of using the permalink.
-    URL.comment(comment, article_path: article&.path)
+    # Logged in users should get the comment permalink
+    return URL.comment(comment) if user_signed_in?
+
+    # Logged out users should get the article URL with the comment anchor
+    URL.fragment_comment(comment, path: article&.path)
   end
 
   private

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -41,8 +41,12 @@ module URL
   # Creates a comment URL
   #
   # @param comment [Comment] the comment to create the URL for
-  def self.comment(comment)
-    url(comment.path)
+  # @param article_path [String, nil] the path of the article to anchor
+  #   the comment link instead. Return the comment permalink if nil
+  def self.comment(comment, article_path: nil)
+    return url(comment.path) if article_path.nil?
+
+    url("#{article_path}#comment-node-#{comment.id}")
   end
 
   # Creates a reaction URL

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -41,12 +41,20 @@ module URL
   # Creates a comment URL
   #
   # @param comment [Comment] the comment to create the URL for
-  # @param article_path [String, nil] the path of the article to anchor
-  #   the comment link instead. Return the comment permalink if nil
-  def self.comment(comment, article_path: nil)
-    return url(comment.path) if article_path.nil?
+  def self.comment(comment)
+    url(comment.path)
+  end
 
-    url("#{article_path}#comment-node-#{comment.id}")
+  # Creates a fragment URL for a comment on an article page
+  # if an article path is available
+  #
+  # @param comment [Comment] the comment to create the URL for
+  # @param path [String, nil] the path of the article to anchor the
+  #   comment link instead of using the comment's permalink
+  def self.fragment_comment(comment, path:)
+    return comment(comment) if path.nil?
+
+    url("#{path}#comment-node-#{comment.id}")
   end
 
   # Creates a reaction URL

--- a/app/lib/url.rb
+++ b/app/lib/url.rb
@@ -54,7 +54,7 @@ module URL
   def self.fragment_comment(comment, path:)
     return comment(comment) if path.nil?
 
-    url("#{path}#comment-node-#{comment.id}")
+    url("#{path}#comment-#{comment.id_code}")
   end
 
   # Creates a reaction URL

--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -1,4 +1,4 @@
-<% cache("whole-comment-area-#{@article.id}-#{@article.last_comment_at}-#{@article.show_comments}-#{@discussion_lock&.updated_at}-#{@comments_order}", expires_in: 2.hours) do %>
+<% cache("whole-comment-area-#{@article.id}-#{@article.last_comment_at}-#{@article.show_comments}-#{@discussion_lock&.updated_at}-#{@comments_order}-#{user_signed_in?}", expires_in: 2.hours) do %>
   <section id="comments" data-follow-button-container="true" data-updated-at="<%= Time.current %>" class="text-padding mb-4 border-t-1 border-0 border-solid border-base-10">
     <% if @article.show_comments %>
       <header class="relative flex justify-between items-center mb-6">

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -24,6 +24,7 @@
     data-path="<%= commentable&.path %>/comments/<%= comment.id_code_generated %>"
     data-comment-author-id="<%= comment_user_id_unless_deleted comment %>"
     data-content-user-id="<%= comment_user_id_unless_deleted comment %>">
+    <a name="comment-<%= comment.id_code %>" style="position: absolute; top: -8px;">&nbsp;</a>
     <%= render("comments/comment_proper",
                comment: comment,
                commentable: commentable,

--- a/app/views/comments/_comment_date.erb
+++ b/app/views/comments/_comment_date.erb
@@ -1,7 +1,6 @@
 <span class="color-base-30 px-2 m:pl-0" role="presentation">&bull;</span>
 
-<% comment_url = URL.comment(decorated_comment, article_path: user_signed_in? ? nil : @article&.path) %>
-<a href="<%= comment_url %>" class="comment-date crayons-link crayons-link--secondary fs-s">
+<a href="<%= comment_url || URL.comment(decorated_comment) %>" class="comment-date crayons-link crayons-link--secondary fs-s">
   <time datetime="<%= decorated_comment.published_timestamp %>" class=<%= decorated_comment.created_at.year == Time.current.year ? "date-no-year" : "date-short-year" %>>
     <%= decorated_comment.readable_publish_date %>
   </time>

--- a/app/views/comments/_comment_date.erb
+++ b/app/views/comments/_comment_date.erb
@@ -1,6 +1,6 @@
 <span class="color-base-30 px-2 m:pl-0" role="presentation">&bull;</span>
 
-<a href="<%= comment_url || URL.comment(decorated_comment) %>" class="comment-date crayons-link crayons-link--secondary fs-s">
+<a href="<%= contextual_comment_url(decorated_comment, article: @article) %>" class="comment-date crayons-link crayons-link--secondary fs-s">
   <time datetime="<%= decorated_comment.published_timestamp %>" class=<%= decorated_comment.created_at.year == Time.current.year ? "date-no-year" : "date-short-year" %>>
     <%= decorated_comment.readable_publish_date %>
   </time>

--- a/app/views/comments/_comment_date.erb
+++ b/app/views/comments/_comment_date.erb
@@ -1,6 +1,6 @@
 <span class="color-base-30 px-2 m:pl-0" role="presentation">&bull;</span>
 
-<% comment_url = URL.comment(decorated_comment, article_path: user_signed_in? ? nil : @article.path) %>
+<% comment_url = URL.comment(decorated_comment, article_path: user_signed_in? ? nil : @article&.path) %>
 <a href="<%= comment_url %>" class="comment-date crayons-link crayons-link--secondary fs-s">
   <time datetime="<%= decorated_comment.published_timestamp %>" class=<%= decorated_comment.created_at.year == Time.current.year ? "date-no-year" : "date-short-year" %>>
     <%= decorated_comment.readable_publish_date %>

--- a/app/views/comments/_comment_date.erb
+++ b/app/views/comments/_comment_date.erb
@@ -1,6 +1,7 @@
 <span class="color-base-30 px-2 m:pl-0" role="presentation">&bull;</span>
 
-<a href="<%= URL.comment(decorated_comment) %>" class="comment-date crayons-link crayons-link--secondary fs-s">
+<% comment_url = URL.comment(decorated_comment, article_path: user_signed_in? ? nil : @article.path) %>
+<a href="<%= comment_url %>" class="comment-date crayons-link crayons-link--secondary fs-s">
   <time datetime="<%= decorated_comment.published_timestamp %>" class=<%= decorated_comment.created_at.year == Time.current.year ? "date-no-year" : "date-short-year" %>>
     <%= decorated_comment.readable_publish_date %>
   </time>

--- a/app/views/comments/_comment_header.html.erb
+++ b/app/views/comments/_comment_header.html.erb
@@ -19,8 +19,7 @@
     <% end %>
   </div>
 
-  <% comment_url = URL.comment(comment, article_path: user_signed_in? ? nil : @article&.path) %>
-  <%= render "comments/comment_date", decorated_comment: decorated_comment, comment_url: comment_url %>
+  <%= render "comments/comment_date", decorated_comment: decorated_comment %>
 
   <div class="comment__dropdown" data-tracking-name="comment_dropdown">
     <button id="comment-dropdown-trigger-<%= comment.id %>" aria-controls="comment-dropdown-<%= comment.id %>" aria-expanded="false"
@@ -30,7 +29,7 @@
     </button>
     <div id="comment-dropdown-<%= comment.id %>" class="crayons-dropdown right-1 s:right-0 s:left-auto fs-base dropdown">
       <ul class="m-0">
-        <li><a href="<%= comment_url %>" class="crayons-link crayons-link--block permalink-copybtn" aria-label="<%= t("views.comments.menu.copy.aria_label", user: comment.user.name) %>" data-no-instant><%= t("views.comments.menu.copy.text") %></a></li>
+        <li><a href="<%= contextual_comment_url(comment, article: @article) %>" class="crayons-link crayons-link--block permalink-copybtn" aria-label="<%= t("views.comments.menu.copy.aria_label", user: comment.user.name) %>" data-no-instant><%= t("views.comments.menu.copy.text") %></a></li>
         <li class="comment-actions hidden" data-user-id="<%= comment.user_id %>" data-action="settings-button" data-path="<%= URL.comment(comment) %>/settings" aria-label="<%= t("views.comments.menu.settings.aria_label", user: comment.user.name) %>"></li>
         <% action = comment.hidden_by_commentable_user ? "unhide" : "hide" %>
         <li class="comment-actions hidden" data-action="hide-button" data-commentable-user-id="<%= commentable&.user_id %>" data-user-id="<%= comment.user_id %>">

--- a/app/views/comments/_comment_header.html.erb
+++ b/app/views/comments/_comment_header.html.erb
@@ -29,7 +29,7 @@
     </button>
     <div id="comment-dropdown-<%= comment.id %>" class="crayons-dropdown right-1 s:right-0 s:left-auto fs-base dropdown">
       <ul class="m-0">
-        <% comment_url = URL.comment(comment, article_path: user_signed_in? ? nil : @article.path) %>
+        <% comment_url = URL.comment(comment, article_path: user_signed_in? ? nil : @article&.path) %>
         <li><a href="<%= comment_url %>" class="crayons-link crayons-link--block permalink-copybtn" aria-label="<%= t("views.comments.menu.copy.aria_label", user: comment.user.name) %>" data-no-instant><%= t("views.comments.menu.copy.text") %></a></li>
         <li class="comment-actions hidden" data-user-id="<%= comment.user_id %>" data-action="settings-button" data-path="<%= URL.comment(comment) %>/settings" aria-label="<%= t("views.comments.menu.settings.aria_label", user: comment.user.name) %>"></li>
         <% action = comment.hidden_by_commentable_user ? "unhide" : "hide" %>

--- a/app/views/comments/_comment_header.html.erb
+++ b/app/views/comments/_comment_header.html.erb
@@ -29,7 +29,8 @@
     </button>
     <div id="comment-dropdown-<%= comment.id %>" class="crayons-dropdown right-1 s:right-0 s:left-auto fs-base dropdown">
       <ul class="m-0">
-        <li><a href="<%= URL.comment(comment) %>" class="crayons-link crayons-link--block permalink-copybtn" aria-label="<%= t("views.comments.menu.copy.aria_label", user: comment.user.name) %>" data-no-instant><%= t("views.comments.menu.copy.text") %></a></li>
+        <% comment_url = URL.comment(comment, article_path: user_signed_in? ? nil : @article.path) %>
+        <li><a href="<%= comment_url %>" class="crayons-link crayons-link--block permalink-copybtn" aria-label="<%= t("views.comments.menu.copy.aria_label", user: comment.user.name) %>" data-no-instant><%= t("views.comments.menu.copy.text") %></a></li>
         <li class="comment-actions hidden" data-user-id="<%= comment.user_id %>" data-action="settings-button" data-path="<%= URL.comment(comment) %>/settings" aria-label="<%= t("views.comments.menu.settings.aria_label", user: comment.user.name) %>"></li>
         <% action = comment.hidden_by_commentable_user ? "unhide" : "hide" %>
         <li class="comment-actions hidden" data-action="hide-button" data-commentable-user-id="<%= commentable&.user_id %>" data-user-id="<%= comment.user_id %>">

--- a/app/views/comments/_comment_header.html.erb
+++ b/app/views/comments/_comment_header.html.erb
@@ -19,7 +19,8 @@
     <% end %>
   </div>
 
-  <%= render "comments/comment_date", decorated_comment: decorated_comment %>
+  <% comment_url = URL.comment(comment, article_path: user_signed_in? ? nil : @article&.path) %>
+  <%= render "comments/comment_date", decorated_comment: decorated_comment, comment_url: comment_url %>
 
   <div class="comment__dropdown" data-tracking-name="comment_dropdown">
     <button id="comment-dropdown-trigger-<%= comment.id %>" aria-controls="comment-dropdown-<%= comment.id %>" aria-expanded="false"
@@ -29,7 +30,6 @@
     </button>
     <div id="comment-dropdown-<%= comment.id %>" class="crayons-dropdown right-1 s:right-0 s:left-auto fs-base dropdown">
       <ul class="m-0">
-        <% comment_url = URL.comment(comment, article_path: user_signed_in? ? nil : @article&.path) %>
         <li><a href="<%= comment_url %>" class="crayons-link crayons-link--block permalink-copybtn" aria-label="<%= t("views.comments.menu.copy.aria_label", user: comment.user.name) %>" data-no-instant><%= t("views.comments.menu.copy.text") %></a></li>
         <li class="comment-actions hidden" data-user-id="<%= comment.user_id %>" data-action="settings-button" data-path="<%= URL.comment(comment) %>/settings" aria-label="<%= t("views.comments.menu.settings.aria_label", user: comment.user.name) %>"></li>
         <% action = comment.hidden_by_commentable_user ? "unhide" : "hide" %>

--- a/app/views/comments/_liquid.html.erb
+++ b/app/views/comments/_liquid.html.erb
@@ -7,7 +7,7 @@
       <a href="/<%= comment.user.username %>">
         <span class="comment-username"><%= comment.user.name %></span>
       </a>
-      <%= render "comments/comment_date", decorated_comment: comment.decorate, comment_url: nil %>
+      <%= render "comments/comment_date", decorated_comment: comment.decorate %>
     </div>
     <div class="body">
       <%= comment.safe_processed_html %>

--- a/app/views/comments/_liquid.html.erb
+++ b/app/views/comments/_liquid.html.erb
@@ -7,7 +7,7 @@
       <a href="/<%= comment.user.username %>">
         <span class="comment-username"><%= comment.user.name %></span>
       </a>
-      <%= render "comments/comment_date", decorated_comment: comment.decorate %>
+      <%= render "comments/comment_date", decorated_comment: comment.decorate, comment_url: nil %>
     </div>
     <div class="body">
       <%= comment.safe_processed_html %>

--- a/spec/system/comments/user_views_article_comments_spec.rb
+++ b/spec/system/comments/user_views_article_comments_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Visiting article comments", type: :system, js: true do
   end
 
   context "when root is specified" do
-    before { visit "#{article.path}/comments/#{comment.id.to_s(26)}" }
+    before { visit "#{article.path}/comments/#{comment.id.to_s(26)}" } # rubocop:disable Rails/ToSWithArgument
 
     it "displays related comments" do
       expect(page).to have_selector(".single-comment-node", visible: :visible, count: 4)
@@ -48,23 +48,19 @@ RSpec.describe "Visiting article comments", type: :system, js: true do
     end
   end
 
-  context "when looking into comment links", focus: true do
-    let!(:new_article) { create(:article) }
-    let!(:new_comment) { create(:comment, commentable: new_article, user: user) }
-
+  context "when looking into comment links" do
     it "uses the permalink for signed in users" do
       sign_in user
-      # ENV['WAT'] = new_comment.id.to_s
-      visit new_article.path
-      date_link = find("#comment-node-#{new_comment.id} a.comment-date")
-      # binding.break
-      expect(date_link[:href]).to end_with(new_comment.path)
+      visit article.path
+      date_link = find("#comment-node-#{grandchild_comment.id} a.comment-date")
+      expect(date_link[:href]).to end_with(grandchild_comment.path)
     end
 
     it "uses an anchor tag instead of permalink for signed out users" do
-      visit new_article.path
-      date_link = find("#comment-node-#{new_comment.id} a.comment-date")
-      expected_path = "#{new_article.path}#comment-node-#{new_comment.id}"
+      sign_out user
+      visit article.path
+      date_link = find("#comment-node-#{grandchild_comment.id} a.comment-date")
+      expected_path = "#{article.path}#comment-node-#{grandchild_comment.id}"
       expect(date_link[:href]).to end_with(expected_path)
     end
   end

--- a/spec/system/comments/user_views_article_comments_spec.rb
+++ b/spec/system/comments/user_views_article_comments_spec.rb
@@ -47,4 +47,25 @@ RSpec.describe "Visiting article comments", type: :system, js: true do
                                                                                               count: 1)
     end
   end
+
+  context "when looking into comment links", focus: true do
+    let!(:new_article) { create(:article) }
+    let!(:new_comment) { create(:comment, commentable: new_article, user: user) }
+
+    it "uses the permalink for signed in users" do
+      sign_in user
+      # ENV['WAT'] = new_comment.id.to_s
+      visit new_article.path
+      date_link = find("#comment-node-#{new_comment.id} a.comment-date")
+      # binding.break
+      expect(date_link[:href]).to end_with(new_comment.path)
+    end
+
+    it "uses an anchor tag instead of permalink for signed out users" do
+      visit new_article.path
+      date_link = find("#comment-node-#{new_comment.id} a.comment-date")
+      expected_path = "#{new_article.path}#comment-node-#{new_comment.id}"
+      expect(date_link[:href]).to end_with(expected_path)
+    end
+  end
 end

--- a/spec/system/comments/user_views_article_comments_spec.rb
+++ b/spec/system/comments/user_views_article_comments_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Visiting article comments", type: :system, js: true do
       sign_out user
       visit article.path
       date_link = find("#comment-node-#{grandchild_comment.id} a.comment-date")
-      expected_path = "#{article.path}#comment-node-#{grandchild_comment.id}"
+      expected_path = "#{article.path}#comment-#{grandchild_comment.id_code}"
       expect(date_link[:href]).to end_with(expected_path)
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Optimization

## Description

This PR changes the way comment links are rendered on Posts. If you're signed out you should be get a link to the article with an anchor tag to the comment. If you're signed in you should get the same result as the app currently has (comment permalink).

## Related Tickets & Documents

- Closes #18489

## QA Instructions, Screenshots, Recordings

1. Boot app locally and open Article with comments without signing in
2. Click on a comment's date
   - The link should redirect to the same article with an anchor tag that scrolls you down to the comment
3. Open the comment's dropdown (3 dots icon) and "copy link"
   - The link in the clipboard should be the same as the previous step 
4. Sign in and open another article with comments
5. Click on a comment's date
   - The link should redirect to the comment's permalink
6. Open the comment's dropdown (3 dots icon) and "copy link"
   - The link in the clipboard should be the same as the previous step 

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Small refactor that shouldn't affect the overall experience in the app

## [optional] What gif best describes this PR or how it makes you feel?

![here for the comments](https://media.giphy.com/media/SvvHAKfSMqjyWLrZqq/giphy.gif)

