### PR TITLE
Disallow /ahoy/* in robots.txt

### DIFF
--- a/app/views/pages/robots.text.erb
+++ b/app/views/pages/robots.text.erb
@@ -13,5 +13,6 @@ Disallow: /mod?*
 Disallow: /admin/*
 Disallow: /reactions?*
 Disallow: /async_info/base_data
+Disallow: /ahoy/*
 
 Sitemap: <%= URL.url("sitemap-index.xml") %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Bug Fix

## Description

This PR adds `Disallow: /ahoy/*` to `robots.txt`.

## Related Tickets & Documents

Closes #18530

## Added/updated tests?

- [X] No, and this is why: existing tests don't test for other disallows
