### PR TITLE
Create a note when a users' articles are being unpublished via API

### DIFF
--- a/app/controllers/concerns/api/users_controller.rb
+++ b/app/controllers/concerns/api/users_controller.rb
@@ -50,7 +50,6 @@ module Api
 
       target_user = User.find(params[:id].to_i)
 
-      # Unpublish posts and delete comments w/ boolean attr to allow revert
       Moderator::UnpublishAllArticlesWorker.perform_async(target_user.id, @user.id)
 
       render status: :no_content

--- a/app/controllers/concerns/api/users_controller.rb
+++ b/app/controllers/concerns/api/users_controller.rb
@@ -52,6 +52,11 @@ module Api
 
       Moderator::UnpublishAllArticlesWorker.perform_async(target_user.id, @user.id)
 
+      if params[:note] && params[:note][:content]
+        Note.create(noteable: target_user, reason: "unpublish_all_articles",
+                    content: params[:note][:content], author: @user)
+      end
+
       render status: :no_content
     end
   end

--- a/app/controllers/concerns/api/users_controller.rb
+++ b/app/controllers/concerns/api/users_controller.rb
@@ -52,10 +52,10 @@ module Api
 
       Moderator::UnpublishAllArticlesWorker.perform_async(target_user.id, @user.id)
 
-      if params[:note] && params[:note][:content]
-        Note.create(noteable: target_user, reason: "unpublish_all_articles",
-                    content: params[:note][:content], author: @user)
-      end
+      note_content = params[:note].presence || "#{@user.username} requested unpublish all articles via API"
+
+      Note.create(noteable: target_user, reason: "unpublish_all_articles",
+                  content: note_content, author: @user)
 
       render status: :no_content
     end

--- a/app/services/moderator/unpublish_all_articles.rb
+++ b/app/services/moderator/unpublish_all_articles.rb
@@ -1,3 +1,5 @@
+# Unpublish posts and delete comments w/ boolean attr (setting deleted: true) to allow revert
+# Create a corresponding audit_log record
 module Moderator
   class UnpublishAllArticles
     # @param target_user_id [Integer] the id of the user whose posts are being unpublished

--- a/spec/requests/api/v1/admin/users_spec.rb
+++ b/spec/requests/api/v1/admin/users_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "/api/admin/users", type: :request do
     let(:api_secret) { create(:api_secret, user: super_admin) }
     let(:headers) { v1_headers.merge({ "api-key" => api_secret.secret }) }
 
-    it "accepts reqeuest with a super-admin token" do
+    it "accepts request with a super-admin token" do
       expect do
         post api_admin_users_path, params: params, headers: headers
       end.to change(User, :count).by(1)

--- a/spec/requests/api/v1/docs/articles_spec.rb
+++ b/spec/requests/api/v1/docs/articles_spec.rb
@@ -129,6 +129,11 @@ will remain."
                   },
                   example: 1
 
+        parameter name: :note, in: :query, required: false,
+                  description: "Content for the note that's created along with unpublishing",
+                  schema: { type: :string },
+                  example: "Admin requested unpublishing all articles via API"
+
         response "204", "Article successfully unpublished" do
           let(:"api-key") { api_secret.secret }
           let(:id) { article.id }

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -259,6 +259,25 @@ RSpec.describe "Api::V1::Users", type: :request do
         expect(log.data["target_article_ids"]).to match_array(target_articles.map(&:id))
         expect(log.data["target_comment_ids"]).to match_array(target_comments.map(&:id))
       end
+
+      it "create a note when note text is passed" do
+        sidekiq_perform_enqueued_jobs(only: Moderator::UnpublishAllArticlesWorker) do
+          expect do
+            put api_user_unpublish_path(id: target_user.id, note: { content: "hehe" }), headers: auth_headers
+          end.to change(Note, :count).by(1)
+        end
+        note = target_user.notes.last
+        expect(note.content).to eq("hehe")
+        expect(note.reason).to eq("unpublish_all_articles")
+      end
+
+      it "doesn't create a note when note text is not passed" do
+        sidekiq_perform_enqueued_jobs(only: Moderator::UnpublishAllArticlesWorker) do
+          expect do
+            put api_user_unpublish_path(id: target_user.id), headers: auth_headers
+          end.not_to change(Note, :count)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature
- [x] Bug Fix

## Description
On unpublishing all articles of a user via API: accept a note text and create a corresponding note if the text was passed.
The note is created the same way as it is when unpublishing all articles from the admin action (implemented in #18535)
[Related discussion](https://github.com/forem/forem/pull/18535#discussion_r987698022)

### Concerns
Do we need to adjust the code that sends requests to the api? @fdocr mentioned that it's used by Forem Shield.

## Related Tickets & Documents
 - forem/forem-internal-eng/issues/491

## QA Instructions, Screenshots, Recordings
Unpublishing all articles of a user via the api:
- if note text is passed, the note should be created
- if it's not passed, the note shouldn't be created

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams


