### PR TITLE
Add a MultiSelect Autocomplete component to the Display Ads Page

### DIFF
--- a/app/javascript/CommentSubscription/__tests__/commentSubscriptionUtilities.test.js
+++ b/app/javascript/CommentSubscription/__tests__/commentSubscriptionUtilities.test.js
@@ -4,19 +4,20 @@ import {
   setCommentSubscriptionStatus,
 } from '../commentSubscriptionUtilities';
 
-/* global globalThis */
+const csrfToken = 'this-is-a-csrf-token';
+jest.mock('../../utilities/http/csrfToken', () => ({
+  getCSRFToken: jest.fn(() => Promise.resolve(csrfToken)),
+}));
 
+/* global globalThis */
 describe('Comment Subscription Utilities', () => {
-  const csrfToken = 'this-is-a-csrf-token';
   const articleID = 26; // Just a random article ID.
 
   beforeAll(() => {
     globalThis.fetch = fetch;
-    globalThis.getCsrfToken = async () => csrfToken;
   });
   afterAll(() => {
     delete globalThis.fetch;
-    delete globalThis.getCsrfToken;
   });
 
   afterEach(() => {

--- a/app/javascript/display-ad/tags.jsx
+++ b/app/javascript/display-ad/tags.jsx
@@ -1,0 +1,57 @@
+import { h } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import PropTypes from 'prop-types';
+
+import { useTagsField } from '../hooks/useTagsField';
+import { TagAutocompleteOption } from '@crayons/MultiSelectAutocomplete/TagAutocompleteOption';
+import { TagAutocompleteSelection } from '@crayons/MultiSelectAutocomplete/TagAutocompleteSelection';
+import { MultiSelectAutocomplete } from '@crayons';
+
+/**
+ * Tags for the article form. Allows users to search and select up to 4 tags.
+ *
+ * @param {Function} onInput Callback to sync selections to article form state
+ * @param {string} defaultValue Comma separated list of any currently selected tags
+ * @param {Function} switchHelpContext Callback to switch the help context when the field is focused
+ */
+export const Tags = ({ onInput, defaultValue, switchHelpContext }) => {
+  const [topTags, setTopTags] = useState([]);
+  const { defaultSelections, fetchSuggestions, syncSelections } = useTagsField({
+    defaultValue,
+    onInput,
+  });
+
+  useEffect(() => {
+    fetch('/tags/suggest')
+      .then((res) => res.json())
+      .then((results) => setTopTags(results));
+  }, []);
+
+  return (
+    <MultiSelectAutocomplete
+      defaultValue={defaultSelections}
+      fetchSuggestions={fetchSuggestions}
+      staticSuggestions={topTags}
+      staticSuggestionsHeading={
+        <h2 className="c-autocomplete--multi__top-tags-heading">Top tags</h2>
+      }
+      border
+      showLabel
+      labelText="Targeted Tag(s)"
+      placeholder="Add up to 10 tags..."
+      maxSelections={10}
+      SuggestionTemplate={TagAutocompleteOption}
+      SelectionTemplate={TagAutocompleteSelection}
+      onSelectionsChanged={syncSelections}
+      onFocus={switchHelpContext}
+      inputId="display-ad-targeted-tags"
+      allowUserDefinedSelections={true}
+    />
+  );
+};
+
+Tags.propTypes = {
+  onInput: PropTypes.func.isRequired,
+  defaultValue: PropTypes.string,
+  switchHelpContext: PropTypes.func,
+};

--- a/app/javascript/githubRepos/__tests__/githubRepos.test.jsx
+++ b/app/javascript/githubRepos/__tests__/githubRepos.test.jsx
@@ -5,6 +5,10 @@ import { axe } from 'jest-axe';
 import { GithubRepos } from '../githubRepos';
 
 global.fetch = fetch;
+const csrfToken = 'this-is-a-csrf-token';
+jest.mock('../../utilities/http/csrfToken', () => ({
+  getCSRFToken: jest.fn(() => Promise.resolve(csrfToken)),
+}));
 
 function getRepositories() {
   return [
@@ -201,10 +205,7 @@ function getRepositories() {
 }
 
 describe('<GithubRepos />', () => {
-  const csrfToken = 'this-is-a-csrf-token';
-
   beforeEach(() => {
-    global.getCsrfToken = async () => csrfToken;
     global.Honeybadger = { notify: jest.fn() };
   });
 

--- a/app/javascript/listings/__tests__/ListingTagsField.test.jsx
+++ b/app/javascript/listings/__tests__/ListingTagsField.test.jsx
@@ -9,6 +9,10 @@ import '@testing-library/jest-dom';
 fetch.enableMocks();
 
 let renderResult;
+const csrfToken = 'this-is-a-csrf-token';
+jest.mock('../../utilities/http/csrfToken', () => ({
+  getCSRFToken: jest.fn(() => Promise.resolve(csrfToken)),
+}));
 
 describe('<ListingTagsField />', () => {
   beforeAll(() => {
@@ -17,7 +21,6 @@ describe('<ListingTagsField />', () => {
     document.body.appendChild(environment);
     fetch.resetMocks();
     window.fetch = fetch;
-    window.getCsrfToken = async () => 'this-is-a-csrf-token';
     fetch.mockResponse((_req) =>
       Promise.resolve(JSON.stringify({ result: [] })),
     );

--- a/app/javascript/packs/admin/displayAds.jsx
+++ b/app/javascript/packs/admin/displayAds.jsx
@@ -1,5 +1,5 @@
 import { h, render } from 'preact';
-import { MultiSelectAutocomplete } from '@crayons';
+import { Tags } from '../../display-ad/tags';
 
 Document.prototype.ready = new Promise((resolve) => {
   if (document.readyState !== 'loading') {
@@ -13,29 +13,8 @@ function loadForm() {
   const displayAdsTargetedTags = document.getElementById(
     'display-ad-targeted-tags',
   );
-  render(
-    <MultiSelectAutocomplete
-      border
-      fetchSuggestions={() => {}}
-      labelText="Targeted Tag(s)"
-      maxSelections={10}
-      placeholder="Add up to 10 tags"
-      showLabel
-      staticSuggestions={[
-        {
-          name: '#javascript',
-        },
-        {
-          name: '#beginner',
-        },
-        {
-          name: '#codenewbie',
-        },
-      ]}
-      staticSuggestionsHeading="Top Tags"
-    />,
-    displayAdsTargetedTags,
-  );
+
+  render(<Tags />, displayAdsTargetedTags);
 }
 
 document.ready.then(() => {

--- a/app/javascript/packs/admin/displayAds.jsx
+++ b/app/javascript/packs/admin/displayAds.jsx
@@ -11,20 +11,16 @@ Document.prototype.ready = new Promise((resolve) => {
 
 function saveTags() {}
 
-function loadForm() {
+function loadTagsField() {
   const displayAdsTargetedTags = document.getElementById(
     'display-ad-targeted-tags',
   );
 
-  render(<Tags onInput={saveTags} />, displayAdsTargetedTags);
+  if (displayAdsTargetedTags) {
+    render(<Tags onInput={saveTags} />, displayAdsTargetedTags);
+  }
 }
 
 document.ready.then(() => {
-  // To Fix: loadForm is getting called twice.
-  loadForm();
-  // window.InstantClick.on('change', () => {
-  if (document.getElementById('display-ad-form')) {
-    loadForm();
-  }
-  // });
+  loadTagsField();
 });

--- a/app/javascript/packs/admin/displayAds.jsx
+++ b/app/javascript/packs/admin/displayAds.jsx
@@ -9,12 +9,14 @@ Document.prototype.ready = new Promise((resolve) => {
   return null;
 });
 
+function saveTags() {}
+
 function loadForm() {
   const displayAdsTargetedTags = document.getElementById(
     'display-ad-targeted-tags',
   );
 
-  render(<Tags />, displayAdsTargetedTags);
+  render(<Tags onInput={saveTags} />, displayAdsTargetedTags);
 }
 
 document.ready.then(() => {

--- a/app/javascript/packs/admin/displayAds.jsx
+++ b/app/javascript/packs/admin/displayAds.jsx
@@ -1,0 +1,49 @@
+import { h, render } from 'preact';
+import { MultiSelectAutocomplete } from '@crayons';
+
+Document.prototype.ready = new Promise((resolve) => {
+  if (document.readyState !== 'loading') {
+    return resolve();
+  }
+  document.addEventListener('DOMContentLoaded', () => resolve());
+  return null;
+});
+
+function loadForm() {
+  const displayAdsTargetedTags = document.getElementById(
+    'display-ad-targeted-tags',
+  );
+  render(
+    <MultiSelectAutocomplete
+      border
+      fetchSuggestions={() => {}}
+      labelText="Targeted Tag(s)"
+      maxSelections={10}
+      placeholder="Add up to 10 tags"
+      showLabel
+      staticSuggestions={[
+        {
+          name: '#javascript',
+        },
+        {
+          name: '#beginner',
+        },
+        {
+          name: '#codenewbie',
+        },
+      ]}
+      staticSuggestionsHeading="Top Tags"
+    />,
+    displayAdsTargetedTags,
+  );
+}
+
+document.ready.then(() => {
+  // To Fix: loadForm is getting called twice.
+  loadForm();
+  // window.InstantClick.on('change', () => {
+  if (document.getElementById('display-ad-form')) {
+    loadForm();
+  }
+  // });
+});

--- a/app/javascript/utilities/__tests__/search.test.js
+++ b/app/javascript/utilities/__tests__/search.test.js
@@ -8,18 +8,18 @@ import {
 } from '../search';
 import '../../../assets/javascripts/lib/xss';
 
-/* global globalThis */
+const csrfToken = 'this-is-a-csrf-token';
+jest.mock('../../utilities/http/csrfToken', () => ({
+  getCSRFToken: jest.fn(() => Promise.resolve(csrfToken)),
+}));
 
+/* global globalThis */
 describe('Search utilities', () => {
   beforeAll(() => {
-    const csrfToken = 'this-is-a-csrf-token';
-
     globalThis.fetch = fetch;
-    globalThis.getCsrfToken = async () => csrfToken;
   });
   afterAll(() => {
     delete globalThis.fetch;
-    delete globalThis.getCsrfToken;
   });
 
   describe('getSearchTermFromUrl', () => {

--- a/app/javascript/utilities/http/__tests__/csrfToken.test.js
+++ b/app/javascript/utilities/http/__tests__/csrfToken.test.js
@@ -1,0 +1,10 @@
+import { getCSRFToken } from '@utilities/http/csrfToken';
+
+document.head.innerHTML = `<meta name="csrf-token" content="this-is-a-csrf-token"></head>`;
+
+describe('getCSRFToken', () => {
+  it('should return a resolved Promise with the CSRF token', async () => {
+    const data = await getCSRFToken();
+    expect(data).toBe('this-is-a-csrf-token');
+  });
+});

--- a/app/javascript/utilities/http/__tests__/csrfToken.test.js
+++ b/app/javascript/utilities/http/__tests__/csrfToken.test.js
@@ -1,10 +1,14 @@
 import { getCSRFToken } from '@utilities/http/csrfToken';
 
-document.head.innerHTML = `<meta name="csrf-token" content="this-is-a-csrf-token"></head>`;
-
 describe('getCSRFToken', () => {
-  it('should return a resolved Promise with the CSRF token', async () => {
+  it('should resolve with the CSRF token when there is a meta tag', async () => {
+    document.head.innerHTML = `<meta name="csrf-token" content="this-is-a-csrf-token"></head>`;
+
     const data = await getCSRFToken();
     expect(data).toBe('this-is-a-csrf-token');
   });
+
+  // [@ridhwanak] It was proving to be really difficult to test the error case
+  // since there are timers and max retries on setInterval, and I was
+  // struggling to achieve the scenario with jest timers.
 });

--- a/app/javascript/utilities/http/__tests__/csrfToken.test.js
+++ b/app/javascript/utilities/http/__tests__/csrfToken.test.js
@@ -8,7 +8,7 @@ describe('getCSRFToken', () => {
     expect(data).toBe('this-is-a-csrf-token');
   });
 
-  // [@ridhwanak] It was proving to be really difficult to test the error case
+  // [@ridhwana] It was proving to be really difficult to test the error case
   // since there are timers and max retries on setInterval, and I was
   // struggling to achieve the scenario with jest timers.
 });

--- a/app/javascript/utilities/http/__tests__/request.test.js
+++ b/app/javascript/utilities/http/__tests__/request.test.js
@@ -1,5 +1,4 @@
 import fetch from 'jest-fetch-mock';
-// import { getCSRFToken } from '../csrfToken';
 import { request } from '@utilities/http';
 
 const csrfToken = 'this-is-a-csrf-token';

--- a/app/javascript/utilities/http/__tests__/request.test.js
+++ b/app/javascript/utilities/http/__tests__/request.test.js
@@ -1,20 +1,23 @@
 import fetch from 'jest-fetch-mock';
+// import { getCSRFToken } from '../csrfToken';
 import { request } from '@utilities/http';
+
+const csrfToken = 'this-is-a-csrf-token';
+jest.mock('../csrfToken', () => ({
+  getCSRFToken: jest.fn(() => Promise.resolve(csrfToken)),
+}));
 
 // NOTE: Everything that native fetch in the browser does, e.g. CREATE, DELETE etc. could be tested here, but that is pointless.
 // The tests below are really just to check the functionality that request offers on top of native fetch.
 
 /* global globalThis */
 describe('request', () => {
-  const csrfToken = 'this-is-a-csrf-token';
-
   beforeAll(() => {
     globalThis.fetch = fetch;
-    globalThis.getCsrfToken = async () => csrfToken;
   });
+
   afterAll(() => {
     delete globalThis.fetch;
-    delete globalThis.getCsrfToken;
   });
 
   afterEach(() => {

--- a/app/javascript/utilities/http/csrfToken.js
+++ b/app/javascript/utilities/http/csrfToken.js
@@ -4,9 +4,9 @@ const RETRY_INTERVAL = 250;
 export function getCSRFToken() {
   const promise = new Promise((resolve, reject) => {
     // eslint-disable-next-line consistent-return
+    let i = 0;
     const waitingOnCSRF = setInterval(() => {
       const metaTag = document.querySelector("meta[name='csrf-token']");
-      let i = 0;
       i += 1;
 
       if (metaTag) {
@@ -26,6 +26,5 @@ export function getCSRFToken() {
       }
     }, RETRY_INTERVAL);
   });
-
   return promise;
 }

--- a/app/javascript/utilities/http/csrfToken.js
+++ b/app/javascript/utilities/http/csrfToken.js
@@ -1,0 +1,31 @@
+const MAX_RETRIES = 30;
+const RETRY_INTERVAL = 250;
+
+export function getCSRFToken() {
+  const promise = new Promise((resolve, reject) => {
+    // eslint-disable-next-line consistent-return
+    const waitingOnCSRF = setInterval(() => {
+      const metaTag = document.querySelector("meta[name='csrf-token']");
+      let i = 0;
+      i += 1;
+
+      if (metaTag) {
+        clearInterval(waitingOnCSRF);
+        const authToken = metaTag.getAttribute('content');
+        return resolve(authToken);
+      }
+
+      if (i === MAX_RETRIES) {
+        clearInterval(waitingOnCSRF);
+        Honeybadger.notify(
+          `Could not locate CSRF metatag ${JSON.stringify(
+            localStorage.current_user,
+          )}`,
+        );
+        return reject(new Error('Could not locate CSRF meta tag on the page.'));
+      }
+    }, RETRY_INTERVAL);
+  });
+
+  return promise;
+}

--- a/app/javascript/utilities/http/request.js
+++ b/app/javascript/utilities/http/request.js
@@ -1,3 +1,5 @@
+import { getCSRFToken } from './csrfToken';
+
 /**
  * Generic request with all the default headers required by the application.
  *
@@ -25,7 +27,7 @@ export async function request(url, options = {}) {
     headers,
     body,
     method = 'GET',
-    csrfToken = await getCsrfToken(),
+    csrfToken = await getCSRFToken(),
     // These are any other options that might be passed in e.g. keepalive
     ...restOfOptions
   } = options;

--- a/app/views/admin/display_ads/_form.html.erb
+++ b/app/views/admin/display_ads/_form.html.erb
@@ -20,9 +20,11 @@
       <%= select_tag :placement_area, options_for_select(display_ads_placement_area_options_array, selected: @display_ad.placement_area), include_blank: "Select...", class: "crayons-select" %>
     </div>
 
-    <div class="crayons-field">
-      <div id="display-ad-targeted-tags"></div>
-    </div>
+    <% if FeatureFlag.enabled?(:display_ad_tags) %>
+      <div class="crayons-field">
+        <div id="display-ad-targeted-tags"></div>
+      </div>
+    <% end %>
 
     <div class="crayons-field">
       <fieldset aria-describedby="section-description" aria-describedby="display-to-description">
@@ -77,4 +79,6 @@
   </div>
 </div>
 
-<%= javascript_packs_with_chunks_tag "admin/displayAds", defer: true %>
+<% if FeatureFlag.enabled?(:display_ad_tags) %>
+  <%= javascript_packs_with_chunks_tag "admin/displayAds", defer: true %>
+<% end %>

--- a/app/views/admin/display_ads/_form.html.erb
+++ b/app/views/admin/display_ads/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="grid l:grid-cols-2 gap-6 mb-4">
+<div id="display-ad-form" class="grid l:grid-cols-2 gap-6 mb-4">
   <div class="flex flex-col gap-4">
     <div class="crayons-field">
       <%= label_tag :name, "Name:", class: "crayons-field__label" %>
@@ -18,6 +18,10 @@
     <div class="crayons-field">
       <%= label_tag :placement_area, "Placement Area:", class: "crayons-field__label" %>
       <%= select_tag :placement_area, options_for_select(display_ads_placement_area_options_array, selected: @display_ad.placement_area), include_blank: "Select...", class: "crayons-select" %>
+    </div>
+
+    <div class="crayons-field">
+      <div id="display-ad-targeted-tags"></div>
     </div>
 
     <div class="crayons-field">
@@ -72,3 +76,5 @@
     </div>
   </div>
 </div>
+
+<%= javascript_packs_with_chunks_tag "admin/displayAds", defer: true %>

--- a/app/views/admin/display_ads/_form.html.erb
+++ b/app/views/admin/display_ads/_form.html.erb
@@ -1,4 +1,4 @@
-<div id="display-ad-form" class="grid l:grid-cols-2 gap-6 mb-4">
+<div class="grid l:grid-cols-2 gap-6 mb-4">
   <div class="flex flex-col gap-4">
     <div class="crayons-field">
       <%= label_tag :name, "Name:", class: "crayons-field__label" %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR partially refactors some code whilst adding some new functionality. 

**Refactor:** 
The asset pipeline (`app/assets/javascripts`) is where we have the "legacy" JavaScript. It's legacy in the sense that it's not EcmaScript Modules (ESM). It's a bunch of JS files concatenated together.

In `app/javascript/utilities/http/request.js` we were using a method called `getCsrfToken` and this method was being included automatically in the [the application layout file](https://github.com/forem/forem/blob/effb2b0a87783106af4b481035699fd34ca1e96f/app/views/layouts/application.html.erb#L21-L22). Hence, it was not being imported in [app/javascript/utilities/http/request.js](https://github.com/forem/forem/blob/effb2b0a87783106af4b481035699fd34ca1e96f/app/javascript/utilities/http/request.js) because it was already a global method. 

However, using this legacy system meant that when we want to use the request utility on the admin, we would need to include the "legacy" javascript, which is not a good idea.

Hence, what I've tried to do instead is to create a `getCSRFToken` utility in the packs files.  I then went back and imported this in the request file that is needed for the display ads tags to work. As a result a couple of other files where a request was been made will now depend on this new utility in the tests. 

There are many many other instances where we use `getCsrfToken` but updating all of those instances seem out of scope and instead I will create an issue on the board for this technical debt refactor. 

**Feature:** 
In this PR we add the Tags AutoComplete component to the Display ads form, and we allow a user to select up to 10 tags. I do not do anything with the tags as I just wanted to get the component working. In subsequent PRs, I will save the tags and update the UI accordingly. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #https://github.com/forem/forem/issues/18519
- Closes #

## QA Instructions, Screenshots, Recordings
1. Enable the display_ads_tags feature flag with `FeatureFlag.enable(:display_ad_tags)`
2. Navigate to the `http://localhost:3000/admin/customization/display_ads/new` where you should see a tags component on the page.
3. Try to enter tags, play with suggestions etc. 
4. Your information would not be saved because I haven't yet built that functionality in. 

Now,  disable the Feature Flag and you should see the component disappear from the page.
<img width="1503" alt="Screenshot 2022-10-20 at 08 38 28" src="https://user-images.githubusercontent.com/2786819/196875612-e29bdc03-aac6-4303-818a-1c92c4f5bf1b.png">

<img width="1512" alt="Screenshot 2022-10-20 at 08 38 20" src="https://user-images.githubusercontent.com/2786819/196875598-491e21ea-be61-4258-b546-653a6febc3d1.png">

### UI accessibility concerns?

The component is already accessible. 

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/XxufzXHub5zdIj8yp2/giphy.gif)

