### PR TITLE
Increase defaultCommandTimeout for cypress tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -10,5 +10,6 @@ module.exports = defineConfig({
     trashAssetsBeforeRuns: false,
     video: false,
     retries: 3,
+    defaultCommandTimeout: 8000,
   },
 });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Optimization

## Description

We're seeing some E2E tests fail with errors along the lines of:

```
1) Logged out Home feed
       shows a profile preview card for an article's author:
     TestingLibraryElementError: Timed out retrying after 4000ms: Unable to find an accessible element with the role "link" and name "Admin McAdmin"
```

This is a quick attempt at increasing (double) the `defaultCommandTimeout` to see if that improves the reliability on these tests that randomly fail this way. We've done similar things, i.e. https://github.com/forem/forem/pull/18436

[Cypress config reference](https://docs.cypress.io/guides/references/configuration#Timeouts)

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] No, and this is why: Only updated Cypress test configs

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] What gif best describes this PR or how it makes you feel?

![Biden: But it does give us more time](https://media.giphy.com/media/qfrLqLXFLzmhgfoU34/giphy.gif)

