### PR TITLE
Add more descriptive accessible names for save/bookmark-buttons

### DIFF
--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -285,7 +285,7 @@ function buildArticleHTML(article, currentUserId = null) {
           class="c-btn c-btn--icon-alone bookmark-button"
           data-reactable-id="${article.id}"
           data-article-author-id="${article.user_id}"
-          aria-label="Save to reading list">
+          aria-label="Save post ${article.title} to reading list">
           <span class="bm-initial">${saveSVG}</span>
           <span class="bm-success">${saveFilledSVG}</span>
         </button>

--- a/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
+++ b/app/javascript/articles/__tests__/__snapshots__/Article.test.jsx.snap
@@ -243,13 +243,13 @@ Object {
                     1 min read
                   </small>
                   <button
-                    aria-label="Save to reading list"
+                    aria-label="Save post Unbranded Home Loan Account to reading list"
                     aria-pressed="false"
                     class="c-btn c-btn--icon-alone"
                     data-initial-feed="true"
                     data-reactable-id="62407"
                     id="article-save-button-62407"
-                    title="Save to reading list"
+                    title="Save post Unbranded Home Loan Account to reading list"
                     type="button"
                   >
                     <svg
@@ -512,13 +512,13 @@ Object {
                   1 min read
                 </small>
                 <button
-                  aria-label="Save to reading list"
+                  aria-label="Save post Unbranded Home Loan Account to reading list"
                   aria-pressed="false"
                   class="c-btn c-btn--icon-alone"
                   data-initial-feed="true"
                   data-reactable-id="62407"
                   id="article-save-button-62407"
-                  title="Save to reading list"
+                  title="Save post Unbranded Home Loan Account to reading list"
                   type="button"
                 >
                   <svg

--- a/app/javascript/articles/components/SaveButton.jsx
+++ b/app/javascript/articles/components/SaveButton.jsx
@@ -24,8 +24,8 @@ export const SaveButton = ({
       <Button
         id={`article-save-button-${article.id}`}
         variant="default"
-        title="Save to reading list"
-        aria-label="Save to reading list"
+        title={`Save post ${article.title} to reading list`}
+        aria-label={`Save post ${article.title} to reading list`}
         aria-pressed={isBookmarked}
         icon={isBookmarked ? BookmarkFilledSVG : BookmarkSVG}
         data-initial-feed

--- a/app/javascript/articles/components/__tests__/SaveButton.test.jsx
+++ b/app/javascript/articles/components/__tests__/SaveButton.test.jsx
@@ -22,10 +22,10 @@ it('should have no a11y violations', async () => {
 });
 
 it('should render button as bookmarked', () => {
-  const article = { class_name: 'Article', id: 1 };
+  const article = { class_name: 'Article', id: 1, title: 'Article' };
   const { queryByRole } = render(<SaveButton article={article} isBookmarked />);
   const saveButton = queryByRole('button', {
-    name: 'Save to reading list',
+    name: `Save post ${article.title} to reading list`,
     pressed: true,
   });
 
@@ -33,12 +33,12 @@ it('should render button as bookmarked', () => {
 });
 
 it('should button as not being bookmarked', () => {
-  const article = { class_name: 'Article', id: 1 };
+  const article = { class_name: 'Article', id: 1, title: 'Article' };
   const { queryByRole } = render(
     <SaveButton article={article} isBookmarked={false} />,
   );
   const saveButton = queryByRole('button', {
-    name: 'Save to reading list',
+    name: `Save post ${article.title} to reading list`,
     pressed: false,
   });
 
@@ -46,15 +46,17 @@ it('should button as not being bookmarked', () => {
 });
 
 it('should bookmark when it previously was not', async () => {
-  const article = { class_name: 'Article', id: 1 };
+  const article = { class_name: 'Article', id: 1, title: 'Article' };
   const { getByRole, findByRole } = render(
     <SaveButton onClick={jest.fn()} article={article} isBookmarked={false} />,
   );
-  const saveButton = getByRole('button', { name: 'Save to reading list' });
+  const saveButton = getByRole('button', {
+    name: `Save post ${article.title} to reading list`,
+  });
   saveButton.click();
 
   const savedButton = await findByRole('button', {
-    name: 'Save to reading list',
+    name: `Save post ${article.title} to reading list`,
     pressed: true,
   });
 
@@ -62,19 +64,19 @@ it('should bookmark when it previously was not', async () => {
 });
 
 it('should unbookmark when it previously was bookmarked', async () => {
-  const article = { class_name: 'Article', id: 1 };
+  const article = { class_name: 'Article', id: 1, title: 'Article' };
   const { getByRole, findByRole } = render(
     <SaveButton onClick={jest.fn()} article={article} isBookmarked />,
   );
 
   const savedButton = getByRole('button', {
-    name: 'Save to reading list',
+    name: `Save post ${article.title} to reading list`,
     pressed: true,
   });
   savedButton.click();
 
   const saveButton = await findByRole('button', {
-    name: 'Save to reading list',
+    name: `Save post ${article.title} to reading list`,
     pressed: false,
   });
 

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -153,8 +153,8 @@
             class="c-btn c-btn--icon-alone bookmark-button"
             data-reactable-id="<%= story.id %>"
             data-article-author-id="<%= story.user_id %>"
-            aria-label="<%= t("views.articles.save.aria_label") %>"
-            title="<%= t("views.articles.save.title") %>">
+            aria-label="<%= t("views.articles.save.aria_label", title: story.title) %>"
+            title="<%= t("views.articles.save.title", title: story.title) %>">
             <span class="bm-initial">
               <%= inline_svg_tag("small-save.svg", alt: "", aria_hidden: true) %>
             </span>

--- a/config/locales/views/articles/en.yml
+++ b/config/locales/views/articles/en.yml
@@ -52,8 +52,8 @@ en:
         one: '#discuss <img src="%{image}" />%{count}'
         other: '#discuss <img src="%{image}" />%{count}'
       save:
-        title: Save to reading list
-        aria_label: Save to reading list
+        title: "Save post %{title} to reading list"
+        aria_label: "Save post %{title} to reading list"
         initial: Save
         success: Saved
       scheduled:

--- a/config/locales/views/articles/fr.yml
+++ b/config/locales/views/articles/fr.yml
@@ -49,8 +49,8 @@ fr:
         one: '#discuss <img src="%{image}" />%{count}'
         other: '#discuss <img src="%{image}" />%{count}'
       save:
-        title: Save to reading list
-        aria_label: Save to reading list
+        title: "Save post %{title} to reading list"
+        aria_label: "Save post %{title} to reading list"
         initial: Save
         success: Saved
       series:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
Adds more descriptive labels for Save / Bookmark-buttons so that users relying on information in text form will know which post they're about to save.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #18286 

## QA Instructions, Screenshots, Recordings

Before:
<img width="1440" alt="List of form controls in Voice Over Rotor with Dev (local)'s home page open. There are multiple 'Save to reading list button'-buttons in the list." src="https://user-images.githubusercontent.com/28345294/195966032-07798a8a-9e80-49c3-b6e7-9026f5ef8871.png">

After: 
<img width="1440" alt="List of form controls in Voice Over Rotor with Dev (local)'s home page open. Buttons starting with 'Save post' have the name of the article included." src="https://user-images.githubusercontent.com/28345294/195966029-243d1dcc-76ab-489a-a077-8565d27ffee2.png">

To test these changes, you can either use a screen reader to pull up the list of buttons on the feed, or other tools that display the accessible name of the element. One option is to use Developer tools and inspect the element and verify that `aria-label` includes the name of the article. 

This has been tested on Mac and VoiceOver on Chrome, Firefox and Safari.

### UI accessibility concerns?

This PR improves accessibility as described in the ticket.

## Added/updated tests?

- [x] Yes


