### PR TITLE
Used preact modal for userSubscriptionLiquidTag

### DIFF
--- a/app/assets/stylesheets/ltags/UserSubscriptionTag.scss
+++ b/app/assets/stylesheets/ltags/UserSubscriptionTag.scss
@@ -61,14 +61,3 @@
     box-shadow: 0 0 0 4px var(--body-color-inverted);
   }
 }
-
-// modal styles overwrite crayons component WIP
-#user-subscription-confirmation-modal {
-  .crayons-modal__box__header {
-    padding: var(--su-2) var(--su-4);
-  }
-
-  .crayons-modal__box__body {
-    padding: var(--su-6);
-  }
-}

--- a/app/javascript/liquidTags/userSubscriptionLiquidTag.js
+++ b/app/javascript/liquidTags/userSubscriptionLiquidTag.js
@@ -1,5 +1,31 @@
 import { getUserDataAndCsrfToken } from '@utilities/getUserDataAndCsrfToken';
+import {
+  closeWindowModal,
+  showWindowModal,
+  WINDOW_MODAL_ID,
+} from '@utilities/showModal';
 /* global userData  */
+
+const modalContents = new Map();
+
+/**
+ * Helper function to handle finding and caching modal content. Since our Preact modal helper works by duplicating HTML content,
+ * and our modals rely on IDs to label form controls, we remove the original hidden content from the DOM to avoid ID conflicts.
+ *
+ * @param {string} modalContentSelector The CSS selector used to identify the correct modal content
+ */
+const getModalContents = (modalContentSelector) => {
+  if (!modalContents.has(modalContentSelector)) {
+    const modalContentElement =
+      window.parent.document.querySelector(modalContentSelector);
+    const modalContent = modalContentElement.innerHTML;
+
+    modalContentElement.remove();
+    modalContents.set(modalContentSelector, modalContent);
+  }
+
+  return modalContents.get(modalContentSelector);
+};
 
 function toggleSubscribeActionUI({
   tagContainer,
@@ -85,31 +111,38 @@ function initSignedInState(tagContainer, appleAuth = false) {
   tagContainer
     .querySelector('.ltag__user-subscription-tag__signed-in .crayons-btn')
     .addEventListener('click', () => {
-      window.Forem.showModal({
-        title: 'Confirm subscribe',
-        contentSelector:
-          '.user-subscription-confirmation-modal .crayons-modal__box__body',
-        overlay: true,
-        onOpen: () => {
-          // Attach listeners for cancel button and subscribe button
-          document
-            .querySelector(
-              '#window-modal .ltag__user-subscription-tag____cancel-btn',
-            )
-            .addEventListener('click', window.Forem.closeModal);
-
-          document
-            .querySelector(
-              '#window-modal .ltag__user-subscription-tag__confirmation-btn',
-            )
-            .addEventListener('click', confirmSubscribe);
-        },
-      });
+      showConfirmSubscribeModal();
     });
 }
 
+function showConfirmSubscribeModal() {
+  showWindowModal({
+    title: 'Confirm subscribe',
+    size: 'small',
+    modalContent: getModalContents(
+      '.user-subscription-confirmation-modal .crayons-modal__box__body',
+    ),
+    onOpen: () => {
+      // Attach listeners for cancel button and subscribe button
+      document
+        .querySelector(
+          `#${WINDOW_MODAL_ID} .ltag__user-subscription-tag____cancel-btn`,
+        )
+        .addEventListener('click', () => {
+          closeWindowModal();
+        });
+
+      document
+        .querySelector(
+          `#${WINDOW_MODAL_ID} .ltag__user-subscription-tag__confirmation-btn`,
+        )
+        .addEventListener('click', confirmSubscribe);
+    },
+  });
+}
+
 function confirmSubscribe() {
-  window.Forem.closeModal();
+  closeWindowModal();
   clearNotices();
 
   submitSubscription().then((response) => {

--- a/app/javascript/liquidTags/userSubscriptionLiquidTag.js
+++ b/app/javascript/liquidTags/userSubscriptionLiquidTag.js
@@ -6,27 +6,6 @@ import {
 } from '@utilities/showModal';
 /* global userData  */
 
-const modalContents = new Map();
-
-/**
- * Helper function to handle finding and caching modal content. Since our Preact modal helper works by duplicating HTML content,
- * and our modals rely on IDs to label form controls, we remove the original hidden content from the DOM to avoid ID conflicts.
- *
- * @param {string} modalContentSelector The CSS selector used to identify the correct modal content
- */
-const getModalContents = (modalContentSelector) => {
-  if (!modalContents.has(modalContentSelector)) {
-    const modalContentElement =
-      window.parent.document.querySelector(modalContentSelector);
-    const modalContent = modalContentElement.innerHTML;
-
-    modalContentElement.remove();
-    modalContents.set(modalContentSelector, modalContent);
-  }
-
-  return modalContents.get(modalContentSelector);
-};
-
 function toggleSubscribeActionUI({
   tagContainer,
   showSubscribeAction = false,
@@ -119,9 +98,9 @@ function showConfirmSubscribeModal() {
   showWindowModal({
     title: 'Confirm subscribe',
     size: 'small',
-    modalContent: getModalContents(
+    modalContent: document.querySelector(
       '.user-subscription-confirmation-modal .crayons-modal__box__body',
-    ),
+    ).innerHTML,
     onOpen: () => {
       // Attach listeners for cancel button and subscribe button
       document

--- a/app/views/liquids/_user_subscription.html.erb
+++ b/app/views/liquids/_user_subscription.html.erb
@@ -48,7 +48,8 @@
         <div class="ltag__user-subscription-tag__response-message crayons-notice fs-base w-100 hidden" aria-live="polite"></div>
       </div>
     </div>
-      <div class="user-subscription-confirmation-modal hidden crayons-modal__box__body">
+    <div class="user-subscription-confirmation-modal hidden">
+      <div class="crayons-modal__box__body">
         <p class="fs-base mb-4 mt-0">
           <%= t("views.liquids.user_subscription.confirm.text_html", community: community_name, username: tag.span(author_username, class: "ltag__user-subscription-tag__author-username fw-medium")) %>
         <p>
@@ -60,6 +61,7 @@
             <%= t("views.liquids.user_subscription.confirm.cancel_text") %>
           </button>
         </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/liquids/_user_subscription.html.erb
+++ b/app/views/liquids/_user_subscription.html.erb
@@ -48,8 +48,7 @@
         <div class="ltag__user-subscription-tag__response-message crayons-notice fs-base w-100 hidden" aria-live="polite"></div>
       </div>
     </div>
-    <div class="user-subscription-confirmation-modal hidden">
-      <div class="crayons-modal__box__body">
+      <div class="user-subscription-confirmation-modal hidden crayons-modal__box__body">
         <p class="fs-base mb-4 mt-0">
           <%= t("views.liquids.user_subscription.confirm.text_html", community: community_name, username: tag.span(author_username, class: "ltag__user-subscription-tag__author-username fw-medium")) %>
         <p>
@@ -61,7 +60,6 @@
             <%= t("views.liquids.user_subscription.confirm.cancel_text") %>
           </button>
         </div>
-      </div>
     </div>
   </div>
 </div>

--- a/cypress/e2e/seededFlows/articleFlows/liquidTagFlows/userSubscriptionTagWithSubscribableEmail.spec.js
+++ b/cypress/e2e/seededFlows/articleFlows/liquidTagFlows/userSubscriptionTagWithSubscribableEmail.spec.js
@@ -31,7 +31,10 @@ describe('User subscription liquid tag - subscribable email', () => {
     }).should('have.length', 2);
 
     cy.findAllByRole('button', { name: 'Subscribe' }).last().click();
-    cy.getModal()
+
+    cy.findByTestId('modal-container').as('modal');
+
+    cy.get('@modal')
       .findByRole('button', { name: 'Confirm subscription' })
       .click();
 
@@ -43,7 +46,10 @@ describe('User subscription liquid tag - subscribable email', () => {
 
   it('cancels subscription action', () => {
     cy.findAllByRole('button', { name: 'Subscribe' }).last().click();
-    cy.getModal().findByRole('button', { name: 'Cancel' }).click();
+
+    cy.findByTestId('modal-container').as('modal');
+
+    cy.get('@modal').findByRole('button', { name: /Close/ }).click();
 
     cy.findAllByRole('button', { name: 'Subscribe' }).should('have.length', 2);
     cy.findByText(
@@ -57,7 +63,10 @@ describe('User subscription liquid tag - subscribable email', () => {
     });
 
     cy.findAllByRole('button', { name: 'Subscribe' }).last().click();
-    cy.getModal()
+
+    cy.findByTestId('modal-container').as('modal');
+
+    cy.get('@modal')
       .findByRole('button', { name: 'Confirm subscription' })
       .click();
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This PR simply uses the preact modal instead of creating our own modal.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #16328
- Closes #

## QA Instructions, Screenshots, Recordings

To test this PR, create a post with following content
```
Test Post User Subscription

{% user_subscription Your call to action text comes here %}

```

After creating the post, signed-in users will see below screen
<img width="500" alt="Screenshot 2022-10-24 at 11 43 52 AM" src="https://user-images.githubusercontent.com/9396084/197459543-7b9486a9-10d9-4cb2-98b2-fc400fe0ccb8.png">

Click on subscribe to show the modal
<img width="500" alt="Screenshot 2022-10-24 at 11 40 26 AM" src="https://user-images.githubusercontent.com/9396084/197459624-06e82b9b-c0ed-47d1-9d7b-955bbedc17d1.png">


### UI accessibility concerns?

No

## Added/updated tests?

- [ ] Yes
- [x] No
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
