### PR TITLE
Timecop freeze ab_experiment spec

### DIFF
--- a/spec/models/ab_experiment/goal_conversion_handler_spec.rb
+++ b/spec/models/ab_experiment/goal_conversion_handler_spec.rb
@@ -123,7 +123,10 @@ RSpec.describe AbExperiment::GoalConversionHandler do
 
       before do
         field_test(AbExperiment::CURRENT_FEED_STRATEGY_EXPERIMENT, participant: user)
+        Timecop.freeze(Time.current.utc.at_noon)
       end
+
+      after { Timecop.return }
 
       it "records a field test when user views a page", :aggregate_failures do
         create(:page_view, user_id: user.id)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix
- [x] Optimization

## Description

This PR is an attempt to fix an issue we're seeing in some AbExperiment specs where current time of execution and/or timezones would sometimes break CI due to seed data being created inconsistently.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- #18577

## QA Instructions, Screenshots, Recordings

Specs are the change. These are the times that you see when running the specs locally (randomized TZ means same minutes/seconds as local machine but different hour of the day)

<img width="343" alt="Screen Shot 2022-10-28 at 10 23 39" src="https://user-images.githubusercontent.com/6045239/198687340-4ae5667a-e58a-4b0b-a261-9af08341791d.png">

When specs are executed at a TZ where seed data overlaps more than one day (i.e. 7 PageViews created over the past 7 hours) the experiment results vary (instead of 7 events in one day they span 2 days). This is what those look like with the Timecop freeze call (consistent):

<img width="351" alt="Screen Shot 2022-10-28 at 10 23 28" src="https://user-images.githubusercontent.com/6045239/198687882-bbb7a7bc-0fbb-4b7d-be44-eaf300811083.png">

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] This change does not need to be communicated, and this is why not: Small test suite improvement

## [optional] What gif best describes this PR or how it makes you feel?

![Obama looking at his watch](https://media.giphy.com/media/3o6ZsUxHFSRNpTIXmg/giphy.gif)

