### PR TITLE
Fix a spec failing because of the daylight savings

### DIFF
--- a/spec/requests/articles/articles_update_spec.rb
+++ b/spec/requests/articles/articles_update_spec.rb
@@ -200,7 +200,9 @@ RSpec.describe "ArticlesUpdate", type: :request do
       put "/articles/#{draft.id}", params: { article: attributes }
       draft.reload
       published_at_utc = draft.published_at.in_time_zone("UTC").strftime("%m/%d/%Y %H:%M")
-      expect(published_at_utc).to eq("#{tomorrow.strftime('%m/%d/%Y')} 23:00")
+      draft.published_at.in_time_zone(attributes[:timezone])
+      expected_time = "#{(tomorrow + 1.day).strftime('%m/%d/%Y')} 00:00"
+      expect(published_at_utc).to eq(expected_time)
       expect(draft.published).to be true
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix (in a test)

## Description
This pr fixes a failing spec that started failing because of the daylight savings time.
In general, I put hardcoded time in the tests of this type because I wanted to test the actual values that are written. Otherwise I would put the logic similar to the logic in `ArticlesController#article_params_json`, so that would not fully test what's happening. 
We would still need some kind of logic to work with dst in tests. But I have also read that Mexico [has abolished dst](https://www.timeanddate.com/news/time/mexico-abolishes-dst-2022.html) recently, so we can just change the values from -5 to -6 in this test. 
I have also checked other places with similar logic in tests and timezones that are used there don't use dst, so they should work,

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

