### PR TITLE
Fix removing published_at for a scheduled draft

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -831,10 +831,11 @@ class Article < ApplicationRecord
   def correct_published_at?
     return unless changes["published_at"]
 
-    # for drafts (that were never published before) or scheduled articles => allow future or current dates
+    # for drafts (that were never published before) or scheduled articles
+    # => allow future or current dates, or no published_at
     if !published_at_was || published_at_was > Time.current
       # for articles published_from_feed (exported from rss) we allow past published_at
-      if (!published_at || published_at < 15.minutes.ago) && !published_from_feed
+      if (published_at && published_at < 15.minutes.ago) && !published_from_feed
         errors.add(:published_at, I18n.t("models.article.future_or_current_published_at"))
       end
     else

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -21,7 +21,8 @@ en:
       must_not_have_spaces: must not have spaces
       published: Published
       unique_url: has already been taken. Email %{email} for further details.
-      future_or_current_published_at: only future or current published_at allowed when publishing an article
+      future_or_current_published_at: only future or current published_at allowed
+
       immutable_published_at: updating published_at for articles that have already been published is not allowed
       mention_too_many:
         one: You cannot mention more than %{count} users in a post!

--- a/config/locales/models/fr.yml
+++ b/config/locales/models/fr.yml
@@ -21,7 +21,7 @@ fr:
       must_not_have_spaces: must not have spaces
       published: Published
       unique_url: has already been taken. Email %{email} for further details.
-      future_or_current_published_at: only future or current published_at allowed when publishing an article
+      future_or_current_published_at: only future or current published_at allowed
       immutable_published_at: updating published_at for articles that have already been published is not allowed
       mention_too_many:
         one: You cannot mention more than %{count} users in a post!

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -528,6 +528,12 @@ RSpec.describe Article, type: :model do
       expect(article2.valid?).to be true
     end
 
+    it "allows removing published_at when updating a scheduled draft" do
+      scheduled_draft = create(:article, published: false, published_at: 1.day.from_now)
+      scheduled_draft.published_at = nil
+      expect(scheduled_draft).to be_valid
+    end
+
     context "when unpublishing" do
       let!(:published_at_was) { article.published_at }
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -513,14 +513,14 @@ RSpec.describe Article, type: :model do
       article2 = build(:article, published_at: 10.days.ago, published: true)
       expect(article2.valid?).to be false
       expect(article2.errors[:published_at])
-        .to include("only future or current published_at allowed when publishing an article")
+        .to include("only future or current published_at allowed")
     end
 
     it "doesn't allow recent published_at when publishing on create" do
       article2 = build(:article, published_at: 1.hour.ago, published: true)
       expect(article2.valid?).to be false
       expect(article2.errors[:published_at])
-        .to include("only future or current published_at allowed when publishing an article")
+        .to include("only future or current published_at allowed")
     end
 
     it "allows recent published_at when publishing on create" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
Allow removing `published_at` for scheduled drafts.

## Related Tickets & Documents
- Closes #18673 

## QA Instructions, Screenshots, Recordings

First, I would recommend reproducing the bug described in #18673 in the main branch.

- Create a scheduled draft article (choose published date and time in "Post options", then click "Save draft" instead of "Publish") 
- Open "edit" page for this article
- In the "Post options" remove published date and time, click "Save draft"
- the draft should be saved, it shouldn't have `published_at` anymore

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

