### PR TITLE
Update cache keys for the Display Ads on post_comments placement area

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -190,7 +190,7 @@
 
       </article>
 
-      <% cache("article-bottom-content-#{@article.id}-#{user_signed_in?}-#{(@organization || @user).latest_article_updated_at}", expires_in: 18.hours) do %>
+      <% cache("article-bottom-content-#{rand(5)}-#{@article.id}-#{user_signed_in?}-#{(@organization || @user).latest_article_updated_at}", expires_in: 15.minutes) do %>
         <% @display_ad = DisplayAd.for_display("post_comments", user_signed_in?, @article.decorate.cached_tag_list_array) %>
         <% if @display_ad %>
           <div class="crayons-card crayons-card--secondary p-4 crayons-sponsorship-article text-styles"
@@ -201,7 +201,9 @@
             <%= @display_ad.processed_html.html_safe %>
           </div>
         <% end %>
+      <% end %>
 
+      <% cache("article-bottom-content-#{@article.id}-#{user_signed_in?}-#{(@organization || @user).latest_article_updated_at}", expires_in: 18.hours) do %>
         <% suggested_articles = Articles::Suggest.call(@article, max: 4) %>
         <%= render "articles/bottom_content", articles: suggested_articles %>
       <% end %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

### Some background observations about Display Ads and Caching: 
- When editing, adding and deleting a Display Ad or any information about a Display Ad, the changes will not show up immediately on the user facing side due to caching. It will only show up if a cache key has been changed or after 18 hours when the cache expires. 

   The cache keys differ based on the placement of the ad. However, the cache keys in the context of targeted tags for placement area "Below the Comments section" include `@article.id`, `user_signed_in?`, `(@organization || @user).latest_article_updated_at)`. 

- We use a `for_display` method that is responsible for showing a single Display Ad from the correct pool of Display Ads based on certain conditions like the placement area, the tags, and the user group. Within this method lies some logic that shows the more successful ads based on the success rate. 

   However since we’re caching the Display Ads section, we don’t call the `for_display` method very often to implement this logic, but instead users are just seeing the same cached ad until one of the cache keys change or the cache expires in 18 hours. 


### This PR implementation

We would want our Ads to be more dynamic than above and Ben has mentioned that we’re about to introduce a new feature request issue  to change from server-rendered to async rendered for all display ad contexts where it is possible. This will help tons, however it's still in product discussion. 

For now I think we may need a quicker fix to make sure that we account for changes in Display Ads and we also calculate which ad to show more often using the `for_display` method. 

Hence, I've updated the cache keys with the `rand` cache key within a bounds of 1 to 5 or to expire in a maximum of 15 min which would align with the expiry time for the other Display Ad caches within the sidebars. [The sidebars have an expiry of 5 min.](https://github.com/forem/forem/blob/5eafe1ff346389db59147fd9d35e6072b7ab405f/app/views/articles/_sidebar.html.erb#L22) Some positive implications of this will be: 
- More easily account for changes to the Display Ads making them appear more dynamically. 
- Hitting the `for_display` method more often, hence making better use of our success rate calculation. 
- This will also make testing the targeted tags possible.  

The negative implications:
- The cache will need to be updated more often possibly making this section of the article page more reliant on data retrieval more often thus possibly slowing down the page by a bit. The numbers can be tweaked if this feels drastic. 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #https://github.com/forem/forem/issues/18519
- Closes #

## QA Instructions, Screenshots, Recordings

You can replicate the prod caching env for Display Ads by running `bundle exec rails dev:cache`.

### UI accessibility concerns?

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This touches our cache keys
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/ZNnQvIYzIBmZAbrBR7/giphy-downsized-large.gif)

