### PR TITLE
Add missing onInput for `canonical_url`

### DIFF
--- a/app/javascript/article-form/components/Options.jsx
+++ b/app/javascript/article-form/components/Options.jsx
@@ -168,6 +168,7 @@ export const Options = ({
             placeholder="https://yoursite.com/post-title"
             name="canonicalUrl"
             onKeyUp={onConfigChange}
+            onInput={onConfigChange}
             id="canonicalUrl"
           />
         </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes pasting `canonical_url` to the post options with the right click, the problem is described [here](https://github.com/forem/forem/issues/18622#issuecomment-1301364132) and in the following comments.


## Related Tickets & Documents
- Closes #18622

## QA Instructions, Screenshots, Recordings
- go to "Create post" page
- fill in the required fields like title and body
- copy any url
- go to the post options
- paste into the `canonical_url` field with the right click

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: almost no logic changes
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: a small bugfix

