### PR TITLE
Fix image and padding behavior on below-comment Display Ad

### DIFF
--- a/app/assets/stylesheets/widgets.scss
+++ b/app/assets/stylesheets/widgets.scss
@@ -282,15 +282,7 @@
 // Sidebar sponsors
 .crayons-sponsorship-article {
   margin-bottom: 10px;
-
-  img {
-    width: 100%;
-    height: auto;
-    border-radius: var(--radius);
-    display: block;
-    vertical-align: top;
-    margin: 10px auto;
-  }
+  padding: var(--content-padding-y) var(--content-padding-x);
 }
 
 .crayons-sponsorship-widget {

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -193,7 +193,7 @@
       <% cache("article-bottom-content-#{rand(5)}-#{@article.id}-#{user_signed_in?}-#{(@organization || @user).latest_article_updated_at}", expires_in: 15.minutes) do %>
         <% @display_ad = DisplayAd.for_display("post_comments", user_signed_in?, @article.decorate.cached_tag_list_array) %>
         <% if @display_ad %>
-          <div class="crayons-card crayons-card--secondary p-4 crayons-sponsorship-article text-styles"
+          <div class="crayons-card crayons-card--secondary crayons-sponsorship-article text-styles"
                data-display-unit data-id="<%= @display_ad.id %>"
                data-category-click="<%= DisplayAdEvent::CATEGORY_CLICK %>"
                data-category-impression="<%= DisplayAdEvent::CATEGORY_IMPRESSION %>"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a small style bug fix related to when we added `text-styles` which ultimately made the other image styles in this class unnecessary, and fixed an issue where the image is _always_ 100%, when we actually want a `max-width` of 100% — same as the article.

Also makes padding line up with the article padding — more padding for wide screen, less for mobile. This can be settled upon as "correct" behavior, even if it was not always clear.

This further re-uses existing classes and variables.

## Related Tickets & Documents

- Closes https://github.com/forem/forem/issues/18626

## QA Instructions, Screenshots, Recordings

Before:

<img width="826" alt="Screen Shot 2022-11-15 at 9 28 33 AM" src="https://user-images.githubusercontent.com/3102842/201944621-3cb7cc36-c538-48a7-853a-34c61328bbe1.png">


After:

<img width="831" alt="Screen Shot 2022-11-15 at 9 28 10 AM" src="https://user-images.githubusercontent.com/3102842/201944645-f10a6b08-1b03-4af6-b730-d785e8becd2b.png">


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Only small visual adjustments
- [ ] I need help with writing tests

