### PR TITLE
Use HTTParty for fastly_purge

### DIFF
--- a/app/services/edge_cache/bust/fastly.rb
+++ b/app/services/edge_cache/bust/fastly.rb
@@ -9,10 +9,8 @@ module EdgeCache
       end
 
       def self.fastly_purge(api_key, path)
-        fastly = ::Fastly.new(api_key: api_key)
-
         urls(path).map do |url|
-          fastly.purge(url)
+          HTTParty.post("https://api.fastly.com/purge/#{url}", headers: { "Fastly-Key" => api_key })
         end
       end
       private_class_method :fastly_purge

--- a/app/services/edge_cache/bust/fastly.rb
+++ b/app/services/edge_cache/bust/fastly.rb
@@ -21,7 +21,7 @@ module EdgeCache
           URL.url("#{path}?i=i"),
         ]
       end
-      private_class_method :fastly_purge
+      private_class_method :urls
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] bug fix

## Description
Reverting work introduced in https://github.com/forem/forem/pull/16903

According to [Fastly ruby gem ](https://github.com/fastly/fastly-ruby#usage-notes)
> If you are performing many purges per second we recommend you use the API directly with an HTTP client of your choice. 
> fastly-ruby has not been audited for thread-safety. If you are performing actions that require multiple threads (such as performing many purges) we recommend you use the API directly.

which explains the problem we've intermittedly experienced. Using our own HTTP client of choice will also allow us to easily tweak timeout when we need it.


## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
This work was deployed on staging for testing

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a