### PR TITLE
Comment icon tooltip: css fix

### DIFF
--- a/app/assets/stylesheets/components/tooltips.scss
+++ b/app/assets/stylesheets/components/tooltips.scss
@@ -1,3 +1,5 @@
+@import '../config/import';
+
 .crayons-tooltip {
   &__content {
     position: absolute;

--- a/app/assets/stylesheets/components/tooltips.scss
+++ b/app/assets/stylesheets/components/tooltips.scss
@@ -15,9 +15,13 @@
     transition-delay: 250ms;
     z-index: var(--z-popover);
     border-radius: var(--radius);
-    width: max-content;
+    width: auto;
     opacity: var(--opacity-0);
     pointer-events: none;
+    @media (min-width: $breakpoint-m) and (max-width: $breakpoint-l) {
+      font-size: var(--fs-xs);
+      padding: var(--su-1) var(--su-2);
+    }
   }
 
   .js-focus-visible &__activator.focus-visible:focus,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The below image shows that on certain screens the content "Jump to comments" is cut-off from screen.

<img width = "100" src="https://user-images.githubusercontent.com/42510740/198678536-e7666a3b-15c1-4d4f-a48f-25cc9dc413c7.png" />

This issue was happening for screens sizes between `768px` and `1024px`. To fix this correctly along with keeping the icon and the tooltip centre aligned I had to reduce the font-size and padding, which does work correctly as show in below screenshots. 

(If, we don't decrease the font-size and padding, then the icon and tooltip content won't be centre aligned.)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #18654
- Closes #18654

## How to test?

- Check out the PR, start up a local forem, and visit /admin/feature_flags. Create a flag named `replace_unicorn_with_jump_to_comments` and enable it.
- Visit article page
- Hover over `comments` icon available below `like` icon.

## QA Instructions, Screenshots, Recordings


<img width="499" alt="Screenshot 2022-11-22 at 12 25 22 PM" src="https://user-images.githubusercontent.com/9396084/203247031-f92b027b-947c-44d8-ba64-120ec8367fc4.png">
<img width="873" alt="Screenshot 2022-11-22 at 12 25 34 PM" src="https://user-images.githubusercontent.com/9396084/203247071-d184d439-ed95-4fe6-bc2f-e1cba09f342d.png">
<img width="1053" alt="Screenshot 2022-11-22 at 12 25 49 PM" src="https://user-images.githubusercontent.com/9396084/203247083-02adf15c-2168-44b5-a484-3077bf6e16f6.png">
<img width="1512" alt="Screenshot 2022-11-22 at 12 25 59 PM" src="https://user-images.githubusercontent.com/9396084/203247087-8b54ddd6-e4ee-4d39-b424-3c5f4ff617c5.png">


https://user-images.githubusercontent.com/9396084/203247225-e4e750d7-e4eb-454f-a1f8-ba4f27e61e11.mov


### UI accessibility concerns?

No

## Added/updated tests?

- [ ] Yes
- [x] No -- because only css change
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [x] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_
