### PR TITLE
Investigate article published psych error

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -686,12 +686,15 @@ class Article < ApplicationRecord
     Articles::BustMultipleCachesWorker.perform_bulk(job_params)
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def evaluate_front_matter(front_matter)
     self.title = front_matter["title"] if front_matter["title"].present?
     set_tag_list(front_matter["tags"]) if front_matter["tags"].present?
     self.published = front_matter["published"] if %w[true false].include?(front_matter["published"].to_s)
 
-    self.published_at = front_matter["published_at"] if front_matter["published_at"] unless published_changed? && !published
+    if !published_changed? && !published.nil? && (front_matter["published_at"])
+      self.published_at = front_matter["published_at"]
+    end
     self.published_at ||= parse_date(front_matter["date"]) if published
 
     set_main_image(front_matter)
@@ -703,6 +706,7 @@ class Article < ApplicationRecord
     self.collection_id = nil if front_matter["title"].present?
     self.collection_id = Collection.find_series(front_matter["series"], user).id if front_matter["series"].present?
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   def set_main_image(front_matter)
     # At one point, we have set the main_image based on the front matter. Forever will that now dictate the behavior.

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -691,7 +691,7 @@ class Article < ApplicationRecord
     set_tag_list(front_matter["tags"]) if front_matter["tags"].present?
     self.published = front_matter["published"] if %w[true false].include?(front_matter["published"].to_s)
 
-    self.published_at = front_matter["published_at"] if front_matter["published_at"]
+    self.published_at = front_matter["published_at"] if front_matter["published_at"] unless published_changed? && !published
     self.published_at ||= parse_date(front_matter["date"]) if published
 
     set_main_image(front_matter)

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -577,7 +577,7 @@ RSpec.describe Article, type: :model do
       end
 
       it "keeps published at when trying to set published_at" do
-        new_body_markdown = "---\ntitle: Title\npublished: false\npublished_at:2022-12-05 18:00 +0300---\n\n"
+        new_body_markdown = "---\ntitle: Title\npublished: false\npublished_at: 2022-12-05 18:00 +0300---\n\n"
         frontmatter_article.update(body_markdown: new_body_markdown)
         expect(frontmatter_article.published_at).to be_within(1.minute).of(DateTime.parse(published_at))
       end
@@ -587,7 +587,7 @@ RSpec.describe Article, type: :model do
         time_str = scheduled_time.strftime("%d/%m/%Y %H:%M %z")
         scheduled_body_markdown = "---\ntitle: Title\npublished: true\npublished_at: #{time_str}\n---\n\n"
         frontmatter_scheduled_article = create(:article, body_markdown: scheduled_body_markdown)
-        new_body_markdown = "---\ntitle: Title\npublished: false\npublished_at:2022-12-05 18:00 +0300---\n\n"
+        new_body_markdown = "---\ntitle: Title\npublished: false\npublished_at: 2022-12-05 18:00 +0300---\n\n"
         frontmatter_scheduled_article.update(body_markdown: new_body_markdown)
         expect(frontmatter_scheduled_article.published_at).to be_within(1.minute).of(scheduled_time)
       end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Article, type: :model do
+RSpec.describe Article do
   def build_and_validate_article(*args)
     article = build(:article, *args)
     article.validate!
@@ -162,7 +162,7 @@ RSpec.describe Article, type: :model do
     end
 
     describe "#canonical_url_must_not_have_spaces" do
-      let!(:article) { build :article, user: user }
+      let!(:article) { build(:article, user: user) }
 
       it "is valid without spaces" do
         valid_url = "https://www.positronx.io/angular-radio-buttons-example/"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I found an interesting bug while working on #18754. These two tests are supplying a `published_at` field in a way that Psych can't parse, but the error is being [swallowed as a validation problem](https://github.com/forem/forem/blob/331499e8e618df6e853f62e36fa93f81ae990bb5/app/models/article.rb#L623-L639). The net effect is that this test is a false positive -- it seems as if the expected behavior (not updating `published_at`) is working, however it's _only_ working because the frontmatter is raising an exception instead of being parsed.

The difference is _super_ miniscule:
```ruby
new_body_markdown = "---\ntitle: Title\npublished: false\npublished_at:2022-12-05 18:00 +0300---\n\n"
```

Compared to:
```ruby
new_body_markdown = "---\ntitle: Title\npublished: false\npublished_at: 2022-12-05 18:00 +0300---\n\n"
```

I'm also having a problem with fixing this.

These two tests (the ones which are failing now) indicate "when unpublishing a frontmatter article keeps published at when trying to set published_at" and "when unpublishing a frontmatter article keeps published_at when unpublishing a scheduled article". 

In other words -- as I understand this from reading tests -- if frontmatter includes `published: false` on an article that was previously `published: true`, then it seems we're to **ignore** any date from frontmatter `published_at`. This feels really counter-intuitive to me, as a feature -- I would imagine if I were un-publishing a previously published article by editing frontmatter, if I were also setting a future date, I think I would expect that date to be the published-at-date in the future. (But also, the dates in these tests have been hard-coded, which means they could break in the future, unless we use time-travel.)

And these tests seem to contradict [these two tests](https://github.com/forem/forem/blob/331499e8e618df6e853f62e36fa93f81ae990bb5/spec/models/article_spec.rb#L479-L493) "sets published_at from a valid frontmatter date" and "sets future published_at from frontmatter".

I can get some of these tests to pass with this logic:

```ruby
self.published_at = front_matter["published_at"] if front_matter["published_at"] unless published_changed? && !published
```

But this breaks yet _more_ tests and feels convoluted to me, and I'm not :100: confident this is how we want the whole "unpublishing via frontmatter" to work. (Also, it's going to be flaky behavior, in the sense that editing the article and saving it a second time, it would then no longer be un-publishing a previously published article and _would_ set the `published_at` date via frontmatter afterall.)

Also: I'm wondering if these tests need to be dealing with validity differently, to more explicitly avoid the false positive from frontmatter parsing errors. (In other words: I'm wondering how we avoid these kinds of headaches in the future?)

`cc` @lightalloy
:link: https://github.com/forem/forem/issues/18398
:link: https://github.com/forem/forem/pull/18384

## Added/updated tests?

- [ ] Yes
- [x] Yes, and ... it's complicated?
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media2.giphy.com/media/4JVTF9zR9BicshFAb7/giphy.gif?cid=ecf05e47zz2r6ttoipw6o9s9jdyhuoq63fl79t9o77abf1tu&rid=giphy.gif&ct=g)

