### PR TITLE
Attempt short delay after cypress loginUser failed request

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -123,17 +123,29 @@ Cypress.Commands.add('loginUser', ({ email, password }) => {
     );
   }
 
-  return getLoginRequest().then((response) => {
-    if (response.status === 200) {
-      return response;
-    }
+  return getLoginRequest()
+    .then((response) => {
+      if (response.status === 200) {
+        return response;
+      }
 
-    cy.log('Login failed. Attempting one more login.');
+      cy.log(
+        'Login failed. Attempting one more login after 0.2s delay to avoid retrying too quickly.',
+      );
 
-    // If we have a login failure, try one more time.
-    // This is to combat some flaky tests where the login fails occasionally.
-    return getLoginRequest();
-  });
+      // If we have a login failure, try one more time.
+      // This is to combat some flaky tests where the login fails occasionally.
+      return new Promise((resolve) => setTimeout(resolve(response), 200));
+    })
+    .then((response) => {
+      if (response.status === 200) {
+        // First login request was successful
+        return response;
+      } else {
+        // Retry login request
+        return getLoginRequest();
+      }
+    });
 });
 
 /**


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR introduces a short delay after the cypress loginUser command first attempt. We've been seeing 500 errors sporadically in cypress tests while logging in users. The logs appear to show DB timeouts and it's been hard to tell what is the cause of this. Perhaps we're hitting the DB too hard on CI and a short delay, which **will only happen when the first request fails**, might get rid of these issues 🤞🏼 

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- #18839

## QA Instructions, Screenshots, Recordings

CI passes  ✅  😄 

### UI accessibility concerns?

None

## Added/updated tests?

- [x] Yes

## [Forem core team only] How will this change be communicated?

- [x] I will share this change internally with the appropriate teams

## [optional] What gif best describes this PR or how it makes you feel?

![wait. hold up. hold up.](https://media.giphy.com/media/xULW8MYvpNOfMXfDH2/giphy.gif)

