### PR TITLE
Extract comments rendering

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -215,6 +215,29 @@ class Comment < ApplicationRecord
   end
 
   def evaluate_markdown
+    if FeatureFlag.enabled?(:consistent_rendering, FeatureFlag::Actor[user])
+      extracted_evaluate_markdown
+    else
+      original_evaluate_markdown
+    end
+  end
+
+  def processed_content
+    return @processed_content if @processed_content && !body_markdown_changed?
+    return unless user
+
+    @processed_content = ContentRenderer.new(body_markdown, source: self, user: user)
+  end
+
+  def extracted_evaluate_markdown
+    self.processed_html = processed_content.finalize(link_attributes: { rel: "nofollow" })
+    wrap_timestamps_if_video_present! if commentable
+    shorten_urls!
+  rescue ContentRenderer::ContentParsingError => e
+    errors.add(:base, ErrorMessages::Clean.call(e.message))
+  end
+
+  def original_evaluate_markdown
     fixed_body_markdown = MarkdownProcessor::Fixer::FixForComment.call(body_markdown)
     parsed_markdown = MarkdownProcessor::Parser.new(fixed_body_markdown, source: self, user: user)
     self.processed_html = parsed_markdown.finalize(link_attributes: { rel: "nofollow" })

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -230,6 +230,8 @@ class Comment < ApplicationRecord
   end
 
   def extracted_evaluate_markdown
+    return unless processed_content
+
     self.processed_html = processed_content.finalize(link_attributes: { rel: "nofollow" })
     wrap_timestamps_if_video_present! if commentable
     shorten_urls!

--- a/app/services/content_renderer.rb
+++ b/app/services/content_renderer.rb
@@ -24,8 +24,8 @@ class ContentRenderer
     raise ContentParsingError, e.message
   end
 
-  def finalize
-    processed.finalize
+  def finalize(link_attributes: {})
+    processed.finalize(link_attributes: link_attributes)
   # TODO: Replicating prior behaviour, but this swallows errors we probably shouldn't
   rescue StandardError => e
     raise ContentParsingError, e.message

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,9 +1,11 @@
 require "rails_helper"
 
-RSpec.describe Comment, type: :model do
+RSpec.describe Comment do
   let(:user) { create(:user) }
   let(:article) { create(:article, user: user) }
   let(:comment) { create(:comment, user: user, commentable: article) }
+
+  before { allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(true) }
 
   include_examples "#sync_reactions_count", :article_comment
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Use `ContentRenderer` for evaluating comment's markdown.  Evaluate with `ContentRenderer` when the feature flag is enabled, evaluate the old way when it's not
I followed a pattern from Joshua's pr #18754

## Related Tickets & Documents
- Related Issue #18649
- Closes [#18650](https://github.com/forem/forem/issues/18650)

## Added/updated tests?
This pr changes the implementation details, not the behavior, so the existing tests apply.

## [Forem core team only] How will this change be communicated?
- [x] I will share this change internally with the appropriate teams
