### PR TITLE
Fixed redundant article and comment markdown parsing

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -647,8 +647,8 @@ class Article < ApplicationRecord
     content_renderer = processed_content
     return unless content_renderer
 
-    self.processed_html = content_renderer.process(calculate_reading_time: true) # fix, parse, finalize
-    self.reading_time = content_renderer.reading_time # ну такое
+    self.processed_html = content_renderer.process(calculate_reading_time: true)
+    self.reading_time = content_renderer.reading_time
 
     front_matter = content_renderer.front_matter
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -446,12 +446,10 @@ class Article < ApplicationRecord
 
   def has_frontmatter?
     if FeatureFlag.enabled?(:consistent_rendering, FeatureFlag::Actor[user])
-      front_matter.any? && front_matter["title"].present?
+      processed_content.has_front_matter?
     else
       original_has_frontmatter?
     end
-  rescue ContentRenderer::ContentParsingError
-    true
   end
 
   def original_has_frontmatter?
@@ -637,8 +635,6 @@ class Article < ApplicationRecord
     @processed_content = ContentRenderer.new(body_markdown, source: self, user: user)
   end
 
-  delegate :front_matter, to: :processed_content
-
   def evaluate_markdown
     if FeatureFlag.enabled?(:consistent_rendering, FeatureFlag::Actor[user])
       extracted_evaluate_markdown
@@ -648,13 +644,16 @@ class Article < ApplicationRecord
   end
 
   def extracted_evaluate_markdown
-    return unless processed_content
+    content_renderer = processed_content
+    return unless content_renderer
 
-    self.reading_time = processed_content.calculate_reading_time
-    self.processed_html = processed_content.finalize
+    self.processed_html = content_renderer.process(calculate_reading_time: true) # fix, parse, finalize
+    self.reading_time = content_renderer.reading_time # ну такое
+
+    front_matter = content_renderer.front_matter
 
     if front_matter.any?
-      evaluate_front_matter
+      evaluate_front_matter(front_matter)
     elsif tag_list.any?
       set_tag_list(tag_list)
     end
@@ -730,8 +729,7 @@ class Article < ApplicationRecord
     Articles::BustMultipleCachesWorker.perform_bulk(job_params)
   end
 
-  # TODO: The param can be removed after with FeatureFlag :consistent_rendering
-  def evaluate_front_matter(hash = front_matter)
+  def evaluate_front_matter(hash)
     self.title = hash["title"] if hash["title"].present?
     set_tag_list(hash["tags"]) if hash["tags"].present?
     self.published = hash["published"] if %w[true false].include?(hash["published"].to_s)
@@ -739,7 +737,7 @@ class Article < ApplicationRecord
     self.published_at = hash["published_at"] if hash["published_at"]
     self.published_at ||= parse_date(hash["date"]) if published
 
-    set_main_image
+    set_main_image(hash)
     self.canonical_url = hash["canonical_url"] if hash["canonical_url"].present?
 
     update_description = hash["description"].present? || hash["title"].present?
@@ -749,13 +747,13 @@ class Article < ApplicationRecord
     self.collection_id = Collection.find_series(hash["series"], user).id if hash["series"].present?
   end
 
-  def set_main_image
+  def set_main_image(hash)
     # At one point, we have set the main_image based on the front matter. Forever will that now dictate the behavior.
     if main_image_from_frontmatter?
-      self.main_image = front_matter["cover_image"]
-    elsif front_matter.key?("cover_image")
+      self.main_image = hash["cover_image"]
+    elsif hash.key?("cover_image")
       # They've chosen the set cover image in the front matter, so we'll proceed with that assumption.
-      self.main_image = front_matter["cover_image"]
+      self.main_image = hash["cover_image"]
       self.main_image_from_frontmatter = true
     end
   end

--- a/spec/services/content_renderer_spec.rb
+++ b/spec/services/content_renderer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ContentRenderer do
-  describe "#finalize" do
+  describe "#process" do
     let(:markdown) { "hello, hey" }
     let(:expected_result) { "<p>hello, hey</p>\n\n" }
     let(:mock_fixer) { class_double MarkdownProcessor::Fixer::FixAll }
@@ -35,12 +35,12 @@ RSpec.describe ContentRenderer do
     # rubocop:enable RSpec/InstanceVariable
 
     it "is the result of fixing, parsing, and processing" do
-      result = described_class.new(markdown, source: nil, user: nil).finalize
+      result = described_class.new(markdown, source: nil, user: nil).process
       expect(result).to eq(expected_result)
       expect(mock_fixer).to have_received(:call)
       expect(mock_front_matter_parser).to have_received(:call).with(fixed_markdown)
       expect(mock_processor).to have_received(:new)
-      expect(processed_contents).to have_received(:finalize)
+      expect(processed_contents).to have_received(:process)
     end
   end
 
@@ -58,7 +58,7 @@ RSpec.describe ContentRenderer do
     RESULT
 
     it "processes markdown" do
-      result = described_class.new(markdown, source: nil, user: nil).finalize
+      result = described_class.new(markdown, source: nil, user: nil).process
       expect(result).to eq(expected_result)
     end
   end
@@ -74,7 +74,7 @@ RSpec.describe ContentRenderer do
 
     it "raises ContentParsingError" do
       expect do
-        described_class.new(markdown, source: article, user: user).finalize
+        described_class.new(markdown, source: article, user: user).process
       end.to raise_error(ContentRenderer::ContentParsingError, /User is not permitted to use this liquid tag/)
     end
   end
@@ -90,7 +90,7 @@ RSpec.describe ContentRenderer do
 
     it "raises ContentParsingError" do
       expect do
-        described_class.new(markdown, source: source, user: user).finalize
+        described_class.new(markdown, source: source, user: user).process
       end.to raise_error(ContentRenderer::ContentParsingError, /This liquid tag can only be used in Articles/)
     end
   end
@@ -100,7 +100,7 @@ RSpec.describe ContentRenderer do
 
     it "raises ContentParsingError" do
       expect do
-        described_class.new(markdown, source: nil, user: nil).front_matter
+        described_class.new(markdown, source: nil, user: nil).process
       end.to raise_error(ContentRenderer::ContentParsingError, /while scanning a simple key/)
     end
   end

--- a/spec/services/content_renderer_spec.rb
+++ b/spec/services/content_renderer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ContentRenderer do
     let(:mock_front_matter_parser) { instance_double FrontMatterParser::Parser }
     let(:mock_processor) { class_double MarkdownProcessor::Parser }
     let(:fixed_markdown) { :fixed_markdown }
-    let(:parsed_contents) { Struct.new(:content).new(:parsed_content) }
+    let(:parsed_contents) { Struct.new(:content, :front_matter).new(:parsed_content) }
     let(:processed_contents) { instance_double MarkdownProcessor::Parser }
 
     # rubocop:disable RSpec/InstanceVariable
@@ -17,7 +17,6 @@ RSpec.describe ContentRenderer do
       allow(mock_front_matter_parser).to receive(:call).with(fixed_markdown).and_return(parsed_contents)
       allow(mock_processor).to receive(:new).and_return(processed_contents)
       allow(processed_contents).to receive(:finalize).and_return(expected_result)
-
       @original_fixer = described_class.fixer
       @original_parser = described_class.front_matter_parser
       @original_processor = described_class.processor
@@ -40,7 +39,7 @@ RSpec.describe ContentRenderer do
       expect(mock_fixer).to have_received(:call)
       expect(mock_front_matter_parser).to have_received(:call).with(fixed_markdown)
       expect(mock_processor).to have_received(:new)
-      expect(processed_contents).to have_received(:process)
+      expect(processed_contents).to have_received(:finalize)
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
While working on Extracting `DisplayAd rendering` #18651 , I noticed a couple of issues:
- `processed_content` was set multiple times (though the code assumes that it was cached), `front_matter` which is delegated to `processed_content` is also called multiple times in this case, so it ends up being parsed multiple times. That happens because we check for `!body_markdown_changed?`  inside the `processed_content`  method, and `body_markdown_changed?`  will return true multiple times when it's called inside the callbacks.
- `set_main_image` was using frontmatter which was delegated to `ContentRenderer` even when the feature flag was disabled. The result ended up being the same in this case, but when the feature flag is disabled the "old" code should be used.

In this pr I removed some of the delegation and put actions in the `ContentRenderer` together, so that it would be clear what runs after what. There is a bit of duplication, but I suppose that in this case is less evil because it's easier to understand in such a way. We will see how to modify the code to be convenient for `DisplayAd` as well.

## Related Tickets & Documents
- Related Issue #18904 #18754

## QA Instructions, Screenshots, Recordings
The behaviour shouldn't be changed.


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

