### PR TITLE
Try having sync_reactions_count as a background job

### DIFF
--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -49,7 +49,7 @@ class Reaction < ApplicationRecord
   before_save :assign_points
   after_create :notify_slack_channel_about_vomit_reaction, if: -> { category == "vomit" }
   before_destroy :bust_reactable_cache_without_delay
-  before_destroy :update_reactable_without_delay, unless: :destroyed_by_association
+  before_destroy :update_reactable, unless: :destroyed_by_association
   after_commit :async_bust
   after_commit :bust_reactable_cache, :update_reactable, on: %i[create update]
   after_commit :record_field_test_event, on: %i[create]
@@ -192,10 +192,6 @@ class Reaction < ApplicationRecord
 
   def bust_reactable_cache_without_delay
     Reactions::BustReactableCacheWorker.new.perform(id)
-  end
-
-  def update_reactable_without_delay
-    Reactions::UpdateRelevantScoresWorker.new.perform(id)
   end
 
   def reading_time

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Reaction do
         { category: "readinglist", count: 0 },
         { category: "unicorn", count: 1 },
       ]
-      expect(described_class.count_for_article(article.id)).to eq(expected_result)
+      expect(described_class.count_for_article(article.id)).to contain_exactly(*expected_result)
     end
   end
 

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -243,9 +243,9 @@ RSpec.describe Reaction do
     end
 
     it "updates reactable without delay" do
-      allow(reaction).to receive(:update_reactable_without_delay)
+      allow(reaction).to receive(:update_reactable_with_delay)
       reaction.destroy
-      expect(reaction).to have_received(:update_reactable_without_delay)
+      expect(reaction).to have_received(:update_reactable_with_delay)
     end
 
     it "busts reactable cache without delay" do

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -139,8 +139,8 @@ RSpec.describe Reaction do
 
       expected_result = [
         { category: "like", count: 1 },
-        { category: "unicorn", count: 1 },
         { category: "readinglist", count: 0 },
+        { category: "unicorn", count: 1 },
       ]
       expect(described_class.count_for_article(article.id)).to eq(expected_result)
     end
@@ -234,7 +234,7 @@ RSpec.describe Reaction do
   end
 
   context "when callbacks are called before destroy" do
-    let(:reaction) { create(:reaction, reactable: article, user: user) }
+    let!(:reaction) { create(:reaction, reactable: article, user: user) }
 
     it "enqueues a ScoreCalcWorker on article reaction destroy" do
       sidekiq_assert_enqueued_with(job: Articles::ScoreCalcWorker, args: [article.id]) do
@@ -242,10 +242,10 @@ RSpec.describe Reaction do
       end
     end
 
-    it "updates reactable without delay" do
-      allow(reaction).to receive(:update_reactable_with_delay)
+    it "updates reactable with delay" do
+      allow(Reactions::UpdateRelevantScoresWorker).to receive(:perform_async)
       reaction.destroy
-      expect(reaction).to have_received(:update_reactable_with_delay)
+      expect(Reactions::UpdateRelevantScoresWorker).to have_received(:perform_async)
     end
 
     it "busts reactable cache without delay" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While working on #18808, we discovered an issue where the count of "public reactions" could get out of sync. Some investigation revealed a race condition:

* `counter_culture` works as an callback, sending "increment" or "decrement" instructions to the DB 
* [`sync_reactions_count`](https://github.com/forem/forem/blob/ce23832988a27c74ecf4292fe3d06a6eea0967ee/app/models/concerns/reactable.rb#L9) also invoked via a callback (as part of `UpdateRelevantScoresWorker`), but explicitly "without delay" - this version updates `reactable` with a count of currently public reactions

The issue, then, is if `counter_culture`'s callback should happen _after_ `sync_reactions_count`, it will end up decrementing from what is actually the correct count. It seems like a solution could be introducing a delay, so that the `sync_reactions_count` happens in a background job. 

Maybe there's a better way, I'm certainly open to ideas.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #18808 

## QA Instructions, Screenshots, Recordings

* It's easiest to see the bug if you have `multiple_reactions` enabled locally.


## Added/updated tests?

- [x] Yes - updated as needed
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_


## [optional] What gif best describes this PR or how it makes you feel?

![math](https://user-images.githubusercontent.com/2077/214097879-65335566-da34-4c7a-9466-fdea6ac31319.gif)
