### PR TITLE
Multiple reactions minor fixes

### DIFF
--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -413,7 +413,7 @@
 
   flex-direction: column;
 
-  @media (min-width: $breakpoint-s) {
+  @media (min-width: $breakpoint-m) {
     max-width: 360px;
     width: max-content;
     top: -5px;

--- a/app/views/articles/_multiple_reactions.html.erb
+++ b/app/views/articles/_multiple_reactions.html.erb
@@ -5,17 +5,14 @@
     aria-label="reaction-drawer-trigger"
     aria-pressed="false"
     class="hoverdown-trigger crayons-reaction pseudo-reaction crayons-tooltip__activator relative">
-      <span class="crayons-reaction__icon crayons-reaction__icon--inactive" style="width: 40px; height: 40px">
-        <%= image_tag "heart-plus.svg", aria_hidden: true, height: 24, width: 24 %>
+      <span class="crayons-reaction__icon crayons-reaction--like crayons-reaction__icon--inactive" style="width: 40px; height: 40px">
+        <%= crayons_icon_tag("heart-plus.svg", aria_hidden: true, height: 24, width: 24) %>
       </span>
       <span class="crayons-reaction__icon crayons-reaction__icon--active" style="width: 40px; height: 40px">
         <%= image_tag "heart-plus-active.svg", aria_hidden: true, height: 24, width: 24 %>
       </span>
       <span class="crayons-reaction_total_count" id="reaction_total_count">
         <%= @article.public_reactions_count %>
-      </span>
-      <span data-testid="tooltip" class="crayons-tooltip__content">
-        <%= t("views.reactions.drawer_button") %>
       </span>
   </button>
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

This PR fixes three things:
1. Dark mode multiple-reaction icon color fix
2. Show drawer above on screens between 640px to 768px
3. Remove `Add Reaction` hover tooltip

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #19008

## QA Instructions, Screenshots, Recordings

**How to use multiple reactions?**
1. Enable the `multiple_reactions` FeatureFlag at `/admin/feature_flags/features`
2. View an article
3. Check heart+ icon.

### Dark mode
Check dark mode design for multiple reaction icon

| Before  | After |
| ------------- | ------------- |
| <img width="67" alt="Screenshot 2023-01-30 at 8 22 10 PM" src="https://user-images.githubusercontent.com/9396084/215517873-118527cb-f9f3-4027-9f1c-73849e68891a.png"> | <img width="59" alt="Screenshot 2023-01-30 at 8 25 49 PM" src="https://user-images.githubusercontent.com/9396084/215517886-bdebc065-2826-44f3-97f0-fdb3a8188298.png"> |
| <img width="86" alt="Screenshot 2023-01-30 at 8 22 30 PM" src="https://user-images.githubusercontent.com/9396084/215517882-da58ed3f-6664-41c8-91b8-981ffcb3566e.png"> | <img width="86" alt="Screenshot 2023-01-30 at 8 22 30 PM" src="https://user-images.githubusercontent.com/9396084/215517882-da58ed3f-6664-41c8-91b8-981ffcb3566e.png"> |

### Show drawer above bottom bar in screens between 600px and 768px

| Before  | After |
| ------------- | ------------- |
| <img width="622" alt="Screenshot 2023-01-30 at 8 02 48 PM" src="https://user-images.githubusercontent.com/9396084/215518367-9e1087cd-43f5-43b0-aaad-c1dcc747f491.png"> |  <img width="651" alt="Screenshot 2023-01-30 at 8 51 55 PM" src="https://user-images.githubusercontent.com/9396084/215518384-4ed24285-a199-4dac-b124-b60e8d93fd74.png"> |

### Remove tooltip for Add Reaction

Reference and result: https://github.com/forem/forem/issues/19008#issuecomment-1404344776

### UI accessibility concerns?

No

## Added/updated tests?

- [x] No

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [x] I will share this change internally with the appropriate teams
