### PR TITLE
Update Users::ProfileImageGenerator

### DIFF
--- a/app/controllers/admin/invitations_controller.rb
+++ b/app/controllers/admin/invitations_controller.rb
@@ -25,7 +25,7 @@ module Admin
       username = "#{email.split('@').first.gsub(/[^0-9a-z ]/i, '')}_#{rand(1000)}"
       User.invite!(email: email,
                    username: username,
-                   remote_profile_image_url: ::Users::ProfileImageGenerator.call,
+                   profile_image: ::Users::ProfileImageGenerator.call,
                    registered: false)
       flash[:success] = I18n.t("admin.invitations_controller.create_success")
       redirect_to admin_invitations_path

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -77,7 +77,7 @@ class RegistrationsController < Devise::RegistrationsController
     build_resource(sign_up_params)
     resource.registered_at = Time.current
     resource.build_setting(editor_version: "v2")
-    resource.remote_profile_image_url = Users::ProfileImageGenerator.call if resource.profile_image.blank?
+    resource.profile_image = Users::ProfileImageGenerator.call if resource.profile_image.blank?
     if Settings::General.waiting_on_first_user
       resource.password_confirmation = resource.password
     end

--- a/app/services/authentication/providers/apple.rb
+++ b/app/services/authentication/providers/apple.rb
@@ -20,7 +20,7 @@ module Authentication
         if Rails.env.test?
           user_data[:profile_image] = Settings::General.mascot_image_url
         else
-          user_data[:remote_profile_image_url] = Users::ProfileImageGenerator.call
+          user_data[:profile_image] = Users::ProfileImageGenerator.call
         end
 
         user_data

--- a/app/services/users/profile_image_generator.rb
+++ b/app/services/users/profile_image_generator.rb
@@ -1,26 +1,7 @@
 module Users
   module ProfileImageGenerator
-    EMOJI_IMAGES =
-      %w[dog-face_1f436.png
-         monkey-face_1f435.png
-         unicorn_1f984.png
-         mouse-face_1f42d.png
-         hamster_1f439.png
-         koala_1f428.png
-         bear_1f43b.png
-         panda_1f43c.png
-         penguin_1f427.png
-         spouting-whale_1f433.png
-         honeybee_1f41d.png
-         lion_1f981.png
-         tiger-face_1f42f.png
-         fox_1f98a.png
-         wolf_1f43a.png].freeze
-
     def self.call
-      # This pulls from emojipedia source for the liberally open source twemoji lib.
-      # TODO: Make this much more interesting than just emojis.
-      "https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/240/twitter/248/#{EMOJI_IMAGES.sample}"
+      File.open(Rails.root.join("app/assets/images/#{rand(1..40)}.png"))
     end
   end
 end

--- a/spec/services/users/profile_image_generator_spec.rb
+++ b/spec/services/users/profile_image_generator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Users::ProfileImageGenerator, type: :service do
-  it "returns an emoji url" do
-    expect(described_class.call).to include("asset")
+  it "returns an image file" do
+    expect(described_class.call).to be_a(File)
   end
 end

--- a/spec/services/users/profile_image_generator_spec.rb
+++ b/spec/services/users/profile_image_generator_spec.rb
@@ -2,6 +2,6 @@ require "rails_helper"
 
 RSpec.describe Users::ProfileImageGenerator, type: :service do
   it "returns an emoji url" do
-    expect(described_class.call).to start_with("https://emojipedia-us.s3")
+    expect(described_class.call).to include("asset")
   end
 end

--- a/spec/services/users/safe_remote_profile_image_url_spec.rb
+++ b/spec/services/users/safe_remote_profile_image_url_spec.rb
@@ -7,15 +7,15 @@ RSpec.describe Users::SafeRemoteProfileImageUrl, type: :service do
   end
 
   it "returns fallback image if passed nil" do
-    expect(described_class.call(nil)).to start_with("https://emojipedia-us.s3")
+    expect(described_class.call(nil)).to be_a(File)
   end
 
   it "returns fallback image if passed blank" do
-    expect(described_class.call("")).to start_with("https://emojipedia-us.s3")
+    expect(described_class.call("")).to be_a(File)
   end
 
   it "returns fallback image if passed non-URL" do
-    expect(described_class.call("image")).to start_with("https://emojipedia-us.s3")
+    expect(described_class.call("image")).to be_a(File)
   end
 
   it "returns a secure HTTPS image link if pass a regular HTTP link" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug fix

## Description
Our CI were failing because our backup image source to our user's profile page using emojipedia's direct s3 link.

I am not sure where they moved their link, but it's not a good idea to rely on a 3rd party service for our CI. I figure the better fallback would be to use the assets that are already part of our repository.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a