### PR TITLE
Revert hidden shell cleanup (after I gave bad information 🤦‍♂️ )

### DIFF
--- a/app/assets/stylesheets/base/main.scss
+++ b/app/assets/stylesheets/base/main.scss
@@ -11,6 +11,15 @@ body {
   flex-direction: column;
   min-height: 100vh;
 
+  &.hidden-shell {
+    padding-top: 0 !important;
+
+    .crayons-header,
+    .crayons-footer {
+      display: none;
+    }
+  }
+
   &.user-tags-followed-0,
   &.user-tags-followed-1,
   &.user-tags-followed-2 {

--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -22,6 +22,9 @@
     if (navigator.userAgent === 'DEV-Native-ios') {
       document.body.classList.add("dev-ios-native-body");
     }
+    if (window.frameElement) { // Hide top bar and footer when loaded within iframe
+      document.body.classList.add("hidden-shell");
+    }
     if (userString && userString.length > 0) {
       const user = JSON.parse(userString)
       const numTags = JSON.parse(user.followed_tags).length

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,7 +76,6 @@
         </div>
         <%= render "layouts/top_bar" %>
         <div id="active-broadcast" class="broadcast-wrapper"></div>
-        <div id="message-notice"></div>
     <% end %>
   <% end %>
 <% if Settings::General.payment_pointer.present? %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I believe I introduced misinformation about what was, in fact, dead code which lead to a bug.

I think I spoke to casually about what exactly is likely to be "dead code", and pointed to a place and was wrong about it.

We introduced [this PR](https://github.com/forem/forem/pull/19036) which was code which is _mostly_ not used anymore, but it turns out it is. This "hidden shell" code is added to iframes — and since we actually do still use an iframe to load the mod panel, the code is still needed.

This was my bad about introducing confusion.

***

In order to make up for this, I have deleted _one line of code which is in fact un-used in a similar way_.

The line `<div id="message-notice"></div>` is only used in our since retired messaging part of the app, and this _can_ be removed.

There are other similar parts of the app, which also can be removed, but it just so happens, this was a false positive on dead code.

## Related Tickets & Documents

This reverts changes made in https://github.com/forem/forem/pull/19036

## QA Instructions, Screenshots, Recordings

This PR fixes a style bug introduced here:

**Note in the mod panel, the "hidden shell" functionality has made the text at the top cut off.**

<img width="356" alt="Screen Shot 2023-02-03 at 12 18 49 PM" src="https://user-images.githubusercontent.com/3102842/216666404-b7ddd2be-2847-4c86-b34c-38428cbb5ad4.png">


### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

This is a small fix, shouldn't need much more.