### PR TITLE
Fix FilteredAdsQuery ordering bug

### DIFF
--- a/app/queries/display_ads/filtered_ads_query.rb
+++ b/app/queries/display_ads/filtered_ads_query.rb
@@ -29,7 +29,7 @@ module DisplayAds
                                 authenticated_ads(%w[all logged_out])
                               end
 
-      @filtered_display_ads.order(success_rate: :desc)
+      @filtered_display_ads = @filtered_display_ads.order(success_rate: :desc)
       @filtered_display_ads = sample_ads
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixing a bug which was introduced in https://github.com/forem/forem/pull/18981

This behavior is somewhat hard to test given the final "randomization" step, so I did not improve on the testing miss, but I believe this will fix the bug.

This bug was introduced in a refactor — which was really caused by a problem with _the old code_.

Here is the old code before the refactor. You'll see that `order` was set in two places, but the second place actually doesn't do anything.

<img width="533" alt="Screen Shot 2023-02-07 at 11 09 29 AM" src="https://user-images.githubusercontent.com/3102842/217299369-e2db0c01-a604-4744-808a-2fcd7deff009.png">

The second statement changes the query in place without actually applying it to the query changing. This bug was in place in the old code, but as noted, we used to actually set this in that first statement.

## Related Tickets & Documents

- Related Issue https://github.com/forem/forem/pull/18981

## Screenshots

This chart demonstrates the problem that arised because of this.

Here is impressions from the most successful billboard:

<img width="1580" alt="Screen Shot 2023-02-07 at 10 43 42 AM" src="https://user-images.githubusercontent.com/3102842/217301271-70c0575c-b27d-4c37-b913-ff0c0745e60e.png">

As you can see, as we merged the prior PR, impressions to this billboard dropped to levels of "random", from the heavy weight to success.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This fix does not change test coverage, however exploration into more _behavior_ testing seems worth a shot later.
- [ ] I need help with writing tests

