### PR TITLE
Enable rspec-retry on system and request specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -146,7 +146,17 @@ RSpec.configure do |config|
     allow(FeatureFlag).to receive(:enabled?).with(:connect).and_return(true)
   end
 
+  config.verbose_retry = true
+
   config.around(:each, :flaky) do |ex|
+    ex.run_with_retry retry: 3
+  end
+
+  config.around(:each, type: :request) do |ex|
+    ex.run_with_retry retry: 3
+  end
+
+  config.around(:each, type: :system) do |ex|
     ex.run_with_retry retry: 3
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
Not sure how long it has been like this but we do not have proper retry for retry enabled
## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
resolves https://github.com/forem/forem/issues/19097

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a