### PR TITLE
Revert "Enable rspec-retry on system and request specs (#19103)"

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -146,17 +146,7 @@ RSpec.configure do |config|
     allow(FeatureFlag).to receive(:enabled?).with(:connect).and_return(true)
   end
 
-  config.verbose_retry = true
-
   config.around(:each, :flaky) do |ex|
-    ex.run_with_retry retry: 3
-  end
-
-  config.around(:each, type: :request) do |ex|
-    ex.run_with_retry retry: 3
-  end
-
-  config.around(:each, type: :system) do |ex|
     ex.run_with_retry retry: 3
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
I have a reason to believe that the recent uprise of db related failure is related to retries. I have an unverified suspicion that rspec-retry does not work well with rspec's `use_transactional_fixtures`.
## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a