### PR TITLE
Fix icon memory issue

### DIFF
--- a/app/views/articles/_multiple_engagements.html.erb
+++ b/app/views/articles/_multiple_engagements.html.erb
@@ -1,7 +1,7 @@
 <div class="multiple_reactions_engagement">
   <% ReactionCategory.for_view.each do |reaction_type| %>
     <span class="reaction_engagement_<%= reaction_type.slug %> hidden">
-      <%= image_tag reaction_type.icon, size: "24x24" %>
+      <%= image_tag "#{reaction_type.icon}.svg", size: "24x24" %>
       <span id="reaction_engagement_<%= reaction_type.slug %>_count">&nbsp;</span>
     </span>
   <% end %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Flipping the multiple reactions feature flag created a site slowdown and memory issue.

I've tracked it down to calling `image_tag reaction.icon` _without_ including the `.svg`. The _first time this is called_ takes a long time — negligible in development, but basically times out and causes problems in prod.

In both cases, once it tries and fails, it works fine afterwards — but the damage caused on this attempt are pretty severe, and this actually continue to happen every time we redeployed if we didn't deal with it.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/19008

