### PR TITLE
Update CI node count

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   RSpec:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       COVERAGE: true
       RAILS_ENV: test
@@ -37,8 +37,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [9]
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8]
+        ci_node_total: [6]
+        ci_node_index: [0, 1, 2, 3, 4, 5]
 
     steps:
       - uses: actions/checkout@v3
@@ -82,7 +82,7 @@ jobs:
 
   Jest:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       RAILS_ENV: test
       NODE_ENV: test
@@ -118,7 +118,7 @@ jobs:
 
   Build-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       RAILS_ENV: test
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/Forem_prod_test
@@ -166,7 +166,7 @@ jobs:
 
   Cypress:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       RAILS_ENV: test
       DATABASE_URL_TEST: postgres://postgres:postgres@localhost:5432/Forem_test
@@ -188,8 +188,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [9]
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, non-seed]
+        ci_node_total: [6]
+        ci_node_index: [0, 1, 2, 3, 4, 5, non-seed]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -161,7 +161,6 @@ jobs:
   Cypress:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
 
     services:
       postgres:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,26 +7,27 @@ on:
   pull_request:
     branches:
       - main
+env:
+  COVERAGE: true
+  RAILS_ENV: test
+  NODE_ENV: test
+  DATABASE_URL_TEST: postgres://postgres:postgres@localhost:5432/Forem_test
+  DATABASE_NAME_TEST: Forem_test
+  KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
+  POSTGRES_PASSWORD: postgres
 
 jobs:
   RSpec:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      COVERAGE: true
-      RAILS_ENV: test
       KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
       KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
       KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
-      KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
-      DATABASE_URL_TEST: postgres://postgres:postgres@localhost:5432/Forem_test
-      DATABASE_NAME_TEST: Forem_test
 
     services:
       postgres:
         image: postgres:13-alpine
-        env:
-          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
       redis:
@@ -83,9 +84,6 @@ jobs:
   Jest:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      RAILS_ENV: test
-      NODE_ENV: test
 
     steps:
       - uses: actions/checkout@v3
@@ -120,7 +118,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      RAILS_ENV: test
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/Forem_prod_test
       DATABASE_NAME: Forem_prod_test
       APP_PROTOCOL: http://
@@ -129,13 +126,10 @@ jobs:
       SECRET_KEY_BASE: dummydummydummy
       GITHUB_KEY: dummy
       GITHUB_SECRET: dummy
-      KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
 
     services:
       postgres:
         image: postgres:13-alpine
-        env:
-          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
       redis:
@@ -168,16 +162,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
-      RAILS_ENV: test
-      DATABASE_URL_TEST: postgres://postgres:postgres@localhost:5432/Forem_test
-      DATABASE_NAME_TEST: Forem_test
-      KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
 
     services:
       postgres:
         image: postgres:13-alpine
-        env:
-          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
       redis:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -236,7 +236,7 @@ jobs:
   CI-status-report:
     runs-on: ubuntu-latest
     needs: [rspec, jest, cypress, build-test]
-    if: success() || failure()
+    if: always()
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -243,7 +243,7 @@ jobs:
   CI-status-report:
     runs-on: ubuntu-latest
     needs: [rspec, jest, cypress, build-test]
-    if: always()
+    if: success() || failure()
 
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,6 +28,8 @@ jobs:
     services:
       postgres:
         image: postgres:13-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
       redis:
@@ -130,6 +132,8 @@ jobs:
     services:
       postgres:
         image: postgres:13-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
       redis:
@@ -165,6 +169,8 @@ jobs:
     services:
       postgres:
         image: postgres:13-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
       redis:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,3 @@
-codecov:
-  notify:
-    after_n_builds: 10
-comment:
-  after_n_builds: 10
 ignore:
   - "vendor"
   - "bin"

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,10 @@ ignore:
   - "lib/generators"
 flag_management:
   default_rules:
+    carryforward: true
     statuses:
       - type: project
         target: auto
         threshold: 1%
+      - type: patch
+        target: 90%


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
After speaking with @jaw6 , we both agree that, anecdotally, expanding CI count seems to have made spec flakier. We want to test that assumption here. This adds 3 minutes to CI time but I think not too significant.

- Cut CI node down by 3 each for Rspec and Cypress
- Slightly change how CI-status-check works, hoping that it will re-run more reliably.
- Change CodeCov's patch target to be 90% while removing the wait time.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a