### PR TITLE
Touch reactable after taking admin action

### DIFF
--- a/app/controllers/admin/reactions_controller.rb
+++ b/app/controllers/admin/reactions_controller.rb
@@ -7,6 +7,7 @@ module Admin
     def update
       @reaction = Reaction.find(params[:id])
       if @reaction.update(status: params[:status])
+        @reaction.reactable.touch
         Moderator::SinkArticles.call(@reaction.reactable_id) if confirmed_vomit_reaction?
         render json: { outcome: "Success" }
       else

--- a/spec/requests/admin/reactions_spec.rb
+++ b/spec/requests/admin/reactions_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "/admin/reactions" do
   let(:user)             { create(:user) }
-  let(:article)          { create(:article, user_id: user.id) }
+  let(:article)          { create(:article, user: user) }
   let(:admin)            { create(:user, :super_admin) }
 
   describe "PUT /admin/reactions as admin" do
@@ -11,7 +11,7 @@ RSpec.describe "/admin/reactions" do
       sign_in admin
     end
 
-    let(:reaction) { create(:reaction, category: "vomit", user_id: user.id, reactable: article) }
+    let(:reaction) { create(:reaction, category: "vomit", user: user, reactable: article) }
 
     it "updates reaction to be confirmed" do
       put admin_reaction_path(reaction.id), params: { id: reaction.id, status: "confirmed" }
@@ -19,7 +19,11 @@ RSpec.describe "/admin/reactions" do
     end
 
     it "updates reaction to be invalid" do
+      initial_updated_at = reaction.reactable.updated_at
+
       put admin_reaction_path(reaction.id), params: { id: reaction.id, status: "invalid" }
+
+      expect(reaction.reload.reactable.updated_at).not_to eq(initial_updated_at)
       expect(reaction.reload.status).to eq("invalid")
     end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] bug fix

## Description
Occasionally, a reactable will receive a false vomit report. When the report is invalidated, the reactable would need some cache to be purged.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a