### PR TITLE
[CI] Add concurrency & remove slack alert

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   COVERAGE: true
   RAILS_ENV: test

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,7 +9,7 @@ on:
       - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{  github.ref != 'main' }}
 
 env:
   COVERAGE: true

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -391,15 +391,6 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
 
-      - name: Report failure to Slack channel
-        uses: slackapi/slack-github-action@v1
-        with:
-          payload: |
-            { "link": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: failure() && github.ref == 'refs/heads/main'
-
   deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] CI

## Description
- Remove the now redundant slack notification on CI failure.
- add build concurrency:  You can have only one workflow running at a time per branch/pr. This mean on subsequent push, the previous workflow will be canceled and replaced. However, `main` branch will operate more of a queue style.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a