### PR TITLE
[CI] Lock setup-ruby to v1.144.0

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1.144.0
         with:
           bundler-cache: true
 
@@ -74,7 +74,7 @@ jobs:
           key: ${{ runner.os }}-precompiled-assets-${{ hashFiles('app/assets/**', 'app/javascript/**', 'config/webpack/**', 'config/webpacker.yml', '**/package.json', '**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-precompiled-assets-
       - name: setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.144.0
         with:
           bundler-cache: true
         if: steps.precompiled-asset.outputs.cache-hit != 'true'
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.144.0
         with:
           bundler-cache: true
       - uses: actions/setup-node@v3
@@ -174,7 +174,7 @@ jobs:
           node-version: 16
           cache: yarn
       - name: setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.144.0
         with:
           bundler-cache: true
       - run: bundle exec rails db:test:prepare
@@ -297,7 +297,7 @@ jobs:
           node-version: 16
           cache: yarn
       - name: setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.144.0
         with:
           bundler-cache: true
       - run: bundle exec rails assets:precompile
@@ -349,7 +349,7 @@ jobs:
           node-version: 16
           cache: yarn
       - name: setup ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1.144.0
         with:
           bundler-cache: true
       - run: bundle exec rails db:test:prepare


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] CI optimization

## Description
`setup-ruby` action is broken with the latest update. It does not restore cache anymore, making all of my optimization redundant. They are working on a fix, but it's already been a few days.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a