### PR TITLE
Undo changes to Sprockets::UglifierWithSourceMapsCompressor

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -254,6 +254,8 @@ jobs:
     needs: [bundle_install, yarn_install, precompile_assets]
     timeout-minutes: 20
     env:
+      RAILS_ENV: production
+      NODE_ENV: production
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/Forem_prod_test
       DATABASE_NAME: Forem_prod_test
       APP_PROTOCOL: http://

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -279,15 +279,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Cache compiled assets
-        uses: actions/cache/@v3
-        with:
-          path: |
-            public/assets
-            public/packs-test
-            tmp/cache/webpacker
-          key: ${{ runner.os }}-precompiled-assets-${{ hashFiles('app/assets/**', 'app/javascript/**', 'config/webpack/**', 'config/webpacker.yml', '**/package.json', '**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-precompiled-assets-
       - name: Restore node_modules
         uses: actions/cache/restore@v3
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -294,7 +294,7 @@ jobs:
         with:
           bundler-cache: true
       - run: bundle exec rails assets:precompile
-      - run: bin/test-console-check
+      - run: RAILS_ENV=test bin/test-console-check
 
   cypress:
     runs-on: ubuntu-latest

--- a/config/initializers/sprockets_uglifier_with_source_maps_compressor.rb
+++ b/config/initializers/sprockets_uglifier_with_source_maps_compressor.rb
@@ -21,7 +21,9 @@ module Sprockets
         ::Rails.application.config.assets.prefix,
         "#{name}-#{digest(sourcemap_json)}.js.map",
       )
+      # rubocop:disable Rails/RootPathnameMethods
       sourcemap_path = File.join(::Rails.public_path, sourcemap_filename)
+      # rubocop:enable Rails/RootPathnameMethods
       sourcemap_url  = filename_to_url(sourcemap_filename)
 
       FileUtils.mkdir_p File.dirname(sourcemap_path)

--- a/config/initializers/sprockets_uglifier_with_source_maps_compressor.rb
+++ b/config/initializers/sprockets_uglifier_with_source_maps_compressor.rb
@@ -21,7 +21,7 @@ module Sprockets
         ::Rails.application.config.assets.prefix,
         "#{name}-#{digest(sourcemap_json)}.js.map",
       )
-      sourcemap_path = ::Rails.public_path.join(sourcemap_filename)
+      sourcemap_path = File.join(::Rails.public_path, sourcemap_filename)
       sourcemap_url  = filename_to_url(sourcemap_filename)
 
       FileUtils.mkdir_p File.dirname(sourcemap_path)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug fix

## Description
For some reason, the suggested Rubocop rule for file append is prohibited during production asset compilation.

## Related Tickets & Documents
n/a

## QA Instructions, Screenshots, Recordings
Test should pass. I also updated 1 build environment is be production-like.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a