### PR TITLE
Fix like icon in sidebar

### DIFF
--- a/app/assets/javascripts/initializers/initializeArticleReactions.js
+++ b/app/assets/javascripts/initializers/initializeArticleReactions.js
@@ -73,6 +73,15 @@ function hideUserReaction(reactionName) {
   );
   reactionButton.classList.remove('user-activated', 'user-animated');
   reactionButton.setAttribute('aria-pressed', 'false');
+  const reactionDrawerButton = document.getElementById(
+    'reaction-drawer-trigger',
+  );
+  const userActivatedReactions = document
+    .querySelector('.reaction-drawer')
+    .querySelectorAll('.user-activated');
+  if (userActivatedReactions.length == 0) {
+    reactionDrawerButton.classList.remove('user-activated', 'user-animated');
+  }
 }
 
 function hasUserReacted(reactionName) {
@@ -191,7 +200,7 @@ function requestReactionCounts(articleId) {
   ajaxReq.onreadystatechange = () => {
     if (ajaxReq.readyState === XMLHttpRequest.DONE) {
       var json = JSON.parse(ajaxReq.response);
-      setSumReactionCount(json.article_reaction_counts)
+      setSumReactionCount(json.article_reaction_counts);
       showCommentCount();
       json.article_reaction_counts.forEach((reaction) => {
         setReactionCount(reaction.category, reaction.count);
@@ -217,7 +226,7 @@ function openDrawerOnHover() {
   drawerTrigger.addEventListener('click', function (event) {
     var articleId = document.getElementById('article-body').dataset.articleId;
     reactToArticle(articleId, 'like');
-    
+
     drawerTrigger.parentElement.classList.add('open');
   });
 
@@ -249,11 +258,15 @@ function openDrawerOnHover() {
 function closeDrawerOnOutsideClick() {
   document.addEventListener('click', function (event) {
     const reactionDrawerElement = document.querySelector('.reaction-drawer');
-    const reactionDrawerTriggerElement = document.querySelector('#reaction-drawer-trigger');
+    const reactionDrawerTriggerElement = document.querySelector(
+      '#reaction-drawer-trigger',
+    );
     if (reactionDrawerElement && reactionDrawerTriggerElement) {
-      const isClickInside = reactionDrawerElement.contains(event.target) || reactionDrawerTriggerElement.contains(event.target);
+      const isClickInside =
+        reactionDrawerElement.contains(event.target) ||
+        reactionDrawerTriggerElement.contains(event.target);
 
-      const openDrawerElement = document.querySelector('.hoverdown.open')
+      const openDrawerElement = document.querySelector('.hoverdown.open');
       if (!isClickInside && openDrawerElement) {
         openDrawerElement.classList.remove('open');
       }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR fixes the heart+ icon appearance in the sidebar when all reactions in the drawer are deselected.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Closes #19138 

## QA Instructions, Screenshots, Recordings

1. Log in as admin
2. Enable multiple reactions feature flag
3. Go to any published post
4. Hover your mouse pointer over the heart icon in the sidebar to open up the reaction drawer
5. Select any combination of reactions then deselect all
6. See that the heart icon is inactive


https://user-images.githubusercontent.com/88938117/227767516-7ffff828-6c5b-408d-8115-bd7de0996d9f.mp4



### UI accessibility concerns?
None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Unable to locate test file
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?


