### PR TITLE
Update FilteredAdQuery to better support community ads

### DIFF
--- a/spec/queries/display_ads/filtered_ads_query_spec.rb
+++ b/spec/queries/display_ads/filtered_ads_query_spec.rb
@@ -86,19 +86,23 @@ RSpec.describe DisplayAds::FilteredAdsQuery, type: :query do
     let!(:external_ad) { create_display_ad organization_id: organization.id, type_of: :external }
     let!(:other_external) { create_display_ad organization_id: other_org.id, type_of: :external }
 
-    it "always shows :in_house, only shows community/external appropriately" do
+    it "always shows :community ad if matching, otherwise shows in_house/external" do
       filtered = filter_ads organization_id: organization.id
-      expect(filtered).to contain_exactly(community_ad, in_house_ad, other_external)
+      expect(filtered).to contain_exactly(community_ad)
+      expect(filtered).not_to include(other_community)
+
+      filtered = filter_ads organization_id: 123
+      expect(filtered).to contain_exactly(in_house_ad)
       expect(filtered).not_to include(other_community)
 
       filtered = filter_ads organization_id: nil
       expect(filtered).to contain_exactly(in_house_ad, external_ad, other_external)
-      expect(filtered).not_to include(other_community)
+      expect(filtered).not_to include(community_ad, other_community)
     end
 
     it "suppresses external ads when permit_adjacent_sponsors is false" do
       filtered = filter_ads organization_id: organization.id, permit_adjacent_sponsors: false
-      expect(filtered).to contain_exactly(community_ad, in_house_ad)
+      expect(filtered).to contain_exactly(community_ad)
       expect(filtered).not_to include(other_community)
 
       filtered = filter_ads organization_id: nil, permit_adjacent_sponsors: false


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We'd like to improve the billboards experience for organizations:

* An organization post (eg, article with a non-nil `organization_id`) should **only** show `in-house` and _matching_ `community`-type ads.
* An organization post (non-nil `organization_id`) should show matching `community`-type ads if any exist (that is:_only_ show `in-house`-type ads if there are no matching `community`-type ad)

As best I can figure, this requires an additional query phase, but I think we can limit it to _only_ having a second phase **for organization posts**.

That is, for a non-organization post we see:

```
  DisplayAd Load (0.7ms)  SELECT "display_ads".* FROM "display_ads" WHERE "display_ads"."approved" = $1 AND "display_ads"."published" = $2 AND "display_ads"."placement_area" = $3 AND ("display_ads"."cached_tag_list" = $4 OR cached_tag_list ~ '[[:<:]]career[[:>:]]' OR cached_tag_list ~ '[[:<:]]computerscience[[:>:]]' OR cached_tag_list ~ '[[:<:]]discuss[[:>:]]') AND "display_ads"."display_to" IN ($5, $6) AND ((type_of = 0) OR (type_of = 2)) ORDER BY "display_ads"."success_rate" DESC LIMIT $7  [["approved", true], ["published", true], ["placement_area", "post_sidebar"], ["cached_tag_list", ""], ["display_to", 0], ["display_to", 1], ["LIMIT", 3]]
```

And for an organization post we see:

```
  DisplayAd Exists? (53.2ms)  SELECT 1 AS one FROM "display_ads" WHERE "display_ads"."approved" = $1 AND "display_ads"."published" = $2 AND "display_ads"."placement_area" = $3 AND ("display_ads"."cached_tag_list" = $4 OR cached_tag_list ~ '[[:<:]]giphy[[:>:]]') AND "display_ads"."display_to" IN ($5, $6) AND ((type_of = 1 AND organization_id = 1)) LIMIT $7  [["approved", true], ["published", true], ["placement_area", "post_comments"], ["cached_tag_list", ""], ["display_to", 0], ["display_to", 1], ["LIMIT", 1]]
  DisplayAd Load (1.5ms)  SELECT "display_ads".* FROM "display_ads" WHERE "display_ads"."approved" = $1 AND "display_ads"."published" = $2 AND "display_ads"."placement_area" = $3 AND ("display_ads"."cached_tag_list" = $4 OR cached_tag_list ~ '[[:<:]]giphy[[:>:]]') AND "display_ads"."display_to" IN ($5, $6) AND ((type_of = 0)) ORDER BY "display_ads"."success_rate" DESC LIMIT $7  [["approved", true], ["published", true], ["placement_area", "post_comments"], ["cached_tag_list", ""], ["display_to", 0], ["display_to", 1], ["LIMIT", 15]]
```

## Related Tickets & Documents

- Closes #https://github.com/forem/forem/issues/19224


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [x] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media4.giphy.com/media/b3aJDNQhXxWNjnh4iF/giphy.gif?cid=ecf05e47dp504lsglkcyb8fyhq5ewezmybakzix8jzq8y5w8&rid=giphy.gif&ct=g)

