### PR TITLE
Refactor cache-key on FeedbackMessagesController#create

### DIFF
--- a/app/controllers/feedback_messages_controller.rb
+++ b/app/controllers/feedback_messages_controller.rb
@@ -21,7 +21,7 @@ class FeedbackMessagesController < ApplicationController
       rate_limiter.track_limit_by_action(:feedback_message_creation)
 
       if user_signed_in?
-        Rails.cache.fetch("user-#{current_user.id}-feedback-response-sent-at", expires_in: 24.hours) do
+        Rails.cache.fetch("#{current_user.cache_key}/feedback-response-sent-at", expires_in: 24.hours) do
           NotifyMailer.with(email_to: current_user.email).feedback_response_email.deliver_later
           Time.current
         end


### PR DESCRIPTION
## What type of PR is this?

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Ｗe want to have better cache key convention, and about this key why not use `cache-key-with-version`? 

My idea is that the original `key` itself is not related to `updated_at` or other timestamp colums, so only `cache-key` is used, which can be closer to the convention on one hand and not change the original behavior on the other.

```ruby
Product.new.cache_key     # => "products/new"
Product.find(5).cache_key # => "products/5"
Product.find(5).cache_key_with_version # => "products/5-20071224150000"
```

## Related Tickets & Documents

- Related Issue #19102

## Added/updated tests?

- [x] No, because they aren't needed

