### PR TITLE
fix lazy-loaded multiple reaction icons joined by commas

### DIFF
--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -131,7 +131,7 @@ function buildArticleHTML(article, currentUserId = null) {
       }">
                           <div class="multiple_reactions_aggregate">
                             <span class="multiple_reactions_icons_container" dir="rtl">
-                                ${icons.join()}
+                                ${icons.join('')}
                             </span>
                             <span class="aggregate_reactions_counter">
                               <span class="hidden s:inline">${reactionsCount}&nbsp;${reactionsText}</span>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Reaction icons in lazy-loaded feed items are unexpectedly joined by commas, which makes the row of icons visibly bloat compared with server-rendered ones.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #19202
- Closes #

## QA Instructions, Screenshots, Recordings

Server-rendered reaction icon train:
![server-rendered icons container: width = 87.5](https://user-images.githubusercontent.com/84892012/229297318-df85498f-d5b4-4d88-851b-75885dbdf9df.png)

Lazy-loaded reaction icon train:
![JS-rendered icons container: width = 99.5](https://user-images.githubusercontent.com/84892012/229297359-512bae74-ce02-44e8-9541-82538a1f2f2f.png)

The latter has commas between spans:
![inspector DOM panel, commas between spans](https://user-images.githubusercontent.com/84892012/229297433-b29dd876-6439-43d8-84fe-1f5d834089dc.png)

### UI accessibility concerns?

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [Forem core team only] How will this change be communicated?

_Will this PR introduce a change that impacts Forem members or creators, the
development process, or any of our internal teams? If so, please note how you
will share this change with the people who need to know about it._

- [ ] I've updated the [Developer Docs](https://developers.forem.com) or
      [Storybook](https://storybook.forem.com/) (for Crayons components)
- [ ] This PR changes the Forem platform and our documentation needs to be
      updated. I have filled out the
      [Changes Requested](https://github.com/forem/admin-docs/issues/new?assignees=&labels=&template=changes_requested.md)
      issue template so Community Success can help update the Admin Docs
      appropriately.
- [ ] I've updated the README or added inline documentation
- [ ] I've added an entry to
      [`CHANGELOG.md`](https://github.com/forem/forem/tree/main/CHANGELOG.md)
- [ ] I will share this change in a [Changelog](https://forem.dev/t/changelog)
      or in a [forem.dev](http://forem.dev) post
- [ ] I will share this change internally with the appropriate teams
- [ ] I'm not sure how best to communicate this change and need help
- [ ] This change does not need to be communicated, and this is why not: _please
      replace this line with details on why this change doesn't need to be
      shared_

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)

