### PR TITLE
Tell Bullet to ignore unused `distinct_reaction_categories`

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -138,6 +138,7 @@ Rails.application.configure do
     # Suppress incorrect warnings from Bullet due to included columns: https://github.com/flyerhzm/bullet/issues/147
     Bullet.add_safelist(type: :unused_eager_loading, class_name: "Article", association: :top_comments)
     Bullet.add_safelist(type: :unused_eager_loading, class_name: "Article", association: :collection)
+    Bullet.add_safelist(type: :unused_eager_loading, class_name: "Article", association: :distinct_reaction_categories)
     Bullet.add_safelist(type: :unused_eager_loading, class_name: "Comment", association: :user)
     # There were some warnings about eager loading the organization for a display ad, however since the code goes down
     # different paths (in_house where we don’t need the organization info vs external/community where we need the


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Bullet sometimes complains about an unused eager-loading for `distinct_reaction_categories`, but this is a false-positive. The Bullet error can be seen if you have an entire page's count of articles without reactions. That's situational at best and is very unlikely to be worth addressing with conditional scopes in our code.

## QA Instructions, Screenshots, Recordings

* Create a bunch of articles locally in `console` ?
* Or maybe delete seeded reactions?

```
 GET /locale/fr?i=i
15:58:55 web.1       | AVOID eager loading detected
15:58:55 web.1       |   Article => [:distinct_reaction_categories]
15:58:55 web.1       |   Remove from your query: .includes([:distinct_reaction_categories])
15:58:55 web.1       | Call stack
15:58:55 web.1       |   /path/to/forem/app/services/articles/feeds/large_forem_experimental.rb:103:in `featured_story_from'
15:58:55 web.1       |   /path/to/forem/app/services/articles/feeds/large_forem_experimental.rb:93:in `globally_hot_articles'
15:58:55 web.1       |   /path/to/forem/app/services/articles/feeds/large_forem_experimental.rb:25:in `featured_story_and_default_home_feed'
15:58:55 web.1       |   /path/to/forem/app/controllers/stories_controller.rb:238:in `assign_feed_stories'
15:58:55 web.1       |   /path/to/forem/app/controllers/stories_controller.rb:127:in `handle_base_index'
15:58:55 web.1       |   /path/to/forem/app/controllers/stories_controller.rb:31:in `index'
```

`cc` @filleduchaos 

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: config change only impacts `development` environment
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media0.giphy.com/media/1zJaB28JqGw3m/giphy.gif?cid=ecf05e4737nv2v9fv8js321tw6hvvxqg139rljt45z8sjquf&rid=giphy.gif&ct=g)
