### PR TITLE
Restore marking notifications as read via InstantClick

### DIFF
--- a/app/javascript/packs/baseInitializers.js
+++ b/app/javascript/packs/baseInitializers.js
@@ -8,7 +8,10 @@ import {
 
 initializeCommentDate();
 initializeCommentPreview();
-initializeNotifications();
+
+InstantClick.on('change', () => {
+  initializeNotifications();
+});
 
 window.showUserAlertModal = showUserAlertModal;
 window.showModalAfterError = showModalAfterError;

--- a/app/javascript/packs/baseInitializers.js
+++ b/app/javascript/packs/baseInitializers.js
@@ -8,6 +8,7 @@ import {
 
 initializeCommentDate();
 initializeCommentPreview();
+initializeNotifications();
 
 InstantClick.on('change', () => {
   initializeNotifications();


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If one navigates directly to `/notifications`, there's a background XHR to `/reads` (which marks notifications as read). If one clicks to this page via the "bell icon", there's no XHR to `/reads`.

## Related Tickets & Documents

- Closes #19337

## QA Instructions, Screenshots, Recordings

* Navigate to `/notifications` by clicking on the "bell icon"
* Observe that there is a request to `/reads` (via either `log/development.log` or browser console/network)


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: meh, InstantClick 
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media0.giphy.com/media/dZoIQZTWB1iwtLSaCi/giphy.gif?cid=ecf05e47plgpqw114jru4h1cnsoe3rplbeh9sbnu8mzmp459&rid=giphy.gif&ct=g)


`cc` @benhalpern @lboogie04 