### PR TITLE
Set flash[:error] when markdown has invalid liquid tags on comment update

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -152,6 +152,7 @@ class CommentsController < ApplicationController
       render :index
     else
       @commentable = @comment.commentable
+      flash.now[:error] = I18n.t("comments_controller.markdown", error: @commentable.errors_as_sentence)
       render :edit
     end
   rescue StandardError => e

--- a/spec/requests/articles/articles_create_spec.rb
+++ b/spec/requests/articles/articles_create_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "ArticlesCreate" do
 
   before do
     sign_in user
+    allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(true)
   end
 
   it "creates ordinary article with proper params" do

--- a/spec/requests/articles/articles_update_spec.rb
+++ b/spec/requests/articles/articles_update_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "ArticlesUpdate" do
 
   before do
     sign_in user
+    allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(true)
   end
 
   it "updates ordinary article with proper params" do

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe "Comments" do
   let(:podcast_episode) { create(:podcast_episode, podcast_id: podcast.id) }
   let!(:comment) { create(:comment, commentable: article, user: user) }
 
+  before { allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(true) }
+
   describe "GET comment index" do
     it "returns 200" do
       get comment.path

--- a/spec/services/content_renderer_spec.rb
+++ b/spec/services/content_renderer_spec.rb
@@ -66,6 +66,22 @@ RSpec.describe ContentRenderer do
     end
   end
 
+  context "when markdown contains an invalid liquid tag" do
+    let(:markdown) { "hello hey hey hey {% gist 123 %}" }
+    let(:user) { instance_double(User) }
+
+    before do
+      allow(user).to receive(:any_admin?).and_return(true)
+    end
+
+    it "raises ContentParsingError for comment" do
+      source = build(:comment)
+      expect do
+        described_class.new(markdown, source: source, user: user).process
+      end.to raise_error(ContentRenderer::ContentParsingError, /Invalid Gist link: 123 Links must follow this format/)
+    end
+  end
+
   context "when markdown has liquid tags that aren't allowed for source" do
     let(:markdown) { "hello hey hey hey {% poll 123 %}" }
     let(:user) { instance_double(User) }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
While working on #19099 I enabled the `:consistent` rendering feature flag for comments and articles request specs. One spec was failing ("does not raise a StandardError for invalid liquid tags" on updating a comment).
With new rendering, we catch parsing errors and add them as validation messages:
https://github.com/forem/forem/blob/692795407fe30a92e4d23d224dbd64a49a0ee4eb/app/models/comment.rb#L232-L234
In this case, the exception was not caught and `flash[:error]` was not set. In this pr I added the flash message and enabled 
the feature flag for articles and comments request specs.

I have also added the spec that checks that in case of an invalid liquid tag `ContentRenderer` raises an appropriate error.

## Related Tickets & Documents
- Related Issue #19099

## QA Instructions, Screenshots, Recordings
- enable the feature flag `FeatureFlag.enable(:consistent_rendering)`
- try to update your comment with a markdown containing an invalid liquid tag, e.g. `{% gist 123 %}`
- when trying to save, you should get a corresponding error message

## Added/updated tests?
- [x] Yes
