### PR TITLE
Removed tracking 'comments section viewable' ahoy event

### DIFF
--- a/app/javascript/packs/articlePage.jsx
+++ b/app/javascript/packs/articlePage.jsx
@@ -1,5 +1,4 @@
 import { h, render } from 'preact';
-import ahoy from 'ahoy.js';
 import { Snackbar, addSnackbarItem } from '../Snackbar';
 import { addFullScreenModeControl } from '../utilities/codeFullscreenModeSwitcher';
 import { initializeDropdown } from '../utilities/dropdownUtils';
@@ -88,28 +87,6 @@ function showAnnouncer() {
   document.getElementById('article-copy-link-announcer').hidden = false;
 }
 
-// Temporary Ahoy Stats for displaying comments section either on page load or after scrolling
-function trackCommentsSectionDisplayed() {
-  const callback = (entries, observer) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        ahoy.track('Comment section viewable', { page: location.href });
-        observer.disconnect();
-      }
-      if (location.hash === '#comments') {
-        //handle focus event on text area
-        const element = document.getElementById('text-area');
-        const event = new FocusEvent('focus');
-        element.dispatchEvent(event);
-      }
-    });
-  };
-
-  const target = document.getElementById('comments');
-  const observer = new IntersectionObserver(callback, {});
-  observer.observe(target);
-}
-
 function copyArticleLink() {
   const postUrlValue = document
     .getElementById('copy-post-url-button')
@@ -177,4 +154,3 @@ setupDisplayAdDropdown();
 initializeUserSubscriptionLiquidTagContent();
 // Temporary Ahoy Stats for comment section clicks on controls
 trackCommentClicks('comments');
-trackCommentsSectionDisplayed();

--- a/app/javascript/packs/articlePage.jsx
+++ b/app/javascript/packs/articlePage.jsx
@@ -87,6 +87,15 @@ function showAnnouncer() {
   document.getElementById('article-copy-link-announcer').hidden = false;
 }
 
+function focusOnComments() {
+  if (location.hash === '#comments') {
+    //handle focus event on text area
+    const element = document.getElementById('text-area');
+    const event = new FocusEvent('focus');
+    element.dispatchEvent(event);
+  }
+}
+
 function copyArticleLink() {
   const postUrlValue = document
     .getElementById('copy-post-url-button')
@@ -152,5 +161,6 @@ targetNode && embedGists(targetNode);
 
 setupDisplayAdDropdown();
 initializeUserSubscriptionLiquidTagContent();
+focusOnComments();
 // Temporary Ahoy Stats for comment section clicks on controls
 trackCommentClicks('comments');


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Removed "Comment section viewable" ahoy event, discussed in https://github.com/forem/forem-internal-eng/issues/523#issuecomment-1506086754

## Related Tickets & Documents
- Related Issue https://github.com/forem/forem-internal-eng/issues/523

## QA Instructions, Screenshots, Recordings
The comments section should be viewable/usable as before.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: haven't added any logic
- [ ] I need help with writing tests


