### PR TITLE
Update sidebar link to trusted member guide

### DIFF
--- a/app/views/moderations/_mod_sidebar_left.html.erb
+++ b/app/views/moderations/_mod_sidebar_left.html.erb
@@ -56,7 +56,7 @@
       <%= t("views.moderations.aside.resources") %>
     </h3>
     <div id="mod-center-other-options">
-      <a href="<%= URL.url %>/community-moderation" class="crayons-link crayons-link--block mod-center--nav__item">
+      <a href="<%= URL.url %>/trusted-member" class="crayons-link crayons-link--block mod-center--nav__item">
         <%= t("views.moderations.aside.trusted") %>
         <%= crayons_icon_tag("external-link", title: t("views.moderations.aside.external")) %>
       </a>

--- a/app/views/moderations/_mod_sidebar_left.html.erb
+++ b/app/views/moderations/_mod_sidebar_left.html.erb
@@ -56,10 +56,17 @@
       <%= t("views.moderations.aside.resources") %>
     </h3>
     <div id="mod-center-other-options">
-      <a href="<%= URL.url %>/trusted-member" class="crayons-link crayons-link--block mod-center--nav__item">
-        <%= t("views.moderations.aside.trusted") %>
-        <%= crayons_icon_tag("external-link", title: t("views.moderations.aside.external")) %>
-      </a>
+      <% if Page.exists?(slug: "trusted-member") %>
+        <a href="<%= URL.url %>/trusted-member" class="crayons-link crayons-link--block mod-center--nav__item">
+          <%= t("views.moderations.aside.trusted") %>
+          <%= crayons_icon_tag("external-link", title: t("views.moderations.aside.external")) %>
+        </a>
+      <% else %>
+        <a href="<%= URL.url %>/community-moderation" class="crayons-link crayons-link--block mod-center--nav__item">
+          <%= t("views.moderations.aside.trusted") %>
+          <%= crayons_icon_tag("external-link", title: t("views.moderations.aside.external")) %>
+        </a>
+      <% end %>
       <a href="<%= URL.url %>/tag-moderation" class="crayons-link crayons-link--block mod-center--nav__item">
         <%= t("views.moderations.aside.tag") %>
         <%= crayons_icon_tag("external-link", title: t("views.moderations.aside.external")) %>

--- a/config/locales/views/moderations/en.yml
+++ b/config/locales/views/moderations/en.yml
@@ -137,7 +137,7 @@ en:
         resources: Resources
         tag: Tag Moderation Guide
         terms_and_conditions: Terms & Conditions
-        trusted: Trusted User Guide
+        trusted: Trusted Member Guide
       author: Author
       date: Date
       notice:
@@ -148,5 +148,5 @@ en:
         desc4: P.S. You are not currently signed in.
         code_of_conduct: Code of Conduct
         tag: Tag Moderation Guide
-        trusted: Trusted User Guide
+        trusted: Trusted Member Guide
       post: Post

--- a/config/locales/views/moderations/fr.yml
+++ b/config/locales/views/moderations/fr.yml
@@ -136,7 +136,7 @@ fr:
         resources: Ressources
         tag: Guide de modération des étiquettes
         terms_and_conditions: Conditions générales d'utilisation
-        trusted: Guide de l'utilisateur de confiance
+        trusted: Guide du membre de confiance
       author: Auteur
       date: Date
       notice:
@@ -147,5 +147,5 @@ fr:
         desc4: P.S. Vous n'êtes pas actuellement connecté.
         code_of_conduct: Code de conduite
         tag: Guide de modération des étiquettes
-        trusted: Guide de l'utilisateur de confiance
+        trusted: Guide du membre de confiance
       post: Article

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "Moderations" do
     let(:dev_name_copy) { "We periodically award some DEV members with heightened privileges" }
     # rubocop:disable Layout/LineLength
     let(:coc_guides_copy) do
-      'Check out our <a href="/code-of-conduct">Code of Conduct</a> and read through our <a href="/community-moderation">Trusted User Guide</a> and <a href="/tag-moderation">Tag Moderation Guide</a>.'
+      'Check out our <a href="/code-of-conduct">Code of Conduct</a> and read through our <a href="/community-moderation">Trusted Member Guide</a> and <a href="/tag-moderation">Tag Moderation Guide</a>.'
     end
     # rubocop:enable Layout/LineLength
     let(:become_mod_copy) { "If you'd like to assist us as a trusted user or tag mod" }


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description

In [a recent walkthrough](https://www.loom.com/share/6ba7840a61664c2f8fb3e695d3564ac3), it was observed that the sidebar links on `/mod` are a bit out-of-date. This PR updates the link to point to the new guide, if the relevant page exists on the instance.

## QA Instructions, Screenshots, Recordings

* As a trusted user, navigate to `/mod`, click "Trusted Member Guide" in the sidebar.


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: documentation update
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media1.giphy.com/media/pIATVyMEwDQPe/giphy.gif?cid=ecf05e476qhv9x1pzg4d682q446ge4xlezcol0dsa6x8zs6j&rid=giphy.gif&ct=g)
