### PR TITLE
Update issue templates and automatic comment on new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/-core-team-only---new-approved-feature.md
+++ b/.github/ISSUE_TEMPLATE/-core-team-only---new-approved-feature.md
@@ -1,0 +1,31 @@
+---
+name: "[Core Team Only]: New Approved Feature"
+about: This template is for Core Team only. For feature requests, please use GitHub
+  Discussions.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- ⚠️⚠️⚠️ This issue template is for Core Team only to outline approved features.  For new Feature Requests, please use GitHub Discussions: https://github.com/forem/forem/discussions -->
+
+## Is this feature related to a problem?  Please describe.
+
+<!-- Be sure to cover the Who / What / Why.  IE: As a (role), I want (function) so that (value).-->
+
+## Describe the solution you’d like
+
+<!-- Describe the end state that solves your problem. -->
+
+## Definition of Done
+
+<!-- The granular tasks / acceptance criteria that need to be completed as part of this issue. -->
+
+- [ ] Task 1
+- [ ] Task 2
+- [ ] Task 3
+
+## Additional Context
+
+<!-- Please share any implementation notes, specific requirements, potential rabbit holes, historical knowledge, etc. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,10 @@
 ---
 name: Bug report
 about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 <!-- Before creating a bug report, try disabling browser extensions to see if the bug is still present. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Request
-    url: https://github.com/forem/forem/discussions
-    about: Visit our GitHub Discussions page to suggest an idea to make Forem better. 
-  - name: Forem Questions and Discussions
-    url: https://forem.dev/
-    about: Please ask and answer questions, discuss features, or reach out for help on forem.dev
+    url: https://github.com/forem/forem/discussions/categories/feature-requests
+    about: Have a feature request?  Please let us know via GitHub Discussions. 
+  - name: Forem Q&A
+    url: https://github.com/forem/forem/discussions/categories/q-a
+    about: Have a general questions?  Please let us know via GitHub Discussions.
   - name: Self-Host Bug Report
     url: https://github.com/forem/selfhost/issues/new
     about: Create a report to help us improve the Self-Host repository.

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -23,9 +23,9 @@ jobs:
           body: |
             Thanks for the issue, we will take it into consideration! Our team of engineers is busy working on many types of features, please give us time to get back to you.
             
-            Feature requests that require more discussion may be closed. Read more about our [feature request process](https://forem.dev/foremteam/heads-up-github-discussions-and-feature-requests-54ff) on forem.dev.
-
             To our amazing contributors: [issues labeled `bug`](https://github.com/forem/forem/issues?q=is%3Aissue+is%3Aopen+label%3Abug) are always up for grabs, but for feature requests, please wait until we add a `ready for dev` before starting to work on it.
+
+            If this is a feature request from an external contributor (not core team at Forem), please close the issue and re-post via [GitHub Discussions](https://github.com/forem/forem/discussions/categories/feature-requests).
 
             To claim an issue to work on, please leave a comment. If you've claimed the issue and need help, please ping @forem-team. The OSS Community Manager or the engineers on OSS rotation will follow up.
 


### PR DESCRIPTION
A few changes to clean up our GitHub / GitHub Discussions flow.

* Adding a new issue template (FYI I used the [GUI here](https://github.com/forem/forem/issues/templates/edit))
* Cleaning up links found on the "[choose issue](https://github.com/forem/forem/issues/new/choose)" page
* Tweaking our (GitHub Actions powered) automated comment that is posted after a new issue is created