### PR TITLE
Try to catch unhandled exception

### DIFF
--- a/app/javascript/packs/hideBookmarkButtons.js
+++ b/app/javascript/packs/hideBookmarkButtons.js
@@ -1,12 +1,19 @@
 import { getUserDataAndCsrfToken } from '@utilities/getUserDataAndCsrfToken';
 
-getUserDataAndCsrfToken().then(({ currentUser }) => {
-  const currentUserId = currentUser && currentUser.id;
+getUserDataAndCsrfToken().then(
+  ({ currentUser }) => {
+    const currentUserId = currentUser && currentUser.id;
 
-  document.querySelectorAll('.bookmark-button').forEach((button) => {
-    const { articleAuthorId } = button.dataset;
-    if (currentUserId && articleAuthorId == currentUserId) {
-      button.classList.add('hidden');
+    document.querySelectorAll('.bookmark-button').forEach((button) => {
+      const { articleAuthorId } = button.dataset;
+      if (currentUserId && articleAuthorId == currentUserId) {
+        button.classList.add('hidden');
+      }
+    });
+  },
+  (error) => {
+    if (!/find user data/.test(error)) {
+      Honeybadger.notify(error);
     }
-  });
-});
+  },
+);


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I found a weird, flickering Cypress test today and might have figured out how to get it to not flicker. Maybe?

The branch that originally saw the test fail was on [audience segmentation](https://github.com/forem/forem/pull/19284), but the test is unrelated to the changes in that branch, and I have also seen the test fail (locally) on `main`.

The failing test was [this one: loggedOut/taggedIndex](https://github.com/forem/forem/blob/main/cypress/e2e/seededFlows/loggedOutFlows/tagIndex.spec.js), but the test *itself* is passing. 

What's failing appears to be an `afterAll` hook (though I can't find it's definition, so it might be a default set by Cypress), that's noticing an unhandled exception coming from [getUserDataAndCsrfToken](https://github.com/forem/forem/blob/main/app/javascript/utilities/getUserDataAndCsrfToken.js).

That function will fail if 3000 seconds go by without loading in any data for `user` from `document.body.dataset`. _That_ data should be set by `async_info/base_data`, but [that _only_ sets user if the user is signed-in](https://github.com/forem/forem/blob/main/app/controllers/async_info_controller.rb#L8-L26) — that is to say, if the user isn't signed in, `getUserDataAndCsrfToken` _should_ throw an exception.

So, according to `console.trace()`, the function that called `getUserDataAndCsrfToken` was in [hideBookmarmButtons](https://github.com/forem/forem/blob/main/app/javascript/packs/hideBookmarkButtons.js) — which (sort of) makes sense, because [hideBookmarkButtons *is* included when viewing tagged articles index](https://github.com/forem/forem/blob/main/app/views/stories/tagged_articles/index.html.erb#L133) (where the test appears to be failing).

And tagged articles index _did_ change recently — we added [drawerSlides initializer](https://github.com/forem/forem/blob/bef1c4a1e0c90c6f26af90bc3c38093c7254c785/app/views/stories/tagged_articles/index.html.erb#L133).

My current _theory_ is that the test passes when the main test body finishes "fast enough" (and Cypress counts the test as "passing") and fails when the unhandled exception hits before Cypress "finishes" (so Cypress is "aware of" the unhandled exception before counting the test as "passing"), so it's flickering due to pure random fluctuations in timing. (And _maybe_ adding drawersliders _after_ hidebookmarks shifted the timing in some way that it's more likely to hit now?)

But... my question is: how did this _ever_ work?

`getUserDataAndCsrfToken` wants to throw an exception if the user is _not_ signed in. It has [not really changed in ~2 years](https://github.com/forem/forem/commits/main/app/javascript/utilities/getUserDataAndCsrfToken.js). `hideBookmarks` is newer — it's been here longer than I have, but I mean it's relatively new — and there was _some_ discussion about [how to get user data](https://github.com/forem/forem/pull/17293#discussion_r854211535), but my best guess is that the whole bookmarks PR just never checked behavior with a logged-out user.

My sense is that we'd actually _rather_ have a version of `getUserDataAndCsrfToken` that does _not_ throw exceptions so we have the [async benefits](https://github.com/forem/forem/pull/17293#discussion_r854211535) while treating a logged-out situation as a non-exceptional no-op. We _can_ pass a Promise rejection handler, but then we have to determine _if_ the rejection error is an ignorable "you are logged-out" or something more signficant — the way I'm attempting here seems likely to cause problems by occasionally swallowing exceptions more silently than we'd like.

By way of analogy: in Rails, `save!` and `create!` throw exceptions, when `save` and `create` do not (they set validation errors, but don't normally raise), while `find` _does_ raise `NotFound`, `find_by` does _not_ raise. It seems like we have treated `getUserDataAndCsrfToken` as though it's non-raising `find_by` but it's _actually_ exception-raising `find`.

As of now, my branch is passing again, so I don't need this urgently, but given how unrelated my branch was to this area of the code, I think we're likely to see this test fail again soon. This PR gets things to pass consistently, so it might be better than what we have now, but I am also thinking we _might_ rather try to solve this in a different way? 

`cc` @filleduchaos @Ridhwana @maestromac @lboogie04 @lightalloy @rt4914 — If nothing else, I thought I should draw attention to the situation where `getUserDataAndCsrfToken` will cause unhandled exceptions if the user is logged-out and we should be more aware of that.

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExNzZmYmI2ODhhODEyMWRkZjhmNzY1OGIyZjRmMjY3ZTkxNTVlNzEzOSZlcD12MV9pbnRlcm5hbF9naWZzX2dpZklkJmN0PWc/THxnKZJ4B8VKd737Ss/giphy.gif)
