### PR TITLE
Consistent rendering on preview: comments and articles

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -112,10 +112,10 @@ class ArticlesController < ApplicationController
 
     begin
       if FeatureFlag.enabled?(:consistent_rendering, FeatureFlag::Actor[current_user])
-        renderer = ContentRenderer.new(params[:article_body], source: self, user: current_user)
+        renderer = ContentRenderer.new(params[:article_body], source: Article.new, user: current_user)
         result = renderer.process_article
         processed_html = result.processed_html
-        front_matter = result.front_matter
+        front_matter = result.front_matter.to_h
       else
         fixed_body_markdown = MarkdownProcessor::Fixer::FixForPreview.call(params[:article_body])
         parsed = FrontMatterParser::Parser.new(:md).call(fixed_body_markdown)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -111,10 +111,18 @@ class ArticlesController < ApplicationController
     authorize Article
 
     begin
-      fixed_body_markdown = MarkdownProcessor::Fixer::FixForPreview.call(params[:article_body])
-      parsed = FrontMatterParser::Parser.new(:md).call(fixed_body_markdown)
-      parsed_markdown = MarkdownProcessor::Parser.new(parsed.content, source: Article.new, user: current_user)
-      processed_html = parsed_markdown.finalize
+      if FeatureFlag.enabled?(:consistent_rendering, FeatureFlag::Actor[current_user])
+        renderer = ContentRenderer.new(params[:article_body], source: self, user: current_user)
+        result = renderer.process_article
+        processed_html = result.processed_html
+        front_matter = result.front_matter
+      else
+        fixed_body_markdown = MarkdownProcessor::Fixer::FixForPreview.call(params[:article_body])
+        parsed = FrontMatterParser::Parser.new(:md).call(fixed_body_markdown)
+        parsed_markdown = MarkdownProcessor::Parser.new(parsed.content, source: Article.new, user: current_user)
+        processed_html = parsed_markdown.finalize
+        front_matter = parsed.front_matter.to_h
+      end
     rescue StandardError => e
       @article = Article.new(body_markdown: params[:article_body])
       @article.errors.add(:base, ErrorMessages::Clean.call(e.message))
@@ -125,7 +133,6 @@ class ArticlesController < ApplicationController
         format.json { render json: @article.errors, status: :unprocessable_entity }
       else
         format.json do
-          front_matter = parsed.front_matter.to_h
           if front_matter["tags"]
             tags = Article.new.tag_list.add(front_matter["tags"], parser: ActsAsTaggableOn::TagParser)
           end

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe "ArticlesShow" do
   end
 
   describe "GET /:username/:slug (scheduled)" do
+    before { allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(true) }
+
     let(:scheduled_article) { create(:article, published: true, published_at: Date.tomorrow) }
     let(:query_params) { "?preview=#{scheduled_article.password}" }
     let(:scheduled_article_path) { scheduled_article.path + query_params }

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "ArticlesShow" do
       expect(response).to have_http_status(:ok)
     end
 
-    # rubocop:disable RSpec/ExampleLength
     it "renders the proper JSON-LD for an article" do
       expect(response_json).to include(
         "@context" => "http://schema.org",
@@ -111,7 +110,6 @@ RSpec.describe "ArticlesShow" do
       },
     )
   end
-  # rubocop:enable RSpec/ExampleLength
 
   context "when keywords are set" do
     it "shows keywords" do

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe "Comments" do
   let(:podcast_episode) { create(:podcast_episode, podcast_id: podcast.id) }
   let!(:comment) { create(:comment, commentable: article, user: user) }
 
-  before { allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(true) }
-
   describe "GET comment index" do
     it "returns 200" do
       get comment.path
@@ -256,6 +254,7 @@ RSpec.describe "Comments" do
 
   describe "PUT /comments/:id" do
     before do
+      allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(true)
       sign_in user
     end
 
@@ -291,9 +290,28 @@ RSpec.describe "Comments" do
       expect(response).to have_http_status(:unauthorized)
     end
 
-    context "when logged-in" do
+    context "when logged-in and consistent rendering" do
       before do
         sign_in user
+        allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(true)
+        post "/comments/preview",
+             params: { comment: { body_markdown: "hi" } },
+             headers: { HTTP_ACCEPT: "application/json" }
+      end
+
+      it "returns 200 on good request" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns json" do
+        expect(response.media_type).to eq("application/json")
+      end
+    end
+
+    context "when logged-in and inconsistent rendering" do
+      before do
+        sign_in user
+        allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(false)
         post "/comments/preview",
              params: { comment: { body_markdown: "hi" } },
              headers: { HTTP_ACCEPT: "application/json" }
@@ -321,7 +339,9 @@ RSpec.describe "Comments" do
       }
     end
 
-    context "when a user is coment_suspended" do
+    before { allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(true) }
+
+    context "when a user is comment_suspended" do
       before do
         sign_in user
         user.add_role(:comment_suspended)

--- a/spec/requests/editor_spec.rb
+++ b/spec/requests/editor_spec.rb
@@ -55,16 +55,45 @@ RSpec.describe "Editor" do
     end
 
     context "when logged-in" do
-      it "returns json" do
+      before do
         sign_in user
+        allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(false)
+      end
+
+      it "returns json" do
         post "/articles/preview", headers: headers
         expect(response.media_type).to eq("application/json")
       end
+
+      it "returns successfully with frontmatter" do
+        article_body = <<~MARKDOWN
+          ---
+          ---
+
+          Hello
+        MARKDOWN
+
+        post "/articles/preview",
+             headers: headers,
+             params: { article_body: article_body },
+             as: :json
+
+        expect(response).to be_successful
+      end
     end
 
-    context "with front matter" do
-      it "returns successfully" do
+    context "when logged-in + consistent rendering" do
+      before do
         sign_in user
+        allow(FeatureFlag).to receive(:enabled?).with(:consistent_rendering, any_args).and_return(true)
+      end
+
+      it "returns json" do
+        post "/articles/preview", headers: headers
+        expect(response.media_type).to eq("application/json")
+      end
+
+      it "returns successfully" do
         article_body = <<~MARKDOWN
           ---
           ---


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Use `ContentRenderer` when previewing comments and articles, if the `:consistent_rendering` feature flag is enabled.

## Related Tickets & Documents
- Related Issue #18649 #18650
- Closes #19099

## QA Instructions, Screenshots, Recordings
- enable the `:consistent_rendering` feature flag
- you should be able to preview articles and comments as usual

## Added/updated tests?
- [ ] Yes
- [x] No, and this is why: the behaviour was not changed, enabled the feature flag for a couple of tests
- [ ] I need help with writing tests
