### PR TITLE
Refactor 'controller:' to 'to:' in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -187,8 +187,8 @@ Rails.application.routes.draw do
 
     get "/social_previews/article/:id", to: "social_previews#article", as: :article_social_preview
 
-    get "/async_info/base_data", controller: "async_info#base_data", defaults: { format: :json }
-    get "/async_info/navigation_links", controller: "async_info#navigation_links"
+    get "/async_info/base_data", to: "async_info#base_data", defaults: { format: :json }
+    get "/async_info/navigation_links", to: "async_info#navigation_links"
 
     # Display ads
     scope "/:username/:slug" do


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We've defined routes in the following format: 

```
get "<route>", controller: "<controller_name><action>"
```
for example: 

```
get "/async_info/navigation_links", controller: "async_info#navigation_links
```

Whilst this route works and is an established pattern in our routes the `controller: "<controller_name>#<action>"` syntax _should not work_, however _it does_. 


## Related Tickets & Documents

- 💬 https://github.com/forem/forem/pull/19285#discussion_r1160668865
- Closes #19371 

## QA Instructions, Screenshots, Recordings

The changed routes are both pointing at `async_info`, so browser with `console`, `Network` tab, filter for `async_info` — confirm mobile / navigation / hamburger.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: covered by existing checks
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media2.giphy.com/media/kE8qQzL9WFwkM/giphy.gif?cid=ecf05e47tequrwq5x3chhu0zwn8l4r27vwurjlwsyjk8ytgk&rid=giphy.gif&ct=g)
