### PR TITLE
Maintain contrast for onboarding follower button

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -609,7 +609,6 @@ $onboarding-user-selected-hover: rgba(71, 85, 235, 0.2);
 
   label {
     @extend .crayons-field;
-    @extend .crayons-field__label;
 
     a {
       margin-top: 0;

--- a/app/javascript/onboarding/components/FollowUsers.jsx
+++ b/app/javascript/onboarding/components/FollowUsers.jsx
@@ -202,9 +202,7 @@ export class FollowUsers extends Component {
                     </div>
                     <label
                       className={`relative user-following-status crayons-btn ${
-                        selected
-                          ? 'color-base-inverted'
-                          : 'crayons-btn--outlined'
+                        selected ? 'color-primary' : 'crayons-btn--outlined'
                       }`}
                     >
                       <input


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If you navigate to `/onboarding`, the `Follow` / `Following` buttons for suggested follows don't appear to obey the "contrast rules" — things initially seem fine, but if followed, the text becomes much too dark. 

![gif](https://p-DgFRWr8y.t2.n0.cdn.getcloudapp.com/items/llu7W287/2cbfa097-be49-4326-8d62-e9f973ce718d.gif?v=5bb099852f2f0d9f9b760159f033c55f)

The button color setting comes from Admin > Customization > Config > User Experience & Brand > Primary brand color hex.

We [actually have a contrast validator](https://github.com/forem/forem/search?q=low_contrast%3F) that checks this brand color against "white text", but the text in these buttons becomes dark when unfocused.

I was able to track this down to the `.crayons-field__label` extension — without it, the text stays high-contrast white even when unfocused. This class _is_ used in other areas, but I think the bug is specific to onboarding. It's possible there are other ways to solve this, but this seems to work?

![better-gif](https://p-DgFRWr8y.t2.n0.cdn.getcloudapp.com/items/eDurKPel/7d33638e-7762-48c2-b4ea-0a72599084b0.gif?v=12efd79ddc4e25315647ae01e38553c8)

## Related Tickets & Documents

- Closes #19358

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: purely visual change
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media1.giphy.com/media/KGAzoSZ8sGvzrSPCFo/giphy.gif?cid=ecf05e475ndxszvg3q5ucq51dep6cycyapqhd5jfbv4x3pp3&rid=giphy.gif&ct=g)
