### PR TITLE
Tweak 'last step' random sampling to favor new ads

### DIFF
--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -19,6 +19,9 @@ class DisplayAd < ApplicationRecord
   MAX_TAG_LIST_SIZE = 10
   POST_WIDTH = 775
   SIDEBAR_WIDTH = 350
+  LOW_IMPRESSION_COUNT = 1_000
+  RARELY = (0...5) # 5 percent chance
+  SELDOM = (5...35) # 30 percent chance
 
   enum display_to: { all: 0, logged_in: 1, logged_out: 2 }, _prefix: true
   enum type_of: { in_house: 0, community: 1, external: 2 }
@@ -42,6 +45,8 @@ class DisplayAd < ApplicationRecord
                              search: "%#{term}%"
                      }
 
+  scope :seldom_seen, -> { where("impressions_count < ?", LOW_IMPRESSION_COUNT) }
+
   def self.for_display(area:, user_signed_in:, organization_id: nil, article_id: nil,
                        article_tags: [], permit_adjacent_sponsors: true)
     ads_for_display = DisplayAds::FilteredAdsQuery.call(
@@ -54,21 +59,25 @@ class DisplayAd < ApplicationRecord
       permit_adjacent_sponsors: permit_adjacent_sponsors,
     )
 
-    # Business Logic Context:
-    # We are always showing more of the good stuff — but we are also always testing the system to give any a chance to
-    # rise to the top. 1 out of every 8 times we show an ad (12.5%), it is totally random. This gives "not yet
-    # evaluated" stuff a chance to get some engagement and start showing up more. If it doesn't get engagement, it
-    # stays in this area.
-
-    # Ads that get engagement have a higher "success rate", and among this category, we sample from the top 15 that
-    # meet that criteria. Within those 15 top "success rates" likely to be clicked, there is a weighting towards the
-    # top ranked outcome as well, and a steady decline over the next 15 — that's because it's not "Here are the top 15
-    # pick one randomly", it is actually "Let's cut off the query at a random limit between 1 and 15 and sample from
-    # that". So basically the "limit" logic will result in 15 sets, and then we sample randomly from there. The
-    # "first ranked" ad will show up in all 15 sets, where as 15 will only show in 1 of the 15.
-    if rand(8) == 1
+    case rand(99) # output integer from 0-99
+    when RARELY # smallest range, 5%
+      # We are always showing more of the good stuff — but we are also always testing the system to give any a chance to
+      # rise to the top. 5 out of every 100 times we show an ad (5%), it is totally random. This gives "not yet
+      # evaluated" stuff a chance to get some engagement and start showing up more. If it doesn't get engagement, it
+      # stays in this area.
       ads_for_display.sample
-    else
+    when SELDOM # medium range, 30%
+      # Here we sample from only billboards with fewer than 1000 impressions (with a fallback
+      # if there are none of those, causing an extra query, but that shouldn't happen very often).
+      ads_for_display.seldom_seen.sample || ads_for_display.sample
+    else # large range, 65%
+
+      # Ads that get engagement have a higher "success rate", and among this category, we sample from the top 15 that
+      # meet that criteria. Within those 15 top "success rates" likely to be clicked, there is a weighting towards the
+      # top ranked outcome as well, and a steady decline over the next 15 — that's because it's not "Here are the top 15
+      # pick one randomly", it is actually "Let's cut off the query at a random limit between 1 and 15 and sample from
+      # that". So basically the "limit" logic will result in 15 sets, and then we sample randomly from there. The
+      # "first ranked" ad will show up in all 15 sets, where as 15 will only show in 1 of the 15.
       ads_for_display.limit(rand(1..15)).sample
     end
   end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We want to boost ad placements for new ads. This PR adjusts the "random sampling" logic that happens in `DisplayAd.for_display` from a 1/8 chance of a totally random ad to:

*    30% of views should go to "new" billboards, as defined by those from the filter step which also have fewer than 1000 impressions.
*    5% should still go to completely random, from the filter set.
*    The remaining random allotment goes towards that "top" tier.

## Related Tickets & Documents

- Related Issue #18870
- Closes #19302

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: we haven't historically tested this random sampling, possibly because testing random events isn't trivial
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media0.giphy.com/media/ToMjGpKniGqRNLGBrhu/giphy.gif?cid=ecf05e47dv3r3fjhkfxmlcsqv3bh105ii9hseupz1rsxp9tk&rid=giphy.gif&ct=g)
