### PR TITLE
Bullet and access policy fix for HtmlVariant admin page

### DIFF
--- a/app/controllers/admin/html_variants_controller.rb
+++ b/app/controllers/admin/html_variants_controller.rb
@@ -4,14 +4,17 @@ module Admin
 
     def index
       relation = if params[:state] == "mine"
-                   current_user.html_variants.order(created_at: :desc)
-                 elsif params[:state].present? && params[:state] != "admin"
-                   HtmlVariant.where(published: true, approved: true, group: params[:state]).order(created_at: :desc)
+                   current_user.html_variants
+                 elsif params[:state] == "admin"
+                   HtmlVariant.where(published: true, approved: false)
+                 elsif params[:state].present?
+                   HtmlVariant.where(published: true, approved: true, group: params[:state])
                  else
-                   HtmlVariant.where(published: true, approved: true).order(created_at: :desc)
+                   HtmlVariant.where(published: true, approved: true)
                  end
 
-      @html_variants = relation.includes(:user).page(params[:page]).per(30)
+      relation = relation.includes(:user) unless params[:state] == "mine"
+      @html_variants = relation.order(created_at: :desc).page(params[:page]).per(30)
     end
 
     def show


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While working on the UI interaction initializer, I ran into an issue where the `/admin/customization/html_variants?state=mine` page (which you get redirected to when you create an HTML variant) wouldn't load in development, which turned out to be Bullet complaining about a query.

In fixing that I also realised that the page was buggy (i.e. other admins could not see HTML variants that weren't yet approved, only the person that created them could see/approve them in the "mine" tab) so I fixed that as well + added better specs

We're moving off HTML variants entirely in the (fairly near-term?) future, but in the meantime they are still being used and this seemed like an easy enough win

## Related Tickets & Documents

N/A

## QA Instructions, Screenshots, Recordings

- Log in as an admin user
- Navigate to the HtmlVariant admin page (`/admin/customization/html_variants`)
- Create a new HTML variant (don't publish it)
  - It should show up in the "mine" tab (but not in any of the other tabs)
- Publish the variant (don't approve it)
  - It should show up in the "mine" and "admin" tabs (but not any of the other tabs)
- Approve the variant
  - It should show up in the default tab, the "mine" tab, and the tab for its group, but no longer in the "admin" tab

### UI accessibility concerns?

N/A

## Added/updated tests?

- [x] Yes
- [ ] No
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

Nope

## [optional] What gif best describes this PR or how it makes you feel?

![mr turner from fairly odd parents yelling Dinkleberg](https://user-images.githubusercontent.com/29291843/234312709-59dc2948-45a8-4d2f-9452-c780228289a9.gif)

