### PR TITLE
Follow all suggested users by default when onboarding

### DIFF
--- a/app/javascript/onboarding/components/FollowUsers.jsx
+++ b/app/javascript/onboarding/components/FollowUsers.jsx
@@ -27,7 +27,10 @@ export class FollowUsers extends Component {
     })
       .then((response) => response.json())
       .then((data) => {
-        this.setState({ users: data });
+        this.setState({
+          selectedUsers: data,
+          users: data,
+        });
       });
 
     const csrfToken = getContentOfToken('csrf-token');

--- a/testSetup.js
+++ b/testSetup.js
@@ -1,4 +1,4 @@
-/* eslint-env node */
+/* eslint-env jest, node */
 import 'jest-axe/extend-expect';
 import './app/assets/javascripts/lib/xss';
 
@@ -17,4 +17,31 @@ window.getComputedStyle = (elt) => getComputedStyle(elt);
 process.on('unhandledRejection', (error) => {
   // Errors thrown here are typically fetch responses that have not been mocked.
   throw error;
+});
+
+expect.extend({
+  /**
+   * This matcher tests if its subject is neither null nor undefined.
+   *
+   * Jest's `toBeDefined` only tests if its subject is *strictly* not the value
+   * `undefined`, which makes it unsuitable for testing if a value exists as the
+   * value might be `null` (which would pass a `toBeDefined` check).
+   *
+   * @param {any} subject The subject of the matcher
+   * @returns
+   */
+  toExist(subject) {
+    if (subject === null || subject === undefined) {
+      return {
+        pass: false,
+        message: () => `Expected ${this.utils.printReceived(subject)} to exist`,
+      };
+    }
+
+    return {
+      pass: true,
+      message: () =>
+        `Expected ${this.utils.printReceived(subject)} to not exist`,
+    };
+  },
 });


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Part of the onboarding process is a chance to follow some suggested users in that Forem.

Previously by default none of the suggested users were selected to be followed; now the default is that all the suggested users are selected. The user can still opt out with the Deselect all button.

I also updated the `FollowUsers` component's unit tests to properly test for elements' existence

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #19363 
- Closes #19363 

## QA Instructions, Screenshots, Recordings

- Create a new account and sign in
- Go through the onboarding flow
- Note that when you get to the "Suggested people to follow" section, all the suggested users are already selected

https://user-images.githubusercontent.com/29291843/236564539-08a1d495-4bc3-4fcf-8e58-1105e92f2c80.mp4

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

N/A (changes are only at the data layer)

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

Nope!

## [optional] What gif best describes this PR or how it makes you feel?

![Ed Sheeran singing "I want it all"](https://user-images.githubusercontent.com/29291843/236565091-34280ee1-0711-49c5-8845-0814212511be.gif)

