### PR TITLE
Design fixes for home feed comments

### DIFF
--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -25,10 +25,18 @@
 
   &__body {
     padding-left: var(--su-7);
-    width: 100%;
+    width: calc(100% - var(--su-7));
     background: var(--card-tertiary-bg);
     &:hover {
       background: var(--card-tertiary-bg-hover);
+    }
+
+    @media (min-width: 480px) {
+      width: 120px;
+    }
+
+    @media (min-width: $breakpoint-m) {
+      width: calc(100% - var(--su-7));
     }
 
     border-radius: var(--radius);
@@ -45,10 +53,10 @@
       .c-embed__body {
         font-size: var(--fs-s);
       }
-      div:not(.crayons-comment__readmore) {
-        margin-bottom: var(--su-3);
-        background: var(--card-secondary-bg);
-      }
+      // div:not(.crayons-comment__readmore) {
+      //   margin-bottom: var(--su-3);
+      //   background: var(--card-secondary-bg);
+      // }
       .liquid-comment .body {
         :not(:first-child) {
           display: none;
@@ -61,6 +69,12 @@
       blockquote {
         border-left: 4px solid var(--base-20);
         padding-left: var(--su-2);
+      }
+      pre:not(.highlight),
+      div.highlight,
+      li pre.highlight,
+      blockquote pre.highlight {
+        padding: var(--su-2);
       }
     }
     .crayons-comment__readmore {

--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -53,9 +53,11 @@
       .c-embed__body {
         font-size: var(--fs-s);
       }
-      div:not(.crayons-comment__readmore):not(.highlight__panel-action):not(
-          .highlight__panel
-        ):not(.highlight) {
+      div
+        :not(.crayons-comment__readmore)
+        :not(.highlight__panel-action)
+        :not(.highlight__panel)
+        :not(.highlight) {
         background: var(--card-secondary-bg);
       }
       div:not(.crayons-comment__readmore) {

--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -53,6 +53,14 @@
       .c-embed__body {
         font-size: var(--fs-s);
       }
+      div:not(.crayons-comment__readmore):not(.highlight):not(
+          .highlight__panel
+        ):not(.highlight__panel-action) {
+        background: var(--card-secondary-bg);
+      }
+      div:not(.crayons-comment__readmore) {
+        margin-bottom: var(--su-3);
+      }
       .liquid-comment .body {
         :not(:first-child) {
           display: none;

--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -31,10 +31,6 @@
       background: var(--card-tertiary-bg-hover);
     }
 
-    @media (min-width: 480px) {
-      width: 120px;
-    }
-
     @media (min-width: $breakpoint-m) {
       width: calc(100% - var(--su-7));
     }

--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -53,10 +53,6 @@
       .c-embed__body {
         font-size: var(--fs-s);
       }
-      // div:not(.crayons-comment__readmore) {
-      //   margin-bottom: var(--su-3);
-      //   background: var(--card-secondary-bg);
-      // }
       .liquid-comment .body {
         :not(:first-child) {
           display: none;

--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -53,9 +53,9 @@
       .c-embed__body {
         font-size: var(--fs-s);
       }
-      div:not(.crayons-comment__readmore):not(.highlight):not(
+      div:not(.crayons-comment__readmore):not(.highlight__panel-action):not(
           .highlight__panel
-        ):not(.highlight__panel-action) {
+        ):not(.highlight) {
         background: var(--card-secondary-bg);
       }
       div:not(.crayons-comment__readmore) {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

@anujbhavsar96 noticed that the code-block UI in comments on home-feed card overflows and because of which the design looks bad.
![Screenshot 2023-05-08 at 9 37 07 AM](https://user-images.githubusercontent.com/9396084/236745694-01a5f2e7-6dad-402c-931d-18f196b6d5d1.png)

Slack communication: https://forem-team.slack.com/archives/C7GE84DEJ/p1683519258722579

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #19415

## QA Instructions, Screenshots, Recordings

**How to test?**
1. Open `app/models/article.rb` and change logic in `has_many :top_comments,`, basically change `comments: { score: 0.. }`
2. Copy dummy content for comments from here: https://gist.github.com/rt4914/ca54375f012ff25ebd5f39dc7dd83dcc
3. You can post this comment on any post locally. Maybe past it on 2/3 posts so that you can easily find it in home-feed.
4. Once you have added comment on any post, open home feed and check that comment on various screen sizes and notice that it works now.


| Before  | After |
| ------------- | ------------- |
| <img width="469" alt="Screenshot 2023-05-08 at 11 26 19 AM" src="https://user-images.githubusercontent.com/9396084/236746636-d6821cba-cfa2-4a23-89cd-35f0a24d0fb7.png"> | <img width="491" alt="Screenshot 2023-05-08 at 11 23 34 AM" src="https://user-images.githubusercontent.com/9396084/236746599-3aa6dcbf-767b-4b3c-9716-cb2dca9dd303.png"> |
| <img width="611" alt="Screenshot 2023-05-08 at 11 26 39 AM" src="https://user-images.githubusercontent.com/9396084/236746800-483e1ba2-7cc0-402d-aff3-cbe5df5b9693.png"> | <img width="617" alt="Screenshot 2023-05-08 at 11 23 59 AM" src="https://user-images.githubusercontent.com/9396084/236746717-e2213cde-5fab-4c5d-9744-f9bafdf4ebf9.png"> |
| <img width="803" alt="Screenshot 2023-05-08 at 11 26 57 AM" src="https://user-images.githubusercontent.com/9396084/236746927-db0dba34-52d2-47a1-bde3-c2a9484e9e55.png"> | <img width="798" alt="Screenshot 2023-05-08 at 11 24 16 AM" src="https://user-images.githubusercontent.com/9396084/236746905-4871a1bb-c7a8-402f-aee4-f38e9d51026d.png"> |
| <img width="1016" alt="Screenshot 2023-05-08 at 11 27 42 AM" src="https://user-images.githubusercontent.com/9396084/236747145-5e9b056b-5a8b-43fd-8a24-62a5e0c4fe17.png"> | <img width="1013" alt="Screenshot 2023-05-08 at 11 24 38 AM" src="https://user-images.githubusercontent.com/9396084/236747011-5445216f-26f2-41cb-b174-0fb89a5196fd.png"> |
| <img width="587" alt="Screenshot 2023-05-08 at 11 28 05 AM" src="https://user-images.githubusercontent.com/9396084/236747380-39a30ed4-6196-4022-b00f-98a2aa7b514b.png"> | <img width="549" alt="Screenshot 2023-05-08 at 11 28 28 AM" src="https://user-images.githubusercontent.com/9396084/236747389-48e0b6b1-845a-4dbf-86a4-51e93a00c95f.png"> |


### UI accessibility concerns?

No

## Added/updated tests?

- [x] No
