### PR TITLE
Rename cache-key in ApplicationHelper#tag_colors

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -150,7 +150,7 @@ module ApplicationHelper
   end
 
   def tag_colors(tag)
-    Rails.cache.fetch("view-helper-#{tag}/tag_colors", expires_in: 5.hours) do
+    Rails.cache.fetch("tag/#{tag}/colors", expires_in: 5.hours) do
       if (found_tag = Tag.select(%i[bg_color_hex text_color_hex]).find_by(name: tag))
         { background: found_tag.bg_color_hex, color: found_tag.text_color_hex }
       else


### PR DESCRIPTION
## What type of PR is this?

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Ｗe want to have better cache key convention. Let's step by step~

The `tag` itself is a string, so there is no way to use the `cache_key` method.

But I think we can still match the new convention, so that the cache key has the same format

```ruby
Product.new.cache_key     # => "products/new"
Product.find(5).cache_key # => "products/5"
Product.find(5).cache_key_with_version # => "products/5-20071224150000"

# This key would looks like
"tag/beginners/colors"
```

## Related Tickets & Documents

- Related Issue #19102

## Added/updated tests?

- [x] No, because they aren't needed