### PR TITLE
Try to fix mangled github image embed

### DIFF
--- a/app/services/html/image_uri.rb
+++ b/app/services/html/image_uri.rb
@@ -1,0 +1,18 @@
+module Html
+  class ImageUri
+    GITHUB_CAMO = "camo.githubusercontent.com".freeze
+
+    attr_reader :uri, :original_source
+
+    delegate :scheme, :host, to: :uri
+
+    def initialize(src)
+      @uri = URI(src)
+      @original_source = src
+    end
+
+    def github_camo_user_content?
+      scheme == "https" && host == GITHUB_CAMO
+    end
+  end
+end

--- a/app/services/html/image_uri.rb
+++ b/app/services/html/image_uri.rb
@@ -1,18 +1,41 @@
 module Html
   class ImageUri
-    GITHUB_CAMO = "camo.githubusercontent.com".freeze
+    GITHUB_CAMO = {
+        scheme: "https",
+        host: "camo.githubusercontent.com"
+      }.freeze
+
+    GITHUB_BADGE = {
+      scheme: "https",
+      host: "github.com",
+      filename: "badge.svg"
+    }
 
     attr_reader :uri, :original_source
-
-    delegate :scheme, :host, to: :uri
+    delegate :scheme, :host, :path, to: :uri
 
     def initialize(src)
       @uri = URI(src)
       @original_source = src
     end
 
+    def allowed?
+      github_camo_user_content? || github_badge?
+    end
+
+    def github_badge?
+      scheme == GITHUB_BADGE[:scheme] &&
+      host == GITHUB_BADGE[:host] &&
+      filename == GITHUB_BADGE[:filename]
+    end
+
     def github_camo_user_content?
-      scheme == "https" && host == GITHUB_CAMO
+      scheme == GITHUB_CAMO[:scheme] && host == GITHUB_CAMO[:host]
+    end
+
+    private
+    def filename
+      File.basename path
     end
   end
 end

--- a/app/services/html/image_uri.rb
+++ b/app/services/html/image_uri.rb
@@ -1,17 +1,18 @@
 module Html
   class ImageUri
     GITHUB_CAMO = {
-        scheme: "https",
-        host: "camo.githubusercontent.com"
-      }.freeze
+      scheme: "https",
+      host: "camo.githubusercontent.com"
+    }.freeze
 
     GITHUB_BADGE = {
       scheme: "https",
       host: "github.com",
       filename: "badge.svg"
-    }
+    }.freeze
 
     attr_reader :uri, :original_source
+
     delegate :scheme, :host, :path, to: :uri
 
     def initialize(src)
@@ -25,8 +26,8 @@ module Html
 
     def github_badge?
       scheme == GITHUB_BADGE[:scheme] &&
-      host == GITHUB_BADGE[:host] &&
-      filename == GITHUB_BADGE[:filename]
+        host == GITHUB_BADGE[:host] &&
+        filename == GITHUB_BADGE[:filename]
     end
 
     def github_camo_user_content?
@@ -34,6 +35,7 @@ module Html
     end
 
     private
+
     def filename
       File.basename path
     end

--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -270,8 +270,8 @@ module Html
     end
 
     def allowed_image_host?(src)
-      # GitHub camo image won't parse but should be safe to host direct
-      src.start_with?("https://camo.githubusercontent.com")
+      image = ImageUri.new(src)
+      image.github_camo_user_content?
     end
 
     def user_link_if_exists(mention)

--- a/app/services/html/parser.rb
+++ b/app/services/html/parser.rb
@@ -270,8 +270,7 @@ module Html
     end
 
     def allowed_image_host?(src)
-      image = ImageUri.new(src)
-      image.github_camo_user_content?
+      ImageUri.new(src).allowed?
     end
 
     def user_link_if_exists(mention)

--- a/spec/services/html/image_uri_spec.rb
+++ b/spec/services/html/image_uri_spec.rb
@@ -1,8 +1,8 @@
-# https://github.com/forem/forem/actions/workflows/ci-cd.yml/badge.svg?branch=depfu/update/sterile-1.0.24
 require "rails_helper"
 
 RSpec.describe Html::ImageUri, type: :service do
   let(:camo) { "https://camo.githubusercontent.com/64b9f7c7c5f41ec22113b61235256435cd61779a0554b0595b88b6011f94c60b/68747470733a2f2f696d672e736869656c64732e696f2f6769746875622f636f6d6d69742d61637469766974792f772f666f72656d2f666f72656d" }
+  let(:badge) { "https://github.com/forem/forem/actions/workflows/ci-cd.yml/badge.svg?branch=depfu/update/sterile-1.0.24" }
   let(:giphy) { "https://media.giphy.com/media/3ow0TN2M8TH2aAn67F/giphy.gif" }
   let(:other) { "https://image.com/image.jpg" }
 
@@ -10,10 +10,28 @@ RSpec.describe Html::ImageUri, type: :service do
     image = described_class.new(camo)
     expect(image).to be_github_camo_user_content
 
+    image = described_class.new(badge)
+    expect(image).not_to be_github_camo_user_content
+
     image = described_class.new(giphy)
     expect(image).not_to be_github_camo_user_content
 
     image = described_class.new(other)
     expect(image).not_to be_github_camo_user_content
   end
+
+  it "can detect github hosted badge" do
+    image = described_class.new(badge)
+    expect(image).to be_github_badge
+
+    image = described_class.new(camo)
+    expect(image).not_to be_github_badge
+
+    image = described_class.new(giphy)
+    expect(image).not_to be_github_badge
+
+    image = described_class.new(other)
+    expect(image).not_to be_github_badge
+  end
+
 end

--- a/spec/services/html/image_uri_spec.rb
+++ b/spec/services/html/image_uri_spec.rb
@@ -1,0 +1,19 @@
+# https://github.com/forem/forem/actions/workflows/ci-cd.yml/badge.svg?branch=depfu/update/sterile-1.0.24
+require "rails_helper"
+
+RSpec.describe Html::ImageUri, type: :service do
+  let(:camo) { "https://camo.githubusercontent.com/64b9f7c7c5f41ec22113b61235256435cd61779a0554b0595b88b6011f94c60b/68747470733a2f2f696d672e736869656c64732e696f2f6769746875622f636f6d6d69742d61637469766974792f772f666f72656d2f666f72656d" }
+  let(:giphy) { "https://media.giphy.com/media/3ow0TN2M8TH2aAn67F/giphy.gif" }
+  let(:other) { "https://image.com/image.jpg" }
+
+  it "can detect camo.github hosted image" do
+    image = described_class.new(camo)
+    expect(image).to be_github_camo_user_content
+
+    image = described_class.new(giphy)
+    expect(image).not_to be_github_camo_user_content
+
+    image = described_class.new(other)
+    expect(image).not_to be_github_camo_user_content
+  end
+end

--- a/spec/services/html/image_uri_spec.rb
+++ b/spec/services/html/image_uri_spec.rb
@@ -33,5 +33,4 @@ RSpec.describe Html::ImageUri, type: :service do
     image = described_class.new(other)
     expect(image).not_to be_github_badge
   end
-
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There's a subtle problem with GitHub embeds, that's emerging now that we're generally [rendering things consistently](#19091). The mangled images are generally `badge.svg` — the images that are generated from repository CI/CD checks. As a general rule, when embedding, we try to pre-process images to better fit our layout. We exempt `camo.githubusercontent.com` from much of this pre-processing, as we generally trust content coming from github. 

We either need to similarly exempt these badges, or we need pre-processing that does not mangle SVGs. 

## Related Tickets & Documents

- Related Issue #19359

## QA Instructions, Screenshots, Recordings

This can be tricky to replicate, as the local development environment generally does not do any of the image pre-processing. It can be best seen on canary, although the pre-processing there differs from what's done on Dev. You can test this by creating a DisplayAd with an embedded GitHub repo that has a CI/CD badge. (The [original issue](#19359) is a failing badge, but the bug also happens for passing badges, so you don't need to replicate a failing CI. [Here is an example of a mangled image.](https://canary1.forem.lol/images/66U7YQNKLK4Lz4-u9nDVbT_QT_M1iahl-lhVqZxCGZ8/w:775/mb:500000/ar:1/aHR0cHM6Ly9naXRo/dWIuY29tL2ZvcmVt/L2ZvcmVtL2FjdGlv/bnMvd29ya2Zsb3dz/L2NpLWNkLnltbC9i/YWRnZS5zdmc)

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media0.giphy.com/media/l0NwNrl4BtDD7JCx2/giphy.gif?cid=ecf05e47lcukc915oya311ixooj0a504pi733u865iq2bdi1&ep=v1_gifs_search&rid=giphy.gif&ct=g)
