### PR TITLE
Remove manual user follow suggestions

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,6 @@ class UsersController < ApplicationController
                 only: %i[update update_password request_destroy full_delete remove_identity]
   after_action :verify_authorized,
                except: %i[index signout_confirm add_org_admin remove_org_admin remove_from_org confirm_destroy]
-  before_action :set_suggested_users, only: %i[index]
   before_action :initialize_stripe, only: %i[edit]
 
   INDEX_ATTRIBUTES_FOR_SERIALIZATION = %i[id name username summary profile_image].freeze
@@ -255,23 +254,11 @@ class UsersController < ApplicationController
 
   private
 
-  def set_suggested_users
-    @suggested_users = Settings::General.suggested_users
-  end
-
-  def default_suggested_users
-    @default_suggested_users ||= User.includes(:profile).where(username: @suggested_users)
-  end
-
   def determine_follow_suggestions(current_user)
-    return default_suggested_users if Settings::General.prefer_manual_suggested_users? && default_suggested_users
-
-    recent_suggestions = Users::SuggestRecent.call(
+    Users::SuggestRecent.call(
       current_user,
       attributes_to_select: INDEX_ATTRIBUTES_FOR_SERIALIZATION,
     )
-
-    recent_suggestions.presence || default_suggested_users
   end
 
   def handle_organization_tab

--- a/app/lib/constants/settings/general.rb
+++ b/app/lib/constants/settings/general.rb
@@ -114,13 +114,6 @@ module Constants
             description: I18n.t("lib.constants.settings.general.tags.description"),
             placeholder: I18n.t("lib.constants.settings.general.tags.placeholder")
           },
-          suggested_users: {
-            description: I18n.t("lib.constants.settings.general.users.description"),
-            placeholder: I18n.t("lib.constants.settings.general.users.placeholder")
-          },
-          prefer_manual_suggested_users: {
-            description: I18n.t("lib.constants.settings.general.prefer_manual.description")
-          },
           twitter_hashtag: {
             description: I18n.t("lib.constants.settings.general.hashtag.description"),
             placeholder: I18n.t("lib.constants.settings.general.hashtag.placeholder")

--- a/app/models/settings/general.rb
+++ b/app/models/settings/general.rb
@@ -86,8 +86,6 @@ module Settings
     # Onboarding
     setting :onboarding_background_image, type: :string, validates: { url: true, unless: -> { value.blank? } }
     setting :suggested_tags, type: :array, default: %w[]
-    setting :suggested_users, type: :array, default: %w[]
-    setting :prefer_manual_suggested_users, type: :boolean, default: false
 
     # Social Media
     setting :social_media_handles, type: :hash, default: {

--- a/app/services/settings/general/upsert.rb
+++ b/app/services/settings/general/upsert.rb
@@ -1,7 +1,7 @@
 module Settings
   class General
     module Upsert
-      PARAMS_TO_BE_CLEANED = %i[sidebar_tags suggested_tags suggested_users].freeze
+      PARAMS_TO_BE_CLEANED = %i[sidebar_tags suggested_tags].freeze
       TAG_PARAMS = %w[sidebar_tags suggested_tags].freeze
 
       def self.call(settings)

--- a/app/views/admin/settings/forms/_onboarding.html.erb
+++ b/app/views/admin/settings/forms/_onboarding.html.erb
@@ -27,25 +27,6 @@
                            value: Settings::General.suggested_tags.join(","),
                            placeholder: Constants::Settings::General.details[:suggested_tags][:placeholder] %>
         </div>
-
-        <div class="crayons-field">
-          <%= admin_config_label :suggested_users %>
-          <%= admin_config_description Constants::Settings::General.details[:suggested_users][:description] %>
-          <%= f.text_field :suggested_users,
-                           class: "crayons-textfield",
-                           value: Settings::General.suggested_users.join(","),
-                           placeholder: Constants::Settings::General.details[:suggested_users][:placeholder] %>
-        </div>
-
-        <div class="crayons-field crayons-field--checkbox">
-          <%= f.check_box :prefer_manual_suggested_users, checked: Settings::General.prefer_manual_suggested_users, class: "crayons-checkbox" %>
-          <div class="mt-0">
-            <%= admin_config_label :prefer_manual_suggested_users %>
-            <p class="crayons-field__description">
-            <%= Constants::Settings::General.details[:prefer_manual_suggested_users][:description] %>
-            </p>
-          </div>
-        </div>
       </fieldset>
       <%= render "update_setting_button", f: f %>
     </div>

--- a/spec/requests/admin/configs_spec.rb
+++ b/spec/requests/admin/configs_spec.rb
@@ -427,40 +427,6 @@ RSpec.describe "/admin/customization/config" do
           }
           expect(Settings::General.suggested_tags).to eq(%w[hey haha hoho bobofofo])
         end
-
-        it "removes space suggested_users" do
-          post admin_settings_general_settings_path, params: {
-            settings_general: {
-              suggested_users: "piglet, tigger,eeyore, Christopher Robin, kanga,roo"
-            }
-          }
-          expect(Settings::General.suggested_users).to eq(%w[piglet tigger eeyore christopherrobin kanga roo])
-        end
-
-        it "downcases suggested_users" do
-          post admin_settings_general_settings_path, params: {
-            settings_general: {
-              suggested_users: "piglet, tigger,EEYORE, Christopher Robin, KANGA,RoO"
-            }
-          }
-          expect(Settings::General.suggested_users).to eq(%w[piglet tigger eeyore christopherrobin kanga roo])
-        end
-
-        it "updates prefer_manual_suggested_users to true" do
-          prefer_manual = true
-          post admin_settings_general_settings_path, params: {
-            settings_general: { prefer_manual_suggested_users: prefer_manual }
-          }
-          expect(Settings::General.prefer_manual_suggested_users).to eq(prefer_manual)
-        end
-
-        it "updates prefer_manual_suggested_users to false" do
-          prefer_manual = false
-          post admin_settings_general_settings_path, params: {
-            settings_general: { prefer_manual_suggested_users: prefer_manual }
-          }
-          expect(Settings::General.prefer_manual_suggested_users).to eq(prefer_manual)
-        end
       end
 
       describe "Rate Limits and spam" do

--- a/spec/requests/user/user_suggestions_spec.rb
+++ b/spec/requests/user/user_suggestions_spec.rb
@@ -3,19 +3,6 @@ require "rails_helper"
 RSpec.describe "Users" do
   describe "GET /users" do
     let(:user) { create(:user, username: "Sloan") }
-    let!(:suggested_users_list) { %w[eeyore] }
-    let!(:suggested_user_profile) do
-      create(
-        :profile,
-        user: create(:user, :without_profile, username: "eeyore", name: "Eeyore"),
-        summary: "I am always sad",
-      )
-    end
-    let!(:suggested_user) { suggested_user_profile.user }
-
-    before do
-      allow(Settings::General).to receive(:suggested_users).and_return(suggested_users_list)
-    end
 
     context "when no state params are present" do
       it "returns no users" do
@@ -28,20 +15,13 @@ RSpec.describe "Users" do
     end
 
     context "when follow_suggestions params are present and no suggestions are found" do
-      it "returns the default suggested_users from Settings::General if they are present" do
+      it "returns an empty array (no automated suggested follow)" do
         sign_in user
 
         get users_path(state: "follow_suggestions")
 
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body.first).to include(
-          "id" => suggested_user.id,
-          "name" => suggested_user.name,
-          "username" => suggested_user.username,
-          "summary" => suggested_user.profile.summary,
-          "profile_image_url" => suggested_user.profile_image_url_for(length: 90),
-          "following" => false,
-        )
+        expect(response.parsed_body).to eq([])
       end
     end
 
@@ -72,24 +52,6 @@ RSpec.describe "Users" do
 
         response_user = response.parsed_body.first
         expect(response_user["profile_image_url"]).to eq(other_user.profile_image_url)
-      end
-
-      it "returns the default suggested_users from Settings::General if prefer_manual_suggested_users is true" do
-        allow(Settings::General).to receive(:prefer_manual_suggested_users).and_return(true)
-
-        sign_in user
-
-        get users_path(state: "follow_suggestions")
-
-        expect(response).to have_http_status(:ok)
-        expect(response.parsed_body.first).to include(
-          "id" => suggested_user.id,
-          "name" => suggested_user.name,
-          "username" => suggested_user.username,
-          "summary" => suggested_user.profile.summary,
-          "profile_image_url" => suggested_user.profile_image_url_for(length: 90),
-          "following" => false,
-        )
       end
     end
 

--- a/spec/system/articles/user_edits_an_article_spec.rb
+++ b/spec/system/articles/user_edits_an_article_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "Editing with an editor", js: true do
     allow(Settings::General).to receive(:logo_png).and_return("https://dummyimage.com/800x600.png")
     allow(Settings::General).to receive(:mascot_image_url).and_return("https://dummyimage.com/800x600.jpg")
     allow(Settings::General).to receive(:suggested_tags).and_return("coding, beginners")
-    allow(Settings::General).to receive(:suggested_users).and_return("romagueramica")
     sign_in user
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

During `/onboarding`, users are shown a list of users that we recommend they follow. This list is composed by mixing ["recent users"](https://github.com/forem/forem/blob/b09b0207c6b0f3ad32e33452f39ebaf73e1a60e6/app/services/users/suggest_recent.rb) and [admin-defined / manually-curated users](https://github.com/forem/forem/blob/main/app/views/admin/settings/forms/_onboarding.html.erb#L31-L47). This PR removes the latter, removing manual curation for onboarding suggested user follows.

## Related Tickets & Documents

- Closes #19413

## QA Instructions, Screenshots, Recordings

QA via `/onboarding`


## Added/updated tests?

- [x] Yes - modifed
- [ ] No, and this is why: 
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media1.giphy.com/media/hLamfZDW93H7G/giphy.gif?cid=ecf05e47qqjcyiasezs759b1fsbayfzcsz9bcqzt8cf9lt9h&ep=v1_gifs_related&rid=giphy.gif&ct=g)
