### PR TITLE
Notify mod on new user articles

### DIFF
--- a/app/helpers/notifications_helper.rb
+++ b/app/helpers/notifications_helper.rb
@@ -34,7 +34,7 @@ module NotificationsHelper
       )
     else
       I18n.t(action, user: key_to_link.call("user"))
-    end.html_safe # rubocop:disable Rails/OutputSafety
+    end.html_safe
   end
 
   def mod_comment_user(data)
@@ -42,5 +42,12 @@ module NotificationsHelper
 
     comment_username = data["comment"]["path"].split("/")[1]
     { "name" => comment_username, "path" => "/#{comment_username}" }
+  end
+
+  def mod_article_user(data)
+    return data["article_user"] if data["article_user"].present?
+
+    article_username = data["article"]["path"].split("/")[1]
+    { "name" => article_username, "path" => "/#{article_username}" }
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -608,7 +608,7 @@ class Article < ApplicationRecord
     # using nth_published because it doesn't count draft articles by the new author
     return if nth_published_by_author > 2
 
-    Notification.send_moderation_notification(self)
+    Notification.send_article_moderation_notification(self)
   end
 
   private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -608,7 +608,7 @@ class Article < ApplicationRecord
     # using nth_published because it doesn't count draft articles by the new author
     return if nth_published_by_author > 2
 
-    Notification.send_article_moderation_notification(self)
+    Notification.send_moderation_notification(self)
   end
 
   private

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -101,7 +101,6 @@ class Notification < ApplicationRecord
     end
 
     def send_moderation_notification(notifiable)
-      # TODO: make this work for articles in the future. only works for comments right now
       return unless notifiable.commentable
       return if UserBlock.blocking?(notifiable.commentable.user_id, notifiable.user_id)
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -104,7 +104,13 @@ class Notification < ApplicationRecord
       return unless notifiable.commentable
       return if UserBlock.blocking?(notifiable.commentable.user_id, notifiable.user_id)
 
-      Notifications::CreateRoundRobinModerationNotificationsWorker.perform_async(notifiable.id)
+      Notifications::CreateRoundRobinModerationNotificationsWorker.perform_async(notifiable.id, "Comment")
+    end
+
+    def send_article_moderation_notification(article)
+      return unless article.instance_of?(Article)
+
+      Notifications::CreateRoundRobinModerationNotificationsWorker.perform_async(article.id, "Article")
     end
 
     def send_tag_adjustment_notification(tag_adjustment)

--- a/app/services/notifications/moderation/send.rb
+++ b/app/services/notifications/moderation/send.rb
@@ -3,7 +3,7 @@ module Notifications
   module Moderation
     MODERATORS_AVAILABILITY_DELAY = 22.hours
     class Send
-      SUPPORTED = [Comment].freeze
+      SUPPORTED = [Comment, Article].freeze
 
       def self.call(...)
         new(...).call
@@ -14,7 +14,7 @@ module Notifications
         @notifiable = notifiable
       end
 
-      delegate :user_data, :comment_data, to: Notifications
+      delegate :user_data, :comment_data, :article_data, to: Notifications
 
       def call
         # notifiable is currently only comment

--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -3,7 +3,7 @@
   <%= render "notifications/shared/profile_pic", json_data: json_data %>
 
   <div class="notification__content">
-    <% if notification.action.blank? %>
+    <% if notification.action == "Published" %>
       <header class="mb-4">
         <h2 class="fs-base fw-normal">
           <%= message_user_acted_maybe_org(json_data, "views.notifications.new_post.verb_html", if_org: "views.notifications.new_post.if_org_html") %>

--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -3,22 +3,24 @@
   <%= render "notifications/shared/profile_pic", json_data: json_data %>
 
   <div class="notification__content">
-    <header class="mb-4">
-      <h2 class="fs-base fw-normal">
-        <%= message_user_acted_maybe_org(json_data, "views.notifications.new_post.verb_html", if_org: "views.notifications.new_post.if_org_html") %>
-      </h2>
-      <p class="lh-tight"><small class="fs-s color-base-60"><%= time_ago_in_words json_data["article"]["published_at"], scope: :"datetime.distance_in_words_ago" %></small></p>
-    </header>
+    <% if notification.action.blank? %>
+      <header class="mb-4">
+        <h2 class="fs-base fw-normal">
+          <%= message_user_acted_maybe_org(json_data, "views.notifications.new_post.verb_html", if_org: "views.notifications.new_post.if_org_html") %>
+        </h2>
+        <p class="lh-tight"><small class="fs-s color-base-60"><%= time_ago_in_words json_data["article"]["published_at"], scope: :"datetime.distance_in_words_ago" %></small></p>
+      </header>
 
-    <%= render "notifications/shared/article_preview", json_data: json_data, notification: notification, context: "default" %>
-
-    <% if notification.action == "Moderation" %>
+      <%= render "notifications/shared/article_preview", json_data: json_data, notification: notification, context: "default" %>
+    <% elsif notification.action == "Moderation" %>
       <% new_user = mod_article_user(json_data) %>
       <header class="mb-4">
         <h2 class="fs-xl"><%= t("views.notifications.article.mod_greeting", user: @user.name) %></h2>
         <p class="mb-4"><%= t("views.notifications.article.welcome_html", user: new_user["name"]) %></p>
         <p><%= t("views.notifications.article.published_html", user: link_to(new_user["name"], new_user["path"], class: "crayons-link fw-bold"), title: link_to(h(json_data["article"]["title"]), json_data["article"]["path"], class: "crayons-link fw-bold")) %></p>
       </header>
+
+      <%= render "notifications/shared/article_preview", json_data: json_data, notification: notification, context: "default" %>
 
       <div class="flex justify-between fs-s color-base-60 pt-4">
         <p><%= t("views.notifications.article.mod_opt_out") %></p>

--- a/app/views/notifications/_article.html.erb
+++ b/app/views/notifications/_article.html.erb
@@ -11,5 +11,19 @@
     </header>
 
     <%= render "notifications/shared/article_preview", json_data: json_data, notification: notification, context: "default" %>
+
+    <% if notification.action == "Moderation" %>
+      <% new_user = mod_article_user(json_data) %>
+      <header class="mb-4">
+        <h2 class="fs-xl"><%= t("views.notifications.article.mod_greeting", user: @user.name) %></h2>
+        <p class="mb-4"><%= t("views.notifications.article.welcome_html", user: new_user["name"]) %></p>
+        <p><%= t("views.notifications.article.published_html", user: link_to(new_user["name"], new_user["path"], class: "crayons-link fw-bold"), title: link_to(h(json_data["article"]["title"]), json_data["article"]["path"], class: "crayons-link fw-bold")) %></p>
+      </header>
+
+      <div class="flex justify-between fs-s color-base-60 pt-4">
+        <p><%= t("views.notifications.article.mod_opt_out") %></p>
+        <%= link_to t("views.notifications.article.change_settings"), user_settings_path(:notifications) %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/workers/notifications/create_round_robin_moderation_notifications_worker.rb
+++ b/app/workers/notifications/create_round_robin_moderation_notifications_worker.rb
@@ -6,17 +6,21 @@ module Notifications
 
     MODERATOR_SAMPLE_SIZE = 4
 
-    def perform(notifiable_id)
+    def perform(notifiable_id, notifiable_type)
       random_moderators = Users::SelectModeratorsQuery.call.order(Arel.sql("RANDOM()"))
         .first(MODERATOR_SAMPLE_SIZE)
       return unless random_moderators.any?
 
-      # notifiable is currently only comment
-      notifiable = Comment.find_by(id: notifiable_id)
-      return unless notifiable
+      if notifiable_type == "Comment"
+        notifiable = Comment.find_by(id: notifiable_id)
+        # return if it's a comment whose commentable has been deleted
+        return unless notifiable.commentable
 
-      # return if it's a comment whose commentable has been deleted
-      return unless notifiable.commentable
+      elsif notifiable_type == "Article"
+        notifiable = Article.find_by(id: notifiable_id)
+      end
+
+      return unless notifiable
 
       random_moderators.each do |mod|
         next if mod == notifiable.user

--- a/config/locales/views/notifications/en.yml
+++ b/config/locales/views/notifications/en.yml
@@ -7,6 +7,12 @@ en:
         og:
           title: Notifications - %{community}
       heading: Notifications
+      article:
+        published_html: "%{user} published %{title}"
+        mod_greeting: "Hey %{user} 👋"
+        welcome_html: "%{user} is new to the community. Please drop a nice reply to make them feel welcome."
+        mod_opt_out: Don't want to receive these notifications?
+        change_settings: Change settings
       badge:
         heading_html: You received the %{badge} badge
         awarded_html: "You also get %{credits} to use for %{listings} if you have anything you'd like to promote. 🎉"

--- a/config/locales/views/notifications/en.yml
+++ b/config/locales/views/notifications/en.yml
@@ -10,7 +10,7 @@ en:
       article:
         published_html: "%{user} published %{title}"
         mod_greeting: "Hey %{user} 👋"
-        welcome_html: "%{user} is new to the community. Please drop a nice reply to make them feel welcome."
+        welcome_html: "%{user} is new to the community. Please check out their post and drop a nice reply to make them feel welcome!"
         mod_opt_out: Don't want to receive these notifications?
         change_settings: Change settings
       badge:

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -173,13 +173,13 @@ RSpec.describe "NotificationsIndex" do
     end
 
     context "when a user has new reaction notifications" do
-      let(:article1)                   { create(:article, user_id: user.id) }
-      let(:article2)                   { create(:article, user_id: user.id) }
+      let(:first_article) { create(:article, user_id: user.id) }
+      let(:second_article) { create(:article, user_id: user.id) }
       let(:special_characters_article) { create(:article, user_id: user.id, title: "What's Become of Waring") }
 
       before { sign_in user }
 
-      def mock_heart_reaction_notifications(amount, categories, reactable = article1)
+      def mock_heart_reaction_notifications(amount, categories, reactable = first_article)
         create_list(:user, amount)
         reactions = User.last(amount).map do |user|
           create(
@@ -223,8 +223,8 @@ RSpec.describe "NotificationsIndex" do
       end
 
       it "does not group notifications that are on the same day but have different reactables" do
-        mock_heart_reaction_notifications(1, %w[unicorn like], article1)
-        mock_heart_reaction_notifications(1, %w[unicorn like], article2)
+        mock_heart_reaction_notifications(1, %w[unicorn like], first_article)
+        mock_heart_reaction_notifications(1, %w[unicorn like], second_article)
         get "/notifications"
         notifications = controller.instance_variable_get(:@notifications)
         expect(notifications.count).to eq 2
@@ -245,8 +245,8 @@ RSpec.describe "NotificationsIndex" do
     end
 
     context "when a user's organization has new reaction notifications" do
-      let(:article1) { create(:article, user: user, organization: organization) }
-      let(:article2) { create(:article, user: user, organization: organization) }
+      let(:first_article) { create(:article, user: user, organization: organization) }
+      let(:second_article) { create(:article, user: user, organization: organization) }
       let(:special_characters_article) do
         create(:article, user: user, organization: organization, title: "What's Become of Waring")
       end
@@ -258,7 +258,7 @@ RSpec.describe "NotificationsIndex" do
         sign_in user
       end
 
-      def mock_heart_reaction_notifications(followers_amount, categories, reactable = article1)
+      def mock_heart_reaction_notifications(followers_amount, categories, reactable = first_article)
         users = create_list(:user, followers_amount)
 
         reactions = users.map do |user|
@@ -303,8 +303,8 @@ RSpec.describe "NotificationsIndex" do
       end
 
       it "does not group notifications that are on the same day but have different reactables" do
-        mock_heart_reaction_notifications(1, %w[unicorn like], article1)
-        mock_heart_reaction_notifications(1, %w[unicorn like], article2)
+        mock_heart_reaction_notifications(1, %w[unicorn like], first_article)
+        mock_heart_reaction_notifications(1, %w[unicorn like], second_article)
 
         get notifications_path(filter: :org, org_id: organization.id)
         notifications = controller.instance_variable_get(:@notifications)
@@ -489,7 +489,7 @@ RSpec.describe "NotificationsIndex" do
       end
     end
 
-    context "when a user has a new moderation notification" do
+    context "when a user has a new comment moderation notification" do
       let(:moderator)  { create(:user, name: "Alice", last_reacted_at: 2.days.ago) }
       let(:user2)      { create(:user, name: "Bob") }
       let(:article)  { create(:article, user_id: user.id) }
@@ -518,7 +518,34 @@ RSpec.describe "NotificationsIndex" do
       end
     end
 
-    context "when a user should not receive moderation notification" do
+    context "when a user has a new article moderation notification" do
+      let(:moderator) { create(:user, name: "Alice", last_reacted_at: 2.days.ago) }
+      let(:user2) { create(:user, name: "Jesse") }
+      let(:article) { create(:article, user_id: user2.id) }
+
+      before do
+        moderator.add_role(:trusted)
+        sign_in moderator
+        sidekiq_perform_enqueued_jobs do
+          Notification.send_moderation_notification(article)
+        end
+        get "/notifications"
+      end
+
+      it "renders a round robin notification with the option to opt out", :aggregate_failures do
+        expect(response.body).to include "Hey Alice 👋"
+        expect(response.body).to include(
+          "Jesse is new to the community. Please drop a nice reply to make them feel welcome",
+        )
+        renders_article_path(article)
+        expect(response.body).to include CGI.escapeHTML("Don't want to receive these notifications?")
+        expect(response.body).to include <<~HTML
+          <a href="/settings/notifications">Change settings</a>
+        HTML
+      end
+    end
+
+    context "when a user should not receive moderation notification on a comment" do
       let(:user2)    { create(:user) }
       let(:article)  { create(:article, user_id: user.id) }
       let(:comment)  { create(:comment, user_id: user2.id, commentable_id: article.id, commentable_type: "Article") }

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -496,12 +496,18 @@ RSpec.describe "NotificationsIndex" do
       let(:comment)  { create(:comment, user_id: user2.id, commentable_id: article.id, commentable_type: "Article") }
 
       before do
+        # Avoid notifying the mod on the article
+        Article.skip_callback(:commit, :after, :send_to_moderator)
         moderator.add_role(:trusted)
         sign_in moderator
         sidekiq_perform_enqueued_jobs do
           Notification.send_moderation_notification(comment)
         end
         get "/notifications"
+      end
+
+      after do
+        Article.set_callback(:commit, :after, :send_to_moderator)
       end
 
       it "renders a round robin notification with the option to opt out", :aggregate_failures do

--- a/spec/services/notifications/moderation/send_spec.rb
+++ b/spec/services/notifications/moderation/send_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe Notifications::Moderation::Send, type: :service do
         described_class.call(moderator, comment)
       end.not_to change(Notification, :count)
     end
+
+    it "includes all needed user data in the notification" do
+      notification = described_class.call(moderator, comment)
+
+      expect(notification.json_data["user"]["id"]).to eq(staff_account.id)
+      expect(notification.json_data["comment_user"]["id"]).to eq(comment.user.id)
+    end
   end
 
   context "when notifying on articles" do

--- a/spec/services/notifications/moderation/send_spec.rb
+++ b/spec/services/notifications/moderation/send_spec.rb
@@ -9,51 +9,73 @@ RSpec.describe Notifications::Moderation::Send, type: :service do
   let(:selected_moderators) { Users::SelectModeratorsQuery.call }
   let(:moderator) { selected_moderators.first }
 
-  before do
-    u = create(:user, :trusted, last_reacted_at: 2.days.ago, last_moderation_notification: last_moderation_time)
-    u.notification_setting.update(mod_roundrobin_notifications: true)
-    allow(User).to receive(:staff_account).and_return(staff_account)
-    # Creating a comment calls moderation job which itself call moderation service
-    Comment.skip_callback(:commit, :after, :send_to_moderator)
-  end
+  context "when notifying on comments" do
+    before do
+      u = create(:user, :trusted, last_reacted_at: 2.days.ago, last_moderation_notification: last_moderation_time)
+      u.notification_setting.update(mod_roundrobin_notifications: true)
+      allow(User).to receive(:staff_account).and_return(staff_account)
+      # Creating a comment calls moderation job which itself call moderation service
+      Comment.skip_callback(:commit, :after, :send_to_moderator)
+    end
 
-  after do
-    Comment.set_callback(:commit, :after, :send_to_moderator)
-  end
+    after do
+      Comment.set_callback(:commit, :after, :send_to_moderator)
+    end
 
-  it "calls comment_data since parameter is a comment" do
-    allow(Notifications).to receive(:comment_data)
-    described_class.call(moderator, comment)
-    expect(Notifications).to have_received(:comment_data)
-  end
-
-  it "checks whether Notification is inserted on DB" do
-    expect do
+    it "calls comment_data since parameter is a comment" do
+      allow(Notifications).to receive(:comment_data)
       described_class.call(moderator, comment)
-    end.to change(Notification, :count).by(1)
+      expect(Notifications).to have_received(:comment_data)
+    end
+
+    it "checks whether Notification is inserted on DB" do
+      expect do
+        described_class.call(moderator, comment)
+      end.to change(Notification, :count).by(1)
+    end
+
+    it "checks whether created Notification is valid", :aggregate_failures do
+      notification = described_class.call(moderator, comment)
+      expect(notification).to be_a Notification
+      expect(notification.action).to eq "Moderation"
+      expect(notification.notifiable_type).to eq "Comment"
+      expect(notification.user_id).to eq moderator.id
+      expect(notification.notifiable_id).to eq comment.id
+    end
+
+    it "checks that moderator last notification time updates" do
+      expect do
+        described_class.call(moderator, comment)
+      end.to change(moderator, :last_moderation_notification)
+    end
+
+    it "does not create a notification if the moderator is the comment's author" do
+      comment = create(:comment, user: moderator, commentable: article)
+
+      expect do
+        described_class.call(moderator, comment)
+      end.not_to change(Notification, :count)
+    end
   end
 
-  it "checks whether created Notification is valid", :aggregate_failures do
-    notification = described_class.call(moderator, comment)
-    expect(notification).to be_a Notification
-    expect(notification.action).to eq "Moderation"
-    expect(notification.notifiable_type).to eq "Comment"
-    expect(notification.user_id).to eq moderator.id
-    expect(notification.notifiable_id).to eq comment.id
-  end
+  context "when notifying on articles" do
+    before do
+      u = create(:user, :trusted, last_reacted_at: 2.days.ago, last_moderation_notification: last_moderation_time)
+      u.notification_setting.update(mod_roundrobin_notifications: true)
+      allow(User).to receive(:staff_account).and_return(staff_account)
+      # Creating an article calls moderation job which itself calls moderation service
+      Article.skip_callback(:commit, :after, :send_to_moderator)
+    end
 
-  it "checks that moderator last notification time updates" do
-    expect do
-      described_class.call(moderator, comment)
-    end.to change(moderator, :last_moderation_notification)
-  end
+    after do
+      Article.set_callback(:commit, :after, :send_to_moderator)
+    end
 
-  it "does not create a notification if the moderator is the comment's author" do
-    comment = create(:comment, user: moderator, commentable: article)
-
-    expect do
-      described_class.call(moderator, comment)
-    end.not_to change(Notification, :count)
+    it "calls article_data since parameter is a comment" do
+      allow(Notifications).to receive(:article_data)
+      described_class.call(moderator, article)
+      expect(Notifications).to have_received(:article_data)
+    end
   end
 
   it "includes all needed user data in the notification" do

--- a/spec/workers/notifications/create_round_robin_moderation_notifications_worker_spec.rb
+++ b/spec/workers/notifications/create_round_robin_moderation_notifications_worker_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Notifications::CreateRoundRobinModerationNotificationsWorker do
     allow(comment).to receive(:commentable).and_return(true)
     comment
   end
+  let(:article) do
+    article = double
+    allow(Article).to receive(:find_by).and_return(article)
+    allow(article).to receive(:user)
+    article
+  end
   let(:mod) do
     last_moderation_time = Time.current - Notifications::Moderation::MODERATORS_AVAILABILITY_DELAY - 1.week
     u = create(:user, :trusted, last_moderation_notification: last_moderation_time, last_reacted_at: 2.days.ago)
@@ -17,13 +23,13 @@ RSpec.describe Notifications::CreateRoundRobinModerationNotificationsWorker do
   end
   let(:worker) { subject }
 
-  def check_received_call
-    worker.perform(id)
+  def check_received_call(notifiable_type = nil)
+    worker.perform(id, notifiable_type)
     expect(Notifications::Moderation::Send).to have_received(:call)
   end
 
-  def check_non_received_call
-    worker.perform(id)
+  def check_non_received_call(notifiable_type = nil)
+    worker.perform(id, notifiable_type)
     expect(Notifications::Moderation::Send).not_to have_received(:call)
   end
 
@@ -36,39 +42,62 @@ RSpec.describe Notifications::CreateRoundRobinModerationNotificationsWorker do
       it "calls the service" do
         mod
         comment
-        check_received_call
+        check_received_call("Comment")
       end
     end
 
-    describe "When no available moderator" do
+    describe "When available moderator(s) + article" do
+      it "calls the service" do
+        mod
+        article
+        check_received_call("Article")
+      end
+    end
+
+    describe "When no available moderator for comment" do
       it "does not call the service" do
         comment
-        check_non_received_call
+        check_non_received_call("Comment")
       end
     end
 
-    describe "When no valid comment" do
+    describe "When no available moderator for article" do
+      it "does not call the service" do
+        article
+        check_non_received_call("Article")
+      end
+    end
+
+    describe "When no valid comment or article" do
       it "does not call the service" do
         mod
         check_non_received_call
       end
     end
 
-    describe "When no valid comment + no moderator" do
+    describe "When no valid comment/article + no moderator" do
       it "does not call the service" do
-        check_non_received_call
+        check_non_received_call("Comment")
       end
     end
 
     describe "when moderator is the comment author" do
       it "does not call the service" do
         comment = create(:comment, user: mod, commentable: create(:article))
-        worker.perform(comment.id)
+        worker.perform(comment.id, "Comment")
         expect(Notifications::Moderation::Send).not_to have_received(:call)
       end
     end
 
-    describe "when the commentable does not exist" do
+    describe "when moderator is the article author" do
+      it "does not call the service" do
+        article = create(:article, user: mod)
+        worker.perform(article.id, "Article")
+        expect(Notifications::Moderation::Send).not_to have_received(:call)
+      end
+    end
+
+    describe "when the commenent's commentable does not exist" do
       it "does not call the service" do
         mod # prepare a moderator
 
@@ -77,7 +106,7 @@ RSpec.describe Notifications::CreateRoundRobinModerationNotificationsWorker do
 
         article.destroy!
 
-        worker.perform(comment.id)
+        worker.perform(comment.id, "Comment")
         expect(Notifications::Moderation::Send).not_to have_received(:call)
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adding Articles to the moderation notification worker,  and sending the notification for the first couple articles per author. This change takes the current approach to notifying moderators of new comments by a user, and expands it to notify on article publication.

Added more tests to cover more of the new code. Refactoring suggestions welcomed and appreciated! Not sure how Rails-y the polymorphic behavior of mod-"notifiable" Comments/ Articles should be, attempted to extend the existing comment notification behavior in a reasonable way and allowed for some things to be repeated rather than abstracted (eg the mod_comment_user and mod_article_user methods could take a `type` string argument and fold together into mod_notifiable_user, but I'm not certain they `should` in the name of keeping helper methods clear and readable in-place.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #19295
- Closes #19295

## QA Instructions, Screenshots, Recordings

In my local environment, my first user is a trusted mod. Mod notifications only go out if the user has reacted to a post recently, so I started by clicking a heart as a mod.

Then, in `rails console`, I used `User.first.update(last_moderation_notification: "2023-05-11 17:41:59.260460")` between notification tests to make sure that mod would still be searchable according to the query we use.

Then I tested mod notification by 
  - opening a different browser (eg my mod was using chrome and my users were in Safari), 
  - logging in as a first-time user, and 
  - posting an article or two as that user.
  - Returning to the mod's browser, I clicked the bell icon top right to navigate to /notifications.

Expected behavior is that the first two posts by a user ping the mod with the welcome message (mentioning the post is from a new user), posts after the second published post are ignored.

Drafting a post should not notify the mod.



### UI accessibility concerns?

## Added/updated tests?

- [X ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![the rock saying "finally"](https://gifdb.com/images/high/finally-the-rock-wwe-wrestling-cjy5wfj9u9e3dx58.webp)
