### PR TITLE
[CI] Remove seed container from Uffizzi

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,7 @@
 # rubocop:disable Rails/Output
 
+return if Rails.env.production?
+
 # NOTE: when adding new data, please use the Seeder class to ensure the seed tasks
 # stays idempotent.
 require Rails.root.join("app/lib/seeder")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,5 @@
 # rubocop:disable Rails/Output
 
-return if Rails.env.production?
-
 # NOTE: when adding new data, please use the Seeder class to ensure the seed tasks
 # stays idempotent.
 require Rails.root.join("app/lib/seeder")

--- a/uffizzi/Dockerfile
+++ b/uffizzi/Dockerfile
@@ -77,7 +77,7 @@ RUN ./scripts/bundle.sh
 ## Yarn install
 RUN bash -c yarn install --dev
 
-
-ENTRYPOINT ["./scripts/entrypoint.sh"]
-
-CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-p", "3000"]
+# Document that we're going to expose port 3000
+EXPOSE 3000
+# Use Bash as the default command
+CMD ["/usr/bin/bash"]

--- a/uffizzi/docker-compose.uffizzi.yml
+++ b/uffizzi/docker-compose.uffizzi.yml
@@ -26,7 +26,7 @@ services:
       APP_DOMAIN: localhost:3000
       APP_PROTOCOL: https://
     entrypoint: ["dockerize", "-wait", "tcp://localhost:5432", "-wait", "tcp://localhost:6379", "-wait", "file:///opt/apps/forem/vendor/bundle/.bundle_finished", "-timeout", "5400s"]
-    command: [ "bash", "-c", "./scripts/entrypoint.sh bootstrap && bundle exec rails db:seed && bundle exec rails server -b 0.0.0.0 -p 3000"]
+    command: [ "bash", "-c", "./uffizzi/entrypoint.sh bootstrap"]
     deploy:
       resources:
         limits:

--- a/uffizzi/docker-compose.uffizzi.yml
+++ b/uffizzi/docker-compose.uffizzi.yml
@@ -26,7 +26,7 @@ services:
       APP_DOMAIN: localhost:3000
       APP_PROTOCOL: https://
     entrypoint: ["dockerize", "-wait", "tcp://localhost:5432", "-wait", "tcp://localhost:6379", "-wait", "file:///opt/apps/forem/vendor/bundle/.bundle_finished", "-timeout", "5400s"]
-    command: [ "bash", "-c", "./uffizzi/entrypoint.sh bootstrap"]
+    command: [ "bash", "-c", "./scripts/entrypoint.sh bootstrap && bundle exec rails db:seed && bundle exec rails server -b 0.0.0.0 -p 3000"]
     deploy:
       resources:
         limits:

--- a/uffizzi/docker-compose.uffizzi.yml
+++ b/uffizzi/docker-compose.uffizzi.yml
@@ -30,27 +30,27 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4000M     
+          memory: 4000M
 
-  seed:
-    image: "${APP_IMAGE}"
-    container_name: forem_seed
-    depends_on:
-      - rails
-      - redis
-      - db
-    environment:
-      RAILS_ENV: development
-      REDIS_SESSIONS_URL: redis://localhost:6379
-      REDIS_SIDEKIQ_URL: redis://localhost:6379
-      REDIS_URL: redis://localhost:6379
-      DATABASE_URL: postgresql://forem:forem@localhost:5432/PracticalDeveloper_development
-    entrypoint: ["dockerize", "-wait", "tcp://localhost:5432", "-wait", "tcp://localhost:6379", "-wait", "http://localhost:3000", "-timeout", "5400s"]
-    command: ["./uffizzi/db_seed.sh"]
-    deploy:
-      resources:
-        limits:
-          memory: 500M
+  # seed:
+  #   image: "${APP_IMAGE}"
+  #   container_name: forem_seed
+  #   depends_on:
+  #     - rails
+  #     - redis
+  #     - db
+  #   environment:
+  #     RAILS_ENV: development
+  #     REDIS_SESSIONS_URL: redis://localhost:6379
+  #     REDIS_SIDEKIQ_URL: redis://localhost:6379
+  #     REDIS_URL: redis://localhost:6379
+  #     DATABASE_URL: postgresql://forem:forem@localhost:5432/PracticalDeveloper_development
+  #   entrypoint: ["dockerize", "-wait", "tcp://localhost:5432", "-wait", "tcp://localhost:6379", "-wait", "http://localhost:3000", "-timeout", "5400s"]
+  #   command: ["./uffizzi/db_seed.sh"]
+  #   deploy:
+  #     resources:
+  #       limits:
+  #         memory: 500M
 
   sidekiq:
     image: "${APP_IMAGE}"

--- a/uffizzi/docker-compose.uffizzi.yml
+++ b/uffizzi/docker-compose.uffizzi.yml
@@ -32,26 +32,6 @@ services:
         limits:
           memory: 4000M
 
-  # seed:
-  #   image: "${APP_IMAGE}"
-  #   container_name: forem_seed
-  #   depends_on:
-  #     - rails
-  #     - redis
-  #     - db
-  #   environment:
-  #     RAILS_ENV: development
-  #     REDIS_SESSIONS_URL: redis://localhost:6379
-  #     REDIS_SIDEKIQ_URL: redis://localhost:6379
-  #     REDIS_URL: redis://localhost:6379
-  #     DATABASE_URL: postgresql://forem:forem@localhost:5432/PracticalDeveloper_development
-  #   entrypoint: ["dockerize", "-wait", "tcp://localhost:5432", "-wait", "tcp://localhost:6379", "-wait", "http://localhost:3000", "-timeout", "5400s"]
-  #   command: ["./uffizzi/db_seed.sh"]
-  #   deploy:
-  #     resources:
-  #       limits:
-  #         memory: 500M
-
   sidekiq:
     image: "${APP_IMAGE}"
     container_name: forem_sidekiq

--- a/uffizzi/entrypoint.sh
+++ b/uffizzi/entrypoint.sh
@@ -45,6 +45,7 @@ case "$@" in
   bootstrap)
     echo "Running rake app_initializer:setup..."
     bundle exec rake app_initializer:setup
+    bundle exec rails db:seed
     ;;
   *)
     echo "Running command:"

--- a/uffizzi/entrypoint.sh
+++ b/uffizzi/entrypoint.sh
@@ -53,3 +53,5 @@ case "$@" in
     ;;
 
 esac
+
+bundle exec rails server -b 0.0.0.0 -p 3000

--- a/uffizzi/entrypoint.sh
+++ b/uffizzi/entrypoint.sh
@@ -53,5 +53,3 @@ case "$@" in
     ;;
 
 esac
-
-bundle exec rails server -b 0.0.0.0 -p 3000


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
Move seeding db a part of rails startup and remove the seed container.

This also fixes the issue where user's profile generated in the seed.rb isn't saving. THis was because it was because the rails container and seed container did not share the same volume.

## Related Tickets & Documents
https://github.com/forem/forem-internal-eng/issues/602

## QA Instructions, Screenshots, Recordings
Visit the Preview environment. You should be able to see all profiles pictures and all operation should work normally.

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a