### PR TITLE
Background and border color adjustment for the cards 

### DIFF
--- a/app/assets/stylesheets/components/cards.scss
+++ b/app/assets/stylesheets/components/cards.scss
@@ -4,13 +4,13 @@
   border-radius: var(--radius-auto);
   background: var(--card-bg);
   color: var(--card-color);
-  box-shadow: 0 0 0 1px var(--card-border);
+  box-shadow: 0 0 0 1px var(--card-secondary-border);
   // overflow-wrap: anywhere isn't supported in Safari, in which case this fallback applies
   overflow-wrap: break-word;
   overflow-wrap: anywhere;
 
   &--secondary {
-    background: var(--card-secondary-bg);
+    background: var(--card-bg);
     color: var(--card-secondary-color);
     box-shadow: 0 0 0 1px var(--card-secondary-border);
   }

--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -11,7 +11,7 @@
 
 .crayons-story {
   background: var(--card-bg);
-  box-shadow: 0 0 0 1px var(--card-border);
+  box-shadow: 0 0 0 1px var(--card-secondary-border);
   margin: 0 0 var(--su-2);
   position: relative;
   border-radius: var(--radius-auto);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Optimization

## Description


1. Change the background of all the sidebar cards + billboards to white _(same as article cards)_ `background: var(--card-bg)`. Changing the style of the CSS class `.crayons-card--secondary` should change all the sidebar cards's backgrounds. 
2. Change the border of the main cards _(article card, header in profile, etc.)_ to `box-shadow: 0 0 0 1px var(--card-secondary-border)`, same as the sidebar cards border. Changing the value in `.crayons-story` & `.crayons-card` should work. 

| Before | After |
| ------ | ------ |
| ![dev to_](https://github.com/forem/forem/assets/84626054/6aeb806a-fe89-4938-a72e-f92eefecd14c) | ![dev to_ (1)](https://github.com/forem/forem/assets/84626054/9b1bdd3d-f7d9-4be3-8939-6a69ddb115f0) |
| ![dev to_arafat4693_hot-css-tools-for-everyone-1b8o (1)](https://github.com/forem/forem/assets/84626054/a2e2bf8e-a41b-4731-8f9e-121d611bd1ab) | ![dev to_arafat4693_hot-css-tools-for-everyone-1b8o](https://github.com/forem/forem/assets/84626054/48d7ddc1-c1b1-4652-981d-65a221910255) |
| ![dev to_ben](https://github.com/forem/forem/assets/84626054/ff29bde8-8c3b-4ee7-b7b3-bece5148b03f) | ![dev to_arafat4693_hot-css-tools-for-everyone-1b8o (2)](https://github.com/forem/forem/assets/84626054/017482f5-e866-4b17-ba65-5d2227e403ad) |

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #19449

## QA Instructions, Screenshots, Recordings

No need to do any specific QA, simply check uffizzi link and see that all sidebar cards have white background now. 
Also you can have a look at this [quick loom video](https://www.loom.com/share/ebe29c2a379545f78dd11657af4c2218).

### UI accessibility concerns?

No

## Added/updated tests?

- [x] No

