### PR TITLE
Fixed billboard placement on home feed

### DIFF
--- a/app/views/stories/_main_stories_feed.html.erb
+++ b/app/views/stories/_main_stories_feed.html.erb
@@ -14,35 +14,45 @@
   <% end %>
 <% end %>
 
+<%# This second-display-ad should be shown between 2nd and 3rd article. %>
+<% second_display_ad_position = 2 %>
+
 <% if @pinned_article %>
+  <% second_display_ad_position -= 1 %>
   <%= render partial: "articles/single_story", locals: { story: @pinned_article, pinned: true, featured: @pinned_article.id == @featured_story.id } %>
 <% end %>
 
 <% if @featured_story.id && @pinned_article&.id != @featured_story.id %>
+  <% second_display_ad_position -= 1 %>
   <%= render partial: "articles/single_story", locals: { story: @featured_story, featured: true, pinned: false } %>
 <% end %>
 
 <div id="article-index-podcast-div"></div>
 
+<%# This third-display-ad should be shown between 7th and 8th article. %>
+<% third_display_ad_position = second_display_ad_position + 5 %>
+
 <div class="substories" id="substories">
   <% if @stories.any? %>
     <% @stories.each_with_index do |story, i| %>
-      <% if !user_signed_in? && i == 1 %>
+      <% if !user_signed_in? && i == second_display_ad_position %>
         <% @sidebar_ad_second = DisplayAd.for_display(area: "feed_second", user_signed_in: user_signed_in?) %>
         <% if @sidebar_ad_second %>
           <%= render partial: "shared/display_ad", locals: { display_ad: @sidebar_ad_second, data_context_type: DisplayAdEvent::CONTEXT_TYPE_HOME } %>
         <% end %>
       <% end %>
 
-      <% if !user_signed_in? && i == 7 %>
+      <% if !user_signed_in? && i == third_display_ad_position %>
         <% @sidebar_ad_third = DisplayAd.for_display(area: "feed_third", user_signed_in: user_signed_in?) %>
         <% if @sidebar_ad_third %>
           <%= render partial: "shared/display_ad", locals: { display_ad: @sidebar_ad_third, data_context_type: DisplayAdEvent::CONTEXT_TYPE_HOME } %>
         <% end %>
       <% end %>
-      <% next if story.id == @featured_story.id %>
-      <% next if story.id == @pinned_article&.id %>
-      <%= render partial: "articles/single_story", locals: { story: story, featured: false, pinned: false } %>
+      <% if story.id != @featured_story.id && story.id != @pinned_article&.id %>
+        <%= render partial: "articles/single_story", locals: { story: story, featured: false, pinned: false } %>
+      <% else %>
+        <% third_display_ad_position += 1 %>
+      <% end %>
     <% end %>
     <% if @stories.size > 1 %>
       <div class="placeholder-div"></div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

We currently show three billboards in home-feed:

-`feed_first` - Before all home page posts
-`feed_second` - Between 2nd and 3rd posts in the feed
-`feed_third` - Between 7th and 8th posts in the feed
The placement of `feed_second` and `feed_third` is incorrect in some cases.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related #19225
- Closes #19505

## QA Instructions, Screenshots, Recordings

[Video Output with all testing related guidelines.](https://www.loom.com/share/48f05a48b9814bbab0921859de23f476)

The reason I have not provided detailed steps here only because:
- it involves using two windows, one for admin and one for incognito user and multiple back & forth between both the windows
- the logic has also been explained in the video just to make sure that it makes sense to reviewer too.

That being said if you still need any help, feel free to ping me to do this review together.

### UI accessibility concerns?

No

## Added/updated tests?

- [ ] Yes
- [x] No
- [ ] I need help with writing tests
