### PR TITLE
Use tabindex instead of disabled to get proper keyboard nav on /onboa…

### DIFF
--- a/app/assets/stylesheets/preact/onboarding-modal.scss
+++ b/app/assets/stylesheets/preact/onboarding-modal.scss
@@ -238,6 +238,7 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    cursor: pointer;
     $item: &;
 
     input[type='checkbox'] {

--- a/app/javascript/onboarding/components/FollowTags.jsx
+++ b/app/javascript/onboarding/components/FollowTags.jsx
@@ -161,7 +161,7 @@ export class FollowTags extends Component {
                         class="crayons-checkbox"
                         type="checkbox"
                         checked={selected}
-                        disabled
+                        tabindex="-1"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
…rding tags

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Quick follow up fix to this shipped PR related to the onboarding tag page.

https://github.com/forem/forem/pull/19475

The problem is that the input box itself was marked `disabled` — and I believe this was done to help keyboard navigation. Great intentions with the a11y, but side effects of the item itself not being clickable (The space around it is, so it's still usable, just weird).

Changed to `tabindex="-1"` which I think is the more appropriate way to deal with this for a11y and general semantics.

Also fixed the pointer to `cursor` on the whole element, which I believe to be appropriate.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/pull/19475

## QA Instructions, Screenshots, Recordings


<img width="299" alt="Screen Shot 2023-05-19 at 3 40 16 PM" src="https://github.com/forem/forem/assets/3102842/e0e13c15-2dbe-4b3e-b828-66353d92e5e3">


### UI accessibility concerns?

Should improve a11y. While the original implementation was good for keyboard nav, this is better overall.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Regression tests should cover meaningful behavior?
- [ ] I need help with writing tests

