### PR TITLE
Fix styling for orgs-with-long-names promoted billboard

### DIFF
--- a/app/assets/stylesheets/config/_generator.scss
+++ b/app/assets/stylesheets/config/_generator.scss
@@ -386,6 +386,7 @@
     'fs',
     'font-size',
     (
+      '2xs': var(--fs-2xs),
       'xs': var(--fs-xs),
       's': var(--fs-s),
       'base': var(--fs-base),

--- a/app/assets/stylesheets/config/_variables.scss
+++ b/app/assets/stylesheets/config/_variables.scss
@@ -86,6 +86,7 @@
 
   // Font sizes
 
+  --fs-2xs: 0.675rem; // 11px
   --fs-xs: 0.75rem; // 12px
   --fs-s: 0.875rem; // 14px
   --fs-base: 1rem; // 16px

--- a/app/assets/stylesheets/widgets.scss
+++ b/app/assets/stylesheets/widgets.scss
@@ -324,6 +324,7 @@
     font-size: var(--fs-s);
     line-height: var(--lh-base);
     margin-left: var(--su-1);
+    align-self: center;
   }
 
   &__dropdown {
@@ -335,11 +336,15 @@
     border-radius: var(--radius);
     display: inline-block;
     vertical-align: middle;
+    align-self: center;
   }
 
   &__indicator {
     letter-spacing: -0.02em;
     text-transform: uppercase;
+    align-self: center;
+    word-wrap: normal;
+    word-break: keep-all;
   }
 }
 

--- a/app/views/shared/_display_ad_header.html.erb
+++ b/app/views/shared/_display_ad_header.html.erb
@@ -6,7 +6,7 @@
         <div class="crayons-sponsorship__title ml-2 fs-s fw-medium"><%= display_ad.organization.name %></div>
       </a>
       <% if display_ad.type_of == "external" %>
-        <span class="crayons-sponsorship__indicator c-indicator c-indicator--subtle c-indicator--round fs-xs fw-medium ml-2 py-1 px-2"><%= I18n.t("display_ad.promoted") %></span>
+        <span class="crayons-sponsorship__indicator c-indicator c-indicator--subtle c-indicator--round fs-2xs fw-medium ml-2 py-1 px-2"><%= I18n.t("display_ad.promoted") %></span>
       <% end %>
     </div>
   <% else %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes the styling for overly-long organization names.

While I think this is an okay fix from a code perspective, I'm going to leave the bug open in case we want to circle back with a better design solution.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/19527
- Closes #

## QA Instructions, Screenshots, Recordings

**Bug:**

<img width="366" alt="Screen Shot 2023-05-23 at 12 13 39 PM" src="https://github.com/forem/forem/assets/3102842/50c3f888-a2e8-471b-a69d-10ed2dca461f">

**Fix (still sort of awkward, but not totally broken):**

<img width="349" alt="Screen Shot 2023-05-23 at 5 35 42 PM" src="https://github.com/forem/forem/assets/3102842/79ce747e-4261-4582-bb54-9442973d6588">

**Validation that it still looks appropriate on shorter orgs:**

<img width="351" alt="Screen Shot 2023-05-23 at 5 38 17 PM" src="https://github.com/forem/forem/assets/3102842/96633050-3a66-4dea-8cd1-7b7a7ca8e4d9">

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Not inherently testable
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![shapes](https://media.giphy.com/media/l0RQ0v3dF9IGY/giphy.gif)
