### PR TITLE
Add billboard locations on signed in feed

### DIFF
--- a/app/controllers/display_ads_controller.rb
+++ b/app/controllers/display_ads_controller.rb
@@ -15,7 +15,7 @@ class DisplayAdsController < ApplicationController
         area: params[:placement_area],
         user_signed_in: user_signed_in?,
         user_id: current_user&.id,
-        article: ArticleDecorator.new(@article),
+        article: @article ? ArticleDecorator.new(@article) : nil,
       )
 
       if @display_ad && !session_current_user_id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,7 @@ Rails.application.routes.draw do
     scope "/:username/:slug" do
       get "/display_ads/:placement_area", to: "display_ads#show", as: :article_display_ad
     end
+    get "/display_ads/:placement_area", to: "display_ads#show"
 
     # Settings
     post "users/join_org", to: "users#join_org"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5505,9 +5505,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001304, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426:
-  version "1.0.30001474"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz#13b6fe301a831fe666cce8ca4ef89352334133d5"
-  integrity sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==
+  version "1.0.30001489"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz"
+  integrity sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==
 
 canvas@^2.11.0:
   version "2.11.2"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR is very much still in a draft state. There are probably (actually most likely) some bugs, no tests and more work to be done. However, before moving forward, I wanted some preliminary feedback on the approach to show billboard locations on signed in feed as it required some big changes. 

The way that the feed was being rendered made it difficult to insert billboards because of the way that we were organising the feed in the render function (i.e. the view). 

In the render function of `homePage.jsx` we were ordering the items on the feed. We then needed to insert the billboards in the following places: 
- `feed_first` - Before all home page posts
- `feed_second` - Between 2nd and 3rd posts in the feed
- `feed_third` - Between 7th and 8th posts in the feed

It became difficult to do so because the placement of the `feed_second` and `feed_third` depended on whether there was a featured post, a pinned post, or podcast episodes and for each of permutations the billboard would need to be placed accordingly. In my opinion the view was going to become very brittle littered with _many_ really difficult to follow if conditions. 

Hence, I thought that perhaps we could apply a refactored approach where we can organize the feed first through the data thats been passed through and then insert the billboard once all the items are placed in an array. This decoupled the need to know what types of items was in the feed in order to place the billboard, and the billboard placement now simply relies on the position. 

I'd like some feedback (even just a thumbsup or thumbs down) on the approach before proceeding.  

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility concerns?

_If your PR includes UI changes, please replace this line with details on how
accessibility is impacted and tested. For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
