### PR TITLE
Fix mod notifications for draft posts

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -205,7 +205,7 @@ class Article < ApplicationRecord
   after_save :bust_cache
   after_save :collection_cleanup
 
-  after_create_commit :send_to_moderator
+  after_create_commit :send_to_moderator, if: :published?
 
   after_update_commit :update_notifications, if: proc { |article|
                                                    article.notifications.any? && !article.saved_changes.empty?

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -700,8 +700,8 @@ RSpec.describe Article do
 
   describe "#slug" do
     let(:title) { "hey This' is$ a SLUG" }
-    let(:article0) { build(:article, title: title, published: false) }
-    let(:article1) { build(:article, title: title, published: false) }
+    let(:article0) { build(:article, title: title, published: false) } # rubocop:disable RSpec/IndexedLet
+    let(:article1) { build(:article, title: title, published: false) } # rubocop:disable RSpec/IndexedLet
 
     before do
       article0.validate!
@@ -1218,7 +1218,7 @@ RSpec.describe Article do
       co_author1 = create(:user)
       co_author2 = create(:user)
       article.co_author_ids_list = "#{co_author1.id}, #{co_author2.id}"
-      expect(article.co_author_ids).to match_array([co_author1.id, co_author2.id])
+      expect(article.co_author_ids).to contain_exactly(co_author1.id, co_author2.id)
     end
   end
 
@@ -1356,11 +1356,11 @@ RSpec.describe Article do
 
     it "reports accurately" do
       categories = article.public_reaction_categories
-      expect(categories.map(&:slug)).to contain_exactly(*%i[like])
+      expect(categories.map(&:slug)).to match_array(%i[like])
     end
   end
 
-  it "should not send moderator notifications when a draft post" do
+  it "does not send moderator notifications when a draft post" do
     allow(Notification).to receive(:send_moderation_notification)
 
     draft_post = build(:article, published: false)

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1359,4 +1359,17 @@ RSpec.describe Article do
       expect(categories.map(&:slug)).to contain_exactly(*%i[like])
     end
   end
+
+  it "should not send moderator notifications when a draft post" do
+    allow(Notification).to receive(:send_moderation_notification)
+
+    draft_post = build(:article, published: false)
+    draft_post.save!
+    expect(draft_post).not_to be_published
+    expect(Notification).not_to have_received(:send_moderation_notification)
+
+    published_post = build(:article, published: true)
+    published_post.save!
+    expect(Notification).to have_received(:send_moderation_notification)
+  end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

> We've had a report of a trusted user being prompted to look at the articles of a new post author - only that the posts lead to a 404. - The URLs all include 'temp-slug', which is used to create draft posts (e.g. https://dev.to/codenewbieteam/dream-big-whats-your-ideal-job-2ngb-temp-slug-2389119)

## Related Tickets & Documents

- Closes #19562 

## QA Instructions, Screenshots, Recordings

You can observe the bug if you have at least one moderator user and create a new draft post as another user.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: 

## [optional] Are there any post deployment tasks we need to perform?

No.

## [optional] What gif best describes this PR or how it makes you feel?

![swatting_bugs](https://media3.giphy.com/media/8Fln5PNICOmhmu1viX/giphy.gif?cid=ecf05e47mmfpv7jk2sz5a3oqwj4m7gdvvkc5j2lz780148lp&ep=v1_gifs_search&rid=giphy.gif&ct=g)
