### PR TITLE
Add image title for comment

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -104,6 +104,10 @@ class Comment < ApplicationRecord
     I18n.t("models.comment.hidden")
   end
 
+  def self.title_image_only
+    I18n.t("models.comment.image_only")
+  end
+
   def self.build_comment(params, &blk)
     includes(user: :profile).new(params, &blk)
   end
@@ -160,6 +164,8 @@ class Comment < ApplicationRecord
     return self.class.title_hidden if hidden_by_commentable_user
 
     text = ActionController::Base.helpers.strip_tags(processed_html).strip
+    return self.class.title_image_only if text.blank? && processed_html.include?("<img") # Indicates that we escaped a lone image
+
     truncated_text = ActionController::Base.helpers.truncate(text, length: length).gsub("&#39;", "'").gsub("&amp;", "&")
     Nokogiri::HTML.fragment(truncated_text).text # unescapes all HTML entities
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -164,7 +164,7 @@ class Comment < ApplicationRecord
     return self.class.title_hidden if hidden_by_commentable_user
 
     text = ActionController::Base.helpers.strip_tags(processed_html).strip
-    return self.class.title_image_only if text.blank? && processed_html.include?("<img") # Indicates that we escaped a lone image
+    return self.class.title_image_only if only_contains_image?(text)
 
     truncated_text = ActionController::Base.helpers.truncate(text, length: length).gsub("&#39;", "'").gsub("&amp;", "&")
     Nokogiri::HTML.fragment(truncated_text).text # unescapes all HTML entities
@@ -394,5 +394,10 @@ class Comment < ApplicationRecord
 
   def parent_exists?
     parent_id && Comment.exists?(id: parent_id)
+  end
+
+  def only_contains_image?(stripped_text)
+    # If stripped text is blank and processed html has <img> tags, then it's an image-only comment
+    stripped_text.blank? && processed_html.include?("<img")
   end
 end

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -47,6 +47,7 @@ en:
       deleted: '[deleted]'
       has_been_deleted: '%{type} has been deleted.'
       hidden: '[hidden by post author]'
+      image_only: '[image]'
       is_not_valid: is not valid.
       locked: the discussion is locked on this Post
       published_article: is not a published article

--- a/config/locales/models/fr.yml
+++ b/config/locales/models/fr.yml
@@ -46,6 +46,7 @@ fr:
       deleted: '[supprimé]'
       has_been_deleted: '%{type} a été supprimé'
       hidden: "[caché par l'auteur du message]"
+      image_only: '[image]'
       is_not_valid: n'est pas valide.
       locked: la discussion est verrouillée sur ce message
       published_article: n'est pas un article publié

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -327,6 +327,12 @@ RSpec.describe Comment do
       expect(comment.title).to eq("[deleted]")
     end
 
+    it "is converted to image text if the comment is image" do
+      comment.body_markdown = "![image](https://myimage.com/image.png)"
+      comment.validate!
+      expect(comment.title).to eq("[image]")
+    end
+
     it "does not contain the wrong encoding" do
       comment.body_markdown = "It's the best post ever. It's so great."
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds a "title" of `[image]` to comments which otherwise have a "blank" title. This fixes a notification bug and UX issue, as well as providing a page title to comment permalinks which are just an image, and currently just show `- DEV Community`.

This will close a notifications bug, but may not actually address the root cause. I thought this was an appropriate improvement given the multiple problems with a fully blank title in this context.

Overall this is an upstream fix to help a few areas.

## Related Tickets & Documents


- Relates to https://github.com/forem/forem/issues/19336

## QA Instructions, Screenshots, Recordings

This may be small enough to just validate via code review, but to see the title in prod:

- Sign in to Uffizzi (`admin@forem.local`, password: `password`)
- Create a comment that is just an image
- Click into that image's permalink. It should now have a page title that starts with `[image]`

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

