### PR TITLE
Spinner during onboarding follow suggestions

### DIFF
--- a/app/javascript/onboarding/components/FollowUsers.jsx
+++ b/app/javascript/onboarding/components/FollowUsers.jsx
@@ -4,6 +4,7 @@ import he from 'he';
 import { getContentOfToken } from '../utilities';
 import { locale } from '../../utilities/locale';
 import { Navigation } from './Navigation';
+import { Spinner } from '@crayons/Spinner/Spinner';
 
 function groupFollowsByType(array) {
   return array.reduce((returning, item) => {
@@ -31,6 +32,7 @@ export class FollowUsers extends Component {
     this.state = {
       follows: [],
       selectedFollows: [],
+      loading: true,
     };
   }
 
@@ -47,6 +49,7 @@ export class FollowUsers extends Component {
         this.setState({
           selectedFollows: data,
           follows: data,
+          loading: false,
         });
       });
 
@@ -179,7 +182,7 @@ export class FollowUsers extends Component {
   }
 
   render() {
-    const { follows, selectedFollows } = this.state;
+    const { follows, selectedFollows, loading } = this.state;
     const { prev, slidesCount, currentSlideIndex } = this.props;
     const canSkip = selectedFollows.length === 0;
 
@@ -212,6 +215,13 @@ export class FollowUsers extends Component {
               <div className="onboarding-selection-status">
                 {this.renderFollowCount()}
                 {this.renderFollowToggle()}
+              </div>
+              <div
+                className={`loading-spinner align-center ${
+                  loading ? '' : 'hidden'
+                }`}
+              >
+                <Spinner />
               </div>
             </header>
 


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

@PhilipHow and I were chatting about the follow suggestions page during `/onboarding` (because of the [org suggestions feature](https://github.com/forem/forem/pull/19619)) and how it's a bit slower than we'd like — the network round-trip isn't detectably slower than other `/onboarding` end-points, but subjectively, it feels like there's more delay. We may later decide we want to look more closely at query performance, but for the short-term, it seemed a loading-spinner might help with the user experience around the delay.

## Related Tickets & Documents

_I don't think we have an issue for the performance, specifically..._

## QA Instructions, Screenshots, Recordings

For developers, you can add `sleep(10)` to the `onboardings_controller#users_and_organizations` to delay the response.

Here is a recording (with a long `sleep`):

![Screen Recording 2023-06-22 at 12 08 17](https://github.com/forem/forem/assets/2077/6791ba31-5a0f-4fb6-bf82-baa11f880ad9)

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: loading spinner is a temporary patch for a subjective experience
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media0.giphy.com/media/wbXkGmM7YMgpCggnPB/giphy.gif?cid=ecf05e479rcmqwievr7sgf2qcmc1qyqleb0lvsvx51rdnyko&ep=v1_gifs_search&rid=giphy.gif&ct=g)
