### PR TITLE
Try to stop eslint complaining about destructuring

### DIFF
--- a/app/javascript/utilities/videoPlayback.js
+++ b/app/javascript/utilities/videoPlayback.js
@@ -130,7 +130,7 @@ export function initializeVideoPlayback() {
         videoPlayerEvent(false);
         break;
       case 'tick':
-        currentTime = message.currentTime;
+        currentTime = message.currentTime; // eslint-disable-line prefer-destructuring
         break;
       default:
         console.log('Unrecognized message: ', message); // eslint-disable-line no-console


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

There are low-level warnings from eslint about this line that I would rather we didn't ignore. I kinda think I don't like `prefer-destructuring`, but for now I just want to disable the one line that is constantly getting the warning, we can have the larger conversation later.

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media2.giphy.com/media/l3UcvawxYUTWRpeMw/giphy.gif?cid=ecf05e4714f7yetln5ukl86fihckz7rjccpy90bi00urxlru&ep=v1_gifs_related&rid=giphy.gif&ct=g)
