### PR TITLE
devxp: Replace forem/ruby image with open-source Debian-based analogue.

### DIFF
--- a/Containerfile.base
+++ b/Containerfile.base
@@ -1,0 +1,24 @@
+FROM public.ecr.aws/docker/library/ruby:3.0.2-slim-bullseye AS ruby-upstream
+
+RUN apt update && \
+    apt install -y \
+        curl \
+        gnupg2 \
+        && \
+    curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt update && \
+    apt install -y \
+        imagemagick \
+        iproute2 \
+        libjemalloc2 \
+        less \
+        postgresql-client \
+        tzdata \
+        nodejs \
+        yarn \
+        && \
+    apt clean
+
+CMD [ "/usr/local/bin/irb" ]


### PR DESCRIPTION
This builds a Debian-derived base image that targets Ruby 3.0.2 (our current version lock) to replace `quay.io/forem/ruby`, which is based on Fedora 35 (and as such, lacks ARM64 support).

The building of this image is not yet automated, I intend to add that as a follow-up some time vaguely soon-ish. This has been built and pushed to a temporary tag,
[ghcr.io/forem/ruby:klardotsh-test](https://github.com/orgs/forem/packages/container/ruby/103882793?tag=klardotsh-test). Once this merges, I'll build and push the result in main (pending any revisions that come up in PR review) with the following incantation, which will generate a multiarch manifest:

```sh
docker buildx build --platform linux/amd64,linux/arm64 -f Containerfile.base . -t ghcr.io/forem/ruby:latest -t ghcr.io/forem/ruby:$(git rev-parse --short HEAD) --push
```

This refs, but does not complete, #19626, and is one of several blockers on the path to getting #19603 merged.