### PR TITLE
Make sidebar billboard margins consistent and handle varied browser s…

### DIFF
--- a/app/assets/stylesheets/components/cards.scss
+++ b/app/assets/stylesheets/components/cards.scss
@@ -13,6 +13,8 @@
     background: var(--card-bg);
     color: var(--card-secondary-color);
     box-shadow: 0 0 0 1px var(--card-secondary-border);
+    max-height: calc(100vh - var(--header-height) - 2*var(--layout-padding));
+    overflow: auto;
   }
 
   &--elevated {

--- a/app/views/articles/_sticky_nav.html.erb
+++ b/app/views/articles/_sticky_nav.html.erb
@@ -1,5 +1,5 @@
 <% @actor = @article.organization || @article.user %>
-<div class="crayons-article-sticky grid gap-4 break-word" id="article-show-primary-sticky-nav">
+<div class="crayons-article-sticky grid gap-4 pb-4 break-word" id="article-show-primary-sticky-nav">
   <div class="crayons-card crayons-card--secondary branded-7 p-4 pt-0 gap-4 grid" style="border-top-color: <%= Color::CompareHex.new([user_colors(@actor)[:bg], user_colors(@actor)[:text]]).brightness(0.88) %>;">
     <%= render "shared/profile_card_content", actor: @actor, context: "sidebar" %>
   </div>
@@ -55,4 +55,4 @@
   <% end %>
 </div>
 
-<div class="crayons-article-sticky grid gap-4 break-word pt-4 js-display-ad-container" data-async-url="<%= article_display_ad_path(username: @article.username, slug: @article.slug, placement_area: :post_sidebar) %>"></div>
+<div class="crayons-article-sticky grid gap-4 break-word js-display-ad-container" data-async-url="<%= article_display_ad_path(username: @article.username, slug: @article.slug, placement_area: :post_sidebar) %>"></div>


### PR DESCRIPTION
…izes for overflow

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes an issue where the sticky margin was not consistent with the rest of the margins on the page, and fixes an issue where too-long content is not visible.

Content on the sidebar can be handled with guidelines, but they cannot account for all browser sizes (or other Forems with looser guidelines). This ensures cut off content is handled better with overflow.

Fixed these issues by moving the `pt-4` to `pb-4` on the above element, making for the intended outcome, and adding proper additional classes to the cards for handling height issues and overflow.

## Related Tickets & Documents

- Closes https://github.com/forem/forem/issues/19634

## QA Instructions, Screenshots, Recordings

**Before: Note extra space above**

<img width="393" alt="Screenshot 2023-06-25 at 2 30 55 PM" src="https://github.com/forem/forem/assets/3102842/95344daf-3888-497c-8bc4-cf6ef56e9478">

**After: Note both consistent margins and max height being handled**

<img width="387" alt="Screenshot 2023-06-25 at 2 36 39 PM" src="https://github.com/forem/forem/assets/3102842/3bbe147f-bff0-45ba-a65c-73587d74c409">

