### PR TITLE
Quick fix: Only apply overflow conditions to billboard cards

### DIFF
--- a/app/assets/stylesheets/components/cards.scss
+++ b/app/assets/stylesheets/components/cards.scss
@@ -13,8 +13,10 @@
     background: var(--card-bg);
     color: var(--card-secondary-color);
     box-shadow: 0 0 0 1px var(--card-secondary-border);
-    max-height: calc(100vh - var(--header-height) - 2*var(--layout-padding));
-    overflow: auto;
+    &.billboard {
+      max-height: calc(100vh - var(--header-height) - 2*var(--layout-padding));
+      overflow: auto;
+    }
   }
 
   &--elevated {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Quick fix as follow up to: https://github.com/forem/forem/pull/19635

It is causing profile images to be cut off. This reduces the scope of the css to only apply to that one type of card.

## Screenshots

![image](https://github.com/forem/forem/assets/3102842/d8262560-5056-4375-8107-4be203e32caa)
