### PR TITLE
Remove unnecessary fragment cache

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -233,12 +233,10 @@
 <div class="fullscreen-code js-fullscreen-code"></div>
 <%= javascript_packs_with_chunks_tag "followButtons", "billboard", "localizeArticleDates", "articleReactions", defer: true %>
 
-<% cache("article-show-scripts", expires_in: 8.hours) do %>
-  <script>
-    <%# we consider these scripts safe for embedding as they come from our code %>
-    <%== PodcastTag.script %>
-    <%== PollTag.script %>
-    <%== RunkitTag.script %>
-    <%== TweetTag.script %>
-  </script>
-<% end %>
+<script>
+  <%# we consider these scripts safe for embedding as they come from our code %>
+  <%== PodcastTag.script %>
+  <%== PollTag.script %>
+  <%== RunkitTag.script %>
+  <%== TweetTag.script %>
+</script>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The code contained within this fragment does not need to cached. It's all hardcoded _and frozen_ strings. The Redis call is almost certainly more expensive than the calls contained within.

We also do the same thing elsewhere and don't have fragment caches.

Just a tiny optimization. 

