### PR TITLE
infra: Automatically build and push base container image when Ruby versions are updated.

### DIFF
--- a/.github/workflows/build-base-ruby-image.yml
+++ b/.github/workflows/build-base-ruby-image.yml
@@ -1,0 +1,49 @@
+---
+name: Build ghcr.io/forem/ruby Container Image
+on:
+  workflow_call:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'Containerfile.base'
+      - '.ruby-version'
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'Containerfile.base'
+      - '.ruby-version'
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: "2" # Get current and preceding commit only
+      - name: Detect relevant changed files in this job
+        id: containerfile-changed
+        uses: tj-actions/changed-files@v37
+        with:
+          files: Containerfile.base
+      - name: Do not push to GHCR if this commit does not target the main branch
+        if: ${{ github.event_name != 'push' }}
+        run: echo "SKIP_PUSH=1" >> $GITHUB_ENV
+      - name: Set up QEMU for cross-compiling to ARM64
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker BuildX
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        if: ${{ github.event_name == 'push' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      - name: Build Images
+        env:
+          EXTERNAL_QEMU: "1"
+        run: scripts/build_base_ruby_image.sh

--- a/Containerfile.base
+++ b/Containerfile.base
@@ -1,4 +1,6 @@
-FROM public.ecr.aws/docker/library/ruby:3.0.2-slim-bullseye AS ruby-upstream
+ARG RUBY_VERSION=3.0.6
+ARG DEBIAN_VERSION=bullseye
+FROM public.ecr.aws/docker/library/ruby:${RUBY_VERSION}-slim-${DEBIAN_VERSION} AS ruby-upstream
 
 RUN apt update && \
     apt install -y \

--- a/scripts/build_base_ruby_image.sh
+++ b/scripts/build_base_ruby_image.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Must be bash (or compatible) for read -a and array access.
+
+set -eu
+
+if [ "$(pwd)" != "$(git rev-parse --show-toplevel)" ]; then
+	echo "This script must be run from the root of the Forem repository!" > /dev/stderr
+	exit 1
+fi
+
+BUILD_PLATFORMS="${BUILD_PLATFORMS:-linux/amd64,linux/arm64}"
+RUBY_VERSION="${RUBY_VERSION:-$(cat .ruby-version)}"
+IMAGE="ghcr.io/forem/ruby:${RUBY_VERSION}"
+
+if [ -z "${SKIP_PUSH:-}" ]; then
+	PUSH_FLAG="--push"
+fi
+
+IFS=',' read -ra BUILD_PLATFORMS_ARR <<< "${BUILD_PLATFORMS}"
+for platform in "${BUILD_PLATFORMS_ARR[@]}"; do
+  if docker pull --platform "${platform}" "${IMAGE}"; then
+    echo "Image ${IMAGE} already exists for platform ${platform}, but it will be overridden by this script." > /dev/stderr
+  fi
+done
+
+if [ -z "${EXTERNAL_QEMU:-}" ]; then
+	docker run --rm --privileged multiarch/qemu-user-static \
+		--reset \
+		-p yes \
+		--credential yes
+fi
+
+# shellcheck disable=SC2086
+docker buildx build \
+	--platform "${BUILD_PLATFORMS}" \
+	-f Containerfile.base \
+	-t "${IMAGE}"\
+	${PUSH_FLAG:-} \
+	--build-arg RUBY_VERSION="${RUBY_VERSION}" \
+	.


### PR DESCRIPTION
This refs (but still doesn't *quite* resolve: we're getting close!) #19626, and is some opportunistic/bonus drive-by work on the way to getting #19651 merged. #19632 introduced a new `forem/ruby` image, but those builds have been generated on my workstation up til now. This automates the process with GitHub Actions: assuming I got this right, images will be auto-built and tagged any time we update `.ruby-version` or the `Containerfile.base` itself.

I unfortunately worked ahead of myself a little bit: since I've already built and pushed a `ghcr.io/forem/ruby:3.0.6`, this workflow will fail on #19626 and its merge unless I can get permissions (or can bug @maestromac to do it) to delete that tag from GHCR: it appears I can't do so currently (I can't even delete `ghcr.io/forem/ruby:klardotsh-test`, which is rather unfortunate).