### PR TITLE
Disable DD's log_injection in development

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -2,7 +2,7 @@ Datadog.configure do |c|
   c.env = Rails.env
   c.tracing.enabled = ENV["DD_API_KEY"].present?
   c.tracing.partial_flush.enabled = true
-  c.tracing.log_injection = !Rails.env.development?
+  c.tracing.log_injection = Rails.env.production?
   service_name = ENV.fetch("DD_SERVICE") { "rails-#{Rails.env}" }
 
   c.tracing.instrument :rails, service_name: service_name

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -2,6 +2,7 @@ Datadog.configure do |c|
   c.env = Rails.env
   c.tracing.enabled = ENV["DD_API_KEY"].present?
   c.tracing.partial_flush.enabled = true
+  c.tracing.log_injection = !Rails.env.development?
   service_name = ENV.fetch("DD_SERVICE") { "rails-#{Rails.env}" }
 
   c.tracing.instrument :rails, service_name: service_name


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
I did not realize that DataDog's log_injection was applied to all, making server log a pain to use in development. This will hopefully improve DX.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a