### PR TITLE
Move max-height and overflow auto to proper billboard child

### DIFF
--- a/app/assets/stylesheets/components/cards.scss
+++ b/app/assets/stylesheets/components/cards.scss
@@ -13,10 +13,6 @@
     background: var(--card-bg);
     color: var(--card-secondary-color);
     box-shadow: 0 0 0 1px var(--card-secondary-border);
-    &.billboard {
-      max-height: calc(100vh - var(--header-height) - 2*var(--layout-padding));
-      overflow: auto;
-    }
   }
 
   &--elevated {

--- a/app/assets/stylesheets/widgets.scss
+++ b/app/assets/stylesheets/widgets.scss
@@ -410,5 +410,9 @@
     .text-styles {
       font-size: var(--fs-base);
     }
+    &.billboard {
+      max-height: calc(100vh - var(--header-height) - 2*var(--layout-padding));
+      overflow: auto;
+    }
   }
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Quick style fix. The max height and overflow is currently applying to below-comment locations when it should only actually apply to the sidebar widget spot.

## Related Tickets & Documents

- Closes https://github.com/forem/forem/issues/19682

