### PR TITLE
Try to mitigate flaky article publication spec(s)

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -205,7 +205,7 @@ class Article < ApplicationRecord
   after_save :bust_cache
   after_save :collection_cleanup
 
-  after_create_commit :send_to_moderator
+  after_commit :send_to_moderator, on: :create, if: :published?
 
   after_update_commit :update_notifications, if: proc { |article|
                                                    article.notifications.any? && !article.saved_changes.empty?
@@ -616,8 +616,9 @@ class Article < ApplicationRecord
 
   def send_to_moderator
     # Don't send notifications if this isn't published
-    # Note: `if: :published?` isn't reliable on `after_create_commit`, thus guarding
-    return unless published?
+    # Note: `if: :published?` might be buggy on `after_commit`,
+    # so an extra guard clause, just in case
+    return false unless published?
 
     # using nth_published because it doesn't count draft articles by the new author
     return if nth_published_by_author > 2

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -205,7 +205,7 @@ class Article < ApplicationRecord
   after_save :bust_cache
   after_save :collection_cleanup
 
-  after_create_commit :send_to_moderator, if: :published?
+  after_create_commit :send_to_moderator
 
   after_update_commit :update_notifications, if: proc { |article|
                                                    article.notifications.any? && !article.saved_changes.empty?
@@ -615,6 +615,10 @@ class Article < ApplicationRecord
   end
 
   def send_to_moderator
+    # Don't send notifications if this isn't published
+    # Note: `if: :published?` isn't reliable on `after_create_commit`, thus guarding
+    return unless published?
+
     # using nth_published because it doesn't count draft articles by the new author
     return if nth_published_by_author > 2
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -880,7 +880,7 @@ class Article < ApplicationRecord
   end
 
   def correct_published_at?
-    return unless changes["published_at"]
+    return false unless changes["published_at"]
 
     # for drafts (that were never published before) or scheduled articles
     # => allow future or current dates, or no published_at

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     end
 
     co_author_ids { [] }
-    association :user, factory: :user, strategy: :create
+    user factory: %i[user], strategy: :create
     description { Faker::Hipster.paragraph(sentence_count: 1)[0..100] }
     main_image    do
       if with_main_image
@@ -67,6 +67,7 @@ FactoryBot.define do
       past_published_at { 3.days.ago }
     end
 
+    user
     title { generate(:title) }
     published { true }
     tag_list { "javascript, html, discuss" }
@@ -75,6 +76,7 @@ FactoryBot.define do
   end
 
   factory :unpublished_article, class: "Article" do
+    user
     title { generate(:title) }
     published { false }
     published_at { nil }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1386,20 +1386,22 @@ RSpec.describe Article do
     end
   end
 
+  # This test has a history of being flaky, curreent theory is that the
+  # after_create_commit callback is not reliable
   it "does not send moderator notifications when a draft post" do
-    # This test has a history of being flaky, probably because
-    # expectations on classes are tricky to clear. Try to mitigate
-    # flakiness by ensuring that mocks are reset every time?
+    # Another flakiness theory is that the class expectations aren't fully
+    # reset in some other test, so try to clear them out before setting ours:
     RSpec::Mocks.space.proxy_for(Notification).reset
     allow(Notification).to receive(:send_moderation_notification)
 
-    draft_post = build(:article, published: false)
+    draft_post = build(:unpublished_article, title: "This should not be published")
     draft_post.save!
     expect(draft_post).not_to be_published
     expect(Notification).not_to have_received(:send_moderation_notification)
 
-    published_post = build(:article, published: true)
+    published_post = build(:published_article, title: "This should be published")
     published_post.save!
     expect(Notification).to have_received(:send_moderation_notification)
+      .with(published_post)
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1386,7 +1386,11 @@ RSpec.describe Article do
     end
   end
 
-  xit "does not send moderator notifications when a draft post" do
+  it "does not send moderator notifications when a draft post" do
+    # This test has a history of being flaky, probably because
+    # expectations on classes are tricky to clear. Try to mitigate
+    # flakiness by ensuring that mocks are reset every time?
+    RSpec::Mocks.space.proxy_for(Notification).reset
     allow(Notification).to receive(:send_moderation_notification)
 
     draft_post = build(:article, published: false)

--- a/spec/requests/articles/articles_update_spec.rb
+++ b/spec/requests/articles/articles_update_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe "ArticlesUpdate" do
 
     # draft => scheduled
     it "sets published_at according to the timezone when updating draft => scheduled" do
-      draft = create(:article, published: false, user_id: user.id, published_at: nil)
+      draft = create(:unpublished_article, user_id: user.id, published_at: nil)
       attributes[:published] = true
       attributes[:timezone] = "America/Mexico_City"
       put "/articles/#{draft.id}", params: { article: attributes }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Last week, this test was being very flaky, so we disabled it: https://github.com/forem/forem/blob/08fc1319dd3feba40c85175a1d92f0a18c89b449/spec/models/article_spec.rb#L1389-L1400

I was able to replicate the flakiness locally, and this branch attempts to address the issues I saw:

* My original theory was that maybe `mock expectations` were being set on the `Notification` class in another test and not fully cleared. That can _sometimes_ happen with `rspec-mocks` if another test has an error or exception that interrupts the "normal" test tear-down process. I tried explicitly clearing rspec's "mock proxy space", but this did not resolve the test failures for me. 
* My next investigation was to see if `if: :published?` wasn't working for any reason and this was immediately helpful locally. It seems likely that either [this test](https://github.com/forem/forem/blob/a8b503083ae141faad460654352a6fd0cb2e8228/spec/services/notifications/moderation/send_spec.rb#L74) and/or [this test](https://github.com/forem/forem/blob/a8b503083ae141faad460654352a6fd0cb2e8228/spec/requests/notifications_spec.rb#L500) are re-setting the callback in a way that the [`after_create_commit` macro specifically does _not_ support](https://stackoverflow.com/questions/71273548/why-does-the-presence-of-after-create-commit-make-my-after-update-commit-never-f) — that is to say, when their `after` hooks re-create the callback, they don't restore it in a way that respects the `if: :published?` configuration. That would account for the flakiness, as different test run ordering would sometimes see the callback with the `if` config and sometimes without.
* It's _possible_ we should (also?) alter those specs (or alter our callback-heavy approach to notifications), but, for now, adding a semi-redundant `unless published?` guard clause seems like a "minimally invasive" solution.
* There seems to be a [timezone bug of some sort](https://forem-team.slack.com/archives/C7GE84DEJ/p1688397556103449) in a related test, that came up repeatedly while working on this flaky test. I had one machine where the test failed repeatedly, and another where it was always passing. I suspect there's a buggy `tzinfo` somewhere (the test _explicitly_ sets the timezone to Mexico City, which _did_ have some changes to "daylight savings" / "summer time" in the last year). For me, `bundle clean --force`, `brew update` and a system software update seems to have fixed things for now, but I also tweaked the test to use a _slightly_ more appropriate factory for `unpublished_article`.

`cc` @dukegreene @filleduchaos @lightalloy — ya'll might have further insights here, based on conversations in Slack and/or [history](https://github.com/forem/forem/commits/jaw6/flaky_draft_notifications_spec/spec/services/notifications/moderation/send_spec.rb)

## Related Tickets & Documents

- Closes #19668

## QA Instructions, Screenshots, Recordings

`rspec spec/models/article_spec.rb` a couple dozen times locally?


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: 
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media4.giphy.com/media/MZpA2B8bX8uSBDmdRY/giphy.gif?cid=ecf05e47kgvw1vg8xuhgr27f0odss6i6mdwkoq9k5xlg055z&ep=v1_gifs_search&rid=giphy.gif&ct=g)
