### PR TITLE
Fixed deprecation message in specs

### DIFF
--- a/spec/system/homepage/user_visits_homepage_articles_spec.rb
+++ b/spec/system/homepage/user_visits_homepage_articles_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "User visits a homepage" do
   let!(:article) { create(:article, reactions_count: 12, featured: true, user: create(:user, profile_image: nil)) }
   let!(:article2) { create(:article, reactions_count: 20, featured: true, user: create(:user, profile_image: nil)) }
   # Let's use yesterday's date for this instead of relying on a magic date.
-  let!(:timestamp) { "#{Date.yesterday.to_s('%Y-%M-%d')}T10:00:00Z" }
+  let!(:timestamp) { "#{Date.yesterday.to_fs('%Y-%M-%d')}T10:00:00Z" }
   let(:published_datetime) { Time.zone.parse(timestamp) }
   let(:published_date) { published_datetime.strftime("%b %e").gsub("  ", " ") }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
A tiny commit to fix the deprecation message in tests.
```
DEPRECATION WARNING: Date#to_s("%Y-%M-%d") is deprecated. Please use Date#to_fs("%Y-%M-%d") instead. (called from block (2 levels) in <top (required)> at /home/light/sites/dev.to/spec/system/homepage/user_visits_homepage_articles_spec.rb:7)
```


## Added/updated tests?
- [x] Yes
