### PR TITLE
Change feed billboard font size to fs-base and link embed adjustments

### DIFF
--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -107,6 +107,9 @@
       padding-left: calc(var(--su-7) + var(--su-2));
       padding-right: calc(var(--su-7) + var(--su-2));
     }
+    .text-styles {
+      font-size: var(--fs-base);
+    }
   }
 
   &__top {

--- a/app/assets/stylesheets/ltags/LinkTag.scss
+++ b/app/assets/stylesheets/ltags/LinkTag.scss
@@ -149,8 +149,8 @@
       color: var(--tag-color);
     }
     .ltag__link__tag {
-      margin-right: calc(0.4vw + 4px);
-      font-size: 0.8em;
+      margin-right: calc(0.02vw + 4px);
+      font-size: 0.9em;
       margin-left: 1px;
     }
     .ltag__link__servicename {
@@ -167,7 +167,7 @@
   }
 }
 
-.crayons-article-sticky {
+.crayons-article-sticky, .crayons-story__indention-display-ad {
   .ltag__link {
     .ltag__link__org__pic {
       width: 60px;

--- a/app/views/articles/_liquid.html.erb
+++ b/app/views/articles/_liquid.html.erb
@@ -19,7 +19,7 @@
   <a href='<%= article.path %>' class='ltag__link__link'>
     <div class='ltag__link__content'>
       <h2><%= title %></h2>
-      <h3><%= article.user.name %><%= t("views.articles.for_org_html", org: article.organization.name, start: "", end: "") %> ・ <%= article.readable_publish_date %> ・ <%= t("views.articles.reading_time", count: article.reading_time < 2 ? 1 : article.reading_time) %></h3>
+      <h3><%= article.user.name %><%= t("views.articles.for_org_html", org: article.organization.name, start: "", end: "") %> ・ <%= article.readable_publish_date %></h3>
       <div class='ltag__link__taglist'>
       <% article.tag_list.each do |t| %>
         <span class='ltag__link__tag'>#<%= t %></span>
@@ -36,7 +36,7 @@
   <a href='<%= article.path %>' class='ltag__link__link'>
     <div class='ltag__link__content'>
       <h2><%= title %></h2>
-      <h3><%= article.user.name %> ・ <%= article.readable_publish_date %> ・ <%= t("views.articles.reading_time", count: article.reading_time < 2 ? 1 : article.reading_time) %></h3>
+      <h3><%= article.user.name %> ・ <%= article.readable_publish_date %></h3>
       <div class='ltag__link__taglist'>
       <% article.tag_list.each do |t| %>
         <span class='ltag__link__tag'>#<%= t %></span>

--- a/spec/liquid_tags/link_tag_spec.rb
+++ b/spec/liquid_tags/link_tag_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe LinkTag, type: :liquid_tag do
         <a href='#{article.path}' class='ltag__link__link'>
           <div class='ltag__link__content'>
             <h2>#{CGI.escapeHTML(article.title)}</h2>
-            <h3>#{CGI.escapeHTML(article.user.name)} ・ #{article.readable_publish_date} ・ #{article.reading_time} min read</h3>
+            <h3>#{CGI.escapeHTML(article.user.name)} ・ #{article.readable_publish_date}</h3>
             <div class='ltag__link__taglist'>
               #{tags}
             </div>
@@ -67,7 +67,7 @@ RSpec.describe LinkTag, type: :liquid_tag do
         <a href='#{article.path}' class='ltag__link__link'>
           <div class='ltag__link__content'>
             <h2>#{CGI.escapeHTML(article.title)}</h2>
-            <h3>#{CGI.escapeHTML(article.user.name)} for #{CGI.escapeHTML(article.organization.name)} ・ #{article.readable_publish_date} ・ #{article.reading_time} min read</h3>
+            <h3>#{CGI.escapeHTML(article.user.name)} for #{CGI.escapeHTML(article.organization.name)} ・ #{article.readable_publish_date}</h3>
             <div class='ltag__link__taglist'>
               #{tags}
             </div>
@@ -133,18 +133,6 @@ RSpec.describe LinkTag, type: :liquid_tag do
     expect do
       generate_new_liquid(slug: "https://xkcd.com/2363/")
     end.to raise_error(StandardError)
-  end
-
-  it "renders default reading time of 1 minute for short articles" do
-    liquid = generate_new_liquid(slug: "/#{user.username}/#{article.slug}/")
-    expect(liquid.render).to include("1 min read")
-  end
-
-  it "renders reading time of article lengthy articles" do
-    template = file_fixture("article_long_content.txt").read
-    article = create(:article, user: user, body_markdown: template)
-    liquid = generate_new_liquid(slug: "/#{user.username}/#{article.slug}/")
-    expect(liquid.render).to include("3 min read")
   end
 
   it "renders with a full link with a trailing slash" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

As we introduce more dynamic content into the feed via billboards, this is a pass to get the font size just right for this scenario. The current size we'd been using is too large for the varied content and looks out of place in the feed.

This includes an adjustment to make the base paragraph font size in feed billboards `fs-base` as well as some tweaks to make link embeds less gigantic.

Also included is a tweak to remove the read time from link embeds, as a small de-cluttering of a functionality which could use simplification. This will not not break any styling, but won't automatically update old embeds. This falls in line with the approach of making small compatible tweaks to improve liquid embeds where possible given re-rendering constraints.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/19313

## QA Instructions, Screenshots, Recordings

### Before
<img width="678" alt="Screenshot 2023-07-06 at 12 08 40 PM" src="https://github.com/forem/forem/assets/3102842/e7c977e1-5f44-4c99-9efb-a6eec858f7e2">

### After
<img width="683" alt="Screenshot 2023-07-06 at 12 42 04 PM" src="https://github.com/forem/forem/assets/3102842/7a9a81cc-81ed-4e18-904a-bd4fd8339573">


## Added/updated tests?

- [x] Yes

## [optional] What gif best describes this PR or how it makes you feel?

![smol](https://media.giphy.com/media/DVnofP4pfLyH4FQxKk/giphy.gif?cid=ecf05e47508tgawgbqwv9670x622ut232df7zjo225gfa2kn&ep=v1_gifs_search&rid=giphy.gif&ct=g)