### PR TITLE
Renamed display_ads => billboards in the api

### DIFF
--- a/app/controllers/api/v1/billboards_controller.rb
+++ b/app/controllers/api/v1/billboards_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class DisplayAdsController < ApiController
+    class BillboardsController < ApiController
       before_action :authenticate_with_api_key!
       before_action :require_admin
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,11 @@ Rails.application.routes.draw do
         post "/reactions", to: "reactions#create"
         post "/reactions/toggle", to: "reactions#toggle"
 
-        resources :display_ads, only: %i[index show create update] do
+        resources :billboards, only: %i[index show create update] do
+          put "unpublish", on: :member
+        end
+        # temporary keeping both routes while transitioning (renaming) display_ads => billboards
+        resources :display_ads, only: %i[index show create update], controller: :billboards do
           put "unpublish", on: :member
         end
 

--- a/spec/requests/api/v1/billboards_spec.rb
+++ b/spec/requests/api/v1/billboards_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Api::V1::DisplayAds" do
+RSpec.describe "Api::V1::Billboards" do
   let!(:v1_headers) { { "content-type" => "application/json", "Accept" => "application/vnd.forem.api-v1+json" } }
 
   let(:organization) { create(:organization) }
@@ -28,18 +28,18 @@ RSpec.describe "Api::V1::DisplayAds" do
   context "when authenticated and authorized and get to index" do
     include_context "when user is authorized"
 
-    describe "GET /api/display_ads" do
+    describe "GET /api/billboards" do
       it "returns json response" do
-        get api_display_ads_path, headers: auth_header
+        get api_billboards_path, headers: auth_header
         expect(response).to have_http_status(:success)
         expect(response.media_type).to eq("application/json")
         expect(response.parsed_body.size).to eq(1)
       end
     end
 
-    describe "POST /api/display_ads" do
+    describe "POST /api/billboards" do
       it "creates a new display_ad" do
-        post api_display_ads_path, params: display_ad_params.to_json, headers: auth_header
+        post api_billboards_path, params: display_ad_params.to_json, headers: auth_header
 
         expect(response).to have_http_status(:success)
         expect(response.media_type).to eq("application/json")
@@ -55,7 +55,7 @@ RSpec.describe "Api::V1::DisplayAds" do
       end
 
       it "returns a malformed response" do
-        post api_display_ads_path, params: display_ad_params.merge(display_to: "steve").to_json, headers: auth_header
+        post api_billboards_path, params: display_ad_params.merge(display_to: "steve").to_json, headers: auth_header
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.media_type).to eq("application/json")
@@ -63,9 +63,9 @@ RSpec.describe "Api::V1::DisplayAds" do
       end
     end
 
-    describe "GET /api/display_ads/:id" do
+    describe "GET /api/billboards/:id" do
       it "returns json response" do
-        get api_display_ad_path(ad1.id), headers: auth_header
+        get api_billboard_path(ad1.id), headers: auth_header
 
         expect(response).to have_http_status(:success)
         expect(response.media_type).to eq("application/json")
@@ -81,9 +81,9 @@ RSpec.describe "Api::V1::DisplayAds" do
       end
     end
 
-    describe "PUT /api/display_ads/:id" do
+    describe "PUT /api/billboards/:id" do
       it "updates an existing display_ad" do
-        put api_display_ad_path(ad1.id),
+        put api_billboard_path(ad1.id),
             params: display_ad_params.merge(name: "Updated!", type_of: "external").to_json,
             headers: auth_header
 
@@ -104,9 +104,9 @@ RSpec.describe "Api::V1::DisplayAds" do
       end
     end
 
-    describe "PUT /api/display_ads/:id/unpublish" do
+    describe "PUT /api/billboards/:id/unpublish" do
       it "unpublishes the display_ad" do
-        put unpublish_api_display_ad_path(ad1.id), headers: auth_header
+        put unpublish_api_billboard_path(ad1.id), headers: auth_header
 
         expect(response).to have_http_status(:success)
         expect(ad1.reload).not_to be_published
@@ -116,15 +116,15 @@ RSpec.describe "Api::V1::DisplayAds" do
 
   context "when unauthenticated and get to index" do
     it "returns unauthorized" do
-      get api_display_ads_path, headers: v1_headers
+      get api_billboards_path, headers: v1_headers
       expect(response).to have_http_status(:unauthorized)
     end
   end
 
   context "when unauthorized and get to show" do
     it "returns unauthorized" do
-      get api_display_ads_path, params: { id: ad1.id },
-                                headers: v1_headers.merge({ "api-key" => "invalid api key" })
+      get api_billboards_path, params: { id: ad1.id },
+                               headers: v1_headers.merge({ "api-key" => "invalid api key" })
       expect(response).to have_http_status(:unauthorized)
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
- Renamed `Api::V1::DisplayAdsController` to `Api::V1::BillboardsController`
- updated the related routes, kept old routes

## Related Tickets & Documents
- Related Issue #19372 

## Added/updated tests?
- [x] Yes
