### PR TITLE
Apply focus styles to `crayons-btn`

### DIFF
--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -76,6 +76,19 @@
   box-shadow: var(--shadow);
   color: var(--color);
 
+  .js-focus-visible &.focus-visible:focus,
+  &:is(label):focus-within {
+    background-color: var(--bg-hover);
+    color: var(--color-hover);
+    z-index: var(--z-elevate);
+  }
+
+  .js-focus-visible &.focus-visible:focus,
+  &:is(label):focus-within {
+    box-shadow: var(--focus-ring);
+    outline: 0;
+  }
+
   &[href]:hover,
   &[href]:focus,
   &:hover:enabled,
@@ -133,17 +146,6 @@
       pointer-events: revert;
     }
   }
-}
-
-.js-focus-visible .crayons-btn.focus-visible:focus,
-.js-focus-visible .crayons-btn.focus-visible:focus-within,
-label[class*='crayons-btn']:focus-within // label for input[type="file"] made to look like a button as the browse... button can't be styled.
-{
-  background-color: var(--bg-hover);
-  border-color: var(--border-hover);
-  box-shadow: var(--shadow-hover);
-  color: var(--color-hover);
-  z-index: var(--z-elevate);
 }
 
 .crayons-btn--secondary {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When using keyboard navigation on the notifcations page, buttons like the "Like" button would not have the same `focus` styles as some others. Tested across Chrome, Safari and Firefox.

I was a bit clueless when starting to work on this issue and so I'm jotting down some of my learnings for others and my future self:

- The reason that we do not have a focus style on keyboard navigation for the "Like" button, whilst we have the appropriate focus styles for  "Reply" and "View" is because those are links and not actual buttons.
- I noticed that some buttons across the site had working keyboard navigation focus styles whilst others did not. After doing some more digging, I realized that the buttons with class `c-btn` had working focu styles whilst buttons with `crayons-btn` did not have working focus styles. This led me to the discovery that we had these different classnames for buttons which I must have forgotten about. For some context from storybook, it outlines that all Crayons components use the `crayons-` or `c-` prefix.  `crayons-*` prefix will eventually be superseded by the `c-*` prefix. The `c-` prefix is just shorter, faster to type and it keep the markup a tiny bit cleaner. Plus we save some bytes :). `crayons-btn` has 751 results in 171 files whilst `c-btn` has 324 results in 87. So, it seems like we might have been slowly switching to/applying the `c-` prefix slowly. However, we also seem to have more types of buttons  (like a ghost button) with the `crayons-`  prefix at the moment than with the `c- prefix.`

Finally, just a disclaimer that I've not really worked on these accessibility changes before so I've done some research and tried to use what we have for `c-btn` and apply it to `crayons-btn` whilst keeping the other styles as is. However, I'm open to other approaches.  

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #https://github.com/forem/forem/issues/19685
- Closes #19685 

## QA Instructions, Screenshots, Recordings

Loom Video demo
https://www.loom.com/share/cf60aafa0d7a49fc8e8f2df2ce6d129e?sid=b4bbdcaf-b4db-4404-8b78-205e2dbe5c03

Test keyboard navigations on some of the pages that have `crayons-btn`. For example the notifications page and the article page comments section where we have "Like". The badge achievements page where we have the button "remove". 

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: css changes
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
