### PR TITLE
Un-flag subscribe-to-comments

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -288,8 +288,6 @@ class ApplicationController < ActionController::Base
   end
 
   def feature_flag_enabled?(flag_name, acting_as: current_user)
-    return true if ENV.fetch("E2E", nil) && flag_name.to_sym == :subscribe_to_comments
-
     FeatureFlag.enabled?(flag_name, FeatureFlag::Actor[acting_as])
   end
 

--- a/app/views/notifications/shared/_article_preview.html.erb
+++ b/app/views/notifications/shared/_article_preview.html.erb
@@ -30,19 +30,17 @@
         <span class="reaction-button-text hidden m:inline-block"><%= t("views.reactions.readingList.text") %></span>
       </button>
 
-      <% if feature_flag_enabled?(:subscribe_to_comments) %>
-        <% subscription = notification.subscription_for(current_user) %>
-        <button
-          class="ml-auto crayons-btn crayons-btn--ghost crayons-btn--icon-left crayons-btn--s subscribe-button <%= subscription ? "comment-subscribed" : "" %>"
-          data-subscription_id="<%= subscription&.id %>"
-          data-subscribed_to="<%= subscription&.notifiable_type&.downcase %>"
-          data-subscription_config="<%= subscription&.config %>"
-          data-article_id="<%= notification.article_id %>">
-          <%= crayons_icon_tag("bell-active", class: "subscribe-icon subscribed", aria_hidden: true, title: t("views.comments.footer.subscribe.icon")) %>
-          <%= crayons_icon_tag("bell", class: "subscribe-icon not-subscribed", aria_hidden: true, title: t("views.comments.footer.subscribe.icon")) %>
-          <span class="m:inline-block subscribe-button-title"><%= t("views.comments.footer.subscribe.text") %></span>
-        </button>
-      <% end %>
+      <% subscription = notification.subscription_for(current_user) %>
+      <button
+        class="ml-auto crayons-btn crayons-btn--ghost crayons-btn--icon-left crayons-btn--s subscribe-button <%= subscription ? "comment-subscribed" : "" %>"
+        data-subscription_id="<%= subscription&.id %>"
+        data-subscribed_to="<%= subscription&.notifiable_type&.downcase %>"
+        data-subscription_config="<%= subscription&.config %>"
+        data-article_id="<%= notification.article_id %>">
+        <%= crayons_icon_tag("bell-active", class: "subscribe-icon subscribed", aria_hidden: true, title: t("views.comments.footer.subscribe.icon")) %>
+        <%= crayons_icon_tag("bell", class: "subscribe-icon not-subscribed", aria_hidden: true, title: t("views.comments.footer.subscribe.icon")) %>
+        <span class="m:inline-block subscribe-button-title"><%= t("views.comments.footer.subscribe.text") %></span>
+      </button>
     </footer>
   <% end %>
 </article>

--- a/app/views/notifications/shared/_comment_box.html.erb
+++ b/app/views/notifications/shared/_comment_box.html.erb
@@ -72,22 +72,19 @@
             <span class="hidden m:inline-block"><%= t("views.comments.footer.view.text") %></span>
           </a>
 
-          <% if feature_flag_enabled?(:subscribe_to_comments) %>
-            <% subscription = notification.subscription_for(current_user) %>
-            <button
-              class="ml-auto crayons-btn crayons-btn--ghost crayons-btn--icon-left crayons-btn--s subscribe-button <%= subscription ? "comment-subscribed" : "" %>"
-              data-subscription_id="<%= subscription&.id %>"
-              data-subscribed_to="<%= subscription&.notifiable_type&.downcase %>"
-              data-subscription_config="<%= subscription&.notifiable_type == "Comment" ? "thread" : (subscription&.config || "all_comments") %>"
-              data-article_id="<%= notification.article_id || notification.commentable_article_id %>"
-              data-comment_id="<%= subscription&.notifiable_id if subscription&.notifiable_type == "Comment" %>"
-              data-ancestry="<%= notification.comment_ancestry %>">
-              <%= crayons_icon_tag("bell-active", class: "subscribe-icon subscribed", aria_hidden: true, title: t("views.comments.footer.subscribe.icon")) %>
-              <%= crayons_icon_tag("bell", class: "subscribe-icon not-subscribed", aria_hidden: true, title: t("views.comments.footer.subscribe.icon")) %>
-              <span class="m:inline-block subscribe-button-title"><%= t("views.comments.footer.subscribe.text") %></span>
-            </button>
-          <% end %>
-
+          <% subscription = notification.subscription_for(current_user) %>
+          <button
+            class="ml-auto crayons-btn crayons-btn--ghost crayons-btn--icon-left crayons-btn--s subscribe-button <%= subscription ? "comment-subscribed" : "" %>"
+            data-subscription_id="<%= subscription&.id %>"
+            data-subscribed_to="<%= subscription&.notifiable_type&.downcase %>"
+            data-subscription_config="<%= subscription&.notifiable_type == "Comment" ? "thread" : (subscription&.config || "all_comments") %>"
+            data-article_id="<%= notification.article_id || notification.commentable_article_id %>"
+            data-comment_id="<%= subscription&.notifiable_id if subscription&.notifiable_type == "Comment" %>"
+            data-ancestry="<%= notification.comment_ancestry %>">
+            <%= crayons_icon_tag("bell-active", class: "subscribe-icon subscribed", aria_hidden: true, title: t("views.comments.footer.subscribe.icon")) %>
+            <%= crayons_icon_tag("bell", class: "subscribe-icon not-subscribed", aria_hidden: true, title: t("views.comments.footer.subscribe.icon")) %>
+            <span class="m:inline-block subscribe-button-title"><%= t("views.comments.footer.subscribe.text") %></span>
+          </button>
         </div>
 
         <% @comment = Comment.new %>

--- a/cypress/e2e/seededFlows/notificationsFlows/notificationInitialization.spec.js
+++ b/cypress/e2e/seededFlows/notificationsFlows/notificationInitialization.spec.js
@@ -40,9 +40,7 @@ describe('Notification initialization', () => {
     });
 
     it('initializes comment subscriptions', () => {
-      // FeatureFlag makes this tricky to test with Cypress
-      // TODO: Uncomment this as part of cleanup for FeatureFlag :subscribe_to_comments
-      // cy.get('.subscribe-button').should('exist');
+      cy.get('.subscribe-button').should('exist');
     });
   });
 });


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we're ready to "fully launch" subscribe-to-comments, this PR removes the feature flag, enabling the feature for all users.

## Related Tickets & Documents

- Closes #19350 

## [optional] Are there any post deployment tasks we need to perform?

There's extra queries on the `/notifications` page now, would be good to keep an eye on performance under heavier user-load.

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media1.giphy.com/media/J5k8XuTKXiaMye1row/giphy.gif?cid=ecf05e47lnx2tmmvw99fl3az68hyopv49uft58h3qo7iug6s&ep=v1_gifs_search&rid=giphy.gif&ct=g)
