### PR TITLE
Try to fix inconsistent scrolling bug

### DIFF
--- a/app/javascript/packs/base.jsx
+++ b/app/javascript/packs/base.jsx
@@ -179,3 +179,10 @@ document.ready.then(() => {
 trackCreateAccountClicks('authentication-hamburger-actions');
 trackCreateAccountClicks('authentication-top-nav-actions');
 trackCreateAccountClicks('comments-locked-cta');
+
+// Our infinite scroll pattern causes problems with the browser's back button:
+// specifically, if you've scrolled into page 2+, click into a post, then back
+// to the feed, the browser scroll position will not be where you had previously
+// scrolled. This seems to fix it, even though it seems like it should have
+// the opposite effect.
+history.scrollRestoration = 'manual';


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Our infinite scroll pattern causes problems with the browser's back button: specifically, if you've scrolled into page 2+, click into a post, then back to the feed, the browser scroll position will not be where you had previously scrolled. This seems to fix it, even though it seems like it should have  the opposite effect.

## Related Tickets & Documents

- Closes #19595 

## QA Instructions, Screenshots, Recordings

<img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/c7e595c9608247e086e4f0b7b00b621d-with-play.gif">

https://www.loom.com/share/c7e595c9608247e086e4f0b7b00b621d?sid=9b2e1049-695a-4a86-9c9b-a7d5527c04b5

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: I'm not really sure this is something we can automatically test?
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

No

## [optional] What gif best describes this PR or how it makes you feel?

![giphy](https://github.com/forem/forem/assets/2077/6ab41682-ab57-4b13-a8fe-429677a24339)
