### PR TITLE
Aliased DisplayAdEvent.display_ad_id to billboard_id

### DIFF
--- a/app/assets/javascripts/initializers/initializeDisplayAdVisibility.js
+++ b/app/assets/javascripts/initializers/initializeDisplayAdVisibility.js
@@ -30,7 +30,7 @@ function trackAdImpression(adBox) {
 
   var dataBody = {
     billboard_event: {
-      display_ad_id: adBox.dataset.id,
+      billboard_id: adBox.dataset.id,
       context_type: adBox.dataset.contextType,
       category: adBox.dataset.categoryImpression,
     },
@@ -65,7 +65,7 @@ function trackAdClick(adBox) {
 
   var dataBody = {
     billboard_event: {
-      display_ad_id: adBox.dataset.id,
+      billboard_id: adBox.dataset.id,
       context_type: adBox.dataset.contextType,
       category: adBox.dataset.categoryClick,
     },

--- a/app/controllers/billboard_events_controller.rb
+++ b/app/controllers/billboard_events_controller.rb
@@ -34,6 +34,9 @@ class BillboardEventsController < ApplicationMetalController
 
   def billboard_event_params
     event_params = params[:billboard_event] || params[:display_ad_event]
+    # keeping while we may receive data in the "old" format from cached js
+    display_ad_id = event_params.delete(:display_ad_id)
+    event_params[:billboard_id] ||= display_ad_id
     event_params.slice(:context_type, :category, :billboard_id)
   end
 end

--- a/app/controllers/billboard_events_controller.rb
+++ b/app/controllers/billboard_events_controller.rb
@@ -15,7 +15,7 @@ class BillboardEventsController < ApplicationMetalController
   private
 
   def update_billboards_data
-    billboard_event_id = billboard_event_params[:display_ad_id]
+    billboard_event_id = billboard_event_params[:billboard_id]
 
     ThrottledCall.perform("billboards_data_update-#{billboard_event_id}", throttle_for: 15.minutes) do
       @billboard = DisplayAd.find(billboard_event_id)
@@ -34,6 +34,6 @@ class BillboardEventsController < ApplicationMetalController
 
   def billboard_event_params
     event_params = params[:billboard_event] || params[:display_ad_event]
-    event_params.slice(:context_type, :category, :display_ad_id)
+    event_params.slice(:context_type, :category, :billboard_id)
   end
 end

--- a/app/javascript/packs/billboardAfterRenderActions.js
+++ b/app/javascript/packs/billboardAfterRenderActions.js
@@ -61,7 +61,7 @@ function trackAdImpression(adBox) {
 
   const dataBody = {
     billboard_event: {
-      display_ad_id: adBox.dataset.id,
+      billboard_id: adBox.dataset.id,
       context_type: adBox.dataset.contextType,
       category: adBox.dataset.categoryImpression,
     },
@@ -97,7 +97,7 @@ function trackAdClick(adBox) {
 
   const dataBody = {
     billboard_event: {
-      display_ad_id: adBox.dataset.id,
+      billboard_id: adBox.dataset.id,
       context_type: adBox.dataset.contextType,
       category: adBox.dataset.categoryClick,
     },

--- a/app/models/display_ad_event.rb
+++ b/app/models/display_ad_event.rb
@@ -2,8 +2,10 @@
 #        :delete for the relationship.  That means no before/after
 #        destroy callbacks will be called on this object.
 class DisplayAdEvent < ApplicationRecord
-  belongs_to :billboard, class_name: "DisplayAd", foreign_key: "display_ad_id", inverse_of: :billboard_events
+  belongs_to :billboard, class_name: "DisplayAd", foreign_key: :display_ad_id, inverse_of: :billboard_events
   belongs_to :user, optional: true
+
+  alias_attribute :billboard_id, :display_ad_id
 
   CATEGORY_IMPRESSION = "impression".freeze
   CATEGORY_CLICK = "click".freeze

--- a/spec/requests/billboard_events_spec.rb
+++ b/spec/requests/billboard_events_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "BillboardEvents" do
       it "creates a display ad click event" do
         post "/billboard_events", params: {
           billboard_event: {
-            display_ad_id: display_ad.id,
+            billboard_id: display_ad.id,
             context_type: DisplayAdEvent::CONTEXT_TYPE_HOME,
             category: DisplayAdEvent::CATEGORY_CLICK
           }
@@ -36,7 +36,7 @@ RSpec.describe "BillboardEvents" do
       it "creates a display ad impression event" do
         post "/billboard_events", params: {
           billboard_event: {
-            display_ad_id: display_ad.id,
+            billboard_id: display_ad.id,
             context_type: DisplayAdEvent::CONTEXT_TYPE_HOME,
             category: DisplayAdEvent::CATEGORY_IMPRESSION
           }
@@ -45,7 +45,7 @@ RSpec.describe "BillboardEvents" do
       end
 
       it "creates a display ad success rate" do
-        ad_event_params = { display_ad_id: display_ad.id, context_type: DisplayAdEvent::CONTEXT_TYPE_HOME }
+        ad_event_params = { billboard_id: display_ad.id, context_type: DisplayAdEvent::CONTEXT_TYPE_HOME }
         impression_params = ad_event_params.merge(category: DisplayAdEvent::CATEGORY_IMPRESSION, user: user)
         create_list(:display_ad_event, 4, impression_params)
 
@@ -60,7 +60,7 @@ RSpec.describe "BillboardEvents" do
       it "assigns event to current user" do
         post "/billboard_events", params: {
           billboard_event: {
-            display_ad_id: display_ad.id,
+            billboard_id: display_ad.id,
             context_type: DisplayAdEvent::CONTEXT_TYPE_HOME,
             category: DisplayAdEvent::CATEGORY_IMPRESSION
           }
@@ -71,7 +71,7 @@ RSpec.describe "BillboardEvents" do
       it "uses a ThrottledCall for data updates" do
         post "/billboard_events", params: {
           billboard_event: {
-            display_ad_id: display_ad.id,
+            billboard_id: display_ad.id,
             context_type: DisplayAdEvent::CONTEXT_TYPE_HOME,
             category: DisplayAdEvent::CATEGORY_IMPRESSION
           }

--- a/spec/services/billboard_event_rollup_spec.rb
+++ b/spec/services/billboard_event_rollup_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe BillboardEventRollup, type: :service do
         [ad2.id, nil, 1],
       ]
       results_mapped = DisplayAdEvent.where(created_at: days_ago_as_range(2)).map do |event|
-        [event.display_ad_id, event.user_id, event.counts_for]
+        [event.billboard_id, event.user_id, event.counts_for]
       end
       expect(results_mapped).to match_array(expectations)
     end
@@ -66,8 +66,8 @@ RSpec.describe BillboardEventRollup, type: :service do
     expect(by_category["click"]["counts_for"]).to eq(2)
   end
 
-  # separate display_ad_id
-  it "groups by display_ad_id" do
+  # separate billboard_id
+  it "groups by billboard_id" do
     create(:display_ad_event, billboard: ad1, user_id: nil)
     create(:display_ad_event, billboard: ad1, user_id: nil)
     create(:display_ad_event, billboard: ad1, user_id: nil)
@@ -76,7 +76,7 @@ RSpec.describe BillboardEventRollup, type: :service do
 
     described_class.rollup(Date.current)
     results = DisplayAdEvent.where(created_at: Date.current.all_day)
-    by_ad = results.index_by { |r| r["display_ad_id"] }
+    by_ad = results.index_by { |r| r["billboard_id"] }
     expect(by_ad[ad1.id]["counts_for"]).to eq(3)
     expect(by_ad[ad2.id]["counts_for"]).to eq(2)
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
Alias `display_ad_id` to `billboard_id` as suggested [here](https://github.com/forem/forem/pull/19788/files#r1270377284)

## Related Tickets & Documents
- Related Issue #19372 

## Added/updated tests?
- [x] Yes
