### PR TITLE
Address minimal_admin deprecation

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -201,12 +201,6 @@ class ApplicationPolicy
 
   delegate :super_moderator?, :super_admin?, :any_admin?, :suspended?, to: :user, prefix: true
 
-  alias minimal_admin? user_any_admin?
-  deprecate minimal_admin?: "Deprecating #{self}#minimal_admin?, use #{self}#user_any_admin?"
-
-  alias user_admin? user_super_admin?
-  deprecate minimal_admin?: "Deprecating #{self}#user_admin?, use #{self}#user_super_admin?"
-
   def user_trusted?
     user.has_trusted_role?
   end

--- a/app/policies/html_variant_policy.rb
+++ b/app/policies/html_variant_policy.rb
@@ -3,17 +3,17 @@ class HtmlVariantPolicy < ApplicationPolicy
     user_any_admin?
   end
 
-  alias show? minimal_admin?
+  alias show? user_any_admin?
 
-  alias edit? minimal_admin?
+  alias edit? user_any_admin?
 
-  alias update? minimal_admin?
+  alias update? user_any_admin?
 
-  alias new? minimal_admin?
+  alias new? user_any_admin?
 
-  alias create? minimal_admin?
+  alias create? user_any_admin?
 
-  alias destroy? minimal_admin?
+  alias destroy? user_any_admin?
 
   def permitted_attributes
     %i[html name published approved target_tag group]


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I've been seeing a lot of warnings like this recently:

```
DEPRECATION WARNING: minimal_admin? is deprecated and will be removed from Rails 7.1 (Deprecating ApplicationPolicy#user_admin?, use ApplicationPolicy#user_super_admin?) (called from block (3 levels) in <top (required)> at /home/runner/work/forem/forem/spec/policies/html_variant_policy_spec.rb:10)
```

This is a _little_ misleading... the deprecation warning isn't connected to Rails at all, it's [something we did](https://github.com/forem/forem/pull/16523), but the default messaging from the `deprecate` macro assumes Rails' lingo. 

To summarize:

* We used to have a method `minimal_admin?`, which meant something like "at least `admin` but possibly also `super_admin`"
* We refactored, moved some methods around, such that we preferred to use `Authorizer#any_admin?` 
* We deprecated the old `minimal_admin?` in favor of `user_any_admin?` but aliased it, so we could keep using both
* This PR removes what I believe is the last remaining use of `minimal_admin?`
* Since this seems to be the last use, I am also removing the `alias` and `deprecate`

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: invisible rename
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media2.giphy.com/media/XtbZRlXuRQ6WVLTAtW/giphy.gif?cid=ecf05e47b1aimv82wrauyb5zlkmjxov24ht9i5vru96uxxex&ep=v1_gifs_search&rid=giphy.gif&ct=g)
