### PR TITLE
Take :display_ad_event params as well as :billboard_event 

### DIFF
--- a/app/controllers/billboard_events_controller.rb
+++ b/app/controllers/billboard_events_controller.rb
@@ -33,6 +33,7 @@ class BillboardEventsController < ApplicationMetalController
   end
 
   def billboard_event_params
-    params[:billboard_event].slice(:context_type, :category, :display_ad_id)
+    event_params = params[:billboard_event] || params[:display_ad_event]
+    event_params.slice(:context_type, :category, :display_ad_id)
   end
 end

--- a/spec/requests/billboard_events_spec.rb
+++ b/spec/requests/billboard_events_spec.rb
@@ -22,6 +22,17 @@ RSpec.describe "BillboardEvents" do
         expect(display_ad.reload.clicks_count).to eq(1)
       end
 
+      it "creates a display ad click event with old params" do
+        post "/billboard_events", params: {
+          display_ad_event: {
+            display_ad_id: display_ad.id,
+            context_type: DisplayAdEvent::CONTEXT_TYPE_HOME,
+            category: DisplayAdEvent::CATEGORY_CLICK
+          }
+        }
+        expect(display_ad.reload.clicks_count).to eq(1)
+      end
+
       it "creates a display ad impression event" do
         post "/billboard_events", params: {
           billboard_event: {


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Take both :display_ad_event params and :billboard_event in case of cached js

## Related Tickets & Documents
- Related Issue #19372 
