### PR TITLE
Only query unpublish_all data on a relevant tab in the member manager

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -418,7 +418,12 @@ module Admin
     def set_unpublish_all_log
       # in theory, there could be multiple "unpublish all" actions
       # but let's query and display the last one for now, that should be enough for most cases
-      @unpublish_all_data = AuditLog::UnpublishAllsQuery.call(@user.id)
+      @unpublish_all_data = if @current_tab == "unpublish_logs"
+                              AuditLog::UnpublishAllsQuery.call(@user.id)
+                            else
+                              # only find if the data exists for most tabs
+                              AuditLog::UnpublishAllsQuery.new(@user.id).exists?
+                            end
     end
 
     def calculate_countable_flags(reactions)

--- a/app/queries/audit_log/unpublish_alls_query.rb
+++ b/app/queries/audit_log/unpublish_alls_query.rb
@@ -12,6 +12,12 @@ class AuditLog
       @target_comments = []
     end
 
+    def exists?
+      exists = AuditLog.where(slug: %w[api_user_unpublish unpublish_all_articles])
+        .where("data @> '{\"target_user_id\": ?}'", user_id).present?
+      Result.new(exists?: exists)
+    end
+
     def call
       audit_log = AuditLog.where(slug: %w[api_user_unpublish unpublish_all_articles])
         .where("data @> '{\"target_user_id\": ?}'", user_id)

--- a/spec/queries/audit_log/unpublish_alls_query_spec.rb
+++ b/spec/queries/audit_log/unpublish_alls_query_spec.rb
@@ -18,14 +18,24 @@ RSpec.describe AuditLog::UnpublishAllsQuery, type: :query do
         expect(res.audit_log).to eq(audit_log)
       end
 
-      it "exists?" do
+      it "exists? when data requested" do
         res = described_class.call(user.id)
+        expect(res.exists?).to be true
+      end
+
+      it "exists? when exists requested" do
+        res = described_class.new(user.id).exists?
         expect(res.exists?).to be true
       end
     end
 
-    it "doesn't exist when there is no related audit_log" do
+    it "doesn't exist when there is no related audit_log and asked for data" do
       res = described_class.call(user.id)
+      expect(res.exists?).to be false
+    end
+
+    it "doesn't exist when there is no related audit_log and asked for exists?" do
+      res = described_class.new(user.id).exists?
       expect(res.exists?).to be false
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Optimization

## Description
Bullet was complaining on member manager => users in development ( `/admin/member_manager/users/:id` ) because of the unused "includes(:user)" (mentioned in https://github.com/forem/forem/pull/19812) .
We could remove the `includes` (it's not a big deal because it's only used by admins), but it's not the ideal solution: we do use `includes` , but only on one tab (`unpublish_logs`).

In this pr I changed the logic so that data will only be requested on a relevant tab, not on all user tabs. So, a bit of optimization along with the bullet warning removal.
