### PR TITLE
fastly_config: Soft-deprecate FastlyConfig service used only for DEV.

### DIFF
--- a/app/services/fastly_config/snippets.rb
+++ b/app/services/fastly_config/snippets.rb
@@ -1,3 +1,14 @@
+# In general this service should be considered deprecated, as it duplicates
+# infrastructure management that is better left to the Fastly Terraform
+# provider. It solely exists to support the not-yet-Terraformed DEV.to
+# deployment, and should be removed whenever that instance has been migrated
+# to Terraform control (and, presumably, the relevant bits of Terraform open-
+# sourced and documented to replace this).
+#
+# As such, if VCL snippets are added to the snippets directory, a Forem employee
+# should replicate them in the appropriate infrastructure repository and roll
+# them out to other non-DEV Forems.
+
 module FastlyConfig
   class Snippets < Base
     FASTLY_FILES = Rails.root.join("config/fastly/snippets/*.vcl").freeze


### PR DESCRIPTION
This is the sibling commit to an internal infra PR (which will be linked to anyone who has viz to that repo...) which has more of the context of "why" on this, but for public record keeping's sake, here's a partial copy of that text:

> In forem/forem, there's a FastlyConfig service which uploads various VCL snippets to Fastly and manages versions of them. This is a conflict of concerns in a Terraformed environment: if the Forem service uploads a VCL snippet to the service, the next Terraform apply may wipe those snippets out, as the Terraform state has no idea those snippets are supposed to be part of the service it's managing.
>
> Rather than allowing drift (allow_changes would allow us to create "dummy" snippets with no contents but matching names to what the Ruby side would create, and then mark them as being allowed to differ from whatever the HCL has said the content should be), let's use this as an opportunity to remove some code from forem/forem and reinvent fewer wheels: use Terraform for what it's good at (exactly this problem) [...]