### PR TITLE
Renamed display_ad variables to billboard

### DIFF
--- a/app/controllers/admin/billboards_controller.rb
+++ b/app/controllers/admin/billboards_controller.rb
@@ -5,51 +5,51 @@ module Admin
     after_action :bust_ad_caches, only: %i[create update destroy]
 
     def index
-      @display_ads = DisplayAd.order(id: :desc)
+      @billboards = DisplayAd.order(id: :desc)
         .page(params[:page]).per(50)
 
       return if params[:search].blank?
 
-      @display_ads = @display_ads.search_ads(params[:search])
+      @billboards = @billboards.search_ads(params[:search])
     end
 
     def new
-      @display_ad = DisplayAd.new
+      @billboard = DisplayAd.new
     end
 
     def edit
-      @display_ad = DisplayAd.find(params[:id])
+      @billboard = DisplayAd.find(params[:id])
     end
 
     def create
-      @display_ad = DisplayAd.new(display_ad_params)
-      @display_ad.creator = current_user
+      @billboard = DisplayAd.new(billboard_params)
+      @billboard.creator = current_user
 
-      if @display_ad.save
+      if @billboard.save
         flash[:success] = I18n.t("admin.billboards_controller.created")
-        redirect_to edit_admin_billboard_path(@display_ad.id)
+        redirect_to edit_admin_billboard_path(@billboard.id)
       else
-        flash[:danger] = @display_ad.errors_as_sentence
+        flash[:danger] = @billboard.errors_as_sentence
         render :new
       end
     end
 
     def update
-      @display_ad = DisplayAd.find(params[:id])
+      @billboard = DisplayAd.find(params[:id])
 
-      if @display_ad.update(display_ad_params)
+      if @billboard.update(billboard_params)
         flash[:success] = I18n.t("admin.billboards_controller.updated")
         redirect_to edit_admin_billboard_path(params[:id])
       else
-        flash[:danger] = @display_ad.errors_as_sentence
+        flash[:danger] = @billboard.errors_as_sentence
         render :edit
       end
     end
 
     def destroy
-      @display_ad = DisplayAd.find(params[:id])
+      @billboard = DisplayAd.find(params[:id])
 
-      if @display_ad.destroy
+      if @billboard.destroy
         render json: { message: I18n.t("admin.billboards_controller.deleted") }, status: :ok
       else
         render json: { error: I18n.t("admin.billboards_controller.wrong") }, status: :unprocessable_entity
@@ -58,7 +58,7 @@ module Admin
 
     private
 
-    def display_ad_params
+    def billboard_params
       params.permit(:organization_id, :body_markdown, :placement_area, :published, :approved, :name, :display_to,
                     :tag_list, :type_of, :exclude_article_ids, :audience_segment_id, :priority)
     end

--- a/app/controllers/api/v1/billboards_controller.rb
+++ b/app/controllers/api/v1/billboards_controller.rb
@@ -5,41 +5,41 @@ module Api
       before_action :require_admin
 
       def index
-        @display_ads = DisplayAd.order(id: :desc).page(params[:page]).per(50)
-        @display_ads = @display_ads.search_ads(params[:search]) if params[:search].present?
-        render json: @display_ads
+        @billboards = DisplayAd.order(id: :desc).page(params[:page]).per(50)
+        @billboards = @billboards.search_ads(params[:search]) if params[:search].present?
+        render json: @billboards
       end
 
       def show
-        @display_ad = DisplayAd.find(params[:id])
-        render json: @display_ad
+        @billboard = DisplayAd.find(params[:id])
+        render json: @billboard
       end
 
       def create
-        @display_ad = DisplayAd.new(permitted_params)
-        result = @display_ad.save
-        render json: @display_ad, status: (result ? :ok : :unprocessable_entity)
+        @billboard = DisplayAd.new(permitted_params)
+        result = @billboard.save
+        render json: @billboard, status: (result ? :ok : :unprocessable_entity)
       rescue ArgumentError => e
         # enums raise ArgumentError exceptions on unexpected inputs!
         render json: { error: e }, status: :unprocessable_entity
       end
 
       def update
-        @display_ad = DisplayAd.find(params[:id])
-        result = @display_ad.update(permitted_params)
-        render json: @display_ad, status: (result ? :ok : :unprocessable_entity)
+        @billboard = DisplayAd.find(params[:id])
+        result = @billboard.update(permitted_params)
+        render json: @billboard, status: (result ? :ok : :unprocessable_entity)
       rescue ArgumentError => e
         # enums raise ArgumentError exceptions on unexpected inputs!
         render json: { error: e }, status: :unprocessable_entity
       end
 
       def unpublish
-        @display_ad = DisplayAd.find(params[:id])
-        result = @display_ad.update(published: false)
+        @billboard = DisplayAd.find(params[:id])
+        result = @billboard.update(published: false)
         if result
           head :no_content
         else
-          render json: @display_ad, status: :unprocessable_entity
+          render json: @billboard, status: :unprocessable_entity
         end
       end
 

--- a/app/controllers/billboards_controller.rb
+++ b/app/controllers/billboards_controller.rb
@@ -1,18 +1,18 @@
 class BillboardsController < ApplicationController
   before_action :set_cache_control_headers, only: %i[show], unless: -> { current_user }
   include BillboardHelper
-  CACHE_EXPIRY_FOR_DISPLAY_ADS = 15.minutes.to_i.freeze
+  CACHE_EXPIRY_FOR_BILLBOARDS = 15.minutes.to_i.freeze
 
   def show
     skip_authorization
-    set_cache_control_headers(CACHE_EXPIRY_FOR_DISPLAY_ADS) unless session_current_user_id
+    set_cache_control_headers(CACHE_EXPIRY_FOR_BILLBOARDS) unless session_current_user_id
 
     if placement_area
       if params[:username].present? && params[:slug].present?
         @article = Article.find_by(slug: params[:slug])
       end
 
-      @display_ad = DisplayAd.for_display(
+      @billboard = DisplayAd.for_display(
         area: placement_area,
         user_signed_in: user_signed_in?,
         user_id: current_user&.id,
@@ -20,8 +20,8 @@ class BillboardsController < ApplicationController
         user_tags: user_tags,
       )
 
-      if @display_ad && !session_current_user_id
-        set_surrogate_key_header @display_ad.record_key
+      if @billboard && !session_current_user_id
+        set_surrogate_key_header @billboard.record_key
       end
     end
 

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -54,7 +54,7 @@ class StoriesController < ApplicationController
   end
 
   def assign_hero_banner
-    @hero_display_ad = DisplayAd.for_display(area: "home_hero", user_signed_in: user_signed_in?)
+    @hero_billboard = DisplayAd.for_display(area: "home_hero", user_signed_in: user_signed_in?)
   end
 
   def assign_hero_html

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -85,7 +85,7 @@ class DisplayAd < ApplicationRecord
     when (random_range_max(area)..new_and_priority_range_max(area)) # medium range, 30%
       # Here we sample from only billboards with fewer than 1000 impressions (with a fallback
       # if there are none of those, causing an extra query, but that shouldn't happen very often).
-      billboards_for_display.seldom_seen(area).sample || ads_for_display.sample
+      billboards_for_display.seldom_seen(area).sample || billboards_for_display.sample
     else # large range, 65%
 
       # Ads that get engagement have a higher "success rate", and among this category, we sample from the top 15 that

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -48,7 +48,7 @@ class DisplayAd < ApplicationRecord
            :validate_geolocations
 
   before_save :process_markdown
-  after_save :generate_display_ad_name
+  after_save :generate_billboard_name
   after_save :refresh_audience_segment, if: :should_refresh_audience_segment?
 
   scope :approved_and_published, -> { where(approved: true, published: true) }
@@ -63,8 +63,8 @@ class DisplayAd < ApplicationRecord
   def self.for_display(area:, user_signed_in:, user_id: nil, article: nil, user_tags: nil)
     permit_adjacent = article ? article.permit_adjacent_sponsors? : true
 
-    ads_for_display = DisplayAds::FilteredAdsQuery.call(
-      display_ads: self,
+    billboards_for_display = Billboards::FilteredAdsQuery.call(
+      billboards: self,
       area: area,
       user_signed_in: user_signed_in,
       article_id: article&.id,
@@ -81,11 +81,11 @@ class DisplayAd < ApplicationRecord
       # rise to the top. 5 out of every 100 times we show an ad (5%), it is totally random. This gives "not yet
       # evaluated" stuff a chance to get some engagement and start showing up more. If it doesn't get engagement, it
       # stays in this area.
-      ads_for_display.sample
+      billboards_for_display.sample
     when (random_range_max(area)..new_and_priority_range_max(area)) # medium range, 30%
       # Here we sample from only billboards with fewer than 1000 impressions (with a fallback
       # if there are none of those, causing an extra query, but that shouldn't happen very often).
-      ads_for_display.seldom_seen(area).sample || ads_for_display.sample
+      billboards_for_display.seldom_seen(area).sample || ads_for_display.sample
     else # large range, 65%
 
       # Ads that get engagement have a higher "success rate", and among this category, we sample from the top 15 that
@@ -94,7 +94,7 @@ class DisplayAd < ApplicationRecord
       # pick one randomly", it is actually "Let's cut off the query at a random limit between 1 and 15 and sample from
       # that". So basically the "limit" logic will result in 15 sets, and then we sample randomly from there. The
       # "first ranked" ad will show up in all 15 sets, where as 15 will only show in 1 of the 15.
-      ads_for_display.limit(rand(1..15)).sample
+      billboards_for_display.limit(rand(1..15)).sample
     end
   end
 
@@ -175,7 +175,7 @@ class DisplayAd < ApplicationRecord
 
   private
 
-  def generate_display_ad_name
+  def generate_billboard_name
     return unless name.nil?
 
     self.name = "Display Ad #{id}"
@@ -204,8 +204,8 @@ class DisplayAd < ApplicationRecord
     markdown = Redcarpet::Markdown.new(renderer, Constants::Redcarpet::CONFIG)
     initial_html = markdown.render(body_markdown)
     stripped_html = ActionController::Base.helpers.sanitize initial_html,
-                                                            tags: MarkdownProcessor::AllowedTags::DISPLAY_AD,
-                                                            attributes: MarkdownProcessor::AllowedAttributes::DISPLAY_AD
+                                                            tags: MarkdownProcessor::AllowedTags::BILLBOARD,
+                                                            attributes: MarkdownProcessor::AllowedAttributes::BILLBOARD
     html = stripped_html.delete("\n")
     self.processed_html = Html::Parser.new(html)
       .prefix_all_images(width: prefix_width, synchronous_detail_detection: true).html

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -27,7 +27,7 @@ class Organization < ApplicationRecord
   has_many :articles, dependent: :nullify
   has_many :collections, dependent: :nullify
   has_many :credits, dependent: :restrict_with_error
-  has_many :display_ads, dependent: :destroy
+  has_many :billboards, class_name: "DisplayAd", dependent: :destroy
   has_many :listings, dependent: :destroy
   has_many :notifications, dependent: :delete_all
   has_many :organization_memberships, dependent: :delete_all

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -38,7 +38,7 @@ class Tag < ActsAsTaggableOn::Tag
   belongs_to :badge, optional: true
 
   has_many :articles, through: :taggings, source: :taggable, source_type: "Article"
-  has_many :display_ads, through: :taggings, source: :taggable, source_type: "DisplayAd"
+  has_many :billboards, class_name: "DisplayAd", through: :taggings, source: :taggable, source_type: "DisplayAd"
 
   mount_uploader :profile_image, ProfileImageUploader
   mount_uploader :social_image, ProfileImageUploader

--- a/app/queries/billboards/filtered_ads_query.rb
+++ b/app/queries/billboards/filtered_ads_query.rb
@@ -60,7 +60,7 @@ module Billboards
                              end
 
       if FeatureFlag.enabled?(Geolocation::FEATURE_FLAG)
-        @filtered_display_ads = location_targeted_ads
+        @filtered_billboards = location_targeted_ads
       end
 
       # type_of filter needs to be applied as near to the end as possible
@@ -112,7 +112,7 @@ module Billboards
         geo_query += " OR (#{@location.to_sql_query_clause})"
       end
 
-      @filtered_display_ads.where(geo_query)
+      @filtered_billboards.where(geo_query)
     end
 
     def type_of_ads

--- a/app/queries/billboards/filtered_ads_query.rb
+++ b/app/queries/billboards/filtered_ads_query.rb
@@ -1,4 +1,4 @@
-module DisplayAds
+module Billboards
   class FilteredAdsQuery
     include BillboardHelper
     def self.call(...)
@@ -7,12 +7,12 @@ module DisplayAds
 
     # @param area [String] the site area where the ad is visible
     # @param user_signed_in [Boolean] whether or not the visitor is signed-in
-    # @param display_ads [DisplayAd] can be a filtered scope or Arel relationship
+    # @param billboards [DisplayAd] can be a filtered scope or Arel relationship
     # @param location [Geolocation|String] the visitor's geographic location
     def initialize(area:, user_signed_in:, organization_id: nil, article_tags: [],
-                   permit_adjacent_sponsors: true, article_id: nil, display_ads: DisplayAd,
+                   permit_adjacent_sponsors: true, article_id: nil, billboards: DisplayAd,
                    user_id: nil, user_tags: nil, location: nil)
-      @filtered_display_ads = display_ads.includes([:organization])
+      @filtered_billboards = billboards.includes([:organization])
       @area = area
       @user_signed_in = user_signed_in
       @user_id = user_signed_in ? user_id : nil
@@ -25,39 +25,39 @@ module DisplayAds
     end
 
     def call
-      @filtered_display_ads = approved_and_published_ads
-      @filtered_display_ads = placement_area_ads
+      @filtered_billboards = approved_and_published_ads
+      @filtered_billboards = placement_area_ads
 
       if @article_id.present?
         if @article_tags.any?
-          @filtered_display_ads = tagged_ads(@article_tags).or(untagged_ads)
+          @filtered_billboards = tagged_ads(@article_tags).or(untagged_ads)
         end
 
         if @article_tags.blank?
-          @filtered_display_ads = untagged_ads
+          @filtered_billboards = untagged_ads
         end
 
-        @filtered_display_ads = unexcluded_article_ads
+        @filtered_billboards = unexcluded_article_ads
       end
 
       if @user_tags.present? && @user_tags.any?
-        @filtered_display_ads = tagged_ads(@user_tags).or(untagged_ads)
+        @filtered_billboards = tagged_ads(@user_tags).or(untagged_ads)
       end
 
       # We apply the condition feed_targeted_tag_placement? because we only want to filter by
       # untagged ads on the home feed area placements. We do not want to have any side effects happen
       # on the article page or anywhere else.
       if @user_tags.blank? && feed_targeted_tag_placement?(@area)
-        @filtered_display_ads = untagged_ads
+        @filtered_billboards = untagged_ads
       end
 
-      @filtered_display_ads = user_targeting_ads
+      @filtered_billboards = user_targeting_ads
 
-      @filtered_display_ads = if @user_signed_in
-                                authenticated_ads(%w[all logged_in])
-                              else
-                                authenticated_ads(%w[all logged_out])
-                              end
+      @filtered_billboards = if @user_signed_in
+                               authenticated_ads(%w[all logged_in])
+                             else
+                               authenticated_ads(%w[all logged_out])
+                             end
 
       if FeatureFlag.enabled?(Geolocation::FEATURE_FLAG)
         @filtered_display_ads = location_targeted_ads
@@ -66,43 +66,43 @@ module DisplayAds
       # type_of filter needs to be applied as near to the end as possible
       # as it checks if any type-matching ads exist (this will apply all/any
       # filters applied up to this point, thus near the end is best)
-      @filtered_display_ads = type_of_ads
+      @filtered_billboards = type_of_ads
 
-      @filtered_display_ads = @filtered_display_ads.order(success_rate: :desc)
+      @filtered_billboards = @filtered_billboards.order(success_rate: :desc)
     end
 
     private
 
     def approved_and_published_ads
-      @filtered_display_ads.approved_and_published
+      @filtered_billboards.approved_and_published
     end
 
     def placement_area_ads
-      @filtered_display_ads.where(placement_area: @area)
+      @filtered_billboards.where(placement_area: @area)
     end
 
     def tagged_ads(tag_type)
-      @filtered_display_ads.cached_tagged_with_any(tag_type)
+      @filtered_billboards.cached_tagged_with_any(tag_type)
     end
 
     def untagged_ads
-      @filtered_display_ads.where(cached_tag_list: "")
+      @filtered_billboards.where(cached_tag_list: "")
     end
 
     def unexcluded_article_ads
-      @filtered_display_ads.where("NOT (:id = ANY(exclude_article_ids))", id: @article_id)
+      @filtered_billboards.where("NOT (:id = ANY(exclude_article_ids))", id: @article_id)
     end
 
     def authenticated_ads(display_auth_audience)
-      @filtered_display_ads.where(display_to: display_auth_audience)
+      @filtered_billboards.where(display_to: display_auth_audience)
     end
 
     def user_targeting_ads
       if @user_id
         segment_ids = SegmentedUser.where(user_id: @user_id).pluck(:audience_segment_id)
-        @filtered_display_ads.where("audience_segment_id IS NULL OR audience_segment_id IN (?)", segment_ids)
+        @filtered_billboards.where("audience_segment_id IS NULL OR audience_segment_id IN (?)", segment_ids)
       else
-        @filtered_display_ads.where(audience_segment_id: nil)
+        @filtered_billboards.where(audience_segment_id: nil)
       end
     end
 
@@ -118,8 +118,8 @@ module DisplayAds
     def type_of_ads
       # If this is an organization article and community-type ads exist, show them
       if @organization_id.present?
-        community = @filtered_display_ads.where(type_of: DisplayAd.type_ofs[:community],
-                                                organization_id: @organization_id)
+        community = @filtered_billboards.where(type_of: DisplayAd.type_ofs[:community],
+                                               organization_id: @organization_id)
         return community if community.any?
       end
 
@@ -135,7 +135,7 @@ module DisplayAds
         types_matching << :external
       end
 
-      @filtered_display_ads.where(type_of: DisplayAd.type_ofs.slice(*types_matching).values)
+      @filtered_billboards.where(type_of: DisplayAd.type_ofs.slice(*types_matching).values)
     end
   end
 end

--- a/app/services/markdown_processor.rb
+++ b/app/services/markdown_processor.rb
@@ -27,13 +27,13 @@ module MarkdownProcessor
       tbody td tfoot th thead time tr u ul
     ].freeze
 
-    # In FEED but not DISPLAY_AD: [i iframe]
-    # In DISPLAY_AD but not FEED: [abbr add figcaption hr kbd mark rp rt ruby source sub video]
-    # In DISPLAY_AD but not RENDERED_MARKDOWN_SCRUBBER: [div]
-    DISPLAY_AD = %w[a abbr add b blockquote br center cite code col colgroup dd del div dl dt
-                    em figcaption h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt
-                    ruby small source span strong sub sup table tbody td tfoot th thead
-                    time tr u ul video].freeze
+    # In FEED but not BILLBOARD: [i iframe]
+    # In BILLBOARD but not FEED: [abbr add figcaption hr kbd mark rp rt ruby source sub video]
+    # In BILLBOARD but not RENDERED_MARKDOWN_SCRUBBER: [div]
+    BILLBOARD = %w[a abbr add b blockquote br center cite code col colgroup dd del div dl dt
+                   em figcaption h1 h2 h3 h4 h5 h6 hr img kbd li mark ol p pre q rp rt
+                   ruby small source span strong sub sup table tbody td tfoot th thead
+                   time tr u ul video].freeze
 
     # In FEED but not RENDERED_MARKDOWN_SCRUBBER: [div i iframe]
     # In RENDERED_MARKDOWN_SCRUBBER but not FEED: [abbr add figcaption hr kbd mark rp rt ruby source sub video]
@@ -68,7 +68,7 @@ module MarkdownProcessor
     PODCAST_SHOW = %w[alt class colspan data-conversation data-lang em height href id ref
                       rel rowspan size span src start strong title value width].freeze
 
-    DISPLAY_AD = %w[alt class height href src width].freeze
+    BILLBOARD = %w[alt class height href src width].freeze
 
     RENDERED_MARKDOWN_SCRUBBER = %w[alt colspan controls data-conversation data-lang
                                     data-no-instant data-url href id loop name ref rel

--- a/app/views/admin/billboards/_form.html.erb
+++ b/app/views/admin/billboards/_form.html.erb
@@ -1,30 +1,30 @@
 <div class="grid l:grid-cols-2 gap-6 mb-4">
   <div class="flex flex-col gap-4">
-    <% if @display_ad.creator.present? %>
+    <% if @billboard.creator.present? %>
       <div class="crayons-field">
         <%= label_tag :creator, "Created by:", class: "crayons-field__label" %>
-        <%= text_field_tag :creator, @display_ad.creator.name, class: "crayons-textfield", disabled: true, autocomplete: "off" %>
+        <%= text_field_tag :creator, @billboard.creator.name, class: "crayons-textfield", disabled: true, autocomplete: "off" %>
       </div>
     <% end %>
 
     <div class="crayons-field">
       <%= label_tag :name, "Name:", class: "crayons-field__label" %>
-      <%= text_field_tag :name, @display_ad.name, class: "crayons-textfield", autocomplete: "off" %>
+      <%= text_field_tag :name, @billboard.name, class: "crayons-textfield", autocomplete: "off" %>
     </div>
 
     <div class="crayons-field">
       <%= label_tag :organization_id, "Organization ID:", class: "crayons-field__label" %>
-      <%= text_field_tag :organization_id, @display_ad.organization_id, class: "crayons-textfield", placeholder: "1234", autocomplete: "off" %>
+      <%= text_field_tag :organization_id, @billboard.organization_id, class: "crayons-textfield", placeholder: "1234", autocomplete: "off" %>
     </div>
 
     <div class="crayons-field">
       <%= label_tag :body_markdown, "Body Markdown:", class: "crayons-field__label" %>
-      <%= text_area_tag :body_markdown, @display_ad.body_markdown, size: "100x5", class: "crayons-textfield" %>
+      <%= text_area_tag :body_markdown, @billboard.body_markdown, size: "100x5", class: "crayons-textfield" %>
     </div>
 
     <div class="crayons-field">
       <%= label_tag :placement_area, "Placement Area:", class: "crayons-field__label" %>
-      <%= select_tag :placement_area, options_for_select(billboards_placement_area_options_array, selected: @display_ad.placement_area), include_blank: "Select...", class: "crayons-select js-placement-area" %>
+      <%= select_tag :placement_area, options_for_select(billboards_placement_area_options_array, selected: @billboard.placement_area), include_blank: "Select...", class: "crayons-select js-placement-area" %>
     </div>
 
     <div class="crayons-field">
@@ -33,12 +33,12 @@
 
     <div class="crayons-field hidden">
       <%= label_tag :tag_list, "Tag List:", class: "crayons-field__label" %>
-      <%= text_field_tag :tag_list, @display_ad.tag_list.to_s, class: "crayons-textfield js-tags-textfield", autocomplete: "off" %>
+      <%= text_field_tag :tag_list, @billboard.tag_list.to_s, class: "crayons-textfield js-tags-textfield", autocomplete: "off" %>
     </div>
 
     <div class="crayons-field hidden">
       <%= label_tag :exclude_article_ids, "Exclude Article IDs:", class: "crayons-field__label" %>
-      <%= text_field_tag :exclude_article_ids, @display_ad.exclude_article_ids.join(", "), class: "crayons-textfield js-exclude-ids-textfield", autocomplete: "off" %>
+      <%= text_field_tag :exclude_article_ids, @billboard.exclude_article_ids.join(", "), class: "crayons-textfield js-exclude-ids-textfield", autocomplete: "off" %>
     </div>
 
     <div class="crayons-field">
@@ -47,32 +47,32 @@
         <p id="display-to-description" class="crayons-field__description mb-2">Determines which user group will be able to see the Display Ad</p>
 
         <label class="crayons-field crayons-field--radio mb-2">
-          <%= radio_button_tag :display_to, "all", @display_ad.display_to_all?, class: "crayons-radio" %>
+          <%= radio_button_tag :display_to, "all", @billboard.display_to_all?, class: "crayons-radio" %>
           <div class="crayons-field__label">All users</div>
         </label>
 
         <label class="crayons-field crayons-field--radio mb-2">
-          <%= radio_button_tag :display_to, "logged_in", @display_ad.display_to_logged_in?, class: "crayons-radio" %>
+          <%= radio_button_tag :display_to, "logged_in", @billboard.display_to_logged_in?, class: "crayons-radio" %>
           <div class="crayons-field__label">Only logged in users</div>
         </label>
 
         <label class="crayons-field crayons-field--radio mb-2">
-          <%= radio_button_tag :display_to, "logged_out", @display_ad.display_to_logged_out?, class: "crayons-radio" %>
+          <%= radio_button_tag :display_to, "logged_out", @billboard.display_to_logged_out?, class: "crayons-radio" %>
           <div class="crayons-field__label">Only logged out users</div>
         </label>
       </fieldset>
     </div>
 
-    <div class="crayons-field <%= "hidden" if @display_ad.audience_segment.blank? %>">
+    <div class="crayons-field <%= "hidden" if @billboard.audience_segment.blank? %>">
       <%= label_tag :audience_segment_id, "Users who:", class: "crayons-field__label" %>
-      <% if @display_ad.audience_segment&.manual? %>
+      <% if @billboard.audience_segment&.manual? %>
         <%= select_tag :audience_segment_id,
-                       options_for_select(single_audience_segment_option(@display_ad), selected: @display_ad.audience_segment_id),
+                       options_for_select(single_audience_segment_option(@billboard), selected: @billboard.audience_segment_id),
                        disabled: true,
                        class: "crayons-select js-audience-segment" %>
       <% else %>
         <%= select_tag :audience_segment_id,
-                       options_for_select(automatic_audience_segments_options_array, selected: @display_ad.audience_segment_id),
+                       options_for_select(automatic_audience_segments_options_array, selected: @billboard.audience_segment_id),
                        include_blank: "All users",
                        class: "crayons-select js-audience-segment" %>
       <% end %>
@@ -83,17 +83,17 @@
         <legend class="crayons-field crayons-field__label pl-0">Type</legend>
 
         <label class="crayons-field crayons-field--radio mb-2">
-          <%= radio_button_tag :type_of, "in_house", @display_ad.in_house?, class: "crayons-radio" %>
+          <%= radio_button_tag :type_of, "in_house", @billboard.in_house?, class: "crayons-radio" %>
           <div class="crayons-field__label">In-House Ad</div>
         </label>
 
         <label class="crayons-field crayons-field--radio mb-2">
-          <%= radio_button_tag :type_of, "community", @display_ad.community?, class: "crayons-radio" %>
+          <%= radio_button_tag :type_of, "community", @billboard.community?, class: "crayons-radio" %>
           <div class="crayons-field__label">Community</div>
         </label>
 
         <label class="crayons-field crayons-field--radio mb-2">
-          <%= radio_button_tag :type_of, "external", @display_ad.external?, class: "crayons-radio" %>
+          <%= radio_button_tag :type_of, "external", @billboard.external?, class: "crayons-radio" %>
           <div class="crayons-field__label">External</div>
         </label>
       </fieldset>
@@ -101,23 +101,23 @@
 
     <div class="crayons-field">
       <%= label_tag :published, "Published:", class: "crayons-field__label" %>
-      <%= select_tag :published, options_for_select([false, true], selected: @display_ad.published), class: "crayons-select" %>
+      <%= select_tag :published, options_for_select([false, true], selected: @billboard.published), class: "crayons-select" %>
     </div>
 
     <div class="crayons-field">
       <%= label_tag :approved, "Approved:", class: "crayons-field__label" %>
-      <%= select_tag :approved, options_for_select([false, true], selected: @display_ad.approved), class: "crayons-select" %>
+      <%= select_tag :approved, options_for_select([false, true], selected: @billboard.approved), class: "crayons-select" %>
     </div>
 
     <div class="crayons-field">
       <%= label_tag :priority, "Prioritized:", class: "crayons-field__label" %>
-      <%= select_tag :priority, options_for_select([false, true], selected: @display_ad.priority), class: "crayons-select" %>
+      <%= select_tag :priority, options_for_select([false, true], selected: @billboard.priority), class: "crayons-select" %>
     </div>
   </div>
   <div>
     <div class="crayons-card crayons-card--secondary crayons-sponsorship text-styles text-styles--display-ad">
-      <% if @display_ad.persisted? %>
-        <%= @display_ad.processed_html.html_safe %>
+      <% if @billboard.persisted? %>
+        <%= @billboard.processed_html.html_safe %>
       <% else %>
         <div class="flex flex-col gap-3">
           <p>

--- a/app/views/admin/billboards/edit.html.erb
+++ b/app/views/admin/billboards/edit.html.erb
@@ -1,7 +1,7 @@
 <%= stylesheet_link_tag "minimal", media: "all" %>
 <h1 class="crayons-title mb-6">Edit Display Ad:</h1>
 <div class="crayons-card p-6">
-  <%= form_for([:admin, @display_ad], url: admin_billboard_path(@display_ad), method: :patch) do %>
+  <%= form_for([:admin, @billboard], url: admin_billboard_path(@billboard), method: :patch) do %>
     <%= render "form" %>
     <%= submit_tag "Update Display Ad", class: "c-btn c-btn--primary" %>
   <% end %>

--- a/app/views/admin/billboards/index.html.erb
+++ b/app/views/admin/billboards/index.html.erb
@@ -17,7 +17,7 @@
     </div>
   </nav>
 
-  <%= paginate @display_ads %>
+  <%= paginate @billboards %>
 
   <table class="crayons-table" width="100%">
     <thead>
@@ -31,7 +31,7 @@
       </tr>
     </thead>
     <tbody class="crayons-card">
-      <% @display_ads.each do |display_ad| %>
+      <% @billboards.each do |display_ad| %>
           <tr data-row-id="<%= display_ad.id %>">
             <td><%= link_to display_ad.name, edit_admin_billboard_path(display_ad) %></td>
             <td><%= display_ad.human_readable_placement_area %></td>
@@ -57,5 +57,5 @@
     </tbody>
   </table>
   <%= render partial: "admin/shared/destroy_confirmation_modal" %>
-  <%= paginate @display_ads %>
+  <%= paginate @billboards %>
 </div>

--- a/app/views/admin/billboards/new.html.erb
+++ b/app/views/admin/billboards/new.html.erb
@@ -1,6 +1,6 @@
 <h1 class="crayons-title mb-4">Make a new Display Ad</h1>
 <div class="crayons-card p-6">
-  <%= form_for([:admin, @display_ad], url: admin_billboards_path, method: :post) do %>
+  <%= form_for([:admin, @billboard], url: admin_billboards_path, method: :post) do %>
     <%= render "form" %>
     <%= submit_tag "Save Display Ad", class: "c-btn c-btn--primary" %>
   <% end %>

--- a/app/views/billboards/show.html.erb
+++ b/app/views/billboards/show.html.erb
@@ -1,9 +1,9 @@
-<% if @display_ad %>
+<% if @billboard %>
   <% if user_signed_in? %>
-    <%= render partial: "shared/display_ad", locals: { display_ad: @display_ad, data_context_type: BillboardEvent::CONTEXT_TYPE_ARTICLE } %>
+    <%= render partial: "shared/display_ad", locals: { display_ad: @billboard, data_context_type: BillboardEvent::CONTEXT_TYPE_ARTICLE } %>
   <% else %>
     <% cache([params[:username], params[:slug], params[:placement_area]], expires_in: 15.minutes) do %>
-      <%= render partial: "shared/display_ad", locals: { display_ad: @display_ad, data_context_type: BillboardEvent::CONTEXT_TYPE_ARTICLE } %>
+      <%= render partial: "shared/display_ad", locals: { display_ad: @billboard, data_context_type: BillboardEvent::CONTEXT_TYPE_ARTICLE } %>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Organization do
       it { is_expected.to have_many(:articles).dependent(:nullify) }
       it { is_expected.to have_many(:collections).dependent(:nullify) }
       it { is_expected.to have_many(:credits).dependent(:restrict_with_error) }
-      it { is_expected.to have_many(:display_ads).dependent(:destroy) }
+      it { is_expected.to have_many(:billboards).dependent(:destroy) }
       it { is_expected.to have_many(:listings).dependent(:destroy) }
       it { is_expected.to have_many(:notifications).dependent(:delete_all) }
       it { is_expected.to have_many(:organization_memberships).dependent(:delete_all) }

--- a/spec/queries/billboards/filtered_ads_query_spec.rb
+++ b/spec/queries/billboards/filtered_ads_query_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe DisplayAds::FilteredAdsQuery, type: :query do
+RSpec.describe Billboards::FilteredAdsQuery, type: :query do
   let(:placement_area) { "post_sidebar" }
 
   def create_display_ad(**options)
@@ -15,7 +15,7 @@ RSpec.describe DisplayAds::FilteredAdsQuery, type: :query do
 
   def filter_ads(**options)
     defaults = {
-      display_ads: DisplayAd, area: placement_area, user_signed_in: false
+      billboards: DisplayAd, area: placement_area, user_signed_in: false
     }
     described_class.call(**options.reverse_merge(defaults))
   end

--- a/spec/views/admin/billboards/new_spec.rb
+++ b/spec/views/admin/billboards/new_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "admin/billboards/new" do
   let(:admin) { build(:user, :super_admin) }
 
   before do
-    assign(:display_ad, build(:display_ad))
+    assign(:billboard, build(:display_ad))
   end
 
   context "when signed-in" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
Renamed variables, constants, method names from `display_ad` to `billboard`.
Renamed `DisplayAds` namespace to `Billboards`, user and organization associations (display_ads => billboards)

## Related Tickets & Documents
- Related Issue #19372 

## QA Instructions
Billboards functionality should continue working as expected

## Added/updated tests?
- [x] Yes