### PR TITLE
Fix flaky FilteredAdsQuery spec

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -486,7 +486,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_20_211851) do
     t.index ["exclude_article_ids"], name: "index_display_ads_on_exclude_article_ids", using: :gin
     t.index ["placement_area"], name: "index_display_ads_on_placement_area"
     t.index ["target_geolocations"], name: "gist_index_display_ads_on_target_geolocations", using: :gist
-    t.index ["target_geolocations"], name: "index_display_ads_on_target_geolocations"
   end
 
   create_table "email_authorizations", force: :cascade do |t|

--- a/spec/queries/display_ads/filtered_ads_query_spec.rb
+++ b/spec/queries/display_ads/filtered_ads_query_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe DisplayAds::FilteredAdsQuery, type: :query do
 
     let(:organization) { create(:organization) }
     let(:other_org) { create(:organization) }
+    let(:no_ads_org) { create(:organization) }
     let!(:community_ad) { create_display_ad organization_id: organization.id, type_of: :community }
     let!(:other_community) { create_display_ad organization_id: other_org.id, type_of: :community }
 
@@ -162,7 +163,7 @@ RSpec.describe DisplayAds::FilteredAdsQuery, type: :query do
       expect(filtered).to contain_exactly(community_ad)
       expect(filtered).not_to include(other_community)
 
-      filtered = filter_ads organization_id: 123
+      filtered = filter_ads organization_id: no_ads_org.id
       expect(filtered).to contain_exactly(in_house_ad)
       expect(filtered).not_to include(other_community)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

While working on the billboards location targeting, I stumbled on this flaky spec and quickly realised what was wrong with it

Basically, the spec was using `123` as a "no org matches this" id - however, when the full test suite is run in parallel like in CI, there's a small chance that there _will_ have been enough other organizations created in other tests that one of the organizations created _for this spec_ actually has the id `123`. The ads query would then pick up that org's community billboard instead of the in-house one it is supposed to detect and return if the org doesn't exist/doesn't have any community billboards.

To fix it I added an organization that explicitly doesn't have any billboards and used its ID instead of `123`.

## Related Tickets & Documents

- Related Issue #19666 (it's already been closed, but it's nice to have a paper trail)

## QA Instructions, Screenshots, Recordings

N/A