### PR TITLE
Renamed leftover @hero_display_ad => @hero_billboard

### DIFF
--- a/app/views/admin/billboards/index.html.erb
+++ b/app/views/admin/billboards/index.html.erb
@@ -31,23 +31,23 @@
       </tr>
     </thead>
     <tbody class="crayons-card">
-      <% @billboards.each do |display_ad| %>
-          <tr data-row-id="<%= display_ad.id %>">
-            <td><%= link_to display_ad.name, edit_admin_billboard_path(display_ad) %></td>
-            <td><%= display_ad.human_readable_placement_area %></td>
-            <td><%= display_ad.display_to %></td>
-            <td><%= display_ad.type_of.titleize %></td>
-            <% if display_ad.published? && display_ad.approved? %>
+      <% @billboards.each do |billboard| %>
+          <tr data-row-id="<%= billboard.id %>">
+            <td><%= link_to billboard.name, edit_admin_billboard_path(billboard) %></td>
+            <td><%= billboard.human_readable_placement_area %></td>
+            <td><%= billboard.display_to %></td>
+            <td><%= billboard.type_of.titleize %></td>
+            <% if billboard.published? && billboard.approved? %>
               <td><span class="crayons-icon" role="img" aria-label="Ad is published and approved">✅</span></td>
             <% else %>
               <td><span class="crayons-icon" role="img" aria-label="Ad is not published or approved">❌</span></td>
             <% end %>
-            <td><%= display_ad.success_rate %></td>
-            <td><%= link_to "Edit", edit_admin_billboard_path(display_ad), class: "crayons-btn" %></td>
+            <td><%= billboard.success_rate %></td>
+            <td><%= link_to "Edit", edit_admin_billboard_path(billboard), class: "crayons-btn" %></td>
             <td>
               <button
                 class="crayons-btn crayons-btn--danger"
-                data-item-id="<%= display_ad.id %>"
+                data-item-id="<%= billboard.id %>"
                 data-endpoint="/admin/customization/billboards"
                 data-username="<%= current_user.username %>"
                 data-action="click->confirmation-modal#openModal">Destroy</button>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -26,8 +26,8 @@
 
 <%= javascript_packs_with_chunks_tag "homePage", defer: true %>
 <% cache(release_adjusted_cache_key("main-stories-index-#{params}-#{user_signed_in?}"), expires_in: 90.seconds) do %>
-  <% if @hero_display_ad && FeatureFlag.enabled?(:hero_billboard) %>
-    <%= render partial: "shared/display_ad", locals: { display_ad: @hero_display_ad, data_context_type: BillboardEvent::CONTEXT_TYPE_HOME } %>
+  <% if @hero_billboard && FeatureFlag.enabled?(:hero_billboard) %>
+    <%= render partial: "shared/display_ad", locals: { display_ad: @hero_billboard, data_context_type: BillboardEvent::CONTEXT_TYPE_HOME } %>
   <% end %>
   <div class="crayons-layout crayons-layout--3-cols crayons-layout--3-cols--drop-right-left" id="index-container"
       data-params="<%= params.merge(sort_by: "hotness_score", sort_direction: "desc").to_json(only: %i[tag username q sort_by sort_direction]) %>" data-which="<%= @list_of %>"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -89,7 +89,7 @@
   <div id="page-content-inner">
     <div id="page-route-change" class="screen-reader-only" aria-live="polite" aria-atomic="true"></div>
 
-    <% if @hero_html && @hero_display_ad.blank? %>
+    <% if @hero_html && @hero_billboard.blank? %>
       <aside id="hero-html-wrapper" aria-label="Campaign banner" class="overflow-x-hidden" data-name="<%= @hero_area.name %>">
         <script>
           // Make sure html variant element has id hero-html-wrapper and data-name as its name

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "StoriesIndex" do
 
   describe "GET stories index" do
     let(:user) { create(:user) }
+    let(:org) { create(:organization) }
 
     it "renders page with article list and proper attributes", :aggregate_failures do
       article = create(:article, featured: true)
@@ -67,7 +68,6 @@ RSpec.describe "StoriesIndex" do
     end
 
     it "renders display_ads when published and approved" do
-      org = create(:organization)
       ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_right",
                                organization: org)
 
@@ -76,7 +76,6 @@ RSpec.describe "StoriesIndex" do
     end
 
     it "does not render display_ads when not approved" do
-      org = create(:organization)
       ad = create(:display_ad, published: true, approved: false, placement_area: "sidebar_right",
                                organization: org)
 
@@ -85,7 +84,6 @@ RSpec.describe "StoriesIndex" do
     end
 
     it "renders only one display ad per placement" do
-      org = create(:organization)
       ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_right", organization: org)
       second_ad = create(:display_ad, published: true, approved: true, placement_area: "sidebar_right",
                                       organization: org)
@@ -94,6 +92,13 @@ RSpec.describe "StoriesIndex" do
       expect(response.body).to include(ad.processed_html).or(include(second_ad.processed_html))
       expect(response.body).to include("crayons-card crayons-card--secondary crayons-sponsorship").once
       expect(response.body).to include("sponsorship-dropdown-trigger-").once
+    end
+
+    it "renders a hero display ad" do
+      allow(FeatureFlag).to receive(:enabled?).with(:hero_billboard).and_return(true)
+      billboard = create(:display_ad, published: true, approved: true, placement_area: "home_hero", organization: org)
+      get "/"
+      expect(response.body).to include(billboard.processed_html)
     end
 
     it "shows listings" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
Renamed `@hero_display_ad` => `@hero_billboard` in the views

Variables in the controller were renamed in #19851 but missed in the views, so there shoud be a bug right now.
I have also added a test for displaying a hero_billboard.

## Related Tickets & Documents
- Related Issue #19372 

## QA Instructions, Screenshots, Recordings
- create an approved and published hero billboard  (`home_hero` placement area )
- enable the feature flag `:hero_billboard`
- the billboard should be displayed on the main page

## Added/updated tests?
- [x] Yes

