### PR TITLE
ci: Track changes to .ruby-version-next for base image builds.

### DIFF
--- a/.github/workflows/build-base-ruby-image.yml
+++ b/.github/workflows/build-base-ruby-image.yml
@@ -2,18 +2,20 @@
 name: Build ghcr.io/forem/ruby Container Image
 on:
   workflow_call:
+  # Allow manual runs through GitHub GUI in case of emergency.
+  workflow_dispatch:
   push:
     branches:
       - 'main'
     paths:
       - 'Containerfile.base'
-      - '.ruby-version'
+      - '.ruby-version-next'
   pull_request:
     branches:
       - 'main'
     paths:
       - 'Containerfile.base'
-      - '.ruby-version'
+      - '.ruby-version-next'
 
 jobs:
   build-image:


### PR DESCRIPTION
In #19871 base images changed to referencing `.ruby-version-next` (enabling two-PR sequences for updating our Ruby version target), but the corresponding GitHub Action was not updated, now necessitating a manual CI run for that particular version update. This commit fixes this oversight for future runs.