### PR TITLE
ci: Allow workflow_dispatch runs to push to GHCR.

### DIFF
--- a/.github/workflows/build-base-ruby-image.yml
+++ b/.github/workflows/build-base-ruby-image.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           files: Containerfile.base
       - name: Do not push to GHCR if this commit does not target the main branch
-        if: ${{ github.event_name != 'push' }}
+        if: ${{ github.event_name != 'push' && github.event_name != 'workflow_dispatch' }}
         run: echo "SKIP_PUSH=1" >> $GITHUB_ENV
       - name: Set up QEMU for cross-compiling to ARM64
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Turns out I forgot one more condition to make the merge of #19875 actually useful: `workflow_dispatch` has to be allowed to push to GHCR :facepalm: Failure to do so results in actions runs [like this one](https://github.com/forem/forem/actions/runs/5742595405/job/15565026133) which don't populate `ghcr.io/forem/ruby` with a new tag.