### PR TITLE
Renaming display ads to billboards: locales keys + UI language

### DIFF
--- a/app/models/admin_menu.rb
+++ b/app/models/admin_menu.rb
@@ -27,7 +27,7 @@ class AdminMenu
     scope :customization, "tools-line", [
       item(name: "config"),
       item(name: "html variants", controller: "html_variants"),
-      item(name: "display ads", controller: "billboards"),
+      item(name: "billboards"),
       item(name: "navigation links"),
       item(name: "pages"),
       item(name: "profile fields"),

--- a/app/models/display_ad.rb
+++ b/app/models/display_ad.rb
@@ -141,7 +141,7 @@ class DisplayAd < ApplicationRecord
   def validate_in_house_hero_ads
     return unless placement_area == "home_hero" && type_of != "in_house"
 
-    errors.add(:type_of, "must be in_house if display ad is a Home Hero")
+    errors.add(:type_of, "must be in_house if billboard is a Home Hero")
   end
 
   def audience_segment_type
@@ -178,7 +178,7 @@ class DisplayAd < ApplicationRecord
   def generate_billboard_name
     return unless name.nil?
 
-    self.name = "Display Ad #{id}"
+    self.name = "Billboard #{id}"
     save!
   end
 

--- a/app/views/admin/billboards/_form.html.erb
+++ b/app/views/admin/billboards/_form.html.erb
@@ -51,7 +51,7 @@
     <div class="crayons-field">
       <fieldset aria-describedby="section-description" aria-describedby="display-to-description">
         <legend class="crayons-field crayons-field__label pl-0">Display to user group</legend>
-        <p id="display-to-description" class="crayons-field__description mb-2">Determines which user group will be able to see the Display Ad</p>
+        <p id="display-to-description" class="crayons-field__description mb-2">Determines which user group will be able to see the Billboard</p>
 
         <label class="crayons-field crayons-field--radio mb-2">
           <%= radio_button_tag :display_to, "all", @billboard.display_to_all?, class: "crayons-radio" %>
@@ -128,13 +128,13 @@
       <% else %>
         <div class="flex flex-col gap-3">
           <p>
-            Display ads will show up in the designated placement area <strong>once published and approved</strong>. You can safely preview them here before publishing.
+            Billboards will show up in the designated placement area <strong>once published and approved</strong>. You can safely preview them here before publishing.
           </p>
           <p>
-            Multiple ads that share the same placement area will be swapped every few minutes. <strong>The units with the most engagement will show up the most often</strong>.
+            Multiple billboards that share the same placement area will be swapped every few minutes. <strong>The units with the most engagement will show up the most often</strong>.
           </p>
           <p>
-            Organization ID is optional. Use it if you want to attribute an ad to a specific organization.
+            Organization ID is optional. Use it if you want to attribute a billboard to a specific organization.
           </p>
         </div>
       <% end %>

--- a/app/views/admin/billboards/edit.html.erb
+++ b/app/views/admin/billboards/edit.html.erb
@@ -1,8 +1,8 @@
 <%= stylesheet_link_tag "minimal", media: "all" %>
-<h1 class="crayons-title mb-6">Edit Display Ad:</h1>
+<h1 class="crayons-title mb-6">Edit Billboard:</h1>
 <div class="crayons-card p-6">
   <%= form_for([:admin, @billboard], url: admin_billboard_path(@billboard), method: :patch) do %>
     <%= render "form" %>
-    <%= submit_tag "Update Display Ad", class: "c-btn c-btn--primary" %>
+    <%= submit_tag "Update Billboard", class: "c-btn c-btn--primary" %>
   <% end %>
 </div>

--- a/app/views/admin/billboards/index.html.erb
+++ b/app/views/admin/billboards/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="crayons-title mb-3">Display Ads</h1>
+<h1 class="crayons-title mb-3">Billboards</h1>
 
 <div
   data-controller="confirmation-modal"
@@ -6,13 +6,13 @@
   data-confirmation-modal-content-selector-value="#confirmation-modal"
   data-confirmation-modal-title-value="Confirm changes"
   data-confirmation-modal-size-value="m">
-  <nav class="flex mb-4" aria-label="Display Ads navigation">
+  <nav class="flex mb-4" aria-label="Billboards navigation">
     <%= form_tag(admin_billboards_path, method: "get") do %>
      <%= text_field_tag(:search, params[:search], aria: { label: "Search" }, class: "crayons-header--search-input crayons-textfield", placeholder: "Search", autocomplete: "off") %>
     <% end %>
     <div class="ml-auto">
       <div class="justify-end">
-        <%= link_to "Make A New Display Ad", new_admin_billboard_path, class: "crayons-btn" %>
+        <%= link_to "Make A New Billboard", new_admin_billboard_path, class: "crayons-btn" %>
       </div>
     </div>
   </nav>

--- a/app/views/admin/billboards/new.html.erb
+++ b/app/views/admin/billboards/new.html.erb
@@ -1,7 +1,7 @@
-<h1 class="crayons-title mb-4">Make a new Display Ad</h1>
+<h1 class="crayons-title mb-4">Make a new Billboard</h1>
 <div class="crayons-card p-6">
   <%= form_for([:admin, @billboard], url: admin_billboards_path, method: :post) do %>
     <%= render "form" %>
-    <%= submit_tag "Save Display Ad", class: "c-btn c-btn--primary" %>
+    <%= submit_tag "Save Billboard", class: "c-btn c-btn--primary" %>
   <% end %>
 </div>

--- a/app/views/shared/_billboard_header.html.erb
+++ b/app/views/shared/_billboard_header.html.erb
@@ -6,7 +6,7 @@
         <div class="crayons-sponsorship__title ml-2 fs-s fw-medium"><%= billboard.organization.name %></div>
       </a>
       <% if billboard.type_of == "external" %>
-        <span class="crayons-sponsorship__indicator c-indicator c-indicator--subtle c-indicator--round fs-2xs fw-medium ml-2 py-1 px-2"><%= I18n.t("display_ad.promoted") %></span>
+        <span class="crayons-sponsorship__indicator c-indicator c-indicator--subtle c-indicator--round fs-2xs fw-medium ml-2 py-1 px-2"><%= I18n.t("billboard.promoted") %></span>
       <% end %>
     </div>
   <% else %>
@@ -15,8 +15,8 @@
 
   <button id="sponsorship-dropdown-trigger-<%= billboard.id %>" aria-controls="sponsorship-dropdown-<%= billboard.id %>" aria-expanded="false" aria-haspopup="true"
     class="dropBtn crayons-sponsorship__dropdown crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon"
-    aria-label="<%= t("display_ad.menu.aria_label") %>">
-      <%= crayons_icon_tag("small-overflow-horizontal", class: "pointer-events-none", title: t("display_ad.menu.icon")) %>
+    aria-label="<%= t("billboard.menu.aria_label") %>">
+      <%= crayons_icon_tag("small-overflow-horizontal", class: "pointer-events-none", title: t("billboard.menu.icon")) %>
   </button>
 
   <div id="sponsorship-dropdown-<%= billboard.id %>" class="crayons-dropdown sponsorship-dropdown right-0">
@@ -24,20 +24,20 @@
         <li>
           <a class="crayons-link crayons-link--block" href='/billboards'>
             <%= crayons_icon_tag("info", width: 16, height: 16, aria_hidden: true, class: "c-btn__icon") %>
-            <%= I18n.t("display_ad.menu.what_is_a_billboard") %>
+            <%= I18n.t("billboard.menu.what_is_a_billboard") %>
           </a>
         </li>
       <li>
         <a class="crayons-link crayons-link--block" href='/settings/customization#sponsors'>
           <%= crayons_icon_tag("setting", width: 16, height: 16, aria_hidden: true, class: "c-btn__icon") %>
-          <%= I18n.t("display_ad.menu.manage_preferences") %>
+          <%= I18n.t("billboard.menu.manage_preferences") %>
         </a>
       </li>
       <hr />
       <li>
         <a class="crayons-link crayons-link--block" href="/report-abuse?billboard=<%= billboard.id %>">
           <%= crayons_icon_tag("flag", width: 16, height: 16, aria_hidden: true, class: "c-btn__icon") %>
-          <%= I18n.t("display_ad.menu.report_billboard") %>
+          <%= I18n.t("billboard.menu.report_billboard") %>
         </a>
       </li>
     </ul>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -140,7 +140,7 @@ Rails.application.configure do
     Bullet.add_safelist(type: :unused_eager_loading, class_name: "Article", association: :collection)
     Bullet.add_safelist(type: :unused_eager_loading, class_name: "Article", association: :distinct_reaction_categories)
     Bullet.add_safelist(type: :unused_eager_loading, class_name: "Comment", association: :user)
-    # There were some warnings about eager loading the organization for a display ad, however since the code goes down
+    # There were some warnings about eager loading the organization for a billboard, however since the code goes down
     # different paths (in_house where we don’t need the organization info vs external/community where we need the
     # organization info), bullet was getting confused on whether we need the eager loading or not.
     Bullet.add_safelist(type: :unused_eager_loading, class_name: "DisplayAd", association: :organization)

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -29,10 +29,10 @@ en:
       updated: '%{app} has been updated!'
       wrong: Something went wrong with deleting %{app}.
     billboards_controller:
-      created: Display Ad has been created!
-      deleted: Display Ad has been deleted!
-      updated: Display Ad has been updated!
-      wrong: Something went wrong with deleting the Display Ad.
+      created: Billboard has been created!
+      deleted: Billboard has been deleted!
+      updated: Billboard has been updated!
+      wrong: Something went wrong with deleting the Billboard.
     gdpr_delete_requests_controller:
       deleted: Successfully marked as deleted
     extensions_controller:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,7 +144,7 @@ en:
       x_years:
         one: Expires in 1 year
         other: Expires in %{count} years
-  display_ad:
+  billboard:
     promoted: Promoted
     menu:
       aria_label: Toggle dropdown menu

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -159,7 +159,7 @@ fr:
       x_years:
         one: Expire dans 1 an
         other: Expire dans %{count} ans
-  display_ad:
+  billboard:
     promoted: Promu
     menu:
       aria_label: Basculer le menu déroulant

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -296,7 +296,7 @@ en:
               resource_admin_broadcast: Broadcast Admin
               resource_admin_comment: Comment Admin
               resource_admin_config: Config Admin
-              resource_admin_display_ad: Display Ad Admin
+              resource_admin_billboard: Billboard Admin
               resource_admin_data_update_script: Data Update Script Admin
               resource_admin_feedback_message: Feedback Message Admin
               resource_admin_html_variant: HTML Variant Admin
@@ -389,7 +389,7 @@ en:
           "Resource Admin: Broadcast": "Resource Admin: Broadcast"
           "Resource Admin: Comment": "Resource Admin: Comment"
           "Resource Admin: Config": "Resource Admin: Config"
-          "Resource Admin: DisplayAd": "Resource Admin: DisplayAd"
+          "Resource Admin: Billboard": "Resource Admin: Billboard"
           "Resource Admin: DataUpdateScript": "Resource Admin: DataUpdateScript"
           "Resource Admin: FeedbackMessage": "Resource Admin: FeedbackMessage"
           "Resource Admin: HtmlVariant": "Resource Admin: HtmlVariant"

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -389,7 +389,7 @@ en:
           "Resource Admin: Broadcast": "Resource Admin: Broadcast"
           "Resource Admin: Comment": "Resource Admin: Comment"
           "Resource Admin: Config": "Resource Admin: Config"
-          "Resource Admin: Billboard": "Resource Admin: Billboard"
+          "Resource Admin: DisplayAd": "Resource Admin: DisplayAd"
           "Resource Admin: DataUpdateScript": "Resource Admin: DataUpdateScript"
           "Resource Admin: FeedbackMessage": "Resource Admin: FeedbackMessage"
           "Resource Admin: HtmlVariant": "Resource Admin: HtmlVariant"

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -296,7 +296,7 @@ fr:
               resource_admin_broadcast: Broadcast Admin
               resource_admin_comment: Comment Admin
               resource_admin_config: Config Admin
-              resource_admin_display_ad: Display Ad Admin
+              resource_admin_billboard: Billboard Admin
               resource_admin_data_update_script: Data Update Script Admin
               resource_admin_feedback_message: Feedback Message Admin
               resource_admin_html_variant: HTML Variant Admin
@@ -387,7 +387,7 @@ fr:
           "Resource Admin: Broadcast": "Resource Admin: Broadcast"
           "Resource Admin: Comment": "Resource Admin: Comment"
           "Resource Admin: Config": "Resource Admin: Config"
-          "Resource Admin: DisplayAd": "Resource Admin: DisplayAd"
+          "Resource Admin: Billboard": "Resource Admin: Billboard"
           "Resource Admin: DataUpdateScript": "Resource Admin: DataUpdateScript"
           "Resource Admin: FeedbackMessage": "Resource Admin: FeedbackMessage"
           "Resource Admin: HtmlVariant": "Resource Admin: HtmlVariant"

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -387,7 +387,7 @@ fr:
           "Resource Admin: Broadcast": "Resource Admin: Broadcast"
           "Resource Admin: Comment": "Resource Admin: Comment"
           "Resource Admin: Config": "Resource Admin: Config"
-          "Resource Admin: Billboard": "Resource Admin: Billboard"
+          "Resource Admin: DisplayAd": "Resource Admin: DisplayAd"
           "Resource Admin: DataUpdateScript": "Resource Admin: DataUpdateScript"
           "Resource Admin: FeedbackMessage": "Resource Admin: FeedbackMessage"
           "Resource Admin: HtmlVariant": "Resource Admin: HtmlVariant"

--- a/cypress/e2e/seededFlows/adminFlows/billboards/deleteBillboards.spec.js
+++ b/cypress/e2e/seededFlows/adminFlows/billboards/deleteBillboards.spec.js
@@ -48,7 +48,7 @@ describe('Delete Display Ads', () => {
         cy.findByTestId('snackbar').within(() => {
           cy.findByRole('alert').should(
             'have.text',
-            'Display Ad has been deleted!',
+            'Billboard has been deleted!',
           );
         });
 
@@ -60,7 +60,7 @@ describe('Delete Display Ads', () => {
       cy.intercept('DELETE', '/admin/customization/billboards/**', {
         statusCode: 422,
         body: {
-          error: 'Something went wrong with deleting the Display Ad.',
+          error: 'Something went wrong with deleting the Billboard.',
         },
       });
 
@@ -74,7 +74,7 @@ describe('Delete Display Ads', () => {
 
         cy.findByTestId('alertzone').within(() => {
           cy.findByRole('alert')
-            .contains('Something went wrong with deleting the Display Ad.')
+            .contains('Something went wrong with deleting the Billboard.')
             .should('be.visible');
         });
 

--- a/cypress/e2e/seededFlows/adminFlows/billboards/editBillboards.spec.js
+++ b/cypress/e2e/seededFlows/adminFlows/billboards/editBillboards.spec.js
@@ -6,7 +6,7 @@ describe('Billboards Form', () => {
 
       cy.get('@user').then((user) => {
         cy.loginAndVisit(user, '/admin/customization/billboards');
-        cy.findByRole('link', { name: 'Make A New Display Ad' }).click({
+        cy.findByRole('link', { name: 'Make A New Billboard' }).click({
           force: true,
         });
       });
@@ -115,7 +115,7 @@ describe('Billboards Form', () => {
         cy.enableFeatureFlag('billboard_location_targeting');
         cy.get('@user').then((user) => {
           cy.loginAndVisit(user, '/admin/customization/billboards');
-          cy.findByRole('link', { name: 'Make A New Display Ad' }).click({
+          cy.findByRole('link', { name: 'Make A New Billboard' }).click({
             force: true,
           });
         });
@@ -135,7 +135,7 @@ describe('Billboards Form', () => {
         cy.findByRole('textbox', { name: 'Target Geolocations:' }).type(
           'CA-ON, US-OH, US-MI',
         );
-        cy.findByRole('button', { name: 'Save Display Ad' }).click();
+        cy.findByRole('button', { name: 'Save Billboard' }).click();
         cy.get('#flash-0').should(($flashMessage) => {
           expect($flashMessage).to.not.contain(
             'is not a supported ISO 3166-2 code',
@@ -147,7 +147,7 @@ describe('Billboards Form', () => {
         cy.findByRole('textbox', { name: 'Target Geolocations:' }).type(
           'US-NY, MX-CMX',
         );
-        cy.findByRole('button', { name: 'Save Display Ad' }).click();
+        cy.findByRole('button', { name: 'Save Billboard' }).click();
         cy.get('#flash-0').should(($flashMessage) => {
           // We currently support only the US and CA
           expect($flashMessage).to.contain(

--- a/spec/lib/data_update_scripts/generate_display_ad_names_spec.rb
+++ b/spec/lib/data_update_scripts/generate_display_ad_names_spec.rb
@@ -9,7 +9,7 @@ describe DataUpdateScripts::GenerateDisplayAdNames do
       display_ad = create(:display_ad, name: nil)
 
       described_class.new.run
-      expect(display_ad.reload.name).to eq("Display Ad #{display_ad.id}")
+      expect(display_ad.reload.name).to eq("Billboard #{display_ad.id}")
     end
   end
 

--- a/spec/models/display_ad_spec.rb
+++ b/spec/models/display_ad_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe DisplayAd do
       display_ad.type_of = "community"
       expect(display_ad).not_to be_valid
       expect(display_ad.errors[:type_of])
-        .to include("must be in_house if display ad is a Home Hero")
+        .to include("must be in_house if billboard is a Home Hero")
     end
 
     it "disallows unacceptable placement_area" do
@@ -182,7 +182,7 @@ RSpec.describe DisplayAd do
     it "keeps the same processed_html if markdown was not changed" do
       display_ad = create(:display_ad)
       html = display_ad.processed_html
-      display_ad.update(name: "Sample display ad")
+      display_ad.update(name: "Sample billboard")
       display_ad.reload
       expect(display_ad.processed_html).to eq(html)
     end
@@ -194,7 +194,7 @@ RSpec.describe DisplayAd do
     it "generates a name when one does not exist" do
       display_ad_with_name = create(:display_ad, name: "Test")
 
-      expect(display_ad.name).to eq("Display Ad #{display_ad.id}")
+      expect(display_ad.name).to eq("Billboard #{display_ad.id}")
       expect(display_ad_with_name.name).to eq("Test")
     end
   end

--- a/spec/queries/admin/users_query_spec.rb
+++ b/spec/queries/admin/users_query_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Admin::UsersQuery, type: :query do
     end
 
     context "when given multiple single_resource_admin roles" do
-      let(:roles) { ["Admin", "Super Admin", "Resource Admin: DataUpdateScript", "Resource Admin: Billboard"] }
+      let(:roles) { ["Admin", "Super Admin", "Resource Admin: DataUpdateScript", "Resource Admin: DisplayAd"] }
       let!(:user8) { create(:user).tap { |u| u.add_role(:single_resource_admin, DisplayAd) } }
       # This user is provided to ensure our test looks for unique users even if they have duplicate roles
       let!(:user9) { create(:user, :super_admin).tap { |u| u.add_role(:single_resource_admin, DisplayAd) } }

--- a/spec/queries/admin/users_query_spec.rb
+++ b/spec/queries/admin/users_query_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Admin::UsersQuery, type: :query do
     end
 
     context "when given multiple single_resource_admin roles" do
-      let(:roles) { ["Admin", "Super Admin", "Resource Admin: DataUpdateScript", "Resource Admin: DisplayAd"] }
+      let(:roles) { ["Admin", "Super Admin", "Resource Admin: DataUpdateScript", "Resource Admin: Billboard"] }
       let!(:user8) { create(:user).tap { |u| u.add_role(:single_resource_admin, DisplayAd) } }
       # This user is provided to ensure our test looks for unique users even if they have duplicate roles
       let!(:user9) { create(:user, :super_admin).tap { |u| u.add_role(:single_resource_admin, DisplayAd) } }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Renamed locales keys and ui language display ads => billboards
I haven't changed locales and texts in the constants related to roles, because it's a more complex issue, I'll address this in a separate pr.

## Related Tickets & Documents
- Related Issue #19372

## QA Instructions, Screenshots, Recordings
Billboards functionality should continue to work as it used to.