### PR TITLE
Switch settings to safe yaml load

### DIFF
--- a/app/models/settings/base.rb
+++ b/app/models/settings/base.rb
@@ -153,7 +153,17 @@ module Settings
 
     # get the setting's value, YAML decoded
     def value
-      YAML.unsafe_load(self[:value]) if self[:value].present?
+      return if self[:value].blank?
+
+      YAML.safe_load(self[:value],
+                     permitted_classes: [
+                       ActiveSupport::HashWithIndifferentAccess,
+                       ActiveSupport::TimeZone,
+                       ActiveSupport::TimeWithZone,
+                       BigDecimal,
+                       Symbol,
+                       Time,
+                     ])
     end
 
     # set the settings's value, YAML encoded


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

One of the major changes in ruby `3.1.4` is that `psych` (the yaml engine) has switched the `load` method so that it's _no longer_ an alias for `unsafe_load` and is now an alias for `safe_load`. In [that PR](https://github.com/forem/forem/pull/19912), it made more sense to rewrite this method to preserve the original "unsafe" functionality, but I suggested we could switch it over to `safe_load` in a follow-up PR. This is that follow-up.

## QA Instructions, Screenshots, Recordings

This code is backing the Admin::Settings page (although not _all_ the settings use it), you can test this PR by visiting `http://localhost:3000/admin/customization/config`, changing settings and refreshing to ensure that they are displayed correctly. (Any errors would be at read-time, not at write-time, for what it's worth.)

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: existing tests cover this "okay-ish"
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media2.giphy.com/media/tr5M5BaaCBIJJ19O7T/giphy.gif?cid=ecf05e47522w1ughypnmyndig7s4k76mpsluvzfa9v2badmd&ep=v1_gifs_search&rid=giphy.gif&ct=g)
