### PR TITLE
FeatureFlag.enabled_for_user(_id)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -288,7 +288,7 @@ class ApplicationController < ActionController::Base
   end
 
   def feature_flag_enabled?(flag_name, acting_as: current_user)
-    FeatureFlag.enabled?(flag_name, FeatureFlag::Actor[acting_as])
+    FeatureFlag.enabled_for_user?(flag_name, acting_as)
   end
 
   helper_method :feature_flag_enabled?

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,12 +8,20 @@ module FeatureFlag
     end
 
     def flipper_id
-      respond_to?(:id) ? id : nil
+      respond_to?(:id) ? id : self
     end
   end
 
   class << self
     delegate :add, :disable, :enable, :enabled?, :exist?, :remove, to: Flipper
+
+    def enabled_for_user?(_feature_flag_name, user)
+      enabled?(flag_name, FeatureFlag::Actor[user])
+    end
+
+    def enabled_for_user_id?(_feature_flag_name, user_id)
+      enabled?(flag_name, FeatureFlag::Actor[user_id])
+    end
 
     # @!method FeatureFlag.enabled?(feature_flag_name, *args)
     #

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -15,11 +15,11 @@ module FeatureFlag
   class << self
     delegate :add, :disable, :enable, :enabled?, :exist?, :remove, to: Flipper
 
-    def enabled_for_user?(_feature_flag_name, user)
+    def enabled_for_user?(flag_name, user)
       enabled?(flag_name, FeatureFlag::Actor[user])
     end
 
-    def enabled_for_user_id?(_feature_flag_name, user_id)
+    def enabled_for_user_id?(flag_name, user_id)
       enabled?(flag_name, FeatureFlag::Actor[user_id])
     end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "ApplicationController", type: :request do
+  let!(:user) { create(:user) }
+  let!(:controller) { ApplicationController.new }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#feature_flag_enabled?" do
+    it "calls FeatureFlag.enabled_for_user with current_user" do
+      allow(FeatureFlag).to receive(:enabled_for_user?)
+      controller.feature_flag_enabled?("flag_name")
+      expect(FeatureFlag).to have_received(:enabled_for_user?)
+        .with("flag_name", user)
+    end
+  end
+end

--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -49,6 +49,36 @@ describe FeatureFlag, type: :service do
     end
   end
 
+  describe ".enabled_for_user?" do
+    subject(:method_call) { described_class.enabled?(flag) }
+
+    let(:flag) { "foo" }
+    let(:user) { build(:user) }
+
+    it "calls Flipper's enabled? method" do
+      allow(Flipper).to receive(:enabled?)
+
+      described_class.enabled_for_user?(flag, user)
+
+      expect(Flipper).to have_received(:enabled?).with(flag, instance_of(FeatureFlag::Actor))
+    end
+  end
+
+  describe ".enabled_for_user_id?" do
+    subject(:method_call) { described_class.enabled?(flag) }
+
+    let(:flag) { "foo" }
+    let(:user) { build(:user) }
+
+    it "calls Flipper's enabled? method" do
+      allow(Flipper).to receive(:enabled?)
+
+      described_class.enabled_for_user_id?(flag, user.id)
+
+      expect(Flipper).to have_received(:enabled?).with(flag, instance_of(FeatureFlag::Actor))
+    end
+  end
+
   describe ".exist?" do
     it "calls Flipper's exist? method" do
       allow(Flipper).to receive(:exist?).with("foo")
@@ -60,7 +90,7 @@ describe FeatureFlag, type: :service do
   end
 
   describe ".accessible?" do
-    let(:user) { UserStruct.new(flipper_id: 1) }
+    let(:user) { UserStruct.new({ flipper_id: 1 }) }
 
     it "returns false when flag doesn't exist" do
       expect(described_class.accessible?("missing_flag")).to be(true)
@@ -107,6 +137,29 @@ describe FeatureFlag, type: :service do
 
       described_class.disable(:flag2)
       expect(described_class.all).to eq({ flag1: :on, flag2: :off })
+    end
+  end
+
+  describe FeatureFlag::Actor, type: :service do
+    context "when user object" do
+      subject(:actor) { described_class[user] }
+
+      let(:user_id) { 123 }
+      let(:user) { User.new id: user_id }
+
+      it "represents flipper_id as user.id" do
+        expect(actor.flipper_id).to eq(user_id)
+      end
+    end
+
+    context "when user_id" do
+      subject(:actor) { described_class[user_id] }
+
+      let(:user_id) { 123 }
+
+      it "represents flipper_id as user.id" do
+        expect(actor.flipper_id).to eq(user_id)
+      end
     end
   end
 end


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We're still kinda new at using `flipper`, but we'd like to use it more. Specifically, we'd like to use it for `billboard_location_targeting`, but we don't always have access to a fully-inflated `User`, we sometimes _only_ have `user_id`. This is a quick refactor to make our `FeatureFlag` wrapper utility work better for this case.

## Related Tickets & Documents

- Related [#19757 ](https://github.com/forem/forem/issues/19793)

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media1.giphy.com/media/xTiIzAjgTOdqUvwRWM/giphy.gif?cid=ecf05e47131zdt2j5t7163dyxcn25bh9743i9xyzmgh8dvri&ep=v1_gifs_search&rid=giphy.gif&ct=g)
