### PR TITLE
Improve gitpod setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,28 +13,28 @@ ports:
 
 tasks:
   - name: Forem Server
-    before: >
-      redis-server &
-      gp ports await 5432 &&
+    before: |
+      redis-server & gp ports await 5432
       sleep 1
     init: ./gitpod-init.sh
     command: bin/startup
   - name: Open Site
-    command: >
-      gp ports await 3000 &&
-      printf "Waiting for local Forem development environment to load in the browser..." &&
+    command: |
+      gp ports await 3000
+      printf "Waiting for local Forem development environment to load in the browser..."
       gp preview $(gp url 3000)
+      exit
 
 github:
   prebuilds:
     # enable for the master/default branch (defaults to true)
     master: true
     # enable for all branches in this repo (defaults to false)
-    branches: true
+    branches: false
     # enable for pull requests coming from this repo (defaults to true)
     pullRequests: true
     # enable for pull requests coming from forks (defaults to false)
-    pullRequestsFromForks: true
+    pullRequestsFromForks: false
     # add a "Review in Gitpod" button as a comment to pull requests (defaults to true)
     addComment: false
     # add a "Review in Gitpod" button to pull requests (defaults to false)

--- a/gitpod-init.sh
+++ b/gitpod-init.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-ln -s "$(which ruby)" "$(rvm gemdir)/bin/ruby"
 cp .env_sample .env
 echo "APP_DOMAIN=\"$(gp url 3000 | cut -f 3 -d /)\"" >> .env
 echo 'APP_PROTOCOL="https://"' >> .env


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
Quite a bit of changes here.
- organize relevant things into `gitpod/` folder.
- Use a `gitpod/workspace-base` image for a more lightweight approach. `gitpod/workspace-ruby-3.1` doesn't have ruby 3.1.4 so it actually better to use `workspace-base` as a scaffold
- Prefer `rtx` as the universal version manager. It's fast, and speed is necessary on a weaker cloud computers.
- I've taken code directly from gitpod for some of these tool setups.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings
Try it out here https://gitpod.io/new/#https://github.com/forem/forem/tree/mac/gitpod/update-image

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a