### PR TITLE
Renamed display ads to billboards in tests descriptions

### DIFF
--- a/spec/queries/billboards/filtered_ads_query_spec.rb
+++ b/spec/queries/billboards/filtered_ads_query_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe Billboards::FilteredAdsQuery, type: :query do
     let!(:no_tags) { create_billboard cached_tag_list: "" }
     let!(:mismatched) { create_billboard cached_tag_list: "career" }
 
-    it "will show no-tag display ads if the article tags do not contain matching tags" do
+    it "will show no-tag billboards if the article tags do not contain matching tags" do
       filtered = filter_billboards(article_id: 11, article_tags: %w[javascript])
       expect(filtered).not_to include(mismatched)
       expect(filtered).to include(no_tags)
     end
 
-    it "will show display ads with no tags set if there are no article tags" do
+    it "will show billboards with no tags set if there are no article tags" do
       filtered = filter_billboards(article_id: 11, article_tags: [])
       expect(filtered).not_to include(mismatched)
       expect(filtered).to include(no_tags)
@@ -52,7 +52,7 @@ RSpec.describe Billboards::FilteredAdsQuery, type: :query do
     context "when available ads have matching tags" do
       let!(:matching) { create_billboard cached_tag_list: "linux, git, go" }
 
-      it "will show the display ads that contain tags that match any of the article tags" do
+      it "will show the billboards that contain tags that match any of the article tags" do
         filtered = filter_billboards article_id: 11, article_tags: %w[linux productivity]
         expect(filtered).not_to include(mismatched)
         expect(filtered).to include(matching)
@@ -65,13 +65,13 @@ RSpec.describe Billboards::FilteredAdsQuery, type: :query do
     let!(:no_tags) { create_billboard placement_area: "feed_first", cached_tag_list: "" }
     let!(:mismatched) { create_billboard placement_area: "feed_first", cached_tag_list: "career" }
 
-    it "will show no-tag display ads if the user tags do not contain matching tags" do
+    it "will show no-tag billboards if the user tags do not contain matching tags" do
       filtered = filter_billboards(area: "feed_first", user_tags: %w[javascript])
       expect(filtered).not_to include(mismatched)
       expect(filtered).to include(no_tags)
     end
 
-    it "will show display ads with no tags set if there are no user tags" do
+    it "will show billboards with no tags set if there are no user tags" do
       filtered = filter_billboards(area: "feed_first", user_tags: [])
       expect(filtered).not_to include(mismatched)
       expect(filtered).to include(no_tags)
@@ -80,7 +80,7 @@ RSpec.describe Billboards::FilteredAdsQuery, type: :query do
     context "when available ads have matching tags" do
       let!(:matching) { create_billboard placement_area: "feed_first", cached_tag_list: "linux, git, go" }
 
-      it "will show the display ads that contain tags that match any of the user tags" do
+      it "will show the billboards that contain tags that match any of the user tags" do
         filtered = filter_billboards area: "feed_first", user_tags: %w[linux productivity]
         expect(filtered).not_to include(mismatched)
         expect(filtered).to include(matching)
@@ -108,7 +108,7 @@ RSpec.describe Billboards::FilteredAdsQuery, type: :query do
     let!(:another_ex_article2) { create_billboard exclude_article_ids: "12,13" }
     let!(:no_excludes) { create_billboard }
 
-    it "will show display ads that exclude articles appropriately" do
+    it "will show billboards that exclude articles appropriately" do
       filtered = filter_billboards article_id: 11
       expect(filtered).to contain_exactly(another_ex_article2, no_excludes)
 

--- a/spec/requests/billboard_events_spec.rb
+++ b/spec/requests/billboard_events_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "BillboardEvents" do
         sign_in user
       end
 
-      it "creates a display ad click event" do
+      it "creates a billboard click event" do
         post "/billboard_events", params: {
           billboard_event: {
             billboard_id: billboard.id,
@@ -22,7 +22,7 @@ RSpec.describe "BillboardEvents" do
         expect(billboard.reload.clicks_count).to eq(1)
       end
 
-      it "creates a display ad click event with old params" do
+      it "creates a billboard click event with old params" do
         post "/billboard_events", params: {
           display_ad_event: {
             display_ad_id: billboard.id,
@@ -33,7 +33,7 @@ RSpec.describe "BillboardEvents" do
         expect(billboard.reload.clicks_count).to eq(1)
       end
 
-      it "creates a display ad impression event" do
+      it "creates a billboard impression event" do
         post "/billboard_events", params: {
           billboard_event: {
             billboard_id: billboard.id,
@@ -44,7 +44,7 @@ RSpec.describe "BillboardEvents" do
         expect(billboard.reload.impressions_count).to eq(1)
       end
 
-      it "creates a display ad success rate" do
+      it "creates a billboard success rate" do
         ad_event_params = { billboard_id: billboard.id, context_type: BillboardEvent::CONTEXT_TYPE_HOME }
         impression_params = ad_event_params.merge(category: BillboardEvent::CATEGORY_IMPRESSION, user: user)
         create_list(:billboard_event, 4, impression_params)

--- a/spec/services/content_renderer_spec.rb
+++ b/spec/services/content_renderer_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe ContentRenderer do
       end.to raise_error(ContentRenderer::ContentParsingError, /This liquid tag can only be used in Articles/)
     end
 
-    it "raises ContentParsingError for display ad" do
+    it "raises ContentParsingError for billboard" do
       source = build(:billboard)
       expect do
         described_class.new(markdown, source: source, user: user).process


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
Renamed a few test descriptions that were left.
I kept a couple of those referencing class name (`DisplayAd`) - it should be changed with the class renaming.

## Related Tickets & Documents
- Related Issue #19372