### PR TITLE
add smart cropping option with specs

### DIFF
--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -1,12 +1,12 @@
 module Images
   module Optimizer
-    def self.call(img_src, **kwargs)
+    def self.call(img_src, smart_crop: false, **kwargs)
       return img_src if img_src.blank? || img_src.starts_with?("/")
 
       if imgproxy_enabled?
         imgproxy(img_src, **kwargs)
       elsif cloudinary_enabled?
-        cloudinary(img_src, **kwargs)
+        cloudinary(img_src, smart_crop: smart_crop, **kwargs)
       elsif cloudflare_enabled?
         cloudflare(img_src, **kwargs)
       else
@@ -48,8 +48,9 @@ module Images
     end
 
     def self.cloudinary(img_src, **kwargs)
+      smart_crop = kwargs.delete(:smart_crop)
       options = DEFAULT_CL_OPTIONS.merge(kwargs).compact_blank
-      options[:crop] = if kwargs[:crop] == "crop" && ApplicationConfig["CROP_WITH_IMAGGA_SCALE"].present?
+      options[:crop] = if smart_crop && ApplicationConfig["CROP_WITH_IMAGGA_SCALE"].present?
                          "imagga_scale" # Legacy setting if admin imagga_scale set
                        elsif kwargs[:crop] == "crop"
                          "fill"

--- a/app/view_objects/articles/social_image.rb
+++ b/app/view_objects/articles/social_image.rb
@@ -14,7 +14,7 @@ module Articles
       image = user_defined_image
       if image.present?
         image = image.split("w_1000/").last if image.include?("w_1000/https://")
-        return Images::Optimizer.call(image, width: width, height: height, crop: "crop")
+        return Images::Optimizer.call(image, width: width, height: height, crop: "crop", smart_crop: true)
       end
       return legacy_article_social_image unless use_new_social_url?
 
@@ -32,7 +32,7 @@ module Articles
         src = Images::GenerateSocialImage.call(article)
         return src if src.start_with? "https://res.cloudinary.com/"
 
-        Images::Optimizer.call(src, width: "1000", height: "500", crop: "crop")
+        Images::Optimizer.call(src, width: "1000", height: "500", crop: "crop", smart_crop: true)
       end
     end
 

--- a/app/view_objects/cloud_cover_url.rb
+++ b/app/view_objects/cloud_cover_url.rb
@@ -14,7 +14,7 @@ class CloudCoverUrl
     crop = Settings::UserExperience.cover_image_fit
     img_src = url_without_prefix_nesting(url, width)
 
-    Images::Optimizer.call(img_src, width: width, height: height, crop: crop)
+    Images::Optimizer.call(img_src, width: width, height: height, crop: crop, smart_crop: true)
   end
 
   private

--- a/app/views/articles/_bottom_content.html.erb
+++ b/app/views/articles/_bottom_content.html.erb
@@ -7,7 +7,7 @@
           <span class="crayons-avatar crayons-avatar--xl m:crayons-avatar--2xl mr-4 shrink-0">
             <% if article.cached_user.profile_image_url %>
               <%= optimized_image_tag(article.cached_user.profile_image_url,
-                                      optimizer_options: { crop: "crop", width: 100, height: 100 },
+                                      optimizer_options: { crop: "crop", smart_crop: true, width: 100, height: 100 },
                                       image_options: { loading: "lazy", alt: "#{article.cached_user.username} profile image", class: "crayons-avatar__image" }) %>
             <% end %>
           </span>

--- a/app/views/comments/_comment_avatar.html.erb
+++ b/app/views/comments/_comment_avatar.html.erb
@@ -1,6 +1,6 @@
 <% if comment.deleted %>
   <span class="shrink-0 crayons-avatar <% if comment.depth == 0 %>m:crayons-avatar--l mt-4 m:mt-3<% else %>mt-4<% end %>">
-    <%= image_tag(Images::Optimizer.call(Settings::General.mascot_image_url, width: 32, height: 32), class: "crayons-avatar__image overflow-hidden", alt: "Sloan, the sloth mascot", loading: "lazy") %>
+    <%= image_tag(Images::Optimizer.call(Settings::General.mascot_image_url, crop: crop, width: 32, height: 32), class: "crayons-avatar__image overflow-hidden", alt: "Sloan, the sloth mascot", loading: "lazy") %>
   </span>
 <% else %>
   <a href="<%= URL.user(comment.user) %>" class="shrink-0 crayons-avatar <% if comment.depth == 0 %>m:crayons-avatar--l mt-4 m:mt-3<% else %>mt-4<% end %>">

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -55,7 +55,7 @@
       <div class="p-6 m:p-9 crayons-card crayons-card--secondary align-center fs-l h-100 flex items-center justify-center flex-1">
         <div>
           <% if Settings::General.mascot_image_url.present? %>
-            <% image_url = Images::Optimizer.call(Settings::General.mascot_image_url, width: 300, crop: "crop") %>
+            <% image_url = Images::Optimizer.call(Settings::General.mascot_image_url, width: 300, crop: "crop", smart_crop: true) %>
             <%= image_tag(image_url, class: "sloan mb-7", alt: "Mascot image") %>
           <% end %>
           <p class="mb-6"><%= t("views.dashboard.posts.empty.desc") %></p>

--- a/app/views/podcast_episodes/_episodes_feed.html.erb
+++ b/app/views/podcast_episodes/_episodes_feed.html.erb
@@ -3,7 +3,7 @@
     <div class="crayons-card">
       <div class="small-pic">
         <%= optimized_image_tag(episode.image_url || episode.podcast.image_url,
-                                optimizer_options: { crop: "crop", width: 240, height: 240 },
+                                optimizer_options: { crop: "crop", smart_crop: true, width: 240, height: 240 },
                                 image_options: { alt: episode.title, loading: "lazy" }) %>
       </div>
       <div class="content">

--- a/app/views/podcast_episodes/index.html.erb
+++ b/app/views/podcast_episodes/index.html.erb
@@ -46,7 +46,7 @@
       <a href="/<%= episode.podcast.slug %>/<%= episode.slug %>" class="crayons-card media-card <% unless @podcast %>media-card--all<% end %>">
         <div class="media-card__artwork">
           <%= optimized_image_tag(episode.image_url || episode.podcast.image_url,
-                                  optimizer_options: { crop: "crop", width: 240, height: 240 },
+                                  optimizer_options: { crop: "crop", smart_crop: true, width: 240, height: 240 },
                                   image_options: { alt: episode.title, loading: "lazy", class: "w-100 h-100" }) %>
         </div>
         <div class="media-card__content">
@@ -73,7 +73,7 @@
       <% @featured_podcasts.each do |podcast| %>
         <a href="/<%= podcast.slug %>">
             <%= optimized_image_tag(podcast.image_url,
-                                    optimizer_options: { crop: "crop", width: 500, height: 500 },
+                                    optimizer_options: { crop: "crop", smart_crop: true, width: 500, height: 500 },
                                     image_options: { alt: podcast.title, loading: "lazy", class: "w-100 h-auto border-2" }) %>
             <h3 class="crayons-subtitle-2 align-center">
               <%= podcast.title %>

--- a/app/views/videos/index.html.erb
+++ b/app/views/videos/index.html.erb
@@ -30,7 +30,7 @@
         <a href="<%= video_article.path %>" id="video-article-<%= video_article.id %>" class="crayons-card media-card">
           <div class="media-card__artwork">
             <%= optimized_image_tag(video_article.video_thumbnail_url,
-                                    optimizer_options: { crop: "crop", width: 320, height: 180 },
+                                    optimizer_options: { crop: "crop", smart_crop: true, width: 320, height: 180 },
                                     image_options: { alt: video_article.title, loading: "lazy", class: "w-100 object-cover block aspect-16-9 h-auto" }) %>
             <span class="media-card__artwork__badge"><%= video_article.video_duration_in_minutes %></span>
           </div>

--- a/spec/helpers/social_image_helper_spec.rb
+++ b/spec/helpers/social_image_helper_spec.rb
@@ -21,6 +21,16 @@ describe SocialImageHelper do
       expect(url).to include("c_fill,f_auto,fl_progressive,h_500,q_auto,w_1000/")
     end
 
+    it "returns the main image with smart cropping if enabled", cloudinary: true do
+      article.main_image = Faker::CryptoCoin.url_logo
+
+      allow(ApplicationConfig).to receive(:[]).with("CROP_WITH_IMAGGA_SCALE").and_return("true")
+      url = helper.article_social_image_url(article)
+
+      expect(url).to match(/#{article.main_image}/)
+      expect(url).to include("c_imagga_scale,f_auto,fl_progressive,h_500,q_auto,w_1000/")
+    end
+
     it "returns older url2png image if already generated" do
       article.updated_at = Articles::SocialImage::SOCIAL_PREVIEW_MIGRATION_DATETIME - 1.week
 

--- a/spec/view_objects/cloud_cover_url_spec.rb
+++ b/spec/view_objects/cloud_cover_url_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe CloudCoverUrl, cloudinary: true, type: :view_object do
       .and end_with(cloudinary_string)
   end
 
+  it "returns proper url when smart cropping is set" do
+    image_url = article.main_image
+
+    allow(ApplicationConfig).to receive(:[]).with("CROP_WITH_IMAGGA_SCALE").and_return("true")
+    expect(described_class.new(image_url).call)
+      .to start_with(cloudinary_prefix)
+      .and end_with("/c_imagga_scale,f_auto,fl_progressive,h_420,q_auto,w_1000/https://robohash.org/articlefactory.png")
+  end
+
   it "returns proper url when config set to limit" do
     allow(Settings::UserExperience).to receive(:cover_image_fit).and_return("limit")
     expect(described_class.new(article.main_image).call)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

We recently got a report about randomly zoomed in profile images on DEV - I found that the bug was caused by #19936 which flattened things a bit too much and lost some context in the process (i.e. which things we were using Cloudinary's smart cropping fore (like social images?) and which things we weren't (like profile pictures). I added a `smart_crop` parameter to mark the relevant images instead of treating all cropped images the same.

## Related Tickets & Documents

- Related Issue #19970
- Closes #19970

## QA Instructions, Screenshots, Recordings

We can't really QA this in dev or on Uffizzi, but we could deploy it to staging first (which has Cloudinary set up) and see?

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

Nope!