### PR TITLE
Adjust ActiveThreadsQuery to use home_feed_minimum_score

### DIFF
--- a/spec/queries/articles/active_threads_query_spec.rb
+++ b/spec/queries/articles/active_threads_query_spec.rb
@@ -1,16 +1,18 @@
 require "rails_helper"
 
 RSpec.describe Articles::ActiveThreadsQuery, type: :query do
+  let(:min_score) { Settings::UserExperience.home_feed_minimum_score }
+
   before do
-    create(:article, score: described_class::MINIMUM_SCORE - 1, tags: "watercooler")
+    create(:article, score: min_score - 1, tags: "watercooler")
   end
 
   describe "::call" do
     context "when time_ago is latest" do
       it "returns the latest article with a good score", :aggregate_failures do
-        article = create(:article, tags: "discuss", score: described_class::MINIMUM_SCORE + 1)
+        article = create(:article, tags: "discuss", score: min_score + 1)
         create(:article, :past, past_published_at: 2.days.ago, tags: "discuss",
-                                score: described_class::MINIMUM_SCORE + 1)
+                                score: min_score + 1)
 
         result = described_class.call(tags: "discuss", time_ago: "latest", count: 10)
         expect(result.length).to eq(2)
@@ -18,7 +20,7 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
       end
 
       it "returns any article if no higher-quality article is found", :aggregate_failures do
-        article = create(:article, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
+        article = create(:article, tags: "discuss", score: min_score - 10)
 
         result = described_class.call(tags: "discuss", time_ago: "latest", count: 10)
         expect(result.length).to eq(1)
@@ -30,10 +32,10 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
       it "returns article ordered_by comment_count based on time", :aggregate_failures do
         time = 2.days.ago
         article = create(:article, :past, comments_count: 20, past_published_at: time, tags: "discuss",
-                                          score: described_class::MINIMUM_SCORE)
-        create(:article, comments_count: 10, tags: "discuss", score: described_class::MINIMUM_SCORE)
+                                          score: min_score)
+        create(:article, comments_count: 10, tags: "discuss", score: min_score)
         create(:article, :past, past_published_at: time - 2.days, comments_count: 30, tags: "discuss",
-                                score: described_class::MINIMUM_SCORE)
+                                score: min_score)
 
         result = described_class.call(tags: "discuss", time_ago: time, count: 10)
         expect(result.length).to eq(2)
@@ -43,8 +45,8 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
       it "returns any article when no higher-quality article could be found", :aggregate_failures do
         time = 2.days.ago
         article = create(:article, :past, comments_count: 20, past_published_at: time - 5.days, tags: "discuss",
-                                          score: described_class::MINIMUM_SCORE)
-        create(:article, comments_count: 10, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
+                                          score: min_score)
+        create(:article, comments_count: 10, tags: "discuss", score: min_score - 10)
 
         result = described_class.call(tags: "discuss", time_ago: time, count: 10)
         expect(result.length).to eq(2)
@@ -55,8 +57,8 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
     context "when time_ago is not given" do
       it "returns articles ordered by last_comment_at, not based on time", :aggregate_failures do
         article = create(:article, last_comment_at: Time.zone.now, tags: "discuss",
-                                   score: described_class::MINIMUM_SCORE)
-        create(:article, last_comment_at: nil, tags: "discuss", score: described_class::MINIMUM_SCORE)
+                                   score: min_score)
+        create(:article, last_comment_at: nil, tags: "discuss", score: min_score)
 
         result = described_class.call(tags: "discuss", time_ago: nil, count: 10)
         expect(result.length).to eq(2)
@@ -65,8 +67,8 @@ RSpec.describe Articles::ActiveThreadsQuery, type: :query do
 
       it "returns any article, with nil articles last, if no higher-quality articles exist", :aggregate_failures do
         article = create(:article, last_comment_at: Time.zone.now, tags: "discuss",
-                                   score: described_class::MINIMUM_SCORE - 10)
-        create(:article, last_comment_at: 2.days.ago, tags: "discuss", score: described_class::MINIMUM_SCORE - 10)
+                                   score: min_score - 10)
+        create(:article, last_comment_at: 2.days.ago, tags: "discuss", score: min_score - 10)
 
         result = described_class.call(tags: "discuss", time_ago: nil, count: 10)
         expect(result.length).to eq(2)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Remove the _hardcoded_ `MINIMUM_SCORE` for the appropriate score which is configurable by admins.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/20003


## Added/updated tests?

- [x] Yes

