### PR TITLE
Fix typo of configuring redis at datadog initializer

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -25,7 +25,7 @@ Datadog.configure do |c|
   # *lot* of memory on instrumentation alone. This env var allows us to
   # enable it only when needed.
   if ENV["DD_ENABLE_REDIS_SIDEKIQ"] == "true"
-    c.tracing.strument :redis, service_name: "#{service_name}-redis-sidekiq",
+    c.tracing.instrument :redis, service_name: "#{service_name}-redis-sidekiq",
                                describes: { url: ENV.fetch("REDIS_SIDEKIQ_URL", nil) }
   end
   # Generic REDIS_URL comes last, allowing it to overwrite any of the


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix a typo for configuring [Redis](https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/ruby/#redis).


## Related Tickets & Documents

- Related Issue #
- Closes #

## Added/updated tests?

- [ ] Yes
- [x] No need
- [ ] I need help with writing tests
