### PR TITLE
Changed admin docs url from display-ads url to billboards

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -8,7 +8,7 @@ module Admin
       articles: "https://admin.forem.com/docs/forem-basics/posts",
       badges: "https://admin.forem.com/docs/forem-basics/badges",
       badge_achievements: "https://admin.forem.com/docs/forem-basics/badges",
-      display_ads: "https://admin.forem.com/docs/advanced-customization/billboards",
+      billboards: "https://admin.forem.com/docs/advanced-customization/billboards",
       feedback_messages: "https://admin.forem.com/docs/advanced-customization/reports",
       html_variants: "https://admin.forem.com/docs/advanced-customization/html-variants",
       navigation_links: "https://admin.forem.com/docs/advanced-customization/navigation-links",

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -8,7 +8,7 @@ module Admin
       articles: "https://admin.forem.com/docs/forem-basics/posts",
       badges: "https://admin.forem.com/docs/forem-basics/badges",
       badge_achievements: "https://admin.forem.com/docs/forem-basics/badges",
-      display_ads: "https://admin.forem.com/docs/advanced-customization/display-ads",
+      display_ads: "https://admin.forem.com/docs/advanced-customization/billboards",
       feedback_messages: "https://admin.forem.com/docs/advanced-customization/reports",
       html_variants: "https://admin.forem.com/docs/advanced-customization/html-variants",
       navigation_links: "https://admin.forem.com/docs/advanced-customization/navigation-links",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Documentation Update

## Description
After [changing](https://github.com/forem/admin-docs/pull/42) the `admin-docs` we need to update the corresponding url to point to the correct page.

## Related Tickets & Documents
- Related Issue #19372 
