### PR TITLE
Unhiding a tag should unfollow it too

### DIFF
--- a/app/javascript/packs/dashboardTags.js
+++ b/app/javascript/packs/dashboardTags.js
@@ -96,8 +96,7 @@ function handleUnhideButtonClick(tagContainer) {
   const data = {
     followable_type: 'Tag',
     followable_id: tagId,
-    verb: 'follow',
-    explicit_points: 1,
+    verb: 'unfollow',
   };
 
   fetchFollows(data)
@@ -105,12 +104,6 @@ function handleUnhideButtonClick(tagContainer) {
       removeElementFromPage(followId);
       // update the current navigation item count
       updateNavigationItemCount();
-
-      // update the following tags navigation item
-      const followingTagsNavigationItem = document.querySelector(
-        '.js-following-tags-link .c-indicator',
-      );
-      updateNavigationItemCount(followingTagsNavigationItem, 1);
     })
     .catch((error) => console.error(error));
 }

--- a/app/javascript/tags/Tag.jsx
+++ b/app/javascript/tags/Tag.jsx
@@ -25,11 +25,19 @@ export const Tag = ({ id, name, isFollowing, isHidden }) => {
   };
 
   const toggleHideButton = () => {
-    setHidden(!hidden);
-    const updatedFollowing = true;
-    setFollowing(updatedFollowing);
+    const updatedHiddenState = !hidden;
+    setHidden(updatedHiddenState);
+
+    // if the tag's new state will be hidden (clicked on the hide button) then we we set it to following.
+    // if the tags new state is to be unhidden (clicked on the unhide button) then we set it to not following.
+    const updatedFollowingState = updatedHiddenState;
+    setFollowing(updatedFollowingState);
+
     browserStoreCache('remove');
-    postFollowItem({ hidden: !hidden, following: updatedFollowing });
+    postFollowItem({
+      hidden: updatedHiddenState,
+      following: updatedFollowingState,
+    });
   };
 
   const postFollowItem = ({ following, hidden }) => {

--- a/cypress/e2e/seededFlows/dashboardFlows/hiddenTags.spec.js
+++ b/cypress/e2e/seededFlows/dashboardFlows/hiddenTags.spec.js
@@ -34,10 +34,6 @@ describe('Dashboard: Hidden Tags', () => {
     // it decreases the count from the 'Hidden tags' nav item
     cy.get('.js-hidden-tags-link .c-indicator').as('hiddenTagsCount');
     cy.get('@hiddenTagsCount').should('contain', '4');
-
-    // it decreases the count from the 'Following tags' nav item
-    cy.get('.js-following-tags-link .c-indicator').as('followingTagsCount');
-    cy.get('@followingTagsCount').should('contain', '6');
   });
 
   // TODO: add a test for the pagination

--- a/cypress/e2e/seededFlows/tagsFlows/followTag.spec.js
+++ b/cypress/e2e/seededFlows/tagsFlows/followTag.spec.js
@@ -30,7 +30,9 @@ describe('Follow tag', () => {
 
     it('hides and unhides a tag', () => {
       cy.intercept('/follows').as('followsRequest');
-      cy.findByRole('button', { name: 'Follow tag: tag0' }).as('followButton');
+      cy.findByRole('button', { name: 'Follow tag: tag0' }).as(
+        'toBeHiddenFollowButton',
+      );
       cy.findByRole('button', { name: 'Hide tag: tag0' }).as('hideButton');
 
       cy.get('@hideButton').click();
@@ -39,21 +41,26 @@ describe('Follow tag', () => {
       // clicking on 'Hide' should change it to an 'Unhide'
       // and remove the Follow button
       cy.get('@hideButton').should('have.text', 'Unhide');
-      cy.get('@followButton').should('not.exist');
+      cy.get('@toBeHiddenFollowButton').should('not.exist');
 
       // clicking on 'Unhide' should change it back to 'Hide'
-      // and show a 'Following' button
+      // and show a 'Follow' button
       cy.get('@hideButton').click();
       cy.wait('@followsRequest');
 
       cy.get('@hideButton').should('have.text', 'Hide');
-      cy.get('@followButton').should('not.exist');
-      cy.findByRole('button', { name: 'Following tag: tag0' }).as(
-        'followingButton',
+      cy.get('@toBeHiddenFollowButton').should('not.exist');
+
+      cy.findByRole('button', { name: 'Follow tag: tag0' }).as(
+        'toBeShownFollowButton',
       );
-      cy.get('@followingButton').should('exist');
-      cy.get('@followingButton').should('have.text', 'Following');
-      cy.get('@followingButton').should('have.attr', 'aria-pressed', 'true');
+      cy.get('@toBeShownFollowButton').should('exist');
+      cy.get('@toBeShownFollowButton').should('have.text', 'Follow');
+      cy.get('@toBeShownFollowButton').should(
+        'have.attr',
+        'aria-pressed',
+        'false',
+      );
     });
   });
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When we unhide a tag, we should "unfollow" it too, hence the user should see a "Follow" button.

## Related Tickets & Documents

- Related Issue #https://github.com/forem/forem/issues/20039
- Closes #20039 

## QA Instructions, Screenshots, Recordings

**TAGS PAGE:** 
- Go to /tags and click the "follow" button to follow tags. Refresh the page and ensure that they stay followed.
- Now click on the "Following" button to unfollow the tags. Refresh the page and ensure that they stay unfollowed.
- Now find a tag card with a "Follow" button and a "Hide" button. Click on the "Hide" button to to hide the tag. The "Follow" Button should disappear and an "Unhide" button should show up in place of the "Hide" button.
- Now find a tag card with a "Following" button and a "Hide" button. Click on the "Hide" button to to hide the tag. The "Following" Button should disappear and an "Unhide" button should show up in place of the "Hide" button.
- **_(Main purpose of the PR)_** Now click on the "Unhide" Button to unhide the tags. The "Follow" button will appear and the "Hide" button will appear.

**DASHBOARD PAGES:**

**Dashboard - "Following tags" page:**

- Ensure that you go to /tags and follow many tags. These followed tags will show up on the /dashboard/following_tags. - - - - Click on the "Following" Button to unfollow the tags; the tag should disappear from the page and you should see the nav item count drop by 1.
- Click on the overflow menu button and click on "Hide tag" to hide the tag; the tag should disappear from /dashboard/following_tags but it should be added to /dashboard/hidden_tags and you should see the Following Tags nav item count drop by 1 and the Hidden Tags nav item count increase by 1.

**Dashboard - "Hidden tags" page:**

- **_(Main purpose of the PR)_** Click on the "Unhide" Button to unhide the tags; the tag should disappear from /dashboard/hidden_tags, but it should NOT be added to /dashboard/following_tags and you should NOT see the Following
Tags nav item count increase by 1. The Hidden Tags nav item count decrease by 1. When going back to /tags you should see the tag card for that tag have a "Follow" button.

https://www.loom.com/share/f2a6ba6c47984e00be7651c90817ef53?sid=8d66c79e-adc2-4668-8f1f-7fdc974fd347

### UI accessibility checklist
Functionality change 

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/l4KibK3JwaVo0CjDO/giphy.gif)
