### PR TITLE
Store languages that user understands

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,6 +114,8 @@ class User < ApplicationRecord
   has_many :subscribers, through: :source_authored_user_subscriptions, dependent: :destroy
   has_many :tweets, dependent: :nullify
   has_many :devices, dependent: :delete_all
+  # languages that user undestands
+  has_many :languages, class_name: "UserLanguage", inverse_of: :user, dependent: :delete_all
 
   mount_uploader :profile_image, ProfileImageUploader
 

--- a/app/models/user_language.rb
+++ b/app/models/user_language.rb
@@ -1,0 +1,5 @@
+class UserLanguage < ApplicationRecord
+  belongs_to :user, inverse_of: :languages
+
+  validates :language, inclusion: { in: Languages::Detection.codes }, presence: true
+end

--- a/app/services/languages/detection.rb
+++ b/app/services/languages/detection.rb
@@ -4,6 +4,10 @@ module Languages
 
     PROBABILITY_THRESHOLD = 0.5
 
+    def self.codes
+      CLD3::TaskContextParams::LANGUAGE_NAMES.map(&:to_s).freeze
+    end
+
     def self.call(...)
       new(...).call
     end

--- a/db/migrate/20230906112602_create_user_languages.rb
+++ b/db/migrate/20230906112602_create_user_languages.rb
@@ -2,7 +2,7 @@ class CreateUserLanguages < ActiveRecord::Migration[7.0]
   def change
     create_table :user_languages do |t|
       t.references :user, foreign_key: true, null: false
-      t.string :language
+      t.string :language, null: false
 
       t.timestamps
     end

--- a/db/migrate/20230906112602_create_user_languages.rb
+++ b/db/migrate/20230906112602_create_user_languages.rb
@@ -1,0 +1,10 @@
+class CreateUserLanguages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_languages do |t|
+      t.references :user, foreign_key: true, null: false
+      t.string :language
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1172,7 +1172,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_112602) do
 
   create_table "user_languages", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "language"
+    t.string "language", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_user_languages_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_31_160030) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_06_112602) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -1170,6 +1170,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_31_160030) do
     t.index ["blocked_id", "blocker_id"], name: "index_user_blocks_on_blocked_id_and_blocker_id", unique: true
   end
 
+  create_table "user_languages", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "language"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_user_languages_on_user_id"
+  end
+
   create_table "user_subscriptions", force: :cascade do |t|
     t.bigint "author_id", null: false
     t.datetime "created_at", null: false
@@ -1435,6 +1443,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_31_160030) do
   add_foreign_key "tweets", "users", on_delete: :nullify
   add_foreign_key "user_blocks", "users", column: "blocked_id"
   add_foreign_key "user_blocks", "users", column: "blocker_id"
+  add_foreign_key "user_languages", "users"
   add_foreign_key "user_subscriptions", "users", column: "author_id"
   add_foreign_key "user_subscriptions", "users", column: "subscriber_id"
   add_foreign_key "users_notification_settings", "users"

--- a/spec/factories/user_languages.rb
+++ b/spec/factories/user_languages.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user_language do
+    user
+    language { :en }
+  end
+end

--- a/spec/models/user_language_spec.rb
+++ b/spec/models/user_language_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe UserLanguage do
+  describe "validations" do
+    subject { build(:user_language) }
+
+    describe "builtin validations" do
+      it { is_expected.to belong_to(:user) }
+      it { is_expected.to validate_presence_of(:language) }
+    end
+
+    it "actually validates language" do
+      expect(build(:user_language, language: :es)).to be_valid
+    end
+
+    it "actually validates language (invalid)" do
+      lang = build(:user_language, language: :abracadabra)
+      expect(lang).not_to be_valid
+      expect(lang.errors[:language]).to be_present
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe User do
       it { is_expected.to have_many(:subscribed_to_user_subscriptions).dependent(:destroy) }
       it { is_expected.to have_many(:subscribers).dependent(:destroy) }
       it { is_expected.to have_many(:tweets).dependent(:nullify) }
+      it { is_expected.to have_many(:languages).dependent(:delete_all) }
 
       # rubocop:disable RSpec/NamedSubject
       it do

--- a/spec/services/languages/detection_spec.rb
+++ b/spec/services/languages/detection_spec.rb
@@ -3,6 +3,12 @@ require "rails_helper"
 RSpec.describe Languages::Detection, type: :service do
   subject(:language_detection) { described_class.call(text) }
 
+  describe "codes" do
+    it "returns an array including a couple of popular languages" do
+      expect(described_class.codes).to include("en", "es", "fr")
+    end
+  end
+
   context "when the text is clearly identifiable as English" do
     let(:text) { "This is clearly English text." }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Store languages, that user understands, in the database

Discussion on how to store the languages can be found in[ the issue comments](https://github.com/forem/forem/issues/19846#issuecomment-1700587945)

The pr doesn't include the "default forem language" part (will be implemented separately) and populating users languages table.

## Related Tickets & Documents
- Related Issue #19846

## QA Instructions, Screenshots, Recordings
The pr only provides structure for future usage, so doesn't affect the functionality

## Added/updated tests?
- [x] Yes

