### PR TITLE
Replace SiteConfig with Settings::General in the comments

### DIFF
--- a/app/lib/middlewares/set_cookie_domain.rb
+++ b/app/lib/middlewares/set_cookie_domain.rb
@@ -1,6 +1,6 @@
 module Middlewares
-  # Since we must explicitly set the cookie domain in session_store before SiteConfig is available,
-  # this ensures we properly set the cookie to SiteConfig.app_domain at runtime.
+  # Since we must explicitly set the cookie domain in session_store before Settings::General is available,
+  # this ensures we properly set the cookie to Settings::General.app_domain at runtime.
   class SetCookieDomain
     def initialize(app)
       @app = app


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
A tiny pr to remove old SiteConfig references which was replaced by `Settings::General` in the comments to remove confusion.

## Related Tickets & Documents
- Related Issue https://github.com/forem/forem/pull/13573
