### PR TITLE
Record feed events for public reactions

### DIFF
--- a/app/javascript/packs/feedEvents.js
+++ b/app/javascript/packs/feedEvents.js
@@ -56,7 +56,8 @@ function findAndTrackFeedItems(root) {
       findAndTrackFeedItems(element);
     } else if (element.dataset?.feedContentId) {
       element.dataset.feedPosition = tracker.nextFeedPosition;
-      element.addEventListener('click', trackFeedClickListener, true);
+      // Also captures right-click opens
+      element.addEventListener('mousedown', trackFeedClickListener, true);
       tracker.observer.observe(element);
 
       tracker.nextFeedPosition += 1;

--- a/app/models/feed_event.rb
+++ b/app/models/feed_event.rb
@@ -37,7 +37,7 @@ class FeedEvent < ApplicationRecord
 
     create_with(last_click.slice(:article_position, :context_type))
       .find_or_create_by(
-        category: :reaction,
+        category: :category,
         user: user,
         article: article,
       )

--- a/app/models/feed_event.rb
+++ b/app/models/feed_event.rb
@@ -37,7 +37,7 @@ class FeedEvent < ApplicationRecord
 
     create_with(last_click.slice(:article_position, :context_type))
       .find_or_create_by(
-        category: :category,
+        category: category,
         user: user,
         article: article,
       )

--- a/app/models/feed_event.rb
+++ b/app/models/feed_event.rb
@@ -28,4 +28,18 @@ class FeedEvent < ApplicationRecord
   # Since we have disabled association validation, this is handy to filter basic bad data
   validates :article_id, presence: true, numericality: { only_integer: true }
   validates :user_id, numericality: { only_integer: true }, allow_nil: true
+
+  def self.record_journey_for(user, article:, category:)
+    return unless %i[reaction comment].include?(category)
+
+    last_click = where(user: user, category: :click).last
+    return unless last_click&.article_id == article.id
+
+    create_with(last_click.slice(:article_position, :context_type))
+      .find_or_create_by(
+        category: :reaction,
+        user: user,
+        article: article,
+      )
+  end
 end

--- a/app/services/reaction_handler.rb
+++ b/app/services/reaction_handler.rb
@@ -161,7 +161,8 @@ class ReactionHandler
   end
 
   def record_feed_event(reaction)
-    return unless reaction.visible_to_public? && reaction.reactable_type == "Article"
+    return unless (reaction.visible_to_public? || reaction.category == "readinglist") &&
+      reaction.reactable_type == "Article"
 
     FeedEvent.record_journey_for(reaction.user, article: reaction.reactable, category: :reaction)
   end

--- a/app/services/reaction_handler.rb
+++ b/app/services/reaction_handler.rb
@@ -163,18 +163,7 @@ class ReactionHandler
   def record_feed_event(reaction)
     return unless reaction.visible_to_public? && reaction.reactable_type == "Article"
 
-    last_click = reaction.user.feed_events.where(category: :click).last
-    return unless last_click&.article_id == reaction.reactable_id
-
-    reaction
-      .user
-      .feed_events
-      .create_with(last_click.slice(:article_position, :context_type))
-      .find_or_create_by(
-        category: :reaction,
-        user: reaction.user,
-        article: reaction.reactable,
-      )
+    FeedEvent.record_journey_for(reaction.user, article: reaction.reactable, category: :reaction)
   end
 
   def rate_article(reaction)

--- a/spec/models/feed_event_spec.rb
+++ b/spec/models/feed_event_spec.rb
@@ -11,4 +11,56 @@ RSpec.describe FeedEvent do
     it { is_expected.to validate_numericality_of(:article_position).is_greater_than(0).only_integer }
     it { is_expected.to validate_inclusion_of(:context_type).in_array(%w[home search tag]) }
   end
+
+  describe ".record_journey_for" do
+    subject(:record_journey) { described_class.record_journey_for(user, article: article, category: category) }
+
+    let(:article) { create(:article) }
+    let(:user) { create(:user) }
+    let(:category) { :reaction }
+
+    it "records a feed event if the user's last click was on the specified article" do
+      click = create(:feed_event, user: user, article: article, category: :click)
+
+      expect { record_journey }.to change(described_class, :count).by(1)
+      expect(user.feed_events.last).to have_attributes(
+        category: "reaction",
+        article_id: article.id,
+        user_id: user.id,
+        context_type: click.context_type,
+        article_position: click.article_position,
+      )
+    end
+
+    it "does not record a feed event if the user has no feed events for the specified article" do
+      expect { record_journey }.not_to change(described_class, :count)
+      expect(user.feed_events).to be_empty
+    end
+
+    it "does not record a feed event if the user did not click through from the feed" do
+      impression = create(:feed_event, user: user, article: article, category: :impression)
+
+      expect { record_journey }.not_to change(described_class, :count)
+      expect(user.feed_events).to contain_exactly(impression)
+    end
+
+    it "does not record a feed event if the user's last click was not on the specified article" do
+      click = create(:feed_event, user: user, article: article, category: :click)
+      other_click = create(:feed_event, user: user, category: :click)
+
+      expect { record_journey }.not_to change(described_class, :count)
+      expect(user.feed_events).to contain_exactly(click, other_click)
+    end
+
+    context "when the interaction is not a comment or reaction" do
+      let(:category) { :impression }
+
+      it "does not record a feed event" do
+        click = create(:feed_event, user: user, article: article, category: :click)
+
+        expect { record_journey }.not_to change(described_class, :count)
+        expect(user.feed_events).to contain_exactly(click)
+      end
+    end
+  end
 end

--- a/spec/services/reaction_handler_spec.rb
+++ b/spec/services/reaction_handler_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe ReactionHandler, type: :service do
       end
     end
 
-    context "when the reaction is not a public reaction" do
+    context "when the reaction is not a public reaction or bookmark" do
       let(:user) { moderator }
       let(:category) { "vomit" }
 
@@ -121,7 +121,7 @@ RSpec.describe ReactionHandler, type: :service do
       end
     end
 
-    context "when the reaction is not in a notifiable category" do
+    context "when the reaction is a bookmark" do
       let(:category) { "readinglist" }
 
       it "does not send a notification to the author" do
@@ -129,6 +129,17 @@ RSpec.describe ReactionHandler, type: :service do
           expect(result).to be_success
           expect(result.action).to eq("create")
         end
+      end
+
+      it "records a feed event if reached through a feed" do
+        create(:feed_event, category: :click, article: article, user: user)
+
+        expect { result }.to change(FeedEvent, :count).by(1)
+        expect(user.feed_events.last).to have_attributes(
+          category: "reaction",
+          article_id: article.id,
+          user_id: user.id,
+        )
       end
     end
 

--- a/spec/services/reaction_handler_spec.rb
+++ b/spec/services/reaction_handler_spec.rb
@@ -55,15 +55,13 @@ RSpec.describe ReactionHandler, type: :service do
       end
 
       it "records a feed event for articles reached through a feed" do
-        click = create(:feed_event, category: :click, article: article, user: user)
+        create(:feed_event, category: :click, article: article, user: user)
 
         expect { result }.to change(FeedEvent, :count).by(1)
         expect(user.feed_events.last).to have_attributes(
-          category: :reaction,
+          category: "reaction",
           article_id: article.id,
           user_id: user.id,
-          context_type: click.context_type,
-          article_position: click.article_position,
         )
       end
 
@@ -99,7 +97,7 @@ RSpec.describe ReactionHandler, type: :service do
         click = create(:feed_event, category: :click, article: article, user: moderator)
 
         expect { result }.not_to change(FeedEvent, :count)
-        expec(moderator.feed_events).to contain_exactly(click)
+        expect(moderator.feed_events).to contain_exactly(click)
       end
     end
 
@@ -205,15 +203,13 @@ RSpec.describe ReactionHandler, type: :service do
       end
 
       it "records a feed event for articles reached through a feed" do
-        click = create(:feed_event, category: :click, article: article, user: user)
+        create(:feed_event, category: :click, article: article, user: user)
 
         expect { result }.to change(FeedEvent, :count).by(1)
         expect(user.feed_events.last).to have_attributes(
-          category: :reaction,
+          category: "reaction",
           article_id: article.id,
           user_id: user.id,
-          context_type: click.context_type,
-          article_position: click.article_position,
         )
       end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This updates the reaction handling service to record a `reaction` feed event when a user makes a public reaction (including bookmarks) on an article that they reached through their feed.

Per the linked issue, we're determining "reached through their feed" through simply checking if their last click (already being recorded via the UI) was on the article being reacted to.

## Related Tickets & Documents

- Related Issue #19925 
- Closes #19925 

## QA Instructions, Screenshots, Recordings

https://www.loom.com/share/1d0e252ad3a045a4875c953294f09c34

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

Not a gif but ❤️ 🦄 🔥 🙌🏾 🤯 🔖 
