### PR TITLE
Username inputs for admin

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -46,21 +46,10 @@ module Admin
     end
 
     def index
-      @users = Admin::UsersQuery.call(
-        relation: User.registered,
-        search: params[:search],
-        role: params[:role],
-        roles: params[:roles],
-        statuses: params[:statuses],
-        joining_start: params[:joining_start],
-        joining_end: params[:joining_end],
-        date_format: params[:date_format],
-        organizations: params[:organizations],
-      ).page(params[:page]).per(50)
-
-      @organization_limit = 3
-      @organizations = Organization.order(name: :desc)
-      @earliest_join_date = User.first.registered_at.to_s
+      respond_to do |format|
+        format.html { index_for_html }
+        format.json { index_for_json }
+      end
     end
 
     def show
@@ -332,6 +321,33 @@ module Admin
     end
 
     private
+
+    def index_for_html
+      @users = Admin::UsersQuery.call(
+        relation: User.registered,
+        search: params[:search],
+        role: params[:role],
+        roles: params[:roles],
+        statuses: params[:statuses],
+        joining_start: params[:joining_start],
+        joining_end: params[:joining_end],
+        date_format: params[:date_format],
+        organizations: params[:organizations],
+      ).page(params[:page]).per(50)
+
+      @organization_limit = 3
+      @organizations = Organization.order(name: :desc)
+      @earliest_join_date = User.first.registered_at.to_s
+    end
+
+    def index_for_json
+      @users = Admin::UsersQuery.call(
+        relation: User.registered,
+        search: params[:search],
+      )
+
+      render json: @users.to_json(only: %i[id name username])
+    end
 
     def set_user_details
       @organizations = @user.organizations.order(:name)

--- a/app/javascript/packs/admin/convertUserIdsToUsernameInputs.js
+++ b/app/javascript/packs/admin/convertUserIdsToUsernameInputs.js
@@ -1,0 +1,108 @@
+import { h, render } from 'preact';
+import { UsernameInput } from '../../shared/components/UsernameInput';
+import { UserStore } from '../../shared/components/UserStore';
+import '@utilities/document_ready';
+
+async function convertUserIdFieldToUsernameField(targetField, users, fetchUrl) {
+  targetField.type = 'hidden';
+
+  const inputId = `auto${targetField.id}`;
+  const newDiv = document.createElement('div');
+  targetField.parentElement.append(newDiv);
+
+  await users.fetch(fetchUrl).then(() => {
+    const value = users.matchingIds(targetField.value.split(','));
+
+    const fetchSuggestions = function (term) {
+      return users.search(term);
+    };
+
+    const handleSelectionsChanged = function (ids) {
+      targetField.value = ids;
+    };
+
+    render(
+      <UsernameInput
+        labelText="Enter a username"
+        placeholder="Enter a username"
+        maxSelections={1}
+        inputId={inputId}
+        defaultValue={value}
+        fetchSuggestions={fetchSuggestions}
+        handleSelectionsChanged={handleSelectionsChanged}
+      />,
+      newDiv,
+    );
+  });
+}
+
+async function convertCoAuthorIdsToUsernameInputs(
+  targetField,
+  users,
+  fetchUrl,
+) {
+  targetField.type = 'hidden';
+
+  const exceptAuthorId = targetField.form.querySelector(
+    'input[name="article[user_id]"]',
+  )?.value;
+
+  let searchOptions = {};
+  if (exceptAuthorId) {
+    searchOptions = { except: exceptAuthorId };
+  }
+
+  const inputId = `auto${targetField.id}`;
+  const newDiv = document.createElement('div');
+  targetField.parentElement.append(newDiv);
+
+  await users.fetch(fetchUrl).then(() => {
+    const value = users.matchingIds(targetField.value.split(','));
+
+    const fetchSuggestions = function (term) {
+      return users.search(term, searchOptions);
+    };
+
+    const handleSelectionsChanged = function (ids) {
+      targetField.value = ids;
+    };
+
+    render(
+      <UsernameInput
+        labelText="Add up to 4"
+        placeholder="Add up to 4..."
+        maxSelections={4}
+        inputId={inputId}
+        defaultValue={value}
+        fetchSuggestions={fetchSuggestions}
+        handleSelectionsChanged={handleSelectionsChanged}
+      />,
+      newDiv,
+    );
+  });
+}
+
+export async function convertCoauthorIdsToUsernameInputs() {
+  const users = new UserStore();
+  const fetchUrl = '/admin/member_manager/users.json';
+
+  const usernameFields = document.getElementsByClassName(
+    'js-username_id_input',
+  );
+
+  for (const targetField of usernameFields) {
+    convertUserIdFieldToUsernameField(targetField, users, fetchUrl);
+  }
+
+  const coAuthorFields = document.getElementsByClassName(
+    'js-coauthor_username_id_input',
+  );
+
+  for (const coAuthorField of coAuthorFields) {
+    convertCoAuthorIdsToUsernameInputs(coAuthorField, users, fetchUrl);
+  }
+}
+
+document.ready.then(() => {
+  convertCoauthorIdsToUsernameInputs();
+});

--- a/app/views/admin/articles/_article_item.html.erb
+++ b/app/views/admin/articles/_article_item.html.erb
@@ -153,13 +153,13 @@
       <div class="flex gap-4">
         <div class="crayons-field flex-1">
           <label for="author_id_<%= article.id %>" class="crayons-field__label"><%= t("views.moderations.article.author_id") %></label>
-          <input id="author_id_<%= article.id %>" class="crayons-textfield" size="6" name="article[user_id]"
+          <input id="author_id_<%= article.id %>" class="js-username_id_input crayons-textfield" size="6" name="article[user_id]"
             value="<%= article.user_id %>">
         </div>
 
         <div class="crayons-field flex-1">
           <label for="co_author_ids_list_<%= article.id %>" class="crayons-field__label"><%= t("views.moderations.article.co_author_ids") %></label>
-          <input id="co_author_ids_list_<%= article.id %>" class="crayons-textfield" size="6" name="article[co_author_ids_list]" placeholder="Comma separated"
+          <input id="co_author_ids_list_<%= article.id %>" class="js-coauthor_username_id_input crayons-textfield" size="6" name="article[co_author_ids_list]" placeholder="Comma separated"
             value="<%= article.co_author_ids&.join(", ") %>">
         </div>
       </div>

--- a/app/views/admin/articles/index.html.erb
+++ b/app/views/admin/articles/index.html.erb
@@ -52,3 +52,4 @@
 </div>
 
 <%= render partial: "image_upload_script" %>
+<%= javascript_packs_with_chunks_tag "admin/convertUserIdsToUsernameInputs" %>

--- a/app/views/admin/settings/forms/_community.html.erb
+++ b/app/views/admin/settings/forms/_community.html.erb
@@ -54,7 +54,7 @@
           <%= admin_config_label :staff_user_id, model: Settings::Community %>
           <%= admin_config_description Constants::Settings::Community.details[:staff_user_id][:description] %>
           <%= f.text_field :staff_user_id,
-                           class: "crayons-textfield",
+                           class: "crayons-textfield js-username_id_input",
                            value: Settings::Community.staff_user_id,
                            placeholder: Constants::Settings::Community.details[:staff_user_id][:placeholder] %>
         </div>

--- a/app/views/admin/settings/forms/_mascot.html.erb
+++ b/app/views/admin/settings/forms/_mascot.html.erb
@@ -9,10 +9,10 @@
     <div class="p-6 pt-0">
       <fieldset class="grid gap-4">
         <div class="crayons-field">
-          <%= admin_config_label :mascot_user_id, "Mascot user ID" %>
+          <%= admin_config_label :mascot_user_id, "Mascot user" %>
           <%= admin_config_description Constants::Settings::General.details[:mascot_user_id][:description] %>
           <%= f.text_field :mascot_user_id,
-                           class: "crayons-textfield",
+                           class: "crayons-textfield js-username_id_input",
                            value: Settings::General.mascot_user_id,
                            min: 1,
                            placeholder: Constants::Settings::General.details[:mascot_user_id][:placeholder] %>

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -27,3 +27,5 @@
   <%= render partial: "forms/tags" %>
   <%= render partial: "forms/user_experience" %>
 </div>
+
+<%= javascript_packs_with_chunks_tag "admin/convertUserIdsToUsernameInputs" %>

--- a/app/views/admin/tags/edit.html.erb
+++ b/app/views/admin/tags/edit.html.erb
@@ -15,8 +15,10 @@
     <div class="flex flex-col gap-2">
       <%= form_with url: admin_tag_moderator_path(@tag.id), model: [:admin, @tag], method: :post, local: true do |f| %>
         <div class="crayons-field w-50 my-4">
-          <%= f.label :user_id, "Add Moderator (ID):", class: "crayons-field__label" %>
-          <%= f.text_field :user_id, class: "crayons-textfield" %>
+          <%= f.label :user_id, "Add Moderator:", class: "crayons-field__label" %>
+          <div>
+            <%= f.text_field :user_id, class: "crayons-textfield js-username_id_input" %>
+          </div>
           <%= f.submit "Add Moderator", class: "crayons-btn" %>
         </div>
       <% end %>
@@ -45,3 +47,5 @@
     <%= render "form", tag: @tag, badges_for_options: @badges_for_options %>
   </div>
 </div>
+
+<%= javascript_packs_with_chunks_tag "admin/convertUserIdsToUsernameInputs" %>

--- a/config/locales/lib/en.yml
+++ b/config/locales/lib/en.yml
@@ -89,7 +89,7 @@ en:
             description: Used as the primary name for your Forem, e.g. DEV, DEV Community, The DEV Community, etc.
             placeholder: New Forem
           staff:
-            description: Account ID which acts as automated 'staff'— used principally for welcome thread.
+            description: Account which acts as automated 'staff'— used principally for welcome thread.
           tagline:
             description: Used in signup modal.
             placeholder: We're a place where coders share, stay up-to-date and grow their careers.

--- a/config/locales/lib/en.yml
+++ b/config/locales/lib/en.yml
@@ -138,7 +138,7 @@ en:
           mascot_image:
             description: Used as the mascot image.
           mascot_user:
-            description: User ID of the Mascot account
+            description: The Mascot account
           meta_keywords:
             description: 'List of valid keywords: comma separated, letters only e.g. engineering, development'
           payment:

--- a/config/locales/lib/fr.yml
+++ b/config/locales/lib/fr.yml
@@ -138,7 +138,7 @@ fr:
           mascot_image:
             description: Used as the mascot image.
           mascot_user:
-            description: User ID of the Mascot account
+            description: The Mascot account
           meta_keywords:
             description: 'List of valid keywords: comma separated, letters only e.g. engineering, development'
           payment:

--- a/config/locales/lib/fr.yml
+++ b/config/locales/lib/fr.yml
@@ -89,7 +89,7 @@ fr:
             description: Used as the primary name for your Forem, e.g. DEV, DEV Community, The DEV Community, etc.
             placeholder: New Forem
           staff:
-            description: Account ID which acts as automated 'staff'— used principally for welcome thread.
+            description: Account which acts as automated 'staff'— used principally for welcome thread.
           tagline:
             description: Used in signup modal.
             placeholder: We're a place where coders share, stay up-to-date and grow their careers.


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Following on after #20008, let's try adding `UsernameInput`s to other areas in `/admin`.

A big change here is that we're allowing admins to search through **all** users, which I expect may need performance tweaks on larger datasets. 

## Related Tickets & Documents

- Related Issue #19828 

## QA Instructions, Screenshots, Recordings

<img width="854" alt="image" src="https://github.com/forem/forem/assets/2077/458c6d30-e269-4730-936f-d05a7b418233">
<img width="841" alt="image" src="https://github.com/forem/forem/assets/2077/4de129c6-52f6-424b-80fa-cdbbb65aea3d">
<img width="830" alt="image" src="https://github.com/forem/forem/assets/2077/31118df6-2503-450f-b170-fad9e865dcee">

**Note:** There are still some areas where the layout is a little rough, some labels may need updating with the new UX, but I think the advantages of "names > numbers" outweigh some awkwardness in these areas:

<img width="817" alt="image" src="https://github.com/forem/forem/assets/2077/07beeb07-f53c-47d1-8248-0ce3f01eea24">



## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: front-end enhancement
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media4.giphy.com/media/WjLh5GG4VH42Y/giphy.gif?cid=ecf05e47ct6pig12q90vuup2y2v8v3hxzbqxbyzmw25fs3ya&ep=v1_gifs_search&rid=giphy.gif&ct=g)
