### PR TITLE
skip feed events e2e specs

### DIFF
--- a/app/javascript/packs/feedEvents.js
+++ b/app/javascript/packs/feedEvents.js
@@ -18,6 +18,8 @@ window.observeFeedElements = observeFeedElements;
 /**
  * Sets up the feed events tracker.
  * Called every time posts are inserted into the feed.
+ *
+ * NOTE: this module has E2E tests at `seededFlows/homeFeedFlows/events.spec.js`
  */
 export function observeFeedElements() {
   const feedContainer = document.getElementById('index-container');

--- a/cypress/e2e/seededFlows/homeFeedFlows/events.spec.js
+++ b/cypress/e2e/seededFlows/homeFeedFlows/events.spec.js
@@ -1,4 +1,12 @@
-describe('Home page feed events', () => {
+/**
+ * Cypress takes extensive control of browser scrolling in order to facilitate
+ * its automation and testing; unfortunately that means that various scrolling
+ * behaviours (such as smooth scrolling or firing `IntersectionObserver` events)
+ * don't work consistently.
+ * This makes these tests flaky, but they are still useful to run locally and
+ * update if you are modifying feed event functionality.
+ */
+describe.skip('Home page feed events', () => {
   beforeEach(() => {
     cy.testSetup();
   });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The end-to-end tests introduced for feed events are flaky (which is expected due to Cypress not playing very well with normal browser scroll events, making testing collecting impressions inconsistent). This skips them and adds context for the skip

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests