### PR TITLE
Display post languages in the dashboard

### DIFF
--- a/app/views/dashboards/_dashboard_article_row.html.erb
+++ b/app/views/dashboards/_dashboard_article_row.html.erb
@@ -24,6 +24,9 @@
         <% if article.collection_id %>
           <strong class="fw-medium pl-2"><%= t("views.dashboard.article.series") %></strong> <%= article.series %>
         <% end %>
+        <% if article.language %>
+          <strong class="fw-medium pl-2"><%= t("views.dashboard.article.language") %></strong> <%= t(article.language, scope: "languages.display_name") %>
+        <% end %>
       </p>
     <% end %>
   </div>

--- a/config/locales/languages/en.yml
+++ b/config/locales/languages/en.yml
@@ -1,0 +1,107 @@
+---
+en:
+  languages:
+    display_name:
+      af: Afrikaans
+      am: Amharic
+      ar: Arabic
+      az: Azerbaijani
+      be: Belarusian
+      bg: Bulgarian
+      bn: Bangla
+      bs: Bosnian
+      ca: Catalan
+      ceb: Cebuano
+      co: Corsican
+      cs: Czech
+      cy: Welsh
+      da: Danish
+      de: German
+      el: Greek
+      en: English
+      eo: Esperanto
+      es: Spanish
+      et: Estonian
+      eu: Basque
+      fa: Persian
+      fi: Finnish
+      fil: Filipino
+      fr: French
+      fy: Western Frisian
+      ga: Irish
+      gd: Scottish Gaelic
+      gl: Galician
+      gu: Gujarati
+      ha: Hausa
+      haw: Hawaiian
+      hi: Hindi
+      hi-Latn: Hindi (Latin)
+      hmn: Hmong
+      hr: Croatian
+      ht: Haitian Creole
+      hu: Hungarian
+      hy: Armenian
+      id: Indonesian
+      ig: Igbo
+      is: Icelandic
+      it: Italian
+      ja: Japanese
+      jv: Javanese
+      ka: Georgian
+      kk: Kazakh
+      km: Khmer
+      kn: Kannada
+      ko: Korean
+      ku: Kurdish
+      ky: Kyrgyz
+      la: Latin
+      lb: Luxembourgish
+      lo: Lao
+      lt: Lithuanian
+      lv: Latvian
+      mg: Malagasy
+      mi: Māori
+      mk: Macedonian
+      ml: Malayalam
+      mn: Mongolian
+      mr: Marathi
+      ms: Malay
+      mt: Maltese
+      my: Burmese
+      ne: Nepali
+      nl: Dutch
+      no: Norwegian
+      ny: Nyanja
+      pa: Punjabi
+      pl: Polish
+      ps: Pashto
+      pt: Portuguese
+      ro: Romanian
+      ru: Russian
+      sd: Sindhi
+      si: Sinhala
+      sk: Slovak
+      sl: Slovenian
+      sm: Samoan
+      sn: Shona
+      so: Somali
+      sq: Albanian
+      sr: Serbian
+      st: Southern Sotho
+      su: Sundanese
+      sv: Swedish
+      sw: Swahili
+      ta: Tamil
+      te: Telugu
+      tg: Tajik
+      th: Thai
+      tr: Turkish
+      uk: Ukrainian
+      ur: Urdu
+      uz: Uzbek
+      vi: Vietnamese
+      xh: Xhosa
+      yi: Yiddish
+      yo: Yoruba
+      zh: Chinese
+      zu: Zulu

--- a/config/locales/languages/en.yml
+++ b/config/locales/languages/en.yml
@@ -8,6 +8,7 @@ en:
       az: Azerbaijani
       be: Belarusian
       bg: Bulgarian
+      bg-Latn: Bulgarian (Latin)
       bn: Bangla
       bs: Bosnian
       ca: Catalan
@@ -18,6 +19,7 @@ en:
       da: Danish
       de: German
       el: Greek
+      el-Latn: Greek (Latin)
       en: English
       eo: Esperanto
       es: Spanish
@@ -45,7 +47,9 @@ en:
       ig: Igbo
       is: Icelandic
       it: Italian
+      iw: Hebrew
       ja: Japanese
+      ja-Latn: Japanese (Latin)
       jv: Javanese
       ka: Georgian
       kk: Kazakh
@@ -78,6 +82,7 @@ en:
       pt: Portuguese
       ro: Romanian
       ru: Russian
+      ru-Latn: Russian (Latin)
       sd: Sindhi
       si: Sinhala
       sk: Slovak
@@ -104,4 +109,5 @@ en:
       yi: Yiddish
       yo: Yoruba
       zh: Chinese
+      zh-Latn: Chinese (Latin)
       zu: Zulu

--- a/config/locales/languages/fr.yml
+++ b/config/locales/languages/fr.yml
@@ -1,0 +1,107 @@
+---
+fr:
+  languages:
+    display_name:
+      af: Afrikaans
+      am: Amharic
+      ar: Arabic
+      az: Azerbaijani
+      be: Belarusian
+      bg: Bulgarian
+      bn: Bangla
+      bs: Bosnian
+      ca: Catalan
+      ceb: Cebuano
+      co: Corsican
+      cs: Czech
+      cy: Welsh
+      da: Danish
+      de: German
+      el: Greek
+      en: English
+      eo: Esperanto
+      es: Spanish
+      et: Estonian
+      eu: Basque
+      fa: Persian
+      fi: Finnish
+      fil: Filipino
+      fr: French
+      fy: Western Frisian
+      ga: Irish
+      gd: Scottish Gaelic
+      gl: Galician
+      gu: Gujarati
+      ha: Hausa
+      haw: Hawaiian
+      hi: Hindi
+      hi-Latn: Hindi (Latin)
+      hmn: Hmong
+      hr: Croatian
+      ht: Haitian Creole
+      hu: Hungarian
+      hy: Armenian
+      id: Indonesian
+      ig: Igbo
+      is: Icelandic
+      it: Italian
+      ja: Japanese
+      jv: Javanese
+      ka: Georgian
+      kk: Kazakh
+      km: Khmer
+      kn: Kannada
+      ko: Korean
+      ku: Kurdish
+      ky: Kyrgyz
+      la: Latin
+      lb: Luxembourgish
+      lo: Lao
+      lt: Lithuanian
+      lv: Latvian
+      mg: Malagasy
+      mi: Māori
+      mk: Macedonian
+      ml: Malayalam
+      mn: Mongolian
+      mr: Marathi
+      ms: Malay
+      mt: Maltese
+      my: Burmese
+      ne: Nepali
+      nl: Dutch
+      no: Norwegian
+      ny: Nyanja
+      pa: Punjabi
+      pl: Polish
+      ps: Pashto
+      pt: Portuguese
+      ro: Romanian
+      ru: Russian
+      sd: Sindhi
+      si: Sinhala
+      sk: Slovak
+      sl: Slovenian
+      sm: Samoan
+      sn: Shona
+      so: Somali
+      sq: Albanian
+      sr: Serbian
+      st: Southern Sotho
+      su: Sundanese
+      sv: Swedish
+      sw: Swahili
+      ta: Tamil
+      te: Telugu
+      tg: Tajik
+      th: Thai
+      tr: Turkish
+      uk: Ukrainian
+      ur: Urdu
+      uz: Uzbek
+      vi: Vietnamese
+      xh: Xhosa
+      yi: Yiddish
+      yo: Yoruba
+      zh: Chinese
+      zu: Zulu

--- a/config/locales/languages/fr.yml
+++ b/config/locales/languages/fr.yml
@@ -8,6 +8,7 @@ fr:
       az: Azerbaijani
       be: Belarusian
       bg: Bulgarian
+      bg-Latn: Bulgarian (Latin)
       bn: Bangla
       bs: Bosnian
       ca: Catalan
@@ -18,6 +19,7 @@ fr:
       da: Danish
       de: German
       el: Greek
+      el-Latn: Greek (Latin)
       en: English
       eo: Esperanto
       es: Spanish
@@ -45,7 +47,9 @@ fr:
       ig: Igbo
       is: Icelandic
       it: Italian
+      iw: Hebrew
       ja: Japanese
+      ja-Latn: Japanese (Latin)
       jv: Javanese
       ka: Georgian
       kk: Kazakh
@@ -78,6 +82,7 @@ fr:
       pt: Portuguese
       ro: Romanian
       ru: Russian
+      ru-Latn: Russian (Latin)
       sd: Sindhi
       si: Sinhala
       sk: Slovak
@@ -104,4 +109,5 @@ fr:
       yi: Yiddish
       yo: Yoruba
       zh: Chinese
+      zh-Latn: Chinese (Latin)
       zu: Zulu

--- a/config/locales/views/dashboard/en.yml
+++ b/config/locales/views/dashboard/en.yml
@@ -49,6 +49,7 @@ en:
         draft: Draft
         scheduled: Scheduled
         scheduled_at: 'Scheduled:'
+        language: 'Language:'
         reactions:
           title: Reactions
           icon: Reactions

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe "Dashboards" do
         expect(response.body).to include "Scheduled"
       end
 
+      it "renders the detected language if an article has it" do
+        article
+        article.update_column(:language, :es)
+        get "/dashboard"
+        expect(response.body).to include "Language:"
+        expect(response.body).to include "Spanish"
+      end
+
       it "renders the delete button for scheduled article" do
         scheduled_article
         get "/dashboard"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
If a post (article) has a detected language: display it in the user dashboard.

I was reluctant to add a gem (like[ `i18n_data`](https://github.com/grosser/i18n_data)) to get the language names, so I "extracted" them from [the cld-related source](https://github.com/unicode-org/cldr-json/blob/main/cldr-json/cldr-localenames-full/main/en-001/languages.json) and kept only those that are in `CLD3::TaskContextParams::LANGUAGE_NAMES` (`Languages::Detection.codes`).

Though we display only in the dashbord currently, the names themselfves seem pretty generic, so I put the names into separate locales (however open to other suggestions).

Update: I have [added](https://github.com/forem/forem/pull/20137/commits/b37ef7c4da3d74688af566128c67364612e1247e) several locales for "Latn" variations though we shouldn't need it, but they are included in `CLD3::TaskContextParams::LANGUAGE_NAMES`, so will appear in tests, and can appear in the app in theory.  I took the information about the locales meaning [here](CLD3::TaskContextParams::LANGUAGE_NAMES)

## Related Tickets & Documents
- Closes #19847

## QA Instructions, Screenshots, Recordings
![изображение](https://github.com/forem/forem/assets/30115/ebb438db-a2ae-4fb1-b1fe-10e5db7da55e)

I mentioned the issue with the bold (or not) "Language: " in [slack](https://forem-team.slack.com/archives/C7GE84DEJ/p1695122126569039)

## Added/updated tests?
- [x] Yes


![alt_text](gif_link)
