### PR TITLE
Tweak config to enable rails console requests

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -90,6 +90,9 @@ Rails.application.configure do
   if (uffizzi_url = ENV.fetch("UFFIZZI_URL", nil))
     config.hosts << /.*#{URI.parse(uffizzi_url).host}/
   end
+
+  config.hosts << "www.example.com"
+
   config.app_domain = ENV.fetch("APP_DOMAIN", "localhost:3000")
 
   config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

It is sometimes useful to pop into the `rails console` to examine how the app is routing our requests. Rails 6 introduced a feature to [protect against DNS rebinding attacks](https://blog.saeloun.com/2019/10/31/rails-6-adds-guard-against-dns-rebinding-attacks/) that effectively blocks us from using `rails console`. 

```
> app.get '/'
[ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked host: www.example.com
=> 403
```

Tweaking this configuration will enable us to use the console again:

```
> app.get '/'
Started GET "/" for 127.0.0.1 at 2023-09-22 10:23:43 +0200
  ActiveRecord::SchemaMigration Pluck (4.8ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
   (4.5ms)  SELECT "flipper_features"."key" AS feature_key, "flipper_gates"."key", "flipper_gates"."value" FROM "flipper_features" LEFT OUTER JOIN "flipper_gates" ON "flipper_features"."key" = "flipper_gates"."feature_key"
Processing by StoriesController#index as HTML
  Parameters: {"locale"=>nil}
[...]
  Rendered layouts/_signup_modal.html.erb (Duration: 2.8ms | Allocations: 3785)
  Rendered articles/_reaction_category_resources.html.erb (Duration: 2.4ms | Allocations: 4309)
  Rendered layout layouts/application.html.erb (Duration: 1077.9ms | Allocations: 554403)
Completed 200 OK in 1617ms (Views: 978.2ms | ActiveRecord: 214.6ms | Allocations: 1050407)
```

## QA Instructions, Screenshots, Recordings

`rails c`


## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: enabling a dev-only feature
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media0.giphy.com/media/3orif44xVq5hx7lEsM/giphy.gif?cid=ecf05e47ljsvqsoai2zvbv9mv4ty4pwmhls30nn8tsfeph1a&ep=v1_gifs_search&rid=giphy.gif&ct=g)
