### PR TITLE
Add out-of-date notice to admin overview

### DIFF
--- a/app/views/admin/overview/_notices.html.erb
+++ b/app/views/admin/overview/_notices.html.erb
@@ -1,0 +1,11 @@
+
+<% if ForemInstance.deployed_at.to_i.positive? && ForemInstance.deployed_at < 2.weeks.ago %>
+  <div class="crayons-notice crayons-notice--<%= ForemInstance.deployed_at < 4.weeks.ago ? "danger" : "warning" %> mb-6">
+    <p class="p-1">
+      It has been <strong><%= time_ago_in_words ForemInstance.deployed_at %></strong> since this Forem was deployed. We recommend you <a href="https://github.com/forem/forem" class="fw-bold">re-deploy from the main branch</a> to stay up-to-date.
+    </p>
+    <p class="p-1 py-2 fs-s">
+      If you stay out of date for too long, it greatly increases the risk that something could go wrong when you try to re-deploy.
+    </p>
+  </div>
+<% end %>

--- a/app/views/admin/overview/index.html.erb
+++ b/app/views/admin/overview/index.html.erb
@@ -3,6 +3,7 @@
 <h1 class="crayons-title mb-4">
   Overview
 </h1>
+<%= render "notices" %>
 
 <div class="flex flex-col gap-4">
   <div class="flex flex-col l:flex-row gap-4">

--- a/spec/requests/admin/overview_spec.rb
+++ b/spec/requests/admin/overview_spec.rb
@@ -8,6 +8,31 @@ RSpec.describe "/admin" do
     allow(FeatureFlag).to receive(:enabled?).and_call_original
   end
 
+  describe "Notices" do
+    it "does not show warning if deployed at is recent" do
+      allow(ForemInstance).to receive(:deployed_at).and_return(1.day.ago)
+      get admin_path
+
+      expect(response.body).not_to include("If you stay out of date for too long")
+    end
+
+    it "shows warning notice if deployed at is over two weeks ago" do
+      allow(ForemInstance).to receive(:deployed_at).and_return(3.weeks.ago)
+      get admin_path
+
+      expect(response.body).to include("If you stay out of date for too long")
+      expect(response.body).to include("crayons-notice--warning")
+    end
+
+    it "shows danger notice if deployed at is over four weeks ago" do
+      allow(ForemInstance).to receive(:deployed_at).and_return(5.weeks.ago)
+      get admin_path
+
+      expect(response.body).to include("If you stay out of date for too long")
+      expect(response.body).to include("crayons-notice--danger")
+    end
+  end
+
   describe "Last deployed and Latest Commit ID card" do
     before do
       ForemInstance.instance_variable_set(:@deployed_at, nil)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds a notice to the admin section which begins warning admins that their Forem is out of date if it is two weeks since recent re-deployment from `main` and steps from yellow to red notice when the timeframe passes 4 weeks.

This alert could get more sophisticated in the future, but is a minimum notice to help maintain more healthy and up-to-date self-hosted Forems.

<img width="1007" alt="Screenshot 2023-09-27 at 9 05 40 AM" src="https://github.com/forem/forem/assets/3102842/ae1b994b-a4da-4cad-b496-934e27b3670c">


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/forem/forem-internal-eng/issues/290

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes: Covered the different scenarios with request spec
