### PR TITLE
Do not show suspended followers in aggregated siblings for notification

### DIFF
--- a/app/services/notifications/new_follower/send.rb
+++ b/app/services/notifications/new_follower/send.rb
@@ -21,8 +21,8 @@ module Notifications
       delegate :user_data, to: Notifications
 
       def call
-        recent_follows = Follow.where(followable_type: followable_type, followable_id: followable_id)
-          .where("created_at > ?", 24.hours.ago).order(created_at: :desc)
+        recent_follows = Follow.non_suspended(followable_type, followable_id)
+          .where("follows.created_at > ?", 24.hours.ago).order(created_at: :desc)
 
         notification_params = { action: "Follow" }
         case followable_type


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Don't show suspended followers in aggregate notification

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes https://github.com/forem/forem/issues/20173


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
