### PR TITLE
Change profile image max size to 8 MB

### DIFF
--- a/app/uploaders/logo_uploader.rb
+++ b/app/uploaders/logo_uploader.rb
@@ -1,5 +1,5 @@
 class LogoUploader < BaseUploader
-  MAX_FILE_SIZE = 3.megabytes
+  MAX_FILE_SIZE = 8.megabytes
   STORE_DIRECTORY = "uploads/logos/".freeze
   EXTENSION_ALLOWLIST = %w[png jpg jpeg jpe].freeze
   IMAGE_TYPE_ALLOWLIST = %i[png jpg jpeg jpe].freeze

--- a/app/uploaders/profile_image_uploader.rb
+++ b/app/uploaders/profile_image_uploader.rb
@@ -1,10 +1,12 @@
 class ProfileImageUploader < BaseUploader
+  MAX_FILE_SIZE = 8.megabytes
+
   def filename
     "#{secure_token}.#{file.extension}" if original_filename.present?
   end
 
   def size_range
-    1..(2.megabytes)
+    1..MAX_FILE_SIZE
   end
 
   protected

--- a/spec/services/users/update_spec.rb
+++ b/spec/services/users/update_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe Users::Update, type: :service do
   end
 
   it "returns an error if Profile image is too large" do
+    stub_const("ProfileImageUploader::MAX_FILE_SIZE", 2.megabytes)
     profile_image = fixture_file_upload("large_profile_img.jpg", "image/jpeg")
     service = described_class.call(user, profile: {}, user: { profile_image: profile_image })
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a small modification to profile image upload max to better meet user expectations. This still falls well below the 25mb max we have for other types of images.

## Related Tickets & Documents

- Closes https://github.com/forem/forem/issues/20182

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: This is not complicated enough behavior to warrant test
- [ ] I need help with writing tests

