### PR TITLE
Fixed Norvegian locale key

### DIFF
--- a/config/locales/languages/en.yml
+++ b/config/locales/languages/en.yml
@@ -74,7 +74,7 @@ en:
       my: Burmese
       ne: Nepali
       nl: Dutch
-      no: Norwegian
+      "no": Norwegian
       ny: Nyanja
       pa: Punjabi
       pl: Polish

--- a/config/locales/languages/fr.yml
+++ b/config/locales/languages/fr.yml
@@ -74,7 +74,7 @@ fr:
       my: Burmese
       ne: Nepali
       nl: Dutch
-      no: Norwegian
+      "no": Norwegian
       ny: Nyanja
       pa: Punjabi
       pl: Polish


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Bug Fix

## Description
"no" is a reserved word in yaml, so `I18n.t "languages.display_name.no"` was giving `"Translation missing: en.languages.display_name.no"`, this pr is fixing the issue.

## Related Tickets & Documents
This lead to [a failing build ](https://github.com/forem/forem/actions/runs/6385030154/job/17329164982?pr=20189)