### PR TITLE
Fix code block rendering not working inside details

### DIFF
--- a/app/liquid_tags/details_tag.rb
+++ b/app/liquid_tags/details_tag.rb
@@ -12,8 +12,7 @@ class DetailsTag < Liquid::Block
     content = Nokogiri::HTML.parse(super)
     parsed_content = sanitize(
       content.xpath("//html/body").inner_html,
-      tags: MarkdownProcessor::AllowedTags::RENDERED_MARKDOWN_SCRUBBER,
-      attributes: MarkdownProcessor::AllowedAttributes::RENDERED_MARKDOWN_SCRUBBER,
+      scrubber: RenderedMarkdownScrubber.new,
     )
 
     ApplicationController.render(

--- a/spec/liquid_tags/details_tag_spec.rb
+++ b/spec/liquid_tags/details_tag_spec.rb
@@ -2,19 +2,142 @@ require "rails_helper"
 
 RSpec.describe DetailsTag, type: :liquid_tag do
   describe "#render" do
-    let(:summary) { "Click to see the answer!" }
-    let(:content) { "The answer is Forem!" }
-
     def generate_details_liquid(summary, content)
       Liquid::Template.register_tag("details", described_class)
       Liquid::Template.parse("{% details #{summary} %} #{content} {% enddetails %}")
     end
 
-    it "generates proper details div with summary" do
-      rendered = generate_details_liquid(summary, content).render
+    context "when content has simple text" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "The answer is Forem!" }
 
-      expect(rendered).to include("<details")
-      expect(rendered).to include('<summary>Click to see the answer!') # rubocop:disable Style/StringLiterals
+      it "generates proper details div with summary" do
+        rendered = generate_details_liquid(summary, content).render
+
+        expect(rendered).to include("<details")
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
+    end
+
+    context "when content has a strong tag" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "<strong>foo</strong>" }
+
+      it "accepts a strong tag" do
+        rendered = generate_details_liquid(summary, content).render
+
+        expect(rendered).to include("<strong>foo</strong>")
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
+    end
+
+    context "when content has a link tag" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "<a href=\"https://example.com\">link</a>" }
+
+      it "accepts a link tag" do
+        rendered = generate_details_liquid(summary, content).render
+
+        expect(rendered).to include("<a href=\"https://example.com\">link</a>")
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
+    end
+
+    context "when content has a h2 tag" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "<h2>heading</h2>" }
+
+      it "accepts a h2 tag" do
+        rendered = generate_details_liquid(summary, content).render
+
+        expect(rendered).to include("<h2>heading</h2>")
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
+    end
+
+    context "when content has a list" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "<ol><li>one</li><li>two</li></ol>" }
+
+      it "accepts a list tag" do
+        rendered = generate_details_liquid(summary, content).render
+
+        expect(rendered).to include("<li>one</li>")
+        expect(rendered).to include("<li>two</li>")
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
+    end
+
+    context "when content has an img tag" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "<img src=\"https://example.com/foo.png\" alt=\"\">" }
+
+      it "accepts an img tag" do
+        rendered = generate_details_liquid(summary, content).render
+
+        expect(rendered).to include("<img src=\"https://example.com/foo.png\" alt=\"\">")
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
+    end
+
+    context "when content has a code tag" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "<code>aaaa</code>" }
+
+      it "accepts a code tag" do
+        rendered = generate_details_liquid(summary, content).render
+
+        expect(rendered).to include("<code>aaaa</code>")
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
+    end
+
+    context "when content has a div tag" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "<div class=\"highlight\">foo<div>" }
+
+      it "removes a div tag" do
+        rendered = generate_details_liquid(summary, content).render
+        expect(rendered).not_to include("div")
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
+    end
+
+    context "when content has unpermitted tags" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "<script>alert(1)</script><object>foo</object>" }
+
+      it "removes unpermitted tags" do
+        rendered = generate_details_liquid(summary, content).render
+        expect(rendered).not_to include("script")
+        expect(rendered).not_to include("object")
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
+    end
+
+    context "when content has an unpermitted attribute" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "<p alt=\"alt\" onclick=\"javascript:alert(1)\">foo</p>" }
+
+      it "removes an unpermitted attribute" do
+        rendered = generate_details_liquid(summary, content).render
+        expect(rendered).not_to include("onclick")
+        expect(rendered).to include("<p alt=\"alt\">foo</p>")
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
+    end
+
+    context "when content has tags for creating a code block" do
+      let(:summary) { "Click to see the answer!" }
+      let(:content) { "<div class=\"highlight\"><pre class=\"highlight plaintext\"><code>foo</code></pre></div>" }
+
+      it "accepts these tags" do
+        rendered = generate_details_liquid(summary, content).render
+        expect(rendered).to include(
+          "<div class=\"highlight\"><pre class=\"highlight plaintext\"><code>foo</code></pre></div>",
+        )
+        expect(rendered).to include("<summary>Click to see the answer!")
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes the issue of code blocks not working with details/spoiler/collapsible liquid tags.
I used `RenderedMarkdownScrubber` class to sanitize HTML tags. This class can sanitize tags while considering code blocks and is already used in the [`MarkdownProcessor::Parser`](https://github.com/forem/forem/blob/eb52b91f75c5d0c8c4f0dec03b50a72f04f3cc2f/app/services/markdown_processor/parser.rb#L38) class for the same purpose.  
(I believe that the behavior of RenderedMarkdownScrubber class is the same as that of the default scrubber, except for the consideration of code blocks.)

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes https://github.com/forem/forem/issues/19900

## QA Instructions, Screenshots, Recordings

|before|after|
|---|---|
|<img width="713" alt="スクリーンショット 2023-10-08 17 35 29" src="https://github.com/forem/forem/assets/17381979/10029974-8283-4969-9ef5-7ada4e0c3fc0">|<img width="713" alt="スクリーンショット 2023-10-08 17 34 38" src="https://github.com/forem/forem/assets/17381979/9a6c64b1-343d-4b78-a337-46142ccd2cc9">|


### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [x] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [x] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
