### PR TITLE
Fix flaky Cypress test

### DIFF
--- a/cypress/e2e/seededFlows/articleFlows/commentOnArticle.spec.js
+++ b/cypress/e2e/seededFlows/articleFlows/commentOnArticle.spec.js
@@ -191,12 +191,12 @@ describe('Comment on articles', () => {
 
         cy.get('@commentTextArea').type('Some text @se');
         verifyComboboxMode();
-        cy.get('@commentTextArea').type('{backspace}{backspace}');
+        cy.get('@commentTextArea').type('{backspace}{backspace}{backspace}');
       });
 
       cy.findByRole('option', { name: /@search_user_1/ }).should('not.exist');
 
-      cy.get('@commentTextArea').type('se');
+      cy.get('@commentTextArea').type('@se');
       cy.findByRole('option', { name: /@search_user_1/ }).should('exist');
     });
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR fixes a flaky Cypress test I encountered during my contribution.
This test appears to verify that a suggestion disappears when a user enters two words following the '@' symbol and deletes two words. However, I think this test is incorrect because, when I try it manually, the suggestion remains until a user deletes the '@' character.
I think this test is supposed to always fail, but in practice, it sometimes passes because Cypress runs these processes quickly.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related: https://github.com/forem/forem/actions/runs/6434138956/job/17472750723?pr=20223
- Related: https://github.com/forem/forem/actions/runs/6452622377/job/17515018063?pr=20230
- Related: https://github.com/forem/forem/actions/runs/6446292233/job/17523394422?pr=20229

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [x] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [x] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
