### PR TITLE
Make it possible to schedule articles via the API

### DIFF
--- a/app/controllers/concerns/api/articles_controller.rb
+++ b/app/controllers/concerns/api/articles_controller.rb
@@ -147,7 +147,8 @@ module Api
     def article_params
       allowed_params = [
         :title, :body_markdown, :published, :series,
-        :main_image, :canonical_url, :description, { tags: [] }
+        :main_image, :canonical_url, :description, { tags: [] },
+        :published_at
       ]
       allowed_params << :organization_id if params.dig("article", "organization_id") && allowed_to_change_org_id?
       params.require(:article).permit(allowed_params)

--- a/app/services/articles/creator.rb
+++ b/app/services/articles/creator.rb
@@ -4,6 +4,20 @@ module Articles
       new(...).call
     end
 
+    # @param user [User]
+    # @param article_params [Hash]
+    # @option article_params [NilClass, String] :title
+    # @option article_params [NilClass, String] :body_markdown
+    # @option article_params [NilClass, String] :main_image
+    # @option article_params [Boolean] :published
+    # @option article_params [NilClass, String] :description
+    # @option article_params [NilClass, String] :video_thumbnail_url
+    # @option article_params [NilClass, String] :canonical_url
+    # @option article_params [NilClass, String] :series series slug
+    # @option article_params [Integer, NilClass] :collection_id
+    # @option article_params [Boolean] :archived
+    # @option article_params [String<Array>] :tags
+    # @option article_params [NilClass, String, ActiveSupport::TimeWithZone] :published_at
     def initialize(user, article_params)
       @user = user
       @article_params = normalize_params(article_params)

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -881,19 +881,21 @@ RSpec.describe "Api::V1::Articles" do
 
       it "creates an articles with published_at in the future" do
         formatted_date = tomorrow.strftime("%Y-%m-%d")
+        formatted_published_at = "#{formatted_date} 18:00 MSK"
+        published_at = DateTime.parse(formatted_published_at)
         expect do
           post_article(
             title: Faker::Book.title,
             body_markdown: "yoooo" * 100,
-            published_at: "#{formatted_date} 18:00 MSK",
+            published_at: formatted_published_at,
           )
         end.to change(Article, :count).by(1)
         created_article = Article.find(response.parsed_body["id"])
         expect(created_article.published_at).to be_present
-        expect(created_article.published_at.strftime("%Y-%m-%d")).to eq(formatted_date)
+        expect(created_article.published_at).to be_within(1.minute).of(published_at)
       end
 
-      it "creates an article when publushed_at without time is passed" do
+      it "creates an article when publushed_at in the future without time is passed" do
         formatted_date = tomorrow.strftime("%Y-%m-%d")
         expect do
           post_article(
@@ -926,6 +928,8 @@ RSpec.describe "Api::V1::Articles" do
     let(:article)       { create(:article, user: user, published: false, published_at: nil) }
     let(:path)          { api_article_path(article.id) }
     let!(:organization) { create(:organization) }
+    let(:tomorrow)      { Date.tomorrow }
+    let(:formatted_future_time) { "#{tomorrow.strftime('%Y-%m-%d')} 18:00 UTC" }
 
     describe "when unauthorized" do
       it "fails with no api key" do
@@ -1177,6 +1181,41 @@ RSpec.describe "Api::V1::Articles" do
         put_article(organization_id: organization.id)
         expect(response).to have_http_status(:ok)
         expect(article.reload.organization).to eq(organization)
+      end
+
+      it "updates published_at draft => scheduled" do
+        put_article(published_at: formatted_future_time, published: true)
+        expect(response).to have_http_status(:ok)
+        article.reload
+        expect(article.published_at > Time.current).to be true
+      end
+
+      it "updates published_at sheduled => scheduled" do
+        article.update_columns(published_at: 2.days.from_now, published: true)
+        future_time = DateTime.parse(formatted_future_time)
+        put_article(published_at: formatted_future_time)
+        expect(response).to have_http_status(:ok)
+        article.reload
+        expect(article.published_at).to be_within(1.minute).of(future_time)
+      end
+
+      it "doesn't allow to update published_at of a scheduled article to a past date" do
+        future = 2.days.from_now
+        article.update_columns(published_at: future, published: true)
+        put_article(published_at: "2020-02-02 19:00 UTC")
+        expect(response).to have_http_status(:unprocessable_entity)
+        article.reload
+        expect(article.published_at).to be_within(1.minute).of(future)
+      end
+
+      # published_at is immutable after publishing
+      it "doesn't update published_at for a published article (but doesn't raise an error)" do
+        time = 1.day.ago
+        article.update_columns(published_at: time, published: true)
+        put_article(published_at: formatted_future_time)
+        expect(response).to have_http_status(:ok)
+        article.reload
+        expect(article.published_at).to be_within(1.minute).of(time)
       end
 
       it "fails if params are not a Hash" do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -622,7 +622,8 @@ RSpec.describe "Api::V1::Articles" do
 
     describe "when authorized" do
       let(:default_params) { { body_markdown: "" } }
-      let(:tomorrow) { 1.day.from_now }
+      let(:tomorrow) { Date.tomorrow }
+      let(:formatted_date) { tomorrow.strftime("%Y-%m-%d") }
 
       def post_article(**params)
         params = default_params.merge params
@@ -880,7 +881,6 @@ RSpec.describe "Api::V1::Articles" do
       end
 
       it "creates an articles with published_at in the future" do
-        formatted_date = tomorrow.strftime("%Y-%m-%d")
         formatted_published_at = "#{formatted_date} 18:00 MSK"
         published_at = DateTime.parse(formatted_published_at)
         expect do
@@ -896,7 +896,6 @@ RSpec.describe "Api::V1::Articles" do
       end
 
       it "creates an article when publushed_at in the future without time is passed" do
-        formatted_date = tomorrow.strftime("%Y-%m-%d")
         expect do
           post_article(
             title: Faker::Book.title,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Allow setting and updating `published_at` via the API (creating and updating articles).
Limitations are the same as when creating from the user interface, they are handled by service objects/model.

Added yard docs for `Articles::Creator`

## Related Tickets & Documents
- Closes #20105

## QA Instructions, Screenshots, Recordings
You should be able to create an article via the api with specified current or future `published_at`.
It should also be possible to update `published_at` to current or future values for drafts and scheduled articles.

## Added/updated tests?
- [x] Yes