### PR TITLE
Add email to the users api

### DIFF
--- a/app/controllers/concerns/api/users_controller.rb
+++ b/app/controllers/concerns/api/users_controller.rb
@@ -4,11 +4,11 @@ module Api
 
     SHOW_ATTRIBUTES_FOR_SERIALIZATION = %i[
       id username name summary twitter_username github_username website_url
-      location created_at profile_image registered
+      location created_at profile_image registered display_email_on_profile email
     ].freeze
 
     def show
-      relation = User.joins(:profile).select(SHOW_ATTRIBUTES_FOR_SERIALIZATION)
+      relation = User.joins(:profile).joins(:setting).select(SHOW_ATTRIBUTES_FOR_SERIALIZATION)
 
       @user = if params[:id] == "by_username"
                 relation.find_by!(username: params[:url])

--- a/app/controllers/concerns/api/users_controller.rb
+++ b/app/controllers/concerns/api/users_controller.rb
@@ -4,11 +4,12 @@ module Api
 
     SHOW_ATTRIBUTES_FOR_SERIALIZATION = %i[
       id username name summary twitter_username github_username website_url
-      location created_at profile_image registered display_email_on_profile email
+      location created_at profile_image registered
     ].freeze
 
     def show
-      relation = User.joins(:profile).joins(:setting).select(SHOW_ATTRIBUTES_FOR_SERIALIZATION)
+      attributes_for_select = SHOW_ATTRIBUTES_FOR_SERIALIZATION + %i[display_email_on_profile email]
+      relation = User.joins(:profile).joins(:setting).select(attributes_for_select)
 
       @user = if params[:id] == "by_username"
                 relation.find_by!(username: params[:url])

--- a/app/views/api/v1/shared/_user_show.json.jbuilder
+++ b/app/views/api/v1/shared/_user_show.json.jbuilder
@@ -9,6 +9,8 @@ json.extract!(
   :github_username,
 )
 
+json.email user.setting.display_email_on_profile ? user.email : nil
+
 Profile.static_fields.each do |attr|
   json.set! attr, user.profile.public_send(attr)
 end

--- a/app/views/api/v1/shared/_user_show_extended.json.jbuilder
+++ b/app/views/api/v1/shared/_user_show_extended.json.jbuilder
@@ -9,6 +9,8 @@ json.extract!(
   :github_username,
 )
 
+json.email user.setting.display_email_on_profile ? user.email : nil
+
 Profile.static_fields.each do |attr|
   json.set! attr, user.profile.public_send(attr)
 end

--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.partial! "api/v1/shared/user_show", user: @user
+json.partial! "api/v1/shared/user_show_extended", user: @user

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -297,6 +297,8 @@ RSpec.describe "Api::V1::Organizations" do
 
       expect(response_org_users["joined_at"]).to eq(org_user.created_at.strftime("%b %e, %Y"))
       expect(response_org_users["profile_image"]).to eq(org_user.profile_image_url_for(length: 320))
+
+      expect(response_org_users.key?("email")).to be false
     end
   end
 


### PR DESCRIPTION
~~WIP because the partial is used in other endpoints which is not taken into account in the pr yet.~~

## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Added `email` field to the users api endpoint `/api/users/{id}`
Email will be displayed if `display_email_on_profile` is set, otherwise `nil` is displayed.

## Related Tickets & Documents
- Closes  #20236

## QA Instructions, Screenshots, Recordings
Api should work with the changes described above

## Added/updated tests?
- [x] Yes