### PR TITLE
Update CI's jest reporters

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -224,7 +224,7 @@ jobs:
         with:
           node-version: 16
           cache: yarn
-      - run: yarn test --colors --ci --reporters=jest-junit
+      - run: yarn test --colors --ci --reporters=jest-junit --reporters=default
       - name: Upload test results to BuildPulse for flaky test detection
         if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
         uses: Workshop64/buildpulse-action@master

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -224,7 +224,7 @@ jobs:
         with:
           node-version: 16
           cache: yarn
-      - run: yarn test --colors --ci --reporters=jest-junit --reporters=default
+      - run: yarn test --colors --ci --reporters="jest-junit" --reporters="default"
       - name: Upload test results to BuildPulse for flaky test detection
         if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
         uses: Workshop64/buildpulse-action@master


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
Our CI is not displaying any Jest related failure. This is due to the default reporter being overridden.

see https://jestjs.io/docs/cli#--reporters

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a