### PR TITLE
Remove rails version check from generator

### DIFF
--- a/lib/generators/settings_model/settings_model_generator.rb
+++ b/lib/generators/settings_model/settings_model_generator.rb
@@ -50,7 +50,7 @@ class SettingsModelGenerator < Rails::Generators::NamedBase
   end
 
   def migration_version
-    "[#{rails_version_major}.#{rails_version_minor}]" if rails_version_major >= 5
+    "[#{rails_version_major}.#{rails_version_minor}]"
   end
 
   def table_name


### PR DESCRIPTION


<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Remove rails version 5 check from generator file since the project is already on rails 6.

## QA Instructions, Screenshots, Recordings

All behaviour should be kept the same, it's just a minor optimization that was already returning true all the time.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: Code should already be covered by existing tests and gem versions.
- [ ] I need help with writing tests

