### PR TITLE
Automatically reward thumbs-up milestone badges

### DIFF
--- a/app/services/badges/award_thumbs_up.rb
+++ b/app/services/badges/award_thumbs_up.rb
@@ -1,0 +1,38 @@
+module Badges
+  class AwardThumbsUp
+    THUMBS_UP_BADGES = {
+      1 => "100-thumbs-up-milestone",
+      2 => "500-thumbs-up-milestone",
+      3 => "1-2c000-thumbs-up-milestone",
+      4 => "5-2c000-thumbs-up-milestone",
+      5 => "10-2c000-thumbs-up-milestone"
+    }.freeze
+
+    MIN_THRESHOLD = THUMBS_UP_BADGES.keys.min
+
+    def self.call
+      user_thumbsup_counts = Reaction
+        .where(category: "thumbsup", reactable_type: "Article")
+        .group(:user_id)
+        .having("COUNT(*) >= ?", MIN_THRESHOLD)
+        .order(Arel.sql("COUNT(*) DESC"))
+        .count
+      user_thumbsup_counts.each do |user_thumbsup_count|
+        THUMBS_UP_BADGES.each do |threshold, badge_slug|
+          break unless user_thumbsup_count.count >= threshold
+          next unless (badge_id = Badge.id_for_slug(badge_slug))
+          next unless (user = User.find_by(id: user_thumbsup_count[0]))
+
+          user.badge_achievements.create(
+            badge_id: badge_id,
+            rewarding_context_message_markdown: generate_message(threshold: threshold),
+          )
+        end
+      end
+    end
+
+    def self.generate_message(threshold:)
+      I18n.t("services.badges.thumbs_up", count: threshold)
+    end
+  end
+end

--- a/config/locales/services/en.yml
+++ b/config/locales/services/en.yml
@@ -31,6 +31,7 @@ en:
         first: Thank you for participating in constructive conversation! You posted two or more comments this week. Keep it up to continue the streak!
         longest: 32 weeks! You've achieved the longest streak possible for the Community Wellness badge. Amazing job engaging in the community and keep up your amazing contributions to our community!
         other: Congrats on achieving a %{weeks} week streak for the Community Wellness Badge! Keep the constructive comments flowing to continue the streak!
+      thumbs_up: Thank you for your efforts reviewing posts on and reaching %{count} thumbs-up reactions!
     broadcasts:
       welcome_notification:
         generator:

--- a/config/locales/services/fr.yml
+++ b/config/locales/services/fr.yml
@@ -31,6 +31,7 @@ fr:
         first: Merci de participer à une conversation constructive ! Vous avez posté deux commentaires ou plus cette semaine. Continuez comme ça pour poursuivre la série !
         longest: 32 semaines ! Vous avez atteint la plus longue période possible pour l'insigne du bien-être communautaire. Vous avez fait un travail remarquable en vous engageant dans la communauté et continuez à apporter votre contribution à notre communauté !
         other: Félicitations pour avoir atteint une série de %{weeks} semaines pour l'insigne du bien-être communautaire ! Continuez à envoyer des commentaires constructifs pour que la série continue !
+      thumbs_up: Merci pour vos efforts en examinant les messages et en obtenant %{count} réactions positives!
     broadcasts:
       welcome_notification:
         generator:

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -86,6 +86,14 @@ award_community_wellness_badges:
     - ""
     - award_community_wellness
     - ""
+award_thumbs_up_badges:
+  description: "Awards 'Community Wellness' badges to users (runs every 5 minutes)"
+  cron: "5 * * * *"
+  class: "BadgeAchievements::BadgeAwardWorker"
+  args:
+    - ""
+    - award_community_wellness
+    - ""
 resave_supported_tags:
   description: "Resaves supported tags to recalculate scores (runs daily at 00:25 UTC)"
   cron: "25 0 * * *"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -92,7 +92,7 @@ award_thumbs_up_badges:
   class: "BadgeAchievements::BadgeAwardWorker"
   args:
     - ""
-    - award_community_wellness
+    - award_thumbs_up
     - ""
 resave_supported_tags:
   description: "Resaves supported tags to recalculate scores (runs daily at 00:25 UTC)"

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -88,7 +88,7 @@ award_community_wellness_badges:
     - ""
 award_thumbs_up_badges:
   description: "Awards 'Community Wellness' badges to users (runs every 5 minutes)"
-  cron: "5 * * * *"
+  cron: "*/5 * * * *"
   class: "BadgeAchievements::BadgeAwardWorker"
   args:
     - ""


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents

- Related Issue #2011

## QA Instructions, Screenshots, Recordings

1. Check that the following badges exist, and if not add them (specific wording)
  - 100 Thumbs Up Milestone
  - 500 Thumbs Up Milestone 
  - 1,000 Thumbs Up Milestone
  - 5,000 Thumbs Up Milestone   
  - 10,000 Thumbs Up Milestone
2. Log in to an account that is a trusted member
3. Add a 👍 reaction, to 1 - 5 articles.
4. Wait 5 minutes
5. You should have been awarded 


### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ x] No, and this is why: working on the tests
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

Once this is tested, I'll need to change the badge thresholds to their proper values and update the sidekiq job  to run once a day.

## [optional] What gif best describes this PR or how it makes you feel?

