### PR TITLE
Add a link to Forem GitHub repo on the report abuse page

### DIFF
--- a/app/views/pages/report_abuse.en.html.erb
+++ b/app/views/pages/report_abuse.en.html.erb
@@ -18,8 +18,8 @@
     <h1 class="fs-3xl s:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight mb-4 mt-0"><%= t("core.report_abuse") %></h1>
 
     <p>
-      Thank you for reporting any abuse that violates our <a href="/code-of-conduct">code of conduct</a> or
-      <a href="/terms">terms and conditions</a>. We continue to try to make this environment a great one for everybody.
+      Thank you for reporting any abuse that violates our <a href="/code-of-conduct">Code of Conduct</a> and/or
+      <a href="/terms">Terms and Conditions</a>. We continue to try to make this environment a great one for everybody.  If you are submitting a bug report, please <a href="https://github.com/forem/forem/issues/new?assignees=&labels=bug&projects=&template=bug_report.md&title=">create a GitHub issue</a> in the main Forem repo. 
     </p>
 
     <div class="crayons-card crayons-card--secondary p-4 m:p-6">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Copy update

## Description

Adds a link to the `/report-abuse` page.  I updated this only for the `en` template.

## Related Tickets & Documents

Closes https://github.com/forem/forem/issues/20361

## QA Instructions, Screenshots, Recordings

n/a

### UI accessibility checklist

n/a


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, copy change only
- [ ] I need help with writing tests
