### PR TITLE
Allow creating and updating pages with body_html via the api

### DIFF
--- a/app/controllers/admin/pages_controller.rb
+++ b/app/controllers/admin/pages_controller.rb
@@ -8,7 +8,7 @@ module Admin
     ].freeze
 
     def index
-      @pages = Page.all.order(created_at: :desc)
+      @pages = Page.order(created_at: :desc)
       @code_of_conduct = Page.find_by(slug: Page::CODE_OF_CONDUCT_SLUG)
       @privacy = Page.find_by(slug: Page::PRIVACY_SLUG)
       @terms = Page.find_by(slug: Page::TERMS_SLUG)
@@ -43,7 +43,6 @@ module Admin
 
     def update
       @page = Page.find(params[:id])
-
       if @page.update(page_params)
         flash[:success] = I18n.t("admin.pages_controller.updated")
         redirect_to admin_pages_path

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -40,7 +40,7 @@ module Api
 
       def permitted_params
         params.permit(*%i[title slug description is_top_level_path
-                          body_json body_markdown social_image template])
+                          body_json body_markdown body_html social_image template])
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Allow creating and updating pages with `body_html`, not only `body_markdown` via the api

## Related Tickets & Documents
- Closes #20342

## Added/updated tests?
- [x] Yes
