### PR TITLE
Only render comment sorting for signed-in users

### DIFF
--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -7,31 +7,35 @@
             <%= t("views.articles.comments.subtitle.#{@comments_order}_html",
                   num: tag.span(t("views.articles.comments.num", num: @article.comments_count), class: "js-comments-count", data: { comments_count: @article.comments_count })) %>
           </h2>
-          <button class="c-btn c-btn--ghost crayons-btn--icon-left" id="toggle-comments-sort-dropdown" aria-controls="comments-sort-dropdown-container" aria-expanded="false" aria-label="<%= t("views.articles.comments.sort_button.aria_label") %>" aria-haspopup="true">
-            <%= inline_svg_tag("expand.svg", aria_hidden: true, title: t("views.moderations.actions.admin.icon"), class: "mt-2") %>
-          </button>
+          <% if user_signed_in? %>
+            <button class="c-btn c-btn--ghost crayons-btn--icon-left" id="toggle-comments-sort-dropdown" aria-controls="comments-sort-dropdown-container" aria-expanded="false" aria-label="<%= t("views.articles.comments.sort_button.aria_label") %>" aria-haspopup="true">
+              <%= inline_svg_tag("expand.svg", aria_hidden: true, title: t("views.moderations.actions.admin.icon"), class: "mt-2") %>
+            </button>
+          <% end %>
         </div>
 
-        <nav class="crayons-dropdown p-4" id="comments-sort-dropdown-container" aria-labelledby="comments-sort-title">
-            <h3 id="comments-sort-title" class="mb-3"><%= t("views.articles.comments.sort.heading") %></h3>
-            <ul class="comments-sort-dropdown__list">
-              <%= render "comments/sort_option",
-                         sort_order: "top",
-                         sort_title: t("views.articles.comments.sort.title.top"),
-                         sort_description: t("views.articles.comments.sort.desc.top"),
-                         show_selected: @comments_order == "top" %>
-              <%= render "comments/sort_option",
-                         sort_order: "latest",
-                         sort_title: t("views.articles.comments.sort.title.latest"),
-                         sort_description: t("views.articles.comments.sort.desc.latest"),
-                         show_selected: @comments_order == "latest" %>
-              <%= render "comments/sort_option",
-                         sort_order: "oldest",
-                         sort_title: t("views.articles.comments.sort.title.oldest"),
-                         sort_description: t("views.articles.comments.sort.desc.oldest"),
-                         show_selected: @comments_order == "oldest" %>
-            </ul>
-        </nav>
+        <% if user_signed_in? %>
+          <nav class="crayons-dropdown p-4" id="comments-sort-dropdown-container" aria-labelledby="comments-sort-title">
+              <h3 id="comments-sort-title" class="mb-3"><%= t("views.articles.comments.sort.heading") %></h3>
+              <ul class="comments-sort-dropdown__list">
+                <%= render "comments/sort_option",
+                           sort_order: "top",
+                           sort_title: t("views.articles.comments.sort.title.top"),
+                           sort_description: t("views.articles.comments.sort.desc.top"),
+                           show_selected: @comments_order == "top" %>
+                <%= render "comments/sort_option",
+                           sort_order: "latest",
+                           sort_title: t("views.articles.comments.sort.title.latest"),
+                           sort_description: t("views.articles.comments.sort.desc.latest"),
+                           show_selected: @comments_order == "latest" %>
+                <%= render "comments/sort_option",
+                           sort_order: "oldest",
+                           sort_title: t("views.articles.comments.sort.title.oldest"),
+                           sort_description: t("views.articles.comments.sort.desc.oldest"),
+                           show_selected: @comments_order == "oldest" %>
+              </ul>
+          </nav>
+        <% end %>
 
         <div id="comment-subscription" class="print-hidden">
           <div class="crayons-btn-group">

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -139,6 +139,10 @@ RSpec.describe "ArticlesShow" do
       it "does not render json ld" do
         expect(response.body).not_to include "application/ld+json"
       end
+
+      it "renders comment sort button" do
+        expect(response.body).to include "toggle-comments-sort-dropdown"
+      end
     end
   end
 
@@ -150,6 +154,10 @@ RSpec.describe "ArticlesShow" do
     describe "GET /:slug (user)" do
       it "does not render json ld" do
         expect(response.body).to include "application/ld+json"
+      end
+
+      it "does not render comment sort button" do
+        expect(response.body).not_to include "toggle-comments-sort-dropdown"
       end
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Or comment sorting buttons have created a huge amount of non-indexed pages which is not good for SEO. This submission fixes the issue.

<img width="643" alt="Screenshot 2023-11-27 at 2 04 45 PM" src="https://github.com/forem/forem/assets/3102842/246248f5-906b-4729-9a10-a62921313e90">

For signed-out contexts, instead of showing the icon for comment dropdown, nothing appears:

<img width="309" alt="Screenshot 2023-11-27 at 2 05 43 PM" src="https://github.com/forem/forem/assets/3102842/4d1f791f-1d11-4ce4-af5b-02fc4395a75d">


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes https://github.com/forem/forem/issues/20397


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

