### PR TITLE
Allow to remove suspended role

### DIFF
--- a/app/policies/role_policy.rb
+++ b/app/policies/role_policy.rb
@@ -1,7 +1,5 @@
 class RolePolicy < ApplicationPolicy
   def remove_role?
-    return false if record.suspended?
-
     if user.super_admin?
       true
     else

--- a/cypress/e2e/seededFlows/adminFlows/users/manageRoles.spec.js
+++ b/cypress/e2e/seededFlows/adminFlows/users/manageRoles.spec.js
@@ -74,7 +74,7 @@ describe('Manage User Roles', () => {
         verifyAndDismissFlashMessage('User has been updated', 'flash-success');
 
         cy.findByRole('button', {
-          name: "Suspended You can't remove this role.",
+          name: 'Remove role: Suspended',
         }).should('exist');
         checkUserStatus('Suspended');
 

--- a/spec/policies/role_policy_spec.rb
+++ b/spec/policies/role_policy_spec.rb
@@ -10,8 +10,8 @@ describe RolePolicy do
   let(:admin_user) { build(:user, :admin) }
 
   permissions :remove_role? do
-    it "denies access if current role is suspended" do
-      expect(role).not_to permit(super_admin_user, role_suspended)
+    it "allows access for super_admin if the role is suspended" do
+      expect(role).to permit(super_admin_user, role_suspended)
     end
 
     it "grants access if user is super admin" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
We [discussed](https://forem-team.slack.com/archives/C7GE84DEJ/p1701953913307969) earlier that there is an inconsistency in role permissions: e.g. it's possible to add a `suspended` role as a super_admin, but no one could remove this role (though it was possible to remove it implicitly by adding a trusted role).
This pr fixes the inconsistency: allows to remove the `suspended` role similarly to other roles.