### PR TITLE
GHA Workflows: Sanitize user input from fork workflows.

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -17,13 +17,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Generate UUID image name
         id: uuid
-        run: echo "UUID_TAG_APP=$(uuidgen)" >> $GITHUB_ENV
+        run: echo "UUID_TAG_APP=forem-$(uuidgen --time)" >> $GITHUB_ENV
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v4
         with:
           images: registry.uffizzi.com/${{ env.UUID_TAG_APP }}
-          tags: type=raw,value=60d
+          tags: type=raw,value=30d
       - uses: actions/checkout@master
       - name: Create the .env file
         run: |

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -13,8 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     outputs:
-      compose-file-cache-key: ${{ env.COMPOSE_FILE_HASH }}
-      pr-number: ${{ env.PR_NUMBER }}
+      compose-file-cache-key: ${{ steps.hash.outputs.COMPOSE_FILE_HASH }}
+      git-ref: ${{ steps.event.outputs.GIT_REF }}
+      pr-number: ${{ steps.event.outputs.PR_NUMBER }}
+      action: ${{ steps.event.outputs.ACTION }}
     steps:
       - name: 'Download artifacts'
         # Fetch output (zip archive) from the workflow run that triggered this workflow.
@@ -40,34 +42,35 @@ jobs:
             });
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
-      - name: 'Unzip artifact'
-        run: unzip preview-spec.zip
+      - name: 'Accept event from first stage'
+        run: unzip preview-spec.zip event.json
+
       - name: Read Event into ENV
+        id: event
         run: |
-          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
-          cat event.json >> $GITHUB_ENV
-          echo -e '\nEOF' >> $GITHUB_ENV
+          echo PR_NUMBER=$(jq '.number | tonumber' < event.json) >> $GITHUB_OUTPUT
+          echo ACTION=$(jq --raw-output '.action | tostring | [scan("\\w+")][0]' < event.json) >> $GITHUB_OUTPUT
+          echo GIT_REF=$(jq --raw-output '.pull_request.head.sha | tostring | [scan("\\w+")][0]' < event.json) >> $GITHUB_OUTPUT
+
       - name: Hash Rendered Compose File
         id: hash
-        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
-        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
-        run: echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+        # If the previous workflow was triggered by a PR close event, we will not have a manifests file artifact.
+        if: ${{ steps.event.outputs.ACTION != 'closed' }}
+        run: echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_OUTPUT
       - name: Cache Rendered Compose File
-        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        if: ${{ steps.event.outputs.ACTION != 'closed' }}
         uses: actions/cache@v3
         with:
           path: docker-compose.rendered.yml
-          key: ${{ env.COMPOSE_FILE_HASH }}
-
-      - name: Read PR Number From Event Object
-        id: pr
-        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+          key: ${{ steps.hash.outputs.COMPOSE_FILE_HASH }}
 
       - name: DEBUG - Print Job Outputs
         if: ${{ runner.debug }}
         run: |
-          echo "PR number: ${{ env.PR_NUMBER }}"
-          echo "Compose file hash: ${{ env.COMPOSE_FILE_HASH }}"
+          echo "PR number: ${{ steps.event.outputs.PR_NUMBER }}"
+          echo "Git Ref: ${{ steps.event.outputs.GIT_REF }}"
+          echo "Action: ${{ steps.event.outputs.ACTION }}"
+          echo "Compose file hash: ${{ steps.hash.outputs.COMPOSE_FILE_HASH }}"
           cat event.json
 
   deploy-uffizzi-preview:

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -42,6 +42,7 @@ jobs:
             });
             let fs = require('fs');
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+
       - name: 'Accept event from first stage'
         run: unzip preview-spec.zip event.json
 
@@ -54,9 +55,12 @@ jobs:
 
       - name: Hash Rendered Compose File
         id: hash
-        # If the previous workflow was triggered by a PR close event, we will not have a manifests file artifact.
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
         if: ${{ steps.event.outputs.ACTION != 'closed' }}
-        run: echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_OUTPUT
+        run: |
+          unzip preview-spec.zip docker-compose.rendered.yml
+          echo "COMPOSE_FILE_HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_OUTPUT
+
       - name: Cache Rendered Compose File
         if: ${{ steps.event.outputs.ACTION != 'closed' }}
         uses: actions/cache@v3


### PR DESCRIPTION
## Description

This change sanitizes user input from contributor fork workflows. This mitigates a security vulnerability identified by the `backstage` project.

## Related Tickets & Documents

This builds upon improvements in merged PR #19029 

## Testing

I've tested these workflows on my fork (and on other open-source projects.) https://github.com/axisofentropy/forem/actions/workflows/uffizzi-preview.yml