### PR TITLE
Remove unused user status span

### DIFF
--- a/app/views/admin/users/index/_status_indicator.html.erb
+++ b/app/views/admin/users/index/_status_indicator.html.erb
@@ -1,1 +1,1 @@
-<span class="c-indicator mr-2 inline-block" style="--bg: <%= status_to_indicator_color(status) %>"></span><%= t("views.admin.users.statuses.#{status}") %>
+<%= t("views.admin.users.statuses.#{status}") %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor


## Description
In my previous pr I [mentioned](https://github.com/forem/forem/pull/20449/files/cbc05ef50e5d8fd20ce84479a9a2246c292b79ca#diff-86bc446e94f46524b00122f23d033002aecbfdcf9dcddcebe0af15b365af9cda) that there is a span with a background that is useless because user status is outside of it. I did a bit of research and found out that it was this way from the beginning. As far as I know this partial is only used in the users list in admin. There are other places that display user status with a background (e.g. feedback messages list in admin), but they use different code.
I have also talked to @michael-tharrington about the status backgrounds in the users list and found out that the list is usable as is, w/o background, so adding backgrounds doesn't make much sense. 
So, I'm removing the span in this pr to avoid confusion in the future and simplify logic a little bit.
