### PR TITLE
Removed github/time-elements

### DIFF
--- a/app/javascript/packs/admin.js
+++ b/app/javascript/packs/admin.js
@@ -1,6 +1,5 @@
 import { Application } from '@hotwired/stimulus';
 import { definitionsFromContext } from '@hotwired/stimulus-webpack-helpers';
-import { LocalTimeElement } from '@github/time-elements'; // eslint-disable-line no-unused-vars
 import Rails from '@rails/ujs';
 import 'focus-visible';
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "@babel/plugin-transform-react-jsx": "^7.22.15",
     "@babel/preset-env": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
-    "@github/time-elements": "3.1.2",
     "@honeybadger-io/js": "^5.4.1",
     "@honeybadger-io/webpack": "^1.5.1",
     "@hotwired/stimulus": "3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2704,11 +2704,6 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@github/time-elements@3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@github/time-elements/-/time-elements-3.1.2.tgz#cc36d7a34ff2033d7f0b216f1a724405b8fbc201"
-  integrity sha512-YVtZVLBikP6I7na22kfB9PKIseISwX41MFJ7lPuNz1VVH2IR5cpRRU6F1X6kcchPChljuvMUR4OiwMWHOJQ8kQ==
-
 "@honeybadger-io/core@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@honeybadger-io/core/-/core-5.2.0.tgz#158d495ac9300a98734a2aeedad9dbd2785fc363"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
I did the research for the now deprecated `time-elements` package
(there was a [failed upgrade](https://github.com/forem/forem/pull/20335#pullrequestreview-1724529895) earlier)

The package was added in #14283 and was used at that time. There [was](https://www.npmjs.com/package/@github/time-elements/v/3.2.0) a tag `<local-time>` (the new `relative-time-element` package has `relative-time` tag (as well as the newest `time-elements` one), so it was a bit harder to find out).

Currently, we don't have any `<local-time>` tags, so the deprecated package can be removed.

## Related Tickets & Documents
- Closes #20426
