### PR TITLE
Add cookie requirement option for billboards

### DIFF
--- a/app/controllers/admin/billboards_controller.rb
+++ b/app/controllers/admin/billboards_controller.rb
@@ -60,7 +60,7 @@ module Admin
       params.permit(:organization_id, :body_markdown, :placement_area, :target_geolocations,
                     :published, :approved, :name, :display_to, :tag_list, :type_of,
                     :exclude_article_ids, :audience_segment_id, :priority,
-                    :render_mode, :template, :custom_display_label)
+                    :render_mode, :template, :custom_display_label, :requires_cookies)
     end
 
     def authorize_admin

--- a/app/controllers/api/v1/billboards_controller.rb
+++ b/app/controllers/api/v1/billboards_controller.rb
@@ -53,7 +53,7 @@ module Api
                       :audience_segment_type, :audience_segment_id, :priority,
                       :custom_display_label, :template, :render_mode, :preferred_article_ids,
                       # Permitting twice allows both comma-separated string and array values
-                      :target_geolocations, target_geolocations: []
+                      :target_geolocations, target_geolocations: [], :requires_cookies
       end
     end
   end

--- a/app/controllers/api/v1/billboards_controller.rb
+++ b/app/controllers/api/v1/billboards_controller.rb
@@ -49,11 +49,11 @@ module Api
       def permitted_params
         params.permit :approved, :body_markdown, :creator_id, :display_to,
                       :name, :organization_id, :placement_area, :published,
-                      :tag_list, :type_of, :exclude_article_ids, :weight,
+                      :tag_list, :type_of, :exclude_article_ids, :weight, :requires_cookies,
                       :audience_segment_type, :audience_segment_id, :priority,
                       :custom_display_label, :template, :render_mode, :preferred_article_ids,
                       # Permitting twice allows both comma-separated string and array values
-                      :target_geolocations, target_geolocations: [], :requires_cookies
+                      :target_geolocations, target_geolocations: []
       end
     end
   end

--- a/app/controllers/billboards_controller.rb
+++ b/app/controllers/billboards_controller.rb
@@ -31,6 +31,7 @@ class BillboardsController < ApplicationController
         user_id: current_user&.id,
         article: @article ? ArticleDecorator.new(@article) : nil,
         user_tags: user_tags,
+        cookies_allowed: cookies_allowed?,
         location: client_geolocation,
       )
 
@@ -68,5 +69,9 @@ class BillboardsController < ApplicationController
 
   def return_test_billboard?
     params[:bb_test_placement_area] == placement_area && params[:bb_test_id].present? && current_user&.any_admin?
+  end
+
+  def cookies_allowed?
+    params[:cookies_allowed] == "true"
   end
 end

--- a/app/models/billboard.rb
+++ b/app/models/billboard.rb
@@ -65,7 +65,7 @@ class Billboard < ApplicationRecord
 
   self.table_name = "display_ads"
 
-  def self.for_display(area:, user_signed_in:, user_id: nil, article: nil, user_tags: nil, location: nil)
+  def self.for_display(area:, user_signed_in:, user_id: nil, article: nil, user_tags: nil, location: nil, cookies_allowed: false)
     permit_adjacent = article ? article.permit_adjacent_sponsors? : true
 
     billboards_for_display = Billboards::FilteredAdsQuery.call(
@@ -79,6 +79,7 @@ class Billboard < ApplicationRecord
       user_id: user_id,
       user_tags: user_tags,
       location: location,
+      cookies_allowed: cookies_allowed
     )
 
     case rand(99) # output integer from 0-99

--- a/app/models/billboard.rb
+++ b/app/models/billboard.rb
@@ -79,7 +79,7 @@ class Billboard < ApplicationRecord
       user_id: user_id,
       user_tags: user_tags,
       location: location,
-      cookies_allowed: cookies_allowed
+      cookies_allowed: cookies_allowed,
     )
 
     case rand(99) # output integer from 0-99

--- a/app/queries/billboards/filtered_ads_query.rb
+++ b/app/queries/billboards/filtered_ads_query.rb
@@ -28,7 +28,7 @@ module Billboards
     def call
       @filtered_billboards = approved_and_published_ads
       @filtered_billboards = placement_area_ads
-      @filtered_billboards = cookies_allowed_ads if !@cookies_allowed
+      @filtered_billboards = cookies_allowed_ads unless @cookies_allowed
 
       if @article_id.present?
         if @article_tags.any?

--- a/app/queries/billboards/filtered_ads_query.rb
+++ b/app/queries/billboards/filtered_ads_query.rb
@@ -11,7 +11,7 @@ module Billboards
     # @param location [Geolocation|String] the visitor's geographic location
     def initialize(area:, user_signed_in:, organization_id: nil, article_tags: [],
                    permit_adjacent_sponsors: true, article_id: nil, billboards: Billboard,
-                   user_id: nil, user_tags: nil, location: nil)
+                   user_id: nil, user_tags: nil, location: nil, cookies_allowed: false)
       @filtered_billboards = billboards.includes([:organization])
       @area = area
       @user_signed_in = user_signed_in
@@ -22,11 +22,13 @@ module Billboards
       @permit_adjacent_sponsors = permit_adjacent_sponsors
       @user_tags = user_tags
       @location = Geolocation.from_iso3166(location)
+      @cookies_allowed = cookies_allowed
     end
 
     def call
       @filtered_billboards = approved_and_published_ads
       @filtered_billboards = placement_area_ads
+      @filtered_billboards = cookies_allowed_ads if !@cookies_allowed
 
       if @article_id.present?
         if @article_tags.any?
@@ -95,6 +97,10 @@ module Billboards
 
     def authenticated_ads(display_auth_audience)
       @filtered_billboards.where(display_to: display_auth_audience)
+    end
+
+    def cookies_allowed_ads
+      @filtered_billboards.where(requires_cookies: false)
     end
 
     def user_targeting_ads

--- a/db/migrate/20240102154708_add_requires_cookies_to_billboards.rb
+++ b/db/migrate/20240102154708_add_requires_cookies_to_billboards.rb
@@ -1,0 +1,5 @@
+class AddRequiresCookiesToBillboards < ActiveRecord::Migration[7.0]
+  def change
+    add_column :display_ads, :requires_cookies, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_08_165454) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_02_154708) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -488,6 +488,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_08_165454) do
     t.text "processed_html"
     t.boolean "published", default: false
     t.integer "render_mode", default: 0
+    t.boolean "requires_cookies", default: false
     t.float "success_rate", default: 0.0
     t.ltree "target_geolocations", default: [], array: true
     t.integer "template", default: 0

--- a/spec/queries/billboards/filtered_ads_query_spec.rb
+++ b/spec/queries/billboards/filtered_ads_query_spec.rb
@@ -318,4 +318,42 @@ RSpec.describe Billboards::FilteredAdsQuery, type: :query do
       end
     end
   end
+
+  context "when considering cookie requirements" do
+    let!(:requires_cookies_ad) { create_billboard(requires_cookies: true) }
+    let!(:no_cookies_required_ad) { create_billboard(requires_cookies: false) }
+
+    context "when cookies are allowed" do
+      it "includes ads that require cookies" do
+        filtered = filter_billboards(cookies_allowed: true)
+        expect(filtered).to include(requires_cookies_ad)
+        expect(filtered).to include(no_cookies_required_ad)
+      end
+    end
+
+    context "when cookies are not allowed" do
+      it "excludes ads that require cookies" do
+        filtered = filter_billboards(cookies_allowed: false)
+        expect(filtered).not_to include(requires_cookies_ad)
+        expect(filtered).to include(no_cookies_required_ad)
+      end
+    end
+  end
+
+  # Helper methods for setting up test data (if not already defined)
+  def create_billboard(**options)
+    defaults = {
+      # ... [existing defaults] ...
+      requires_cookies: false  # Default value for requires_cookies
+    }
+    create(:billboard, **options.reverse_merge(defaults))
+  end
+
+  def filter_billboards(**options)
+    defaults = {
+      # ... [existing defaults] ...
+      cookies_allowed: false  # Default value for cookies_allowed
+    }
+    described_class.call(**options.reverse_merge(defaults))
+  end
 end

--- a/spec/queries/billboards/filtered_ads_query_spec.rb
+++ b/spec/queries/billboards/filtered_ads_query_spec.rb
@@ -343,16 +343,14 @@ RSpec.describe Billboards::FilteredAdsQuery, type: :query do
   # Helper methods for setting up test data (if not already defined)
   def create_billboard(**options)
     defaults = {
-      # ... [existing defaults] ...
-      requires_cookies: false  # Default value for requires_cookies
+      billboards: Billboard, area: placement_area, user_signed_in: false, requires_cookies: false
     }
     create(:billboard, **options.reverse_merge(defaults))
   end
 
   def filter_billboards(**options)
     defaults = {
-      # ... [existing defaults] ...
-      cookies_allowed: false  # Default value for cookies_allowed
+      billboards: Billboard, area: placement_area, user_signed_in: false, requires_cookies: false
     }
     described_class.call(**options.reverse_merge(defaults))
   end

--- a/spec/queries/billboards/filtered_ads_query_spec.rb
+++ b/spec/queries/billboards/filtered_ads_query_spec.rb
@@ -339,19 +339,4 @@ RSpec.describe Billboards::FilteredAdsQuery, type: :query do
       end
     end
   end
-
-  # Helper methods for setting up test data (if not already defined)
-  def create_billboard(**options)
-    defaults = {
-      billboards: Billboard, area: placement_area, user_signed_in: false, requires_cookies: false
-    }
-    create(:billboard, **options.reverse_merge(defaults))
-  end
-
-  def filter_billboards(**options)
-    defaults = {
-      billboards: Billboard, area: placement_area, user_signed_in: false, requires_cookies: false
-    }
-    described_class.call(**options.reverse_merge(defaults))
-  end
 end

--- a/spec/requests/api/v1/billboards_spec.rb
+++ b/spec/requests/api/v1/billboards_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Api::V1::Billboards" do
                           "creator_id", "exclude_article_ids",
                           "audience_segment_type", "audience_segment_id",
                           "custom_display_label", "template", "render_mode", "preferred_article_ids",
-                          "priority", "weight", "target_geolocations")
+                          "priority", "weight", "target_geolocations", "requires_cookies")
         expect(response.parsed_body["target_geolocations"]).to contain_exactly("US-WA", "CA-BC")
       end
 
@@ -73,7 +73,7 @@ RSpec.describe "Api::V1::Billboards" do
                           "creator_id", "exclude_article_ids",
                           "audience_segment_type", "audience_segment_id",
                           "custom_display_label", "template", "render_mode", "preferred_article_ids",
-                          "priority", "weight", "target_geolocations")
+                          "priority", "weight", "target_geolocations", "requires_cookies")
         expect(response.parsed_body["target_geolocations"]).to contain_exactly("US-WA", "CA-BC")
       end
 

--- a/spec/requests/api/v1/billboards_spec.rb
+++ b/spec/requests/api/v1/billboards_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Api::V1::Billboards" do
       type_of: "community",
       published: true,
       approved: true,
+      requires_cookies: false,
       target_geolocations: "US-WA, CA-BC"
     }
   end
@@ -136,7 +137,7 @@ RSpec.describe "Api::V1::Billboards" do
                           "impressions_count", "name", "organization_id",
                           "placement_area", "processed_html", "published",
                           "success_rate", "tag_list", "type_of", "updated_at",
-                          "creator_id", "exclude_article_ids",
+                          "creator_id", "exclude_article_ids", "requires_cookies",
                           "audience_segment_type", "audience_segment_id",
                           "custom_display_label", "template", "render_mode", "preferred_article_ids",
                           "priority", "weight", "target_geolocations")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is only the data backend of this feature.

Some billboards could rely on cookie consent to be displayed. By default none do, and `requires_cookie` can be false, so if `cookies_allowed` is _not_ passed from the frontend, then we can only use `requires_cookie: false` (which is all billboards now and by default), but in the future if we have billboards which require cookies, then these should only show up when we pass `cookies_allowed` from the request.



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/20463
- Closes #

## QA Instructions, Screenshots, Recordings

Mostly just check if this is logically viable. If we do not pass "allowed" one way or another, we should only return `requires_cookie: false` but if cookies are passes as allowed via param, then we can return any required status (i.e. true and false are valid)

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes: Added some new tests

