### PR TITLE
Remove calls to trigger round robin notifications

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -65,7 +65,6 @@ class Comment < ApplicationRecord
 
   after_create_commit :record_field_test_event
   after_create_commit :send_email_notification, if: :should_send_email_notification?
-  after_create_commit :send_to_moderator
 
   after_commit :calculate_score, on: %i[create update]
 

--- a/app/workers/articles/publish_worker.rb
+++ b/app/workers/articles/publish_worker.rb
@@ -14,10 +14,6 @@ module Articles
         # create mentions and notifications
         # Send notifications to any mentioned users, followed by any users who follow the article's author.
         Notification.send_to_mentioned_users_and_followers(article)
-
-        # using nth_published because it doesn't count draft articles by the new author
-        from_newish_author = article.nth_published_by_author < 3
-        Notification.send_moderation_notification(article) if from_newish_author
       end
     end
   end

--- a/spec/services/notifications/moderation/send_spec.rb
+++ b/spec/services/notifications/moderation/send_spec.rb
@@ -14,12 +14,6 @@ RSpec.describe Notifications::Moderation::Send, type: :service do
       u = create(:user, :trusted, last_reacted_at: 2.days.ago, last_moderation_notification: last_moderation_time)
       u.notification_setting.update(mod_roundrobin_notifications: true)
       allow(User).to receive(:staff_account).and_return(staff_account)
-      # Creating a comment calls moderation job which itself call moderation service
-      Comment.skip_callback(:commit, :after, :send_to_moderator)
-    end
-
-    after do
-      Comment.set_callback(:commit, :after, :send_to_moderator)
     end
 
     it "calls comment_data since parameter is a comment" do

--- a/spec/workers/articles/publish_worker_spec.rb
+++ b/spec/workers/articles/publish_worker_spec.rb
@@ -39,36 +39,6 @@ RSpec.describe Articles::PublishWorker, type: :worker do
     expect(Notification).not_to have_received(:send_to_mentioned_users_and_followers).with(scheduled_article)
   end
 
-  it "sends moderation notification for a published article" do
-    allow(Notification).to receive(:send_moderation_notification)
-    worker.perform
-    expect(Notification).to have_received(:send_moderation_notification).with(article)
-  end
-
-  it "does not send moderation notification for an unpublished article" do
-    unpublished = create(:unpublished_article, user: article.user)
-    allow(Notification).to receive(:send_moderation_notification)
-    worker.perform
-    expect(Notification).not_to have_received(:send_moderation_notification).with(unpublished)
-  end
-
-  it "does not send moderation notification for a scheduled article" do
-    scheduled = create(:article, published: true, published_at: Date.tomorrow)
-    allow(Notification).to receive(:send_moderation_notification)
-    worker.perform
-    expect(Notification).not_to have_received(:send_moderation_notification).with(scheduled)
-  end
-
-  it "does not send moderation notification for second published article" do
-    second = create(:published_article, title: "This is number two", user: article.user)
-    third = create(:published_article, title: "This is number three", user: article.user)
-    allow(Notification).to receive(:send_moderation_notification)
-    worker.perform
-    expect(Notification).to have_received(:send_moderation_notification).with(article)
-    expect(Notification).to have_received(:send_moderation_notification).with(second)
-    expect(Notification).not_to have_received(:send_moderation_notification).with(third)
-  end
-
   context "with 2 articles" do
     let!(:article2) { create(:article, published: true) }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This disables calls to the code that triggers round-robin notifications, as we are re-visiting their effectiveness.

## Related Tickets & Documents

- Related Issue #20453 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
