### PR TITLE
Do not vacate tags if parameter not passed via API

### DIFF
--- a/app/services/articles/attributes.rb
+++ b/app/services/articles/attributes.rb
@@ -15,7 +15,7 @@ module Articles
       hash = attributes.slice(*ATTRIBUTES)
       # don't reset the collection when no series was passed
       hash[:collection] = collection if attributes.key?(:series)
-      hash[:tag_list] = tag_list
+      hash[:tag_list] = tag_list if !attributes[:tag_list].nil? || !attributes[:tags].nil?
       hash[:edited_at] = Time.current if update_edited_at
       hash[:published_at] = hash[:published_at].to_datetime if hash[:published_at]
       hash

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1051,6 +1051,27 @@ RSpec.describe "Api::V1::Articles" do
         end.to change(article, :body_markdown) && change(article, :cached_tag_list)
       end
 
+      it "does not update the tags if not included in the request" do
+        article.update_column(:cached_tag_list, "meta, discussion")
+        expect do
+          put_article(
+            body_markdown: "something here",
+          )
+          article.reload
+        end.not_to change(article, :cached_tag_list)
+      end
+
+      it "does update the tags if empty string is provided" do
+        article.update_column(:cached_tag_list, "meta, discussion")
+        expect do
+          put_article(
+            body_markdown: "something here",
+            tags: %w[],
+          )
+          article.reload
+        end.to change(article, :cached_tag_list)
+      end
+
       it "assigns the article to a new series belonging to the user" do
         expect do
           put_article(


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This is a hot fix which fixes an issue where hitting the article update endpoint updates tags to empty if the parameter is not passed. Tags should only be updated to empty if the parameter is passed and it is empty.