### PR TITLE
  Make articles from a user with spam role inaccessible (direct access)

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -262,6 +262,7 @@ class StoriesController < ApplicationController
   def assign_article_show_variables
     not_found if permission_denied?
     not_found unless @article.user
+    not_found if @article.user.spam?
 
     @pinned_article_id = PinnedArticle.id
 

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -130,12 +130,21 @@ RSpec.describe "ArticlesShow" do
   end
 
   context "when author has spam role" do
+    before do
+      article.user.add_role(:spam)
+    end
+
     it "renders 404" do
       expect do
-        article.user.add_role(:spam)
         get article.path
       end.to raise_error(ActiveRecord::RecordNotFound)
-      # expect(response).to have_http_status(:not_found)
+    end
+
+    it "renders 404 for authorized user" do
+      sign_in user
+      expect do
+        get article.path
+      end.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -129,6 +129,16 @@ RSpec.describe "ArticlesShow" do
     end
   end
 
+  context "when author has spam role" do
+    it "renders 404" do
+      expect do
+        article.user.add_role(:spam)
+        get article.path
+      end.to raise_error(ActiveRecord::RecordNotFound)
+      # expect(response).to have_http_status(:not_found)
+    end
+  end
+
   context "when user signed in" do
     before do
       sign_in user


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Return 404 if user article author has spam role.

## Related Tickets & Documents
- Related Issue #20452 

## QA Instructions, Screenshots, Recordings
If a user has spam role, article path should return 404.

## Added/updated tests?
- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
