### PR TITLE
Don't show low scoring articles in timeframe feeds

### DIFF
--- a/app/controllers/stories/tagged_articles_controller.rb
+++ b/app/controllers/stories/tagged_articles_controller.rb
@@ -81,6 +81,7 @@ module Stories
     def stories_by_timeframe(stories:)
       if Timeframe::FILTER_TIMEFRAMES.include?(params[:timeframe])
         stories.where("published_at > ?", Timeframe.datetime(params[:timeframe]))
+          .where(score: -20..)
           .order(public_reactions_count: :desc)
       elsif params[:timeframe] == Timeframe::LATEST_TIMEFRAME
         stories.where(score: -20..).order(published_at: :desc)

--- a/app/services/articles/feeds/timeframe.rb
+++ b/app/services/articles/feeds/timeframe.rb
@@ -1,12 +1,14 @@
 module Articles
   module Feeds
     module Timeframe
-      def self.call(timeframe, tag: nil, number_of_articles: Article::DEFAULT_FEED_PAGINATION_WINDOW_SIZE, page: 1)
+      def self.call(timeframe, tag: nil, minimum_score: -20,
+                    number_of_articles: Article::DEFAULT_FEED_PAGINATION_WINDOW_SIZE, page: 1)
         articles = ::Articles::Feeds::Tag.call(tag)
 
         articles
           .where("published_at > ?", ::Timeframe.datetime(timeframe))
           .includes(:distinct_reaction_categories)
+          .where("score > ?", minimum_score)
           .order(score: :desc)
           .page(page)
           .per(number_of_articles)

--- a/spec/requests/stories/tagged_articles_spec.rb
+++ b/spec/requests/stories/tagged_articles_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe "Stories::TaggedArticlesIndex" do
           expect(response.body).to include(tag.name)
         end
 
+        it "displays articles with score > -20 on top/week", :aggregate_failures do
+          article
+          bad_article = create(:article, tags: tag.name, score: -30)
+          get "/t/#{tag.name}/top/week"
+          expect(response.body).to include(CGI.escapeHTML(article.title))
+          expect(response.body).not_to include(CGI.escapeHTML(bad_article.title))
+        end
+
         it "renders tag after alias change" do
           tag2 = create(:tag, alias_for: tag.name)
           get "/t/#{tag2.name}"

--- a/spec/services/articles/feeds/timeframe_spec.rb
+++ b/spec/services/articles/feeds/timeframe_spec.rb
@@ -11,7 +11,12 @@ RSpec.describe Articles::Feeds::Timeframe, type: :service do
   it "returns correct articles ordered by score", :aggregate_failures do
     result = described_class.call("week")
     expect(result.slice(0, 2)).to eq [hot_article, moderately_high_scoring_article]
-    expect(result.last).to eq low_scoring_article
+    expect(result).not_to include(low_scoring_article)
     expect(result).not_to include(month_old_article)
+  end
+
+  it "returns low scoring articles if lower score is passed" do
+    result = described_class.call("week", minimum_score: -1001)
+    expect(result).to include(low_scoring_article)
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Don't show articles with low score on timeframe feeds (/top/week, /top/month) and tag pages by timeframe: (/t/tagname/top/year).
This is part of #20452 , most of the cases were already covered, but some feeds still displayed articles with low score as I described in [the comment]((/top/week, /top/month) and tag pages by timeframe: (/t/tagname/top/year).).

## Related Tickets & Documents
- Closes #20452 

## QA Instructions, Screenshots, Recordings
- create an article with a low score, or assign a user with articles a "spam" role
- article should not appear in feeds like `/top/week` or `/t/tagname/top/year` , it's easier to check on tag pages that don't have a lot of articles

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
