### PR TITLE
Make icon for the mod center visible to trusted members

### DIFF
--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -33,7 +33,7 @@
             <%= t("views.main.create_post") %>
           <% end %>
 
-          <span class="mod-icon-visible-block">
+          <span class="trusted-visible-block">
             <a id="moderation-link" class="c-link c-link--icon-alone c-link--block mx-1" aria-label="<%= t("views.main.header.moderation.aria_label") %>" href="<%= mod_path %>">
               <%= crayons_icon_tag(:mod, title: t("views.main.header.moderation.icon")) %>
             </a>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Shows the mod icon in the top bar for trusted members.

## Related Tickets & Documents

- Closes #20520

## QA Instructions, Screenshots, Recordings

Login into an account of a trusted member (not a tag moderator) and see the mod icon (shield) in the top menu bar.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _small UI change_
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](https://media.giphy.com/media/gHOAu2veIeySCvVzMs/giphy.gif)
