### PR TITLE
Return 404 on user profile if user is a spammer

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -26,7 +26,6 @@ class StoriesController < ApplicationController
 
   def index
     @page = (params[:page] || 1).to_i
-
     return handle_user_or_organization_or_podcast_or_page_index if params[:username]
 
     handle_base_index
@@ -184,7 +183,8 @@ class StoriesController < ApplicationController
     end
     not_found if @user.username.include?("spam_") && @user.decorate.fully_banished?
     not_found unless @user.registered
-    if !user_signed_in? && (@user.spam_or_suspended? && @user.has_no_published_content?)
+    not_found if @user.spam?
+    if !user_signed_in? && (@user.suspended? && @user.has_no_published_content?)
       not_found
     end
     assign_user_comments


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Return 404 on user profile if user has spam role.
Haven't impemented access for admins because I can't use `current_user` directly because of caching (so need to figure it out), I would address that in a separate pr.

## Related Tickets & Documents
- Related Issue #20473

## Added/updated tests?
- [x] Yes