### PR TITLE
Hide low score comments on user profile

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -307,7 +307,7 @@ class StoriesController < ApplicationController
     @comments = []
     return unless user_signed_in? && @user.comments_count.positive?
 
-    @comments = @user.comments.where(deleted: false)
+    @comments = @user.comments.good_quality.where(deleted: false)
       .order(created_at: :desc)
       .includes(commentable: [:podcast])
       .limit(comment_count)

--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -1,8 +1,6 @@
 class CommentDecorator < ApplicationDecorator
-  LOW_QUALITY_THRESHOLD = -75
-
   def low_quality
-    score < LOW_QUALITY_THRESHOLD
+    score < Comment::LOW_QUALITY_THRESHOLD
   end
 
   def published_timestamp

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -9,6 +9,8 @@ class Comment < ApplicationRecord
 
   COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze
 
+  LOW_QUALITY_THRESHOLD = -75
+
   VALID_SORT_OPTIONS = %w[top latest oldest].freeze
 
   URI_REGEXP = %r{
@@ -84,6 +86,7 @@ class Comment < ApplicationRecord
                   }
 
   scope :eager_load_serialized_data, -> { includes(:user, :commentable) }
+  scope :good_quality, -> { where("score > ?", LOW_QUALITY_THRESHOLD) }
 
   alias touch_by_reaction save
 

--- a/spec/decorators/comment_decorator_spec.rb
+++ b/spec/decorators/comment_decorator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CommentDecorator, type: :decorator do
   end
 
   describe "#low_quality" do
-    let(:threshold) { CommentDecorator::LOW_QUALITY_THRESHOLD }
+    let(:threshold) { Comment::LOW_QUALITY_THRESHOLD }
     let(:comment) { build(:comment) }
 
     it "returns true if the comment is low quality" do

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -93,6 +93,26 @@ RSpec.describe "UserProfiles" do
       expect(response.body).to include "M18.364 17.364L12 23.728l-6.364-6.364a9 9 0 1112.728 0zM12 13a2 2 0 100-4 2 2 0"
     end
 
+    context "when has comments" do
+      before do
+        create(:comment, user: user, body_markdown: "nice_comment")
+        create(:comment, user: user, score: Comment::LOW_QUALITY_THRESHOLD - 50, body_markdown: "bad_comment")
+      end
+
+      it "displays only good standing comments comments", :aggregate_failures do
+        sign_in current_user
+        get user.path
+        expect(response.body).to include("nice_comment")
+        expect(response.body).not_to include("bad_comment")
+      end
+
+      it "doesn't display any comments for not signed in user", :aggregate_failures do
+        get user.path
+        expect(response.body).not_to include("nice_comment")
+        expect(response.body).not_to include("bad_comment")
+      end
+    end
+
     context "when organization" do
       it "renders organization page if org" do
         get organization.path

--- a/spec/views/comments/_comment.html.erb_spec.rb
+++ b/spec/views/comments/_comment.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "rendering locals in a partial" do
   context "when comment is low-quality" do
     it "renders the comment with low-quality marker", skip: "hiding low-quality for now" do
       allow(Settings::General).to receive(:mascot_image_url).and_return("https://i.imgur.com/fKYKgo4.png")
-      comment = create(:comment, processed_html: "hi", score: CommentDecorator::LOW_QUALITY_THRESHOLD - 100)
+      comment = create(:comment, processed_html: "hi", score: Comment::LOW_QUALITY_THRESHOLD - 100)
       article = create(:article)
 
       render "comments/comment",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix

## Description
We hide comments with score lower than threshold on articles page, so we need to hide them on users profile for consistency.

## Related Tickets & Documents
- Related Issue #20472

## Added/updated tests?
- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests