### PR TITLE
Render 404 when root comment has low score and no children

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -16,6 +16,11 @@ class CommentsController < ApplicationController
 
     @root_comment = Comment.find(params[:id_code].to_i(26)) if params[:id_code].present?
 
+    # hide low quality comments w/o children
+    if @root_comment && @root_comment.decorate.low_quality && !@root_comment.has_children?
+      not_found
+    end
+
     if @podcast
       @user = @podcast
       @commentable = @user.podcast_episodes.find_by(slug: params[:slug]) if @user.podcast_episodes

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,5 +1,5 @@
 <%= javascript_include_tag "postCommentsPage", defer: true %>
-<% if @root_comment.present? %>
+<% if @root_comment.present? && !@root_comment.decorate.low_quality %>
   <% title(@root_comment.title.to_s) %>
 <% else %>
   <% title(t("views.comments.meta.title_root", title: @commentable.title)) %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Render 404 on the comment path if the comment has low score (below threshold) and doesn't have children.
If a comment has children, it is displayed as deleted and children are displayed (it was implemented earlier in a different pr and `/comments` page also uses that logic)

## Related Tickets & Documents
- Related Issue  #20472

## Added/updated tests?
- [x] Yes