### PR TITLE
Changed logic for hiding and displaying low-quality marker for comments based on their score

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -16,9 +16,11 @@ class CommentsController < ApplicationController
 
     @root_comment = Comment.find(params[:id_code].to_i(26)) if params[:id_code].present?
 
-    # hide low quality comments w/o children
-    if @root_comment && @root_comment.decorate.low_quality && !@root_comment.has_children?
-      not_found
+    if @root_comment
+      # 404 for all low-quality for not signed in
+      not_found if @root_comment.score < Comment::LOW_QUALITY_THRESHOLD && !user_signed_in?
+      # 404 only for < -400 w/o children for signed in
+      not_found if @root_comment.score < Comment::HIDE_THRESHOLD && !@root_comment.has_children?
     end
 
     if @podcast

--- a/app/decorators/comment_decorator.rb
+++ b/app/decorators/comment_decorator.rb
@@ -3,6 +3,10 @@ class CommentDecorator < ApplicationDecorator
     score < Comment::LOW_QUALITY_THRESHOLD
   end
 
+  def super_low_quality
+    score < Comment::HIDE_THRESHOLD
+  end
+
   def published_timestamp
     return "" if created_at.nil?
 

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -30,6 +30,10 @@ module CommentsHelper
     end
   end
 
+  def tree_for(comment, sub_comments, commentable)
+    nested_comments(tree: { comment => sub_comments }, commentable: commentable, is_view_root: true)
+  end
+
   def comment_class(comment, is_view_root: false)
     if comment.root? || is_view_root
       "root"
@@ -56,10 +60,6 @@ module CommentsHelper
     else
       I18n.t("helpers.comments_helper.author")
     end
-  end
-
-  def tree_for(comment, sub_comments, commentable)
-    nested_comments(tree: { comment => sub_comments }, commentable: commentable, is_view_root: true)
   end
 
   def should_be_hidden?(comment, root_comment)

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -15,24 +15,16 @@ module CommentsHelper
   end
 
   def article_comment_tree(article, count, order)
-    @article_comment_tree ||= begin
-      collection = Comment.tree_for(article, count, order)
-      collection.reject! { |comment| comment.score.negative? } unless user_signed_in?
-      collection
-    end
+    Comments::Tree.for_article(article, count, order, user_signed_in?)
   end
 
   def podcast_comment_tree(episode)
-    @podcast_comment_tree ||= begin
-      collection = Comment.tree_for(episode, 12)
-      collection.reject! { |comment| comment.score.negative? } unless user_signed_in?
-      collection
-    end
+    Comments::Tree.for_episode(episode, user_signed_in?)
   end
 
-  def tree_for(comment, sub_comments, commentable)
-    nested_comments(tree: { comment => sub_comments }, commentable: commentable, is_view_root: true)
-  end
+  # def tree_for(comment, sub_comments, commentable)
+  #   nested_comments(tree: { comment => sub_comments }, commentable: commentable, is_view_root: true)
+  # end
 
   def comment_class(comment, is_view_root: false)
     if comment.root? || is_view_root

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -14,17 +14,13 @@ module CommentsHelper
     !(commentable.any_comments_hidden || any_hidden_negative_comments?(commentable))
   end
 
-  def article_comment_tree(article, count, order)
-    Comments::Tree.for_article(article, count, order, user_signed_in?)
+  def article_comment_tree(article, limit, order)
+    Comments::Tree.for_commentable(article, limit: limit, order: order, signed_in: user_signed_in?)
   end
 
   def podcast_comment_tree(episode)
-    Comments::Tree.for_episode(episode, user_signed_in?)
+    Comments::Tree.for_commentable(episode, signed_in: user_signed_in?, limit: 12)
   end
-
-  # def tree_for(comment, sub_comments, commentable)
-  #   nested_comments(tree: { comment => sub_comments }, commentable: commentable, is_view_root: true)
-  # end
 
   def comment_class(comment, is_view_root: false)
     if comment.root? || is_view_root

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -15,11 +15,11 @@ module CommentsHelper
   end
 
   def article_comment_tree(article, limit, order)
-    Comments::Tree.for_commentable(article, limit: limit, order: order, signed_in: user_signed_in?)
+    Comments::Tree.for_commentable(article, limit: limit, order: order, include_negative: user_signed_in?)
   end
 
   def podcast_comment_tree(episode)
-    Comments::Tree.for_commentable(episode, signed_in: user_signed_in?, limit: 12)
+    Comments::Tree.for_commentable(episode, include_negative: user_signed_in?, limit: 12)
   end
 
   def comment_class(comment, is_view_root: false)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -91,14 +91,6 @@ class Comment < ApplicationRecord
 
   alias touch_by_reaction save
 
-  def self.tree_for(commentable, limit = 0, order = nil)
-    commentable.comments
-      .includes(user: %i[setting profile])
-      .arrange(order: build_sort_query(order))
-      .to_a[0..limit - 1]
-      .to_h
-  end
-
   def self.title_deleted
     I18n.t("models.comment.deleted")
   end
@@ -113,17 +105,6 @@ class Comment < ApplicationRecord
 
   def self.build_comment(params, &blk)
     includes(user: :profile).new(params, &blk)
-  end
-
-  def self.build_sort_query(order)
-    case order
-    when "latest"
-      "created_at DESC"
-    when "oldest"
-      "created_at ASC"
-    else
-      "score DESC"
-    end
   end
 
   def search_id
@@ -209,7 +190,7 @@ class Comment < ApplicationRecord
     Comments::CalculateScoreWorker.perform_async(id)
   end
 
-  private_class_method :build_sort_query
+  # private_class_method :build_sort_query
 
   private
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,6 +10,7 @@ class Comment < ApplicationRecord
   COMMENTABLE_TYPES = %w[Article PodcastEpisode].freeze
 
   LOW_QUALITY_THRESHOLD = -75
+  HIDE_THRESHOLD = -400 # hide comments below this threshold
 
   VALID_SORT_OPTIONS = %w[top latest oldest].freeze
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -190,8 +190,6 @@ class Comment < ApplicationRecord
     Comments::CalculateScoreWorker.perform_async(id)
   end
 
-  # private_class_method :build_sort_query
-
   private
 
   def remove_notifications?

--- a/app/queries/comments/tree.rb
+++ b/app/queries/comments/tree.rb
@@ -1,22 +1,25 @@
 module Comments
-  class Tree
-    def self.for_commentable(commentable, limit: 0, order: nil, signed_in: false)
+  module Tree
+
+    module_function
+
+    def for_commentable(commentable, limit: 0, order: nil, include_negative: false)
       collection = commentable.comments
         .includes(user: %i[setting profile])
         .arrange(order: build_sort_query(order))
         .to_a[0..limit - 1]
         .to_h
-      collection.reject! { |comment| comment.score.negative? } unless signed_in
+      collection.reject! { |comment| comment.score.negative? } unless include_negative
       collection
     end
 
-    def self.for_root_comment(root_comment, signed_in: false)
+    def for_root_comment(root_comment, include_negative: false)
       sub_comments = root_comment.subtree.includes(user: %i[setting profile]).arrange[root_comment]
-      sub_comments.reject! { |comment| comment.score.negative? } unless signed_in
+      sub_comments.reject! { |comment| comment.score.negative? } unless include_negative
       { root_comment => sub_comments }
     end
 
-    def self.build_sort_query(order)
+    def build_sort_query(order)
       case order
       when "latest"
         "created_at DESC"

--- a/app/queries/comments/tree.rb
+++ b/app/queries/comments/tree.rb
@@ -1,35 +1,19 @@
 module Comments
   class Tree
-    def self.for_episode(episode, signed_in = false)
-      collection = tree_for(episode, 12)
-      collection.reject! { |comment| comment.score.negative? } unless signed_in
-      collection
-    end
-
-    def self.for_article(article, count = 0, order = nil, signed_in = false)
-      collection = tree_for(article, count, order)
-      collection.reject! { |comment| comment.score.negative? } unless signed_in
-      collection
-    end
-
-    def self.for_comments_page(commentable, signed_in)
-      collection = tree_for(commentable)
-      collection.reject! { |comment| comment.score.negative? } unless signed_in
-      collection
-    end
-
-    def self.for_root_comment(root_comment, signed_in)
-      sub_comments = root_comment.subtree.includes(user: %i[setting profile]).arrange[root_comment]
-      sub_comments.reject! { |comment| comment.score.negative? } unless signed_in
-      { root_comment => sub_comments }
-    end
-
-    def self.tree_for(commentable, limit = 0, order = nil)
-      commentable.comments
+    def self.for_commentable(commentable, limit: 0, order: nil, signed_in: false)
+      collection = commentable.comments
         .includes(user: %i[setting profile])
         .arrange(order: build_sort_query(order))
         .to_a[0..limit - 1]
         .to_h
+      collection.reject! { |comment| comment.score.negative? } unless signed_in
+      collection
+    end
+
+    def self.for_root_comment(root_comment, signed_in: false)
+      sub_comments = root_comment.subtree.includes(user: %i[setting profile]).arrange[root_comment]
+      sub_comments.reject! { |comment| comment.score.negative? } unless signed_in
+      { root_comment => sub_comments }
     end
 
     def self.build_sort_query(order)

--- a/app/queries/comments/tree.rb
+++ b/app/queries/comments/tree.rb
@@ -1,0 +1,46 @@
+module Comments
+  class Tree
+    def self.for_episode(episode, signed_in = false)
+      collection = tree_for(episode, 12)
+      collection.reject! { |comment| comment.score.negative? } unless signed_in
+      collection
+    end
+
+    def self.for_article(article, count = 0, order = nil, signed_in = false)
+      collection = tree_for(article, count, order)
+      collection.reject! { |comment| comment.score.negative? } unless signed_in
+      collection
+    end
+
+    def self.for_comments_page(commentable, signed_in)
+      collection = tree_for(commentable)
+      collection.reject! { |comment| comment.score.negative? } unless signed_in
+      collection
+    end
+
+    def self.for_root_comment(root_comment, signed_in)
+      sub_comments = root_comment.subtree.includes(user: %i[setting profile]).arrange[root_comment]
+      sub_comments.reject! { |comment| comment.score.negative? } unless signed_in
+      { root_comment => sub_comments }
+    end
+
+    def self.tree_for(commentable, limit = 0, order = nil)
+      commentable.comments
+        .includes(user: %i[setting profile])
+        .arrange(order: build_sort_query(order))
+        .to_a[0..limit - 1]
+        .to_h
+    end
+
+    def self.build_sort_query(order)
+      case order
+      when "latest"
+        "created_at DESC"
+      when "oldest"
+        "created_at ASC"
+      else
+        "score DESC"
+      end
+    end
+  end
+end

--- a/app/queries/comments/tree.rb
+++ b/app/queries/comments/tree.rb
@@ -1,6 +1,5 @@
 module Comments
   module Tree
-
     module_function
 
     def for_commentable(commentable, limit: 0, order: nil, include_negative: false)
@@ -29,5 +28,7 @@ module Comments
         "score DESC"
       end
     end
+
+    private_class_method :build_sort_query
   end
 end

--- a/app/views/articles/_comment_tree.html.erb
+++ b/app/views/articles/_comment_tree.html.erb
@@ -1,4 +1,4 @@
 <% comment, sub_comments = comment_node %>
-<% unless comment.decorate.low_quality && sub_comments.empty? %>
+<% unless comment.decorate.super_low_quality && sub_comments.empty? %>
   <%= nested_comments(tree: { comment => sub_comments }, commentable: @article, is_view_root: true) %>
 <% end %>

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -5,7 +5,7 @@
 
   <div class="inner-comment comment__details">
     <div class="comment__content crayons-card">
-      <% if comment.deleted || decorated_comment.low_quality %>
+      <% if comment.deleted || decorated_comment.super_low_quality %>
         <div class="p-6 align-center opacity-50 fs-s">
           <span class="js-comment-username">
             <%= t("views.comments.delete.comment_deleted") %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -139,12 +139,12 @@
     <div class="comments" id="comment-trees-container">
       <% if @root_comment.present? %>
         <% cache ["comment_root-view-root_#{user_signed_in?}", @root_comment] do %>
-          <%= nested_comments(tree: Comments::Tree.for_root_comment(@root_comment, user_signed_in?), commentable: @commentable, is_view_root: true) %>
+          <%= nested_comments(tree: Comments::Tree.for_root_comment(@root_comment, signed_in: user_signed_in?), commentable: @commentable, is_view_root: true) %>
         <% end %>
       <% else %>
-        <% Comments::Tree.for_comments_page(@commentable, user_signed_in?).each do |comment, sub_comments| %>
-         <% unless comment.decorate.super_low_quality && sub_comments.empty? %>
-            <% cache ["comment_root_#{user_signed_in?}", comment] do %>
+        <% Comments::Tree.for_commentable(@commentable, signed_in: user_signed_in?).each do |comment, sub_comments| %>
+          <% cache ["comment_root_#{user_signed_in?}", comment] do %>
+            <% unless comment.decorate.super_low_quality && sub_comments.empty? %>
               <%= nested_comments(tree: { comment => sub_comments }, commentable: @commentable, is_view_root: true) %>
             <% end %>
           <% end %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -1,5 +1,5 @@
 <%= javascript_include_tag "postCommentsPage", defer: true %>
-<% if @root_comment.present? && !@root_comment.decorate.low_quality %>
+<% if @root_comment.present? && !@root_comment.decorate.super_low_quality %>
   <% title(@root_comment.title.to_s) %>
 <% else %>
   <% title(t("views.comments.meta.title_root", title: @commentable.title)) %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -139,10 +139,10 @@
     <div class="comments" id="comment-trees-container">
       <% if @root_comment.present? %>
         <% cache ["comment_root-view-root_#{user_signed_in?}", @root_comment] do %>
-          <%= nested_comments(tree: Comments::Tree.for_root_comment(@root_comment, signed_in: user_signed_in?), commentable: @commentable, is_view_root: true) %>
+          <%= nested_comments(tree: Comments::Tree.for_root_comment(@root_comment, include_negative: user_signed_in?), commentable: @commentable, is_view_root: true) %>
         <% end %>
       <% else %>
-        <% Comments::Tree.for_commentable(@commentable, signed_in: user_signed_in?).each do |comment, sub_comments| %>
+        <% Comments::Tree.for_commentable(@commentable, include_negative: user_signed_in?).each do |comment, sub_comments| %>
           <% cache ["comment_root_#{user_signed_in?}", comment] do %>
             <% unless comment.decorate.super_low_quality && sub_comments.empty? %>
               <%= nested_comments(tree: { comment => sub_comments }, commentable: @commentable, is_view_root: true) %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -143,8 +143,10 @@
         <% end %>
       <% else %>
         <% Comment.tree_for(@commentable).each do |comment, sub_comments| %>
-          <% cache ["comment_root_#{user_signed_in?}", comment] do %>
-            <%= tree_for(comment, sub_comments, @commentable) %>
+         <% unless comment.decorate.super_low_quality && sub_comments.empty? %>
+            <% cache ["comment_root_#{user_signed_in?}", comment] do %>
+              <%= tree_for(comment, sub_comments, @commentable) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -139,13 +139,13 @@
     <div class="comments" id="comment-trees-container">
       <% if @root_comment.present? %>
         <% cache ["comment_root-view-root_#{user_signed_in?}", @root_comment] do %>
-          <%= tree_for(@root_comment, @root_comment.subtree.includes(user: %i[setting profile]).arrange[@root_comment], @commentable) %>
+          <%= nested_comments(tree: Comments::Tree.for_root_comment(@root_comment, user_signed_in?), commentable: @commentable, is_view_root: true) %>
         <% end %>
       <% else %>
-        <% Comment.tree_for(@commentable).each do |comment, sub_comments| %>
+        <% Comments::Tree.for_comments_page(@commentable, user_signed_in?).each do |comment, sub_comments| %>
          <% unless comment.decorate.super_low_quality && sub_comments.empty? %>
             <% cache ["comment_root_#{user_signed_in?}", comment] do %>
-              <%= tree_for(comment, sub_comments, @commentable) %>
+              <%= nested_comments(tree: { comment => sub_comments }, commentable: @commentable, is_view_root: true) %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/podcast_episodes/show.html.erb
+++ b/app/views/podcast_episodes/show.html.erb
@@ -105,7 +105,7 @@
         <div class="comment-trees" id="comment-trees-container">
           <% podcast_comment_tree(@episode).each do |comment, sub_comments| %>
             <% cache ["comment_root_#{user_signed_in?}", comment] do %>
-              <%= tree_for(comment, sub_comments, @episode) %>
+              <%= nested_comments(tree: { comment => sub_comments }, commentable: @episode, is_view_root: true) %>
             <% end %>
           <% end %>
         </div>

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -360,59 +360,6 @@ RSpec.describe Comment do
     end
   end
 
-  describe ".tree_for" do
-    let!(:other_comment) { create(:comment, commentable: article, user: user) }
-    let!(:child_comment) { create(:comment, commentable: article, parent: comment, user: user) }
-
-    before { comment.update_column(:score, 1) }
-
-    it "returns a full tree" do
-      comments = described_class.tree_for(article)
-      expect(comments).to eq(comment => { child_comment => {} }, other_comment => {})
-    end
-
-    it "returns part of the tree" do
-      comments = described_class.tree_for(article, 1)
-      expect(comments).to eq(comment => { child_comment => {} })
-    end
-
-    context "with sort order" do
-      let!(:new_comment) { create(:comment, commentable: article, user: user, created_at: Date.tomorrow) }
-      let!(:old_comment) { create(:comment, commentable: article, user: user, created_at: Date.yesterday) }
-
-      before { comment }
-
-      it "returns comments in the right order when order is oldest" do
-        comments = described_class.tree_for(article, 0, "oldest")
-        comments = comments.map { |key, _| key.id }
-        expect(comments).to eq([old_comment.id, other_comment.id, comment.id, new_comment.id])
-      end
-
-      it "returns comments in the right order when order is latest" do
-        comments = described_class.tree_for(article, 0, "latest")
-        comments = comments.map { |key, _| key.id }
-        expect(comments).to eq([new_comment.id, comment.id, other_comment.id, old_comment.id])
-      end
-
-      # rubocop:disable RSpec/ExampleLength
-      it "returns comments in the right order when order is top" do
-        comment.update_column(:score, 5)
-        highest_rated_comment = comment
-        new_comment.update_column(:score, 1)
-        lowest_rated_comment = new_comment
-        old_comment.update_column(:score, 3)
-        mid_high_rated_comment = old_comment
-        other_comment.update_column(:score, 2)
-        mid_low_rated_comment = other_comment
-        comments = described_class.tree_for(article, 0)
-
-        comments = comments.map { |key, _| key.id }
-        expect(comments).to eq([highest_rated_comment.id, mid_high_rated_comment.id, mid_low_rated_comment.id, lowest_rated_comment.id]) # rubocop:disable Layout/LineLength
-      end
-      # rubocop:enable RSpec/ExampleLength
-    end
-  end
-
   context "when callbacks are triggered after create" do
     let(:comment) { build(:comment, user: user, commentable: article) }
 

--- a/spec/queries/comments/tree_spec.rb
+++ b/spec/queries/comments/tree_spec.rb
@@ -1,0 +1,87 @@
+require "rails_helper"
+
+RSpec.describe Comments::Tree do
+  let(:user) { create(:user) }
+  let(:article) { create(:article) }
+  let!(:comment) { create(:comment, user: user, commentable: article) }
+  let!(:other_comment) { create(:comment, commentable: article, user: user, created_at: 1.hour.from_now) }
+  let!(:child_comment) { create(:comment, commentable: article, parent: comment, user: user) }
+
+  before { comment.update_column(:score, 1) }
+
+  describe "#for_commentable" do
+    it "returns a full tree" do
+      comments = described_class.for_commentable(article)
+      expect(comments).to eq(comment => { child_comment => {} }, other_comment => {})
+    end
+
+    it "returns part of the tree" do
+      comments = described_class.for_commentable(article, limit: 1)
+      expect(comments).to eq(comment => { child_comment => {} })
+    end
+
+    context "with include_negative" do
+      before do
+        other_comment.update_column(:score, -10)
+      end
+
+      it "returns comments with low score if include_negative is passed" do
+        comments = described_class.for_commentable(article, include_negative: true)
+        expect(comments).to eq({ comment => { child_comment => {} }, other_comment => {} })
+      end
+
+      it "doesn't return comments with low score if include_negative is false" do
+        comments = described_class.for_commentable(article)
+        expect(comments).to eq(comment => { child_comment => {} })
+      end
+    end
+
+    context "with sort order" do
+      let!(:new_comment) { create(:comment, commentable: article, user: user, created_at: Date.tomorrow) }
+      let!(:old_comment) { create(:comment, commentable: article, user: user, created_at: Date.yesterday) }
+
+      before { comment }
+
+      it "returns comments in the right order when order is oldest" do
+        comments = described_class.for_commentable(article, limit: 0, order: "oldest")
+        comments = comments.map { |key, _| key.id }
+        expect(comments).to eq([old_comment.id, comment.id, other_comment.id, new_comment.id])
+      end
+
+      it "returns comments in the right order when order is latest" do
+        comments = described_class.for_commentable(article, limit: 0, order: "latest")
+        comments = comments.map { |key, _| key.id }
+        expect(comments).to eq([new_comment.id, other_comment.id, comment.id, old_comment.id])
+      end
+
+      it "returns comments in the right order when order is top" do
+        comment.update_column(:score, 5)
+        highest_rated_comment = comment
+        new_comment.update_column(:score, 1)
+        lowest_rated_comment = new_comment
+        old_comment.update_column(:score, 3)
+        mid_high_rated_comment = old_comment
+        other_comment.update_column(:score, 2)
+        mid_low_rated_comment = other_comment
+        comments = described_class.for_commentable(article, limit: 0)
+
+        comments = comments.map { |key, _| key.id }
+        expect(comments).to eq([highest_rated_comment.id, mid_high_rated_comment.id, mid_low_rated_comment.id, lowest_rated_comment.id]) # rubocop:disable Layout/LineLength
+      end
+    end
+  end
+
+  describe "#for_root_comment" do
+    let!(:low_comment) { create(:comment, commentable: article, parent: comment, score: -100) }
+
+    it "returns tree for a particular comment" do
+      comments = described_class.for_root_comment(comment)
+      expect(comments).to eq(comment => { child_comment => {} })
+    end
+
+    it "returns tree with negative comments" do
+      comments = described_class.for_root_comment(comment, include_negative: true)
+      expect(comments).to eq(comment => { child_comment => {}, low_comment => {} })
+    end
+  end
+end

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -187,6 +187,7 @@ RSpec.describe "ArticlesShow" do
     before do
       create(:comment, score: 10, commentable: article, body_markdown: "Good comment")
       create(:comment, score: -99, commentable: article, body_markdown: "Bad comment")
+      create(:comment, score: -10, commentable: article, body_markdown: "Mediocre comment")
     end
 
     context "when user signed in" do
@@ -224,14 +225,11 @@ RSpec.describe "ArticlesShow" do
         expect(response.body).to include("Good comment")
       end
 
-      it "hides comments with score from -400 to -75" do
+      it "hides all negative comments", :aggregate_failures do
         get article.path
         expect(response.body).not_to include("Bad comment")
-      end
-
-      it "hides comments with score < -400" do
-        get article.path
         expect(response.body).not_to include("Spam comment")
+        expect(response.body).not_to include("Mediocre comment")
       end
 
       it "doesn't show children of a low-quality comment" do

--- a/spec/requests/articles/articles_show_spec.rb
+++ b/spec/requests/articles/articles_show_spec.rb
@@ -182,11 +182,11 @@ RSpec.describe "ArticlesShow" do
   end
 
   context "with comments" do
-    let!(:spam_comment) { create(:comment, score: -80, commentable: article, body_markdown: "Spam comment") }
+    let!(:spam_comment) { create(:comment, score: -450, commentable: article, body_markdown: "Spam comment") }
 
     before do
       create(:comment, score: 10, commentable: article, body_markdown: "Good comment")
-      create(:comment, score: -10, commentable: article, body_markdown: "Bad comment")
+      create(:comment, score: -99, commentable: article, body_markdown: "Bad comment")
     end
 
     context "when user signed in" do
@@ -199,12 +199,12 @@ RSpec.describe "ArticlesShow" do
         expect(response.body).to include("Good comment")
       end
 
-      it "shows comments with score from -75 (low quality threshold) to 0" do
+      it "shows comments with score from -400 to -75" do
         get article.path
         expect(response.body).to include("Bad comment")
       end
 
-      it "hides comments with score < -75 and no comment deleted message" do
+      it "hides comments with score < -400 and no comment deleted message" do
         get article.path
         expect(response.body).not_to include("Spam comment")
         expect(response.body).not_to include("Comment deleted")
@@ -224,12 +224,12 @@ RSpec.describe "ArticlesShow" do
         expect(response.body).to include("Good comment")
       end
 
-      it "hides comments with score from -75 to 0" do
+      it "hides comments with score from -400 to -75" do
         get article.path
         expect(response.body).not_to include("Bad comment")
       end
 
-      it "hides comments with score < -75" do
+      it "hides comments with score < -400" do
         get article.path
         expect(response.body).not_to include("Spam comment")
       end

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe "Comments" do
       it "is displayed as deleted when has children + user signed in", :aggregate_failures do
         create(:comment, commentable: article, user: user, parent: low_comment,
                          body_markdown: "child of a low-quality comment")
+        sign_in user
         get low_comment.path
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Comment deleted")

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Comments" do
 
     context "when there are comments with different score" do
       let!(:spam_comment) do
-        create(:comment, commentable: article, user: user, score: -1000, body_markdown: "spam-comment")
+        create(:comment, commentable: article, user: user, score: -1000, body_markdown: "spammer-comment")
       end
 
       before do
@@ -49,7 +49,7 @@ RSpec.describe "Comments" do
         expect(response.body).to include("low quality")
         expect(response.body).to include("bad-comment")
         expect(response.body).to include("good-comment")
-        expect(response.body).not_to include("spam-comment")
+        expect(response.body).not_to include("spammer-comment")
       end
 
       it "displays deleted message and children of a spam comment for signed in", :aggregate_failures do
@@ -57,7 +57,7 @@ RSpec.describe "Comments" do
                          body_markdown: "child-of-a-spam-comment")
         sign_in user
         get "#{article.path}/comments"
-        expect(response.body).not_to include("spam-comment")
+        expect(response.body).not_to include("spammer-comment")
         expect(response.body).to include("Comment deleted")
         expect(response.body).to include("child-of-a-spam-comment")
       end
@@ -67,7 +67,7 @@ RSpec.describe "Comments" do
         expect(response.body).to include("mediocre-comment")
         expect(response.body).not_to include("bad-comment")
         expect(response.body).to include("good-comment")
-        expect(response.body).not_to include("spam-comment")
+        expect(response.body).not_to include("spammer-comment")
       end
     end
 

--- a/spec/requests/podcasts/podcast_episodes_show_spec.rb
+++ b/spec/requests/podcasts/podcast_episodes_show_spec.rb
@@ -2,20 +2,65 @@ require "rails_helper"
 
 RSpec.describe "Podcast Episodes Show Spec" do
   describe "GET podcast episodes show" do
+    let(:podcast) { create(:podcast) }
+    let!(:podcast_episode) { create(:podcast_episode, podcast: podcast) }
+    let(:user) { create(:user) }
+
     it "renders the correct podcast episode" do
-      podcast = create(:podcast)
-      podcast_episode = create(:podcast_episode, podcast: podcast)
       get "/#{podcast.slug}/#{podcast_episode.slug}"
       expect(response.body).to include podcast_episode.title
     end
 
     it "does not render another podcast's episode if the wrong podcast slug is given" do
-      podcast = create(:podcast)
       other_podcast = create(:podcast)
-      podcast_episode = create(:podcast_episode, podcast: podcast)
       expect do
         get "/#{other_podcast.slug}/#{podcast_episode.slug}"
       end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    context "with comments" do
+      let!(:spam_comment) do
+        create(:comment, commentable: podcast_episode, user: user, score: -1000, body_markdown: "spammer-comment")
+      end
+
+      before do
+        create(:comment, commentable: podcast_episode, body_markdown: "episode-comment")
+        create(:comment, commentable: podcast_episode, user: user, score: -50, body_markdown: "mediocre-comment")
+        create(:comment, commentable: podcast_episode, user: user, score: -100, body_markdown: "bad-comment")
+      end
+
+      it "displays only good standing comments for signed out", :aggregate_failures do
+        get "/#{podcast.slug}/#{podcast_episode.slug}"
+        expect(response.body).to include("episode-comment")
+        expect(response.body).not_to include("spammer-comment")
+        expect(response.body).not_to include("mediocre-comment")
+        expect(response.body).not_to include("bad-comment")
+      end
+
+      it "displays all comments above > -400 for signed in", :aggregate_failures do
+        sign_in user
+        get "/#{podcast.slug}/#{podcast_episode.slug}"
+        expect(response.body).to include("episode-comment")
+        expect(response.body).not_to include("spammer-comment")
+        expect(response.body).to include("mediocre-comment")
+        expect(response.body).to include("bad-comment")
+      end
+
+      it "displays deleted message and children of a spam comment for signed in", :aggregate_failures do
+        create(:comment, user: user, parent: spam_comment, commentable: podcast_episode,
+                         body_markdown: "child-of-a-spam-comment")
+        sign_in user
+        get "/#{podcast.slug}/#{podcast_episode.slug}"
+        expect(response.body).not_to include("spammer-comment")
+        expect(response.body).to include("Comment deleted")
+        expect(response.body).to include("child-of-a-spam-comment")
+      end
+
+      it "displays a low-quality marker for a low-quality comment" do
+        sign_in user
+        get "/#{podcast.slug}/#{podcast_episode.slug}"
+        expect(response.body).to include("low quality/non-constructive") # for bad-comment
+      end
     end
   end
 end

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -96,13 +96,15 @@ RSpec.describe "UserProfiles" do
     context "when has comments" do
       before do
         create(:comment, user: user, body_markdown: "nice_comment")
-        create(:comment, user: user, score: Comment::LOW_QUALITY_THRESHOLD - 50, body_markdown: "bad_comment")
+        create(:comment, user: user, score: -100, body_markdown: "low_comment")
+        create(:comment, user: user, score: -401, body_markdown: "bad_comment")
       end
 
-      it "displays only good standing comments comments", :aggregate_failures do
+      it "displays good standing and low quality (but not too low) comments", :aggregate_failures do
         sign_in current_user
         get user.path
         expect(response.body).to include("nice_comment")
+        expect(response.body).to include("low_comment")
         expect(response.body).not_to include("bad_comment")
       end
 
@@ -235,7 +237,8 @@ RSpec.describe "UserProfiles" do
           suspended_user.add_role(:suspended)
           create(:article, user_id: user.id, published: false, published_at: Date.tomorrow)
 
-          expect { get "/#{suspended_user.username}" }.not_to raise_error(ActiveRecord::RecordNotFound)
+          get "/#{suspended_user.username}"
+          expect(response).to be_successful
         end
       end
 

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -100,11 +100,11 @@ RSpec.describe "UserProfiles" do
         create(:comment, user: user, score: -401, body_markdown: "bad_comment")
       end
 
-      it "displays good standing and low quality (but not too low) comments", :aggregate_failures do
+      it "displays good standing comments", :aggregate_failures do
         sign_in current_user
         get user.path
         expect(response.body).to include("nice_comment")
-        expect(response.body).to include("low_comment")
+        expect(response.body).not_to include("low_comment")
         expect(response.body).not_to include("bad_comment")
       end
 

--- a/spec/views/comments/_comment.html.erb_spec.rb
+++ b/spec/views/comments/_comment.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "rendering locals in a partial" do
     it "renders the comment with low-quality marker" do
       allow(Settings::General).to receive(:mascot_image_url).and_return("https://i.imgur.com/fKYKgo4.png")
       article = create(:article)
-      comment = create(:comment, processed_html: "hi", score: -100, article: article)
+      comment = create(:comment, processed_html: "hi", score: -100, commentable: article)
 
       render "comments/comment",
              comment: comment,

--- a/spec/views/comments/_comment.html.erb_spec.rb
+++ b/spec/views/comments/_comment.html.erb_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe "rendering locals in a partial" do
   context "when comment is low-quality" do
-    it "renders the comment with low-quality marker", skip: "hiding low-quality for now" do
+    it "renders the comment with low-quality marker" do
       allow(Settings::General).to receive(:mascot_image_url).and_return("https://i.imgur.com/fKYKgo4.png")
-      comment = create(:comment, processed_html: "hi", score: Comment::LOW_QUALITY_THRESHOLD - 100)
       article = create(:article)
+      comment = create(:comment, processed_html: "hi", score: -100, article: article)
 
       render "comments/comment",
              comment: comment,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Implemented thresholds described in the  https://github.com/forem/forem/issues/20551#issuecomment-1911950047
Made logic on `/commentable/comments` page the same as on `/commentable/comments` page.
404 on comments direct path when the comment should be hidden
Added more specs for comments/comment/commentable pages.
Moved part of the tree logic from `CommentsHelper` to `Comments::Tree`

## Related Tickets & Documents
- Closes #20551

## QA Instructions, Screenshots, Recordings
Comments should be displayed according to the rules described in the https://github.com/forem/forem/issues/20551#issuecomment-1911950047 on both commentable and commentable/comments pages

## Added/updated tests?
- [x] Yes
