### PR TITLE
Add Sendgrid Category to Digest Emails

### DIFF
--- a/app/mailers/digest_mailer.rb
+++ b/app/mailers/digest_mailer.rb
@@ -7,6 +7,14 @@ class DigestMailer < ApplicationMailer
     @unsubscribe = generate_unsubscribe_token(@user.id, :email_digest_periodic)
 
     subject = generate_title
+
+    # set sendgrid category in the header using smtp api
+    # https://docs.sendgrid.com/for-developers/sending-email/building-an-x-smtpapi-header
+    if ForemInstance.sendgrid_enabled?
+      smtpapi_header = { category: ["Digest Email"] }.to_json
+      headers["X-SMTPAPI"] = smtpapi_header
+    end
+
     mail(to: @user.email, subject: subject)
   end
 

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -8,8 +8,11 @@ RSpec.describe DigestMailer do
   describe "#digest_email" do
     before do
       allow(article).to receive(:title).and_return("test title")
-      allow(Settings::SMTP).to receive(:provided_minimum_settings?).and_return(true)
-      allow(Settings::SMTP).to receive(:from_email_address).and_return(from_email_address)
+      allow(Settings::SMTP).to receive_messages(
+        provided_minimum_settings?: true,
+        from_email_address: from_email_address,
+      )
+      allow(ForemInstance).to receive(:sendgrid_enabled?).and_return(true)
     end
 
     it "works correctly", :aggregate_failures do
@@ -20,6 +23,15 @@ RSpec.describe DigestMailer do
       expect(email.from).to eq([from_email_address])
       expected_from = "#{Settings::Community.community_name} Digest <#{from_email_address}>"
       expect(email["from"].value).to eq(expected_from)
+    end
+
+    it "includes the correct X-SMTPAPI header for SendGrid", :aggregate_failures do
+      email = described_class.with(user: user, articles: [article]).digest_email.deliver_now
+
+      expect(email.header["X-SMTPAPI"]).not_to be_nil
+      smtpapi_header = JSON.parse(email.header["X-SMTPAPI"].value)
+      expect(smtpapi_header).to have_key("category")
+      expect(smtpapi_header["category"]).to include("Digest Email")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

> Add a Category to Digest Emails sent via Sendgrid to distinguish them from other types of emails sent via Forem.

## Related Tickets & Documents
- Closes #20594

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
