### PR TITLE
Hide spam comments if they are child comments

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -94,12 +94,14 @@ module CommentsHelper
   private
 
   def nested_comments(tree:, commentable:, is_view_root: false)
-    comments = tree.map do |comment, sub_comments|
-      render("comments/comment", comment: comment, commentable: commentable,
-                                 is_view_root: is_view_root, is_childless: sub_comments.empty?,
-                                 subtree_html: nested_comments(tree: sub_comments, commentable: commentable))
+    comments = tree.filter_map do |comment, sub_comments|
+      is_childless = sub_comments.empty?
+      unless comment.decorate.super_low_quality && is_childless
+        render("comments/comment", comment: comment, commentable: commentable,
+                                   is_view_root: is_view_root, is_childless: is_childless,
+                                   subtree_html: nested_comments(tree: sub_comments, commentable: commentable))
+      end
     end
-
     safe_join(comments)
   end
 end

--- a/app/views/articles/_comment_tree.html.erb
+++ b/app/views/articles/_comment_tree.html.erb
@@ -1,4 +1,2 @@
 <% comment, sub_comments = comment_node %>
-<% unless comment.decorate.super_low_quality && sub_comments.empty? %>
-  <%= nested_comments(tree: { comment => sub_comments }, commentable: @article, is_view_root: true) %>
-<% end %>
+<%= nested_comments(tree: { comment => sub_comments }, commentable: @article, is_view_root: true) %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -144,9 +144,7 @@
       <% else %>
         <% Comments::Tree.for_commentable(@commentable, include_negative: user_signed_in?).each do |comment, sub_comments| %>
           <% cache ["comment_root_#{user_signed_in?}", comment] do %>
-            <% unless comment.decorate.super_low_quality && sub_comments.empty? %>
-              <%= nested_comments(tree: { comment => sub_comments }, commentable: @commentable, is_view_root: true) %>
-            <% end %>
+            <%= nested_comments(tree: { comment => sub_comments }, commentable: @commentable, is_view_root: true) %>
           <% end %>
         <% end %>
       <% end %>

--- a/spec/requests/comments_spec.rb
+++ b/spec/requests/comments_spec.rb
@@ -80,6 +80,16 @@ RSpec.describe "Comments" do
       end
     end
 
+    context "when there are child spam comments" do
+      it "hides child spam comment if it has no children" do
+        create(:comment, commentable: article, score: -500, body_markdown: "child-spam-comment", parent: comment)
+        sign_in user
+        get "#{article.path}/comments"
+        expect(response.body).not_to include("child-spam-comment")
+        expect(response.body).not_to include("Comment deleted")
+      end
+    end
+
     context "when the comment is a root" do
       it "displays the comment hidden message if the comment is hidden" do
         comment.update(hidden_by_commentable_user: true)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description
Previously, child comments with score < -400 were displayed as deleted when they had no children but were child comments themselves.
Spam comments (with score <-400 ) should be displayed as deleted if they have children and be hidden w/o a deleted message if they don't have children.
This comment fixes the bug.

## Related Tickets & Documents
- Related Issue #20551

## Added/updated tests?
- [x] Yes
