### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,7 @@ jobs:
 
   build_test:
     runs-on: ubuntu-latest
-    needs: [precompile_assets]
+    needs: [bundle_install, yarn_install]
     timeout-minutes: 20
     env:
       RAILS_ENV: production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,14 +183,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: rspec-artifacts
+          name: rspec-artifacts-${{ matrix.runs-on }}
           path: tmp/capybara
       - name: Rename folder
         run: mv coverage/simplecov coverage/simplecov-${{ matrix.ci_node_index }}
       - name: Upload test coverage result
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-rspec-${{ matrix.runs-on }}
           path: coverage/
       - name: Upload test results to BuildPulse for flaky test detection
         if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
@@ -232,7 +232,7 @@ jobs:
       - name: Upload test coverage result
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage-jest
           path: coverage/
 
   storybook:
@@ -373,7 +373,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-artifacts
+          name: cypress-artifacts-${{ matrix.runs-on }}
           path: |
             tmp/cypress_screenshots
             cypress/logs
@@ -392,9 +392,10 @@ jobs:
     needs: [rspec, jest, cypress]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: coverage
+          pattern: coverage-*
+          merge-multiple: true
       - run: |
           mkdir coverage coverage/simplecov coverage/cypress
           mv simplecov-* coverage/simplecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Look up if compiled assets exist
         uses: actions/cache@v4
-        id: precompiled-asset
+        id: cache
         with:
           fail-on-cache-miss: false
           path: |
@@ -80,21 +80,21 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-        if: steps.precompiled-asset.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true'
       - name: Cache node_modules
         uses: actions/cache/restore@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-v2-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-node-modules-v2-
-        if: steps.precompiled-asset.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true'
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-        if: steps.precompiled-asset.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true'
       - run: bundle exec rails assets:precompile
-        if: steps.precompiled-asset.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true'
 
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
   rspec:
     runs-on: ubuntu-latest
-    needs: [bundle_install, yarn_install]
+    needs: [precompile_assets]
     timeout-minutes: 20
     env:
       KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [6]
-        ci_node_index: [0, 1, 2, 3, 4, 5]
+        ci_node_total: [8]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,14 +183,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: rspec-artifacts-${{ matrix.runs-on }}
+          name: rspec-artifacts-${{ matrix.ci_node_index }}
           path: tmp/capybara
       - name: Rename folder
         run: mv coverage/simplecov coverage/simplecov-${{ matrix.ci_node_index }}
       - name: Upload test coverage result
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-rspec-${{ matrix.runs-on }}
+          name: coverage-rspec-${{ matrix.ci_node_index }}
           path: coverage/
       - name: Upload test results to BuildPulse for flaky test detection
         if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
@@ -373,7 +373,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-artifacts-${{ matrix.runs-on }}
+          name: cypress-artifacts-${{ matrix.ci_node_index }}
           path: |
             tmp/cypress_screenshots
             cypress/logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,6 @@ jobs:
           node-version-file: '.nvmrc'
           cache: yarn
         if: steps.precompiled-asset.outputs.cache-hit != 'true'
-      - run: yarn install --immutable
-        if: steps.precompiled-asset.outputs.cache-hit != 'true'
       - run: bundle exec rails assets:precompile
         if: steps.precompiled-asset.outputs.cache-hit != 'true'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
 
   precompile_assets:
+    needs: [bundle_install, yarn_install]
     runs-on: ubuntu-latest
     env:
       E2E: true
@@ -73,8 +74,7 @@ jobs:
           fail-on-cache-miss: false
           path: |
             public/assets
-            tmp/cache/webpacker
-          key: ${{ runner.os }}-compiled-assets-v3-${{ hashFiles('app/assets/**', 'app/javascript/**', 'config/webpack/**', 'config/webpacker.yml', '**/package.json', '**/yarn.lock', '**/babel.config.js') }}
+          key: ${{ runner.os }}-compiled-assets-v3-${{ hashFiles('app/assets/**', 'app/javascript/**', '**/package.json', '**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-compiled-assets-v3-
       - name: setup ruby
         uses: ruby/setup-ruby@v1
@@ -129,7 +129,7 @@ jobs:
 
   rspec:
     runs-on: ubuntu-latest
-    needs: [bundle_install, yarn_install, precompile_assets]
+    needs: [bundle_install, yarn_install]
     timeout-minutes: 20
     env:
       KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
@@ -151,8 +151,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ci_node_total: [8]
-        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7]
+        ci_node_total: [6]
+        ci_node_index: [0, 1, 2, 3, 4, 5]
 
     steps:
       - uses: actions/checkout@v4
@@ -162,8 +162,7 @@ jobs:
           fail-on-cache-miss: true
           path: |
             public/assets
-            tmp/cache/webpacker
-          key: ${{ runner.os }}-compiled-assets-v3-${{ hashFiles('app/assets/**', 'app/javascript/**', 'config/webpack/**', 'config/webpacker.yml', '**/package.json', '**/yarn.lock', '**/babel.config.js') }}
+          key: ${{ runner.os }}-compiled-assets-v3-${{ hashFiles('app/assets/**', 'app/javascript/**', '**/package.json', '**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-compiled-assets-v3-
       - name: Restore node_modules
         uses: actions/cache/restore@v4
@@ -258,7 +257,7 @@ jobs:
 
   build_test:
     runs-on: ubuntu-latest
-    needs: [bundle_install, yarn_install, precompile_assets]
+    needs: [precompile_assets]
     timeout-minutes: 20
     env:
       RAILS_ENV: production
@@ -306,7 +305,7 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [bundle_install, yarn_install, precompile_assets]
+    needs: [precompile_assets]
     env:
       E2E: true
 
@@ -336,8 +335,7 @@ jobs:
           fail-on-cache-miss: true
           path: |
             public/assets
-            tmp/cache/webpacker
-          key: ${{ runner.os }}-compiled-assets-v3-${{ hashFiles('app/assets/**', 'app/javascript/**', 'config/webpack/**', 'config/webpacker.yml', '**/package.json', '**/yarn.lock', '**/babel.config.js') }}
+          key: ${{ runner.os }}-compiled-assets-v3-${{ hashFiles('app/assets/**', 'app/javascript/**', '**/package.json', '**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-compiled-assets-v3-
       - name: Restore node_modules
         uses: actions/cache/restore@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
       - name: RSpec
         run: bin/knapsack_pro_rspec
       - name: Upload RSpec artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rspec-artifacts
@@ -188,7 +188,7 @@ jobs:
       - name: Rename folder
         run: mv coverage/simplecov coverage/simplecov-${{ matrix.ci_node_index }}
       - name: Upload test coverage result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage/
@@ -230,7 +230,7 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
       - name: Upload test coverage result
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage/
@@ -370,7 +370,7 @@ jobs:
         run: CREATOR_ONBOARDING_SEED_DATA=1 E2E_FOLDER=creatorOnboardingFlows E2E=true bin/rails cypress:run
         if: ${{ matrix.ci_node_index == 'non-seed' }}
       - name: Upload Cypress artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-artifacts


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
- Use newer and faster version of `upload-artifact`.
- `precompile_assets` now runs after `bundle_install` and `yarn_install` is completed to cut down repeated work and redundant caching of assets. Although the improvement is arguable, it makes more sense and the time we saved from using latest yarn made this changes possible.
- Remove remnant of webpacker data used for cache.
## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a