### PR TITLE
Rremove de-indexing From Accounts With No Comments

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -631,11 +631,9 @@ class Article < ApplicationRecord
   def skip_indexing?
     # should the article be skipped indexed by crawlers?
     # true if unpublished, or spammy,
-    # or low score, not featured, and from a user with no comments
+    # or low score, and not featured
     !published ||
-      (score < Settings::UserExperience.index_minimum_score &&
-       user.comments_count < 1 &&
-       !featured) ||
+      (score < Settings::UserExperience.index_minimum_score && !featured) ||
       published_at.to_i < Settings::UserExperience.index_minimum_date.to_i ||
       score < -1
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR addresses issue #20650 by removing the requirement for authors to have comments for their posts to be indexed by search engines. Additionally, it includes test coverage for this previously uncovered check.

## Related Tickets & Documents

- Related Issue #20650
- Closes #20650

## QA Instructions, Screenshots, Recordings

I'm not sure how this could be tested 🤔.

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
