### PR TITLE
Add a/b test for feed style on new users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -221,11 +221,14 @@ class ApplicationController < ActionController::Base
   helper_method :internal_navigation?
 
   def feed_style_preference
+    default = Settings::UserExperience.feed_style
+    return default unless user_signed_in?
+
     after_date = current_user && current_user.registered_at >= Time.zone.parse("2024-02-20")
     flag_on = feature_flag_enabled?(:feed_style_test_running)
-    return field_test(:feed_style_20240220, participant: current_user) if after_date && flag_on
+    return default unless after_date && flag_on
 
-    Settings::UserExperience.feed_style
+    field_test(:feed_style_20240220, participant: current_user)
   end
   helper_method :feed_style_preference
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -221,7 +221,7 @@ class ApplicationController < ActionController::Base
   helper_method :internal_navigation?
 
   def feed_style_preference
-    after_date = current_user.registered_at >= Time.zone.parse("2024-02-20")
+    after_date = current_user && current_user.registered_at >= Time.zone.parse("2024-02-20")
     flag_on = feature_flag_enabled?(:feed_style_test_running)
     return field_test(:feed_style_20240220, participant: current_user) if after_date && flag_on
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -221,14 +221,7 @@ class ApplicationController < ActionController::Base
   helper_method :internal_navigation?
 
   def feed_style_preference
-    default = Settings::UserExperience.feed_style
-    return default unless user_signed_in?
-
-    after_date = current_user && current_user.registered_at >= Time.zone.parse("2024-02-20")
-    flag_on = feature_flag_enabled?(:feed_style_test_running)
-    return default unless after_date && flag_on
-
-    field_test(:feed_style_20240220, participant: current_user)
+    Settings::UserExperience.feed_style
   end
   helper_method :feed_style_preference
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -221,8 +221,10 @@ class ApplicationController < ActionController::Base
   helper_method :internal_navigation?
 
   def feed_style_preference
-    # TODO: Future functionality will let current_user override this value with UX preferences
-    # if current_user exists and has a different preference.
+    after_date = current_user.registered_at >= Time.zone.parse("2024-02-20")
+    flag_on = feature_flag_enabled?(:feed_style_test_running)
+    return field_test(:feed_style_20240220, participant: current_user) if after_date && flag_on
+
     Settings::UserExperience.feed_style
   end
   helper_method :feed_style_preference

--- a/app/models/async_info.rb
+++ b/app/models/async_info.rb
@@ -5,6 +5,7 @@
 # @see UserDecorator
 # @see ApplicationPolicy
 class AsyncInfo
+  include FieldTest::Helpers
   # @api public
   #
   # Generate a Hash of the relevant user data.
@@ -46,7 +47,7 @@ class AsyncInfo
       trusted: user.trusted?,
       moderator_for_tags: user.moderator_for_tags,
       config_body_class: user.config_body_class,
-      feed_style: feed_style_preference,
+      feed_style: feed_style_preference_variable(user),
       created_at: user.created_at,
       admin: user.any_admin?,
       policies: [
@@ -74,5 +75,13 @@ class AsyncInfo
     context.__send__(:policy, record).public_send(query)
   rescue Pundit::NotAuthorizedError
     false
+  end
+
+  def feed_style_preference_variable(user)
+    after_date = user.registered_at >= Time.zone.parse("2024-02-20")
+    flag_on = FeatureFlag.enabled?(:feed_style_test_running)
+    return field_test(:feed_style_20240220, participant: user) if after_date && flag_on
+
+    feed_style_preference
   end
 end

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -27,6 +27,27 @@
 ################################################################################
 ################################################################################
 experiments:
+  feed_style_20240220:
+    started_at: 2024-02-20
+    variants:
+      - basic
+      - rich
+    weights:
+      - 50
+      - 50
+    goals:
+      - user_creates_pageview
+      - user_creates_article_reaction
+      - user_creates_comment
+      - user_views_pages_on_at_least_two_different_days_within_a_week
+      - user_views_pages_on_at_least_four_different_days_within_a_week
+      - user_creates_article_reaction_on_four_different_days_within_a_week
+      - user_creates_comment_on_at_least_four_different_days_within_a_week
+      - user_views_pages_on_at_least_three_different_hours_within_a_day
+      - user_views_pages_on_at_least_four_different_hours_within_a_day
+      - user_views_pages_on_at_least_twelve_different_hours_within_five_days
+      - user_views_pages_on_at_least_nine_different_days_within_two_weeks
+
   comments_to_display_20240129:
     started_at: 2024-01-29
     variants:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

First step for closing the loop in offering users the ability to customize the style of their feed (whether rich, basic, compact).

First step is adding an a/b test so we can make an informed decision on the best new "default".

Let's see if either approach encourages more repeat use of the platform. There is more to the decision than just the results of this experiment but it's an important thing to know.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue https://github.com/forem/forem/issues/20665
- Closes #

