### PR TITLE
[Tiny tweak] Add max style for fixed billboard to ensure it can't overflow the screen

### DIFF
--- a/app/assets/stylesheets/billboards.scss
+++ b/app/assets/stylesheets/billboards.scss
@@ -57,6 +57,8 @@
   z-index: var(--z-popover);
   animation: popoverEnter 0.5s;
   box-shadow: 0 0 100px 60px rgba(0, 0, 0, 0.2) !important;
+  max-height: calc(100vh - var(--header-height));
+  overflow-y: auto;
   .text-styles {
     padding-top: var(--su-4);
     padding-bottom: var(--su-4);


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Quick tweak to fix a potential edge case where an admin creates content which overflows the screen and the billboard is not closable.

This shouldn't happen in general, but could — so this just adds a max height and makes it scrollable if the max is reached.

