### PR TITLE
Allow admin to declare whether to include the badge description in message

### DIFF
--- a/app/controllers/admin/badge_achievements_controller.rb
+++ b/app/controllers/admin/badge_achievements_controller.rb
@@ -32,9 +32,11 @@ module Admin
       end
 
       usernames = permitted_params[:usernames].downcase.split(/\s*,\s*/)
+      include_default_description = permitted_params[:include_default_description] == "1"
       message = permitted_params[:message_markdown].presence ||
         I18n.t("admin.badge_achievements_controller.congrats", community: ::Settings::Community.community_name)
-      BadgeAchievements::BadgeAwardWorker.perform_async(usernames, permitted_params[:badge], message)
+      BadgeAchievements::BadgeAwardWorker
+        .perform_async(usernames, permitted_params[:badge], message, include_default_description)
 
       flash[:success] = I18n.t("admin.badge_achievements_controller.rewarded")
       redirect_to admin_badge_achievements_path
@@ -46,7 +48,7 @@ module Admin
     private
 
     def permitted_params
-      params.permit(:usernames, :badge, :message_markdown)
+      params.permit(:usernames, :badge, :message_markdown, :include_default_description)
     end
   end
 end

--- a/app/controllers/admin/badge_achievements_controller.rb
+++ b/app/controllers/admin/badge_achievements_controller.rb
@@ -39,7 +39,7 @@ module Admin
         .perform_async(usernames,
                        permitted_params[:badge],
                        message,
-                       include_default_description: include_default_description)
+                       include_default_description)
 
       flash[:success] = I18n.t("admin.badge_achievements_controller.rewarded")
       redirect_to admin_badge_achievements_path

--- a/app/controllers/admin/badge_achievements_controller.rb
+++ b/app/controllers/admin/badge_achievements_controller.rb
@@ -36,7 +36,10 @@ module Admin
       message = permitted_params[:message_markdown].presence ||
         I18n.t("admin.badge_achievements_controller.congrats", community: ::Settings::Community.community_name)
       BadgeAchievements::BadgeAwardWorker
-        .perform_async(usernames, permitted_params[:badge], message, include_default_description)
+        .perform_async(usernames,
+                       permitted_params[:badge],
+                       message,
+                       include_default_description: include_default_description)
 
       flash[:success] = I18n.t("admin.badge_achievements_controller.rewarded")
       redirect_to admin_badge_achievements_path

--- a/app/services/badges/award.rb
+++ b/app/services/badges/award.rb
@@ -1,6 +1,6 @@
 module Badges
   class Award
-    def self.call(user_relation, slug, message_markdown)
+    def self.call(user_relation, slug, message_markdown, include_default_description = true) # rubocop:disable Style/OptionalBooleanParameter
       return unless (badge_id = Badge.id_for_slug(slug))
 
       user_relation.find_each do |user|
@@ -9,6 +9,7 @@ module Badges
         achievement = user.badge_achievements.create(
           badge_id: badge_id,
           rewarding_context_message_markdown: message_markdown,
+          include_default_description: include_default_description,
         )
         user.touch if achievement.persisted?
       end

--- a/app/services/badges/award.rb
+++ b/app/services/badges/award.rb
@@ -1,6 +1,6 @@
 module Badges
   class Award
-    def self.call(user_relation, slug, message_markdown, include_default_description = true) # rubocop:disable Style/OptionalBooleanParameter
+    def self.call(user_relation, slug, message_markdown, include_default_description: true) # rubocop:disable Style/OptionalBooleanParameter
       return unless (badge_id = Badge.id_for_slug(slug))
 
       user_relation.find_each do |user|

--- a/app/services/badges/award.rb
+++ b/app/services/badges/award.rb
@@ -1,6 +1,6 @@
 module Badges
   class Award
-    def self.call(user_relation, slug, message_markdown, include_default_description: true) # rubocop:disable Style/OptionalBooleanParameter
+    def self.call(user_relation, slug, message_markdown, include_default_description: true)
       return unless (badge_id = Badge.id_for_slug(slug))
 
       user_relation.find_each do |user|

--- a/app/services/badges/award_first_post.rb
+++ b/app/services/badges/award_first_post.rb
@@ -6,6 +6,7 @@ module Badges
       return unless (badge_id = Badge.id_for_slug(BADGE_SLUG))
 
       Article.joins(:user)
+        .published
         .where("articles.published_at > ?", 1.week.ago)
         .where("articles.published_at < ?", 1.hour.ago)
         .where("articles.score >= ?", 0)

--- a/app/services/notifications/new_badge_achievement/send.rb
+++ b/app/services/notifications/new_badge_achievement/send.rb
@@ -27,6 +27,7 @@ module Notifications
       attr_reader :badge_achievement
 
       def json_data
+        description = badge_achievement.include_default_description ? badge_achievement.badge.description : nil
         {
           user: user_data(badge_achievement.user),
           badge_achievement: {
@@ -34,7 +35,7 @@ module Notifications
             rewarding_context_message: badge_achievement.rewarding_context_message,
             badge: {
               title: badge_achievement.badge.title,
-              description: badge_achievement.badge.description,
+              description: description,
               badge_image_url: badge_achievement.badge.badge_image_url,
               credits_awarded: badge_achievement.badge.credits_awarded
             }

--- a/app/views/admin/badge_achievements/award.html.erb
+++ b/app/views/admin/badge_achievements/award.html.erb
@@ -19,10 +19,17 @@
     <div class="crayons-field">
       <%= f.label :message_markdown, "Override Default Message", class: "crayons-field__label" %>
       <p class="crayons-field__description">
-        Supports Markdown
+        Supports Markdown. This overrides the "message" sent in notifications and emails, it does not override the badge description.
       </p>
       <%= f.text_area :message_markdown, size: "40x3", class: "crayons-textfield" %>
     </div>
+    <div class="crayons-field crayons-field--checkbox pb-2 pl-1">
+      <%= f.check_box :include_default_description, checked: true %>
+      <%= f.label :include_default_description, "Include Default Description", class: "crayons-field__label pt-2" %>
+    </div>
+    <p class="crayons-field__description">
+      If checked, the default badge <em>description</em> will be included above the message. If unchecked, only the message will be included.
+    </p>
     <div>
       <%= f.submit "Award Badges", class: "c-btn c-btn--primary" %>
     </div>

--- a/app/views/mailers/notify_mailer/new_badge_email.html.erb
+++ b/app/views/mailers/notify_mailer/new_badge_email.html.erb
@@ -5,9 +5,12 @@
   <p style="text-align:center;padding:20px 0px">
     <img src="<%= @badge.badge_image_url %>" style="height:200px" alt="<%= @badge.title %> badge" loading="lazy" />
   </p>
-  <p>
-    <%= @badge.description %>
-  </p>
+
+  <% if @badge_achievement.include_default_description %>
+    <p>
+      <%= @badge.description %>
+    </p>
+  <% end %>
 
   <% if @badge_achievement.rewarding_context_message.present? %>
     <p>
@@ -21,7 +24,7 @@
   <p>
     <a
       href="<%= user_url(@user) %>"
-      style="font-weight:bold;color:white;background:#4e57ef;padding: 5px 10px;border-radius:3px;text-decoration:none">
+      style="font-weight:bold;color:white;background:#4e57ef;padding: 12px 15px;border-radius:6px;text-decoration:none">
       Check out your profile
     </a>
   </p>

--- a/app/views/mailers/notify_mailer/new_badge_email.text.erb
+++ b/app/views/mailers/notify_mailer/new_badge_email.text.erb
@@ -1,6 +1,6 @@
 Congratulations, <%= @user.name %>! You got the <%= @badge.title %> badge! Be sure to check out your profile.
 
-<%= @badge.description %>
+<%= @badge.description if @badge_achievement.include_default_description %>
 
 <%= strip_tags @badge_achievement.rewarding_context_message %>
 

--- a/app/views/notifications/_badgeachievement.html.erb
+++ b/app/views/notifications/_badgeachievement.html.erb
@@ -4,7 +4,9 @@
       <h3 class="fw-normal fs-l s:fs-xl m:fs-2xl">
       <%= t("views.notifications.badge.heading_html", badge: tag.strong(sanitize(json_data["badge_achievement"]["badge"]["title"]), class: "fw-bold")) %>
       </h3>
-      <p class="fs-l"><%= json_data["badge_achievement"]["badge"]["description"] %></p>
+      <% if json_data["badge_achievement"]["badge"]["description"] %>
+        <p class="fs-l"><%= json_data["badge_achievement"]["badge"]["description"] %></p>
+      <% end %>
     </header>
 
     <div class="crayons-card crayons-card--secondary p-4 w-100 grid gap-2">

--- a/app/workers/badge_achievements/badge_award_worker.rb
+++ b/app/workers/badge_achievements/badge_award_worker.rb
@@ -4,7 +4,7 @@ module BadgeAchievements
 
     sidekiq_options queue: :high_priority, retry: 10
 
-    def perform(usernames, badge_slug, message)
+    def perform(usernames, badge_slug, message, include_default_description = true) # rubocop:disable Style/OptionalBooleanParameter
       if (award_class = "Badges::#{badge_slug.classify}".safe_constantize)
         award_class.call
       else
@@ -12,6 +12,7 @@ module BadgeAchievements
           User.where(username: usernames),
           badge_slug,
           message,
+          include_default_description,
         )
       end
     end

--- a/app/workers/badge_achievements/badge_award_worker.rb
+++ b/app/workers/badge_achievements/badge_award_worker.rb
@@ -4,7 +4,7 @@ module BadgeAchievements
 
     sidekiq_options queue: :high_priority, retry: 10
 
-    def perform(usernames, badge_slug, message, include_default_description = true) # rubocop:disable Style/OptionalBooleanParameter
+    def perform(usernames, badge_slug, message, include_default_description: true)
       if (award_class = "Badges::#{badge_slug.classify}".safe_constantize)
         award_class.call
       else
@@ -12,7 +12,7 @@ module BadgeAchievements
           User.where(username: usernames),
           badge_slug,
           message,
-          include_default_description,
+          include_default_description: include_default_description,
         )
       end
     end

--- a/app/workers/badge_achievements/badge_award_worker.rb
+++ b/app/workers/badge_achievements/badge_award_worker.rb
@@ -4,7 +4,7 @@ module BadgeAchievements
 
     sidekiq_options queue: :high_priority, retry: 10
 
-    def perform(usernames, badge_slug, message, include_default_description: true)
+    def perform(usernames, badge_slug, message, include_default_description = true) # rubocop:disable Style/OptionalBooleanParameter
       if (award_class = "Badges::#{badge_slug.classify}".safe_constantize)
         award_class.call
       else

--- a/db/migrate/20240227181740_add_include_badge_description_in_email.rb
+++ b/db/migrate/20240227181740_add_include_badge_description_in_email.rb
@@ -1,0 +1,5 @@
+class AddIncludeBadgeDescriptionInEmail < ActiveRecord::Migration[7.0]
+  def change
+    add_column :badge_achievements, :include_default_description, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_12_142953) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_27_181740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -200,6 +200,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_12_142953) do
   create_table "badge_achievements", force: :cascade do |t|
     t.bigint "badge_id", null: false
     t.datetime "created_at", precision: nil, null: false
+    t.boolean "include_default_description", default: true, null: false
     t.bigint "rewarder_id"
     t.text "rewarding_context_message"
     t.text "rewarding_context_message_markdown"

--- a/spec/requests/admin/badge_achievements_spec.rb
+++ b/spec/requests/admin/badge_achievements_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
           message_markdown: "you got a badge nice one"
         }
         expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(
-          usernames_array, badge.slug, "you got a badge nice one"
+          usernames_array, badge.slug, "you got a badge nice one", include_default_description: false
         )
         expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
       end
@@ -60,7 +60,10 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         message_markdown: "Hinder me? Thou fool. No living man may hinder me!"
       }
       expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(
-        usernames_array, badge.slug, "Hinder me? Thou fool. No living man may hinder me!"
+        usernames_array,
+        badge.slug,
+        "Hinder me? Thou fool. No living man may hinder me!",
+        include_default_description: false
       )
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
@@ -72,9 +75,11 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         usernames: usernames_string,
         message_markdown: ""
       }
-      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(usernames_array,
-                                                                                        badge.slug,
-                                                                                        expected_message)
+      expect(BadgeAchievements::BadgeAwardWorker)
+        .to have_received(:perform_async).with(usernames_array,
+                                               badge.slug,
+                                               expected_message,
+                                               include_default_description: false)
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
@@ -86,10 +91,11 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         message_markdown: "",
         include_default_description: "1"
       }
-      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(usernames_array,
-                                                                                        badge.slug,
-                                                                                        expected_message,
-                                                                                        include_default_description: true)
+      expect(BadgeAchievements::BadgeAwardWorker)
+        .to have_received(:perform_async).with(usernames_array,
+                                               badge.slug,
+                                               expected_message,
+                                               include_default_description: true)
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
@@ -101,10 +107,11 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         message_markdown: "",
         include_default_description: "0"
       }
-      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(usernames_array,
-                                                                                        badge.slug,
-                                                                                        expected_message,
-                                                                                        include_default_description: false)
+      expect(BadgeAchievements::BadgeAwardWorker)
+        .to have_received(:perform_async).with(usernames_array,
+                                               badge.slug,
+                                               expected_message,
+                                               include_default_description: false)
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
@@ -113,10 +120,11 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         usernames: usernames_string,
         message_markdown: ""
       }
-      expect(BadgeAchievements::BadgeAwardWorker).not_to have_received(:perform_async).with(usernames_array,
-                                                                                            badge.slug,
-                                                                                            "",
-                                                                                            include_default_description: false)
+      expect(BadgeAchievements::BadgeAwardWorker)
+        .not_to have_received(:perform_async).with(usernames_array,
+                                                   badge.slug,
+                                                   "",
+                                                   include_default_description: false)
     end
 
     it "does not award a badge if the username provided is not lowercase" do
@@ -125,10 +133,11 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         usernames: user.username.upcase,
         message_markdown: ""
       }
-      expect(BadgeAchievements::BadgeAwardWorker).not_to have_received(:perform_async).with(user.username.upcase,
-                                                                                            badge.slug,
-                                                                                            "",
-                                                                                            include_default_description: false)
+      expect(BadgeAchievements::BadgeAwardWorker)
+        .not_to have_received(:perform_async).with(user.username.upcase,
+                                                   badge.slug,
+                                                   "",
+                                                   include_default_description: false)
     end
   end
 

--- a/spec/requests/admin/badge_achievements_spec.rb
+++ b/spec/requests/admin/badge_achievements_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         usernames_array,
         badge.slug,
         "Hinder me? Thou fool. No living man may hinder me!",
-        include_default_description: false
+        include_default_description: false,
       )
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end

--- a/spec/requests/admin/badge_achievements_spec.rb
+++ b/spec/requests/admin/badge_achievements_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
           message_markdown: "you got a badge nice one"
         }
         expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(
-          usernames_array, badge.slug, "you got a badge nice one", false
+          usernames_array, badge.slug, "you got a badge nice one"
         )
         expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
       end
@@ -60,7 +60,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         message_markdown: "Hinder me? Thou fool. No living man may hinder me!"
       }
       expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(
-        usernames_array, badge.slug, "Hinder me? Thou fool. No living man may hinder me!", false
+        usernames_array, badge.slug, "Hinder me? Thou fool. No living man may hinder me!"
       )
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
@@ -74,8 +74,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
       }
       expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(usernames_array,
                                                                                         badge.slug,
-                                                                                        expected_message,
-                                                                                        false)
+                                                                                        expected_message)
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 

--- a/spec/requests/admin/badge_achievements_spec.rb
+++ b/spec/requests/admin/badge_achievements_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
       expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(usernames_array,
                                                                                         badge.slug,
                                                                                         expected_message,
-                                                                                        true)
+                                                                                        include_default_description: true)
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
@@ -104,7 +104,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
       expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(usernames_array,
                                                                                         badge.slug,
                                                                                         expected_message,
-                                                                                        false)
+                                                                                        include_default_description: false)
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
@@ -114,7 +114,9 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         message_markdown: ""
       }
       expect(BadgeAchievements::BadgeAwardWorker).not_to have_received(:perform_async).with(usernames_array,
-                                                                                            badge.slug, "", false)
+                                                                                            badge.slug,
+                                                                                            "",
+                                                                                            include_default_description: false)
     end
 
     it "does not award a badge if the username provided is not lowercase" do
@@ -124,7 +126,9 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         message_markdown: ""
       }
       expect(BadgeAchievements::BadgeAwardWorker).not_to have_received(:perform_async).with(user.username.upcase,
-                                                                                            badge.slug, "", false)
+                                                                                            badge.slug,
+                                                                                            "",
+                                                                                            include_default_description: false)
     end
   end
 

--- a/spec/requests/admin/badge_achievements_spec.rb
+++ b/spec/requests/admin/badge_achievements_spec.rb
@@ -78,6 +78,36 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
+    it "includes default description if passed as true" do
+      allow(BadgeAchievements::BadgeAwardWorker).to receive(:perform_async)
+      post admin_badge_achievements_award_badges_path, params: {
+        badge: badge.slug,
+        usernames: usernames_string,
+        message_markdown: "",
+        include_default_description: "1"
+      }
+      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(usernames_array,
+                                                                                        badge.slug,
+                                                                                        expected_message,
+                                                                                        true)
+      expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
+    end
+
+    it "does not include default description if passed as false" do
+      allow(BadgeAchievements::BadgeAwardWorker).to receive(:perform_async)
+      post admin_badge_achievements_award_badges_path, params: {
+        badge: badge.slug,
+        usernames: usernames_string,
+        message_markdown: "",
+        include_default_description: "0"
+      }
+      expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(usernames_array,
+                                                                                        badge.slug,
+                                                                                        expected_message,
+                                                                                        false)
+      expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
+    end
+
     it "does not award a badge and raises an error if a badge is not specified" do
       post admin_badge_achievements_award_badges_path, params: {
         usernames: usernames_string,

--- a/spec/requests/admin/badge_achievements_spec.rb
+++ b/spec/requests/admin/badge_achievements_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
           message_markdown: "you got a badge nice one"
         }
         expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(
-          usernames_array, badge.slug, "you got a badge nice one", include_default_description: false
+          usernames_array, badge.slug, "you got a badge nice one", false
         )
         expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
       end
@@ -63,7 +63,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         usernames_array,
         badge.slug,
         "Hinder me? Thou fool. No living man may hinder me!",
-        include_default_description: false,
+        false,
       )
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
@@ -79,7 +79,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         .to have_received(:perform_async).with(usernames_array,
                                                badge.slug,
                                                expected_message,
-                                               include_default_description: false)
+                                               false)
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
@@ -95,7 +95,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         .to have_received(:perform_async).with(usernames_array,
                                                badge.slug,
                                                expected_message,
-                                               include_default_description: true)
+                                               true)
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
@@ -111,7 +111,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         .to have_received(:perform_async).with(usernames_array,
                                                badge.slug,
                                                expected_message,
-                                               include_default_description: false)
+                                               false)
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
@@ -124,7 +124,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         .not_to have_received(:perform_async).with(usernames_array,
                                                    badge.slug,
                                                    "",
-                                                   include_default_description: false)
+                                                   false)
     end
 
     it "does not award a badge if the username provided is not lowercase" do
@@ -137,7 +137,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         .not_to have_received(:perform_async).with(user.username.upcase,
                                                    badge.slug,
                                                    "",
-                                                   include_default_description: false)
+                                                   false)
     end
   end
 

--- a/spec/requests/admin/badge_achievements_spec.rb
+++ b/spec/requests/admin/badge_achievements_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
           message_markdown: "you got a badge nice one"
         }
         expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(
-          usernames_array, badge.slug, "you got a badge nice one"
+          usernames_array, badge.slug, "you got a badge nice one", false
         )
         expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
       end
@@ -60,7 +60,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         message_markdown: "Hinder me? Thou fool. No living man may hinder me!"
       }
       expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(
-        usernames_array, badge.slug, "Hinder me? Thou fool. No living man may hinder me!"
+        usernames_array, badge.slug, "Hinder me? Thou fool. No living man may hinder me!", false
       )
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
@@ -74,7 +74,8 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
       }
       expect(BadgeAchievements::BadgeAwardWorker).to have_received(:perform_async).with(usernames_array,
                                                                                         badge.slug,
-                                                                                        expected_message)
+                                                                                        expected_message,
+                                                                                        false)
       expect(request.flash[:success]).to include("Badges are being rewarded. The task will finish shortly.")
     end
 
@@ -114,7 +115,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         message_markdown: ""
       }
       expect(BadgeAchievements::BadgeAwardWorker).not_to have_received(:perform_async).with(usernames_array,
-                                                                                            badge.slug, "")
+                                                                                            badge.slug, "", false)
     end
 
     it "does not award a badge if the username provided is not lowercase" do
@@ -124,7 +125,7 @@ RSpec.describe "/admin/content_manager/badge_achievements" do
         message_markdown: ""
       }
       expect(BadgeAchievements::BadgeAwardWorker).not_to have_received(:perform_async).with(user.username.upcase,
-                                                                                            badge.slug, "")
+                                                                                            badge.slug, "", false)
     end
   end
 

--- a/spec/services/badges/award_spec.rb
+++ b/spec/services/badges/award_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Badges::Award, type: :service do
       described_class.call(User.all, "one-year-club", "Congrats on a badge!", false)
       expect(user.badge_achievements.pluck(:include_default_description)).to eq([false])
     end
+
     it "creates correct badge achievements with default description" do
       described_class.call(User.all, "one-year-club", "Congrats on a badge!", true)
       expect(user.badge_achievements.pluck(:include_default_description)).to eq([true])

--- a/spec/services/badges/award_spec.rb
+++ b/spec/services/badges/award_spec.rb
@@ -8,21 +8,30 @@ RSpec.describe Badges::Award, type: :service do
 
     it "awards badges" do
       expect do
-        described_class.call(User.all, "one-year-club", "Congrats on a badge!")
+        described_class.call(User.all, "one-year-club", "Congrats on a badge!", true)
       end.to change(BadgeAchievement, :count).by(2)
     end
 
     it "creates correct badge achievements" do
-      described_class.call(User.all, "one-year-club", "Congrats on a badge!")
+      described_class.call(User.all, "one-year-club", "Congrats on a badge!", true)
       expect(user.badge_achievements.pluck(:badge_id)).to eq([badge.id])
       expect(user2.badge_achievements.pluck(:rewarding_context_message_markdown))
         .to eq(["Congrats on a badge!"])
     end
 
+    it "creates correct badge achievements without default description" do
+      described_class.call(User.all, "one-year-club", "Congrats on a badge!", false)
+      expect(user.badge_achievements.pluck(:include_default_description)).to eq([false])
+    end
+    it "creates correct badge achievements with default description" do
+      described_class.call(User.all, "one-year-club", "Congrats on a badge!", true)
+      expect(user.badge_achievements.pluck(:include_default_description)).to eq([true])
+    end
+
     it "doesn't award badges to spam accounts" do
       spammer = create(:user, username: "spam_account")
 
-      described_class.call(User.all, "one-year-club", "Congrats on a badge!")
+      described_class.call(User.all, "one-year-club", "Congrats on a badge!", true)
       expect(user.badge_achievements.any?).to be true
       expect(spammer.badge_achievements.any?).to be false
     end

--- a/spec/services/badges/award_spec.rb
+++ b/spec/services/badges/award_spec.rb
@@ -8,31 +8,31 @@ RSpec.describe Badges::Award, type: :service do
 
     it "awards badges" do
       expect do
-        described_class.call(User.all, "one-year-club", "Congrats on a badge!", true)
+        described_class.call(User.all, "one-year-club", "Congrats on a badge!", include_default_description: true)
       end.to change(BadgeAchievement, :count).by(2)
     end
 
     it "creates correct badge achievements" do
-      described_class.call(User.all, "one-year-club", "Congrats on a badge!", true)
+      described_class.call(User.all, "one-year-club", "Congrats on a badge!", include_default_description: true)
       expect(user.badge_achievements.pluck(:badge_id)).to eq([badge.id])
       expect(user2.badge_achievements.pluck(:rewarding_context_message_markdown))
         .to eq(["Congrats on a badge!"])
     end
 
     it "creates correct badge achievements without default description" do
-      described_class.call(User.all, "one-year-club", "Congrats on a badge!", false)
+      described_class.call(User.all, "one-year-club", "Congrats on a badge!", include_default_description: false)
       expect(user.badge_achievements.pluck(:include_default_description)).to eq([false])
     end
 
     it "creates correct badge achievements with default description" do
-      described_class.call(User.all, "one-year-club", "Congrats on a badge!", true)
+      described_class.call(User.all, "one-year-club", "Congrats on a badge!", include_default_description: true)
       expect(user.badge_achievements.pluck(:include_default_description)).to eq([true])
     end
 
     it "doesn't award badges to spam accounts" do
       spammer = create(:user, username: "spam_account")
 
-      described_class.call(User.all, "one-year-club", "Congrats on a badge!", true)
+      described_class.call(User.all, "one-year-club", "Congrats on a badge!", include_default_description: true)
       expect(user.badge_achievements.any?).to be true
       expect(spammer.badge_achievements.any?).to be false
     end

--- a/spec/workers/badge_achievements/badge_award_worker_spec.rb
+++ b/spec/workers/badge_achievements/badge_award_worker_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe BadgeAchievements::BadgeAwardWorker, type: :worker do
       it "sends badge email" do
         relation = User.none
         allow(User).to receive(:where).with(username: ["jess"]).and_return(relation)
-        worker.perform(["jess"], "test", "yo", include_default_description: false)
+        worker.perform(["jess"], "test", "yo", false)
 
-        expect(Badges::Award).to have_received(:call).with(relation, "test", "yo", false)
+        expect(Badges::Award).to have_received(:call).with(relation, "test", "yo", include_default_description: false)
       end
     end
 
     context "with predefined badge_slug" do
       it "sends badge email" do
         allow(Badges::AwardYearlyClub).to receive(:call)
-        worker.perform([], "award_yearly_club", "", include_default_description: true)
+        worker.perform([], "award_yearly_club", "", true)
 
         expect(Badges::AwardYearlyClub).to have_received(:call)
         expect(Badges::Award).not_to have_received(:call)

--- a/spec/workers/badge_achievements/badge_award_worker_spec.rb
+++ b/spec/workers/badge_achievements/badge_award_worker_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BadgeAchievements::BadgeAwardWorker, type: :worker do
       it "sends badge email" do
         relation = User.none
         allow(User).to receive(:where).with(username: ["jess"]).and_return(relation)
-        worker.perform(["jess"], "test", "yo", false)
+        worker.perform(["jess"], "test", "yo", include_default_description: false)
 
         expect(Badges::Award).to have_received(:call).with(relation, "test", "yo", false)
       end
@@ -24,7 +24,7 @@ RSpec.describe BadgeAchievements::BadgeAwardWorker, type: :worker do
     context "with predefined badge_slug" do
       it "sends badge email" do
         allow(Badges::AwardYearlyClub).to receive(:call)
-        worker.perform([], "award_yearly_club", "", true)
+        worker.perform([], "award_yearly_club", "", include_default_description: true)
 
         expect(Badges::AwardYearlyClub).to have_received(:call)
         expect(Badges::Award).not_to have_received(:call)

--- a/spec/workers/badge_achievements/badge_award_worker_spec.rb
+++ b/spec/workers/badge_achievements/badge_award_worker_spec.rb
@@ -15,16 +15,16 @@ RSpec.describe BadgeAchievements::BadgeAwardWorker, type: :worker do
       it "sends badge email" do
         relation = User.none
         allow(User).to receive(:where).with(username: ["jess"]).and_return(relation)
-        worker.perform(["jess"], "test", "yo")
+        worker.perform(["jess"], "test", "yo", false)
 
-        expect(Badges::Award).to have_received(:call).with(relation, "test", "yo")
+        expect(Badges::Award).to have_received(:call).with(relation, "test", "yo", false)
       end
     end
 
     context "with predefined badge_slug" do
       it "sends badge email" do
         allow(Badges::AwardYearlyClub).to receive(:call)
-        worker.perform([], "award_yearly_club", "")
+        worker.perform([], "award_yearly_club", "", true)
 
         expect(Badges::AwardYearlyClub).to have_received(:call)
         expect(Badges::Award).not_to have_received(:call)


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This allows admins to unselect whether the "description" is included in the badge awarding process. By default it will continue to be included.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes https://github.com/forem/forem/issues/20683

## QA Instructions, Screenshots, Recordings


<img width="973" alt="Screenshot 2024-02-27 at 1 59 00 PM" src="https://github.com/forem/forem/assets/3102842/07ec9041-4fce-4256-9653-9f610c92c014">

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
