### PR TITLE
Add tag moderators by username w/o autocomplete

### DIFF
--- a/app/controllers/admin/tags/moderators_controller.rb
+++ b/app/controllers/admin/tags/moderators_controller.rb
@@ -10,11 +10,11 @@ module Admin
       end
 
       def create
-        user = User.find_by(id: tag_params[:user_id])
+        user = User.find_by(username: tag_params[:username])
         unless user
           flash[:error] =
             I18n.t("errors.messages.general",
-                   errors: I18n.t("admin.tags.moderators_controller.not_found", user_id: tag_params[:user_id]))
+                   errors: I18n.t("admin.tags.moderators_controller.not_found", username: tag_params[:username]))
           return redirect_to edit_admin_tag_path(params[:tag_id])
         end
 
@@ -26,7 +26,7 @@ module Admin
         else
           flash[:error] = I18n.t("errors.messages.general", errors:
             I18n.t("admin.tags.moderators_controller.not_found_or",
-                   user_id: tag_params[:user_id],
+                   user_id: user.id,
                    errors: notification_setting.errors_as_sentence))
         end
         redirect_to edit_admin_tag_path(params[:tag_id])
@@ -58,7 +58,7 @@ module Admin
       private
 
       def tag_params
-        params.require(:tag).permit(:user_id)
+        params.require(:tag).permit(:username, :user_id)
       end
     end
   end

--- a/app/views/admin/tags/edit.html.erb
+++ b/app/views/admin/tags/edit.html.erb
@@ -15,9 +15,9 @@
     <div class="flex flex-col gap-2">
       <%= form_with url: admin_tag_moderator_path(@tag.id), model: [:admin, @tag], method: :post, local: true do |f| %>
         <div class="crayons-field w-50 my-4">
-          <%= f.label :user_id, "Add Moderator:", class: "crayons-field__label" %>
+          <%= f.label :username, "Add Moderator:", class: "crayons-field__label" %>
           <div>
-            <%= f.text_field :user_id, class: "crayons-textfield js-username_id_input" %>
+            <%= f.text_field :username, class: "crayons-textfield js-username_input", placeholder: "username" %>
           </div>
           <%= f.submit "Add Moderator", class: "crayons-btn" %>
         </div>

--- a/app/views/admin/users/show/overview/_tag_moderation.html.erb
+++ b/app/views/admin/users/show/overview/_tag_moderation.html.erb
@@ -25,6 +25,7 @@
   </ul>
 <% end %>
 
-<div id="tag-moderation-description" class="crayons-notice crayons-notice--warning">
-  <%= t("views.admin.users.overview.tag_mod.notice_html", tag_page: link_to(t("views.admin.users.overview.tag_mod.tag_page"), admin_tags_path, class: "c-link c-link--branded"), user_id: tag.strong(@user.id)) %>
+<div id="tag-moderation-description" class="crayons-notice crayons-notice--warning mt-4">
+  <%= t("views.admin.users.overview.tag_mod.notice_html", tag_page: link_to(t("views.admin.users.overview.tag_mod.tag_page"),
+                                                                            admin_tags_path, class: "c-link c-link--branded"), username: tag.strong(@user.username)) %>
 </div>

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -112,7 +112,7 @@ en:
       update_success: Space has been updated.
     tags:
       moderators_controller:
-        not_found: 'User ID #%{user_id} was not found'
+        not_found: 'Username "%{username}" was not found'
         not_found_or: 'User ID #%{user_id} was not found, or their account has errors: %{errors}'
         removed: '@%{username} - ID #%{user_id} was removed as a tag moderator.'
         added: '%{username} was added as a tag moderator!'

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -112,7 +112,7 @@ fr:
       update_success: L'espace a été mis à jour.
     tags:
       moderators_controller:
-        not_found: "L'ID utilisateur #%{user_id} n'a pas été trouvé"
+        not_found: "Le nom d'utilisateur %{username} n'a pas été trouvé"
         not_found_or: "L'identifiant de l'utilisateur #%{user_id} n'a pas été trouvé, ou son compte présente des erreurs : %{errors}"
         removed: "@%{username} - ID #%{user_id} a été supprimé en tant que modérateur de tags."
         added: "%{username} a été ajouté en tant que modérateur de tags !"

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -324,7 +324,7 @@ en:
             icon: Mod
             desc: "Add a tag that this member can moderate. "
             remove: "Remove tag:"
-            notice_html: Adding tags for moderation is currently only possible through a particular %{tag_page}, by providing the user's ID (%{user_id}).
+            notice_html: Adding tags for moderation is currently only possible through a particular %{tag_page}, by providing the username (%{username}).
             tag_page: tag's page
         priviliged_actions:
           description: The user flags affect the scores of articles and comments. Each valid or open user flag further reduces the score of the article and comment.

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -322,7 +322,7 @@ fr:
             icon: Mod
             desc: "Add a tag that this member can moderate. "
             remove: "Remove tag:"
-            notice_html: Adding tags for moderation is currently only possible through a particular %{tag_page}, by providing the user's ID (%{user_id}).
+            notice_html: Adding tags for moderation is currently only possible through a particular %{tag_page}, by providing the username (%{username}).
             tag_page: tag's page
         priviliged_actions:
           description: The user flags affect the scores of articles and comments. Each valid or open user flag further reduces the score of the article and comment.

--- a/spec/requests/admin/tags/moderators_spec.rb
+++ b/spec/requests/admin/tags/moderators_spec.rb
@@ -8,11 +8,18 @@ RSpec.describe "/admin/content_manager/tags/:id/moderator" do
   describe "POST /admin/content_manager/tags/:id/moderator" do
     before { sign_in super_admin }
 
-    it "adds the given user as trusted and as a tag moderator" do
-      post admin_tag_moderator_path(tag.id), params: { tag_id: tag.id, tag: { user_id: user.id } }
+    it "adds the given user as trusted and as a tag moderator by username" do
+      post admin_tag_moderator_path(tag.id), params: { tag_id: tag.id, tag: { username: user.username } }
 
       expect(user.tag_moderator?).to be true
       expect(user.trusted?).to be true
+    end
+
+    it "redirects to edit with not_found message when there is no such username" do
+      post admin_tag_moderator_path(tag.id), params: { tag_id: tag.id, tag: { username: "any_username" } }
+
+      expect(response).to redirect_to(edit_admin_tag_path(tag.id))
+      expect(flash[:error]).to include("Username \"any_username\" was not found")
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes adding tag moderators by removing user autocomplete. The problem is described in #20405 
This pr includes the quick fix:
- remove autocompete for username field
- add tag moderators by submitting username

I have also updated the notice on user's page in member manager on how to add tag mods.

## Related Tickets & Documents
- Related Issue #20405 

## QA Instructions, Screenshots, Recordings
Try creating a tag mod by submitting an existing username on the tag page in admin ( content manager => tags => tag page) => the tag mod should be added.
Try creating a tag mod by submitting a non-existant username => a corresponding `flash[:error]` should be displayed
Autocomplete on other admin pages (e.g. in the content manager => articles, change article author or add coauthors) should work as it was working before (no changes there)/

## Added/updated tests?
- [x] Yes
