### PR TITLE
Admin access to spam comments by url

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -93,13 +93,18 @@ module CommentsHelper
 
   private
 
-  def nested_comments(tree:, commentable:, is_view_root: false)
+  def nested_comments(tree:, commentable:, is_view_root: false, is_admin: false)
     comments = tree.filter_map do |comment, sub_comments|
       is_childless = sub_comments.empty?
-      unless comment.decorate.super_low_quality && is_childless
+      # hide childless comments with score below hide threshold (but show for admins)
+      hide = comment.decorate.super_low_quality && is_childless
+      if is_admin || !hide
         render("comments/comment", comment: comment, commentable: commentable,
                                    is_view_root: is_view_root, is_childless: is_childless,
-                                   subtree_html: nested_comments(tree: sub_comments, commentable: commentable))
+                                   is_admin: is_admin,
+                                   subtree_html: nested_comments(tree: sub_comments,
+                                                                 commentable: commentable,
+                                                                 is_admin: is_admin))
       end
     end
     safe_join(comments)

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -30,6 +30,7 @@
                commentable: commentable,
                is_view_root: is_view_root,
                is_childless: is_childless,
+               is_admin: is_admin,
                subtree_html: subtree_html) %>
   </div>
   <% if comment.depth < 3 %>

--- a/app/views/comments/_comment_proper.html.erb
+++ b/app/views/comments/_comment_proper.html.erb
@@ -5,7 +5,7 @@
 
   <div class="inner-comment comment__details">
     <div class="comment__content crayons-card">
-      <% if comment.deleted || decorated_comment.super_low_quality %>
+      <% if comment.deleted || (decorated_comment.super_low_quality && !is_admin) %>
         <div class="p-6 align-center opacity-50 fs-s">
           <span class="js-comment-username">
             <%= t("views.comments.delete.comment_deleted") %>

--- a/app/views/comments/_comment_quality_marker.html.erb
+++ b/app/views/comments/_comment_quality_marker.html.erb
@@ -1,6 +1,9 @@
 <% if decorated_comment.low_quality %>
   <div class="crayons-notice crayons-notice--warning low-quality-comment-marker">
     <%= t("views.comments.quality.low") %> <a href="/code-of-conduct"><strong><%= t("views.comments.quality.conduct") %></strong></a>
+    <% if decorated_comment.super_low_quality %>
+      <p><strong>(<%= t("views.comments.quality.superlow") %>)</strong></p>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -138,8 +138,9 @@
 
     <div class="comments" id="comment-trees-container">
       <% if @root_comment.present? %>
-        <% cache ["comment_root-view-root_#{user_signed_in?}", @root_comment] do %>
-          <%= nested_comments(tree: Comments::Tree.for_root_comment(@root_comment, include_negative: user_signed_in?), commentable: @commentable, is_view_root: true) %>
+        <% cache ["comment_root-view-root_#{user_signed_in?}-#{@is_admin}", @root_comment] do %>
+          <%= nested_comments(tree: Comments::Tree.for_root_comment(@root_comment, include_negative: user_signed_in?),
+                              commentable: @commentable, is_view_root: true, is_admin: @is_admin) %>
         <% end %>
       <% else %>
         <% Comments::Tree.for_commentable(@commentable, include_negative: user_signed_in?).each do |comment, sub_comments| %>

--- a/config/locales/views/comments/en.yml
+++ b/config/locales/views/comments/en.yml
@@ -73,6 +73,7 @@ en:
           unmute: Unmute notifications
       quality:
         low: Comment marked as low quality/non-constructive by the community.
+        superlow: Comment score below hiding threshold, displayed only for admins
         conduct: View Code of Conduct
         hidden:
           icon: Info

--- a/config/locales/views/comments/fr.yml
+++ b/config/locales/views/comments/fr.yml
@@ -73,6 +73,7 @@ fr:
           unmute: Unmute notifications
       quality:
         low: Comment marked as low quality/non-constructive by the community.
+        superlow: Comment score below hiding threshold, displayed only for admins
         conduct: View Code of Conduct
         hidden:
           icon: Info

--- a/spec/requests/comments_with_cache_spec.rb
+++ b/spec/requests/comments_with_cache_spec.rb
@@ -5,24 +5,23 @@
 require "rails_helper"
 
 RSpec.describe "ArticleCommentsWithCache" do
-  let(:user) { create(:user, :admin) }
-  let(:article) { create(:article, user: user, published: true) }
+  let(:admin) { create(:user, :admin) }
+  let(:article) { create(:article, user: admin, published: true) }
   let(:user2) { create(:user) }
 
-  let(:parent) { create(:comment, commentable: article, user: user, body_markdown: "parent-comment") }
+  let(:parent) { create(:comment, commentable: article, user: admin, body_markdown: "parent-comment") }
 
   let(:cache_store) { ActiveSupport::Cache.lookup_store(:redis_cache_store) }
   let(:cache) { Rails.cache }
 
   before do
-    sign_in user
     allow(Rails).to receive(:cache).and_return(cache_store)
   end
 
   def assign_spam_role
     sidekiq_perform_enqueued_jobs do
       Moderator::ManageActivityAndRoles.handle_user_roles(
-        admin: user,
+        admin: admin,
         user: user2,
         user_params: {
           note_for_current_role: "note",
@@ -34,6 +33,7 @@ RSpec.describe "ArticleCommentsWithCache" do
 
   describe "GET /:slug (articles)" do
     it "busts comments cache" do
+      sign_in admin
       create(:comment, commentable: article, user: user2, body_markdown: "potential-spam-comment")
       get article.path
       expect(response.body).to include("potential-spam-comment")
@@ -43,9 +43,11 @@ RSpec.describe "ArticleCommentsWithCache" do
     end
 
     it "busts cache when spam comment is a child and a parent" do
+      sign_in admin
+
       comment = create(:comment, commentable: article, user: user2, parent: parent,
                                  body_markdown: "potential-spam-comment")
-      create(:comment, commentable: article, user: user, body_markdown: "child-comment", parent: comment)
+      create(:comment, commentable: article, user: admin, body_markdown: "child-comment", parent: comment)
 
       get article.path
       expect(response.body).to include("potential-spam-comment")
@@ -61,9 +63,11 @@ RSpec.describe "ArticleCommentsWithCache" do
 
   describe "GET /:username/comment/:id_code (root comment path)" do
     it "busts cache for root comment" do
+      sign_in user2
+
       comment = create(:comment, commentable: article, user: user2, parent: parent,
                                  body_markdown: "potential-spam-comment")
-      create(:comment, commentable: article, user: user, body_markdown: "child-comment", parent: comment)
+      create(:comment, commentable: article, user: admin, body_markdown: "child-comment", parent: comment)
 
       get parent.path
       expect(response.body).to include("potential-spam-comment")

--- a/spec/views/comments/_comment.html.erb_spec.rb
+++ b/spec/views/comments/_comment.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "rendering locals in a partial" do
              commentable: article,
              is_view_root: true,
              is_childless: true,
+             is_admin: false,
              subtree_html: ""
 
       expect(rendered).to match(/crayons-notice crayons-notice--warning low-quality-comment-marker/)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Comments with score below hiding threshold (< -400)  when accessed by direct url:

**Before the pr:**
- 404 when they have no children
- displayed as deleted when they have children (and the user is signed in):

**After the pr:**
- same behaviour for non-admins
- for admins: display comment text, low-quality marker, notice that they're displayed only for admins.

![изображение](https://github.com/forem/forem/assets/30115/d5dd96a7-4e8f-41a2-aa52-bed085f5782b)

## Related Tickets & Documents
- Closes  #20553

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
