### PR TITLE
Automatically resolve spam reports when the offending user is marked as spam

### DIFF
--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -51,6 +51,10 @@ module Moderator
       Mailchimp::Bot.new(user).manage_tag_moderator_list
     end
 
+    def resolve_spam_reports
+      Users::ResolveSpamReports.call(@user)
+    end
+
     def create_note(reason, content)
       Note.create(
         author_id: @admin.id,
@@ -78,6 +82,7 @@ module Moderator
         user.add_role(:spam)
         remove_privileges
         remove_notifications
+        resolve_reports
       when "Super Moderator"
         assign_elevated_role_to_user(user, :super_moderator)
         TagModerators::AddTrustedRole.call(user)

--- a/app/services/users/resolve_spam_reports.rb
+++ b/app/services/users/resolve_spam_reports.rb
@@ -1,32 +1,30 @@
 module Users
   class ResolveSpamReports
-    def initialize(user)
-      @user = user
-    end
-
     def self.call(...)
       new(...).call
+    end
+
+    def initialize(user)
+      @user = user
     end
 
     def call
       relation = FeedbackMessage.where(status: "Open", category: "spam")
 
+      # profile reports by url and by path
       profile_reports = relation.where(reported_url: [URL.url(user.path), user.path])
       profile_reports.update_all(status: "Resolved")
 
       # articles can be reported by url or by path
       article_paths = user.articles.map(&:path)
       article_paths += article_paths.map { |p| URL.url(p) }
-
       article_reports = relation.where(reported_url: article_paths)
       article_reports.update_all(status: "Resolved")
 
       # comments can be reported by url or by path
       comment_paths = user.comments.map(&:path)
       comment_paths += comment_paths.map { |p| URL.url(p) }
-
       comment_reports = relation.where(reported_url: comment_paths)
-
       comment_reports.update_all(status: "Resolved")
     end
 

--- a/app/services/users/resolve_spam_reports.rb
+++ b/app/services/users/resolve_spam_reports.rb
@@ -1,0 +1,37 @@
+module Users
+  class ResolveSpamReports
+    def initialize(user)
+      @user = user
+    end
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def call
+      relation = FeedbackMessage.where(status: "Open", category: "spam")
+
+      profile_reports = relation.where(reported_url: [URL.url(user.path), user.path])
+      profile_reports.update_all(status: "Resolved")
+
+      # articles can be reported by url or by path
+      article_paths = user.articles.map(&:path)
+      article_paths += article_paths.map { |p| URL.url(p) }
+
+      article_reports = relation.where(reported_url: article_paths)
+      article_reports.update_all(status: "Resolved")
+
+      # comments can be reported by url or by path
+      comment_paths = user.comments.map(&:path)
+      comment_paths += comment_paths.map { |p| URL.url(p) }
+
+      comment_reports = relation.where(reported_url: comment_paths)
+
+      comment_reports.update_all(status: "Resolved")
+    end
+
+    private
+
+    attr_reader :user
+  end
+end

--- a/app/workers/users/resolve_spam_reports_worker.rb
+++ b/app/workers/users/resolve_spam_reports_worker.rb
@@ -1,0 +1,14 @@
+module Users
+  class ResolveSpamReportsWorker
+    include Sidekiq::Job
+
+    sidekiq_options queue: :medium_priority, retry: 10, lock: :until_executing
+
+    def perform(user_id)
+      user = User.find_by(id: user_id)
+      return unless user
+
+      Users::ResolveSpamReports.call(user)
+    end
+  end
+end

--- a/spec/services/users/resolve_spam_reports_spec.rb
+++ b/spec/services/users/resolve_spam_reports_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Users::ResolveSpamReports, type: :service do
+  let(:user) { create(:user) }
+
+  it "doesn't fail when user has no reports" do
+    described_class.call(user)
+  end
+
+  it "updates statused of the user's profile reports" do
+    rep = create(:feedback_message, category: "spam", status: "Open", reported_url: user.path)
+    rep2 = create(:feedback_message, category: "spam", status: "Open", reported_url: URL.url(user.path))
+    described_class.call(user)
+    expect(rep.reload.status).to eq("Resolved")
+    expect(rep2.reload.status).to eq("Resolved")
+  end
+
+  it "updates statused of the user's profile and article reports" do
+  end
+
+  it "updates statused of the user's profile, article and comment reports" do
+  end
+
+  it "doesn't update other users reports" do
+  end
+end

--- a/spec/services/users/resolve_spam_reports_spec.rb
+++ b/spec/services/users/resolve_spam_reports_spec.rb
@@ -2,25 +2,54 @@ require "rails_helper"
 
 RSpec.describe Users::ResolveSpamReports, type: :service do
   let(:user) { create(:user) }
+  let(:user2) { create(:user) }
+  let(:article) { create(:article, user: user) }
+  let(:article2) { create(:article, user: user) }
+  let(:article3) { create(:article, user: user2) }
+  let(:comment) { create(:comment, user: user, commentable: article2) }
+  let(:comment2) { create(:comment, user: user, commentable: article) }
 
   it "doesn't fail when user has no reports" do
     described_class.call(user)
   end
 
-  it "updates statused of the user's profile reports" do
-    rep = create(:feedback_message, category: "spam", status: "Open", reported_url: user.path)
-    rep2 = create(:feedback_message, category: "spam", status: "Open", reported_url: URL.url(user.path))
-    described_class.call(user)
-    expect(rep.reload.status).to eq("Resolved")
-    expect(rep2.reload.status).to eq("Resolved")
+  def spam_report(url)
+    create(:feedback_message, category: "spam", status: "Open", reported_url: url)
   end
 
-  it "updates statused of the user's profile and article reports" do
-  end
+  context "with reports" do
+    let!(:rep) { spam_report(user.path) }
+    let!(:rep2) { spam_report(URL.url(user.path)) }
+    let!(:a_rep) { spam_report(article.path) }
+    let!(:a_rep2) { spam_report(URL.url(article2.path)) }
+    let!(:c_rep) { spam_report(comment.path) }
+    let!(:c_rep2) { spam_report(URL.url(comment2.path)) }
 
-  it "updates statused of the user's profile, article and comment reports" do
-  end
+    it "updates statused of the user's profile, article and comment reports", :aggregate_failures do
+      described_class.call(user)
+      expect(rep.reload.status).to eq("Resolved")
+      expect(rep2.reload.status).to eq("Resolved")
+      expect(a_rep.reload.status).to eq("Resolved")
+      expect(a_rep2.reload.status).to eq("Resolved")
+      expect(c_rep.reload.status).to eq("Resolved")
+      expect(c_rep2.reload.status).to eq("Resolved")
+    end
 
-  it "doesn't update other users reports" do
+    it "doesn't update non-spam reports" do
+      other_rep = create(:feedback_message, category: "other", status: "Open", reported_url: user.path)
+      harassment_rep = create(:feedback_message, category: "harassment", status: "Open",
+                                                 reported_url: URL.url(article.path))
+      described_class.call(user)
+      expect(other_rep.reload.status).to eq("Open")
+      expect(harassment_rep.reload.status).to eq("Open")
+    end
+
+    it "doesn't update other users reports" do
+      u2_rep = spam_report(URL.url(user2.path))
+      a3_rep = spam_report(article3.path)
+      described_class.call(user)
+      expect(u2_rep.reload.status).to eq("Open")
+      expect(a3_rep.reload.status).to eq("Open")
+    end
   end
 end

--- a/spec/workers/users/resolve_spam_reports_worker_spec.rb
+++ b/spec/workers/users/resolve_spam_reports_worker_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Users::ResolveSpamReportsWorker, type: :worker do
+  describe "#perform" do
+    let(:user) { create(:user) }
+    let(:worker) { subject }
+
+    it "calls spam reports resolver" do
+      allow(Users::ResolveSpamReports).to receive(:call).with(user)
+
+      worker.perform(user.id)
+      expect(Users::ResolveSpamReports).to have_received(:call).with(user)
+    end
+
+    it "doesn't fail with invalid url" do
+      worker.perform(-1)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature

## Description
When a user is marked as spam, automatically mark any user reports with the spam category on their account or any of their content as resolved.

## Related Tickets & Documents
- Closes #20511

## QA Instructions, Screenshots, Recordings
Add spam role to the user that has spam reports (`FeedbackMessage` with "spam" `category`) for their profile, articles or comments  => spam reports should be resolved (status changed to "Resolved") after the role is assigned. The reports will be resolved asynchronously, so there may be a slight delay.

## Added/updated tests?
- [x] Yes