### PR TITLE
Small efficiency adjustments

### DIFF
--- a/app/controllers/billboard_events_controller.rb
+++ b/app/controllers/billboard_events_controller.rb
@@ -18,7 +18,7 @@ class BillboardEventsController < ApplicationMetalController
   def update_billboards_data
     billboard_event_id = billboard_event_params[:billboard_id]
 
-    ThrottledCall.perform("billboards_data_update-#{billboard_event_id}", throttle_for: 15.minutes) do
+    ThrottledCall.perform("billboards_data_update-#{billboard_event_id}", throttle_for: 25.minutes) do
       @billboard = Billboard.find(billboard_event_id)
 
       num_impressions = @billboard.billboard_events.impressions.sum(:counts_for)

--- a/app/services/articles/suggest.rb
+++ b/app/services/articles/suggest.rb
@@ -38,6 +38,7 @@ module Articles
     def other_suggestions(max: MAX_DEFAULT, ids_to_ignore: [])
       ids_to_ignore << article.id
       Article.published
+        .where("published_at > ?", 3.months.ago)
         .where.not(id: ids_to_ignore)
         .not_authored_by(article.user_id)
         .order(hotness_score: :desc)
@@ -48,6 +49,7 @@ module Articles
     def suggestions_by_tag(max: MAX_DEFAULT)
       Article
         .published
+        .where("published_at > ?", 3.months.ago)
         .cached_tagged_with_any(cached_tag_list_array)
         .not_authored_by(article.user_id)
         .where(tag_suggestion_query)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

These are a couple of tweaks to create small efficiency adjustments for our most time-consuming queries.

One is a tweak on throttling of tabulating billboard events, and the other is a restriction on how far back we look for article suggestions.

Since suggestions are ultimately being ordered by "hotness score", this should maintain current approx behavior.

These are two of the most time-consuming queries, so this is some low-hanging fruit.