### PR TITLE
Prioritize spam label over suspended, add to async profile check

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -343,9 +343,13 @@ class UsersController < ApplicationController
 
   def attributes_for_show
     default_options = { only: %i[id username] }
-    return default_options unless current_user&.trusted?
 
-    trusted_options = { methods: %i[suspended] }
-    default_options.merge(trusted_options)
+    methods = []
+    methods << :suspended if current_user&.trusted? || current_user&.any_admin?
+    methods << :spam if current_user&.any_admin?
+
+    options_to_merge = methods.empty? ? {} : { methods: methods }
+
+    default_options.merge(options_to_merge)
   end
 end

--- a/app/javascript/__tests__/__snapshots__/asyncUserStatusCheck.test.js.snap
+++ b/app/javascript/__tests__/__snapshots__/asyncUserStatusCheck.test.js.snap
@@ -5,7 +5,7 @@ exports[`asyncUserStatusCheck user **is** suspended **does** badge the user 1`] 
     <div class=\\"profile-header__details\\" data-url=\\"/users/123\\" data-status-checked=\\"true\\">
       <div class=\\"js-username-container\\">
         <h1 class=\\"crayons-title\\">User Hasaname</h1>
-       <span data-testid=\\"user-status\\" class=\\"ml-3 c-indicator c-indicator--danger c-indicator--relaxed\\">Suspended</span></div>
+      <span data-testid=\\"user-status\\" class=\\"ml-3 c-indicator c-indicator--danger c-indicator--relaxed\\">Suspended</span></div>
       <p class=\\"\\">Animi et qui. Voluptatum voluptas omnis. Libero voluptatem cum. Unde.</p>
 
       <div class=\\"profile-header__meta\\">

--- a/app/javascript/packs/asyncUserStatusCheck.js
+++ b/app/javascript/packs/asyncUserStatusCheck.js
@@ -1,8 +1,6 @@
 import '@utilities/document_ready';
 
 export async function asyncUserStatusCheck() {
-  const indicator = ` <span data-testid="user-status" class="ml-3 c-indicator c-indicator--danger c-indicator--relaxed">Suspended</span>`;
-
   const profile = document.querySelector('.profile-header__details');
 
   if (profile && !profile.dataset.statusChecked) {
@@ -11,14 +9,24 @@ export async function asyncUserStatusCheck() {
       .then((res) => res.json())
       .then((data) => {
         profile.dataset.statusChecked = true;
-        const { suspended } = data;
-        if (suspended) {
-          profile.querySelector('.js-username-container').innerHTML +=
-            indicator;
+        const { suspended, spam } = data;
+
+        let status = '';
+        if (spam) status = 'Spam';
+        else if (suspended) status = 'Suspended';
+
+        if (status) {
+          const indicator = `<span data-testid="user-status" class="ml-3 c-indicator c-indicator--danger c-indicator--relaxed">${status}</span>`;
+          profile.querySelector('.js-username-container').innerHTML += indicator;
         }
       });
   }
 }
+
+
+
+
+
 
 document.ready.then(() => {
   asyncUserStatusCheck();

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -465,6 +465,7 @@ class User < ApplicationRecord
     to: :authorizer,
   )
   alias suspended suspended?
+  alias spam spam?
   ##############################################################################
   #
   # End Authorization Refactor

--- a/app/views/admin/feedback_messages/_abuse_reports.html.erb
+++ b/app/views/admin/feedback_messages/_abuse_reports.html.erb
@@ -36,7 +36,9 @@
               <span>
                 <strong><%= reaction.reactable_type %>:</strong>
                 <a href="<%= reaction.reactable.path %>" target="_blank" rel="noopener"><%= reaction.reactable_type == "User" ? reaction.reactable.username : reaction.reactable.title %></a>
-                <% if reaction.reactable_type == "User" && reaction.reactable.spam_or_suspended? %>
+                <% if reaction.reactable_type == "User" && reaction.reactable.spam? %>
+                  <span class="c-indicator c-indicator--danger">Spam</span>
+                <% elsif reaction.reactable_type == "User" && reaction.reactable.suspended? %>
                   <span class="c-indicator c-indicator--danger">Suspended</span>
                 <% end %>
                 <% if reaction.reactable_type == "User" && reaction.reactable.vomited_on? %>

--- a/app/views/admin/users/show/profile/_status.html.erb
+++ b/app/views/admin/users/show/profile/_status.html.erb
@@ -1,9 +1,9 @@
 <span class="ml-3 whitespace-nowrap" title="<%= t("views.admin.users.status_title") %>">
   <span class="screen-reader-only"><%= t("views.admin.users.status_reader") %></span>
-  <% if user.suspended? %>
-    <span data-testid="user-status" class="c-indicator c-indicator--danger c-indicator--relaxed"><%= t("views.admin.users.statuses.Suspended") %></span>
-  <% elsif user.spam? %>
+  <% if user.spam? %>
     <span data-testid="user-status" class="c-indicator c-indicator--danger c-indicator--relaxed"><%= t("views.admin.users.statuses.Spam") %></span>
+  <% elsif user.suspended? %>
+    <span data-testid="user-status" class="c-indicator c-indicator--danger c-indicator--relaxed"><%= t("views.admin.users.statuses.Suspended") %></span>
   <% elsif user.warned? %>
     <span data-testid="user-status" class="c-indicator c-indicator--warning c-indicator--relaxed"><%= t("views.admin.users.statuses.Warned") %></span>
   <% elsif user.comment_suspended? %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- This prioritizes showing `spam` as a user status, over `suspended`, when both are present on a user's profile.
- Additionally this adds `spam` to the async user profile checker shown on a user's profile. This should technically be redundant given we show `spam` as part of the user's name but I think we have some caching issues + showing the `suspended` flag adds confusion. We can remove in the future once we've solved those issues.

## Related Tickets & Documents

- Closes #20795

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests