### PR TITLE
Resolve sidekiq warning

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -26,7 +26,7 @@ Sidekiq.configure_server do |config|
   # https://github.com/ondrejbartas/sidekiq-cron/issues/254
   # Sidekiq default is 5, we don't need it quite that often but would like it more than
   # every 30 seconds which the gem defaults to
-  Sidekiq.options[:poll_interval] = 10
+  Sidekiq[:poll_interval] = 10
 
   if File.exist?(schedule_file)
     Sidekiq::Cron::Job.load_from_hash!(YAML.load_file(schedule_file))

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -26,7 +26,7 @@ Sidekiq.configure_server do |config|
   # https://github.com/ondrejbartas/sidekiq-cron/issues/254
   # Sidekiq default is 5, we don't need it quite that often but would like it more than
   # every 30 seconds which the gem defaults to
-  Sidekiq[:poll_interval] = 10
+  config[:poll_interval] = 10
 
   if File.exist?(schedule_file)
     Sidekiq::Cron::Job.load_from_hash!(YAML.load_file(schedule_file))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
On running `/bin/startup`, I noticed the warning:
"WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`"

pointing to forem/config/initializers/sidekiq.rb:29.

This commit resolves that warning by removing `.options`

## QA Instructions, Screenshots, Recordings
Run the `bin/startup` script locally from `forem/forem:main`. Notice the warning described above. 
Run the `bin/startup` script locally from `medwards1771/forem:resolve-sidekiq-warning-on-startup` (or just make the change on your local copy of forem). Notice the warning disappear.  

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: I'm guessing this configuration detail is not tested. Also, I got some `ActiveRecord::NoDatabaseError` errors when attempting to run the test suite locally with `bin/rspec` since I don't have the database "Forem_test" and figured it would be faster to see the test suite run via CI. 
- [ ] I need help with writing tests
