### PR TITLE
Specs for adding tag moderators

### DIFF
--- a/spec/requests/admin/tags/moderators_spec.rb
+++ b/spec/requests/admin/tags/moderators_spec.rb
@@ -11,8 +11,15 @@ RSpec.describe "/admin/content_manager/tags/:id/moderator" do
     it "adds the given user as trusted and as a tag moderator by username" do
       post admin_tag_moderator_path(tag.id), params: { tag_id: tag.id, tag: { username: user.username } }
 
-      expect(user.tag_moderator?).to be true
+      expect(user.tag_moderator?(tag: tag)).to be true
       expect(user.trusted?).to be true
+    end
+
+    it "updates user's email_tag_mod_newsletter setting" do
+      user.notification_setting.update_column(:email_tag_mod_newsletter, false)
+      expect do
+        post admin_tag_moderator_path(tag.id), params: { tag_id: tag.id, tag: { username: user.username } }
+      end.to change { user.reload.notification_setting.email_tag_mod_newsletter }.from(false).to(true)
     end
 
     it "redirects to edit with not_found message when there is no such username" do

--- a/spec/services/tag_moderators/add_spec.rb
+++ b/spec/services/tag_moderators/add_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe TagModerators::Add, type: :service do
+  let(:user) { create(:user) }
+  let(:tag) { create(:tag) }
+
+  it "adds tag moderator role" do
+    described_class.call([user.id], [tag.id])
+    expect(user.tag_moderator?(tag: tag)).to be true
+  end
+
+  it "updates user's email_tag_mod_newsletter" do
+    described_class.call([user.id], [tag.id])
+    expect(user.reload.notification_setting.email_tag_mod_newsletter?).to be true
+  end
+
+  it "calls Moderators::AddTrustedRole" do
+    allow(TagModerators::AddTrustedRole).to receive(:call)
+    described_class.call([user.id], [tag.id])
+    expect(TagModerators::AddTrustedRole).to have_received(:call).with(user)
+  end
+
+  it "autosupports tag" do
+    unsupported_tag = create(:tag, supported: false)
+    described_class.call([user.id], [unsupported_tag.id])
+    expect(unsupported_tag.reload.supported?).to be true
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor

## Description
I have started working on adding tag moderators from users page, and wanted to reuse `TagModerators::Add`, so added several tests for it.
I haven't finished the solution for "adding tag mods", but it wouldn't harm to add tests first.

## Related Tickets & Documents
- Related Issue #20405 

## Added/updated tests?
- [x] Yes
