### PR TITLE
Update edge VSCode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,6 +11,7 @@
     "sbenp.prettier-vscode",
     "silvenon.mdx",
     "waderyan.nodejs-extension-pack",
-    "koichisasada.vscode-rdbg"
+    "koichisasada.vscode-rdbg",
+    "ms-edgedevtools.vscode-edge-devtools",
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,16 +12,16 @@
       "type": "node"
     },
     {
+      "name": "Attach to Edge",
       "type": "vscode-edge-devtools.debug",
       "request": "attach",
-      "name": "Attach to Edge",
       "port": 2015,
       "webRoot": "${workspaceFolder}"
     },
     {
+      "name": "Attach to Chrome",
       "type": "chrome",
       "request": "attach",
-      "name": "Attach to Chrome",
       "port": 9222,
       "webRoot": "${workspaceFolder}/app/javascript/packs"
     },
@@ -73,9 +73,9 @@
       "program": "${workspaceRoot}/bin/cucumber"
     },
     {
+      "name": "Jest Current File",
       "type": "node",
       "request": "launch",
-      "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": ["${relativeFile}"],
       "console": "integratedTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "type": "node"
     },
     {
-      "type": "edge",
+      "type": "vscode-edge-devtools.debug",
       "request": "attach",
       "name": "Attach to Edge",
       "port": 2015,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This PR 
- updates the extension used in the "Attach to Edge" debug task from `edge` to `vscode-edge-devtools.debug`
- places the `name` attribute for each task at top for consistency

`edge`, aka `msjsdiag.debugger-for-edge`, was added to the list of recommended vscode extensions in [PR #4346](https://github.com/forem/forem/pull/4346/files) so developers could use it to run the "Attach to Edge" debug task. since then, [PR #17870](https://github.com/forem/forem/pull/17870/files) has deleted `msjsdiag.debugger-for-edge` from the recommendation list, but the "Attach to Edge" debug task remains, and throws an error since [edge](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-edge) no longer exists. 

## QA Instructions, Screenshots, Recordings
VSCode users: install `vscode-edge-devtools.debug`, then run the "Attach to Edge" debug task

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: VSCode debug tasks are not tested 
- [ ] I need help with writing tests