### PR TITLE
Define constants once using the or/equals operator ||=

### DIFF
--- a/app/models/settings/general.rb
+++ b/app/models/settings/general.rb
@@ -1,10 +1,10 @@
 module Settings
   class General < Base
-    BANNER_USER_CONFIGS = %w[off logged_out_only all].freeze
-    BANNER_PLATFORM_CONFIGS = %w[off all all_web desktop_web mobile_web mobile_app].freeze
+    BANNER_USER_CONFIGS ||= %w[off logged_out_only all].freeze
+    BANNER_PLATFORM_CONFIGS ||= %w[off all all_web desktop_web mobile_web mobile_app].freeze
 
     self.table_name = "site_configs"
-    SOCIAL_MEDIA_SERVICES = %w[
+    SOCIAL_MEDIA_SERVICES ||= %w[
       twitter facebook github instagram twitch mastodon
     ].freeze
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This PR updates 3 constants, `BANNER_USER_CONFIGS`, `BANNER_PLATFORM_CONFIGS`, and `SOCIAL_MEDIA_SERVICES` to be initialized + defined only once. 
Ruby's or/equals operator checks to see if the value on the left is truthy. If yes (like when the constant is already defined), that value is assigned. If no, the value on the right is assigned.

I was motivated to make this change while running `bin/setup` and seeing these warnings:
![Screen Shot 2024-03-30 at 11 25 22 AM](https://github.com/forem/forem/assets/13890477/02957f85-d8c3-464f-8fc4-790e8e11858d)
![Screen Shot 2024-03-30 at 11 26 12 AM](https://github.com/forem/forem/assets/13890477/aa7a039d-63b1-4abf-8b55-71bb7a2a0d19)


## QA Instructions, Screenshots, Recordings
Pull down a copy of this branch and run `bin/setup`. You should NOT see the warnings screenshotted above. 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: tests in `spec/models/settings/general_spec.rb` are passing locally
- [ ] I need help with writing tests
