### PR TITLE
Create test database on bin/setup

### DIFF
--- a/lib/tasks/app_initializer.rake
+++ b/lib/tasks/app_initializer.rake
@@ -3,6 +3,7 @@ namespace :app_initializer do
   task setup: :environment do
     puts "\n== Preparing database =="
     system("bin/rails db:prepare") || exit!(1)
+    system("bin/rails db:test:prepare") || exit!(1)
     Rake::Task["db:migrate"].execute # it'll re-alphabetize the columns in `schema.rb`
 
     puts "\n== Performing setup tasks =="


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This PR updates the `app_initializer:setup` rake task to prepare the test database. I was motivated to make this change after trying to run a spec locally and getting an `ActiveRecord::NoDatabaseError`:

![Screen Shot 2024-03-30 at 11 50 23 AM](https://github.com/forem/forem/assets/13890477/e6e71ac6-6c14-4bdd-9cff-f1fe4dcbf202)


## QA Instructions, Screenshots, Recordings
For each scenario, make sure you do NOT have a local copy of the test database, "Forem_test". You could check this by opening a postgres console in your terminal with `psql`, then entering the command `\l` to list all databases.

BEFORE this PR change:
- run `bin/setup`
- attempt to run a test locally, ex: `bin/rspec spec/models/settings/general_spec.rb`
- see `ActiveRecord::NoDatabaseError`

AFTER this PR change:
- run `bin/setup`
- attempt to run a test locally, ex: `bin/rspec spec/models/settings/general_spec.rb`
- see the test pass!

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: `app_initializer:setup` rake task not tested
- [ ] I need help with writing tests