### PR TITLE
Remove .env.test symlink

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,0 @@
-.env_sample

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      - run: cp .env_sample .env
       - run: bundle exec rails db:test:prepare
       - name: RSpec
         run: bin/knapsack_pro_rspec
@@ -274,6 +275,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      - run: cp .env_sample .env
       - run: bundle exec rails db:test:prepare
       - run: yarn cypress install
       - name: cypress

--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Create the .env file
         run: |
-          cp .env.test .env
+          cp .env_sample .env
       - name: Build and Push Image to registry.uffizzi.com ephemeral registry
         uses: docker/build-push-action@v2
         with:

--- a/spec/system/comments/user_edits_a_comment_spec.rb
+++ b/spec/system/comments/user_edits_a_comment_spec.rb
@@ -52,15 +52,8 @@ RSpec.describe "Editing A Comment", :js do
 
       click_on(class: "comment__dropdown-trigger")
       click_link_or_button("Edit")
-      assert_updated
-    end
-  end
-
-  context "when user edits via direct path (no referer)" do
-    it "cancels to the article page" do
-      user.reload
-      visit "#{comment.path}/edit"
       expect(page).to have_link("Dismiss")
+      assert_updated
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
This symlink has tripped me so many times. Unlike its counterpart `.env_sample`, this is in a proper format. It will be unintentionally treated as valid `.env.text` file and will overwrite a base `.env`. For example, if you would prefer a certain value to be nil, this file will overwrite it.

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a