### PR TITLE
Update the mdx vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,7 +9,7 @@
     "ms-vsliveshare.vsliveshare-pack",
     "philosowaffle.openapi-designer",
     "sbenp.prettier-vscode",
-    "silvenon.mdx",
+    "unifiedjs.vscode-mdx",
     "waderyan.nodejs-extension-pack",
     "koichisasada.vscode-rdbg",
     "ms-edgedevtools.vscode-edge-devtools",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This PR updates the MDX VSCode extension from `silvenon.mdx` to `unifiedjs.vscode-mdx`. `silvenon.mdx` has been deprecated in favor of `unifiedjs.vscode-mdx`, see https://marketplace.visualstudio.com/items?itemName=silvenon.mdx. 

## QA Instructions, Screenshots, Recordings
VSCode users:
- open Forem in VSCode
- be prompted to install MDX extension
- notice the old prompt to install a deprecated version of the MDX extension is now gone ! 🎉 


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: VSCode recommended extensions not tested
- [ ] I need help with writing tests