### PR TITLE
Add timestamp to users roles table

### DIFF
--- a/db/migrate/20240408101038_add_timestamps_to_users_roles_table.rb
+++ b/db/migrate/20240408101038_add_timestamps_to_users_roles_table.rb
@@ -1,0 +1,5 @@
+class AddTimestampsToUsersRolesTable < ActiveRecord::Migration[7.0]
+  def change
+    add_timestamps :users_roles, default: -> { 'CURRENT_TIMESTAMP' }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_06_173309) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_08_101038) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -1386,7 +1386,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_173309) do
   end
 
   create_table "users_roles", id: false, force: :cascade do |t|
+    t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.bigint "role_id"
+    t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.bigint "user_id"
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This adds timestamps to the `users_roles` table, allowing easy queries to find out when a user was given a specific role. There was no established convention for doing this in the codebase, so I've chosen to just use the timestamp when the migration occurs to backfill the values.

There were a few other approaches [listed here](https://stackoverflow.com/questions/46520907/add-timestamps-to-existing-table-in-db-rails-5), but this seemed the most straightforward approach.
