### PR TITLE
Fix support for adding social image to the Pages API

### DIFF
--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -15,20 +15,14 @@ module Api
       end
 
       def create
-        @page = Page.new permitted_params.except(:social_image)
-        if permitted_params[:social_image].present?
-          @page.remote_social_image_url = permitted_params[:social_image][:url]
-        end
+        @page = Page.new permitted_params
         result = @page.save
         render json: @page, status: (result ? :ok : :unprocessable_entity)
       end
 
       def update
         @page = Page.find(params[:id])
-        if permitted_params[:social_image].present?
-          @page.remote_social_image_url = permitted_params[:social_image][:url]
-        end
-        result = @page.update permitted_params.except(:social_image)
+        result = @page.update permitted_params
         render json: @page, status: (result ? :ok : :unprocessable_entity)
       end
 
@@ -45,8 +39,11 @@ module Api
       end
 
       def permitted_params
+        if params[:social_image].present? && params[:social_image][:url].present?
+          params[:remote_social_image_url] = params[:social_image][:url]
+        end
         params.permit(*%i[title slug description is_top_level_path
-                          body_json body_markdown body_html body_css social_image template], social_image: [:url])
+                          body_json body_markdown body_html body_css remote_social_image_url template])
       end
     end
   end

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -15,14 +15,20 @@ module Api
       end
 
       def create
-        @page = Page.new permitted_params
+        @page = Page.new permitted_params.except(:social_image)
+        if permitted_params[:social_image].present?
+          @page.remote_social_image_url = permitted_params[:social_image][:url]
+        end
         result = @page.save
         render json: @page, status: (result ? :ok : :unprocessable_entity)
       end
 
       def update
         @page = Page.find(params[:id])
-        result = @page.update permitted_params
+        if permitted_params[:social_image].present?
+          @page.remote_social_image_url = permitted_params[:social_image][:url]
+        end
+        result = @page.update permitted_params.except(:social_image)
         render json: @page, status: (result ? :ok : :unprocessable_entity)
       end
 
@@ -40,7 +46,7 @@ module Api
 
       def permitted_params
         params.permit(*%i[title slug description is_top_level_path
-                          body_json body_markdown body_html body_css social_image template])
+                          body_json body_markdown body_html body_css social_image template], social_image: [:url])
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This fixes support for specifying the `social_image` for Pages via the API. The [docs](https://developers.forem.com/api/v1#tag/pages/paths/~1pages~1%7Bid%7D/put) don't specify a format for the URL, I've used the same format as the [GET route](https://developers.forem.com/api/v1#tag/pages/paths/~1pages~1%7Bid%7D/get) `... social_image: { url: "https://blah.png" }`. 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes: I was shamed into doing it.
- [ ] No, and this is why:
- [ ] I need help with writing tests
