### PR TITLE
[Devcontainer] Remove unnecessary volume mount

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
-  "rubyLsp.rubyVersionManager": "auto",
-  "rubyLsp.formatter": "rubocop",
+  "rubyLsp.rubyVersionManager": {
+    "identifier": "auto"
+  },
+  "rubyLsp.formatter": "rubocop"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,6 @@ services:
       - rails_cache:/workspaces/forem/tmp/cache
       - assets:/workspaces/forem/public/assets
       - node_modules:/workspaces/forem/node_modules
-      - builds:/workspaces/forem/app/assets/builds
       - history:/usr/local/hist
       - ${LOCAL_WORKSPACE_FOLDER:-.}/.dockerdev/.psqlrc:/root/.psqlrc:ro
       - /var/run/docker.sock:/var/run/docker-host.sock


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] DX

## Description
The esbuild compile output folder `app/assets/builds` is so small and faster to compile, there's no need to mount the volume and have it confusingly remove the `.keep` within in.,

## Related Tickets & Documents

## QA Instructions, Screenshots, Recordings

## Added tests?
- [x] no, because they aren't needed

## Added to documentation?
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?
n/a