### PR TITLE
 Show spam comments on a user's profile to admins

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -50,18 +50,12 @@ class StoriesController < ApplicationController
 
   private
 
-  # for spam content we need to remove cache control headers to access current_user to check admin access
-  # so that admins could have access to spam articles and profiles
-  def check_admin_access_old
-    unset_cache_control_headers if user_signed_in?
-    is_admin = user_signed_in? && current_user&.any_admin?
-    not_found unless is_admin
-  end
-
   def check_admin_access
     not_found unless @is_admin
   end
 
+  # for spam content we need to remove cache control headers to access current_user to check admin access
+  # so that admins could have access to spam articles and profiles
   def set_is_admin
     unless user_signed_in?
       @is_admin = false
@@ -280,7 +274,10 @@ class StoriesController < ApplicationController
     not_found if permission_denied?
     not_found unless @article.user
 
-    check_admin_access if @article.user.spam?
+    if @article.user.spam?
+      set_is_admin
+      check_admin_access
+    end
 
     @pinned_article_id = PinnedArticle.id
 

--- a/app/views/users/_comments_section.html.erb
+++ b/app/views/users/_comments_section.html.erb
@@ -26,7 +26,12 @@
     <% end %>
     <% @comments.each do |comment| %>
       <% if comment.commentable.present? && comment.commentable.published && !comment.deleted %>
-        <a href="<%= comment.path %>" class="profile-comment-row ">
+        <% if comment.decorate.low_quality %>
+          <h4 class="ml-3 mt-3 c-indicator c-indicator--danger c-indicator--relaxed">
+            <%= t("views.users.comments.low_quality") %>
+          </h4>
+        <% end %>
+        <a href="<%= comment.path %>" class="profile-comment-row">
           <h4 class="fw-bold fs-base m-0 mb-1">
             <%= comment.commentable.title %>
           </h4>

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -18,6 +18,7 @@ en:
         last:
           one: Last %{count} comments
           other: Last %{count} comments
+        low_quality: Low quality comment, displayed only for admins
         recent: Recent comments
         view: View all activity
         view_all:

--- a/config/locales/views/users/fr.yml
+++ b/config/locales/views/users/fr.yml
@@ -18,6 +18,7 @@ fr:
         last:
           one: Last %{count} comments
           other: Last %{count} comments
+        low_quality: Low quality comment, displayed only for admins
         recent: Recent comments
         view: View all activity
         view_all:
@@ -26,6 +27,7 @@ fr:
         view_last:
           one: View last 1 Comment
           other: View last %{count} Comments
+        
       github:
         heading: GitHub Repositories
         fork: Fork

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "UserProfiles" do
         expect(response.body).to include("bad_comment")
       end
 
-      it "displayes info for low quality comments for admins" do
+      it "displays info for low quality comments for admins" do
         sign_in admin_user
         get user.path
         expect(response.body).to include("Low quality comment, displayed only for admins")

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe "UserProfiles" do
         expect(response.body).not_to include("low_comment")
         expect(response.body).not_to include("bad_comment")
       end
-      
       it "displays all comments (good standing + low score) for admins", :aggregate_failures do
         sign_in admin_user
         get user.path


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Show spam comments on a user's profile to admins
Such comments will be displayed with a label:

![изображение](https://github.com/forem/forem/assets/30115/90f80711-d953-416c-8daa-b07272430709)

## Related Tickets & Documents
- Closes #20845

## Added/updated tests?
- [x] Yes


