### PR TITLE
Bust profile header cache on assigning/removing spam role

### DIFF
--- a/app/services/moderator/manage_activity_and_roles.rb
+++ b/app/services/moderator/manage_activity_and_roles.rb
@@ -80,6 +80,7 @@ module Moderator
         remove_notifications
         resolve_spam_reports
         confirm_flag_reactions
+        user.profile.touch
       when "Super Moderator"
         assign_elevated_role_to_user(user, :super_moderator)
         TagModerators::AddTrustedRole.call(user)

--- a/app/services/users/remove_role.rb
+++ b/app/services/users/remove_role.rb
@@ -19,6 +19,7 @@ module Users
       elsif user.remove_role(role)
         response.success = true
       end
+      user.profile.touch
       response
     rescue StandardError => e
       response.error_message = I18n.t("services.users.remove_role.error", e_message: e.message)

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,7 +15,7 @@
   </script>
 <% end %>
 
-<% cache "user-profile-header-area-#{@user.id}-#{@user.profile.cache_key_with_version}-#{user_signed_in?}", expires_in: 10.days do %>
+<% cache "user-profile-header-area-#{@user.id}-#{@user.profile.cache_key_with_version}-#{user_signed_in?}-#{@user.badge_achievements_count}", expires_in: 10.days do %>
   <style>
     :root {
       --profile-brand-color: <%= Color::CompareHex.new([user_colors(@user)[:bg], user_colors(@user)[:text]]).brightness(0.88) %>;

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,7 +15,7 @@
   </script>
 <% end %>
 
-<% cache "user-profile-header-area-#{@user.id}-#{@user.profile_updated_at}-#{user_signed_in?}-#{@user.badge_achievements_count}", expires_in: 10.days do %>
+<% cache "user-profile-header-area-#{@user.id}-#{@user.profile.cache_key_with_version}-#{user_signed_in?}", expires_in: 10.days do %>
   <style>
     :root {
       --profile-brand-color: <%= Color::CompareHex.new([user_colors(@user)[:bg], user_colors(@user)[:text]]).brightness(0.88) %>;

--- a/spec/services/moderator/manage_activity_and_roles_spec.rb
+++ b/spec/services/moderator/manage_activity_and_roles_spec.rb
@@ -305,6 +305,18 @@ RSpec.describe Moderator::ManageActivityAndRoles, type: :service do
     end
   end
 
+  describe "confirms flag reactions when adding the spam role" do
+    # to remove profile header cache
+    it "touches profile" do
+      spam_user = create(:user)
+      profile = instance_double(Profile)
+      allow(spam_user).to receive(:profile).and_return(profile)
+      allow(profile).to receive(:touch)
+      manage_roles_for(spam_user, user_status: "Spam")
+      expect(profile).to have_received(:touch)
+    end
+  end
+
   describe "removes notifications when adding the spam role" do
     let(:nice_article) { create(:article, user: user) }
     let(:spam_user) { create(:user) }

--- a/spec/services/moderator/manage_activity_and_roles_spec.rb
+++ b/spec/services/moderator/manage_activity_and_roles_spec.rb
@@ -305,8 +305,7 @@ RSpec.describe Moderator::ManageActivityAndRoles, type: :service do
     end
   end
 
-  describe "confirms flag reactions when adding the spam role" do
-    # to remove profile header cache
+  describe "busts user profile header cache when adding the spam role" do
     it "touches profile" do
       spam_user = create(:user)
       profile = instance_double(Profile)

--- a/spec/services/users/remove_role_spec.rb
+++ b/spec/services/users/remove_role_spec.rb
@@ -35,4 +35,14 @@ RSpec.describe Users::RemoveRole, type: :service do
 
     expect(role_removal.success).to be false
   end
+
+  # to update profile header cache
+  it "touches users profile" do
+    user = create(:user, :spam)
+    profile = instance_double(Profile)
+    allow(user).to receive(:profile).and_return(profile)
+    allow(profile).to receive(:touch)
+    described_class.call(user: user, role: :spam, resource_type: nil)
+    expect(profile).to have_received(:touch)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
- changed user profile header cache_key
- touch user profile on assigning role/removing role to invalidate that cache fragment

Maybe I would use `users_roles.cache_key_with_version` but we have habtm there (so, the table doesn't have timestamps), so that's not possible.
Touching user profile seemed light and straightforward enough.

## Related Tickets & Documents
Closes #20846

## QA Instructions, Screenshots, Recordings
- enable caching on dev
- assing user a spam role
- their profile header should now include "spam" label
- remove spam role
- their profile header shouldn't include "spam" label

We currently have 2 labels: sync and async 🌚
![изображение](https://github.com/forem/forem/assets/30115/2f50568f-3c71-47f5-a7b7-87aab10dbde2)

## Added/updated tests?
- [x] Yes