### PR TITLE
Adjust TagModerators::Add to reuse in member manager

### DIFF
--- a/app/controllers/admin/tags/moderators_controller.rb
+++ b/app/controllers/admin/tags/moderators_controller.rb
@@ -18,16 +18,14 @@ module Admin
           return redirect_to edit_admin_tag_path(params[:tag_id])
         end
 
-        notification_setting = user.notification_setting
-        if notification_setting.update(email_tag_mod_newsletter: true)
-          TagModerators::Add.call(user.id, params[:tag_id])
-          flash[:success] =
-            I18n.t("admin.tags.moderators_controller.added", username: user.username)
+        result = TagModerators::Add.call(user.id, params[:tag_id])
+        if result.success?
+          flash[:success] = I18n.t("admin.tags.moderators_controller.added", username: user.username)
         else
           flash[:error] = I18n.t("errors.messages.general", errors:
             I18n.t("admin.tags.moderators_controller.not_found_or",
-                   user_id: user.id,
-                   errors: notification_setting.errors_as_sentence))
+                 user_id: user.id,
+                 errors: result.errors))
         end
         redirect_to edit_admin_tag_path(params[:tag_id])
       end

--- a/app/controllers/admin/tags/moderators_controller.rb
+++ b/app/controllers/admin/tags/moderators_controller.rb
@@ -20,7 +20,7 @@ module Admin
 
         notification_setting = user.notification_setting
         if notification_setting.update(email_tag_mod_newsletter: true)
-          TagModerators::Add.call([user.id], [params[:tag_id]])
+          TagModerators::Add.call(user.id, params[:tag_id])
           flash[:success] =
             I18n.t("admin.tags.moderators_controller.added", username: user.username)
         else

--- a/app/controllers/admin/tags/moderators_controller.rb
+++ b/app/controllers/admin/tags/moderators_controller.rb
@@ -24,8 +24,8 @@ module Admin
         else
           flash[:error] = I18n.t("errors.messages.general", errors:
             I18n.t("admin.tags.moderators_controller.not_found_or",
-                 user_id: user.id,
-                 errors: result.errors))
+                   user_id: user.id,
+                   errors: result.errors))
         end
         redirect_to edit_admin_tag_path(params[:tag_id])
       end

--- a/app/services/tag_moderators/add.rb
+++ b/app/services/tag_moderators/add.rb
@@ -1,32 +1,30 @@
 module TagModerators
   class Add
-    def self.call(user_ids, tag_ids)
-      new(user_ids, tag_ids).call
+    def self.call(user_id, tag_id)
+      new(user_id, tag_id).call
     end
 
-    def initialize(user_ids, tag_ids)
-      @user_ids = user_ids
-      @tag_ids = tag_ids
+    def initialize(user_id, tag_id)
+      @user_id = user_id
+      @tag_id = tag_id
     end
 
     def call
-      user_ids.each_with_index do |user_id, index|
-        user = User.find(user_id)
-        tag = Tag.find(tag_ids[index])
-        add_tag_mod_role(user, tag)
-        ::TagModerators::AddTrustedRole.call(user)
-        tag.update(supported: true) unless tag.supported?
+      user = User.find(user_id)
+      tag = Tag.find(tag_id)
+      add_tag_mod_role(user, tag)
+      ::TagModerators::AddTrustedRole.call(user)
+      tag.update(supported: true) unless tag.supported?
 
-        NotifyMailer
-          .with(user: user, tag: tag)
-          .tag_moderator_confirmation_email
-          .deliver_now
-      end
+      NotifyMailer
+        .with(user: user, tag: tag)
+        .tag_moderator_confirmation_email
+        .deliver_now
     end
 
     private
 
-    attr_accessor :user_ids, :tag_ids
+    attr_accessor :user_id, :tag_id
 
     def add_tag_mod_role(user, tag)
       unless user.notification_setting.email_tag_mod_newsletter?

--- a/spec/requests/admin/tags/moderators_spec.rb
+++ b/spec/requests/admin/tags/moderators_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe "/admin/content_manager/tags/:id/moderator" do
       expect(response).to redirect_to(edit_admin_tag_path(tag.id))
       expect(flash[:error]).to include("Username \"any_username\" was not found")
     end
+
+    it "displays error message when notification settings are not updated" do
+      result = instance_double(TagModerators::Add::Result, success?: false, errors: "invalid setting")
+      allow(TagModerators::Add).to receive(:call).with(user.id, tag.id.to_s).and_return(result)
+
+      post admin_tag_moderator_path(tag.id), params: { tag_id: tag.id, tag: { username: user.username } }
+      expect(flash[:error]).to include("or their account has errors: invalid setting")
+    end
   end
 
   describe "DELETE /admin/content_manager/tags/:id/moderator" do

--- a/spec/services/tag_moderators/add_spec.rb
+++ b/spec/services/tag_moderators/add_spec.rb
@@ -25,4 +25,18 @@ RSpec.describe TagModerators::Add, type: :service do
     described_class.call(user.id, unsupported_tag.id)
     expect(unsupported_tag.reload.supported?).to be true
   end
+
+  it "returns success when needed" do
+    result = described_class.call(user.id, tag.id)
+    expect(result.success?).to be true
+  end
+
+  it "returns error when notification setting is not updated" do
+    setting = instance_double(Users::NotificationSetting, update: false, errors_as_sentence: "invalid values")
+    double_user = instance_double(User, notification_setting: setting, id: -1)
+    allow(User).to receive(:find).with(double_user.id).and_return(double_user)
+    result = described_class.call(double_user.id, tag.id)
+    expect(result.success?).to be false
+    expect(result.errors).to eq("invalid values")
+  end
 end

--- a/spec/services/tag_moderators/add_spec.rb
+++ b/spec/services/tag_moderators/add_spec.rb
@@ -5,24 +5,24 @@ RSpec.describe TagModerators::Add, type: :service do
   let(:tag) { create(:tag) }
 
   it "adds tag moderator role" do
-    described_class.call([user.id], [tag.id])
+    described_class.call(user.id, tag.id)
     expect(user.tag_moderator?(tag: tag)).to be true
   end
 
   it "updates user's email_tag_mod_newsletter" do
-    described_class.call([user.id], [tag.id])
+    described_class.call(user.id, tag.id)
     expect(user.reload.notification_setting.email_tag_mod_newsletter?).to be true
   end
 
   it "calls Moderators::AddTrustedRole" do
     allow(TagModerators::AddTrustedRole).to receive(:call)
-    described_class.call([user.id], [tag.id])
+    described_class.call(user.id, tag.id)
     expect(TagModerators::AddTrustedRole).to have_received(:call).with(user)
   end
 
   it "autosupports tag" do
     unsupported_tag = create(:tag, supported: false)
-    described_class.call([user.id], [unsupported_tag.id])
+    described_class.call(user.id, unsupported_tag.id)
     expect(unsupported_tag.reload.supported?).to be true
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Refactor

## Description
To reuse `TagModerators::Add` when adding tag mod roles from users page:
- moved updating users notification_setting to `TagModerators::Add`
- simplified `TagModerators::Add` to accept one user and one tag
- added corresponding specs

I'm working on #20405 in `lightalloy/add-tag-moderators-on-users-page` (based on this branch)

## Related Tickets & Documents
- Related Issue #20405

## Added/updated tests?
- [x] Yes
