### PR TITLE
Add tag moderators on users page (for admins)

### DIFF
--- a/app/controllers/admin/tags/moderators_controller.rb
+++ b/app/controllers/admin/tags/moderators_controller.rb
@@ -18,16 +18,14 @@ module Admin
           return redirect_to edit_admin_tag_path(params[:tag_id])
         end
 
-        notification_setting = user.notification_setting
-        if notification_setting.update(email_tag_mod_newsletter: true)
-          TagModerators::Add.call(user.id, params[:tag_id])
-          flash[:success] =
-            I18n.t("admin.tags.moderators_controller.added", username: user.username)
+        result = TagModerators::Add.call(user.id, params[:tag_id])
+        if result.success?
+          flash[:success] = I18n.t("admin.tags.moderators_controller.added", username: user.username)
         else
           flash[:error] = I18n.t("errors.messages.general", errors:
             I18n.t("admin.tags.moderators_controller.not_found_or",
-                   user_id: user.id,
-                   errors: notification_setting.errors_as_sentence))
+                 user_id: user.id,
+                 errors: result.errors))
         end
         redirect_to edit_admin_tag_path(params[:tag_id])
       end

--- a/app/controllers/admin/tags/moderators_controller.rb
+++ b/app/controllers/admin/tags/moderators_controller.rb
@@ -20,7 +20,7 @@ module Admin
 
         notification_setting = user.notification_setting
         if notification_setting.update(email_tag_mod_newsletter: true)
-          TagModerators::Add.call([user.id], [params[:tag_id]])
+          TagModerators::Add.call(user.id, params[:tag_id])
           flash[:success] =
             I18n.t("admin.tags.moderators_controller.added", username: user.username)
         else

--- a/app/controllers/admin/tags/moderators_controller.rb
+++ b/app/controllers/admin/tags/moderators_controller.rb
@@ -24,8 +24,8 @@ module Admin
         else
           flash[:error] = I18n.t("errors.messages.general", errors:
             I18n.t("admin.tags.moderators_controller.not_found_or",
-                 user_id: user.id,
-                 errors: result.errors))
+                   user_id: user.id,
+                   errors: result.errors))
         end
         redirect_to edit_admin_tag_path(params[:tag_id])
       end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -10,6 +10,7 @@ module Admin
       organization_id identity_id
       credit_action credit_amount
       reputation_modifier
+      tag_name
     ].freeze
 
     EMAIL_ALLOWED_PARAMS = %i[
@@ -176,10 +177,12 @@ module Admin
 
     def add_tag_mod_role
       user = User.find(params[:id])
-      tag = Tag.find_by(name: params[:tag_name])
+      tag = Tag.find_by(name: user_params[:tag_name])
 
       unless tag
-        flash[:error] = "tag not found" # I18n.t("errors.messages.general")
+        flash[:error] = I18n.t("errors.messages.general",
+                               errors: I18n.t("admin.users_controller.tag_not_found",
+                                              tag_name: user_params[:tag_name]))
         return redirect_to admin_user_path(user.id)
       end
 
@@ -189,8 +192,8 @@ module Admin
       else
         flash[:error] = I18n.t("errors.messages.general", errors:
           I18n.t("admin.tags.moderators_controller.not_found_or",
-               user_id: user.id,
-               errors: result.errors))
+                 user_id: user.id,
+                 errors: result.errors))
       end
       redirect_to admin_user_path(user.id)
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -174,6 +174,27 @@ module Admin
       Credits::Manage.call(@user, credit_params)
     end
 
+    def add_tag_mod_role
+      user = User.find(params[:id])
+      tag = Tag.find_by(name: params[:tag_name])
+
+      unless tag
+        flash[:error] = "tag not found" # I18n.t("errors.messages.general")
+        return redirect_to admin_user_path(user.id)
+      end
+
+      result = TagModerators::Add.call(user.id, tag.id)
+      if result.success?
+        flash[:success] = I18n.t("admin.tags.moderators_controller.added", username: user.username)
+      else
+        flash[:error] = I18n.t("errors.messages.general", errors:
+          I18n.t("admin.tags.moderators_controller.not_found_or",
+               user_id: user.id,
+               errors: result.errors))
+      end
+      redirect_to admin_user_path(user.id)
+    end
+
     def export_data
       user = User.find(params[:id])
       send_to_admin = params[:send_to_admin].to_boolean

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -108,14 +108,13 @@ module Admin
       role = Role.find(params[:role_id])
       authorize(role, :remove_role?)
 
-      resource_type = params[:resource_type]
-
       @user = User.find(params[:user_id])
 
       response = ::Users::RemoveRole.call(
         user: @user,
         role: role.name,
-        resource_type: resource_type,
+        resource_type: params[:resource_type],
+        resource_id: params[:resource_id],
       )
 
       if response.success

--- a/app/services/tag_moderators/add.rb
+++ b/app/services/tag_moderators/add.rb
@@ -1,32 +1,30 @@
 module TagModerators
   class Add
-    def self.call(user_ids, tag_ids)
-      new(user_ids, tag_ids).call
+    def self.call(user_id, tag_id)
+      new(user_id, tag_id).call
     end
 
-    def initialize(user_ids, tag_ids)
-      @user_ids = user_ids
-      @tag_ids = tag_ids
+    def initialize(user_id, tag_id)
+      @user_id = user_id
+      @tag_id = tag_id
     end
 
     def call
-      user_ids.each_with_index do |user_id, index|
-        user = User.find(user_id)
-        tag = Tag.find(tag_ids[index])
-        add_tag_mod_role(user, tag)
-        ::TagModerators::AddTrustedRole.call(user)
-        tag.update(supported: true) unless tag.supported?
+      user = User.find(user_id)
+      tag = Tag.find(tag_id)
+      add_tag_mod_role(user, tag)
+      ::TagModerators::AddTrustedRole.call(user)
+      tag.update(supported: true) unless tag.supported?
 
-        NotifyMailer
-          .with(user: user, tag: tag)
-          .tag_moderator_confirmation_email
-          .deliver_now
-      end
+      NotifyMailer
+        .with(user: user, tag: tag)
+        .tag_moderator_confirmation_email
+        .deliver_now
     end
 
     private
 
-    attr_accessor :user_ids, :tag_ids
+    attr_accessor :user_id, :tag_id
 
     def add_tag_mod_role(user, tag)
       unless user.notification_setting.email_tag_mod_newsletter?

--- a/app/services/users/remove_role.rb
+++ b/app/services/users/remove_role.rb
@@ -6,15 +6,22 @@ module Users
       new(...).call
     end
 
-    def initialize(user:, role:, resource_type:)
+    def initialize(user:, role:, resource_type:, resource_id: nil)
       @user = user
       @role = role
       @resource_type = resource_type&.safe_constantize
+      @resource_id = resource_id
       @response = Response.new(success: false)
     end
 
     def call
-      if resource_type && user.remove_role(role, resource_type)
+      resource = if resource_id
+                   resource_type.find(resource_id)
+                 else
+                   resource_type
+                 end
+
+      if resource && user.remove_role(role, resource)
         response.success = true
       elsif user.remove_role(role)
         response.success = true
@@ -28,6 +35,6 @@ module Users
 
     private
 
-    attr_reader :user, :role, :resource_type, :response
+    attr_reader :user, :role, :resource_type, :resource_id, :response
   end
 end

--- a/app/services/users/remove_role.rb
+++ b/app/services/users/remove_role.rb
@@ -15,12 +15,7 @@ module Users
     end
 
     def call
-      resource = if resource_id
-                   resource_type.find(resource_id)
-                 else
-                   resource_type
-                 end
-
+      resource = resource_id ? resource_type.find(resource_id) : resource_type
       if resource && user.remove_role(role, resource)
         response.success = true
       elsif user.remove_role(role)

--- a/app/views/admin/users/show/overview/_tag_moderation.html.erb
+++ b/app/views/admin/users/show/overview/_tag_moderation.html.erb
@@ -24,6 +24,12 @@
     <% end %>
   </ul>
 <% end %>
+<%= form_with url: add_tag_mod_role_admin_user_path(@user.id), scope: :user, method: :post, local: true, html: { class: "" } do |f| %>
+  <div class="crayons-field w-50 my-4">
+    <%= f.text_field :tag_name, placeholder: "Tag name", size: 50, required: true, class: "crayons-textfield w-auto mr-3", autocomplete: "off" %>
+    <%= f.submit "Create tag mod role", class: "crayons-btn" %>
+  </div>
+<% end %>
 
 <div id="tag-moderation-description" class="crayons-notice crayons-notice--warning mt-4">
   <%= t("views.admin.users.overview.tag_mod.notice_html", tag_page: link_to(t("views.admin.users.overview.tag_mod.tag_page"),

--- a/app/views/admin/users/show/overview/_tag_moderation.html.erb
+++ b/app/views/admin/users/show/overview/_tag_moderation.html.erb
@@ -15,18 +15,37 @@
   <ul class="flex flex-wrap gap-2 mb-4">
     <% moderated_tags.each do |role| %>
       <li>
-        <%# You can't currently remove a tag from this view %>
-        <button class="c-pill cursor-default" aria-disabled="true" aria-describedby="tag-moderation-description" style="--icon-right-color: var(--color-secondary); --icon-right-color-hover: var(--accent-danger);" type="button">
-          <span class="screen-reader-only"><%= t("views.admin.users.overview.tag_mod.remove") %></span>
-          #<%= role.resource_name.to_s %>
-        </button>
+        <% if policy(role).remove_role? %>
+          <% confirm_dialog = if role.super_admin?
+                                t("views.admin.users.overview.roles.remove_confirm_super_admin")
+                              else
+                                t("views.admin.users.overview.roles.remove_confirm")
+                              end %>
+          <%= button_to url_for(action: :destroy, user_id: @user.id, role_id: role.id, resource_type: role.resource_type, resource_id: role.resource_id),
+                                method: :delete, data: { confirm: confirm_dialog }, class: "c-pill c-pill--action-icon" do %>
+
+            <span class="screen-reader-only"><%= t("views.admin.users.overview.tag_mod.remove") %></span>
+            #<%= role.resource_name.to_s %>
+
+            <%= crayons_icon_tag(:x, class: "c-pill__action-icon", aria_hidden: true, width: 18, height: 18) %>
+          <% end %>
+        <% else %>
+          <button
+            class="c-pill c-pill--description-icon crayons-tooltip__activator cursor-help"
+            type="button"
+            aria-disabled="true">
+            <%= crayons_icon_tag(:lock, class: "c-pill__description-icon", aria_hidden: true, width: 18, height: 18) %>
+            #<%= role.resource_name.to_s %>
+            <span data-testid="tooltip" class="crayons-tooltip__content"><%= t("views.admin.users.overview.roles.locked") %></span>
+          </button>
+        <% end %>
       </li>
     <% end %>
   </ul>
 <% end %>
 <%= form_with url: add_tag_mod_role_admin_user_path(@user.id), scope: :user, method: :post, local: true, html: { class: "" } do |f| %>
   <div class="crayons-field w-50 my-4">
-    <%= f.text_field :tag_name, placeholder: "Tag name", size: 50, required: true, class: "crayons-textfield w-auto mr-3", autocomplete: "off" %>
+    <%= f.text_field :tag_name, placeholder: "One tag name", size: 50, required: true, class: "crayons-textfield w-auto mr-3", autocomplete: "off" %>
     <%= f.submit "Create tag mod role", class: "crayons-btn" %>
   </div>
 <% end %>

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -143,6 +143,7 @@ en:
       updated_json: Success! %{username} has been updated.
       credits_added: Credits have been added!
       credits_removed: Credits have been removed.
+      tag_not_found: 'Tag "%{tag_name}" was not found'
     welcome_controller:
       thread_content: |
         ---

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -143,6 +143,7 @@ fr:
       updated_json: Succès ! %{username} a été mis à jour.
       credits_added: Les crédits ont été ajoutés !
       credits_removed: Les crédits ont été supprimés.
+      tag_not_found: 'Tag "%{tag_name}" non trouvée'
     welcome_controller:
       thread_content: |
         ---

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -328,7 +328,7 @@ en:
             icon: Mod
             desc: "Add a tag that this member can moderate. "
             remove: "Remove tag:"
-            notice_html: Adding tags for moderation is currently only possible through a particular %{tag_page}, by providing the username (%{username}).
+            notice_html: Adding tags for moderation is also possible through a particular %{tag_page}, by providing the username (%{username}).
             tag_page: tag's page
         priviliged_actions:
           description: The user flags affect the scores of articles and comments. Each valid or open user flag further reduces the score of the article and comment.

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -325,7 +325,7 @@ fr:
             icon: Mod
             desc: "Add a tag that this member can moderate. "
             remove: "Remove tag:"
-            notice_html: Adding tags for moderation is currently only possible through a particular %{tag_page}, by providing the username (%{username}).
+            notice_html: Adding tags for moderation is also possible through a particular %{tag_page}, by providing the username (%{username}).
             tag_page: tag's page
         priviliged_actions:
           description: The user flags affect the scores of articles and comments. Each valid or open user flag further reduces the score of the article and comment.

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -52,6 +52,7 @@ namespace :admin do
         post "export_data"
         post "full_delete"
         patch "user_status"
+        post "add_tag_mod_role"
         post "merge"
         delete "remove_identity"
         post "send_email"

--- a/spec/requests/admin/tags/moderators_spec.rb
+++ b/spec/requests/admin/tags/moderators_spec.rb
@@ -28,6 +28,14 @@ RSpec.describe "/admin/content_manager/tags/:id/moderator" do
       expect(response).to redirect_to(edit_admin_tag_path(tag.id))
       expect(flash[:error]).to include("Username \"any_username\" was not found")
     end
+
+    it "displays error message when notification settings are not updated" do
+      result = instance_double(TagModerators::Add::Result, success?: false, errors: "invalid setting")
+      allow(TagModerators::Add).to receive(:call).with(user.id, tag.id.to_s).and_return(result)
+
+      post admin_tag_moderator_path(tag.id), params: { tag_id: tag.id, tag: { username: user.username } }
+      expect(flash[:error]).to include("or their account has errors: invalid setting")
+    end
   end
 
   describe "DELETE /admin/content_manager/tags/:id/moderator" do

--- a/spec/requests/admin/users_manage_spec.rb
+++ b/spec/requests/admin/users_manage_spec.rb
@@ -207,6 +207,26 @@ RSpec.describe "Admin::Users" do
     end
   end
 
+  context "when adding tag moderator role" do
+    let(:tag) { create(:tag, name: "ruby") }
+
+    it "adds role", :aggregate_failures do
+      params = { user: { tag_name: tag.name } }
+      post add_tag_mod_role_admin_user_path(user.id), params: params
+      user.reload
+      expect(user.tag_moderator?(tag: tag)).to be true
+      expect(response).to redirect_to(admin_user_path(user.id))
+    end
+
+    it "displays tag not found message", :aggregate_failures do
+      tag_name = "su#{tag.name}per"
+      params = { user: { tag_name: tag_name } }
+      post add_tag_mod_role_admin_user_path(user.id), params: params
+      expect(flash[:error]).to include("Error: Tag \"#{tag_name}\" was not found")
+      expect(response).to redirect_to(admin_user_path(user.id))
+    end
+  end
+
   context "when deleting user" do
     def create_mention
       comment = create(

--- a/spec/requests/admin/users_manage_spec.rb
+++ b/spec/requests/admin/users_manage_spec.rb
@@ -205,6 +205,31 @@ RSpec.describe "Admin::Users" do
       expect(user.single_resource_admin_for?(Broadcast)).to be true
       expect(request.flash["success"]).to include("successfully removed from the user!")
     end
+
+    it "removes tag mod role (resource_type and resource_id passed)" do
+      tag = create(:tag)
+      role = user.add_role(:tag_moderator, tag)
+
+      expect do
+        delete admin_user_path(user.id),
+               params: { user_id: user.id, role_id: role.id, resource_type: "Tag", resource_id: tag.id }
+      end.to change(user.roles, :count).by(-1)
+    end
+
+    it "doesn't remove other tag mod role" do
+      tag = create(:tag)
+      tag2 = create(:tag)
+      role = user.add_role(:tag_moderator, tag)
+      role = user.add_role(:tag_moderator, tag2)
+
+      expect do
+        delete admin_user_path(user.id),
+               params: { user_id: user.id, role_id: role.id, resource_type: "Tag", resource_id: tag.id }
+      end.to change(user.roles, :count).by(-1)
+
+      user.reload
+      expect(user.tag_moderator?(tag: tag2)).to be true
+    end
   end
 
   context "when adding tag moderator role" do

--- a/spec/services/tag_moderators/add_spec.rb
+++ b/spec/services/tag_moderators/add_spec.rb
@@ -25,4 +25,18 @@ RSpec.describe TagModerators::Add, type: :service do
     described_class.call(user.id, unsupported_tag.id)
     expect(unsupported_tag.reload.supported?).to be true
   end
+
+  it "returns success when needed" do
+    result = described_class.call(user.id, tag.id)
+    expect(result.success?).to be true
+  end
+
+  it "returns error when notification setting is not updated" do
+    setting = instance_double(Users::NotificationSetting, update: false, errors_as_sentence: "invalid values")
+    double_user = instance_double(User, notification_setting: setting, id: -1)
+    allow(User).to receive(:find).with(double_user.id).and_return(double_user)
+    result = described_class.call(double_user.id, tag.id)
+    expect(result.success?).to be false
+    expect(result.errors).to eq("invalid values")
+  end
 end

--- a/spec/services/tag_moderators/add_spec.rb
+++ b/spec/services/tag_moderators/add_spec.rb
@@ -5,24 +5,24 @@ RSpec.describe TagModerators::Add, type: :service do
   let(:tag) { create(:tag) }
 
   it "adds tag moderator role" do
-    described_class.call([user.id], [tag.id])
+    described_class.call(user.id, tag.id)
     expect(user.tag_moderator?(tag: tag)).to be true
   end
 
   it "updates user's email_tag_mod_newsletter" do
-    described_class.call([user.id], [tag.id])
+    described_class.call(user.id, tag.id)
     expect(user.reload.notification_setting.email_tag_mod_newsletter?).to be true
   end
 
   it "calls Moderators::AddTrustedRole" do
     allow(TagModerators::AddTrustedRole).to receive(:call)
-    described_class.call([user.id], [tag.id])
+    described_class.call(user.id, tag.id)
     expect(TagModerators::AddTrustedRole).to have_received(:call).with(user)
   end
 
   it "autosupports tag" do
     unsupported_tag = create(:tag, supported: false)
-    described_class.call([user.id], [unsupported_tag.id])
+    described_class.call(user.id, unsupported_tag.id)
     expect(unsupported_tag.reload.supported?).to be true
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [x] Feature

## Description
Implemented adding tag moderators from member manager page for admins.
This feature was "stubbed" for a long time and the tag mods could be only added from the tag page which is not always convenient.

Add tags one at a time.

## Related Tickets & Documents
- Closes #20405

## QA Instructions, Screenshots, Recordings
Visit member manager page for admins, go to users page.
You can now add tag moderator roles in the "tags" block and remove them.

![изображение](https://github.com/forem/forem/assets/30115/f1b218ce-b806-4ea5-be4b-50501a39ebaf)

## Added/updated tests?

- [x] Yes