### PR TITLE
Noindex/Not found for spam orgs

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -180,6 +180,9 @@ class StoriesController < ApplicationController
       .order(published_at: :desc).page(@page).per(8))
     @organization_article_index = true
     @organization_users = @organization.users.order(badge_achievements_count: :desc)
+    if !user_signed_in? && @organization_users.sum(:score).negative? && @stories.sum(&:score) <= 0
+      not_found
+    end
     set_organization_json_ld
     set_surrogate_key_header "articles-org-#{@organization.id}"
     render template: "organizations/show"

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -363,7 +363,7 @@ class Article < ApplicationRecord
            :video, :user_id, :organization_id, :video_source_url, :video_code,
            :video_thumbnail_url, :video_closed_caption_track_url,
            :experience_level_rating, :experience_level_rating_distribution, :cached_user, :cached_organization,
-           :published_at, :crossposted_at, :description, :reading_time, :video_duration_in_seconds,
+           :published_at, :crossposted_at, :description, :reading_time, :video_duration_in_seconds, :score,
            :last_comment_at, :main_image_height)
   }
 

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -2,6 +2,10 @@
 
 <%= content_for :page_meta do %>
   <%= render "users/meta" %>
+  <% unless @stories.sum(&:score).positive? %>
+      <meta name="robots" content="noindex">
+      <meta name="robots" content="nofollow">
+  <% end %>
 <% end %>
 <%= render "organizations/header" %>
 <div

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -163,6 +163,54 @@ RSpec.describe "UserProfiles" do
         get organization.path
         expect(response.body).not_to include("/feed/#{organization.slug}")
       end
+
+      it "shows noindex when org has no articles" do
+        get organization.path
+        expect(response.body).to include("<meta name=\"robots\" content=\"noindex\">")
+      end
+
+      it "shows noindex when org has articles with negative total score" do
+        create(:article, organization_id: organization.id, score: 2)
+        create(:article, organization_id: organization.id, score: -4)
+        get organization.path
+        expect(response.body).to include("<meta name=\"robots\" content=\"noindex\">")
+      end
+
+      it "shows noindex when org has only articles with no score" do
+        create(:article, organization_id: organization.id, score: 0)
+        get organization.path
+        expect(response.body).to include("<meta name=\"robots\" content=\"noindex\">")
+      end
+
+      it "does not show noindex when org has articles with positive score" do
+        create(:article, organization_id: organization.id, score: 4)
+        get organization.path
+        expect(response.body).not_to include("<meta name=\"robots\" content=\"noindex\">")
+      end
+
+      it "raises not found if articles have 0 total score and org users have negative total score" do
+        user.update_column(:score, -1)
+        create(:article, organization_id: organization.id, score: 0)
+        create(:organization_membership, user_id: user.id, organization_id: organization.id)
+        expect { get organization.path }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "does not raise not found if articles have positive total score even if users have negative total score" do
+        user.update_column(:score, -1)
+        create(:article, organization_id: organization.id, score: 1)
+        create(:organization_membership, user_id: user.id, organization_id: organization.id)
+        get organization.path
+        expect(response).to be_successful
+      end
+
+      it "does not raise not found if user signed in" do
+        sign_in current_user
+        user.update_column(:score, -1)
+        create(:article, organization_id: organization.id, score: 0)
+        create(:organization_membership, user_id: user.id, organization_id: organization.id)
+        get organization.path
+        expect(response).to be_successful
+      end
     end
 
     context "when displaying a GitHub repository on the profile" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds `noindex` for empty orgs, and adds `not_found` for non-signed-in contexts if the org's users have been net flagged for spam.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes https://github.com/forem/forem/issues/21104
