### PR TITLE
Tweak active discussions to include recently viewed posts

### DIFF
--- a/app/controllers/sidebars_controller.rb
+++ b/app/controllers/sidebars_controller.rb
@@ -37,7 +37,7 @@ class SidebarsController < ApplicationController
   def cached_recent_pageview_article_ids
     Rails.cache.fetch("recent_pageviews_#{current_user.id}", expires_in: 1.hour) do
       PageView.where(user_id: current_user.id)
-        .order("created_at DESC").limit(20).pluck(:article_id)
+        .order("created_at DESC").limit(30).pluck(:article_id)
     end
   end
 end

--- a/app/controllers/sidebars_controller.rb
+++ b/app/controllers/sidebars_controller.rb
@@ -25,8 +25,19 @@ class SidebarsController < ApplicationController
       .where(language: languages)
       .or(Article.featured.published.where("published_at > ?", 1.week.ago)
         .with_at_least_home_feed_minimum_score)
+      .or(Article.where(id: cached_recent_pageview_article_ids).published
+        .where("published_at > ?", 1.week.ago)
+        .where("comments_count > ?", 1)
+          .with_at_least_home_feed_minimum_score)
       .order("last_comment_at DESC")
       .limit(5)
       .pluck(:path, :title, :comments_count, :created_at)
+  end
+
+  def cached_recent_pageview_article_ids
+    Rails.cache.fetch("recent_pageviews_#{current_user.id}", expires_in: 1.hour) do
+      PageView.where(user_id: current_user.id)
+        .order("created_at DESC").limit(20).pluck(:article_id)
+    end
   end
 end

--- a/spec/requests/sidebars_spec.rb
+++ b/spec/requests/sidebars_spec.rb
@@ -41,6 +41,29 @@ RSpec.describe "Sidebars" do
         expect(response.body).to include(CGI.escapeHTML(second_article.title))
       end
 
+      it "includes article without the proper tags if recently viewed and has over 1 comment" do
+        second_article = create(:article, comments_count: 2)
+        create(:page_view, user_id: user.id, article_id: second_article.id)
+        sign_in user
+        get "/sidebars/home"
+        expect(response.body).to include(CGI.escapeHTML(second_article.title))
+      end
+
+      it "does not include recently-viewed page if only one comment" do
+        second_article = create(:article, comments_count: 1)
+        create(:page_view, user_id: user.id, article_id: second_article.id)
+        sign_in user
+        get "/sidebars/home"
+        expect(response.body).not_to include(CGI.escapeHTML(second_article.title))
+      end
+
+      it "does not include a 2 comment article if not recently viewed" do
+        second_article = create(:article, comments_count: 2)
+        sign_in user
+        get "/sidebars/home"
+        expect(response.body).not_to include(CGI.escapeHTML(second_article.title))
+      end
+
       it "does not include non-featured non-tagg-followed article" do
         second_article = create(:article, language: "en")
         sign_in user


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This is an adjustment to add a selection of recently viewed posts to active discussions if they meet criteria of having an ongoing discussion.