### PR TITLE
Test number of active discussion threads to show

### DIFF
--- a/app/controllers/sidebars_controller.rb
+++ b/app/controllers/sidebars_controller.rb
@@ -17,6 +17,8 @@ class SidebarsController < ApplicationController
     tag_names = current_user.cached_followed_tag_names
     languages = current_user.languages.pluck(:language)
     languages = [I18n.default_locale.to_s] if languages.empty?
+    variant = field_test(:active_discussions_count, participant: current_user)
+    limit_count = variant.split("_").last.to_i
     @active_discussions = Article.published
       .where("published_at > ?", 1.week.ago)
       .where("comments_count > ?", 0)
@@ -30,7 +32,7 @@ class SidebarsController < ApplicationController
         .where("comments_count > ?", 1)
           .with_at_least_home_feed_minimum_score)
       .order("last_comment_at DESC")
-      .limit(5)
+      .limit(limit_count)
       .pluck(:path, :title, :comments_count, :created_at)
   end
 

--- a/config/field_test.yml
+++ b/config/field_test.yml
@@ -27,6 +27,28 @@
 ################################################################################
 ################################################################################
 experiments:
+  active_discussions_count:
+    started_at: 2024-06-11
+    variants:
+      - count_4
+      - count_5
+      - count_6
+      - count_7
+      - count_8
+      - count_10
+    weights:
+      - 6
+      - 50
+      - 11
+      - 11
+      - 11
+      - 11
+    goals:
+      - user_creates_pageview
+      - user_creates_article_reaction
+      - user_creates_comment
+      - user_views_pages_on_at_least_two_different_days_within_a_week
+      - user_views_pages_on_at_least_four_different_days_within_a_week
   digest_article_ordering_06_11:
     started_at: 2024-06-11
     variants:


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adds quick field test to modify number of Active Discussion threads to show on home page.