### PR TITLE
Add x.com to embed registry

### DIFF
--- a/app/liquid_tags/tweet_tag.rb
+++ b/app/liquid_tags/tweet_tag.rb
@@ -1,6 +1,6 @@
 class TweetTag < LiquidTagBase
   PARTIAL = "liquids/tweet".freeze
-  REGISTRY_REGEXP = %r{https://twitter\.com/\w{1,15}/status/(?<id>\d{10,20})}
+  REGISTRY_REGEXP = %r{https://(?:twitter\.com|x\.com)/\w{1,15}/status/(?<id>\d{10,20})}
   VALID_ID_REGEXP = /\A(?<id>\d{10,20})\Z/
   REGEXP_OPTIONS = [REGISTRY_REGEXP, VALID_ID_REGEXP].freeze
 

--- a/app/liquid_tags/unified_embed/tag.rb
+++ b/app/liquid_tags/unified_embed/tag.rb
@@ -44,7 +44,7 @@ module UnifiedEmbed
 
     def self.validate_link(input:, retries: MAX_REDIRECTION_COUNT, method: Net::HTTP::Head)
       uri = URI.parse(input.split.first)
-      return input if uri.host == "twitter.com" # Twitter sends a forbidden like to codepen below
+      return input if uri.host == "twitter.com" || uri.host == "x.com" # Twitter sends a forbidden like to codepen below
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if http.port == 443

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -313,6 +313,11 @@ RSpec.describe UnifiedEmbed::Registry do
         .to eq(TweetTag)
     end
 
+    it "returns TweetTag for an x.com url" do
+      expect(described_class.find_liquid_tag_for(link: "https://x.com/aritdeveloper/status/1483614684884484099"))
+        .to eq(TweetTag)
+    end
+
     it "returns TwitchTag for a valid twitch url", :aggregate_failures do
       valid_twitch_url_formats.each do |url|
         expect(described_class.find_liquid_tag_for(link: url))


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allow x.com to automatically trigger tweet embed.