### PR TITLE
Add target blank to outbound links

### DIFF
--- a/app/javascript/packs/articlePage.jsx
+++ b/app/javascript/packs/articlePage.jsx
@@ -8,6 +8,22 @@ import { initializeUserSubscriptionLiquidTagContent } from '../liquidTags/userSu
 import { trackCommentClicks } from '@utilities/ahoy/trackEvents';
 import { isNativeAndroid, copyToClipboard } from '@utilities/runtime';
 
+// Open in new tab backfill
+// We added this behavior on rendering, so this is a backfill for the existing articles
+function backfillLinkTarget() {
+  const links = document.querySelectorAll('a[href]');
+  const appDomain = window.location.hostname;
+
+  links.forEach((link) => {
+    const href = link.getAttribute('href');
+
+    if (href && (href.startsWith('http://') || href.startsWith('https://')) && !href.includes(appDomain)) {
+      link.setAttribute('target', '_blank');
+      link.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
+}
+
 const animatedImages = document.querySelectorAll('[data-animated="true"]');
 if (animatedImages.length > 0) {
   import('@utilities/animatedImageUtils').then(
@@ -164,3 +180,4 @@ initializeUserSubscriptionLiquidTagContent();
 focusOnComments();
 // Temporary Ahoy Stats for comment section clicks on controls
 trackCommentClicks('comments');
+backfillLinkTarget();

--- a/app/javascript/packs/articlePage.jsx
+++ b/app/javascript/packs/articlePage.jsx
@@ -19,7 +19,17 @@ function backfillLinkTarget() {
 
     if (href && (href.startsWith('http://') || href.startsWith('https://')) && !href.includes(appDomain)) {
       link.setAttribute('target', '_blank');
-      link.setAttribute('rel', 'noopener noreferrer');
+      
+      const existingRel = link.getAttribute('rel');
+      const newRelValues = ["noopener", "noreferrer"];
+
+      if (existingRel) {
+        const existingRelValues = existingRel.split(" ");
+        const mergedRelValues = [...new Set([...existingRelValues, ...newRelValues])].join(" ");
+        link.setAttribute('rel', mergedRelValues);
+      } else {
+        link.setAttribute('rel', newRelValues.join(" "));
+      }
     }
   });
 }

--- a/app/javascript/utilities/billboardInteractivity.jsx
+++ b/app/javascript/utilities/billboardInteractivity.jsx
@@ -43,6 +43,10 @@ export function setupBillboardInteractivity() {
       });
       if (sponsorshipCloseButton.closest('.popover-billboard')) {
         document.addEventListener('click', (event) => {
+          // If the event target is the article header and .popover-billboard does not have display none, don't follow that link
+          if (event.target.closest('.crayons-article__header') && document.querySelector('.popover-billboard').style.display !== 'none'){
+            event.preventDefault();
+          }          
           if (!event.target.closest('.js-billboard')) {
             dismissBillboard(sponsorshipCloseButton);
           }

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -55,14 +55,22 @@ module MarkdownProcessor
     end
 
     def add_target_blank_to_outbound_links(html)
-      app_domain = Settings::General.app_domain
+      app_domain = "example.com" # Replace with your actual domain logic if necessary
       doc = Nokogiri::HTML.fragment(html)
       doc.css('a[href^="http"]').each do |link|
         href = link["href"]
-        if href&.exclude?(app_domain)
-          link[:target] = "_blank"
-          link[:rel] = "noopener noreferrer"
+        next unless href && !href.include?(app_domain)
+
+        link[:target] = "_blank"
+        existing_rel = link[:rel]
+        new_rel = %w[noopener noreferrer]
+        if existing_rel
+          existing_rel_values = existing_rel.split
+          new_rel = (existing_rel_values + new_rel).uniq.join(" ")
+        else
+          new_rel = new_rel.join(" ")
         end
+        link[:rel] = new_rel
       end
       doc.to_html
     end

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -55,11 +55,11 @@ module MarkdownProcessor
     end
 
     def add_target_blank_to_outbound_links(html)
-      app_domain = "example.com" # Replace with your actual domain logic if necessary
+      app_domain = Settings::General.app_domain
       doc = Nokogiri::HTML.fragment(html)
       doc.css('a[href^="http"]').each do |link|
         href = link["href"]
-        next unless href && !href.include?(app_domain)
+        next unless href&.exclude?(app_domain)
 
         link[:target] = "_blank"
         existing_rel = link[:rel]

--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -50,7 +50,21 @@ module MarkdownProcessor
         html = e.message
       end
 
+      html = add_target_blank_to_outbound_links(html)
       parse_html(html, prefix_images_options)
+    end
+
+    def add_target_blank_to_outbound_links(html)
+      app_domain = Settings::General.app_domain
+      doc = Nokogiri::HTML.fragment(html)
+      doc.css('a[href^="http"]').each do |link|
+        href = link["href"]
+        if href&.exclude?(app_domain)
+          link[:target] = "_blank"
+          link[:rel] = "noopener noreferrer"
+        end
+      end
+      doc.to_html
     end
 
     def calculate_reading_time

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe Comment do
       it "adds rel=nofollow to links" do
         comment.body_markdown = "this is a comment with a link: http://dev.to"
         comment.validate!
-        expect(comment.processed_html.include?('rel="nofollow"')).to be(true)
+        expect(comment.processed_html.include?('rel="nofollow')).to be(true)
       end
 
       it "adds a mention url if user is mentioned like @mention" do

--- a/spec/services/content_renderer_spec.rb
+++ b/spec/services/content_renderer_spec.rb
@@ -29,6 +29,36 @@ RSpec.describe ContentRenderer do
         expect(parser).to have_received(:finalize).with(finalize_attrs)
       end
     end
+
+    context "when processing links" do
+      let(:markdown) { "[Google](https://www.google.com)" }
+      let(:result) { described_class.new(markdown, source: build(:article), user: build(:user)).process }
+
+      it "adds target='_blank' and rel='noopener noreferrer' for outbound links" do
+        processed_html = result.processed_html
+        p processed_html
+        expect(processed_html).to include('rel="noopener noreferrer"')
+        expect(processed_html).to include('target="_blank"')
+      end
+
+      it "does not add target='_blank' and rel='noopener noreferrer' for internal links" do
+        internal_markdown = "[Home](/home)"
+        internal_renderer = described_class.new(internal_markdown, source: nil, user: nil, fixer: MarkdownProcessor::Fixer::FixAll)
+        processed_html = internal_renderer.process_article.processed_html
+        expect(processed_html).to include("href=\"http://#{Settings::General.app_domain}/home")
+        expect(processed_html).not_to include('target="_blank"')
+        expect(processed_html).not_to include('rel="noopener noreferrer"')
+      end
+
+      it "does not add target='_blank' and rel='noopener noreferrer' for internal links with full domain" do
+        internal_full_domain_markdown = "[Home](http://#{Settings::General.app_domain}/home)"
+        internal_full_domain_renderer = described_class.new(internal_full_domain_markdown, source: nil, user: nil, fixer: MarkdownProcessor::Fixer::FixAll)
+        processed_html = internal_full_domain_renderer.process_article.processed_html
+        expect(processed_html).to include("href=\"http://#{Settings::General.app_domain}/home")
+        expect(processed_html).not_to include('target="_blank"')
+        expect(processed_html).not_to include('rel="noopener noreferrer"')
+      end
+    end
   end
 
   describe "#process_article" do

--- a/spec/services/content_renderer_spec.rb
+++ b/spec/services/content_renderer_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe ContentRenderer do
 
       it "does not add target='_blank' and rel='noopener noreferrer' for internal links" do
         internal_markdown = "[Home](/home)"
-        internal_renderer = described_class.new(internal_markdown, source: nil, user: nil, fixer: MarkdownProcessor::Fixer::FixAll)
+        internal_renderer = described_class.new(internal_markdown, source: nil, user: nil,
+                                                                   fixer: MarkdownProcessor::Fixer::FixAll)
         processed_html = internal_renderer.process_article.processed_html
         expect(processed_html).to include("href=\"http://#{Settings::General.app_domain}/home")
         expect(processed_html).not_to include('target="_blank"')
@@ -51,8 +52,9 @@ RSpec.describe ContentRenderer do
       end
 
       it "does not add target='_blank' and rel='noopener noreferrer' for internal links with full domain" do
-        internal_full_domain_markdown = "[Home](http://#{Settings::General.app_domain}/home)"
-        internal_full_domain_renderer = described_class.new(internal_full_domain_markdown, source: nil, user: nil, fixer: MarkdownProcessor::Fixer::FixAll)
+        internal_domain = "[Home](http://#{Settings::General.app_domain}/home)"
+        internal_full_domain_renderer = described_class.new(internal_domain, source: nil, user: nil,
+                                                                             fixer: MarkdownProcessor::Fixer::FixAll)
         processed_html = internal_full_domain_renderer.process_article.processed_html
         expect(processed_html).to include("href=\"http://#{Settings::General.app_domain}/home")
         expect(processed_html).not_to include('target="_blank"')

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -154,13 +154,15 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     it "renders properly if protocol http is included" do
       code_span = "[github](http://github.com)"
       test = generate_and_parse_markdown(code_span)
-      expect(test).to eq("<p><a href=\"https://github.com\" target=\"_blank\" rel=\"noopener noreferrer\">github</a></p>\n\n")
+      expect(test)
+        .to eq("<p><a href=\"https://github.com\" target=\"_blank\" rel=\"noopener noreferrer\">github</a></p>\n\n")
     end
 
     it "renders properly if protocol https is included" do
       code_span = "[github](https://github.com)"
       test = generate_and_parse_markdown(code_span)
-      expect(test).to eq("<p><a href=\"http://github.com\" target=\"_blank\" rel=\"noopener noreferrer\">github</a></p>\n\n")
+      expect(test)
+        .to eq("<p><a href=\"http://github.com\" target=\"_blank\" rel=\"noopener noreferrer\">github</a></p>\n\n")
     end
 
     it "renders properly if protocol is not included" do

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -155,14 +155,14 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
       code_span = "[github](http://github.com)"
       test = generate_and_parse_markdown(code_span)
       expect(test)
-        .to eq("<p><a href=\"https://github.com\" target=\"_blank\" rel=\"noopener noreferrer\">github</a></p>\n\n")
+        .to eq("<p><a href=\"http://github.com\" target=\"_blank\" rel=\"noopener noreferrer\">github</a></p>\n\n")
     end
 
     it "renders properly if protocol https is included" do
       code_span = "[github](https://github.com)"
       test = generate_and_parse_markdown(code_span)
       expect(test)
-        .to eq("<p><a href=\"http://github.com\" target=\"_blank\" rel=\"noopener noreferrer\">github</a></p>\n\n")
+        .to eq("<p><a href=\"https://github.com\" target=\"_blank\" rel=\"noopener noreferrer\">github</a></p>\n\n")
     end
 
     it "renders properly if protocol is not included" do
@@ -252,7 +252,7 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
       expect(result).to eq(expected_result)
     end
 
-    it "will not work in code tag" do
+    it "does not work in code tag" do
       mention = "this is a chunk of text `@#{user.username}`"
       result = generate_and_parse_markdown(mention)
       expect(result).to include "<code"
@@ -377,7 +377,8 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     it "does not generated nested link tags" do
       nested_links = generate_and_parse_markdown("[[](http://b)](http://a)")
       nested_links = Nokogiri::HTML(nested_links).at("p").inner_html
-      expect(nested_links).to eq("[<a href=\"http://b\" target=\"_blank\" rel=\"noopener noreferrer\"></a>](<a href=\"http://a\" target=\"_blank\" rel=\"noopener noreferrer\">http://a</a>)")
+      attrs = "target=\"_blank\" rel=\"noopener noreferrer\""
+      expect(nested_links).to eq("[<a href=\"http://b\" #{attrs}></a>](<a href=\"http://a\" #{attrs}>http://a</a>)")
     end
   end
 

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -154,13 +154,13 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     it "renders properly if protocol http is included" do
       code_span = "[github](http://github.com)"
       test = generate_and_parse_markdown(code_span)
-      expect(test).to eq("<p><a href=\"http://github.com\">github</a></p>\n\n")
+      expect(test).to eq("<p><a href=\"https://github.com\" target=\"_blank\" rel=\"noopener noreferrer\">github</a></p>\n\n")
     end
 
     it "renders properly if protocol https is included" do
       code_span = "[github](https://github.com)"
       test = generate_and_parse_markdown(code_span)
-      expect(test).to eq("<p><a href=\"https://github.com\">github</a></p>\n\n")
+      expect(test).to eq("<p><a href=\"http://github.com\" target=\"_blank\" rel=\"noopener noreferrer\">github</a></p>\n\n")
     end
 
     it "renders properly if protocol is not included" do
@@ -375,7 +375,7 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     it "does not generated nested link tags" do
       nested_links = generate_and_parse_markdown("[[](http://b)](http://a)")
       nested_links = Nokogiri::HTML(nested_links).at("p").inner_html
-      expect(nested_links).to eq('[<a href="http://b"></a>](<a href="http://a">http://a</a>)')
+      expect(nested_links).to eq("[<a href=\"http://b\" target=\"_blank\" rel=\"noopener noreferrer\"></a>](<a href=\"http://a\" target=\"_blank\" rel=\"noopener noreferrer\">http://a</a>)")
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This modifies behavior so outbound links consistently target new tab. This is already the behavior in some places, but this makes it consistent across UGC.