### PR TITLE
Allow pages to have + symbol

### DIFF
--- a/app/validators/cross_model_slug_validator.rb
+++ b/app/validators/cross_model_slug_validator.rb
@@ -2,7 +2,7 @@ class CrossModelSlugValidator < ActiveModel::EachValidator
   FORMAT_REGEX = /\A[0-9a-z\-_]+\z/
   ORGANIZATION_FORMAT_REGEX = /\A(?![0-9]+\z)[0-9a-z\-_]+\z/
   ## allow / in page slugs
-  PAGE_FORMAT_REGEX = /\A[0-9a-z\-_\/]+\z/
+  PAGE_FORMAT_REGEX = %r{\A[0-9a-z\-_/+]+\z}
   PAGE_DIRECTORY_LIMIT = 6
 
   def validate_each(record, attribute, value)

--- a/spec/validators/cross_model_slug_validator_spec.rb
+++ b/spec/validators/cross_model_slug_validator_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CrossModelSlugValidator do
       def self.name
         "Validatable"
       end
+
       include ActiveModel::Validations
       attr_accessor :name
 
@@ -68,8 +69,8 @@ RSpec.describe CrossModelSlugValidator do
   end
 
   context "when name exists in Page model" do
-    let(:org) { create(:page) }
-    let(:name) { org.slug }
+    let(:page) { create(:page) }
+    let(:name) { page.slug }
 
     it { is_expected.not_to be_valid }
   end
@@ -94,6 +95,22 @@ RSpec.describe CrossModelSlugValidator do
 
     it "is valid" do
       expect(organization).to be_valid
+    end
+  end
+
+  context "when user's slug contains a plus sign" do
+    let(:user) { build(:user, username: "user+name") }
+
+    it "is invalid" do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "when page's slug contains a plus sign" do
+    let(:page) { build(:page, slug: "page+slug") }
+
+    it "is valid" do
+      expect(page).to be_valid
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Small adjustment to provide more flexibility for page slugs, as `+` is a common page character (acts as a de facto space).