### PR TITLE
Allow admin to optionally set score cap on post

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -13,6 +13,7 @@ module Admin
                                  email_digest_eligible
                                  main_image_background_hex_color
                                  user_id
+                                 max_score
                                  co_author_ids_list
                                  published_at].freeze
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -370,7 +370,7 @@ class Article < ApplicationRecord
   scope :limited_columns_internal_select, lambda {
     select(:path, :title, :id, :featured, :approved, :published,
            :comments_count, :public_reactions_count, :cached_tag_list,
-           :main_image, :main_image_background_hex_color, :updated_at,
+           :main_image, :main_image_background_hex_color, :updated_at, :max_score,
            :video, :user_id, :organization_id, :video_source_url, :video_code,
            :video_thumbnail_url, :video_closed_caption_track_url, :social_image,
            :published_from_feed, :crossposted_at, :published_at, :created_at,
@@ -596,6 +596,8 @@ class Article < ApplicationRecord
     spam_adjustment = user.spam? ? -500 : 0
     negative_reaction_adjustment = Reaction.where(reactable_id: user_id, reactable_type: "User").sum(:points)
     self.score = reactions.sum(:points) + spam_adjustment + negative_reaction_adjustment
+    self.score = max_score if max_score.positive? && max_score < score
+
     update_columns(score: score,
                    privileged_users_reaction_points_sum: reactions.privileged_category.sum(:points),
                    comment_score: comments.sum(:score),

--- a/app/views/admin/articles/_article_item.html.erb
+++ b/app/views/admin/articles/_article_item.html.erb
@@ -168,6 +168,13 @@
           <input id="co_author_ids_list_<%= article.id %>" class="js-coauthor_username_id_input crayons-textfield" size="6" name="article[co_author_ids_list]" placeholder="Comma separated"
             value="<%= article.co_author_ids&.join(", ") %>">
         </div>
+        <div class="crayons-field flex-1">
+          <label for="max_score_<%= article.id %>" class="crayons-field__label">
+            <%= t("views.moderations.article.max_score") %>
+            <span class="c-indicator"><%= t("views.moderations.article.no_max_if_zero") %></span>
+          </label>
+          <input id="max_score_<%= article.id %>" class="crayons-textfield" type="number" name="article[max_score]" value="<%= article.max_score %>">
+        </div>
       </div>
       <% if article.published? %>
         <div class="flex">

--- a/config/locales/views/moderations/en.yml
+++ b/config/locales/views/moderations/en.yml
@@ -153,6 +153,8 @@ en:
         comments: comments
         contains_video: Contains video
         co_author_ids: Co-Author IDs
+        max_score: Max score
+        no_max_if_zero: No max if set to zero
         edit: Edit
         featured: Featured
         likes: likes

--- a/config/locales/views/moderations/fr.yml
+++ b/config/locales/views/moderations/fr.yml
@@ -152,6 +152,8 @@ fr:
         comments: commentaires
         contains_video: Contient une vidéo
         co_author_ids: ID de co-auteur
+        max_score: Score maximum
+        no_max_if_zero: Pas de maximum si défini à zéro
         edit: Modifier
         featured: Mis en exergue
         likes: aime

--- a/db/migrate/20240710144409_add_max_score_to_articles.rb
+++ b/db/migrate/20240710144409_add_max_score_to_articles.rb
@@ -1,0 +1,5 @@
+class AddMaxScoreToArticles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :articles, :max_score, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_17_141922) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_10_144409) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -121,6 +121,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_17_141922) do
     t.string "main_image_background_hex_color", default: "#dddddd"
     t.boolean "main_image_from_frontmatter", default: false
     t.integer "main_image_height", default: 420
+    t.integer "max_score", default: 0
     t.integer "nth_published_by_author", default: 0
     t.integer "organic_page_views_count", default: 0
     t.integer "organic_page_views_past_month_count", default: 0


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Under some circumstances an admin may need to set a score cap on a post manually, such as an announcement which does not need to rise even with interactivity. This is a feature which won't affect anything unless used.