### PR TITLE
Add user role names to body class

### DIFF
--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -81,6 +81,10 @@ class UserDecorator < ApplicationDecorator
       "#{setting.config_navbar.tr('_', '-')}-header",
     ]
 
+    cached_role_names.each do |name|
+      body_class << "user-role--#{name}"
+    end
+
     # Backfill ten-x-hacker-theme because the ios app looks for it to render native dark shell.
     body_class << "ten-x-hacker-theme" if setting.config_theme == "dark_theme"
     body_class.join(" ")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -371,6 +371,13 @@ class User < ApplicationRecord
     end
   end
 
+  def cached_role_names
+    cache_key = "user-#{id}/role_names"
+    Rails.cache.fetch(cache_key, expires_in: 200.hours) do
+      roles.pluck(:name)
+    end
+  end
+
   def processed_website_url
     profile.website_url.to_s.strip if profile.website_url.present?
   end
@@ -704,6 +711,7 @@ class User < ApplicationRecord
   def update_user_roles_cache(...)
     authorizer.clear_cache
     Rails.cache.delete("user-#{id}/has_trusted_role")
+    Rails.cache.delete("user-#{id}/role_names")
     refresh_auto_audience_segments
     trusted?
   end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -82,6 +82,17 @@ RSpec.describe UserDecorator, type: :decorator do
       expect(user.decorate.config_body_class).to eq(expected_result)
     end
 
+    it "includes user role names in body class" do
+      user.add_role(:tag_moderator)
+      expected_result = %W[
+        light-theme sans-serif-article-body
+        mod-status-#{user.admin? || !user.moderator_for_tags.empty?}
+        trusted-status-#{user.trusted?} #{user.setting.config_navbar}-header
+        user-role--tag_moderator
+      ].join(" ")
+      expect(user.decorate.config_body_class).to eq(expected_result)
+    end
+
     it "creates proper body class with sans serif config" do
       user.setting.config_font = "sans_serif"
       expected_result = %W[

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe UserDecorator, type: :decorator do
 
         expected_result = %w[
           light-theme sans-serif-article-body mod-status-false
-          trusted-status-true default-header
+          trusted-status-true default-header user-role--trusted
         ].join(" ")
         expect(user.decorate.config_body_class).to eq(expected_result)
       end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds cached user role names to the body class, to go along with some things like the trusted class, to give pages and elsewhere something to grab onto to refer to any role.