### PR TITLE
Add alias for billboard events

### DIFF
--- a/app/assets/javascripts/initializers/initializeBillboardVisibility.js
+++ b/app/assets/javascripts/initializers/initializeBillboardVisibility.js
@@ -38,7 +38,7 @@ function trackAdImpression(adBox) {
   };
 
   window
-    .fetch('/billboard_events', {
+    .fetch('/bb_tabulations', {
       method: 'POST',
       headers: {
         'X-CSRF-Token': csrfToken,
@@ -83,7 +83,7 @@ function trackAdClick(adBox, event, currentPath) {
   var tokenMeta = document.querySelector("meta[name='csrf-token']");
   var csrfToken = tokenMeta && tokenMeta.getAttribute('content');
 
-  window.fetch('/billboard_events', {
+  window.fetch('/bb_tabulations', {
     method: 'POST',
     headers: {
       'X-CSRF-Token': csrfToken,

--- a/app/assets/stylesheets/billboards.scss
+++ b/app/assets/stylesheets/billboards.scss
@@ -3,8 +3,8 @@
 @import '_mixins';
 
 .crayons-layout__comments-billboard {
-  .crayons-bb, .crayons-sponsorship {
-    .c-indicator.crayons-bb__indicator, .c-indicator.crayons-sponsorship__indicator {
+  .crayons-bb, .crayons-unit {
+    .c-indicator.crayons-bb__indicator, .c-indicator.crayons-unit__indicator {
       line-height: 15px;
     }
 
@@ -68,7 +68,7 @@
   }
   @media (min-width: $breakpoint-xl) {
     .crayons-bb__header,
-    .crayons-sponsorship__header,
+    .crayons-unit__header,
     .text-styles {
       margin-left: calc(54% - (var(--site-width) / 2));
     }

--- a/app/assets/stylesheets/widgets.scss
+++ b/app/assets/stylesheets/widgets.scss
@@ -365,7 +365,7 @@
   }
 }
 
-.crayons-bb, .crayons-sponsorship {
+.crayons-bb, .crayons-unit {
   padding: var(--su-3);
   padding-bottom: var(--su-4);
 

--- a/app/javascript/onboarding/Onboarding.jsx
+++ b/app/javascript/onboarding/Onboarding.jsx
@@ -80,7 +80,7 @@ export class Onboarding extends Component {
 
       const tokenMeta = document.querySelector("meta[name='csrf-token']");
       const csrfToken = tokenMeta && tokenMeta.getAttribute('content');
-      window.fetch('/billboard_events', {
+      window.fetch('/bb_tabulations', {
         method: 'POST',
         headers: {
           'X-CSRF-Token': csrfToken,

--- a/app/javascript/onboarding/__tests__/Onboarding.test.jsx
+++ b/app/javascript/onboarding/__tests__/Onboarding.test.jsx
@@ -84,7 +84,7 @@ describe('<Onboarding />', () => {
 
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
-        '/billboard_events',
+        '/bb_tabulations',
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({

--- a/app/javascript/packs/billboardAfterRenderActions.js
+++ b/app/javascript/packs/billboardAfterRenderActions.js
@@ -125,7 +125,7 @@ function trackAdImpression(adBox) {
   };
 
   window
-    .fetch('/billboard_events', {
+    .fetch('/bb_tabulations', {
       method: 'POST',
       headers: {
         'X-CSRF-Token': csrfToken,
@@ -171,7 +171,7 @@ function trackAdClick(adBox, event, currentPath) {
   const tokenMeta = document.querySelector("meta[name='csrf-token']");
   const csrfToken = tokenMeta && tokenMeta.getAttribute('content');
 
-  window.fetch('/billboard_events', {
+  window.fetch('/bb_tabulations', {
     method: 'POST',
     headers: {
       'X-CSRF-Token': csrfToken,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -182,6 +182,9 @@ Rails.application.routes.draw do
     # temporary keeping both routes while transitioning (renaming) display_ads => billboards
     resources :display_ad_events, only: [:create], controller: :billboard_events
     resources :billboard_events, only: [:create]
+    # Alias for reporting in case "events" triggers spam filters
+    post "/bb_tabulations", to: "billboard_events#create", as: :bb_tabulations
+
     resources :badges, only: [:index]
     resources :user_blocks, param: :blocked_id, only: %i[show create destroy]
     resources :podcasts, only: %i[new create]

--- a/spec/requests/billboard_events_spec.rb
+++ b/spec/requests/billboard_events_spec.rb
@@ -1,5 +1,7 @@
 require "rails_helper"
 
+# /billboard_events and /bb_tabulations are aliases for the same controller
+
 RSpec.describe "BillboardEvents" do
   let(:user) { create(:user, :trusted) }
   let(:organization) { create(:organization) }
@@ -12,7 +14,7 @@ RSpec.describe "BillboardEvents" do
       end
 
       it "creates a billboard click event" do
-        post "/billboard_events", params: {
+        post "/bb_tabulations", params: {
           billboard_event: {
             billboard_id: billboard.id,
             context_type: BillboardEvent::CONTEXT_TYPE_HOME,
@@ -23,7 +25,7 @@ RSpec.describe "BillboardEvents" do
       end
 
       it "creates a billboard click event with old params" do
-        post "/billboard_events", params: {
+        post "/bb_tabulations", params: {
           display_ad_event: {
             display_ad_id: billboard.id,
             context_type: BillboardEvent::CONTEXT_TYPE_HOME,
@@ -34,7 +36,7 @@ RSpec.describe "BillboardEvents" do
       end
 
       it "creates a billboard impression event" do
-        post "/billboard_events", params: {
+        post "/bb_tabulations", params: {
           billboard_event: {
             billboard_id: billboard.id,
             context_type: BillboardEvent::CONTEXT_TYPE_HOME,
@@ -50,7 +52,7 @@ RSpec.describe "BillboardEvents" do
         create_list(:billboard_event, 4, impression_params)
 
         post(
-          "/billboard_events",
+          "/bb_tabulations",
           params: { billboard_event: ad_event_params.merge(category: BillboardEvent::CATEGORY_CLICK) },
         )
 
@@ -65,7 +67,7 @@ RSpec.describe "BillboardEvents" do
         create_list(:billboard_event, 4, impression_params)
 
         post(
-          "/billboard_events",
+          "/bb_tabulations",
           params: { billboard_event: ad_event_params.merge(category: BillboardEvent::CATEGORY_SIGNUP) },
         )
 
@@ -74,7 +76,7 @@ RSpec.describe "BillboardEvents" do
       end
 
       it "assigns event to current user" do
-        post "/billboard_events", params: {
+        post "/bb_tabulations", params: {
           billboard_event: {
             billboard_id: billboard.id,
             context_type: BillboardEvent::CONTEXT_TYPE_HOME,
@@ -86,7 +88,7 @@ RSpec.describe "BillboardEvents" do
 
       it "assigns event to passed article_id" do
         article = create(:article)
-        post "/billboard_events", params: {
+        post "/bb_tabulations", params: {
           billboard_event: {
             billboard_id: billboard.id,
             context_type: BillboardEvent::CONTEXT_TYPE_HOME,
@@ -100,7 +102,7 @@ RSpec.describe "BillboardEvents" do
 
       it "assigns event to passed current geolocation" do
         article = create(:article)
-        post "/billboard_events", params: {
+        post "/bb_tabulations", params: {
           billboard_event: {
             billboard_id: billboard.id,
             context_type: BillboardEvent::CONTEXT_TYPE_HOME,
@@ -112,7 +114,7 @@ RSpec.describe "BillboardEvents" do
       end
 
       it "uses a ThrottledCall for data updates" do
-        post "/billboard_events", params: {
+        post "/bb_tabulations", params: {
           billboard_event: {
             billboard_id: billboard.id,
             context_type: BillboardEvent::CONTEXT_TYPE_HOME,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This modifies the endpoint we use with billboard events in case the current one is getting caught up by blockers erroneously.