### PR TITLE
Update organic page views tabulator job logic

### DIFF
--- a/app/workers/articles/update_page_views_worker.rb
+++ b/app/workers/articles/update_page_views_worker.rb
@@ -2,6 +2,8 @@ module Articles
   class UpdatePageViewsWorker
     include Sidekiq::Job
 
+    GOOGLE_REFERRER = "https://www.google.com/".freeze
+
     sidekiq_options queue: :medium_priority,
                     lock: :until_executing,
                     on_conflict: :replace,
@@ -26,6 +28,10 @@ module Articles
       # updates vs. organic page view updates. We kept a similar relationship
       # between the two workers, this one here is schedule after 2 minutes,
       # organic page view updates after 25 minutes.
+
+      # We also don't need to call this unless the new pageview is organic
+      return unless create_params["referrer"] == GOOGLE_REFERRER
+
       Articles::UpdateOrganicPageViewsWorker.perform_at(
         25.minutes.from_now,
         article.id,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Adds logic to only call this when needed, creating less of a build up of scheduled jobs.