### PR TITLE
Put sync detail detection mediastore behind feature flag

### DIFF
--- a/app/lib/redcarpet/render/html_rouge.rb
+++ b/app/lib/redcarpet/render/html_rouge.rb
@@ -26,9 +26,9 @@ module Redcarpet
         end
       end
 
-      def link(link, _title, content)
+      def link(link, _title, content) # rubocop:disable Metrics/PerceivedComplexity
         # Regex to capture src, alt, and title attributes from an img tag
-        if content.include?("<img") && (doc = Nokogiri::HTML(content))
+        if content&.include?("<img") && (doc = Nokogiri::HTML(content))
           image_url = doc.at_css("img")["src"]
           alt_text = doc.at_css("img")["alt"] || nil
           title = doc.at_css("img")["title"] || nil

--- a/app/services/content_renderer.rb
+++ b/app/services/content_renderer.rb
@@ -24,7 +24,7 @@ class ContentRenderer
   # @return [ContentRenderer::Result]
   def process(link_attributes: {},
               prefix_images_options: { width: 800, synchronous_detail_detection: false })
-    if prefix_images_options[:synchronous_detail_detection] && ApplicationConfig["AWS_BUCKET_NAME"].present?
+    if prefix_images_options[:synchronous_detail_detection] && ApplicationConfig["AWS_BUCKET_NAME"].present? && FeatureFlag.enabled?(:store_images) # rubocop:disable Layout/LineLength
       markdown_text = input
       markdown_pattern = /!\[.*?\]\((.*?)\)/
       html_pattern = /<img.*?src=["'](.*?)["']/


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Put this behind feature flag because it's not 100% reliable right now