### PR TITLE
Allow multiple recent billboard clicks to count for conversion

### DIFF
--- a/spec/requests/incoming_webhooks/stripe/stripe_events_spec.rb
+++ b/spec/requests/incoming_webhooks/stripe/stripe_events_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "IncomingWebhooks::StripeEventsController" do
         end
 
         it "does not create a BillboardEvent if there is no recent click event" do
-          last_billboard_event.update(created_at: 2.hours.ago) # Make it too old
+          last_billboard_event.update(created_at: 4.hours.ago) # Make it too old
 
           expect do
             post "/incoming_webhooks/stripe_events", params: payload, headers: headers


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allows multiple billboard events to count for conversion, to give credit if multiple billboards were involved in a conversion funnel.