### PR TITLE
Make notification send query more efficient

### DIFF
--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -38,10 +38,8 @@ module Notifications
                  notifiable&.user&.id, "User", notifiable&.organization&.id, "Organization")
           .where(follows: { subscription_status: "all_articles" })
           .where.not(id: (user_ids_with_article_mentions + [notifiable.user]))
-          .order("users.updated_at DESC").limit(FOLLOWER_SEND_LIMIT)
+          .recently_active(FOLLOWER_SEND_LIMIT)
 
-        # TODO: If article.followers were refactored to be scope-based, this could
-        # update to use User.recently_active (which was originally based on this)
         article_followers.find_each do |follower|
           now = Time.current
           notifications_attributes.push(

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -1,6 +1,7 @@
 # send notification about the action ("Published") that happened on a notifiable (Article)
 module Notifications
   module NotifiableAction
+    FOLLOWER_SEND_LIMIT = 10_000
     class Send
       def self.call(...)
         new(...).call
@@ -30,16 +31,18 @@ module Notifications
         # We explicitly need to exclude them from the article_followers array if they already
         # have a mention in order to avoid sending a user multiple notifications for one article.
         user_ids_with_article_mentions = notifiable.mentions&.pluck(:user_id)
-        article_followers = notifiable.followers.reject do |follower|
-          user_ids_with_article_mentions.include?(follower.id)
-        end
-        # We don't want to notify authors about their own articles, e.g. when
-        # they post under an organization.
-        article_followers -= [notifiable.user]
+
+        article_followers = User.joins("INNER JOIN follows ON follows.follower_id = users.id")
+          .where("(follows.followable_id = ? AND follows.followable_type = ?)
+                 OR (follows.followable_id = ? AND follows.followable_type = ?)",
+                 notifiable&.user&.id, "User", notifiable&.organization&.id, "Organization")
+          .where(follows: { subscription_status: "all_articles" })
+          .where.not(id: (user_ids_with_article_mentions + [notifiable.user]))
+          .order("users.updated_at DESC").limit(FOLLOWER_SEND_LIMIT)
 
         # TODO: If article.followers were refactored to be scope-based, this could
         # update to use User.recently_active (which was originally based on this)
-        article_followers.sort_by(&:updated_at).last(10_000).reverse_each do |follower|
+        article_followers.find_each do |follower|
           now = Time.current
           notifications_attributes.push(
             user_id: follower.id,


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
The current query is really inefficient. This fixes that. We may want to make the `def followers` method more efficient too, but this inline should help where matters most.