### PR TITLE
Add proper self-serve subscription cancel flow

### DIFF
--- a/app/assets/javascripts/initializers/initializeBillboardVisibility.js
+++ b/app/assets/javascripts/initializers/initializeBillboardVisibility.js
@@ -8,7 +8,7 @@ function initializeBillboardVisibility() {
   var user = userData();
 
   billboards.forEach((ad) => {
-    if (user && !user.display_sponsors && ad.dataset['typeOf'] == 'external') {
+    if (user && !user.display_sponsors && ['external','partner'].includes(ad.dataset['typeOf'])) {
       ad.classList.add('hidden');
     } else {
       ad.classList.remove('hidden');

--- a/app/controllers/stripe_subscriptions_controller.rb
+++ b/app/controllers/stripe_subscriptions_controller.rb
@@ -50,14 +50,14 @@ class StripeSubscriptionsController < ApplicationController
         current_user.profile&.touch
         flash[:notice] = "Your subscription has been canceled."
       else
-        flash[:alert] = "No active subscription found."
+        flash[:error] = "No active subscription found."
       end
     elsif current_user.stripe_id_code.present?
-      flash[:alert] = "Invalid verification parameter. Subscription was not canceled."
+      flash[:error] = "Invalid verification parameter. Subscription was not canceled."
     else
-      flash[:alert] = "No active subscription found. Please contact us if you believe this is an error."
+      flash[:error] = "No active subscription found. Please contact us if you believe this is an error."
     end
 
-    redirect_to user_settings_path(current_user)
+    redirect_back(fallback_location: user_settings_path)
   end
 end

--- a/app/models/billboard.rb
+++ b/app/models/billboard.rb
@@ -223,6 +223,10 @@ class Billboard < ApplicationRecord
     selected_number.to_i
   end
 
+  def type_of_display
+    type_of.gsub("external", "partner")
+  end
+
   def human_readable_placement_area
     ALLOWED_PLACEMENT_AREAS_HUMAN_READABLE[ALLOWED_PLACEMENT_AREAS.find_index(placement_area)]
   end

--- a/app/views/shared/_billboard.html.erb
+++ b/app/views/shared/_billboard.html.erb
@@ -7,7 +7,7 @@
     data-context-type="<%= data_context_type %>"
     data-special="<%= billboard.special_behavior %>"
     data-article-id="<%= @article&.id %>"
-    data-type-of="<%= billboard.type_of %>">
+    data-type-of="<%= billboard.type_of_display %>">
       <%= billboard.processed_html.html_safe %>
   </div>
 <% elsif billboard.placement_area.start_with?("feed_") %>
@@ -20,7 +20,7 @@
     data-dismissal-sku="<%= billboard.dismissal_sku %>"
     data-special="<%= billboard.special_behavior %>"
     data-article-id="<%= @article&.id %>"
-    data-type-of="<%= billboard.type_of %>">
+    data-type-of="<%= billboard.type_of_display %>">
     <div class="crayons-story__body">
       <div class="crayons-story__top flex">
         <%= render partial: "shared/billboard_header", locals: { billboard: billboard } %>
@@ -48,7 +48,7 @@
     data-dismissal-sku="<%= billboard.dismissal_sku %>"
     data-special="<%= billboard.special_behavior %>"
     data-article-id="<%= @article&.id %>"
-    data-type-of="<%= billboard.type_of %>">
+    data-type-of="<%= billboard.type_of_display %>">
     <div class="flex">
       <%= render partial: "shared/billboard_header", locals: { billboard: billboard } %>
       <button id="sponsorship-close-trigger-<%= billboard.id %>" aria-controls="sponsorship-close-<%= billboard.id %>"
@@ -74,7 +74,7 @@
     <% else %>
       data-page-id="<%= billboard.page_id %>"
     <% end %>
-    data-type-of="<%= billboard.type_of %>">
+    data-type-of="<%= billboard.type_of_display %>">
     <div class="flex">
       <%= render partial: "shared/billboard_header", locals: { billboard: billboard } %>
       <button id="sponsorship-close-trigger-<%= billboard.id %>" aria-controls="sponsorship-close-<%= billboard.id %>"
@@ -96,7 +96,7 @@
     data-dismissal-sku="<%= billboard.dismissal_sku %>"
     data-special="<%= billboard.special_behavior %>"
     data-article-id="<%= @article&.id %>"
-    data-type-of="<%= billboard.type_of %>">
+    data-type-of="<%= billboard.type_of_display %>">
     <div class="crayons-story__top flex">
       <%= render partial: "shared/billboard_header", locals: { billboard: billboard } %>
       <% if billboard.dismissal_sku.present? %>
@@ -119,7 +119,7 @@
     data-context-type="<%= data_context_type %>"
     data-special="<%= billboard.special_behavior %>"
     data-article-id="<%= @article&.id %>"
-    data-type-of="<%= billboard.type_of %>">
+    data-type-of="<%= billboard.type_of_display %>">
     <%= render partial: "shared/billboard_header", locals: { billboard: billboard } %>
     <div class="p-1 pt-3 text-styles text-styles--billboard">
       <%= billboard.processed_html.html_safe %>

--- a/app/views/users/_account.html.erb
+++ b/app/views/users/_account.html.erb
@@ -27,6 +27,20 @@
   <% end %>
 </div>
 
+  <% if @user.base_subscriber? %>
+    <div class="crayons-card crayons-card--content-rows">
+      <h3 class="crayons-subtitle-2">
+        Cancel DEV++ Subscription
+      </h3>
+
+      <%= form_with(url: stripe_subscription_path("me"), method: :delete) do |f| %>
+        <%= f.label :verification, 'Verify with phrase "pleasecancelmyplusplus"', class: "crayons-field__label" %>
+        <%= f.text_field :verification, class: "crayons-textfield mt-1", placeholder: "Put verification phrase here" %>
+        <%= f.submit "Delete Subscription", class: "crayons-btn crayon-btn--secondary mt-2" %>
+      <% end %>
+    </div>
+  <% end %>
+
 <div class="crayons-card crayons-card--content-rows">
   <h2 class="crayons-subtitle-1 color-accent-danger">
     <%= t("views.settings.danger") %>

--- a/spec/requests/stripe_subscriptions_spec.rb
+++ b/spec/requests/stripe_subscriptions_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe "StripeSubscriptions" do
 
           delete stripe_subscription_path("me"), params: { verification: "pleasecancelmyplusplus" }
 
-          expect(response).to redirect_to(user_settings_path(user))
+          expect(response).to redirect_to(user_settings_path)
           expect(flash[:notice]).to eq("Your subscription has been canceled.")
         end
       end
@@ -221,8 +221,8 @@ RSpec.describe "StripeSubscriptions" do
 
           delete stripe_subscription_path("me"), params: { verification: "wrong_verification" }
 
-          expect(response).to redirect_to(user_settings_path(user))
-          expect(flash[:alert]).to eq("Invalid verification parameter. Subscription was not canceled.")
+          expect(response).to redirect_to(user_settings_path)
+          expect(flash[:error]).to eq("Invalid verification parameter. Subscription was not canceled.")
         end
       end
 
@@ -230,8 +230,8 @@ RSpec.describe "StripeSubscriptions" do
         it "does not cancel the subscription and shows an alert" do
           delete stripe_subscription_path("me"), params: { verification: "pleasecancelmyplusplus" }
 
-          expect(response).to redirect_to(user_settings_path(user))
-          expect(flash[:alert]).to eq("No active subscription found. Please contact us if you believe this is an error.")
+          expect(response).to redirect_to(user_settings_path)
+          expect(flash[:error]).to eq("No active subscription found. Please contact us if you believe this is an error.")
         end
       end
 
@@ -244,8 +244,8 @@ RSpec.describe "StripeSubscriptions" do
         it "does not cancel the subscription and shows an alert" do
           delete stripe_subscription_path("me"), params: { verification: "pleasecancelmyplusplus" }
 
-          expect(response).to redirect_to(user_settings_path(user))
-          expect(flash[:alert]).to eq("No active subscription found.")
+          expect(response).to redirect_to(user_settings_path)
+          expect(flash[:error]).to eq("No active subscription found.")
         end
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds full proper flow for subscription cancellation. Also include tweak to billboard display logic.