### PR TITLE
Use monkeypatch to write to secondary redis

### DIFF
--- a/config/initializers/redis_monkeypatch.rb
+++ b/config/initializers/redis_monkeypatch.rb
@@ -1,0 +1,20 @@
+# config/initializers/redis_monkeypatch.rb
+
+# Monkey patch the ActiveSupport::Cache::RedisCacheStore to write to both stores
+# If the presence of REDIS_SECONDARY_CACHE_URL is defined and different from the primary store
+# we will write to the secondary store as well as the first, for redundancy or cache store changeover.
+class ActiveSupport::Cache::RedisCacheStore
+  alias_method :original_write, :write
+
+  def write(name, value, options = nil)
+    # Write to the primary store as usual
+    original_write(name, value, options)
+
+    # Write to the secondary store if it's defined and different from the primary
+    secondary_redis_url = ENV["REDIS_SECONDARY_CACHE_URL"]
+    if secondary_redis_url.present? && secondary_redis_url != self.redis.id
+      secondary_store = ActiveSupport::Cache::RedisCacheStore.new(url: secondary_redis_url)
+      secondary_store.write(name, value, options)
+    end
+  end
+end

--- a/config/initializers/redis_monkeypatch.rb
+++ b/config/initializers/redis_monkeypatch.rb
@@ -12,7 +12,7 @@ class ActiveSupport::Cache::RedisCacheStore
 
     # Write to the secondary store if it's defined and different from the primary
     secondary_redis_url = ENV["REDIS_SECONDARY_CACHE_URL"]
-    if secondary_redis_url.present? && secondary_redis_url != self.redis.id
+    if secondary_redis_url.present? && secondary_redis_url != ENV["REDIS_URL"]
       secondary_store = ActiveSupport::Cache::RedisCacheStore.new(url: secondary_redis_url)
       secondary_store.write(name, value, options)
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

After unsuccessful attempts to define a custom MultiStoreCache, we are going to patch `ActiveSupport::Cache::RedisCacheStore` to write to secondary store