### PR TITLE
Allow cache max age to be set via ENV var

### DIFF
--- a/app/controllers/concerns/caching_headers.rb
+++ b/app/controllers/concerns/caching_headers.rb
@@ -18,7 +18,7 @@ module CachingHeaders
   #
   # @see {EdgeCacheSafetyCheck#current_user} for impact on "current_user"
   def set_cache_control_headers(
-    max_age = 1.day.to_i,
+    max_age = ((ApplicationConfig["EDGE_CACHE_DURATION_IN_HOURS"] || 24).to_i).hours.to_i,
     surrogate_control: nil,
     stale_while_revalidate: nil,
     stale_if_error: 26_400


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

For optimization, allow this number to be set via variable.

The default is still 24 hours, but an admin could taper up or down.