### PR TITLE
Make processed_html_final step to allow final html mods

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -984,16 +984,6 @@ class Article < ApplicationRecord
     self.cached_user = user ? Articles::CachedEntity.from_object(user) : nil
   end
 
-  Article.published.where("score > 3").where("cached_user like ?", "%res.cloudinary%").where("published_at > ?", 40.weeks.ago).limit(2).each do |a|
-    p a.cached_user.profile_image_90
-    a.update_column(:cached_organization, Articles::CachedEntity.from_object(a.organization)) if a.organization_id.present?
-    a.update_column(:cached_user, Articles::CachedEntity.from_object(a.user))
-    p a.reload.cached_user.profile_image_90
-    p "************"
-  rescue => e
-    p e.message
-  end
-
   def set_all_dates
     set_crossposted_at
     set_last_comment_at

--- a/app/models/billboard.rb
+++ b/app/models/billboard.rb
@@ -223,6 +223,17 @@ class Billboard < ApplicationRecord
     selected_number.to_i
   end
 
+  def processed_html_final
+    # This is a final non-database-driven step to adjust processed html
+    # It is sort of a hack to avoid having to reprocess all articles
+    # It is currently only for this one cloudflare domain change
+    # It is duplicated across article, bullboard and comment where it is most needed
+    # In the future this could be made more customizable. For now it's just this one thing.
+    return processed_html if ApplicationConfig["PRIOR_CLOUDFLARE_IMAGES_DOMAIN"].blank? || ApplicationConfig["CLOUDFLARE_IMAGES_DOMAIN"].blank?
+
+    processed_html.gsub(ApplicationConfig["PRIOR_CLOUDFLARE_IMAGES_DOMAIN"], ApplicationConfig["CLOUDFLARE_IMAGES_DOMAIN"])
+  end
+
   def type_of_display
     type_of.gsub("external", "partner")
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -172,7 +172,7 @@ class Comment < ApplicationRecord
   end
 
   def safe_processed_html
-    processed_html.html_safe # rubocop:disable Rails/OutputSafety
+    processed_html_final.html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def root_exists?
@@ -189,6 +189,17 @@ class Comment < ApplicationRecord
 
   def calculate_score
     Comments::CalculateScoreWorker.perform_async(id)
+  end
+
+  def processed_html_final
+    # This is a final non-database-driven step to adjust processed html
+    # It is sort of a hack to avoid having to reprocess all articles
+    # It is currently only for this one cloudflare domain change
+    # It is duplicated across article, bullboard and comment where it is most needed
+    # In the future this could be made more customizable. For now it's just this one thing.
+    return processed_html if ApplicationConfig["PRIOR_CLOUDFLARE_IMAGES_DOMAIN"].blank? || ApplicationConfig["CLOUDFLARE_IMAGES_DOMAIN"].blank?
+
+    processed_html.gsub(ApplicationConfig["PRIOR_CLOUDFLARE_IMAGES_DOMAIN"], ApplicationConfig["CLOUDFLARE_IMAGES_DOMAIN"])
   end
 
   private

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -189,7 +189,7 @@
           <% end %>
 
           <div class="crayons-article__body text-styles spec__body" data-article-id="<%= @article.id %>" id="article-body">
-            <%= @article.processed_html.html_safe %>
+            <%= @article.processed_html_final.html_safe %>
           </div>
 
           <% if @article.long_markdown? && @collection %>

--- a/app/views/shared/_billboard.html.erb
+++ b/app/views/shared/_billboard.html.erb
@@ -8,7 +8,7 @@
     data-special="<%= billboard.special_behavior %>"
     data-article-id="<%= @article&.id %>"
     data-type-of="<%= billboard.type_of_display %>">
-      <%= billboard.processed_html.html_safe %>
+      <%= billboard.processed_html_final.html_safe %>
   </div>
 <% elsif billboard.placement_area.start_with?("feed_") %>
   <div class="crayons-story crayons-story__billboard billboard js-billboard"
@@ -33,7 +33,7 @@
       </div>
       <div class="crayons-story__indention-billboard">
         <div class="text-styles text-styles--billboard">
-          <%= billboard.processed_html.html_safe %>
+          <%= billboard.processed_html_final.html_safe %>
         </div>
       </div>
     </div>
@@ -57,7 +57,7 @@
       </button>
     </div>
     <div class="p-1 text-styles text-styles--billboard">
-      <%= billboard.processed_html.html_safe %>
+      <%= billboard.processed_html_final.html_safe %>
     </div>
   </div>
 <% elsif billboard.placement_area == "post_fixed_bottom" || billboard.placement_area == "page_fixed_bottom" %>
@@ -83,7 +83,7 @@
       </button>
     </div>
     <div class="p-1 text-styles text-styles--billboard">
-      <%= billboard.processed_html.html_safe %>
+      <%= billboard.processed_html_final.html_safe %>
     </div>
   </div>
 <% elsif billboard.placement_area == "post_body_bottom" %>
@@ -107,7 +107,7 @@
       <% end %>
     </div>
     <div class="p-1 pt-3 text-styles text-styles--billboard">
-      <%= billboard.processed_html.html_safe %>
+      <%= billboard.processed_html_final.html_safe %>
     </div>
   </div>
 <% else %>
@@ -122,7 +122,7 @@
     data-type-of="<%= billboard.type_of_display %>">
     <%= render partial: "shared/billboard_header", locals: { billboard: billboard } %>
     <div class="p-1 pt-3 text-styles text-styles--billboard">
-      <%= billboard.processed_html.html_safe %>
+      <%= billboard.processed_html_final.html_safe %>
     </div>
   </div>
 <% end %>

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1742,4 +1742,38 @@ RSpec.describe Article do
                                                                                      false).once
     end
   end
+
+  describe "#processed_html_final" do
+    let(:prior_domain) { "https://old.cdn.com" }
+    let(:new_domain) { "https://new.cdn.com" }
+
+    before do
+      allow(ApplicationConfig).to receive(:[]).with("PRIOR_CLOUDFLARE_IMAGES_DOMAIN").and_return(prior_domain)
+      allow(ApplicationConfig).to receive(:[]).with("CLOUDFLARE_IMAGES_DOMAIN").and_return(new_domain)
+    end
+
+    context "when the prior domain and new domain are both present" do
+      it "replaces instances of the prior domain with the new domain" do
+        article.processed_html = "Here is an image <img src='#{prior_domain}/image1.jpg'> and another <img src='#{prior_domain}/image2.jpg'>."
+        expect(article.processed_html_final).to eq("Here is an image <img src='#{new_domain}/image1.jpg'> and another <img src='#{new_domain}/image2.jpg'>.")
+      end
+
+      it "does not modify text if the prior domain is not present in the processed_html" do
+        article.processed_html = "Content with no images or domains."
+        expect(article.processed_html_final).to eq("Content with no images or domains.")
+      end
+    end
+
+    context "when the application configuration for the domains is blank" do
+      before do
+        allow(ApplicationConfig).to receive(:[]).with("PRIOR_CLOUDFLARE_IMAGES_DOMAIN").and_return(nil)
+        allow(ApplicationConfig).to receive(:[]).with("CLOUDFLARE_IMAGES_DOMAIN").and_return(nil)
+      end
+
+      it "returns the original processed_html unchanged" do
+        article.processed_html = "Content with the old domain #{prior_domain}."
+        expect(article.processed_html_final).to eq("Content with the old domain #{prior_domain}.")
+      end
+    end
+  end
 end

--- a/spec/models/billboard_spec.rb
+++ b/spec/models/billboard_spec.rb
@@ -696,4 +696,38 @@ RSpec.describe Billboard do
       end
     end
   end
+
+  describe "#processed_html_final" do
+    let(:prior_domain) { "https://old.cdn.com" }
+    let(:new_domain) { "https://new.cdn.com" }
+
+    before do
+      allow(ApplicationConfig).to receive(:[]).with("PRIOR_CLOUDFLARE_IMAGES_DOMAIN").and_return(prior_domain)
+      allow(ApplicationConfig).to receive(:[]).with("CLOUDFLARE_IMAGES_DOMAIN").and_return(new_domain)
+    end
+
+    context "when the prior domain and new domain are both present" do
+      it "replaces instances of the prior domain with the new domain" do
+        billboard.processed_html = "Here is an image <img src='#{prior_domain}/image1.jpg'> and another <img src='#{prior_domain}/image2.jpg'>."
+        expect(billboard.processed_html_final).to eq("Here is an image <img src='#{new_domain}/image1.jpg'> and another <img src='#{new_domain}/image2.jpg'>.")
+      end
+
+      it "does not modify text if the prior domain is not present in the processed_html" do
+        billboard.processed_html = "Content with no images or domains."
+        expect(billboard.processed_html_final).to eq("Content with no images or domains.")
+      end
+    end
+
+    context "when the application configuration for the domains is blank" do
+      before do
+        allow(ApplicationConfig).to receive(:[]).with("PRIOR_CLOUDFLARE_IMAGES_DOMAIN").and_return(nil)
+        allow(ApplicationConfig).to receive(:[]).with("CLOUDFLARE_IMAGES_DOMAIN").and_return(nil)
+      end
+
+      it "returns the original processed_html unchanged" do
+        billboard.processed_html = "Content with the old domain #{prior_domain}."
+        expect(billboard.processed_html_final).to eq("Content with the old domain #{prior_domain}.")
+      end
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -627,9 +627,10 @@ false).once
   let(:new_domain) { "https://new.cdn.com" }
 
   before do
+    allow(ApplicationConfig).to receive(:[]).and_call_original # allow all real calls by default
     allow(ApplicationConfig).to receive(:[]).with("PRIOR_CLOUDFLARE_IMAGES_DOMAIN").and_return(prior_domain)
     allow(ApplicationConfig).to receive(:[]).with("CLOUDFLARE_IMAGES_DOMAIN").and_return(new_domain)
-  end
+    end
 
   context "when the prior domain and new domain are both present" do
     it "replaces instances of the prior domain with the new domain" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -621,4 +621,38 @@ RSpec.describe Comment do
 false).once
     end
   end
+
+  describe "#processed_html_final" do
+  let(:prior_domain) { "https://old.cdn.com" }
+  let(:new_domain) { "https://new.cdn.com" }
+
+  before do
+    allow(ApplicationConfig).to receive(:[]).with("PRIOR_CLOUDFLARE_IMAGES_DOMAIN").and_return(prior_domain)
+    allow(ApplicationConfig).to receive(:[]).with("CLOUDFLARE_IMAGES_DOMAIN").and_return(new_domain)
+  end
+
+  context "when the prior domain and new domain are both present" do
+    it "replaces instances of the prior domain with the new domain" do
+      comment.processed_html = "Here is an image <img src='#{prior_domain}/image1.jpg'> and another <img src='#{prior_domain}/image2.jpg'>."
+      expect(comment.processed_html_final).to eq("Here is an image <img src='#{new_domain}/image1.jpg'> and another <img src='#{new_domain}/image2.jpg'>.")
+    end
+
+    it "does not modify text if the prior domain is not present in the processed_html" do
+      comment.processed_html = "Content with no images or domains."
+      expect(comment.processed_html_final).to eq("Content with no images or domains.")
+    end
+  end
+
+  context "when the application configuration for the domains is blank" do
+    before do
+      allow(ApplicationConfig).to receive(:[]).with("PRIOR_CLOUDFLARE_IMAGES_DOMAIN").and_return(nil)
+      allow(ApplicationConfig).to receive(:[]).with("CLOUDFLARE_IMAGES_DOMAIN").and_return(nil)
+    end
+
+    it "returns the original processed_html unchanged" do
+      comment.processed_html = "Content with the old domain #{prior_domain}."
+      expect(comment.processed_html_final).to eq("Content with the old domain #{prior_domain}.")
+    end
+  end
+end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This is a specific, sort of hacky way to migrate some traffic to a new subdomain. It uses code repetition and only adjusts for this one-off change needed. It also does not yet work on pages. It is there for the main traffic-getting areas.

However, I think this could be modified to be a more flexible/context-specific final method. So this method could be used as a future interface for some changes.