### PR TITLE
Adjust roll up logic to step through billboards for the day

### DIFF
--- a/app/services/billboard_event_rollup.rb
+++ b/app/services/billboard_event_rollup.rb
@@ -4,16 +4,23 @@ class BillboardEventRollup
   STATEMENT_TIMEOUT = ENV.fetch("STATEMENT_TIMEOUT_BULK_DELETE", 10_000).to_i.seconds / 1_000.to_f
 
   class EventAggregator
-    Compact = Struct.new(:events, :user_id, :billboard_id, :category, :context_type) do
+    Compact = Struct.new(:events, :user_id, :display_ad_id, :category, :context_type) do
       def to_h
-        super.except(:events).merge({ counts_for: events.sum(&:counts_for) })
+        {
+          user_id: user_id,
+          display_ad_id: display_ad_id,
+          category: category,
+          context_type: context_type,
+          counts_for: events.sum(&:counts_for),
+          created_at: events.first.created_at
+        }
       end
     end
 
     def initialize
       @aggregator = Hash.new do |level1, user_id|
-        level1[user_id] = Hash.new do |level2, billboard_id|
-          level2[billboard_id] = Hash.new do |level3, category|
+        level1[user_id] = Hash.new do |level2, display_ad_id|
+          level2[display_ad_id] = Hash.new do |level3, category|
             level3[category] = Hash.new do |level4, context_type|
               level4[context_type] = []
             end
@@ -23,17 +30,17 @@ class BillboardEventRollup
     end
 
     def <<(event)
-      @aggregator[event.user_id][event.billboard_id][event.category][event.context_type] << event
+      @aggregator[event.user_id][event.display_ad_id][event.category][event.context_type] << event
     end
 
     def each
-      @aggregator.each_pair do |user_id, grouped_by_user_id|
-        grouped_by_user_id.each_pair do |billboard_id, grouped_by_billboard_id|
-          grouped_by_billboard_id.each_pair do |category, grouped_by_category|
+      @aggregator.each_pair do |user_id, grouped_by_user|
+        grouped_by_user.each_pair do |display_ad_id, grouped_by_display_ad|
+          grouped_by_display_ad.each_pair do |category, grouped_by_category|
             grouped_by_category.each_pair do |context_type, events|
               next unless events.size > 1
 
-              yield Compact.new(events, user_id, billboard_id, category, context_type)
+              yield Compact.new(events, user_id, display_ad_id, category, context_type)
             end
           end
         end
@@ -50,62 +57,63 @@ class BillboardEventRollup
   end
 
   def initialize(relation:)
-    @aggregator = EventAggregator.new
     @relation = relation
   end
 
-  attr_reader :aggregator, :relation
+  attr_reader :relation
 
   def rollup(date, batch_size: 1000)
     created = []
 
-    # Ensure SET LOCAL is done within a transaction block
+    # Wrap the entire method in a transaction and set statement timeout
     relation.transaction do
-      relation.connection.execute("SET LOCAL statement_timeout = '#{STATEMENT_TIMEOUT}s'") # Set temp timeout
+      relation.connection.execute("SET LOCAL statement_timeout = '#{STATEMENT_TIMEOUT}s'")
 
-      relation.where(created_at: date.all_day).in_batches(of: batch_size) do |rows_batch|
-        aggregate_into_groups(rows_batch).each do |compacted_events|
-          created << compact_records(date, compacted_events)
+      # Get list of display_ad_ids for the date within the transaction
+      display_ad_ids = relation.where(created_at: date.all_day).distinct.pluck(:display_ad_id)
+
+      display_ad_ids.each do |display_ad_id|
+        aggregator = EventAggregator.new
+
+        # Process events for each display_ad_id within a transaction
+        relation.transaction(requires_new: true) do
+          relation.connection.execute("SET LOCAL statement_timeout = '#{STATEMENT_TIMEOUT}s'")
+
+          relation.where(display_ad_id: display_ad_id, created_at: date.all_day).in_batches(of: batch_size) do |batch|
+            batch.each do |event|
+              aggregator << event
+            end
+          end
+
+          aggregator.each do |compacted_events|
+            created << compact_records(compacted_events)
+          end
+        ensure
+          relation.connection.execute("RESET statement_timeout")
         end
       end
+    ensure
+      relation.connection.execute("RESET statement_timeout")
     end
 
     created
-  ensure
-    relation.connection.execute("RESET statement_timeout") # Reset after fetching batches
   end
 
   private
 
-  def aggregate_into_groups(rows)
-    # SET LOCAL inside transaction
-    relation.transaction do
-      relation.connection.execute("SET LOCAL statement_timeout = '#{STATEMENT_TIMEOUT}s'") # Set temp timeout
-
-      rows.in_batches.each_record do |event|
-        aggregator << event
-      end
-    end
-
-    aggregator
-  ensure
-    relation.connection.execute("RESET statement_timeout") # Reset after aggregation
-  end
-
-  def compact_records(date, compacted)
+  def compact_records(compacted)
     result = nil
 
     relation.transaction do
-      relation.connection.execute("SET LOCAL statement_timeout = '#{STATEMENT_TIMEOUT}s'") # Set temp timeout
-      result = relation.create!(compacted.to_h) do |event|
-        event.created_at = date
-      end
+      relation.connection.execute("SET LOCAL statement_timeout = '#{STATEMENT_TIMEOUT}s'")
 
-      relation.where(id: compacted.events).delete_all
+      result = relation.create!(compacted.to_h)
+
+      relation.where(id: compacted.events.map(&:id)).delete_all
+    ensure
+      relation.connection.execute("RESET statement_timeout")
     end
 
     result
-  ensure
-    relation.connection.execute("RESET statement_timeout") # Reset to the default timeout
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This adds a step to step through unique billboard Ids before running the roll up logic to reduce the likelihood of timeouts on individual queries.