### PR TITLE
Remove outer transaction from billboard rollup

### DIFF
--- a/app/assets/stylesheets/widgets.scss
+++ b/app/assets/stylesheets/widgets.scss
@@ -393,6 +393,7 @@
     display: inline-block;
     vertical-align: middle;
     align-self: center;
+    background: var(--body-bg);
   }
 
   &__indicator {

--- a/spec/services/billboard_event_rollup_spec.rb
+++ b/spec/services/billboard_event_rollup_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe BillboardEventRollup, type: :service do
     end.not_to raise_error
 
     expect(BillboardEvent.connection).to have_received(:execute)
-      .with("SET LOCAL statement_timeout = '#{BillboardEventRollup::STATEMENT_TIMEOUT}s'").thrice
+      .with("SET LOCAL statement_timeout = '#{BillboardEventRollup::STATEMENT_TIMEOUT}s'").twice
     expect(BillboardEvent.connection).to have_received(:execute).with("RESET statement_timeout").thrice
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

This removes the outer transaction so that if other transactions succeed, they don't all have to succeed.

This is idempotent so it's okay if it only partially finishes.