### PR TITLE
Max 18 day look back for inactive returning user

### DIFF
--- a/app/models/articles/feeds.rb
+++ b/app/models/articles/feeds.rb
@@ -48,6 +48,8 @@ module Articles
       time_of_second_latest_page_view = user&.page_views&.second_to_last&.created_at
       return days_since_published.days.ago unless time_of_second_latest_page_view
 
+      # If they have a page view *well in the past*, let's go max 18 days look back.
+      time_of_second_latest_page_view = 18.days.ago if time_of_second_latest_page_view < 18.days.ago
       time_of_second_latest_page_view - number_of_hours_to_offset_users_latest_article_views.hours
     end
 

--- a/spec/services/articles/feeds_spec.rb
+++ b/spec/services/articles/feeds_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Articles::Feeds do
       it { is_expected.to be_a ActiveSupport::TimeWithZone }
     end
 
-    context "when the user has page views" do
+    context "when the user has recent page views" do
       let(:user) { instance_double(User) }
       let(:page_viewed_at) { Time.current }
       let(:expected_result) do
@@ -59,6 +59,20 @@ RSpec.describe Articles::Feeds do
       end
 
       it { is_expected.to eq(expected_result) }
+    end
+
+    context "when the user has very old page views" do
+      let(:user) { instance_double(User) }
+      let(:page_viewed_at) { 35.days.ago } # Very old page view
+      let(:expected_result) do
+        18.days.ago
+      end
+
+      before do
+        allow(user).to receive_message_chain(:page_views, :second_to_last, :created_at).and_return(page_viewed_at)
+      end
+
+      it { is_expected.to be_within(24.hours).of(expected_result) }
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Currently when a user has any page views (i.e. not new user) but they haven't recorded one in a long time, we look back in the whole timeframe since their last page view, which is not ideal behavior.

This caps the lookback at 18 days.