### PR TITLE
Add email history and draft to internal emails

### DIFF
--- a/app/controllers/admin/emails_controller.rb
+++ b/app/controllers/admin/emails_controller.rb
@@ -46,7 +46,7 @@ module Admin
     private
 
     def email_params
-      params.permit(:subject, :body, :audience_segment_id, :type_of, :drip_day)
+      params.permit(:subject, :body, :audience_segment_id, :type_of, :drip_day, :status)
     end
   end
 end

--- a/app/mailers/custom_mailer.rb
+++ b/app/mailers/custom_mailer.rb
@@ -1,6 +1,13 @@
 class CustomMailer < ApplicationMailer
   default from: -> { email_from(I18n.t("mailers.custom_mailer.from")) }
 
+  has_history extra: lambda {
+    {
+      email_id: params[:email_id]
+    }
+  }, only: :custom_email
+
+
   def custom_email
     @user = params[:user]
     @content = Email.replace_merge_tags(params[:content], @user)

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -1,5 +1,6 @@
 class Email < ApplicationRecord
   belongs_to :audience_segment, optional: true
+  has_many :email_messages
 
   after_create :deliver_to_users
 
@@ -7,7 +8,7 @@ class Email < ApplicationRecord
   validates :body, presence: true
 
   enum type_of: { one_off: 0, newsletter: 1, onboarding_drip: 2 }
-  enum status: { draft: 0, active: 1, inactive: 2, archived: 3 } # Not implemented yet anywhere
+  enum status: { draft: 0, active: 1, delivered: 2 } # Not implemented yet anywhere
 
   BATCH_SIZE = Rails.env.production? ? 1000 : 10
 
@@ -28,8 +29,23 @@ class Email < ApplicationRecord
     end
   end
 
+  def bg_color
+    case status
+    when "draft"
+      # soft yellow hex
+      "#fff9c0"
+    when "active"
+      # soft green hex
+      "#d4f7dc"
+    when "delivered"
+      # soft blue hex
+      "#d4e7f7"
+    end
+  end
+
   def deliver_to_users
     return if type_of == "onboarding_drip"
+    return if status != "active"
 
     user_scope = if audience_segment
                    audience_segment.users.registered.joins(:notification_setting)
@@ -42,7 +58,9 @@ class Email < ApplicationRecord
                  end
 
     user_scope.find_in_batches(batch_size: BATCH_SIZE) do |users_batch|
-      Emails::BatchCustomSendWorker.perform_async(users_batch.map(&:id), subject, body, type_of)
+      Emails::BatchCustomSendWorker.perform_async(users_batch.map(&:id), subject, body, type_of, id)
     end
+
+    self.update_columns(status: "delivered")
   end
 end

--- a/app/models/email_message.rb
+++ b/app/models/email_message.rb
@@ -1,5 +1,6 @@
 class EmailMessage < Ahoy::Message
   belongs_to :feedback_message, optional: true
+  belongs_to :email, optional: true
 
   def self.find_for_reports(feedback_message_ids)
     select(:to, :subject, :content, :utm_campaign, :feedback_message_id)

--- a/app/views/admin/emails/_form.html.erb
+++ b/app/views/admin/emails/_form.html.erb
@@ -20,6 +20,12 @@
       <%= number_field_tag :drip_day, @email.drip_day, class: "crayons-textfield", autocomplete: "off" %>
     </div>
 
+    <%# status select %>
+    <div class="crayons-field">
+      <%= label_tag :status, "Status:", class: "crayons-field__label" %>
+      <%= select_tag :status, options_for_select(Email.statuses.keys, selected: @email.status), class: "crayons-textfield", autocomplete: "off" %>
+    </div>
+
     <div class="crayons-field">
       <%= label_tag :body, "Body Content:", class: "crayons-field__label" %>
       <%= text_area_tag :body, @email.body, size: "100x5", class: "crayons-textfield" %>
@@ -45,6 +51,11 @@
           </p>
           <p>
             <code>*|name|*</code>, <code>*|username|*</code>, <code>*|email|*</code>
+          </p>
+          <p>
+            <strong>
+              One-off and newsletter emails will be sent immediately once marked as "Active". Onboarding drip emails will be sent on the specified day when marked "Active".
+            </strong>
           </p>
         </div>
       <% end %>

--- a/app/views/admin/emails/edit.html.erb
+++ b/app/views/admin/emails/edit.html.erb
@@ -1,6 +1,6 @@
 <h1 class="crayons-title mb-4">Make a new Email</h1>
 <% if @email.type_of != "onboarding_drip" %>
-  <div class="crayons-notice--danger4">
+  <div class="crayons-notice crayons-notice--danger p-4 my-2">
     This email is not an onboarding drip email. It has already been sent, and updating it will not have any affect on sent emails.
   </div>
 <% end %>

--- a/app/views/admin/emails/index.html.erb
+++ b/app/views/admin/emails/index.html.erb
@@ -33,7 +33,7 @@
     </thead>
     <tbody class="crayons-card">
       <% @emails.each do |email| %>
-        <tr data-row-id="<%= email.id %>">
+        <tr data-row-id="<%= email.id %>" style="background: <%= email.bg_color %> !important">
           <td><%= email.type_of %> <%= "(#{email.drip_day})" if email.type_of == "onboarding_drip" %></td>
           <td><%= link_to email.subject, admin_email_path(email) %></td>
           <td><%= email.created_at %></td>

--- a/app/workers/emails/batch_custom_send_worker.rb
+++ b/app/workers/emails/batch_custom_send_worker.rb
@@ -4,9 +4,9 @@ module Emails
 
     sidekiq_options queue: :medium_priority, retry: 15
 
-    def perform(user_ids, subject, content, type_of)
+    def perform(user_ids, subject, content, type_of, email_id)
       user_ids.each do |id|
-        CustomMailer.with(user: User.find(id), subject: subject, content: subject, type_of: type_of).custom_email.deliver_now
+        CustomMailer.with(user: User.find(id), subject: subject, content: subject, type_of: type_of, email_id: email_id).custom_email.deliver_now
       end
     end
   end

--- a/app/workers/emails/drip_email_worker.rb
+++ b/app/workers/emails/drip_email_worker.rb
@@ -11,7 +11,7 @@ module Emails
       return unless last_drip_day
 
       (1..last_drip_day).each do |drip_day|
-        email_template = Email.find_by(type_of: "onboarding_drip", drip_day: drip_day)
+        email_template = Email.find_by(type_of: "onboarding_drip", drip_day: drip_day, status: "active")
         next unless email_template
 
         start_time = ((drip_day * 24) + 1).hours.ago
@@ -23,7 +23,7 @@ module Emails
           recent_email_sent = EmailMessage.where(user: user).where("sent_at >= ?", 12.hours.ago).exists?
           next if recent_email_sent
 
-          CustomMailer.with(user: user, subject: email_template.subject, content: email_template.body, type_of: email_template.type_of)
+          CustomMailer.with(user: user, subject: email_template.subject, content: email_template.body, type_of: email_template.type_of, email_id: email_template.id)
             .custom_email.deliver_now
         end
       end

--- a/db/migrate/20241202170357_add_email_reference_to_email_messages.rb
+++ b/db/migrate/20241202170357_add_email_reference_to_email_messages.rb
@@ -1,0 +1,6 @@
+class AddEmailReferenceToEmailMessages < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def change
+    add_reference :ahoy_messages, :email, type: :bigint, index: { algorithm: :concurrently }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_22_200310) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_02_170357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -34,6 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_22_200310) do
   create_table "ahoy_messages", force: :cascade do |t|
     t.datetime "clicked_at", precision: nil
     t.text "content"
+    t.bigint "email_id"
     t.bigint "feedback_message_id"
     t.string "mailer"
     t.datetime "sent_at", precision: nil
@@ -47,6 +48,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_22_200310) do
     t.string "utm_medium"
     t.string "utm_source"
     t.string "utm_term"
+    t.index ["email_id"], name: "index_ahoy_messages_on_email_id"
     t.index ["feedback_message_id"], name: "index_ahoy_messages_on_feedback_message_id"
     t.index ["to"], name: "index_ahoy_messages_on_to"
     t.index ["token"], name: "index_ahoy_messages_on_token"

--- a/spec/factories/emails.rb
+++ b/spec/factories/emails.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :email do
     subject { Faker::Lorem.sentence }
     body { Faker::Lorem.sentence }
+    status { "active" }
   end
 end

--- a/spec/mailers/custom_mailer_spec.rb
+++ b/spec/mailers/custom_mailer_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe CustomMailer, type: :mailer do
       end
     end
 
+    context "when there is an email passed" do
+      let(:email) { create(:email, type_of: "onboarding_drip") }
+      let(:second_user) { create(:user) }
+
+      before do
+
+        allow(ForemInstance).to receive(:smtp_enabled?).and_return(true)
+      end
+
+      it "tracks the email_id after delivery" do
+        described_class.with(user: second_user, content: content, subject: subject, email_id: email.id).custom_email.deliver_now
+        expect(email.reload.email_messages.count).to eq(1)
+      end
+    end
+
     context "when SendGrid is disabled" do
       before do
         allow(ForemInstance).to receive(:sendgrid_enabled?).and_return(false)

--- a/spec/models/email_spec.rb
+++ b/spec/models/email_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe Email, type: :model do
       end
     end
 
+    context "when status is not 'active'" do
+      let(:email) { create(:email, status: "draft") }
+
+      it "does not enqueue any jobs" do
+        expect(Emails::BatchCustomSendWorker).not_to receive(:perform_async)
+        email.send(:deliver_to_users)
+      end
+    end
+
     context "when there is an audience segment" do
       let(:audience_segment) { create(:audience_segment) }
       let(:email) { create(:email, audience_segment: audience_segment) }
@@ -41,7 +50,8 @@ RSpec.describe Email, type: :model do
           [user_with_notifications.id],
           email.subject,
           email.body,
-          email.type_of
+          email.type_of,
+          email.id
         )
         email.send(:deliver_to_users)
       end
@@ -60,7 +70,8 @@ RSpec.describe Email, type: :model do
           [user_with_notifications.id],
           email.subject,
           email.body,
-          email.type_of
+          email.type_of,
+          email.id
         )
         email.send(:deliver_to_users)
       end
@@ -95,13 +106,15 @@ RSpec.describe Email, type: :model do
           users_batch_1.map(&:id),
           email.subject,
           email.body,
-          email.type_of
+          email.type_of,
+          email.id
         )
         expect(Emails::BatchCustomSendWorker).to receive(:perform_async).with(
           users_batch_2.map(&:id),
           email.subject,
           email.body,
-          email.type_of
+          email.type_of,
+          email.id
         )
 
         email.send(:deliver_to_users)

--- a/spec/workers/emails/drip_email_worker_spec.rb
+++ b/spec/workers/emails/drip_email_worker_spec.rb
@@ -44,13 +44,15 @@ RSpec.describe Emails::DripEmailWorker, type: :worker do
         user: @user_day_1_in_window,
         subject: email_template_day_1.subject,
         content: email_template_day_1.body,
-        type_of: email_template_day_1.type_of
+        type_of: email_template_day_1.type_of,
+        email_id: email_template_day_1.id
       ).once
       expect(CustomMailer).to have_received(:with).with(
         user: @user_day_2_in_window,
         subject: email_template_day_2.subject,
         content: email_template_day_2.body,
-        type_of: email_template_day_2.type_of
+        type_of: email_template_day_2.type_of,
+        email_id: email_template_day_2.id
       ).once
 
       expect(mailer).to have_received(:custom_email).twice
@@ -64,13 +66,15 @@ RSpec.describe Emails::DripEmailWorker, type: :worker do
         user: @user_day_1_out_of_window,
         subject: email_template_day_1.subject,
         content: email_template_day_1.body,
-        type_of: email_template_day_1.type_of
+        type_of: email_template_day_1.type_of,
+        email_id: email_template_day_1.id
       )
       expect(CustomMailer).not_to have_received(:with).with(
         user: @user_day_2_out_of_window,
         subject: email_template_day_2.subject,
         content: email_template_day_2.body,
-        type_of: email_template_day_2.type_of
+        type_of: email_template_day_2.type_of,
+        email_id: email_template_day_2.id
       )
     end
 
@@ -90,7 +94,8 @@ RSpec.describe Emails::DripEmailWorker, type: :worker do
         user: @user_recent_email,
         subject: email_template_day_1.subject,
         content: email_template_day_1.body,
-        type_of: email_template_day_1.type_of
+        type_of: email_template_day_1.type_of,
+        email_id: email_template_day_1.id
       )
     end
 
@@ -105,7 +110,8 @@ RSpec.describe Emails::DripEmailWorker, type: :worker do
         user: user_old_email,
         subject: email_template_day_1.subject,
         content: email_template_day_1.body,
-        type_of: email_template_day_1.type_of
+        type_of: email_template_day_1.type_of,
+        email_id: email_template_day_1.id
       )
       expect(mailer).to have_received(:custom_email).exactly(3).times
       expect(message_delivery).to have_received(:deliver_now).exactly(3).times
@@ -119,13 +125,15 @@ RSpec.describe Emails::DripEmailWorker, type: :worker do
         user: @user_day_1_in_window,
         subject: email_template_day_1.subject,
         content: email_template_day_1.body,
-        type_of: email_template_day_1.type_of
+        type_of: email_template_day_1.type_of,
+        email_id: email_template_day_1.id
       ).once
       expect(CustomMailer).to have_received(:with).with(
         user: @user_day_2_in_window,
         subject: email_template_day_2.subject,
         content: email_template_day_2.body,
-        type_of: email_template_day_2.type_of
+        type_of: email_template_day_2.type_of,
+        email_id: email_template_day_2.id
       ).once
 
       # Ensure no emails are sent for drip day 3 (no email template)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds ahoy email history to one-off and drip emails, and adds the ability to modify email status to create "drafts"