### PR TITLE
Add forem_user_signed_in to edge cache check

### DIFF
--- a/app/controllers/auth_pass_controller.rb
+++ b/app/controllers/auth_pass_controller.rb
@@ -68,7 +68,15 @@ class AuthPassController < ApplicationController
         )
         # Set the cookie with the dynamically adjusted domain
         cookies.signed["remember_user_token"] = cookie_values
-  
+
+        cookies[:forem_user_signed_in] = {
+          value: "true",
+          domain: ".#{custom_domain}",
+          httponly: true,
+          secure: ApplicationConfig["FORCE_SSL_IN_RAILS"] == "true",
+          expires: 2.year.from_now
+        }
+
         render json: { success: true, user: { id: user.id, email: user.email } }
       else
         render json: { success: false, error: "User not found" }, status: :unauthorized

--- a/config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl
+++ b/config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl
@@ -1,19 +1,18 @@
 sub vcl_recv {
-  if (req.http.Cookie ~ "remember_user_token") {
-   set req.http.X-Loggedin = "logged-in";
+  if (req.http.Cookie ~ "remember_user_token" || req.http.Cookie ~ "forem_user_signed_in") {
+    set req.http.X-Loggedin = "logged-in";
   } else {
     set req.http.X-Loggedin = "logged-out";
   }
-
 }
 
 sub vcl_fetch {
   # Vary on the custom header, don't add if shield POP already added
   if (beresp.http.Vary !~ "X-Loggedin") {
     if (beresp.http.Vary) {
-	    set beresp.http.Vary = beresp.http.Vary ", X-Loggedin";
+      set beresp.http.Vary = beresp.http.Vary ", X-Loggedin";
     } else {
-	    set beresp.http.Vary = "X-Loggedin";
+      set beresp.http.Vary = "X-Loggedin";
     }
   }
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds another cookie to check for edge cache vary. The `remember_user_token` is sort of a hack and this should give us a cookie to specifically manipulate as needed. Part of ongoing experimentation with token-based auth.