### PR TITLE
Add subforems to notifications

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -27,7 +27,7 @@ class NotificationsController < ApplicationController
                        @user.notifications
                      end
 
-    @notifications = @notifications.order(notified_at: :desc)
+    @notifications = @notifications.from_subforem.order(notified_at: :desc)
 
     # if offset based pagination is invoked by the frontend code, we filter out all earlier ones
     @notifications = @notifications.where("notified_at < ?", notified_at_offset) if notified_at_offset

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -285,6 +285,10 @@ class Comment < ApplicationRecord
     end
   end
 
+  def subforem_id
+    commentable&.subforem_id
+  end
+
   def after_destroy_actions
     Users::BustCacheWorker.perform_async(user_id)
     user.touch(:last_comment_at)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -26,6 +26,16 @@ class Notification < ApplicationRecord
   }
   scope :unread, -> { where(read: false) }
 
+  scope :from_subforem, lambda { |subforem_id = nil|
+    subforem_id ||= RequestStore.store[:subforem_id]
+    if [0, RequestStore.store[:default_subforem_id]].include?(subforem_id.to_i)
+      where("notifications.subforem_id IN (?) OR notifications.subforem_id IS NULL", [nil, subforem_id])
+    else
+      # where(subforem_id: subforem_id)
+      where("notifications.subforem_id = ?", subforem_id)
+    end
+  }
+
   class << self
     def send_new_follower_notification(follow, is_read: false)
       return unless follow && Follow.need_new_follower_notification_for?(follow.followable_type)

--- a/app/models/podcast_episode.rb
+++ b/app/models/podcast_episode.rb
@@ -88,6 +88,10 @@ class PodcastEpisode < ApplicationRecord
     tags.pluck(:keywords_for_search).join
   end
 
+  def subforem_id
+    nil
+  end
+
   ## Useless stubs
   def nil_method
     nil

--- a/app/services/notifications/new_comment/send.rb
+++ b/app/services/notifications/new_comment/send.rb
@@ -31,6 +31,7 @@ module Notifications
             user_id: user_id,
             notifiable_id: comment.id,
             notifiable_type: comment.class.name,
+            subforem_id: comment.commentable.subforem_id,
             action: nil,
             json_data: json_data,
           )

--- a/app/services/notifications/new_mention/send.rb
+++ b/app/services/notifications/new_mention/send.rb
@@ -22,6 +22,7 @@ module Notifications
           user_id: mention.user_id,
           notifiable_id: mention.id,
           notifiable_type: "Mention",
+          subforem_id: mention.mentionable.subforem_id,
           action: nil,
           json_data: json_data,
         )

--- a/app/services/notifications/notifiable_action/send.rb
+++ b/app/services/notifications/notifiable_action/send.rb
@@ -46,6 +46,7 @@ module Notifications
             user_id: follower.id,
             notifiable_id: notifiable.id,
             notifiable_type: notifiable.class.name,
+            subforem_id: notifiable.subforem_id,
             action: action,
             json_data: json_data,
             created_at: now,

--- a/app/services/notifications/reactions/send.rb
+++ b/app/services/notifications/reactions/send.rb
@@ -37,6 +37,7 @@ module Notifications
         notification_params = {
           notifiable_type: reaction.reactable_type,
           notifiable_id: reaction.reactable_id,
+          subforem_id: reaction.reactable.subforem_id,
           action: "Reaction"
         }
         case receiver

--- a/db/migrate/20241221194443_add_subforemid_to_notifications.rb
+++ b/db/migrate/20241221194443_add_subforemid_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddSubforemidToNotifications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :notifications, :subforem_id, :bigint
+  end
+end

--- a/db/migrate/20241221194511_add_subforemid_index_to_notifications.rb
+++ b/db/migrate/20241221194511_add_subforemid_index_to_notifications.rb
@@ -1,0 +1,6 @@
+class AddSubforemidIndexToNotifications < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def change
+    add_index :notifications, :subforem_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_12_151249) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_21_194511) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -749,6 +749,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_12_151249) do
     t.datetime "notified_at", precision: nil
     t.bigint "organization_id"
     t.boolean "read", default: false
+    t.bigint "subforem_id"
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id"
     t.index ["created_at"], name: "index_notifications_on_created_at"
@@ -757,6 +758,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_12_151249) do
     t.index ["notified_at"], name: "index_notifications_on_notified_at"
     t.index ["organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_org_notifiable_and_action_not_null", unique: true, where: "(action IS NOT NULL)"
     t.index ["organization_id", "notifiable_id", "notifiable_type"], name: "index_notifications_on_org_notifiable_action_is_null", unique: true, where: "(action IS NULL)"
+    t.index ["subforem_id"], name: "index_notifications_on_subforem_id"
     t.index ["user_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_on_user_notifiable_and_action_not_null", unique: true, where: "(action IS NOT NULL)"
     t.index ["user_id", "notifiable_id", "notifiable_type"], name: "index_notifications_on_user_notifiable_action_is_null", unique: true, where: "(action IS NULL)"
     t.index ["user_id", "organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_user_id_organization_id_notifiable_action", unique: true

--- a/spec/services/notifications/new_comment/send_spec.rb
+++ b/spec/services/notifications/new_comment/send_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Notifications::NewComment::Send, type: :service do
   let(:user3)                { create(:user) }
   let(:top_level_subscriber) { create(:user) }
   let(:organization)         { create(:organization) }
-  let(:article)              { create(:article, :with_notification_subscription, user_id: user.id) }
+  let(:subforem)             { create(:subforem) }
+  let(:article)              { create(:article, :with_notification_subscription, user_id: user.id, subforem_id: subforem.id) }
   let(:comment)              { create(:comment, commentable: article, user: user2) }
   let(:author_comment)       { create(:comment, commentable: article, user: user) }
   let!(:child_comment)       { create(:comment, commentable: article, parent: comment, user: user3) }
@@ -23,6 +24,7 @@ RSpec.describe Notifications::NewComment::Send, type: :service do
     notification = child_comment.notifications.last
 
     expect(notification.action).to be_nil
+    expect(notification.subforem_id).to eq(subforem.id)
     expect(notification.json_data["user"]["id"]).to eq(child_comment.user.id)
     expect(notification.json_data["user"]["username"]).to eq(child_comment.user.username)
   end

--- a/spec/services/notifications/new_mention/send_spec.rb
+++ b/spec/services/notifications/new_mention/send_spec.rb
@@ -25,7 +25,8 @@ end
 
 RSpec.describe Notifications::NewMention::Send, type: :service do
   let(:user) { create(:user) }
-  let!(:article) { create(:article) }
+  let(:subforem) { create(:subforem) }
+  let!(:article) { create(:article, subforem: subforem) }
   let(:article_author) { article.user }
   let!(:mention) { create(:mention, mentionable: article, user: user) }
 
@@ -44,6 +45,7 @@ RSpec.describe Notifications::NewMention::Send, type: :service do
     expect(notification.notifiable_id).to eq(mention.id)
     expect(notification.user_id).to eq(mention.user.id)
     expect(notification.action).to be_nil
+    expect(notification.subforem_id).to eq(article.subforem_id)
     expect(notification.json_data["user"]["id"]).to eq(article.user.id)
     expect(notification.json_data["user"]["username"]).to eq(article.user.username)
   end

--- a/spec/services/notifications/notifiable_action/send_spec.rb
+++ b/spec/services/notifications/notifiable_action/send_spec.rb
@@ -3,7 +3,8 @@ require "rails_helper"
 RSpec.describe Notifications::NotifiableAction::Send, type: :service do
   let(:user) { create(:user) }
   let(:organization) { create(:organization) }
-  let(:article) { create(:article, user: user, organization: organization) }
+  let(:subforem) { create(:subforem) }
+  let(:article) { create(:article, user: user, organization: organization, subforem: subforem) }
 
   let(:user2) { create(:user) }
   let(:user3) { create(:user) }
@@ -25,6 +26,7 @@ RSpec.describe Notifications::NotifiableAction::Send, type: :service do
       notifications = Notification.where(user_id: user2.id, notifiable_id: article.id, notifiable_type: "Article")
       expect(notifications.size).to eq(1)
       notification = notifications.first
+      expect(notification.subforem_id).to eq(subforem.id)
       expect(notification.action).to eq("Published")
       expect(notification.json_data["article"]["id"]).to eq(article.id)
       expect(notification.json_data["user"]["id"]).to eq(user.id)

--- a/spec/services/notifications/reactions/send_spec.rb
+++ b/spec/services/notifications/reactions/send_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.describe Notifications::Reactions::Send, type: :service do
   let(:user) { create(:user) }
-  let(:article) { create(:article, user: user) }
+  let(:subforem) { create(:subforem) }
+  let(:article) { create(:article, user: user, subforem: subforem) }
   let(:user2) { create(:user) }
   let(:article_reaction) { create(:reaction, reactable: article, user: user2) }
   let(:user3) { create(:user) }
@@ -30,6 +31,7 @@ RSpec.describe Notifications::Reactions::Send, type: :service do
     it "creates a correct notification" do
       result = described_class.call(reaction_data(article_reaction), user)
       notification = Notification.find(result.notification_id)
+      expect(notification.subforem_id).to eq(subforem.id)
       expect(notification.user_id).to eq(user.id)
       expect(notification.notifiable).to eq(article)
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add subforem id to notifications so that you only get notifications associated with your current subforem.