### PR TITLE
Add subforem_id to articles api

### DIFF
--- a/app/controllers/concerns/api/articles_controller.rb
+++ b/app/controllers/concerns/api/articles_controller.rb
@@ -7,7 +7,7 @@ module Api
       title description main_image published_at crossposted_at social_image
       cached_tag_list slug path canonical_url comments_count
       public_reactions_count created_at edited_at last_comment_at published
-      updated_at video_thumbnail_url reading_time
+      updated_at video_thumbnail_url reading_time subforem_id
     ].freeze
 
     ADDITIONAL_SEARCH_ATTRIBUTES_FOR_SERIALIZATION = [
@@ -25,6 +25,7 @@ module Api
       title description main_image published published_at cached_tag_list
       slug path canonical_url comments_count public_reactions_count
       page_views_count crossposted_at body_markdown updated_at reading_time
+      subforem_id
     ].freeze
     private_constant :ME_ATTRIBUTES_FOR_SERIALIZATION
 
@@ -148,7 +149,7 @@ module Api
       allowed_params = [
         :title, :body_markdown, :published, :series,
         :main_image, :canonical_url, :description, { tags: [] },
-        :published_at
+        :published_at, :subforem_id
       ]
       allowed_params << :organization_id if params.dig("article", "organization_id") && allowed_to_change_org_id?
       allowed_params << :clickbait_score if @user.super_admin?

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -773,6 +773,19 @@ RSpec.describe "Api::V1::Articles" do
         expect(article.collection.user).to eq(user)
       end
 
+      it "creates an article belonging to a subforem" do
+        subforem = create(:subforem)
+        second_subforem = create(:subforem, domain: "other-domain.com")
+        post_article(
+          title: Faker::Book.title,
+          body_markdown: "Yo ho ho",
+          subforem_id: second_subforem.id,
+        )
+        expect(response).to have_http_status(:created)
+        article = Article.find(response.parsed_body["id"])
+        expect(article.subforem).to eq(second_subforem)
+      end
+
       it "creates article within a series using the front matter" do
         body_markdown = file_fixture("article_published_series.txt").read
         expect do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Extends articles api to include subforem