### PR TITLE
Don't show reactions in admin older than two weeks or on posts already fully moderated

### DIFF
--- a/app/controllers/admin/feedback_messages_controller.rb
+++ b/app/controllers/admin/feedback_messages_controller.rb
@@ -86,18 +86,20 @@ module Admin
                         ["invalid", 10]
                       end
       q = Reaction.includes(:user, :reactable)
-        .where(category: "vomit", status: status)
-        .live_reactable
-        .select(:id, :user_id, :reactable_type, :reactable_id)
-        .order(Arel.sql("
-          CASE reactable_type
-            WHEN 'User' THEN 0
-            WHEN 'Comment' THEN 1
-            WHEN 'Article' THEN 2
-            ELSE 3
-          END,
-          reactions.reactable_id ASC"))
-        .limit(limit)
+            .where(category: "vomit", status: status)
+            .where("reactables.score > ?", -150)
+            .where("reactions.created_at >= ?", 2.weeks.ago)
+            .live_reactable
+            .select(:id, :user_id, :reactable_type, :reactable_id)
+            .order(Arel.sql("
+              CASE reactable_type
+                WHEN 'User' THEN 0
+                WHEN 'Comment' THEN 1
+                WHEN 'Article' THEN 2
+                ELSE 3
+              END,
+              reactions.reactable_id ASC"))
+            .limit(limit)
       # don't show reactions where the reactable was not found
       q.select(&:reactable)
     end

--- a/app/controllers/admin/feedback_messages_controller.rb
+++ b/app/controllers/admin/feedback_messages_controller.rb
@@ -89,7 +89,7 @@ module Admin
         .where(category: "vomit", status: status)
         .live_reactable
         .select(:id, :user_id, :reactable_type, :reactable_id)
-        .where("created_at > ?", 2.week.ago)
+        .where("reactions.created_at > ?", 2.week.ago)
         .order(Arel.sql("
           CASE reactable_type
             WHEN 'User' THEN 0


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adjust to not show old reactions or reactions on reactables "already fully moderated"