### PR TITLE
Remove [Boost] from mod center and signed out context

### DIFF
--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -234,6 +234,14 @@
         color: var(--card-color);
       }
     }
+    .crayons-story__innertitle-boost {
+      font-size: calc(var(--fs-xs) + 1px);
+      color: var(--color-secondary);
+      font-weight: var(--fw-medium);
+      a {
+        display: inline-block;
+      }
+    }
   }
 
   &__flare-tag {

--- a/app/controllers/moderations_controller.rb
+++ b/app/controllers/moderations_controller.rb
@@ -38,7 +38,7 @@ class ModerationsController < ApplicationController
     elsif @members == "not_new"
       articles = articles.where("nth_published_by_author > 3")
     end
-    @articles = articles.includes(:user).to_json(JSON_OPTIONS)
+    @articles = articles.includes(:user).reject { |article| article.title == "[Boost]" }.to_json(JSON_OPTIONS)
     @tag = Tag.find_by(name: params[:tag]) || not_found if params[:tag].present?
     @current_user_tags = current_user.moderator_for_tags
     @current_user_following_tags = current_user.currently_following_tags.pluck(:name) - @current_user_tags

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -284,6 +284,7 @@ class StoriesController < ApplicationController
       feed = Articles::Feeds::LargeForemExperimental.new(page: @page, tag: params[:tag])
       @featured_story, @stories = feed.featured_story_and_default_home_feed(user_signed_in: user_signed_in?)
       @stories = @stories.to_a
+      @stories = @stories.reject { |article| article.title == "[Boost]" }
     end
 
     @pinned_article = pinned_article&.decorate

--- a/app/javascript/articles/components/ContentTitle.jsx
+++ b/app/javascript/articles/components/ContentTitle.jsx
@@ -16,7 +16,7 @@ export const ContentTitle = ({ article }) => (
         </span>
       )}
       {/* eslint-disable-next-line react/no-danger */}
-      <span dangerouslySetInnerHTML={{ __html: filterXSS(article.title) }} />
+      {article.title === '[Boost]' ? <span class='crayons-story__innertitle-boost'>Boosted by <a href={`/${article.user.username}`}>{article.user.name}</a></span> : <span dangerouslySetInnerHTML={{ __html: filterXSS(article.title) }} />}
     </a>
   </h3>
 );

--- a/app/javascript/articles/components/Meta.jsx
+++ b/app/javascript/articles/components/Meta.jsx
@@ -11,6 +11,10 @@ export const Meta = ({ article, organization }) => {
     'organization-article-index',
   );
 
+  if (article.title === '[Boost]') {
+    return '';
+  }
+
   return (
     <div className="crayons-story__meta">
       <div className="crayons-story__author-pic">

--- a/spec/requests/moderations_spec.rb
+++ b/spec/requests/moderations_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe "Moderations" do
       expect { get "/mod/dsdsdsweweedsdseweww" }.to raise_exception(ActiveRecord::RecordNotFound)
     end
 
+    it "only includes articles which do not have [Boost] in as title" do
+      non_boost_article = create(:article, title: "Not Boost")
+      boost_article = create(:article, title: "[Boost]")
+      get "/mod"
+      expect(response.body).to include(CGI.escapeHTML(non_boost_article.title))
+      expect(response.body).not_to include(CGI.escapeHTML(boost_article.title))
+    end
+
     it "renders not_found when an article can't be found" do
       expect do
         get "/#{trusted_user.username}/dsdsdsweweedsdseweww/mod/"

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe "StoriesIndex" do
       renders_proper_sidebar(navigation_link)
     end
 
+    it "Does not render article with [Boost] as the title" do
+      boost_article = create(:article, title: "[Boost]", score: 1000, featured: true, type_of: "status", body_markdown: "", main_image: "")
+      non_boost_article = create(:article, title: "Not a boost article", score: 1000, featured: true)
+
+      get "/"
+      expect(response.body).not_to include(CGI.escapeHTML(boost_article.title))
+      expect(response.body).to include(CGI.escapeHTML(non_boost_article.title))
+    end
+
     it "doesn't render a featured scheduled article" do
       article = create(:article, featured: true, published_at: 1.hour.from_now)
       get "/"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

[Boost] posts do not need to be seen in these contexts or moderated like they are now.

Soon we'll have some visual adjustments so the [Boost] language doesn't show up like now.