### PR TITLE
Immediately set dark mode when detected

### DIFF
--- a/app/assets/javascripts/initializers/initializeBodyData.js
+++ b/app/assets/javascripts/initializers/initializeBodyData.js
@@ -48,14 +48,23 @@ function fetchBaseData() {
             JSON.stringify(client_geolocation);
           document.body.dataset.default_email_optin_allowed =
             default_email_optin_allowed;
+          const userJson = JSON.parse(user);
           browserStoreCache('set', user);
+          document.body.className = userJson.config_body_class;
+
+          if (userJson.config_body_class.includes('dark-theme') && document.getElementById('dark-mode-style')) {
+            document.getElementById('body-styles').innerHTML = '<style>'+document.getElementById('dark-mode-style').innerHTML+'</style>'
+          } else {
+            document.getElementById('body-styles').innerHTML = '<style>'+document.getElementById('light-mode-style').innerHTML+'</style>'
+          }
+    
 
           setTimeout(() => {
             if (typeof ga === 'function') {
-              ga('set', 'userId', JSON.parse(user).id);
+              ga('set', 'userId', userJson.id);
             }
             if (typeof gtag === 'function') {
-              gtag('set', 'user_Id', JSON.parse(user).id);
+              gtag('set', 'user_Id', userJson.id);
             }
           }, 400);
         } else if (checkUserLoggedIn()){

--- a/app/assets/javascripts/initializers/initializeBodyData.js
+++ b/app/assets/javascripts/initializers/initializeBodyData.js
@@ -52,7 +52,7 @@ function fetchBaseData() {
           browserStoreCache('set', user);
           document.body.className = userJson.config_body_class;
 
-          if (userJson.config_body_class.includes('dark-theme') && document.getElementById('dark-mode-style')) {
+          if (userJson.config_body_class && userJson.config_body_class.includes('dark-theme') && document.getElementById('dark-mode-style')) {
             document.getElementById('body-styles').innerHTML = '<style>'+document.getElementById('dark-mode-style').innerHTML+'</style>'
           } else {
             document.getElementById('body-styles').innerHTML = '<style>'+document.getElementById('light-mode-style').innerHTML+'</style>'

--- a/app/views/layouts/_user_config.html.erb
+++ b/app/views/layouts/_user_config.html.erb
@@ -1,3 +1,13 @@
+<div id="dark-mode-style" style="display:none;">
+  <%= Rails.application.assets["themes/dark.css"].to_s.squish.html_safe %>
+</div>
+<div id="light-mode-style" style="display:none;">
+  :root {
+    --accent-brand-lighter-rgb: <%= Color::CompareHex.new([Settings::UserExperience.primary_brand_color_hex]).brightness(1.35, only_values: true) %>;
+    --accent-brand-rgb: <%= Color::CompareHex.new([Settings::UserExperience.primary_brand_color_hex]).brightness(1, only_values: true) %>;
+    --accent-brand-darker-rgb: <%= Color::CompareHex.new([Settings::UserExperience.primary_brand_color_hex]).brightness(0.8, only_values: true) %>;
+  }
+</div>
 <script>
   try {
     const bodyClass = localStorage.getItem('config_body_class');
@@ -7,7 +17,7 @@
       document.body.className = bodyClass;
 
       if (bodyClass.includes('dark-theme')) {
-        document.getElementById('body-styles').innerHTML = '<style><%= Rails.application.assets["themes/dark.css"].to_s.squish.html_safe %></style>';
+        document.getElementById('body-styles').innerHTML = '<style>'+document.getElementById('dark-mode-style').innerHTML+'</style>';
       }
 
       if (bodyClass.includes('open-dyslexic-article-body')) { // Preloading custom font for anticipated use


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Currently when dark mode is detected when signining in/changing settings etc it only shows up on refresh due to deferring to the local stored one. This changes so it will immediately change when detected, allowing local one to be the "eager" version.