### PR TITLE
Skip boost in sidebar posts

### DIFF
--- a/app/views/sidebars/_homepage_content.html.erb
+++ b/app/views/sidebars/_homepage_content.html.erb
@@ -13,6 +13,7 @@
         </header>
         <div>
           <% @active_discussions.each do |plucked_article| %>
+            <% next if plucked_article[1] == "[Boost]" %>
             <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
           <% end %>
         </div>
@@ -37,10 +38,12 @@
         <div>
           <% if tag.name == "help" %>
             <% Article.active_help.limit(5).pluck(:path, :title, :comments_count, :created_at, :subforem_id).each do |plucked_article| %>
+              <% next if plucked_article[1] == "[Boost]" %>
               <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
             <% end %>
           <% else %>
             <% active_threads(tags: [tag.name], time_ago: Timeframe.datetime(params[:timeframe]), count: 5).each do |plucked_article| %>
+              <% next if plucked_article[1] == "[Boost]" %>
               <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: true %>
             <% end %>
           <% end %>
@@ -62,6 +65,7 @@
           <div class="widget-body">
             <div class="widget-link-list">
               <% boostable_posts.each do |plucked_article| %>
+                <% next if plucked_article[1] == "[Boost]" %>
                 <%= render "articles/widget_list_item", plucked_article: plucked_article, show_comment_count: false %>
               <% end %>
             </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Quick fix to remove plain "boost" posts from sidebar, could be improved later for DRY.