### PR TITLE
Add optional accent color for nav bar

### DIFF
--- a/app/models/settings/user_experience.rb
+++ b/app/models/settings/user_experience.rb
@@ -27,6 +27,13 @@ module Settings
       },
       color_contrast: true
     }
+    setting :accent_background_color_hex, type: :string, default: nil, validates: {
+      format: {
+        with: HEX_COLOR_REGEX,
+        message: proc { I18n.t("models.settings.user_experience.message") }
+      },
+      color_contrast: true
+    }
 
     # cover images
     setting :cover_image_height, type: :integer, default: 420

--- a/app/views/layouts/_top_bar.html.erb
+++ b/app/views/layouts/_top_bar.html.erb
@@ -1,4 +1,13 @@
 <div class="navigation-progress" id="navigation-progress"></div>
+<% if Settings::UserExperience.accent_background_color_hex.present? && Settings::UserExperience.accent_background_color_hex != "#ffffff" %>
+  <style>
+    body:not(.dark-theme) #topbar {background: <%= Settings::UserExperience.accent_background_color_hex%> }
+    body:not(.dark-theme) #topbar .c-link, body:not(.dark-theme) #topbar .c-cta, body:not(.dark-theme) #topbar .c-btn {color: white !important; border-color: white !important}
+    body:not(.dark-theme) #topbar .crayons-header--search .c-btn { color: <%= Settings::UserExperience.accent_background_color_hex%> !important; }
+    body:not(.dark-theme) #topbar .crayons-dropdown .c-link { color: #333 !important; }
+    </style>
+<% end %>
+
 <header id="topbar" class="crayons-header topbar print-hidden">
   <span id="route-change-target" tabindex="-1"></span>
   <a href="#main-content" class="skip-content-link"><%= t("views.main.header.skip") %></a>

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe "StoriesIndex" do
       expect(response.body).to include("head content")
     end
 
+    it "renders topbar styles if Settings::UserExperience.accent_background_color_hex is set" do
+      allow(Settings::UserExperience).to receive(:accent_background_color_hex).and_return("#000000")
+      get "/"
+      expect(response.body).to include("body:not(.dark-theme) #topbar {background")
+    end
+
+    it "does not render topbar styles if Settings::UserExperience.accent_background_color_hex is not set" do
+      allow(Settings::UserExperience).to receive(:accent_background_color_hex).and_return(nil)
+      get "/"
+      expect(response.body).not_to include("body:not(.dark-theme) #topbar {background")
+    end
+
     it "renders bottom of body content if present" do
       allow(Settings::UserExperience).to receive(:bottom_of_body_content).and_return("bottom of body content")
       get "/"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allow admins to set "accent background color" — currently only used for navbar.