### PR TITLE
Add "Read More" button for extra long billboards

### DIFF
--- a/app/assets/stylesheets/billboards.scss
+++ b/app/assets/stylesheets/billboards.scss
@@ -53,6 +53,18 @@
   display: block;
 }
 
+.long-bb-body {
+  max-height: calc(100vh - 200px);
+  overflow: hidden;
+}
+.long-bb-bottom {
+  height: 180px;
+  background: linear-gradient(to top, var(--card-bg), transparent);
+  margin-top: -180px;
+  position:relative;
+  z-index: 5;
+}
+
 .popover-billboard {
   z-index: var(--z-popover);
   animation: popoverEnter 0.5s;

--- a/app/javascript/actionsPanel/initializeActionsPanelToggle.js
+++ b/app/javascript/actionsPanel/initializeActionsPanelToggle.js
@@ -39,7 +39,6 @@ export function initializeActionsPanel(user, path) {
     );
     modActionsMenuBtns &&
       Array.from(modActionsMenuBtns).forEach((btn) => {
-        console.log('click')
         btn.addEventListener('click', toggleModActionsMenu);
       });
   }

--- a/app/javascript/packs/billboard.js
+++ b/app/javascript/packs/billboard.js
@@ -62,6 +62,7 @@ async function generateBillboard(element) {
           element.innerHTML = '';
         }
       }
+
       executeBBScripts(element);
       implementSpecialBehavior(element);
       setupBillboardInteractivity();
@@ -69,6 +70,22 @@ async function generateBillboard(element) {
       // The original code is still in the asset pipeline, so is not importable.
       // This could be refactored to be importable as we continue that migration.
       // eslint-disable-next-line no-undef
+
+      document.querySelectorAll('.billboard-readmore-button').forEach((button) => {
+        // If the card is shorter than 100vh - 200px we immediately hide the button and related classes
+        if (button.closest('.crayons-card').querySelector('.text-styles').offsetHeight < window.innerHeight - 200) {
+          button.closest('.crayons-card').querySelector('.text-styles').classList.remove('long-bb-body');
+          button.closest('.crayons-card').querySelector('.long-bb-bottom').classList.add('hidden');
+          button.closest('.crayons-card').querySelector('.billboard-readmore-button').classList.add('hidden');
+        }
+
+        button.addEventListener('click', () => {
+          button.closest('.crayons-card').querySelector('.text-styles').classList.remove('long-bb-body');
+          button.closest('.crayons-card').querySelector('.long-bb-bottom').classList.add('hidden');
+          button.closest('.crayons-card').querySelector('.billboard-readmore-button').classList.add('hidden');
+        });
+      });  
+
       observeBillboards();
     } catch (error) {
       if (!/NetworkError/i.test(error.message)) {

--- a/app/views/shared/_billboard.html.erb
+++ b/app/views/shared/_billboard.html.erb
@@ -1,3 +1,17 @@
+<style>
+  .long-bb-body {
+    max-height: calc(100vh - 200px);
+    overflow: hidden;
+  }
+  .long-bb-bottom {
+    height: 180px;
+    background: linear-gradient(to top, var(--card-bg), transparent);
+    margin-top: -180px;
+    position:relative;
+    z-index: 5;
+  }
+</style>
+
 <% if billboard.template == "plain" %>
   <div
     style="<%= billboard.style_string %>"
@@ -87,7 +101,8 @@
     </div>
   </div>
 <% elsif billboard.placement_area == "post_body_bottom" %>
-  <div class="crayons-card crayons-card--secondary crayons-bb billboard js-billboard body-billboard mb-2 mt-6"
+  <% long_bb = billboard.processed_html_final.size > 750 %>
+  <div class="crayons-card crayons-card--secondary crayons-bb js-billboard body-billboard mb-2 mt-6"
     style="<%= billboard.style_string %>"
     data-display-unit data-id="<%= billboard.id %>"
     data-category-click="<%= BillboardEvent::CATEGORY_CLICK %>"
@@ -106,9 +121,17 @@
         </button>
       <% end %>
     </div>
-    <div class="p-1 pt-3 text-styles text-styles--billboard">
+    <div class="p-1 pt-3 text-styles text-styles--billboard <%= "long-bb-body" if long_bb %>">
       <%= billboard.processed_html_final.html_safe %>
     </div>
+    <% if long_bb %>
+      <div class="long-bb-bottom"></div>
+      <div class="crayons-card__footer">
+        <button class="c-cta c-cta--branded billboard-readmore-button">
+          Read More
+        </button>
+      </div>
+    <% end %>
   </div>
 <% else %>
   <div class="crayons-card crayons-card--secondary crayons-bb bb-placement js-billboard"

--- a/spec/requests/billboards_spec.rb
+++ b/spec/requests/billboards_spec.rb
@@ -284,6 +284,20 @@ RSpec.describe "Billboards" do
       end
     end
 
+    context "when the placement area is post_body_bottom" do
+      it "contains read more button when body is long" do
+        billboard = create_billboard(placement_area: "post_body_bottom", body_markdown: "a " * 800)
+        get article_billboard_path(username: article.username, slug: article.slug, placement_area: "post_body_bottom")
+        expect(response.body).to include "text-styles--billboard long-bb-body"
+      end
+
+      it "does not contain read more button when body is short" do  
+        billboard = create_billboard(placement_area: "post_body_bottom", body_markdown: "a " * 100)
+        get article_billboard_path(username: article.username, slug: article.slug, placement_area: "post_body_bottom")
+        expect(response.body).not_to include "text-styles--billboard long-bb-body"
+      end
+    end
+
     context "when the placement area is page_fixed_bottom" do
       let(:page) { create(:page) }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds button for "Read More" for long billboards in below-post-body so they don't take up too much room.