### PR TITLE
Extend cache window for reactions endpoint

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -41,6 +41,7 @@ class ReactionsController < ApplicationController
     }.merge(result).to_json
 
     set_surrogate_key_header params.to_s unless session_current_user_id
+    set_cache_control_headers(2.weeks.to_i, stale_if_error: 1.day.to_i) unless session_current_user_id
   end
 
   # @todo Extract this method into a service class (or classes)

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "Reactions" do
   let(:article) { create(:article, user: user) }
   let(:comment) { create(:comment, commentable: article) }
 
-  let(:max_age) { 1.day.to_i }
-  let(:stale_if_error) { 26_400 }
+  let(:max_age) { 2.weeks.to_i }
+  let(:stale_if_error) { 1.day.to_i }
 
   describe "GET /reactions?article_id=:article_id" do
     before do
@@ -146,7 +146,7 @@ RSpec.describe "Reactions" do
       it "sets Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).to include(
           "Cache-Control" => "public, no-cache",
-          "Surrogate-Control" => "max-age=#{2.weeks.to_i}, stale-if-error=#{1.day.to_i}",
+          "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
         )
       end
     end

--- a/spec/requests/reactions_spec.rb
+++ b/spec/requests/reactions_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Reactions" do
       it "sets Fastly cache control and surrogate control headers" do
         expect(response.headers.to_hash).to include(
           "Cache-Control" => "public, no-cache",
-          "Surrogate-Control" => "max-age=#{max_age}, stale-if-error=#{stale_if_error}",
+          "Surrogate-Control" => "max-age=#{2.weeks.to_i}, stale-if-error=#{1.day.to_i}",
         )
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Since reactions are fetched async in this context and because it's a consistent json response, the cache window can be extended. If we need to bulk expire the cache we could easily do so with a fingerprint in the url later.