### PR TITLE
Add final shuffling weight

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -11,7 +11,7 @@ class Article < ApplicationRecord
   resourcify
 
   include StringAttributeCleaner.nullify_blanks_for(:canonical_url, on: :before_save)
-  DEFAULT_FEED_PAGINATION_WINDOW_SIZE = 50
+  DEFAULT_FEED_PAGINATION_WINDOW_SIZE = 30
 
   # When we cache an entity, either {User} or {Organization}, these are the names of the attributes
   # we cache.

--- a/app/services/articles/feeds/custom.rb
+++ b/app/services/articles/feeds/custom.rb
@@ -35,8 +35,19 @@ module Articles
           end
         end
 
+        articles = weighted_shuffle(articles, @feed_config.shuffle_weight) if @feed_config.shuffle_weight.positive?
         articles
       end
+
+      def weighted_shuffle(arr, shuffle_weight)
+        # Each element gets a new sort key: its original index plus a random offset.
+        # We choose the random offset uniformly from -2*shuffle_weight to 2*shuffle_weight.
+        # The average absolute offset then is (2*shuffle_weight)/2 = shuffle_weight.
+        arr.each_with_index.sort_by do |item, index|
+          index + (rand * (4 * shuffle_weight) - 2 * shuffle_weight)
+        end.map(&:first)
+      end
+      
 
       # Preserve the public interface
       alias feed default_home_feed

--- a/db/migrate/20250306204509_add_shuffle_weight_to_feed_configs.rb
+++ b/db/migrate/20250306204509_add_shuffle_weight_to_feed_configs.rb
@@ -1,0 +1,5 @@
+class AddShuffleWeightToFeedConfigs < ActiveRecord::Migration[7.0]
+  def change
+    add_column :feed_configs, :shuffle_weight, :float, default: 0.0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_03_04_214343) do
+ActiveRecord::Schema[7.0].define(version: 2025_03_06_204509) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -574,6 +574,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_03_04_214343) do
     t.float "recency_weight", default: 1.0
     t.float "recent_article_suppression_rate", default: 0.0, null: false
     t.float "score_weight", default: 1.0
+    t.float "shuffle_weight", default: 0.0, null: false
     t.float "tag_follow_weight", default: 1.0
     t.datetime "updated_at", null: false
     t.float "user_follow_weight", default: 1.0

--- a/spec/requests/stories/feeds_spec.rb
+++ b/spec/requests/stories/feeds_spec.rb
@@ -62,6 +62,22 @@ RSpec.describe "Stories::Feeds" do
           "tag_list" => article.decorate.cached_tag_list_array,
         )
       end
+
+      it "returns feed when feed_strategy is configured" do
+        allow(Settings::UserExperience).to receive(:feed_strategy).and_return("configured")
+
+        get stories_feed_path
+
+        expect(response_article).to include(
+          "id" => article.id,
+          "title" => title,
+          "user_id" => user.id,
+          "user" => hash_including("name" => user.name),
+          "organization_id" => organization.id,
+          "organization" => hash_including("name" => organization.name),
+          "tag_list" => article.decorate.cached_tag_list_array,
+        )
+      end
     end
 
     context "when rendering an article that is pinned" do

--- a/spec/services/articles/feeds/custom_spec.rb
+++ b/spec/services/articles/feeds/custom_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Articles::Feeds::Custom, type: :service do
   # In test environment, TIME_AGO_MAX is 90.days.ago.
   let(:user) { create(:user) }
   # Stub feed_config to return a string rather than a Proc.
-  let(:feed_config) { double("FeedConfig") }
+  let(:feed_config) { build(:feed_config) }
   before do
     allow(feed_config).to receive(:score_sql).with(user).and_return("articles.score")
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Shuffle weight takes the final result and moves elements around slightly to make two consecutive loads more likely to be slightly different.

This is different than the randomness weight which operates on the whole original query.

Since this starts at `0.0` it won't be live unless a config variant is created with another number.