### PR TITLE
Tabulate billboard counts when taking down

### DIFF
--- a/app/models/billboard.rb
+++ b/app/models/billboard.rb
@@ -85,7 +85,7 @@ class Billboard < ApplicationRecord
   after_save :generate_billboard_name
   after_save :refresh_audience_segment, if: :should_refresh_audience_segment?
   after_save :update_links_with_bb_param
-  after_save :update_event_counts_when_taking_down, if: -> { saved_change_to_published? && saved_change_to_approved? && !published && !approved }
+  after_save :update_event_counts_when_taking_down, if: -> { being_taken_down? }
 
   scope :approved_and_published, -> { where(approved: true, published: true) }
 
@@ -378,6 +378,15 @@ class Billboard < ApplicationRecord
       impressions_count: num_impressions
     )
   end
+
+  def being_taken_down?
+    # Only trigger if both approved and published were true before this save.
+    return false unless approved_before_last_save && published_before_last_save
+  
+    # Check if approved changed from true to false or published changed from true to false.
+    (saved_change_to_approved? && !approved) || (saved_change_to_published? && !published)
+  end
+  
 
   def generate_billboard_name
     return unless name.nil?

--- a/spec/models/billboard_spec.rb
+++ b/spec/models/billboard_spec.rb
@@ -731,4 +731,46 @@ RSpec.describe Billboard do
       end
     end
   end
+
+  describe "#update_event_counts_when_taking_down" do
+    let!(:active_billboard) { create(:billboard, published: true, approved: true) }
+    let!(:impression_event) { create(:billboard_event, billboard: active_billboard, category: "impression", counts_for: 2) }
+    let!(:click_event) { create(:billboard_event, billboard: active_billboard, category: "click", counts_for: 1) }
+      let!(:conversion_event) do
+        create(:billboard_event, billboard: active_billboard, category: "conversion", counts_for: 3)
+      end
+
+    it "updates success_rate, clicks_count and impressions_count when taken down" do
+      # Mock the calculation to isolate this test
+      allow(active_billboard).to receive(:update_event_counts_when_taking_down).and_call_original
+
+      # Simulate taking down the billboard (unpublishing and unapproving)
+      active_billboard.update(published: false, approved: false)
+
+      # Assert that the counts and success_rate have been updated
+      active_billboard.reload
+      expect(active_billboard.impressions_count).to eq(2) # From impression_event
+      expect(active_billboard.clicks_count).to eq(1)  # From click_event
+      expected_success_rate = (1 + (3 * 0.5)).to_f / 2 # (clicks + conversion_success) / impressions
+      expect(active_billboard.success_rate).to eq(expected_success_rate)
+      expect(active_billboard).to have_received(:update_event_counts_when_taking_down)
+    end
+
+    it "does not update if published state has not changed" do
+      allow(active_billboard).to receive(:update_event_counts_when_taking_down).and_call_original
+            active_billboard.update(approved: false) # Only change one
+            expect(active_billboard).not_to have_received(:update_event_counts_when_taking_down)
+    end
+
+    it "does not update if approved state has not changed" do
+        allow(active_billboard).to receive(:update_event_counts_when_taking_down).and_call_original
+        active_billboard.update(published: false)
+        expect(active_billboard).not_to have_received(:update_event_counts_when_taking_down)
+    end
+    it "does not update if it is re-approved/published" do
+        allow(active_billboard).to receive(:update_event_counts_when_taking_down).and_call_original
+          active_billboard.update(published: true, approved: true)
+          expect(active_billboard).not_to have_received(:update_event_counts_when_taking_down)
+    end
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When a billboard changes from live to non-live we should tabulate its events, currently we miss some of the last events due to not calculating as a last step essentially.