### PR TITLE
Removal of Default Alt Image Description

### DIFF
--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -22,7 +22,7 @@ module MarkdownProcessor
 
     def initialize(content, source: nil, user: nil,
                    liquid_tag_options: {})
-      @content = content
+      @content = content.gsub(/!\[Image Description\]/i, '![]')
       @source = source
       @user = user
       @liquid_tag_options = liquid_tag_options.merge({ source: @source, user: @user })

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -662,4 +662,14 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
         )
     end
   end
+
+  it "removes alt text if it's the default 'Image Description'" do
+      markdown = '![Image Description](https://example.com/image.jpg)'
+      rendered_html = generate_and_parse_markdown(markdown)
+    
+      expect(rendered_html).to include('<img')
+      expect(rendered_html).to include('src="https://example.com/image.jpg"')
+      expect(rendered_html).not_to include('alt="Image Description"')
+  end
+
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
To avoid having a lot of uploaded images, for example, either on articles or comments, with the default "Image description" alternative text, the Markdown parser was updated to remove this default text from the markdown body content.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #21680 

## QA Instructions, Screenshots, Recordings

The parser modification was ran using the gem `dip` and an according test was added, which can be run from the root of the project like so:
`dip rspec spec/services/markdown_processor/parser_spec.rb` 


## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests


## [optional] What gif best describes this PR or how it makes you feel?

![This gif actually has an alternative text of Stanley being a happy man](https://media.giphy.com/media/CyoQdbc7FHqqTpkSPI/giphy.gif)
