### PR TITLE
refactor: Remove Listing.feature_enabled? method and usage

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -51,12 +51,10 @@ module ApplicationHelper
   # @note [@jeremyf] - making an assumption, namely that the only navigation oriented feature is the
   #                    Listing.  If this changes, adjust this method accordingly.  Normally I like to have method return
   def navigation_link_is_for_an_enabled_feature?(link:)
-    return true if Listing.feature_enabled?
+    listings_url = URL.url(try(:listings_path) || "/listings") # listings_path helper might eventually be removed too
 
-    # The "/listings" is an assumption on the routing.  So let's first try :listings_path.
-    listings_url = URL.url(try(:listings_path) || "/listings")
     return false if listings_url == URL.url(link.url)
-
+    
     true
   end
 

--- a/app/helpers/rate_limit_checker_helper.rb
+++ b/app/helpers/rate_limit_checker_helper.rb
@@ -85,13 +85,6 @@ module RateLimitCheckerHelper
         title: I18n.t("helpers.rate_limit_checker_helper.mention.title"),
         description: I18n.t("helpers.rate_limit_checker_helper.mention.description")
       },
-      listing_creation: {
-        enabled: Listing.feature_enabled?,
-        min: 1,
-        placeholder: 1,
-        title: I18n.t("helpers.rate_limit_checker_helper.listing.title"),
-        description: I18n.t("helpers.rate_limit_checker_helper.listing.description")
-      },
       organization_creation: {
         enabled: true,
         min: 1,

--- a/app/liquid_tags/unified_embed/tag.rb
+++ b/app/liquid_tags/unified_embed/tag.rb
@@ -25,10 +25,6 @@ module UnifiedEmbed
     def self.new(tag_name, input, parse_context)
       stripped_input = ActionController::Base.helpers.strip_tags(input).strip
 
-      # when Listings are disabled, it makes little sense to perform a validate_link
-      # network call.
-      handle_listings_disabled!(stripped_input)
-
       # Before matching against the embed registry, we check if the link
       # is valid (e.g. no typos).
       # If the link is invalid, we raise an error encouraging the user to
@@ -80,12 +76,6 @@ module UnifiedEmbed
       end
     rescue SocketError
       raise StandardError, I18n.t("liquid_tags.unified_embed.tag.invalid_url")
-    end
-
-    def self.handle_listings_disabled!(link)
-      return unless link.start_with?("#{URL.url}/listings/") && !Listing.feature_enabled?
-
-      raise StandardError, I18n.t("liquid_tags.unified_embed.tag.listings_disabled")
     end
 
     def self.safe_user_agent(agent = Settings::Community.community_name)

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -53,9 +53,6 @@ class Listing < ApplicationRecord
   #
   # @return [TrueClass] if the Listing is enabled for this Forem
   # @return [FalseClass] if the Listing is disabled for this Forem
-  def self.feature_enabled?
-    FeatureFlag.enabled?(:listing_feature)
-  end
 
   # Wrapping the column accessor names for consistency. Aliasing did not work.
   def listing_category_id

--- a/app/views/dashboards/_actions.html.erb
+++ b/app/views/dashboards/_actions.html.erb
@@ -65,15 +65,6 @@
       </a>
     </li>
 
-    <%- if Listing.feature_enabled? %>
-    <li>
-      <a class="crayons-link crayons-link--block" href="/listings/dashboard" data-no-instant>
-        <%= t("views.dashboard.actions.listings") %>
-        <%= crayons_icon_tag("external-link", class: "ml-1") %>
-      </a>
-    </li>
-    <%- end %>
-
     <%- if policy(Article).has_existing_articles_or_can_create_new_ones? %>
     <li>
       <a class="crayons-link crayons-link--block" href="<%= dashboard_analytics_path %>">

--- a/app/views/dashboards/_analytics.html.erb
+++ b/app/views/dashboards/_analytics.html.erb
@@ -15,11 +15,4 @@
     <strong class="fs-2xl m:fs-3xl lh-tight color-base-90"><%= num_views > 500 ? number_with_delimiter(num_views, delimiter: ",") : t("views.dashboard.summary.lt_500") %></strong>
     <span class="color-base-60 block fs-base"><%= t("views.dashboard.summary.views") %></span>
   </div>
-
-  <%- if Listing.feature_enabled? %>
-  <div class="crayons-card crayons-card--secondary p-3 m:p-6">
-    <strong class="fs-2xl m:fs-3xl lh-tight color-base-90"><%= @user.listings.size %></strong>
-    <span class="color-base-60 block fs-base"><%= t("views.dashboard.summary.listings") %></span>
-  </div>
-  <%- end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,9 +40,7 @@ Rails.application.routes.draw do
 
     # The lambda (e.g. `->`) allows for dynamic checking.  In other words we check with each
     # request.
-    constraints(->(_req) { Listing.feature_enabled? }) do
       draw :listing
-    end
 
     namespace :stories, defaults: { format: "json" } do
       resource :feed, only: [:show] do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -132,28 +132,31 @@ RSpec.describe ApplicationHelper do
   describe "#navigation_link_is_for_an_enabled_feature?" do
     subject(:method_call) { helper.navigation_link_is_for_an_enabled_feature?(link: link) }
 
-    let(:url) { URL.url("/somehwere") }
-    let(:link) { build(:navigation_link, url: url) }
+    context "when the link does NOT point to /listings" do
+      let(:link) { build(:navigation_link, url: URL.url("/some-other-path")) }
 
-    context "when Listing feature is enabled" do
-      before { allow(Listing).to receive(:feature_enabled?).and_return(true) }
-
+      # The method should now always return true for non-listing paths
       it { is_expected.to be_truthy }
     end
 
-    context "when Listing feature is disabled and link not for listing" do
-      before { allow(Listing).to receive(:feature_enabled?).and_return(false) }
+    context "when the link DOES point to /listings" do
+      let(:link) { build(:navigation_link, url: URL.url("/listings")) }
 
-      it { is_expected.to be_truthy }
-    end
-
-    context "when Listing feature is disabled and link is for /listings" do
-      let(:url) { URL.url("/listings") }
-
-      before { allow(Listing).to receive(:feature_enabled?).and_return(false) }
-
+      # The method should now always return false for the /listings path
       it { is_expected.to be_falsey }
     end
+
+    # Optional: Add a test case if listings_path helper exists vs direct URL
+    # context "when the link uses listings_path helper" do
+    #   before do
+    #     # Stub listings_path if it still exists and you want to test it,
+    #     # otherwise this context isn't strictly needed if /listings URL covers it.
+    #     allow(helper).to receive(:try).with(:listings_path).and_return("/listings")
+    #   end
+    #   let(:link) { build(:navigation_link, url: URL.url("/listings")) }
+    #
+    #   it { is_expected.to be_falsey }
+    # end
   end
 
   describe "#beautified_url" do

--- a/spec/liquid_tags/unified_embed/tag_spec.rb
+++ b/spec/liquid_tags/unified_embed/tag_spec.rb
@@ -135,15 +135,6 @@ RSpec.describe UnifiedEmbed::Tag, type: :liquid_tag do
     expect(OpenGraphTag).to have_received(:new)
   end
 
-  it "raises an error when Listings are disabled and a listing URL is embedded" do
-    allow(Listing).to receive(:feature_enabled?).and_return(false)
-    listing_url = "#{URL.url}/listings/#{listing.slug}"
-
-    expect do
-      Liquid::Template.parse("{% embed #{listing_url} %}")
-    end.to raise_error(StandardError, "Listings are disabled on this Forem; cannot embed a listing URL")
-  end
-
   it "sanitizes community_name into safe user-agent string" do
     unsafe = "Some of this.is_not_safe (but that's okay?) 🌱"
     result = described_class.safe_user_agent(unsafe)

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -9,12 +9,6 @@ RSpec.describe Listing do
   # This may apply default parser on area that should not use it.
   after { ActsAsTaggableOn.default_parser = ActsAsTaggableOn::DefaultParser }
 
-  describe "class methods" do
-    subject(:klass) { described_class }
-
-    it { is_expected.to respond_to(:feature_enabled?) }
-  end
-
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_presence_of(:body_markdown) }
   it { is_expected.to have_many(:credits) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -189,9 +189,6 @@ RSpec.configure do |config|
   # We want our test suite to behave as though it's enabled by default.  This rspec configuration
   # helps with that.  I envision this to be a placeholder.  But we need something to get the RFC out
   # the door (https://github.com/forem/rfcs/issues/291).
-  config.before do
-    allow(Listing).to receive(:feature_enabled?).and_return(true)
-  end
 
   config.before do
     stub_request(:any, /res.cloudinary.com/).to_rack("dsdsdsds")


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor <!-- Removing dead code and its usages -->
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR continues the incremental removal of the deprecated Listings feature by focusing on the now-obsolete `Listing.feature_enabled?` class method.

The method itself is removed from the `Listing` model. All calls to this method across various helpers, views, liquid tags, and route constraints have also been removed, along with associated conditional logic that is no longer relevant.

Additionally, related test code was cleaned up:
- The test for `Listing.feature_enabled?` in `listing_spec.rb` was removed.
- A global spec helper stubbing `Listing.feature_enabled?` in `rails_helper.rb` was removed.
- Specs for modified helpers (`application_helper_spec.rb`) were updated.
- Specs for liquid tags (`unified_embed/tag_spec.rb`) were updated/removed where they tested logic dependent on the feature flag.
- An error in the `UnifiedEmbed::Tag` revealed during testing (caused by the removal of the flag check) was also fixed.

## Related Tickets & Documents

- Related Issue #21624

## QA Instructions, Screenshots, Recordings

## Added/updated tests?

- [x] Yes <!-- Existing tests were modified/removed to reflect the removed code/logic -->
- [ ] No, and this is why: _please replace this line with details on why tests have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?