### PR TITLE
Prevent Sign-out Confirmation Modal From Appearing After Re-login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -219,6 +219,11 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     if current_user.saw_onboarding
       path = request.env["omniauth.origin"] || stored_location_for(resource) || root_path(signin: "true")
+
+      if URI.parse(path).path == "/signout_confirm"
+        path = root_path(signin: "true")
+      end
+
       signin_param = { "signin" => "true" } # the "signin" param is used by the service worker
 
       uri = Addressable::URI.parse(path)

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -41,6 +41,26 @@ RSpec.describe "Sessions", type: :request do
       expect(user.current_sign_in_at).to be_nil
       expect(user.current_sign_in_ip).to be_nil
     end
+
+    it "redirects to root path if stored location is /signout_confirm" do
+      allow_any_instance_of(ApplicationController).to receive(:stored_location_for).and_return("/signout_confirm")
+
+      post user_session_path, params: {
+        user: {
+          email: user.email,
+          password: user.password
+        }
+      }
+
+      # Devise normally redirects to a default or configured path on success.
+      expect(response).to have_http_status(:found)
+      # Check that the user is redirected to the root path.
+      expect(response).to redirect_to(root_path(signin: 'true'))
+      # Reload from DB to observe changes from user.update_tracked_fields!(request).
+      user.reload
+      expect(user.current_sign_in_at).not_to be_nil
+      expect(user.current_sign_in_ip).not_to be_nil
+    end
   end
 
   describe "DELETE /users/sign_out" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

After signing out and immediately signing back in, users were redirected to the "/signout_confirm" path, resulting in the sign-out confirmation modal appearing again. The problem stemmed from the stored location persisting as "/signout_confirm", causing an unintended user experience.

To resolve this, the `after_sign_in_path_for` method in `ApplicationController` has been updated. Now, if the stored location is "/signout_confirm", the user is redirected to the root path with the `signin=true` parameter, ensuring an expected sign-in process.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #21753

## QA Instructions, Screenshots, Recordings

1. Sign out of the application.
2. Immediately sign back in.
3. Confirm that you are redirected to the homepage without encountering the sign-out confirmation modal again.

This modification was ran using the `dip` gem and an according test was added, which can be run from the root of the project using the command:
`dip rspec spec/requests/sessions_spec.rb`

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] What gif best describes this PR or how it makes you feel?

![Shaq](https://github.com/user-attachments/assets/ad6bb681-f1d0-4983-9b3e-15adbc9275e0)
