### PR TITLE
Remove old emails hourly instead of daily

### DIFF
--- a/app/models/email_message.rb
+++ b/app/models/email_message.rb
@@ -7,7 +7,7 @@ class EmailMessage < Ahoy::Message
       .where(feedback_message_id: feedback_message_ids)
   end
 
-  def self.fast_destroy_old_retained_email_deliveries(destroy_before_timestamp = 3.months.ago)
+  def self.fast_destroy_old_retained_email_deliveries(destroy_before_timestamp = 2.months.ago)
     # We remove email delivery records periodically, except some we retain long term.
     # We generally want to retain emails directly sent by human admins.
     # The only email currently sent manually are those that are tied directly to a feedback message.

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -135,8 +135,8 @@ remove_old_notifications:
   cron: "0 5 * * *"
   class: "Notifications::RemoveOldNotificationsWorker"
 remove_old_emails:
-  description: "Deletes old emails we don't need to retain from the database (runs daily at 06:00 UTC)"
-  cron: "0 6 * * *"
+  description: "Deletes old emails we don't need to retain from the database (runs hourly at the 18th minute after the hour)"
+  cron: "18 * * * *"
   class: "Emails::RemoveOldEmailsWorker"
 sync_credits_counter_cache:
   description: "Synchronizes counter caches for credits (runs daily at 16:00 UTC)"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

We have a script that only removes 50000 emails total and runs daily — this creates an issue where we do not get caught up with email clean out. This adjusts so we run hourly instead. If we're done with necessary deletions then we will just start and stop this.

Also adjust to look back 2 months instead of 3.