### PR TITLE
Add function for deleting old visit analytics

### DIFF
--- a/app/workers/visits/remove_old_visits_worker.rb
+++ b/app/workers/visits/remove_old_visits_worker.rb
@@ -1,0 +1,11 @@
+module Visits
+  class RemoveOldVisitsWorker
+    include Sidekiq::Job
+
+    sidekiq_options queue: :low_priority, retry: 10
+
+    def perform
+      EmailMessage.fast_destroy_old_retained_email_deliveries
+    end
+  end
+end

--- a/app/workers/visits/remove_old_visits_worker.rb
+++ b/app/workers/visits/remove_old_visits_worker.rb
@@ -5,7 +5,7 @@ module Visits
     sidekiq_options queue: :low_priority, retry: 10
 
     def perform
-      EmailMessage.fast_destroy_old_retained_email_deliveries
+      Visit.fast_destroy_old_visits
     end
   end
 end

--- a/spec/models/ahoy/visit_spec.rb
+++ b/spec/models/ahoy/visit_spec.rb
@@ -10,5 +10,13 @@ RSpec.describe Ahoy::Visit do
       it { is_expected.to have_many(:events).class_name("Ahoy::Event").dependent(:destroy) }
       it { is_expected.to belong_to(:user).optional }
     end
+
+    describe "#fast_destroy_old_notifications" do
+      it "bulk deletes visits older than given timestamp" do
+        allow(BulkSqlDelete).to receive(:delete_in_batches)
+        described_class.fast_destroy_old_visits("a_time")
+        expect(BulkSqlDelete).to have_received(:delete_in_batches).with(a_string_including("< 'a_time'"))
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Add the ability to delete old ahoy visits (not in use anywhere, but can be called manually)