### PR TITLE
Add logic for alternative subforem drip emails

### DIFF
--- a/app/workers/emails/drip_email_worker.rb
+++ b/app/workers/emails/drip_email_worker.rb
@@ -1,8 +1,11 @@
+# app/workers/emails/drip_email_worker.rb
 module Emails
   class DripEmailWorker
     include Sidekiq::Job
 
     sidekiq_options queue: :medium_priority, retry: 15
+
+    # Treat nil or zero as default grouping
 
     def perform
       return unless FeatureFlag.enabled?("onboarding_drip_emails")
@@ -10,25 +13,54 @@ module Emails
       last_drip_day = Email.where(type_of: "onboarding_drip").maximum(:drip_day)
       return unless last_drip_day
 
-      (1..last_drip_day).each do |drip_day|
-        email_template = Email.find_by(type_of: "onboarding_drip", drip_day: drip_day, status: "active")
-        next unless email_template
 
+      default_onboarding_ids = [nil, Subforem.cached_default_id]
+
+      (1..last_drip_day).each do |drip_day|
         start_time = ((drip_day * 24) + 1).hours.ago
-        end_time = (drip_day * 24).hours.ago
+        end_time   = (drip_day * 24).hours.ago
 
         users = User.where(registered_at: start_time..end_time)
 
         users.each do |user|
-          next unless user.notification_setting.email_newsletter # Stop sending if user not subscribed to newsletter field
+          # skip if unsubscribed or recently emailed
+          next unless user.notification_setting.email_newsletter
+          next if EmailMessage.where(user: user)
+                              .where("sent_at >= ?", 12.hours.ago)
+                              .exists?
 
-          recent_email_sent = EmailMessage.where(user: user).where("sent_at >= ?", 12.hours.ago).exists?
-          next if recent_email_sent
+          # pick template based on user's onboarding_subforem_id
+          email_template = if default_onboarding_ids.include?(user.onboarding_subforem_id)
+                             Email.where(
+                               type_of: "onboarding_drip",
+                               drip_day: drip_day,
+                               status: "active"
+                             )
+                             .where(onboarding_subforem_id: default_onboarding_ids)
+                             .order(:id)
+                             .first
+                           else
+                             Email.find_by(
+                               type_of: "onboarding_drip",
+                               drip_day: drip_day,
+                               status: "active",
+                               onboarding_subforem_id: user.onboarding_subforem_id
+                             )
+                           end
 
-          CustomMailer.with(user: user, subject: email_template.subject, content: email_template.body, type_of: email_template.type_of, email_id: email_template.id)
-            .custom_email.deliver_now
+          next unless email_template
+
+          CustomMailer.with(
+            user:       user,
+            subject:    email_template.subject,
+            content:    email_template.body,
+            type_of:    email_template.type_of,
+            email_id:   email_template.id
+          )
+          .custom_email
+          .deliver_now
         rescue StandardError => e
-          Rails.logger.error("Error sending drip email to user #{user.id}: #{e.message}")
+          Rails.logger.error("Error sending drip email to user \#{user.id}: \#{e.message}")
         end
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds the ability to have alternate onboarding emails (no UI yet, just backend)