### PR TITLE
Fix article destroy action

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -32,7 +32,7 @@ class Comment < ApplicationRecord
   counter_culture :commentable
   counter_culture :user
 
-  has_many :mentions, as: :mentionable, inverse_of: :mentionable, dependent: :destroy
+  has_many :mentions, as: :mentionable, inverse_of: :mentionable, dependent: :delete_all
   has_many :notifications, as: :notifiable, inverse_of: :notifiable, dependent: :delete_all
   has_many :notification_subscriptions, as: :notifiable, inverse_of: :notifiable, dependent: :destroy
   before_validation :evaluate_markdown, if: -> { body_markdown }

--- a/app/services/articles/destroyer.rb
+++ b/app/services/articles/destroyer.rb
@@ -10,7 +10,7 @@ module Articles
 
       article.destroy!
 
-      Notification.remove_all_without_delay(notifiable_ids: article.id, notifiable_type: "Article")
+      Notification.remove_all(notifiable_ids: article.id, notifiable_type: "Article")
 
       return if article_comments_ids.blank?
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Comment do
       it { is_expected.to belong_to(:user) }
       # it { is_expected.to belong_to(:commentable).optional }
       it { is_expected.to have_many(:reactions).dependent(:destroy) }
-      it { is_expected.to have_many(:mentions).dependent(:destroy) }
+      it { is_expected.to have_many(:mentions).dependent(:delete_all) }
       it { is_expected.to have_many(:notifications).dependent(:delete_all) }
       it { is_expected.to have_many(:notification_subscriptions).dependent(:destroy) }
 
@@ -617,7 +617,7 @@ RSpec.describe Comment do
     it "indexes on create" do
       allow(AlgoliaSearch::SearchIndexWorker).to receive(:perform_async)
       create(:comment)
-      expect(AlgoliaSearch::SearchIndexWorker).to have_received(:perform_async).with("Comment", kind_of(Integer), 
+      expect(AlgoliaSearch::SearchIndexWorker).to have_received(:perform_async).with("Comment", kind_of(Integer),
 false).once
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

The article destroy action throws a 503 HTTP status code which
that the server is too busy to actually handle the DELETE request
at the moment.

While digging, I noticed that the article's notifications are
removed straight away and therefore this may be the cause of the
server business.

Also, the while the article is being destroyed, its mentions will
also be destroyed due to the
```
  has_many :mentions, as: :mentionable,
  inverse_of: :mentionable, dependent: :destroy
```
association but this association uses the `dependent: :destroy`
option which means that callbacks will be triggered and therefore
may take some time as well.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #21681 

## QA Instructions, Screenshots, Recordings
N/A

### UI accessibility checklist
N/A

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [X] No, and this is why: the changes are related to sync versus async worker which seems not to be taken into account in the spec
- [ ] I need help with writing tests