### PR TITLE
Add invitation-only guard to magic links reg

### DIFF
--- a/app/controllers/magic_links_controller.rb
+++ b/app/controllers/magic_links_controller.rb
@@ -11,6 +11,10 @@ class MagicLinksController < ApplicationController
     @user = User.find_by(email: params[:email])
     if @user
       @user.send_magic_link!
+    elsif ForemInstance.invitation_only?
+      # If the instance is invite-only, we don't want to create a new user and return early
+      flash[:alert] = "Forem is invite-only."
+      redirect_to new_user_session_path and return
     else
       # Register new user with this email
       @user = User.new(email: params[:email])

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -10,7 +10,7 @@
   <div id="footer-container" class="crayons-footer__container">
 
 
-    <% cache "footer-billboard-#{user_signed_in?}", expires_in: 30.minutes do %>
+    <% cache "footer-billboard-#{user_signed_in?}-x_x", expires_in: 30.minutes do %>
       <% footer_billboard = Billboard.for_display(area: "footer", user_signed_in: user_signed_in?) %>
       <% if footer_billboard %>
         <%= render partial: "shared/billboard", locals: { billboard: footer_billboard, data_context_type: BillboardEvent::CONTEXT_TYPE_HOME } %>

--- a/app/views/magic_links/new.html.erb
+++ b/app/views/magic_links/new.html.erb
@@ -64,6 +64,9 @@ body {
           <%= f.submit "Send me the code",
                 class: "crayons-btn py-6 fs-xl fw-bold" %>
         </div>
+        <div class="mt-4 align-center fs-s fw-normal fs-italic px-0 s:px-9 color-secondary">
+          <%= t("devise.registrations.agreement.sign_up_html", privacy_path: privacy_path, terms_path: terms_path, code_of_conduct_path: code_of_conduct_path) %>
+        </div>
       <% end %>
 
       <!-- Simple alternate links -->


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If a Forem is in invite-only mode it should not allow registration in this route.