### PR TITLE
Ensure mobile web doesn't show up on larger screens

### DIFF
--- a/app/assets/stylesheets/widgets.scss
+++ b/app/assets/stylesheets/widgets.scss
@@ -403,6 +403,13 @@
     word-wrap: normal;
     word-break: keep-all;
   }
+  @media (min-width: $breakpoint-s) {
+    &[data-browser-context="mobile_web"] {
+      @media (min-width: $breakpoint-s) {
+        display: none !important;
+      }
+    }
+  }
 }
 
 .crayons-article-sticky,

--- a/app/views/shared/_billboard.html.erb
+++ b/app/views/shared/_billboard.html.erb
@@ -83,6 +83,7 @@
     data-context-type="<%= data_context_type %>"
     data-dismissal-sku="<%= billboard.dismissal_sku %>"
     data-special="<%= billboard.special_behavior %>"
+    data-browser-context="<%= billboard.browser_context %>"
     <% if billboard.placement_area == "post_fixed_bottom" && @article.present? %>
       data-article-id="<%= @article&.id %>"
     <% else %>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Mobile web targeting is intended to target _phones_, but user agents can be imprecise. This helps ensure that only smaller screens see these billboards.