### PR TITLE
[WIP] Add prefer_paired_with_billboard_id to billboards

### DIFF
--- a/app/models/billboard.rb
+++ b/app/models/billboard.rb
@@ -101,7 +101,7 @@ class Billboard < ApplicationRecord
 
   def self.for_display(area:, user_signed_in:, user_id: nil, article: nil, user_tags: nil,
                        location: nil, cookies_allowed: false, page_id: nil, user_agent: nil,
-                       role_names: nil)
+                       role_names: nil, prefer_paired_with_billboard_id: nil)
     permit_adjacent = article ? article.permit_adjacent_sponsors? : true
 
     billboards_for_display = Billboards::FilteredAdsQuery.call(
@@ -120,6 +120,12 @@ class Billboard < ApplicationRecord
       user_agent: user_agent,
       role_names: role_names,
     )
+
+    # if prefer_paired_with_billboard_id then return 
+    if prefer_paired_with_billboard_id.present?
+      best_paired_billboard = billboards_for_display.find { |bb| bb.id == prefer_paired_with_billboard_id }
+      return best_paired_billboard if best_paired_billboard.present?
+    end
 
     case rand(99) # output integer from 0-99
     when (0..random_range_max(area)) # smallest range, 5%

--- a/app/workers/emails/send_user_digest_worker.rb
+++ b/app/workers/emails/send_user_digest_worker.rb
@@ -18,6 +18,7 @@ module Emails
                                               user_signed_in: true)
       second_billboard = Billboard.for_display(area: "digest_second",
                                                user_id: user.id,
+                                               prefer_paired_with_billboard_id: first_billboard&.id,
                                                user_tags: tags,
                                                user_signed_in: true)
       begin

--- a/db/migrate/20250513181503_add_prefer_paired_with_to_billboards.rb
+++ b/db/migrate/20250513181503_add_prefer_paired_with_to_billboards.rb
@@ -1,0 +1,5 @@
+class AddPreferPairedWithToBillboards < ActiveRecord::Migration[7.0]
+  def change
+    add_column :display_ads, :prefer_paired_with_billboard_id, :bigint
+  end
+end

--- a/db/migrate/20250513181655_add_prefer_paired_with_index_to_billboards.rb
+++ b/db/migrate/20250513181655_add_prefer_paired_with_index_to_billboards.rb
@@ -1,0 +1,6 @@
+class AddPreferPairedWithIndexToBillboards < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def change
+    add_index :display_ads, :prefer_paired_with_billboard_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_05_06_182913) do
+ActiveRecord::Schema[7.0].define(version: 2025_05_13_181655) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -505,6 +505,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_06_182913) do
     t.bigint "organization_id"
     t.bigint "page_id"
     t.string "placement_area"
+    t.bigint "prefer_paired_with_billboard_id"
     t.integer "preferred_article_ids", default: [], array: true
     t.boolean "priority", default: false
     t.text "processed_html"
@@ -525,6 +526,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_05_06_182913) do
     t.index ["include_subforem_ids"], name: "index_display_ads_on_include_subforem_ids", using: :gin
     t.index ["page_id"], name: "index_display_ads_on_page_id"
     t.index ["placement_area"], name: "index_display_ads_on_placement_area"
+    t.index ["prefer_paired_with_billboard_id"], name: "index_display_ads_on_prefer_paired_with_billboard_id"
     t.index ["preferred_article_ids"], name: "index_display_ads_on_preferred_article_ids", using: :gin
     t.index ["target_geolocations"], name: "gist_index_display_ads_on_target_geolocations", using: :gist
     t.index ["target_role_names"], name: "index_display_ads_on_target_role_names", using: :gin

--- a/spec/models/billboard_spec.rb
+++ b/spec/models/billboard_spec.rb
@@ -804,4 +804,54 @@ RSpec.describe Billboard do
       end
     end
   end
+
+  describe ".for_display" do
+    let!(:paired_bb) do
+      create(
+        :billboard,
+        placement_area: "digest_second",
+        published: true,
+        approved: true
+      )
+    end
+
+    let!(:other_bb) do
+      create(
+        :billboard,
+        placement_area: "digest_second",
+        published: true,
+        approved: true
+      )
+    end
+
+    context "when prefer_paired_with_billboard_id is provided" do
+      it "returns the billboard matching that ID" do
+        result = described_class.for_display(
+          area: "digest_second",
+          user_signed_in: true,
+          prefer_paired_with_billboard_id: paired_bb.id,
+          user_tags: nil,
+          user_id: nil
+        )
+
+        expect(result).to eq(paired_bb)
+      end
+
+      it "falls back to normal selection if the paired ID isn't in the available set" do
+        # pick some ID that doesn't exist in billboards_for_display
+        missing_id = other_bb.id + paired_bb.id + 1
+
+        result = described_class.for_display(
+          area: "digest_second",
+          user_signed_in: true,
+          prefer_paired_with_billboard_id: missing_id,
+          user_tags: nil,
+          user_id: nil
+        )
+
+        # since only paired_bb and other_bb exist for this area, it must return one of them
+        expect([paired_bb, other_bb]).to include(result)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/billboards_spec.rb
+++ b/spec/requests/api/v1/billboards_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Api::V1::Billboards" do
                           "success_rate", "tag_list", "type_of", "updated_at", "color",
                           "creator_id", "exclude_article_ids", "dismissal_sku", "browser_context",
                           "audience_segment_type", "audience_segment_id", "page_id",
-                          "exclude_role_names", "target_role_names", "include_subforem_ids",
+                          "exclude_role_names", "target_role_names", "include_subforem_ids", "prefer_paired_with_billboard_id",
                           "custom_display_label", "template", "render_mode", "preferred_article_ids",
                           "priority", "weight", "target_geolocations", "requires_cookies", "special_behavior")
         expect(response.parsed_body["target_geolocations"]).to contain_exactly("US-WA", "CA-BC")
@@ -73,7 +73,7 @@ RSpec.describe "Api::V1::Billboards" do
                           "placement_area", "processed_html", "published",
                           "success_rate", "tag_list", "type_of", "updated_at", "color",
                           "creator_id", "exclude_article_ids", "dismissal_sku", "browser_context",
-                          "audience_segment_type", "audience_segment_id", "page_id",
+                          "audience_segment_type", "audience_segment_id", "page_id", "prefer_paired_with_billboard_id",
                           "exclude_role_names", "target_role_names", "include_subforem_ids",
                           "custom_display_label", "template", "render_mode", "preferred_article_ids",
                           "priority", "weight", "target_geolocations", "requires_cookies", "special_behavior")
@@ -143,7 +143,7 @@ RSpec.describe "Api::V1::Billboards" do
                           "audience_segment_type", "audience_segment_id", "special_behavior",
                           "exclude_role_names", "target_role_names", "include_subforem_ids",
                           "custom_display_label", "template", "render_mode", "preferred_article_ids",
-                          "priority", "weight", "target_geolocations")
+                          "priority", "weight", "target_geolocations", "prefer_paired_with_billboard_id")
       end
 
       it "also accepts target geolocations as an array" do

--- a/spec/workers/emails/send_user_digest_worker_spec.rb
+++ b/spec/workers/emails/send_user_digest_worker_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Emails::SendUserDigestWorker, type: :worker do
     u
   end
   let(:author) { create(:user) }
-  let(:tag) { create(:tag) }
-  let(:mailer) { double }
+  let(:tag)    { create(:tag) }
+  let(:mailer)           { double }
   let(:message_delivery) { double }
 
   before do
@@ -55,7 +55,7 @@ RSpec.describe Emails::SendUserDigestWorker, type: :worker do
 
       it "includes billboards" do
         create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20, tag_list: [tag.name])
-        bb_1 = create(:billboard, placement_area: "digest_first", published: true, approved: true)
+        bb_1 = create(:billboard, placement_area: "digest_first",  published: true, approved: true)
         bb_2 = create(:billboard, placement_area: "digest_second", published: true, approved: true)
 
         worker.perform(user.id)
@@ -67,13 +67,62 @@ RSpec.describe Emails::SendUserDigestWorker, type: :worker do
 
       it "creates billboard events when billboards are present" do
         create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20, tag_list: [tag.name])
-        bb_1 = create(:billboard, placement_area: "digest_first", published: true, approved: true)
+        bb_1 = create(:billboard, placement_area: "digest_first",  published: true, approved: true)
         bb_2 = create(:billboard, placement_area: "digest_second", published: true, approved: true)
 
         worker.perform(user.id)
 
         expect(BillboardEvent.where(billboard_id: bb_1.id, category: "impression").size).to be(1)
         expect(BillboardEvent.where(billboard_id: bb_2.id, category: "impression").size).to be(1)
+      end
+
+      context "when there's a preferred paired billboard" do
+        let!(:bb_1) do
+          create(
+            :billboard,
+            placement_area: "digest_first",
+            published: true,
+            approved: true
+          )
+        end
+        let!(:paired_bb) do
+          create(
+            :billboard,
+            placement_area: "digest_second",
+            published: true,
+            approved: true,
+            prefer_paired_with_billboard_id: bb_1.id
+          )
+        end
+        let!(:other_bb) do
+          create(
+            :billboard,
+            placement_area: "digest_second",
+            published: true,
+            approved: true
+          )
+        end
+
+        it "selects the paired billboard for the second slot" do
+          create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20, tag_list: [tag.name])
+
+          worker.perform(user.id)
+
+          expect(DigestMailer).to have_received(:with) do |args|
+            expect(args[:billboards]).to eq([bb_1, paired_bb])
+          end
+        end
+
+        it "creates events for both the first and the paired second billboard" do
+          create_list(:article, 3, user_id: author.id, public_reactions_count: 20, score: 20, tag_list: [tag.name])
+
+          worker.perform(user.id)
+
+          expect(BillboardEvent.where(billboard_id: bb_1.id,      category: "impression").count).to eq(1)
+          expect(BillboardEvent.where(billboard_id: paired_bb.id, category: "impression").count).to eq(1)
+          # and it should *not* fire for the other_bb
+          expect(BillboardEvent.where(billboard_id: other_bb.id).count).to eq(0)
+        end
       end
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Add the ability to "prefer" one billboard to be paired with another, where we fallback if it's not there.