### PR TITLE
Fix: Remove schedule for non-existent ExpireOldListingsWorker

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -106,10 +106,6 @@ resave_supported_tags:
   description: "Resaves supported tags to recalculate scores (runs daily at 00:25 UTC)"
   cron: "25 0 * * *"
   class: "Tags::ResaveSupportedTagsWorker"
-expire_old_listings:
-  description: "Expires old listings (runs daily at 00:30 UTC)"
-  cron: "30 0 * * *"
-  class: "Listings::ExpireOldListingsWorker"
 send_welcome_notifications:
   description: "Sends welcome notifications to new users (runs daily at 16:30 UTC)"
   cron: "0 16 * * *"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR addresses a recurring `NameError` for `Listings::ExpireOldListingsWorker` that appears in Honeybadger. The error occurs because a scheduled job in `config/schedule.yml` attempts to enqueue this worker, but the worker class no longer exists as the Listings feature has been removed.

## Related Tickets & Documents

- Closes #21875
- Related to #21624 

## QA Instructions, Screenshots, Recordings

 **Monitor Honeybadger post-deployment:** After this PR is deployed, observe Honeybadger (specifically after 00:30 UTC, the job's scheduled time) to ensure that new instances of `NameError in Listings::ExpireOldListingsWorker # perform` no longer appear.
    *   Note: Existing jobs for this worker that are already in Sidekiq's retry queue may continue to fire and log errors until they exhaust their retries. This PR prevents *new* jobs from being scheduled.

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [x] Not applicable
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: This change removes a configuration line for a scheduled job related to a now-defunct feature. There isn't a straightforward unit or integration test for the absence of a cron job definition causing an error for a non-existent class, beyond ensuring the YAML file is parsed correctly.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

Optionally, clear any remaining `Listings::ExpireOldListingsWorker` jobs from Sidekiq's retry and scheduled sets to immediately stop all related Honeybadger notifications.

## [optional] What gif best describes this PR or how it makes you feel?


