### PR TITLE
Enable CSRF protection for Google OAuth2

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -23,7 +23,7 @@ GOOGLE_OAUTH2_OMNIAUTH_SETUP = lambda do |env|
   env["omniauth.strategy"].options[:scope] = "email,profile"
   env["omniauth.strategy"].options[:client_id] = Settings::Authentication.google_oauth2_key
   env["omniauth.strategy"].options[:client_secret] = Settings::Authentication.google_oauth2_secret
-  env["omniauth.strategy"].options[:provider_ignores_state] = true
+  env["omniauth.strategy"].options[:provider_ignores_state] = false
 end
 
 FACEBOOK_OMNIAUTH_SETUP = lambda do |env|


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Addresses a `NoMethodError` (Honeybadger #21901) in Google OAuth callbacks. This error occurs when the callback URL is hit with missing `code`/`error` parameters. It doesn't resolve the error altogether but should help troubleshoot it and makes the error more specific/accurate.

Currently, Google OAuth is set with `provider_ignores_state = true`, bypassing OmniAuth's CSRF check. This allows incomplete callbacks to proceed further than intended, causing the `NoMethodError`.

This PR proposes setting `provider_ignores_state = false` for Google. This enables the standard CSRF check, causing malformed callbacks to fail earlier with a `:csrf_detected` error, thus preventing the `NoMethodError`. 

Should review why `provider_ignores_state = true` was originally set.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
Related to #21901

- Closes #

## QA Instructions, Screenshots, Recordings

1.  **Verify `NoMethodError` is gone:** Monitor Honeybadger post-deployment.
2.  **New expected error:** Direct hits to `/users/auth/google_oauth2/callback` (with only `state` param) should now log a `:csrf_detected` error.
3.  **Test Google Login/Registration:** Ensure legitimate flows work. If they now fail with `:csrf_detected`, it indicates a masked issue that needs further investigation.

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
