### PR TITLE
Adjust magic link auth

### DIFF
--- a/app/controllers/magic_links_controller.rb
+++ b/app/controllers/magic_links_controller.rb
@@ -18,6 +18,7 @@ class MagicLinksController < ApplicationController
     else
       # Register new user with this email
       @user = User.new(email: params[:email])
+      check_allowed_email(@user)
       @user.registered       = true
       @user.registered_at    = Time.current
       dummy_password         = Devise.friendly_token(20)
@@ -52,5 +53,18 @@ class MagicLinksController < ApplicationController
     else
       redirect_to new_user_session_path, alert: "Invalid or expired link"
     end
+  end
+
+  private
+
+  def check_allowed_email(user)
+    domain = user.email.split("@").last
+    return true if Settings::Authentication.acceptable_domain?(domain: domain)
+
+    user.email = nil
+    # Alright, this error message isn't quite correct.  Is the email
+    # from a blocked domain?  Or an explicitly allowed domain.  I
+    # think this is enough.
+    user.errors.add(:email, I18n.t("registrations_controller.error.domain"))
   end
 end

--- a/spec/requests/magic_links_spec.rb
+++ b/spec/requests/magic_links_spec.rb
@@ -19,11 +19,19 @@ RSpec.describe "MagicLinks", type: :request do
 
   describe "POST /magic_links" do
     let(:user) { create(:user, email: "test@example.com", confirmed_at: 1.day.ago) }
+    let(:email) { "new@example.com" }
+    let!(:subforem) { create(:subforem, domain: "example.com") }
+
+    before do
+      allow(Devise).to receive(:friendly_token).with(20).and_return("dummy_password")
+      allow(Images::ProfileImageGenerator).to receive(:call).and_return("avatar_url")
+    end
 
     context "when the email matches an existing user" do
       before do
         allow(User).to receive(:find_by).with(email: user.email).and_return(user)
         allow(user).to receive(:send_magic_link!)
+        allow(Settings::Authentication).to receive(:acceptable_domain?).and_call_original
       end
 
       it "renders the create template and sends a magic link without altering confirmation" do
@@ -33,32 +41,31 @@ RSpec.describe "MagicLinks", type: :request do
 
         expect(response.body).to include("Check your email")
         expect(user).to have_received(:send_magic_link!).once
-        # confirmed_at should remain exactly what it was
         expect(user.reload.confirmed_at).to be_within(1.second).of(original_confirmed_at)
       end
     end
 
     context "when the email does not match any user" do
-      let(:email) { "new@example.com" }
-      let!(:subforem) { create(:subforem, domain: "example.com") }
-
       before do
         allow(User).to receive(:find_by).with(email: email).and_return(nil)
-        allow(Devise).to receive(:friendly_token).with(20).and_return("dummy_password")
-        allow(Images::ProfileImageGenerator).to receive(:call).and_return("avatar_url")
       end
 
       it "returns an error if the instance is invite-only" do
         allow(ForemInstance).to receive(:invitation_only?).and_return(true)
+
         post "/magic_links", params: { email: email }
+
         expect(response).to redirect_to(new_user_session_path)
         expect(flash[:alert]).to eq("Forem is invite-only.")
       end
 
       it "creates a new user, skips confirmation and sends the magic link" do
         freeze_time do
+          allow(ForemInstance).to receive(:invitation_only?).and_return(false)
+          allow(Settings::Authentication).to receive(:acceptable_domain?).with(domain: "example.com").and_return(true)
+
           expect {
-            post "/magic_links", params: { email: email }
+            post "/magic_links", params: { email: email }, headers: { "Host" => subforem.domain }
           }.to change(User, :count).by(1)
 
           new_user = User.order(:created_at).last
@@ -75,12 +82,31 @@ RSpec.describe "MagicLinks", type: :request do
 
       it "assigns onboarding_subforem_id based on the referer header" do
         freeze_time do
+          allow(ForemInstance).to receive(:invitation_only?).and_return(false)
+          allow(Settings::Authentication).to receive(:acceptable_domain?).with(domain: "example.com").and_return(true)
+
           expect {
             post "/magic_links", params: { email: email }, headers: { "Host" => subforem.domain }
           }.to change(User, :count).by(1)
 
           new_user = User.order(:created_at).last
           expect(new_user.onboarding_subforem_id).to eq(subforem.id)
+        end
+      end
+
+      context "when the email domain is not acceptable" do
+        before do
+          allow(ForemInstance).to receive(:invitation_only?).and_return(false)
+          allow(Settings::Authentication).to receive(:acceptable_domain?).with(domain: "example.com").and_return(false)
+        end
+
+        it "does not create a user and redirects with domain error" do
+          expect {
+            post "/magic_links", params: { email: email }
+          }.not_to change(User, :count)
+
+          expect(response).to redirect_to(new_user_session_path)
+          expect(flash[:alert]).to eq(I18n.t("registrations_controller.error.domain"))
         end
       end
     end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This closes a loophole where email auth settings don't 100% apply to magic link flows