### PR TITLE
Preserve Undo History in Markdown Preview Mode

### DIFF
--- a/app/javascript/article-form/components/Form.jsx
+++ b/app/javascript/article-form/components/Form.jsx
@@ -19,9 +19,13 @@ export const Form = ({
   errors,
   coverImageCrop,
   coverImageHeight,
+  previewMode,
 }) => {
   return (
-    <div className="crayons-article-form__content crayons-card">
+    <div className="crayons-article-form__content crayons-card"
+      style={{ display: previewMode ? 'none' : 'block' }}
+    >
+      
       {errors && <ErrorList errors={errors} />}
 
       {version === 'v2' && (
@@ -64,6 +68,7 @@ Form.propTypes = {
   errors: PropTypes.object,
   coverImageHeight: PropTypes.string.isRequired,
   coverImageCrop: PropTypes.string.isRequired,
+  previewMode: PropTypes.bool,
 };
 
 Form.displayName = 'Form';

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -18,6 +18,7 @@ import '@cypress/code-coverage/support';
 import '@testing-library/cypress/add-commands';
 import 'cypress-file-upload';
 import 'cypress-failed-log';
+import 'cypress-real-events/support';
 
 // Custom assertions
 import './assertions';

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "cypress-file-upload": "^5.0.8",
     "cypress-multi-reporters": "^1.6.4",
     "cypress-pipe": "^2.0.0",
+    "cypress-real-events": "^1.14.0",
     "eslint": "^8.57.0",
     "eslint-config-preact": "^1.3.0",
     "eslint-config-prettier": "^8.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8876,6 +8876,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cypress-real-events@npm:^1.14.0":
+  version: 1.14.0
+  resolution: "cypress-real-events@npm:1.14.0"
+  peerDependencies:
+    cypress: ^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x
+  checksum: 10c0/da81f8f5bf829f3bcd2c26a532656d7c588807df7198b2eb72b882895ca0265c8bab49eaea5c78374fd52c196ec3f3f0937245af421ee13f8ce3bf06631b43af
+  languageName: node
+  linkType: hard
+
 "cypress@npm:^13.7.2":
   version: 13.7.2
   resolution: "cypress@npm:13.7.2"
@@ -9365,6 +9374,7 @@ __metadata:
     cypress-file-upload: "npm:^5.0.8"
     cypress-multi-reporters: "npm:^1.6.4"
     cypress-pipe: "npm:^2.0.0"
+    cypress-real-events: "npm:^1.14.0"
     esbuild: "npm:^0.19.12"
     esbuild-plugin-stimulus: "npm:^0.1.5"
     esbuild-plugin-svgr: "npm:^2.1.0"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This new feature aims to improve the user experience when creating content.

Currently, when editing a post and switching to Preview mode, the browser loses the history of the changes made, preventing the user from using the Ctrl+Z shortcut to undo previous edits. With this feature, the Markdown editor remains in the DOM even during preview. This way, the browser retains the edit history, allowing the user to revert changes after returning to edit mode.

Additionally, the feature ensures that while in Preview mode, the Ctrl+Z shortcut has no effect. This guarantees that Preview remains strictly a viewing mode, without permitting any content changes.

-This implementation renders the Form even when the user
switches to Preview. In addition, so that its not allowed
to make changes in Preview mode, this feature ignores the
ctrl+z event while in Preview mode.

-Two E2E tests and 1 unit test were implemented to ensure
this behaviour.

## Related Tickets & Documents

- Related Issue # https://github.com/forem/forem/discussions/21805

## QA Instructions, Screenshots, Recordings

[![See the video of QA](https://img.youtube.com/vi/iekQwCSmZQE/0.jpg)](https://youtu.be/iekQwCSmZQE)

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
