### PR TITLE
Make non-discoverable forems not show up in root feed

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -357,8 +357,8 @@ class Article < ApplicationRecord
   scope :from_subforem, lambda { |subforem_id = nil|
     subforem_id ||= RequestStore.store[:subforem_id]
     if subforem_id.present? && subforem_id == RequestStore.store[:root_subforem_id]
-      # No additional conditions; just return the current scope
-      where(nil)
+      # Includes articles with no subforem or subforem_id in Subforem.cached_discoverable_ids
+      where("articles.subforem_id IN (?) OR articles.subforem_id IS NULL", [nil] + Subforem.cached_discoverable_ids)
     elsif [0, RequestStore.store[:default_subforem_id]].include?(subforem_id.to_i)
       where("articles.subforem_id IN (?) OR articles.subforem_id IS NULL", [nil, subforem_id, RequestStore.store[:default_subforem_id].to_i])
     else

--- a/app/models/subforem.rb
+++ b/app/models/subforem.rb
@@ -66,6 +66,12 @@ class Subforem < ApplicationRecord
     end
   end
 
+  def self.cached_discoverable_ids
+    Rails.cache.fetch('subforem_discoverable_ids', expires_in: 12.hours) do
+      Subforem.where(discoverable: true).pluck(:id)
+    end
+  end
+
   def self.cached_postable_array
     Rails.cache.fetch('subforem_postable_array', expires_in: 12.hours) do
       Subforem.where(discoverable: true).pluck(:id).map { |id| [id, Settings::Community.community_name(subforem_id: id)] }
@@ -79,6 +85,7 @@ class Subforem < ApplicationRecord
     Rails.cache.delete("cached_domains")
     Rails.cache.delete("subforem_id_to_domain_hash")
     Rails.cache.delete('subforem_postable_array')
+    Rails.cache.delete('subforem_discoverable_ids')
     Rails.cache.delete('subforem_root_id')
     Rails.cache.delete('subforem_default_domain')
     Rails.cache.delete('subforem_root_domain')

--- a/spec/models/subforem_spec.rb
+++ b/spec/models/subforem_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Subforem, type: :model do
     expect(Rails.cache).to receive(:delete).with('cached_domains')
     expect(Rails.cache).to receive(:delete).with('subforem_id_to_domain_hash')
     expect(Rails.cache).to receive(:delete).with('subforem_postable_array')
+    expect(Rails.cache).to receive(:delete).with('subforem_discoverable_ids')
     expect(Rails.cache).to receive(:delete).with('subforem_root_id')
     expect(Rails.cache).to receive(:delete).with('subforem_default_domain')
     expect(Rails.cache).to receive(:delete).with('subforem_root_domain')


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Currently despite being "non-discoverable" other subforems can still have _their articles_ still show up in root feed. This adjusts that functionality.