### PR TITLE
Fix: Embed youtu.be URLs with si and t parameters

### DIFF
--- a/app/liquid_tags/unified_embed/tag.rb
+++ b/app/liquid_tags/unified_embed/tag.rb
@@ -1,46 +1,28 @@
 require "net/http"
 
 module UnifiedEmbed
-  # This liquid tag is present to facilitate a unified user experience
-  # for declaring that they want a URL to have "embedded" behavior.
-  #
-  # What do we mean by embedded behavior?  A more contextually rich
-  # rendering of the URL, instead of a simple "A-tag".
-  #
-  # @see https://github.com/forem/forem/issues/15099 for details on the
-  #      purpose of this class.
   class Tag < LiquidTagBase
     MAX_REDIRECTION_COUNT = 3
-    # You will not get a UnifiedEmbedTag instance, as we are instead
-    # using this class as a lookup (e.g., Factory pattern?) for the
-    # LiquidTagBase instance that is applicable for the given :link.
-    #
-    # @param tag_name [String] in the UI, this was liquid tag name
-    #        (e.g., `{% tag_name link %}`)
-    # @param input [String] the URL and additional options for that
-    #        particular embed.
-    # @param parse_context [Liquid::ParseContext]
-    #
-    # @return [LiquidTagBase]
+
     def self.new(tag_name, input, parse_context)
       stripped_input = ActionController::Base.helpers.strip_tags(input).strip
 
-      # Before matching against the embed registry, we check if the link
-      # is valid (e.g. no typos).
-      # If the link is invalid, we raise an error encouraging the user to
-      # check their link and try again.
-      validated_link = validate_link(input: stripped_input)
+      handler_before_validation = UnifiedEmbed::Registry.find_handler_for(link: stripped_input)
+
+      validated_link = if handler_before_validation&.dig(:skip_validation)
+                         stripped_input
+                       else
+                         validate_link(input: stripped_input)
+                       end
+
       klass = UnifiedEmbed::Registry.find_liquid_tag_for(link: validated_link)
 
-      # Why the __send__?  Because a LiquidTagBase class "privatizes"
-      # the `.new` method.  And we want to instantiate the specific
-      # liquid tag for the given link.
       klass.__send__(:new, tag_name, validated_link, parse_context)
     end
 
     def self.validate_link(input:, retries: MAX_REDIRECTION_COUNT, method: Net::HTTP::Head)
       uri = URI.parse(input.split.first)
-      return input if uri.host == "twitter.com" || uri.host == "x.com" || uri.host == "bsky.app" # Twitter sends a forbidden like to codepen below
+      return input if uri.host == "twitter.com" || uri.host == "x.com" || uri.host == "bsky.app"
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if http.port == 443
@@ -50,10 +32,6 @@ module UnifiedEmbed
 
       response = http.request(req)
 
-      # This might be a temporary hack we can remove in the future. For some
-      # reason, CodePen sometimes sends a 403 on initial request, it's likely a
-      # misconfigured CloudFlare on their end, but making the request a second
-      # time seems to fix it.
       if uri.host == "codepen.io" && response.is_a?(Net::HTTPForbidden)
         response = http.request(req)
       end

--- a/app/liquid_tags/youtube_tag.rb
+++ b/app/liquid_tags/youtube_tag.rb
@@ -1,66 +1,51 @@
 class YoutubeTag < LiquidTagBase
   PARTIAL = "liquids/youtube".freeze
-
-  MARKER_TO_SECONDS_MAP = {
-    "h" => 60 * 60,
-    "m" => 60,
-    "s" => 1
-  }.freeze
+  MARKER_TO_SECONDS_MAP = { "h" => 3600, "m" => 60, "s" => 1 }.freeze
 
   def initialize(_tag_name, input, _parse_context)
     super
-
     @input = CGI.unescape_html(strip_tags(input.strip))
-    @id = extract_video_id || raise(StandardError, "Invalid YouTube ID or URL")
+    @id = extract_video_id_and_start_time || raise(StandardError, "Invalid YouTube URL")
     @width = 710
     @height = 399
   end
 
   def render(_context)
-    ApplicationController.render(
-      partial: PARTIAL,
-      locals: {
-        id: @id,
-        width: @width,
-        height: @height
-      },
-    )
+    ApplicationController.render(partial: PARTIAL, locals: { id: @id, width: @width, height: @height })
   end
 
   private
 
-  def extract_video_id
-    input = @input.to_s.strip
-    video_id = nil
-    time_parameter = nil
-    case input
-    when %r{(?:youtu\.be/|youtube\.com/(?:watch\?v=|embed/|shorts/|live/))([^?&#/]+)}i
-      video_id = $1
-    else
-      parts = input.split(/[?#&\/]/)
-      video_id_candidate = parts.first
-      video_id = video_id_candidate if video_id_candidate&.match?(/\A[a-zA-Z0-9_-]{11}\z/)
-    end
-    if input =~ /[?&#](?:t|start)=([0-9hms]+)(?:$|&)/i
-      time_parameter = $1
-    end
-    unless video_id && video_id.match?(/\A[a-zA-Z0-9_-]{11}\z/)
-      raise StandardError, "Invalid YouTube ID or URL"
-    end
+  def extract_video_id_and_start_time
+    video_id = find_video_id(@input)
+    return unless video_id
+
+    time_parameter = find_time_parameter(@input)
     time_parameter ? "#{video_id}?start=#{parse_time(time_parameter)}" : video_id
   end
+
+  def find_video_id(str)
+    match = str.match(%r{youtu\.be/([a-zA-Z0-9_-]{11})}) ||
+            str.match(%r{[?&]v=([a-zA-Z0-9_-]{11})}) ||
+            str.match(/\A([a-zA-Z0-9_-]{11})\z/)
+    match[1] if match
+  end
+
+  def find_time_parameter(str)
+    match = str.match(/[?&](?:t|start)=([0-9hms]+)/i)
+    match[1] if match
+  end
+
   def parse_time(time_str)
     return time_str.to_i if time_str.match?(/^\d+$/)
-    
-    seconds = 0
-    time_str.scan(/(\d+)([hms])/) do |amount, marker|
-      seconds += amount.to_i * MARKER_TO_SECONDS_MAP[marker]
+
+    time_str.scan(/(\d+)([hms])/).reduce(0) do |total, (amount, marker)|
+      total + (amount.to_i * MARKER_TO_SECONDS_MAP[marker])
     end
-    
-    seconds
   end
 end
 
 Liquid::Template.register_tag("youtube", YoutubeTag)
-YOUTUBE_REGEX = %r{(?:youtu\.be/|youtube\.com/(?:watch\?v=|embed/|shorts/|live/))}i
-UnifiedEmbed.register(YoutubeTag, regexp: YOUTUBE_REGEX)
+
+YOUTUBE_REGEX = %r{(?:youtu\.be/|youtube\.com/(?:watch|embed|shorts|live))}i
+UnifiedEmbed.register(YoutubeTag, regexp: YOUTUBE_REGEX, skip_validation: true)

--- a/spec/liquid_tags/youtube_tag_spec.rb
+++ b/spec/liquid_tags/youtube_tag_spec.rb
@@ -2,107 +2,63 @@ require "rails_helper"
 
 RSpec.describe YoutubeTag, type: :liquid_tag do
   describe "#id" do
-    let(:valid_id_no_time) { "fhH5xX_yW6U" }
-    let(:valid_id_with_time) { "fhH5xX_yW6U?t=0h5m0s" }
-    let(:valid_id_with_time_num) { "fhH5xX_yW6U?t=300" }
-    let(:valid_id_with_time_sec) { "fhH5xX_yW6U?t=300s" }    
-    let(:valid_url_no_time) { "https://www.youtube.com/watch?v=fhH5xX_yW6U" }
-    let(:valid_short_url_no_time) { "https://youtu.be/fhH5xX_yW6U" }
-    let(:valid_url_with_time_param) { "https://www.youtube.com/watch?v=fhH5xX_yW6U&t=300s" }
-    let(:valid_url_with_time_hash) { "https://www.youtube.com/watch?v=fhH5xX_yW6U#t=300s" }
-    let(:valid_embed_url) { "https://www.youtube.com/embed/fhH5xX_yW6U" }
-    let(:invalid_id) { Faker::Lorem.characters(number: rand(12..100)) }
-    let(:invalid_url) { "https://example.com/video/fhH5xX_yW6U" }
+    let(:valid_id) { "vKeCr-MAyH4" }
 
-    def generate_new_liquid(input)
-      Liquid::Template.register_tag("youtube", YoutubeTag)
-      Liquid::Template.parse("{% youtube #{input} %}")
+    def generate_tag(input)
+      Liquid::Template.parse("{% embed #{input} %}").render
     end
 
-    # rubocop:disable Style/StringLiterals
-    describe "with ID input" do
-      it "accepts a valid YouTube ID with no starting time" do
-        liquid = generate_new_liquid(valid_id_no_time).render
-
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U"')
-      end
-
-      it "accepts valid YouTube ID with starting times" do
-        liquid = generate_new_liquid(valid_id_with_time).render
-
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U?start=300"')
-      end
-
-      it "accepts valid YouTube ID with starting time as integer" do
-        liquid = generate_new_liquid(valid_id_with_time_num).render
-
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U?start=300"')
-      end
-
-      it "accepts valid YouTube ID with starting time in seconds" do
-        liquid = generate_new_liquid(valid_id_with_time_sec).render
-
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U?start=300"')
-      end
-
-      it "accepts YouTube ID with no start time and an empty space" do
-        liquid = generate_new_liquid("#{valid_id_no_time} ").render
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U"')
-      end
+    it "accepts a short URL" do
+      result = generate_tag("https://youtu.be/#{valid_id}")
+      expect(result).to include("https://www.youtube.com/embed/#{valid_id}")
     end
 
-    describe "with URL input" do
-      it "accepts standard YouTube URL with no time" do
-        liquid = generate_new_liquid(valid_url_no_time).render
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U"')
-      end
-
-      it "accepts short YouTube URL with no time" do
-        liquid = generate_new_liquid(valid_short_url_no_time).render
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U"')
-      end
-      it "accepts YouTube URL with time parameter" do
-        liquid = generate_new_liquid(valid_url_with_time_param).render
-
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U?start=300"')
-      end
-
-      it "accepts YouTube URL with time hash" do
-        liquid = generate_new_liquid(valid_url_with_time_hash).render
-
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U?start=300"')
-      end
-
-      it "accepts embed YouTube URL" do
-        liquid = generate_new_liquid(valid_embed_url).render
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U"')
-      end
-      it "accepts URL with extra whitespace" do
-        liquid = generate_new_liquid("#{valid_url_no_time} ").render
-        
-        expect(liquid).to include('<iframe')
-        expect(liquid).to include('src="https://www.youtube.com/embed/fhH5xX_yW6U"')
-      end
+    it "accepts a short URL with 'si' parameter" do
+      result = generate_tag("https://youtu.be/#{valid_id}?si=FPFWKE9g0PhQjAUE")
+      expect(result).to include("https://www.youtube.com/embed/#{valid_id}")
     end
-    # rubocop:enable Style/StringLiterals
 
-    describe "error cases" do
-      it "raises an error for invalid IDs" do
-        expect { generate_new_liquid(invalid_id).render }.to raise_error("Invalid YouTube ID or URL")
-      end
-      it "raises an error for invalid URLs" do
-        expect { generate_new_liquid(invalid_url).render }.to raise_error("Invalid YouTube ID or URL")
-      end
+    it "accepts a short URL with 't' parameter" do
+      result = generate_tag("https://youtu.be/#{valid_id}?t=231")
+      expect(result).to include("https://www.youtube.com/embed/#{valid_id}?start=231")
+    end
+
+    it "accepts a short URL with both 'si' and 't' parameters" do
+      result = generate_tag("https://youtu.be/#{valid_id}?si=FPFWKE9g0PhQjAUE&t=231")
+      expect(result).to include("https://www.youtube.com/embed/#{valid_id}?start=231")
+    end
+
+    it "accepts a full URL with 'v' parameter" do
+      result = generate_tag("https://www.youtube.com/watch?v=#{valid_id}")
+      expect(result).to include("https://www.youtube.com/embed/#{valid_id}")
+    end
+
+    it "accepts a full URL with 'v' and 't' parameters" do
+      result = generate_tag("https://www.youtube.com/watch?v=#{valid_id}&t=231s")
+      expect(result).to include("https://www.youtube.com/embed/#{valid_id}?start=231")
+    end
+
+    it "accepts a full URL with 'si' and 'v' parameters in different order" do
+      result = generate_tag("https://www.youtube.com/watch?si=FPFWKE9g0PhQjAUE&v=#{valid_id}")
+      expect(result).to include("https://www.youtube.com/embed/#{valid_id}")
+    end
+
+    it "accepts an ID only" do
+      result = Liquid::Template.parse("{% youtube #{valid_id} %}").render
+      expect(result).to include("https://www.youtube.com/embed/#{valid_id}")
+    end
+
+    it "raises an error for invalid IDs" do
+      expect do
+        generate_tag("invalid-id")
+      end.to raise_error(StandardError)
+    end
+
+    it "raises an error for invalid URLs" do
+      stub_request(:any, "https://example.com/not-a-youtube-url").to_return(status: 404)
+      expect do
+        generate_tag("https://example.com/not-a-youtube-url")
+      end.to raise_error(StandardError)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes an issue where YouTube embeds failed for short youtu.be URLs containing si= or t= query parameters. si= and potentially t= params are introduced from default 'share' button on YouTube.

Other embed tag tests in the RSpec suite continue to pass. Manual spot-checks confirmed that GitHub, Spotify, CodePen, Vimeo & Bandcamp embeds still work as expected.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #22054

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
