### PR TITLE
Allow video_source_url in api if youtube

### DIFF
--- a/app/controllers/concerns/api/articles_controller.rb
+++ b/app/controllers/concerns/api/articles_controller.rb
@@ -72,7 +72,6 @@ module Api
       articles_relation = @user.super_admin? ? Article.includes(:user) : @user.articles
       article = articles_relation.find(params[:id])
 
-      p article_params.inspect
       result = Articles::Updater.call(@user, article, article_params)
 
       @article = result.article
@@ -153,6 +152,8 @@ module Api
         :published_at, :subforem_id, :language
       ]
       allowed_params << :organization_id if params.dig("article", "organization_id") && allowed_to_change_org_id?
+      # allow only if a youtube.com URL — could be other sources in future
+      allowed_params << :video_source_url if params.dig("article", "video_source_url")&.match?(/\Ahttps?:\/\/(www\.)?youtube\.com\/watch\?v=/)
       if @user.super_admin?
         allowed_params << :clickbait_score
         allowed_params << :compellingness_score

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -922,6 +922,8 @@ class Article < ApplicationRecord
   end
 
   def fetch_video_duration
+    return if video_source_url.include?("youtube.com")
+
     if video.present? && video_duration_in_seconds.zero?
       url = video_source_url.gsub(".m3u8", "1351620000001-200015_hls_v4.m3u8")
       duration = 0

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -607,7 +607,7 @@ RSpec.describe "Api::V1::Articles" do
       end
 
       it { is_expected.to have_http_status(:unauthorized) }
-    end
+    end      
 
     context "when security comparision fails" do
       before { allow(ActiveSupport::SecurityUtils).to receive(:secure_compare).and_return(false) }
@@ -936,6 +936,28 @@ RSpec.describe "Api::V1::Articles" do
         post_article(title: Faker::Book.title, body_markdown: nil)
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["error"]).to be_present
+      end
+
+      it "allows video_source_url if youtube.com is passed" do
+        user.update_column(:created_at, 1.year.ago)
+        video_source_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        post_article(
+          title: Faker::Book.title,
+          body_markdown: "Yo ho ho",
+          video_source_url: video_source_url,
+        )
+        expect(Article.last.video_source_url).to eq(video_source_url)
+      end
+
+      it "does not allow video_source_url if not youtube.com" do
+        user.update_column(:created_at, 1.year.ago)
+        video_source_url = "https://www.vimeo.com/watch?v=dQw4w9WgXcQ"
+        post_article(
+          title: Faker::Book.title,
+          body_markdown: "Yo ho ho",
+          video_source_url: video_source_url,
+        )
+        expect(Article.find(response.parsed_body["id"]).video_source_url).to be_nil
       end
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allow api to set video_source_url if youtube