### PR TITLE
Fix: Preserve HTML in runkit source code blocks

### DIFF
--- a/app/liquid_tags/runkit_tag.rb
+++ b/app/liquid_tags/runkit_tag.rb
@@ -77,7 +77,8 @@ class RunkitTag < Liquid::Block
 
   def render(context)
     content = Nokogiri::HTML.parse(super)
-    parsed_content = content.xpath("//html/body").text
+    # Get the inner HTML instead of just text to preserve HTML tags
+    parsed_content = content.xpath("//html/body").inner_html
     ApplicationController.render(
       partial: PARTIAL,
       locals: {

--- a/spec/liquid_tags/runkit_tag_spec.rb
+++ b/spec/liquid_tags/runkit_tag_spec.rb
@@ -17,6 +17,19 @@ RSpec.describe RunkitTag, type: :liquid_tag do
       CODE
     end
 
+    let(:content_with_html) do
+      <<~CODE
+        const { ValueViewerSymbol } = require("@runkit/value-viewer");
+
+        const myCustomObject = {
+            [ValueViewerSymbol]: {
+                title: "My First Viewer",
+                HTML: "<marquee>🍔Hello, World!🍔</marquee>"
+            }
+        };
+      CODE
+    end
+
     def generate_runkit_liquid(preamble_str, block)
       Liquid::Template.register_tag("runkit", described_class)
       Liquid::Template.parse("{% runkit #{preamble_str}%}#{block}{% endrunkit %}")
@@ -30,6 +43,14 @@ RSpec.describe RunkitTag, type: :liquid_tag do
       expect(rendered).to include('style="display: none"')
       expect(rendered).to include('await getJSON(&quot;https://storage.googleapis.com/maps-devrel/google.json&quot;);')
       # rubocop:enable Style/StringLiterals
+    end
+
+    it "preserves HTML tags in content" do
+      rendered = generate_runkit_liquid(preamble, content_with_html).render
+
+      # Check that the HTML tags are preserved
+      expect(rendered).to include('&lt;marquee&gt;🍔Hello, World!🍔&lt;/marquee&gt;')
+      expect(rendered).not_to include('🍔Hello, World!🍔') # This would indicate HTML was stripped
     end
   end
 end


### PR DESCRIPTION
This change modifies the RunkitTag class to use inner_html instead of text when parsing the content, which preserves HTML tags in the runkit source.

Fixes #1228

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [x] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

I have read the CLA Document and I hereby sign the CLA
