### PR TITLE
Fix capitalization: Terms of use -> Terms of Use

### DIFF
--- a/config/locales/views/main/en.yml
+++ b/config/locales/views/main/en.yml
@@ -42,7 +42,7 @@ en:
         Privacy Policy: Privacy Policy
         Reading List: Reading List
         Tags: Tags
-        Terms of use: Terms of use
+        Terms of use: Terms of Use
         Videos: Videos
       side:
         active_discussions: "Active discussions"

--- a/config/locales/views/main/fr.yml
+++ b/config/locales/views/main/fr.yml
@@ -42,7 +42,7 @@ fr:
         Privacy Policy: Privacy Policy
         Reading List: Reading List
         Tags: Tags
-        Terms of use: Terms of use
+        Terms of use: Terms of Use
         Videos: Videos
       side:
         listings:


### PR DESCRIPTION
Update nav_name translation strings in both English and French locale files to properly capitalize 'Terms of Use'.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Tiny copy tweak

## Description

Updates the default to Terms of **Use** and not Terms of **use**

## Related Tickets & Documents

- Closes https://github.com/forem/forem/issues/22150

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: I don't think these will be required
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

This PR doesn't update any _existing_ navigation links with the old capitalization, which is fine.