### PR TITLE
Automatically render links included in quickie titles

### DIFF
--- a/app/assets/javascripts/utilities/buildArticleHTML.js
+++ b/app/assets/javascripts/utilities/buildArticleHTML.js
@@ -419,7 +419,7 @@ function buildArticleHTML(article, currentUserId = null) {
         aria-labelledby="article-link-${article.id}"
         class="crayons-story__hidden-navigation-link"
       >
-        ${filterXSS(article.title)}
+        ${filterXSS(article.type_of === 'status' && article.title_finalized ? article.title_finalized : article.title)}
       </a>
     `;
 
@@ -443,7 +443,7 @@ function buildArticleHTML(article, currentUserId = null) {
             <div class="crayons-story__indention">
               <h3 class="crayons-story__title crayons-story__title-${article.type_of}">
                 <a href="${article.path}" id="article-link-${article.id}">
-                  ${filterXSS(article.title)}
+                  ${filterXSS(article.type_of === 'status' && article.title_finalized ? article.title_finalized : article.title)}
                 </a>
               </h3>\
               ${article.type_of !== 'status' ? `<div class="crayons-story__tags">${tagString}</div>` : ''}\

--- a/app/assets/stylesheets/base/typography.scss
+++ b/app/assets/stylesheets/base/typography.scss
@@ -370,8 +370,35 @@ body {
     padding: var(--su-5);
   }
 
+  &__content {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--su-4);
+  }
+
   &__cover {
     margin-bottom: var(--su-4);
+    flex-shrink: 0;
+    
+    // New horizontal layout styles
+    .c-embed__content & {
+      margin-bottom: 0;
+      width: 80px;
+      height: 80px;
+      text-align: center;
+      
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: var(--radius);
+      }
+    }
+  }
+
+  &__body {
+    flex: 1;
+    min-width: 0; // Allows text to truncate properly
   }
 
   h2,

--- a/app/assets/stylesheets/components/comments.scss
+++ b/app/assets/stylesheets/components/comments.scss
@@ -46,6 +46,9 @@
       .c-embed__cover {
         display: none;
       }
+      .c-embed__content {
+        display: block; // Override flex layout in comments
+      }
       .c-embed__body {
         font-size: var(--fs-s);
       }

--- a/app/assets/stylesheets/components/stories.scss
+++ b/app/assets/stylesheets/components/stories.scss
@@ -270,6 +270,18 @@
     .ltag__link .ltag__link__content .ltag__link__tag {
       font-size: 0.75em;
     }
+    br {
+      display: none;
+    }
+    .c-embed {
+      padding: 9px 16px !important;
+      margin: 0 !important;
+      font-size: 14px !important;
+    }
+    // Hide all crayons-cards after the first two
+    .c-embed:nth-child(n+3) {
+      display: none;
+    }
   }
 
   &__bottom {

--- a/app/javascript/articles/components/ContentTitle.jsx
+++ b/app/javascript/articles/components/ContentTitle.jsx
@@ -16,7 +16,7 @@ export const ContentTitle = ({ article }) => (
         </span>
       )}
       {/* eslint-disable-next-line react/no-danger */}
-      {article.title === '[Boost]' ? <span class='crayons-story__innertitle-boost'>Boosted by <a href={`/${article.user.username}`}>{article.user.name}</a></span> : <span dangerouslySetInnerHTML={{ __html: filterXSS(article.title) }} />}
+      {article.title === '[Boost]' ? <span class='crayons-story__innertitle-boost'>Boosted by <a href={`/${article.user.username}`}>{article.user.name}</a></span> : <span dangerouslySetInnerHTML={{ __html: article.type_of === 'status' && article.title_finalized ? article.title_finalized : filterXSS(article.title) }} />}
     </a>
   </h3>
 );

--- a/app/liquid_tags/unified_embed/tag.rb
+++ b/app/liquid_tags/unified_embed/tag.rb
@@ -3,19 +3,36 @@ require "net/http"
 module UnifiedEmbed
   class Tag < LiquidTagBase
     MAX_REDIRECTION_COUNT = 3
+    MINIMAL_ALLOWLIST = [LinkTag].freeze
 
     def self.new(tag_name, input, parse_context)
       stripped_input = ActionController::Base.helpers.strip_tags(input).strip
 
-      handler_before_validation = UnifiedEmbed::Registry.find_handler_for(link: stripped_input)
+      # Parse input to check for 'minimal' keyword
+      parts = stripped_input.split(/\s+/)
+      minimal_mode = parts.include?("minimal")
+
+      # Find the URL (first part that looks like a URL)
+      url = parts.find { |part| part.match?(%r{^https?://}) } || parts.first
+
+      handler_before_validation = UnifiedEmbed::Registry.find_handler_for(link: url)
 
       validated_link = if handler_before_validation&.dig(:skip_validation)
-                         stripped_input
+                         url
                        else
-                         validate_link(input: stripped_input)
+                         validate_link(input: url)
                        end
 
-      klass = UnifiedEmbed::Registry.find_liquid_tag_for(link: validated_link)
+      # In minimal mode, only use allow-listed embeds, otherwise fall back to OpenGraphTag
+      klass = if minimal_mode
+                if handler_before_validation && MINIMAL_ALLOWLIST.include?(handler_before_validation[:klass])
+                  handler_before_validation[:klass]
+                else
+                  OpenGraphTag
+                end
+              else
+                UnifiedEmbed::Registry.find_liquid_tag_for(link: validated_link)
+              end
 
       klass.__send__(:new, tag_name, validated_link, parse_context)
     end
@@ -27,7 +44,8 @@ module UnifiedEmbed
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true if http.port == 443
 
-      req = method.new(uri.request_uri)
+      path = uri.path.empty? ? "/" : uri.path
+      req = method.new(path + (uri.query ? "?#{uri.query}" : ""))
       req["User-Agent"] = "#{safe_user_agent} (#{URL.url})"
 
       response = http.request(req)

--- a/app/views/articles/_single_story.html.erb
+++ b/app/views/articles/_single_story.html.erb
@@ -1,16 +1,16 @@
 <div class="crayons-story <% if featured == true %>crayons-story--featured<% end %>" data-feed-content-id="<%= story.id %>" data-content-user-id="<%= story.user_id %>">
-  <a href="<%= URL.article(story) %>" aria-labelledby="article-link-<%= story.id %>" class="crayons-story__hidden-navigation-link"><%= story.title %></a>
+  <a href="<%= URL.article(story) %>" aria-labelledby="article-link-<%= story.id %>" class="crayons-story__hidden-navigation-link"><%= story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title %></a>
   <% if featured == true %>
     <div id="featured-story-marker" data-featured-article="articles-<%= story.id %>"></div>
   <% end %>
   <% if story.video.present? && story.video.include?("youtube") %>
     <div class="crayons-article__cover crayons-article__cover__image__feed" style="width: 100%; aspect-ratio: 16 / 9; position: relative;">
-      <iframe src="<%= story.video %>" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true" title="<%= story.title%>" style="border: 0px; position: absolute; top: 0px; left: 0px; width: 100%; height: 100%;"></iframe>
+      <iframe src="<%= story.video %>" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true" title="<%= story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title%>" style="border: 0px; position: absolute; top: 0px; left: 0px; width: 100%; height: 100%;"></iframe>
     </div>
   <% elsif featured == true || (feed_style_preference == "rich" && story.main_image.present?) %>
     <div class="crayons-article__cover crayons-article__cover__image__feed" style="aspect-ratio: auto 1000 / <%= story.main_image_height %>;">
-      <a href="<%= URL.article(story) %>" title="<%= story.title %>" aria-label="article" class="crayons-article__cover__image__feed crayons-story__cover__image">
-        <img src="<%= cloud_cover_url(story.main_image) %>" width="1000" height="<%= story.main_image_height %>" style="background-color:<%= story.main_image_background_hex_color %>;" class="crayons-article__cover__image__feed" alt="Cover image for <%= story.title %>">
+              <a href="<%= URL.article(story) %>" title="<%= story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title %>" aria-label="article" class="crayons-article__cover__image__feed crayons-story__cover__image">
+        <img src="<%= cloud_cover_url(story.main_image) %>" width="1000" height="<%= story.main_image_height %>" style="background-color:<%= story.main_image_background_hex_color %>;" class="crayons-article__cover__image__feed" alt="Cover image for <%= story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title %>">
       </a>
     </div>
   <% end %>
@@ -23,7 +23,7 @@
   </a>
   <% end %>
 
-  <div class="crayons-story__body">
+  <div class="crayons-story__body crayons-story__body-<%= story.type_of %>">
     <% note = story.context_notes.first %>
     <% if note && note.processed_html.present? %>
       <a href="<%= URL.article(story) %>" class="crayons-article__context-note crayons-article__context-note__feed"><%= note.processed_html.html_safe %></a>
@@ -108,28 +108,35 @@
     </div>
 
     <div class="crayons-story__indention">
-      <h2 class="crayons-story__title">
+      <h2 class="crayons-story__title crayons-story__title-<%= story.type_of %>">
         <a href="<%= URL.article(story) %>" data-preload-image="<%= cloud_cover_url(story.main_image) %>" id="article-link-<%= story.id %>">
-          <%= story.title %>
+          <%= story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title %>
         </a>
       </h2>
-      <div class="crayons-story__tags">
-        <% flare_tag = FlareTag.new(story, @tag).tag %>
-        <% if flare_tag %>
-          <%= render_tag_link(flare_tag.name, filled: true) %>
-        <% end %>
-        <% tags_to_display = story.cached_tag_list_array
-           if flare_tag
-             tags_to_display = tags_to_display.reject { |tag| tag == flare_tag.name }
-           end %>
-        <% tags_to_display.each do |tag| %>
-          <%= render_tag_link(tag, filled: false, monochrome: true) %>
-        <% end %>
-      </div>
+      <% if story.type_of != 'status' %>
+        <div class="crayons-story__tags">
+          <% flare_tag = FlareTag.new(story, @tag).tag %>
+          <% if flare_tag %>
+            <%= render_tag_link(flare_tag.name, filled: true) %>
+          <% end %>
+          <% tags_to_display = story.cached_tag_list_array
+             if flare_tag
+               tags_to_display = tags_to_display.reject { |tag| tag == flare_tag.name }
+             end %>
+          <% tags_to_display.each do |tag| %>
+            <%= render_tag_link(tag, filled: false, monochrome: true) %>
+          <% end %>
+        </div>
+      <% end %>
+      <% if story.type_of == 'status' && story.body_preview.present? && story.body_preview.length > 10 %>
+        <div class="crayons-story__contentpreview text-styles">
+          <%= story.body_preview.html_safe %>
+        </div>
+      <% end %>
       <div class="crayons-story__bottom">
         <div class="crayons-story__details">
           <% if story.public_reactions_count > 0 %>
-          <a href="<%= URL.article(story) %>" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left" data-reaction-count data-reactable-id="<%= story.id %>" aria-label="<%= t("views.articles.comments.aria_label", title: story.title) %>">
+          <a href="<%= URL.article(story) %>" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left" data-reaction-count data-reactable-id="<%= story.id %>" aria-label="<%= t("views.articles.comments.aria_label", title: story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title) %>">
             <div class="multiple_reactions_aggregate">
               <span class="multiple_reactions_icons_container" dir="rtl">
                 <% story.public_reaction_categories.reverse_each do |reaction_type| %>
@@ -146,7 +153,7 @@
           </a>
           <% end %>
           <% if story.comments_count > 0 %>
-            <a href="<%= URL.article(story) %>#comments" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left flex items-center" aria-label="<%= t("views.articles.comments.aria_label", title: story.title) %>">
+            <a href="<%= URL.article(story) %>#comments" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left flex items-center" aria-label="<%= t("views.articles.comments.aria_label", title: story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title) %>">
               <%= crayons_icon_tag("small-comment", title: t("views.comments.summary.title")) %>
               <%= t("views.comments.summary.count_html",
                     count: story.comments_count,
@@ -154,7 +161,7 @@
                     end: "</span>".html_safe) %>
             </a>
           <% else %>
-            <a href="<%= URL.article(story) %>#comments" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left flex items-center" aria-label="<%= t("views.articles.comments.aria_label", title: story.title) %>">
+            <a href="<%= URL.article(story) %>#comments" class="crayons-btn crayons-btn--s crayons-btn--ghost crayons-btn--icon-left flex items-center" aria-label="<%= t("views.articles.comments.aria_label", title: story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title) %>">
               <%= crayons_icon_tag("small-comment", title: t("views.comments.summary.title")) %>
               <span class="hidden s:inline"><%= t("views.comments.add") %></span>
             </a>
@@ -171,8 +178,8 @@
               class="c-btn c-btn--icon-alone bookmark-button"
               data-reactable-id="<%= story.id %>"
               data-article-author-id="<%= story.user_id %>"
-              aria-label="<%= t("views.articles.save.aria_label", title: story.title) %>"
-              title="<%= t("views.articles.save.title", title: story.title) %>">
+              aria-label="<%= t("views.articles.save.aria_label", title: story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title) %>"
+              title="<%= t("views.articles.save.title", title: story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title) %>">
               <span class="bm-initial">
                 <%= inline_svg_tag("small-save.svg", alt: "", aria_hidden: true) %>
               </span>

--- a/app/views/articles/_tag_identifier.html.erb
+++ b/app/views/articles/_tag_identifier.html.erb
@@ -1,4 +1,4 @@
 <% flare_tag = FlareTag.new(story, @tag).tag %>
 <% if flare_tag %>
   <span class="crayons-story__flare-tag" style="background:<%= flare_tag.bg_color_hex %>;color:<%= flare_tag.text_color_hex %>">
-    #<%= flare_tag.name %></span><% end %><%= story.title %>
+    #<%= flare_tag.name %></span><% end %><%= story.type_of == "status" && story.title_finalized ? story.title_finalized : story.title %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -235,7 +235,7 @@
                 <% if @article.search_optimized_title_preamble.present? && !user_signed_in? %>
                   <span class="fs-xl color-base-70 block"><%= @article.search_optimized_title_preamble %></span>
                 <% end %>
-                <%= @article.title %>
+                <%= @article.type_of == "status" ? @article.title_finalized : @article.title %>
               </h1>
               
               <% if @article.type_of == "full_post" %>

--- a/app/views/liquids/_open_graph.html.erb
+++ b/app/views/liquids/_open_graph.html.erb
@@ -1,32 +1,34 @@
 <div class="crayons-card c-embed text-styles text-styles--secondary">
   <% if page.main_properties_present? %>
-    <% if page.image %>
-      <div class="c-embed__cover">
-        <a href="<%= page.url %>" class="c-link s:max-w-50 align-middle" target="_blank" rel="noopener noreferrer">
-          <img alt="" src="<%= page.image %>" height="auto" loading="lazy" class="m-0">
-        </a>
-      </div>
-    <% end %>
-    <div class="c-embed__body">
-      <h2 class="fs-xl lh-tight">
-        <a href="<%= page.url %>" target="_blank" rel="noopener noreferrer" class="c-link">
-          <%= page.title %>
-        </a>
-      </h2>
-      <% if page.description %>
-        <p class="truncate-at-3">
-          <%= page.preferred_desc %>
-        </p>
+    <div class="c-embed__content">
+      <% if page.image %>
+        <div class="c-embed__cover">
+          <a href="<%= page.url %>" class="c-link align-middle" target="_blank" rel="noopener noreferrer">
+            <img alt="" src="<%= page.image %>" height="auto" loading="lazy" class="m-0">
+          </a>
+        </div>
       <% end %>
-      <div class="color-secondary fs-s flex items-center">
-        <% if page.images.favicon %>
-          <img
-            alt="favicon"
-            class="c-embed__favicon m-0 mr-2 radius-0"
-            src="<%= page.images.favicon %>"
-            loading="lazy" />
+      <div class="c-embed__body">
+        <h2 class="fs-xl lh-tight">
+          <a href="<%= page.url %>" target="_blank" rel="noopener noreferrer" class="c-link">
+            <%= page.title %>
+          </a>
+        </h2>
+        <% if page.description %>
+          <p class="truncate-at-3">
+            <%= page.preferred_desc %>
+          </p>
         <% end %>
-        <%= url_domain %>
+        <div class="color-secondary fs-s flex items-center">
+          <% if page.images.favicon %>
+            <img
+              alt="favicon"
+              class="c-embed__favicon m-0 mr-2 radius-0"
+              src="<%= page.images.favicon %>"
+              loading="lazy" />
+          <% end %>
+          <%= url_domain %>
+        </div>
       </div>
     </div>
   <% else %>

--- a/app/views/stories/feeds/show.json.jbuilder
+++ b/app/views/stories/feeds/show.json.jbuilder
@@ -8,7 +8,7 @@ article_methods_to_include = %i[
   readable_publish_date flare_tag class_name
   cloudinary_video_url video_duration_in_minutes published_at_int
   published_timestamp main_image_background_hex_color
-  public_reaction_categories body_preview
+  public_reaction_categories body_preview title_finalized
 ]
 
 json.array!(@stories) do |article|

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -2253,9 +2253,68 @@ RSpec.describe Article do
   describe "URL extraction from title for quickie posts" do
     let(:user) { create(:user) }
 
+    before do
+      # Stub HTTP requests for URL validation in embed tags
+      stub_request(:head, "https://example.com/")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "", headers: {})
+
+      stub_request(:get, "https://example.com/")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "<html><head><title>Example</title></head><body>Example content</body></html>", headers: {})
+
+      stub_request(:head, "https://another-example.org/")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "", headers: {})
+
+      stub_request(:get, "https://another-example.org/")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "<html><head><title>Another Example</title></head><body>Another example content</body></html>", headers: {})
+
+      stub_request(:head, "https://first.com/")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "", headers: {})
+
+      stub_request(:get, "https://first.com/")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "<html><head><title>First</title></head><body>First content</body></html>", headers: {})
+
+      stub_request(:head, "https://second.org/")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "", headers: {})
+
+      stub_request(:get, "https://second.org/")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "<html><head><title>Second</title></head><body>Second content</body></html>", headers: {})
+
+      stub_request(:head, "https://third.net/")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "", headers: {})
+
+      stub_request(:get, "https://third.net/")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "<html><head><title>Third</title></head><body>Third content</body></html>", headers: {})
+
+      stub_request(:head, "https://example.com/path?param=value#fragment")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "", headers: {})
+
+      stub_request(:get, "https://example.com/path?param=value#fragment")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "<html><head><title>Example with params</title></head><body>Example with params content</body></html>", headers: {})
+
+      stub_request(:head, "https://example.com/path?param=value")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "", headers: {})
+
+      stub_request(:get, "https://example.com/path?param=value")
+        .with(headers: { "Accept" => "*/*", "Accept-Encoding" => /.*/, "User-Agent" => /.*/ })
+        .to_return(status: 200, body: "<html><head><title>Example with params</title></head><body>Example with params content</body></html>", headers: {})
+    end
+
     context "when creating a status post with URLs in title" do
       it "adds embed tags to body_markdown for URLs found in title" do
-        article = build(:article,
+        article = build(:published_article,
                         user: user,
                         type_of: "status",
                         title: "Check out this cool site https://example.com and also https://another-example.org",
@@ -2269,7 +2328,7 @@ RSpec.describe Article do
       end
 
       it "creates embed tags when body_markdown is empty" do
-        article = build(:article,
+        article = build(:published_article,
                         user: user,
                         type_of: "status",
                         title: "Look at this: https://example.com",
@@ -2305,7 +2364,7 @@ RSpec.describe Article do
       end
 
       it "handles multiple URLs in title correctly" do
-        article = build(:article,
+        article = build(:published_article,
                         user: user,
                         type_of: "status",
                         title: "Multiple URLs: https://first.com and https://second.org and https://third.net",
@@ -2319,7 +2378,7 @@ RSpec.describe Article do
       end
 
       it "handles URLs with query parameters and fragments" do
-        article = build(:article,
+        article = build(:published_article,
                         user: user,
                         type_of: "status",
                         title: "Complex URL: https://example.com/path?param=value#fragment",


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This automatically embeds links which are included in quickie titles. It does not spit out full embeds (though could in future)

<img width="643" height="315" alt="Screenshot 2025-08-21 at 4 17 34 PM" src="https://github.com/user-attachments/assets/3dcff9d8-c0ff-465e-9a75-23deb1bbda78" />
