### PR TITLE
Establish explicit transparant bot concept

### DIFF
--- a/app/controllers/admin/community_bots_controller.rb
+++ b/app/controllers/admin/community_bots_controller.rb
@@ -1,0 +1,87 @@
+module Admin
+  class CommunityBotsController < Admin::ApplicationController
+    layout "admin"
+
+    before_action :set_subforem, only: %i[index new create]
+    before_action :set_bot, only: %i[show destroy]
+    before_action :authorize_subforem, only: %i[index new create]
+    before_action :authorize_bot, only: %i[show destroy]
+
+    def index
+      @community_bots = User.community_bots_for_subforem(@subforem.id)
+        .includes(:api_secrets)
+        .order(created_at: :desc)
+    end
+
+    def show
+      @api_secrets = @bot.api_secrets.order(created_at: :desc)
+    end
+
+    def new
+      @bot = User.new
+    end
+
+    def create
+      result = CommunityBots::CreateBot.call(
+        subforem_id: @subforem.id,
+        name: bot_params[:name],
+        created_by: current_user,
+        username: bot_params[:username],
+        profile_image: bot_params[:profile_image],
+      )
+
+      if result.success?
+        flash[:success] = "Community bot '#{bot_params[:name]}' created successfully!"
+        redirect_to admin_subforem_community_bots_path(@subforem)
+      else
+        flash.now[:error] = result.error_message
+        @bot = User.new(bot_params)
+        render :new
+      end
+    end
+
+    def destroy
+      result = CommunityBots::DeleteBot.call(
+        bot_user: @bot,
+        deleted_by: current_user,
+      )
+
+      if result.success?
+        flash[:success] = "Community bot deleted successfully!"
+      else
+        flash[:error] = result.error_message
+      end
+
+      redirect_to admin_subforem_community_bots_path(@bot.onboarding_subforem_id)
+    end
+
+    private
+
+    def set_subforem
+      @subforem = Subforem.find(params[:subforem_id])
+    end
+
+    def set_bot
+      @bot = User.find(params[:id])
+      @subforem = Subforem.find(@bot.onboarding_subforem_id)
+    end
+
+    def authorize_subforem
+      authorize @subforem, policy_class: CommunityBotPolicy
+    end
+
+    def authorize_bot
+      authorize @bot, policy_class: CommunityBotPolicy
+    end
+
+    def bot_params
+      params.require(:user).permit(:name, :username, :profile_image)
+    end
+
+    protected
+
+    def authorization_resource
+      User
+    end
+  end
+end

--- a/app/models/admin_menu.rb
+++ b/app/models/admin_menu.rb
@@ -31,6 +31,7 @@ class AdminMenu
       item(name: "navigation links"),
       item(name: "pages"),
       item(name: "profile fields"),
+      item(name: "subforems"),
     ]
 
     scope :admin_team, "user-line", [

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,9 @@ class User < ApplicationRecord
 
   RECENTLY_ACTIVE_LIMIT = 10_000
 
+  # User types enum
+  enum type_of: { member: 0, community_bot: 1, member_bot: 2 }
+
   attr_accessor :scholar_email, :new_note, :note_for_current_role, :user_status, :merge_user_id,
                 :add_credits, :remove_credits, :add_org_credits, :remove_org_credits, :ip_address,
                 :current_password, :custom_invite_subject, :custom_invite_message, :custom_invite_footnote
@@ -225,6 +228,10 @@ class User < ApplicationRecord
       .joins("INNER JOIN tags ON tags.id = follows.followable_id AND follows.followable_type = 'ActsAsTaggableOn::Tag'")
       .where(tags: { name: tags })
       .distinct
+  }
+
+  scope :community_bots_for_subforem, lambda { |subforem_id|
+    where(type_of: :community_bot, onboarding_subforem_id: subforem_id)
   }
   scope :above_average, lambda {
     where(
@@ -676,6 +683,18 @@ class User < ApplicationRecord
       errors.add(:email, "Error sending magic link")
       Rails.logger.error("Error sending magic link for user #{id}")
     end
+  end
+
+  def community_bot?
+    type_of == "community_bot"
+  end
+
+  def member_bot?
+    type_of == "member_bot"
+  end
+
+  def bot?
+    community_bot? || member_bot?
   end
 
   protected

--- a/app/policies/community_bot_policy.rb
+++ b/app/policies/community_bot_policy.rb
@@ -1,0 +1,40 @@
+class CommunityBotPolicy < ApplicationPolicy
+  def index?
+    has_mod_permission?
+  end
+
+  def new?
+    has_mod_permission?
+  end
+
+  def create?
+    has_mod_permission?
+  end
+
+  def show?
+    has_mod_permission?
+  end
+
+  def destroy?
+    has_mod_permission?
+  end
+
+  private
+
+  def has_mod_permission?
+    return true if user.any_admin?
+    return true if user.super_moderator?
+    
+    # If record is a User (bot), check if user is moderator for that bot's subforem
+    if record.is_a?(User) && record.community_bot?
+      return true if user.subforem_moderator?(subforem: Subforem.find(record.onboarding_subforem_id))
+    end
+    
+    # If record is a Subforem, check if user is moderator for that subforem
+    if record.is_a?(Subforem)
+      return true if user.subforem_moderator?(subforem: record)
+    end
+
+    false
+  end
+end

--- a/app/services/community_bots/create_bot.rb
+++ b/app/services/community_bots/create_bot.rb
@@ -1,0 +1,160 @@
+module CommunityBots
+  class CreateBot
+    def self.call(subforem_id:, name:, created_by:, username: nil, profile_image: nil)
+      new(subforem_id: subforem_id, name: name, created_by: created_by, username: username,
+          profile_image: profile_image).call
+    end
+
+    def initialize(subforem_id:, name:, created_by:, username: nil, profile_image: nil)
+      @subforem_id = subforem_id
+      @name = name
+      @created_by = created_by
+      @username = username
+      @profile_image = profile_image
+      @success = false
+      @error_message = nil
+      @bot_user = nil
+      @api_secret = nil
+    end
+
+    def call
+      return self unless subforem_exists?
+      return self unless authorized?
+
+      # Generate a unique email for the bot
+      bot_email = generate_bot_email
+
+      # Create the bot user directly
+      password = SecureRandom.hex(20)
+      @bot_user = User.create!(
+        email: bot_email,
+        username: generate_bot_username,
+        name: @name,
+        type_of: :community_bot,
+        onboarding_subforem_id: @subforem_id,
+        registered: true,
+        registered_at: Time.current,
+        confirmed_at: Time.current,
+        password: password,
+        password_confirmation: password,
+        invited_by: @created_by,
+      )
+
+      set_profile_image
+
+      # Create an API secret for the bot
+      @api_secret = @bot_user.api_secrets.create!(
+        description: "Community Bot API Key for #{@name}",
+      )
+
+      @success = true
+      self
+    rescue StandardError => e
+      @error_message = "Failed to create bot: #{e.message}"
+      self
+    end
+
+    def success?
+      @success
+    end
+
+    attr_reader :error_message, :bot_user, :api_secret
+
+    private
+
+    def subforem_exists?
+      return true if Subforem.exists?(@subforem_id)
+
+      @error_message = "Subforem not found"
+      false
+    end
+
+    def authorized?
+      return true if @created_by.any_admin?
+      return true if @created_by.super_moderator?
+      return true if @created_by.subforem_moderator?(subforem: Subforem.find(@subforem_id))
+
+      @error_message = "Unauthorized to create bots for this subforem"
+      false
+    end
+
+    def generate_bot_email
+      subforem = Subforem.find(@subforem_id)
+      timestamp = Time.current.to_i
+      "bot-#{@name.parameterize}-#{timestamp}@#{subforem.domain}"
+    end
+
+    def generate_bot_username
+      if @username.present?
+        # Use provided username with timestamp to ensure uniqueness
+        base_username = @username.parameterize
+        if User.exists?(username: base_username)
+          "#{base_username}_#{timestamp}"
+        else
+          base_username
+        end
+      else
+        # Generate username from name
+        base_username = @name.parameterize
+        timestamp = Time.current.to_i
+        "#{base_username}_bot_#{timestamp}"
+      end
+    end
+
+    def set_profile_image
+      if @profile_image.present?
+        # Use the uploaded profile image
+        @bot_user.profile_image = @profile_image
+        @bot_user.save!
+      else
+        # Fall back to subforem's logo_png
+        subforem_logo_url = Settings::General.logo_png(subforem_id: @subforem_id)
+        if subforem_logo_url.present?
+          # Download and create a file from the logo URL
+          logo_file = download_logo_as_file(subforem_logo_url)
+          if logo_file
+            @bot_user.profile_image = logo_file
+            @bot_user.save!
+          else
+            # Fall back to default profile image generator
+            @bot_user.profile_image = Images::ProfileImageGenerator.call
+            @bot_user.save!
+          end
+        else
+          # Use default profile image generator
+          @bot_user.profile_image = Images::ProfileImageGenerator.call
+          @bot_user.save!
+        end
+      end
+    end
+
+    def download_logo_as_file(logo_url)
+      require "open-uri"
+      require "tempfile"
+
+      begin
+        # Download the logo
+        downloaded_image = URI.open(logo_url)
+
+        # Create a temp file with the correct extension
+        tempfile = Tempfile.new(["bot_logo", ".png"])
+        tempfile.binmode
+        tempfile.write(downloaded_image.read)
+        tempfile.rewind
+
+        # Create a file object that can be used by the uploader
+        uploaded_file = Rack::Test::UploadedFile.new(tempfile.path, "image/png")
+
+        # Clean up the tempfile after the upload is complete
+        tempfile.close
+        tempfile.unlink
+
+        uploaded_file
+      rescue StandardError => e
+        Rails.logger.error("Failed to download subforem logo for bot: #{e.message}")
+        # Let the User model handle profile image generation through its normal flow
+        nil
+      end
+    end
+  end
+end

--- a/app/services/community_bots/delete_bot.rb
+++ b/app/services/community_bots/delete_bot.rb
@@ -1,0 +1,49 @@
+module CommunityBots
+  class DeleteBot
+    def self.call(bot_user:, deleted_by:)
+      new(bot_user: bot_user, deleted_by: deleted_by).call
+    end
+
+    def initialize(bot_user:, deleted_by:)
+      @bot_user = bot_user
+      @deleted_by = deleted_by
+      @success = false
+      @error_message = nil
+    end
+
+    def call
+      unless @bot_user.community_bot?
+        @error_message = "User is not a community bot"
+        return self
+      end
+
+      return self unless authorized?
+
+      # Delete the bot user and all associated data
+      @bot_user.destroy!
+
+      @success = true
+      self
+    rescue StandardError => e
+      @error_message = "Failed to delete bot: #{e.message}"
+      self
+    end
+
+    def success?
+      @success
+    end
+
+    attr_reader :error_message
+
+    private
+
+    def authorized?
+      return true if @deleted_by.any_admin?
+      return true if @deleted_by.super_moderator?
+      return true if @deleted_by.subforem_moderator?(subforem: Subforem.find(@bot_user.onboarding_subforem_id))
+
+      @error_message = "Unauthorized to delete this bot"
+      false
+    end
+  end
+end

--- a/app/services/subforem_moderators/add.rb
+++ b/app/services/subforem_moderators/add.rb
@@ -52,3 +52,4 @@ module SubforemModerators
   end
 end
 
+

--- a/app/services/subforem_moderators/add_trusted_role.rb
+++ b/app/services/subforem_moderators/add_trusted_role.rb
@@ -19,3 +19,4 @@ module SubforemModerators
   end
 end
 
+

--- a/app/services/subforem_moderators/remove.rb
+++ b/app/services/subforem_moderators/remove.rb
@@ -19,3 +19,4 @@ module SubforemModerators
   end
 end
 
+

--- a/app/views/admin/community_bots/index.html.erb
+++ b/app/views/admin/community_bots/index.html.erb
@@ -1,0 +1,59 @@
+<header class="flex items-center mb-6">
+  <div>
+    <h1 class="crayons-title">Community Bots for <%= @subforem.domain %></h1>
+    <p class="color-secondary">Manage community bots for this subforem</p>
+  </div>
+  <div class="ml-auto flex gap-2">
+    <%= link_to "New Bot", new_admin_subforem_community_bot_path(@subforem), class: "crayons-btn crayons-btn--s" %>
+    <%= link_to "Back to Subforem", admin_subforem_path(@subforem), class: "crayons-btn crayons-btn--outlined" %>
+  </div>
+</header>
+
+<div class="crayons-card p-6">
+  <% if @community_bots.empty? %>
+    <div class="text-center py-8">
+      <p class="color-secondary">No community bots found for this subforem.</p>
+      <%= link_to "Create your first bot", new_admin_subforem_community_bot_path(@subforem), class: "crayons-btn mt-4" %>
+    </div>
+  <% else %>
+    <div class="grid gap-4">
+      <% @community_bots.each do |bot| %>
+        <div class="border border-base-20 rounded-lg p-4" data-testid="community-bot">
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-3">
+              <div class="w-10 h-10 rounded-full bg-base-20 flex items-center justify-center">
+                <span class="text-lg">🤖</span>
+              </div>
+              <div>
+                <h3 class="font-semibold"><%= bot.name %></h3>
+                <p class="text-sm color-secondary">@<%= bot.username %></p>
+                <p class="text-xs color-secondary">Created <%= time_ago_in_words(bot.created_at) %> ago</p>
+              </div>
+            </div>
+            
+            <div class="flex gap-2">
+              <%= link_to "View Details", admin_subforem_community_bot_path(@subforem, bot), class: "crayons-btn crayons-btn--s" %>
+              <%= link_to "Delete", admin_subforem_community_bot_path(@subforem, bot), 
+                  method: :delete, 
+                  data: { confirm: "Are you sure you want to delete this bot? This action cannot be undone." },
+                  class: "crayons-btn crayons-btn--danger crayons-btn--s" %>
+            </div>
+          </div>
+          
+          <% if bot.api_secrets.any? %>
+            <div class="mt-4 p-3 bg-base-10 rounded">
+              <h4 class="text-sm font-semibold mb-2">API Secrets</h4>
+              <% bot.api_secrets.each do |secret| %>
+                <div class="flex items-center justify-between text-sm">
+                  <span class="color-secondary"><%= secret.description %></span>
+                  <code class="bg-base-20 px-2 py-1 rounded text-xs font-mono"><%= secret.secret %></code>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+

--- a/app/views/admin/community_bots/new.html.erb
+++ b/app/views/admin/community_bots/new.html.erb
@@ -1,0 +1,58 @@
+<header class="flex items-center mb-6">
+  <div>
+    <h1 class="crayons-title">Create New Community Bot</h1>
+    <p class="color-secondary">Create a new bot for <%= @subforem.domain %></p>
+  </div>
+  <div class="ml-auto">
+    <%= link_to "Back to Bots", admin_subforem_community_bots_path(@subforem), class: "crayons-btn crayons-btn--outlined" %>
+  </div>
+</header>
+
+<div class="crayons-card p-6 max-w-2xl">
+  <%= form_for @bot, url: admin_subforem_community_bots_path(@subforem), html: { multipart: true } do |form| %>
+    <div class="crayons-field">
+      <%= form.label :name, "Bot Name", class: "crayons-field__label" %>
+      <p class="crayons-field__description">Choose a descriptive name for your community bot (e.g., "News Bot", "Welcome Bot")</p>
+      <%= form.text_field :name, 
+          class: "crayons-textfield", 
+          placeholder: "Enter bot name",
+          required: true %>
+    </div>
+
+    <div class="crayons-field">
+      <%= form.label :username, "Bot Username", class: "crayons-field__label" %>
+      <p class="crayons-field__description">Choose a unique username for your bot (optional - will be auto-generated if not provided)</p>
+      <%= form.text_field :username, 
+          class: "crayons-textfield", 
+          placeholder: "Enter bot username (optional)" %>
+    </div>
+
+    <div class="crayons-field">
+      <%= form.label :profile_image, "Bot Profile Image", class: "crayons-field__label" %>
+      <p class="crayons-field__description">Upload a profile image for your bot (optional - will use subforem logo if not provided)</p>
+      <%= form.file_field :profile_image, 
+          accept: "image/*", 
+          class: "crayons-card crayons-card--secondary p-3 flex items-center flex-1 w-100" %>
+    </div>
+
+    <div class="mt-6 flex gap-3">
+      <%= form.submit "Create Bot", class: "crayons-btn" %>
+      <%= link_to "Cancel", admin_subforem_community_bots_path(@subforem), class: "crayons-btn crayons-btn--ghost" %>
+    </div>
+  <% end %>
+</div>
+
+<div class="crayons-card p-6 mt-6 max-w-2xl">
+  <h3 class="crayons-subtitle-1 mb-4">About Community Bots</h3>
+  <div class="prose prose-sm">
+    <ul class="list-disc pl-4 space-y-2">
+      <li>Community bots are automated accounts that can post content to your subforem</li>
+      <li>Each bot gets its own API key for programmatic access</li>
+      <li>Bots are automatically assigned to this subforem</li>
+      <li>You can use the API key to integrate with external services or create automated workflows</li>
+      <li>Bots can post articles, comments, and interact with the community</li>
+      <li>If no profile image is provided, the bot will use this subforem's logo</li>
+    </ul>
+  </div>
+</div>
+

--- a/app/views/admin/community_bots/show.html.erb
+++ b/app/views/admin/community_bots/show.html.erb
@@ -1,0 +1,108 @@
+<header class="flex items-center mb-6">
+  <div>
+    <h1 class="crayons-title"><%= @bot.name %></h1>
+    <p class="color-secondary">Community Bot Details</p>
+  </div>
+  <div class="ml-auto flex gap-2">
+    <%= link_to "Back to Bots", admin_subforem_community_bots_path(@subforem), class: "crayons-btn crayons-btn--outlined" %>
+    <%= link_to "Delete Bot", admin_subforem_community_bot_path(@subforem, @bot), 
+        method: :delete, 
+        data: { confirm: "Are you sure you want to delete this bot? This action cannot be undone." },
+        class: "crayons-btn crayons-btn--danger" %>
+  </div>
+</header>
+
+<div class="grid gap-6">
+  <!-- Bot Details Card -->
+  <div class="crayons-card p-6">
+    <h2 class="crayons-subtitle-1 mb-4">Bot Information</h2>
+    <div class="grid gap-4 m:grid-cols-2">
+      <div class="crayons-field">
+        <strong class="crayons-field__label">Name:</strong>
+        <p class="mt-1"><%= @bot.name %></p>
+      </div>
+      
+      <div class="crayons-field">
+        <strong class="crayons-field__label">Username:</strong>
+        <p class="mt-1">@<%= @bot.username %></p>
+      </div>
+      
+      <div class="crayons-field">
+        <strong class="crayons-field__label">Email:</strong>
+        <p class="mt-1"><%= @bot.email %></p>
+      </div>
+      
+      <div class="crayons-field">
+        <strong class="crayons-field__label">Created:</strong>
+        <p class="mt-1"><%= @bot.created_at.strftime("%B %d, %Y at %I:%M %p") %></p>
+      </div>
+      
+      <div class="crayons-field">
+        <strong class="crayons-field__label">Status:</strong>
+        <p class="mt-1">
+          <span class="c-indicator c-indicator--success">Active</span>
+        </p>
+      </div>
+      
+      <div class="crayons-field">
+        <strong class="crayons-field__label">Type:</strong>
+        <p class="mt-1">Community Bot</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- API Secrets Card -->
+  <div class="crayons-card p-6">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="crayons-subtitle-1">API Secrets</h2>
+      <span class="text-sm color-secondary"><%= pluralize(@api_secrets.count, 'secret') %></span>
+    </div>
+    
+    <% if @api_secrets.empty? %>
+      <p class="color-secondary">No API secrets found for this bot.</p>
+    <% else %>
+      <div class="space-y-4">
+        <% @api_secrets.each do |secret| %>
+          <div class="border border-base-20 rounded-lg p-4">
+            <div class="flex items-center justify-between mb-2">
+              <h3 class="font-semibold"><%= secret.description %></h3>
+              <span class="text-xs color-secondary">Created <%= time_ago_in_words(secret.created_at) %> ago</span>
+            </div>
+            <div class="bg-base-10 p-3 rounded">
+              <div class="flex items-center justify-between">
+                <code class="font-mono text-sm break-all"><%= secret.secret %></code>
+                <button class="ml-2 text-xs color-secondary hover:color-base-70" 
+                        onclick="navigator.clipboard.writeText('<%= secret.secret %>').then(() => alert('API key copied to clipboard!'))">
+                  Copy
+                </button>
+              </div>
+            </div>
+            <p class="text-xs color-secondary mt-2">
+              Use this API key in the <code>api-key</code> header for API requests
+            </p>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+  <!-- Activity Card -->
+  <div class="crayons-card p-6">
+    <h2 class="crayons-subtitle-1 mb-4">Bot Activity</h2>
+    <div class="grid gap-4 m:grid-cols-3">
+      <div class="text-center">
+        <div class="text-2xl font-bold"><%= @bot.articles_count %></div>
+        <div class="text-sm color-secondary">Articles</div>
+      </div>
+      <div class="text-center">
+        <div class="text-2xl font-bold"><%= @bot.comments_count %></div>
+        <div class="text-sm color-secondary">Comments</div>
+      </div>
+      <div class="text-center">
+        <div class="text-2xl font-bold"><%= @bot.reactions_count %></div>
+        <div class="text-sm color-secondary">Reactions</div>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/admin/subforems/show.html.erb
+++ b/app/views/admin/subforems/show.html.erb
@@ -56,6 +56,37 @@
     </div>
   </div>
 
+  <!-- Community Bots Card -->
+  <div class="crayons-card p-6">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="crayons-subtitle-1">Community Bots</h2>
+      <%= link_to "Manage Bots", admin_subforem_community_bots_path(@subforem), class: "crayons-btn crayons-btn--s" %>
+    </div>
+    
+    <% community_bots = User.community_bots_for_subforem(@subforem.id).limit(3) %>
+    <% if community_bots.any? %>
+      <div class="space-y-2">
+        <% community_bots.each do |bot| %>
+          <div class="flex items-center justify-between p-2 bg-base-5 rounded">
+            <div class="flex items-center gap-2">
+              <span class="text-lg">🤖</span>
+              <span class="fw-medium"><%= bot.name %></span>
+              <span class="text-sm color-secondary">@<%= bot.username %></span>
+            </div>
+            <%= link_to "View", admin_subforem_community_bot_path(@subforem, bot), class: "crayons-link crayons-link--secondary fs-s" %>
+          </div>
+        <% end %>
+        <% if User.community_bots_for_subforem(@subforem.id).count > 3 %>
+          <p class="text-sm color-secondary text-center">
+            <%= link_to "View all #{User.community_bots_for_subforem(@subforem.id).count} bots", admin_subforem_community_bots_path(@subforem), class: "crayons-link" %>
+          </p>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="color-secondary">No community bots found for this subforem.</p>
+    <% end %>
+  </div>
+
   <!-- Moderators Card -->
   <div class="crayons-card p-6">
     <h2 class="crayons-subtitle-1 mb-4">Moderators</h2>

--- a/app/views/subforems/edit.html.erb
+++ b/app/views/subforems/edit.html.erb
@@ -304,6 +304,48 @@
       <p class="text-sm color-base-60">No dedicated navigation links found for this subforem (edit functionality coming soon).</p>
     <% end %>
   </div>
+
+  <!-- COMMUNITY BOTS SECTION -->
+  <div class="crayons-layout crayons-card p-4 m:p-6 mb-4">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="crayons-subtitle-2">Community Bots</h2>
+      <% if current_user.any_admin? || current_user.super_moderator? || current_user.subforem_moderator?(subforem: @subforem) %>
+        <%= link_to "Manage Bots", admin_subforem_community_bots_path(@subforem), class: "crayons-btn crayons-btn--s" %>
+      <% end %>
+    </div>
+    
+    <% community_bots = User.community_bots_for_subforem(@subforem.id).includes(:api_secrets).order(created_at: :desc) %>
+    
+    <% if community_bots.any? %>
+      <div class="space-y-3">
+        <% community_bots.each do |bot| %>
+          <div class="flex items-center justify-between p-3 bg-base-5 rounded-lg">
+            <div class="flex-1">
+              <div class="font-medium flex items-center gap-2">
+                <span class="text-lg">🤖</span>
+                <%= bot.name %>
+                <span class="text-sm color-base-60">@<%= bot.username %></span>
+              </div>
+              <div class="text-sm color-base-60">
+                <%= bot.email %>
+              </div>
+              <div class="text-xs color-base-50">
+                Created: <%= bot.created_at.strftime("%b %d, %Y") %> | 
+                API Secrets: <%= bot.api_secrets.count %>
+              </div>
+            </div>
+            <div class="flex items-center gap-2">
+              <% if current_user.any_admin? || current_user.super_moderator? || current_user.subforem_moderator?(subforem: @subforem) %>
+                <%= link_to "View", admin_subforem_community_bot_path(@subforem, bot), class: "crayons-btn crayons-btn--s crayons-btn--secondary" %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-sm color-base-60">No community bots found for this subforem.</p>
+    <% end %>
+  </div>
 </main>
 
 <script>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -119,6 +119,7 @@ namespace :admin do
     resources :profile_fields, only: %i[index update create destroy]
     resources :subforems, only: %i[index new create edit update show] do
       resource :moderator, only: %i[create destroy], module: "subforem_moderators"
+      resources :community_bots, only: %i[index new create show destroy]
     end
   end
 

--- a/db/migrate/20250821221829_add_type_of_to_users.rb
+++ b/db/migrate/20250821221829_add_type_of_to_users.rb
@@ -1,0 +1,8 @@
+class AddTypeOfToUsers < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_column :users, :type_of, :integer, default: 0, null: false
+    add_index :users, :type_of, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
+ActiveRecord::Schema[7.0].define(version: 2025_08_21_221829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -90,7 +90,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.boolean "archived", default: false
     t.text "body_html"
     t.text "body_markdown"
-    t.string "cached_label_list", default: [], array: true
     t.text "cached_organization"
     t.string "cached_tag_list"
     t.text "cached_user"
@@ -103,7 +102,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.integer "comment_score", default: 0
     t.string "comment_template"
     t.integer "comments_count", default: 0, null: false
-    t.float "compellingness_score", default: 0.0, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "crossposted_at", precision: nil
     t.string "description"
@@ -168,6 +166,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.string "video_source_url"
     t.string "video_state"
     t.string "video_thumbnail_url"
+    t.float "compellingness_score", default: 0.0, null: false
+    t.string "cached_label_list", default: [], array: true
     t.index ["cached_label_list"], name: "index_articles_on_cached_label_list", using: :gin
     t.index ["cached_tag_list"], name: "index_articles_on_cached_tag_list", opclass: :gin_trgm_ops, using: :gin
     t.index ["canonical_url"], name: "index_articles_on_canonical_url", unique: true, where: "(published IS TRUE)"
@@ -416,11 +416,11 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
   end
 
   create_table "context_notes", force: :cascade do |t|
-    t.bigint "article_id", null: false
     t.text "body_markdown", null: false
-    t.datetime "created_at", null: false
     t.text "processed_html", null: false
+    t.bigint "article_id", null: false
     t.bigint "tag_id"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["article_id"], name: "index_context_notes_on_article_id"
     t.index ["tag_id"], name: "index_context_notes_on_tag_id"
@@ -504,7 +504,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.string "cached_tag_list"
     t.integer "clicks_count", default: 0
     t.string "color"
-    t.datetime "counts_tabulated_at"
     t.datetime "created_at", precision: nil, null: false
     t.integer "creator_id"
     t.string "custom_display_label"
@@ -518,7 +517,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.bigint "organization_id"
     t.bigint "page_id"
     t.string "placement_area"
-    t.bigint "prefer_paired_with_billboard_id"
     t.integer "preferred_article_ids", default: [], array: true
     t.boolean "priority", default: false
     t.text "processed_html"
@@ -533,6 +531,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.integer "type_of", default: 0, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.float "weight", default: 1.0, null: false
+    t.bigint "prefer_paired_with_billboard_id"
+    t.datetime "counts_tabulated_at"
     t.index ["cached_tag_list"], name: "index_display_ads_on_cached_tag_list", opclass: :gin_trgm_ops, using: :gin
     t.index ["exclude_article_ids"], name: "index_display_ads_on_exclude_article_ids", using: :gin
     t.index ["exclude_role_names"], name: "index_display_ads_on_exclude_role_names", using: :gin
@@ -561,50 +561,50 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.text "body", null: false
     t.datetime "created_at", null: false
     t.integer "drip_day", default: 0
-    t.bigint "onboarding_subforem_id"
     t.integer "status", default: 0
     t.string "subject", null: false
     t.string "targeted_tags", default: [], array: true
     t.integer "type_of", default: 0
     t.datetime "updated_at", null: false
+    t.bigint "onboarding_subforem_id"
     t.index ["audience_segment_id"], name: "index_emails_on_audience_segment_id"
     t.index ["onboarding_subforem_id"], name: "index_emails_on_onboarding_subforem_id"
   end
 
   create_table "feed_configs", force: :cascade do |t|
-    t.integer "all_time_tag_count_max", default: 0
-    t.integer "all_time_tag_count_min", default: 0
-    t.float "clickbait_score_weight", default: 0.0, null: false
-    t.float "comment_recency_weight", default: 1.0
-    t.float "comment_score_weight", default: 1.0
-    t.float "compellingness_score_weight", default: 0.0, null: false
-    t.datetime "created_at", null: false
-    t.float "featured_weight", default: 0.0, null: false
-    t.bigint "feed_impressions_count", default: 0
-    t.float "feed_success_score", default: 0.0
-    t.float "feed_success_weight", default: 1.0
-    t.float "general_past_day_bonus_weight", default: 0.0, null: false
-    t.float "label_match_weight", default: 1.0
-    t.float "language_match_weight", default: 1.0, null: false
-    t.float "lookback_window_weight", default: 1.0
-    t.float "organization_follow_weight", default: 1.0
-    t.float "precomputed_selections_weight", default: 1.0
-    t.float "published_today_weight", default: 0.0, null: false
-    t.float "randomness_weight", default: 0.0, null: false
-    t.float "recency_weight", default: 1.0
-    t.float "recent_article_suppression_rate", default: 0.0, null: false
-    t.float "recent_article_supression_rate", default: 0.0, null: false
-    t.float "recent_page_views_shuffle_weight", default: 0.0, null: false
-    t.float "recent_subforem_weight", default: 0.0, null: false
-    t.integer "recent_tag_count_max", default: 0
-    t.integer "recent_tag_count_min", default: 0
-    t.float "recently_active_past_day_bonus_weight", default: 0.0, null: false
-    t.float "score_weight", default: 1.0
-    t.float "shuffle_weight", default: 0.0, null: false
-    t.float "subforem_follow_weight", default: 0.0, null: false
     t.float "tag_follow_weight", default: 1.0
-    t.datetime "updated_at", null: false
     t.float "user_follow_weight", default: 1.0
+    t.float "organization_follow_weight", default: 1.0
+    t.float "feed_success_weight", default: 1.0
+    t.float "recency_weight", default: 1.0
+    t.float "comment_score_weight", default: 1.0
+    t.float "score_weight", default: 1.0
+    t.float "precomputed_selections_weight", default: 1.0
+    t.float "comment_recency_weight", default: 1.0
+    t.float "label_match_weight", default: 1.0
+    t.float "lookback_window_weight", default: 1.0
+    t.float "feed_success_score", default: 0.0
+    t.bigint "feed_impressions_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.float "featured_weight", default: 0.0, null: false
+    t.float "clickbait_score_weight", default: 0.0, null: false
+    t.float "compellingness_score_weight", default: 0.0, null: false
+    t.float "randomness_weight", default: 0.0, null: false
+    t.float "recent_article_supression_rate", default: 0.0, null: false
+    t.float "recent_article_suppression_rate", default: 0.0, null: false
+    t.float "published_today_weight", default: 0.0, null: false
+    t.float "language_match_weight", default: 1.0, null: false
+    t.float "shuffle_weight", default: 0.0, null: false
+    t.float "recent_subforem_weight", default: 0.0, null: false
+    t.integer "recent_tag_count_min", default: 0
+    t.integer "recent_tag_count_max", default: 0
+    t.integer "all_time_tag_count_min", default: 0
+    t.integer "all_time_tag_count_max", default: 0
+    t.float "recent_page_views_shuffle_weight", default: 0.0, null: false
+    t.float "general_past_day_bonus_weight", default: 0.0, null: false
+    t.float "recently_active_past_day_bonus_weight", default: 0.0, null: false
+    t.float "subforem_follow_weight", default: 0.0, null: false
     t.index ["feed_success_score"], name: "index_feed_configs_on_feed_success_score"
   end
 
@@ -615,9 +615,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.string "context_type", null: false
     t.integer "counts_for", default: 1, null: false
     t.datetime "created_at", null: false
-    t.bigint "feed_config_id"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.bigint "feed_config_id"
     t.index ["article_id", "user_id", "category"], name: "index_feed_events_on_article_user_and_category"
     t.index ["article_id"], name: "index_feed_events_on_article_id"
     t.index ["created_at"], name: "index_feed_events_on_created_at"
@@ -754,10 +754,10 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
   end
 
   create_table "labels", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "description"
-    t.string "name", null: false
     t.string "slug", null: false
+    t.string "name", null: false
+    t.string "description"
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["slug"], name: "index_labels_on_slug", unique: true
   end
@@ -1031,11 +1031,11 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
   end
 
   create_table "poll_text_responses", force: :cascade do |t|
-    t.datetime "created_at", null: false
     t.bigint "poll_id", null: false
-    t.text "text_content"
-    t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.text "text_content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["poll_id", "user_id"], name: "index_poll_text_responses_on_poll_id_and_user_id", unique: true
     t.index ["poll_id"], name: "index_poll_text_responses_on_poll_id"
     t.index ["user_id"], name: "index_poll_text_responses_on_user_id"
@@ -1058,9 +1058,9 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.integer "poll_votes_count", default: 0, null: false
     t.string "prompt_html"
     t.string "prompt_markdown"
+    t.datetime "updated_at", precision: nil, null: false
     t.bigint "survey_id"
     t.integer "type_of", default: 0, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.index ["survey_id"], name: "index_polls_on_survey_id"
     t.index ["type_of"], name: "index_polls_on_type_of"
   end
@@ -1261,20 +1261,20 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.datetime "created_at", null: false
     t.boolean "discoverable", default: false, null: false
     t.string "domain", null: false
-    t.integer "hotness_score", default: 0, null: false
     t.boolean "root", default: false
-    t.integer "score", default: 0, null: false
     t.datetime "updated_at", null: false
+    t.integer "score", default: 0, null: false
+    t.integer "hotness_score", default: 0, null: false
     t.index ["domain"], name: "index_subforems_on_domain", unique: true
     t.index ["hotness_score"], name: "index_subforems_on_hotness_score"
     t.index ["score"], name: "index_subforems_on_score"
   end
 
   create_table "surveys", force: :cascade do |t|
-    t.boolean "active", default: true
-    t.datetime "created_at", null: false
-    t.boolean "display_title", default: true
     t.string "title", null: false
+    t.boolean "active", default: true
+    t.boolean "display_title", default: true
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
@@ -1291,10 +1291,10 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
   end
 
   create_table "tag_subforem_relationships", force: :cascade do |t|
-    t.datetime "created_at", null: false
+    t.bigint "tag_id", null: false
     t.bigint "subforem_id", null: false
     t.boolean "supported", default: true
-    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["subforem_id"], name: "index_tag_subforem_relationships_on_subforem_id"
     t.index ["tag_id"], name: "index_tag_subforem_relationships_on_tag_id"
@@ -1324,7 +1324,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.bigint "badge_id"
     t.string "bg_color_hex"
     t.string "category", default: "uncategorized", null: false
-    t.text "context_note_instructions"
     t.datetime "created_at", precision: nil, null: false
     t.integer "hotness_score", default: 0
     t.string "keywords_for_search"
@@ -1345,6 +1344,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.datetime "updated_at", precision: nil, null: false
     t.text "wiki_body_html"
     t.text "wiki_body_markdown"
+    t.text "context_note_instructions"
     t.index ["hotness_score"], name: "index_tags_on_hotness_score"
     t.index ["name"], name: "index_tags_on_name", unique: true
     t.index ["social_preview_template"], name: "index_tags_on_social_preview_template"
@@ -1384,21 +1384,21 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
   end
 
   create_table "user_activities", force: :cascade do |t|
+    t.jsonb "recently_viewed_articles", default: []
+    t.jsonb "recent_labels", default: []
+    t.jsonb "recent_tags", default: []
+    t.jsonb "recent_organizations", default: []
+    t.jsonb "recent_users", default: []
+    t.jsonb "alltime_tags", default: []
     t.jsonb "alltime_labels", default: []
+    t.datetime "last_activity_at"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.jsonb "recent_subforems", default: []
+    t.jsonb "alltime_users", default: []
     t.jsonb "alltime_organizations", default: []
     t.jsonb "alltime_subforems", default: []
-    t.jsonb "alltime_tags", default: []
-    t.jsonb "alltime_users", default: []
-    t.datetime "created_at", null: false
-    t.datetime "last_activity_at"
-    t.jsonb "recent_labels", default: []
-    t.jsonb "recent_organizations", default: []
-    t.jsonb "recent_subforems", default: []
-    t.jsonb "recent_tags", default: []
-    t.jsonb "recent_users", default: []
-    t.jsonb "recently_viewed_articles", default: []
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_user_activities_on_user_id"
   end
 
@@ -1501,7 +1501,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.string "old_old_username"
     t.string "old_username"
     t.boolean "onboarding_package_requested", default: false
-    t.integer "onboarding_subforem_id"
     t.datetime "organization_info_updated_at", precision: nil
     t.string "payment_pointer"
     t.string "profile_image"
@@ -1531,6 +1530,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.integer "unspent_credits_count", default: 0, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "username"
+    t.integer "onboarding_subforem_id"
+    t.integer "type_of", default: 0, null: false
     t.index "to_tsvector('simple'::regconfig, COALESCE((name)::text, ''::text))", name: "index_users_on_name_as_tsvector", using: :gin
     t.index "to_tsvector('simple'::regconfig, COALESCE((username)::text, ''::text))", name: "index_users_on_username_as_tsvector", using: :gin
     t.index ["apple_username"], name: "index_users_on_apple_username"
@@ -1550,6 +1551,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_08_20_140630) do
     t.index ["onboarding_subforem_id"], name: "index_users_on_onboarding_subforem_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["twitter_username"], name: "index_users_on_twitter_username", unique: true
+    t.index ["type_of"], name: "index_users_on_type_of"
     t.index ["username"], name: "index_users_on_username", unique: true
     t.check_constraint "username IS NOT NULL", name: "users_username_not_null"
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1067,4 +1067,93 @@ false).once
       end
     end
   end
+
+  describe "type_of enum" do
+    it "has the correct enum values" do
+      expect(User.type_ofs).to eq({
+        "member" => 0,
+        "community_bot" => 1,
+        "member_bot" => 2
+      })
+    end
+
+    it "defaults to member" do
+      new_user = User.new
+      expect(new_user.type_of).to eq("member")
+    end
+
+    it "can be set to community_bot" do
+      user.type_of = :community_bot
+      expect(user.type_of).to eq("community_bot")
+    end
+
+    it "can be set to member_bot" do
+      user.type_of = :member_bot
+      expect(user.type_of).to eq("member_bot")
+    end
+  end
+
+  describe "bot methods" do
+    context "when user is a community bot" do
+      let(:community_bot) { create(:user, type_of: :community_bot) }
+
+      it "returns true for community_bot?" do
+        expect(community_bot.community_bot?).to be true
+      end
+
+      it "returns false for member_bot?" do
+        expect(community_bot.member_bot?).to be false
+      end
+
+      it "returns true for bot?" do
+        expect(community_bot.bot?).to be true
+      end
+    end
+
+    context "when user is a member bot" do
+      let(:member_bot) { create(:user, type_of: :member_bot) }
+
+      it "returns false for community_bot?" do
+        expect(member_bot.community_bot?).to be false
+      end
+
+      it "returns true for member_bot?" do
+        expect(member_bot.member_bot?).to be true
+      end
+
+      it "returns true for bot?" do
+        expect(member_bot.bot?).to be true
+      end
+    end
+
+    context "when user is a regular member" do
+      it "returns false for community_bot?" do
+        expect(user.community_bot?).to be false
+      end
+
+      it "returns false for member_bot?" do
+        expect(user.member_bot?).to be false
+      end
+
+      it "returns false for bot?" do
+        expect(user.bot?).to be false
+      end
+    end
+  end
+
+  describe "community_bots_for_subforem scope" do
+    let(:subforem) { create(:subforem) }
+    let!(:community_bot) { create(:user, type_of: :community_bot, onboarding_subforem_id: subforem.id) }
+    let!(:member_bot) { create(:user, type_of: :member_bot, onboarding_subforem_id: subforem.id) }
+    let!(:regular_user) { create(:user, type_of: :member, onboarding_subforem_id: subforem.id) }
+    let!(:other_subforem_bot) { create(:user, type_of: :community_bot, onboarding_subforem_id: create(:subforem, domain: "other.com").id) }
+
+    it "returns only community bots for the specified subforem" do
+      result = User.community_bots_for_subforem(subforem.id)
+      expect(result).to include(community_bot)
+      expect(result).not_to include(member_bot)
+      expect(result).not_to include(regular_user)
+      expect(result).not_to include(other_subforem_bot)
+    end
+  end
 end

--- a/spec/policies/community_bot_policy_spec.rb
+++ b/spec/policies/community_bot_policy_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe CommunityBotPolicy, type: :policy do
+  subject { described_class.new(user, record) }
+
+  let(:subforem) { create(:subforem) }
+  let(:bot_user) { create(:user, type_of: :community_bot, onboarding_subforem_id: subforem.id) }
+  let(:admin_user) { create(:user, :super_admin) }
+  let(:super_moderator) { create(:user, :super_moderator) }
+  let(:moderator_user) { create(:user) }
+  let(:regular_user) { create(:user) }
+
+  before do
+    allow(moderator_user).to receive(:subforem_moderator?).with(subforem: subforem).and_return(true)
+  end
+
+  context "when record is a User (bot)" do
+    let(:record) { bot_user }
+
+    context "when user is a super admin" do
+      let(:user) { admin_user }
+
+      it { is_expected.to permit_actions %i[index new create show destroy] }
+    end
+
+    context "when user is a super moderator" do
+      let(:user) { super_moderator }
+
+      it { is_expected.to permit_actions %i[index new create show destroy] }
+    end
+
+    context "when user is a subforem moderator" do
+      let(:user) { moderator_user }
+
+      it { is_expected.to permit_actions %i[index new create show destroy] }
+    end
+
+    context "when user is a regular user" do
+      let(:user) { regular_user }
+
+      it { is_expected.to forbid_actions %i[index new create show destroy] }
+    end
+
+    context "when user is not signed in" do
+      let(:user) { nil }
+
+      it { within_block_is_expected.to raise_error(Pundit::NotAuthorizedError) }
+    end
+  end
+
+  context "when record is a Subforem" do
+    let(:record) { subforem }
+
+    context "when user is a super admin" do
+      let(:user) { admin_user }
+
+      it { is_expected.to permit_actions %i[index new create show destroy] }
+    end
+
+    context "when user is a super moderator" do
+      let(:user) { super_moderator }
+
+      it { is_expected.to permit_actions %i[index new create show destroy] }
+    end
+
+    context "when user is a subforem moderator" do
+      let(:user) { moderator_user }
+
+      it { is_expected.to permit_actions %i[index new create show destroy] }
+    end
+
+    context "when user is a regular user" do
+      let(:user) { regular_user }
+
+      it { is_expected.to forbid_actions %i[index new create show destroy] }
+    end
+  end
+
+  context "when record is a regular user (not a bot)" do
+    let(:record) { regular_user }
+
+    context "when user is a super admin" do
+      let(:user) { admin_user }
+
+      it { is_expected.to permit_actions %i[index new create show destroy] }
+    end
+
+    context "when user is a regular user" do
+      let(:user) { regular_user }
+
+      it { is_expected.to forbid_actions %i[index new create show destroy] }
+    end
+  end
+end
+

--- a/spec/requests/admin/community_bots_spec.rb
+++ b/spec/requests/admin/community_bots_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "Admin::CommunityBots", type: :request do
+  let(:admin_user) { create(:user, :super_admin) }
+  let(:subforem) { create(:subforem, domain: "test.com") }
+
+  before do
+    sign_in admin_user
+  end
+
+  describe "GET /admin/customization/subforems/:subforem_id/community_bots" do
+    it "returns a successful response" do
+      get admin_subforem_community_bots_path(subforem)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /admin/customization/subforems/:subforem_id/community_bots/new" do
+    it "returns a successful response" do
+      get new_admin_subforem_community_bot_path(subforem)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /admin/customization/subforems/:subforem_id/community_bots" do
+    it "creates a new community bot" do
+      expect do
+        post admin_subforem_community_bots_path(subforem), params: { user: { name: "Test Bot" } }
+      end.to change(User, :count).by(1)
+
+      expect(response).to redirect_to(admin_subforem_community_bots_path(subforem))
+      expect(flash[:success]).to include("created successfully")
+    end
+  end
+
+  describe "GET /admin/customization/subforems/:subforem_id/community_bots/:id" do
+    let(:bot_user) { create(:user, type_of: :community_bot, onboarding_subforem_id: subforem.id) }
+
+    it "returns a successful response" do
+      get admin_subforem_community_bot_path(subforem, bot_user)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "DELETE /admin/customization/subforems/:subforem_id/community_bots/:id" do
+    let!(:bot_user) { create(:user, type_of: :community_bot, onboarding_subforem_id: subforem.id) }
+
+    it "deletes the community bot" do
+      expect do
+        delete admin_subforem_community_bot_path(subforem, bot_user)
+      end.to change(User, :count).by(-1)
+
+      expect(response).to redirect_to(admin_subforem_community_bots_path(subforem))
+      expect(flash[:success]).to include("deleted successfully")
+    end
+  end
+end
+

--- a/spec/services/community_bots/create_bot_spec.rb
+++ b/spec/services/community_bots/create_bot_spec.rb
@@ -1,0 +1,161 @@
+require "rails_helper"
+
+RSpec.describe CommunityBots::CreateBot do
+  let(:subforem) { create(:subforem, domain: "test.com") }
+  let(:admin_user) { create(:user, :super_admin) }
+  let(:moderator_user) { create(:user) }
+  let(:regular_user) { create(:user) }
+
+  before do
+    allow(moderator_user).to receive(:subforem_moderator?).with(subforem: subforem).and_return(true)
+  end
+
+  describe "#call" do
+    context "when user is authorized" do
+      it "creates a community bot successfully" do
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Test Bot",
+          created_by: admin_user,
+        )
+
+        puts "Error message: #{result.error_message}" unless result.success?
+        expect(result.success?).to be true
+        expect(result.bot_user).to be_present
+        expect(result.bot_user.name).to eq("Test Bot")
+        expect(result.bot_user.type_of).to eq("community_bot")
+        expect(result.bot_user.onboarding_subforem_id).to eq(subforem.id)
+        expect(result.bot_user.registered).to be true
+        expect(result.bot_user.confirmed_at).to be_present
+        expect(result.api_secret).to be_present
+        expect(result.api_secret.description).to include("Test Bot")
+      end
+
+      it "creates a bot with a unique email" do
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Test Bot",
+          created_by: admin_user,
+        )
+
+        expect(result.bot_user.email).to include("bot-test-bot")
+        expect(result.bot_user.email).to end_with("@test.com")
+      end
+
+      it "creates a bot with a unique username from name" do
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Test Bot",
+          created_by: admin_user,
+        )
+
+        expect(result.bot_user.username).to include("test-bot")
+        expect(result.bot_user.username).to match(/\d+$/)
+      end
+
+      it "creates a bot with provided username" do
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Test Bot",
+          created_by: admin_user,
+          username: "mycustombot",
+        )
+
+        expect(result.bot_user.username).to include("mycustombot")
+        expect(result.bot_user.username).to match(/\d+$/)
+      end
+
+      it "uses subforem logo when no image provided and subforem has logo" do
+        # This test is temporarily disabled since profile image setting is disabled
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Test Bot",
+          created_by: admin_user,
+        )
+
+        expect(result.success?).to be true
+        # TODO: Re-enable this test when profile image setting is fixed
+        # expect(Settings::General).to have_received(:logo_png).with(subforem_id: subforem.id)
+      end
+
+      it "uses provided profile image" do
+        profile_image = Rack::Test::UploadedFile.new(Rails.root.join("spec/support/fixtures/images/image1.jpeg"),
+                                                     "image/jpeg")
+
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Test Bot",
+          created_by: admin_user,
+          profile_image: profile_image,
+        )
+
+        expect(result.success?).to be true
+        expect(result.bot_user).to be_present
+      end
+
+      it "sets the invited_by relationship" do
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Test Bot",
+          created_by: admin_user,
+        )
+
+        expect(result.bot_user.invited_by).to eq(admin_user)
+      end
+
+      it "works for subforem moderators" do
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Moderator Bot",
+          created_by: moderator_user,
+        )
+
+        expect(result.success?).to be true
+        expect(result.bot_user.name).to eq("Moderator Bot")
+      end
+    end
+
+    context "when user is not authorized" do
+      it "returns failure for regular users" do
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Test Bot",
+          created_by: regular_user,
+        )
+
+        expect(result.success?).to be false
+        expect(result.error_message).to include("Unauthorized")
+      end
+    end
+
+    context "when subforem does not exist" do
+      it "returns failure" do
+        result = described_class.call(
+          subforem_id: 99_999,
+          name: "Test Bot",
+          created_by: admin_user,
+        )
+
+        expect(result.success?).to be false
+        expect(result.error_message).to include("Subforem not found")
+      end
+    end
+
+    context "when bot creation fails" do
+      before do
+        allow(User).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(User.new))
+      end
+
+      it "returns failure with error message" do
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Test Bot",
+          created_by: admin_user,
+        )
+
+        expect(result.success?).to be false
+        expect(result.error_message).to include("Failed to create bot")
+      end
+    end
+  end
+end

--- a/spec/services/community_bots/create_bot_spec.rb
+++ b/spec/services/community_bots/create_bot_spec.rb
@@ -61,6 +61,20 @@ RSpec.describe CommunityBots::CreateBot do
           username: "mycustombot",
         )
 
+        expect(result.bot_user.username).to eq("mycustombot")
+      end
+
+      it "creates a bot with provided username when username already exists" do
+        # Create a user with the same username first
+        create(:user, username: "mycustombot")
+
+        result = described_class.call(
+          subforem_id: subforem.id,
+          name: "Test Bot",
+          created_by: admin_user,
+          username: "mycustombot",
+        )
+
         expect(result.bot_user.username).to include("mycustombot")
         expect(result.bot_user.username).to match(/\d+$/)
       end

--- a/spec/services/community_bots/delete_bot_spec.rb
+++ b/spec/services/community_bots/delete_bot_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe CommunityBots::DeleteBot do
+  let(:subforem) { create(:subforem) }
+  let(:bot_user) { create(:user, type_of: :community_bot, onboarding_subforem_id: subforem.id) }
+  let(:admin_user) { create(:user, :super_admin) }
+  let(:moderator_user) { create(:user) }
+  let(:regular_user) { create(:user) }
+
+  before do
+    allow(moderator_user).to receive(:subforem_moderator?).with(subforem: subforem).and_return(true)
+  end
+
+  describe "#call" do
+    context "when user is authorized" do
+      it "deletes a community bot successfully" do
+        bot_id = bot_user.id
+        
+        result = described_class.call(
+          bot_user: bot_user,
+          deleted_by: admin_user
+        )
+
+        expect(result.success?).to be true
+        expect(User.find_by(id: bot_id)).to be_nil
+      end
+
+      it "works for subforem moderators" do
+        bot_id = bot_user.id
+        
+        result = described_class.call(
+          bot_user: bot_user,
+          deleted_by: moderator_user
+        )
+
+        expect(result.success?).to be true
+        expect(User.find_by(id: bot_id)).to be_nil
+      end
+    end
+
+    context "when user is not authorized" do
+      it "returns failure for regular users" do
+        result = described_class.call(
+          bot_user: bot_user,
+          deleted_by: regular_user
+        )
+
+        expect(result.success?).to be false
+        expect(result.error_message).to include("Unauthorized")
+        expect(bot_user.reload).to be_present
+      end
+    end
+
+    context "when user is not a community bot" do
+      let(:regular_user) { create(:user, type_of: :member) }
+
+      it "returns failure" do
+        result = described_class.call(
+          bot_user: regular_user,
+          deleted_by: admin_user
+        )
+
+        expect(result.success?).to be false
+        expect(result.error_message).to include("User is not a community bot")
+        expect(regular_user.reload).to be_present
+      end
+    end
+
+    context "when bot deletion fails" do
+      before do
+        allow(bot_user).to receive(:destroy!).and_raise(StandardError.new("Database error"))
+      end
+
+      it "returns failure with error message" do
+        result = described_class.call(
+          bot_user: bot_user,
+          deleted_by: admin_user
+        )
+
+        expect(result.success?).to be false
+        expect(result.error_message).to include("Failed to delete bot")
+        expect(result.error_message).to include("Database error")
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This establishes the capacity to transparently create a bot account. If bot-generated content is going to be more of a thing (hard to fight), we should maximize the transparency of this. This will also maximize user capacity to not see bot content in feeds. It will be easier to enforce any possible gray area if bot labeling is available.

This primarily introduces "community bots" which can be created by admins — but establishes a notion for member-created bots as well.