### PR TITLE
Add test coverage for Timeframe.datetime_iso8601 method

### DIFF
--- a/spec/models/timeframe_spec.rb
+++ b/spec/models/timeframe_spec.rb
@@ -28,4 +28,24 @@ RSpec.describe Timeframe do
       expect(timeframe).to eq(5.years.ago)
     end
   end
+
+  describe ".datetime_iso8601" do
+    it "returns ISO8601 formatted datetime string for valid timeframe" do
+      Timecop.freeze(Time.current) do
+        iso_string = described_class.datetime_iso8601("week")
+        expected_iso = 1.week.ago.iso8601
+        expect(iso_string).to eq(expected_iso)
+      end
+    end
+
+    it "returns nil for latest timeframe since it's not a datetime" do
+      iso_string = described_class.datetime_iso8601("latest")
+      expect(iso_string).to be_nil
+    end
+
+    it "returns nil for invalid timeframe" do
+      iso_string = described_class.datetime_iso8601("invalid")
+      expect(iso_string).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
- Test valid timeframe returns ISO8601 formatted string
- Test latest timeframe returns nil (not a datetime object)
- Test invalid timeframe returns nil
- Follows existing test patterns with Timecop.freeze

