### PR TITLE
Add retry logic to ContentModerationLabeler

### DIFF
--- a/spec/services/ai/content_moderation_labeler_spec.rb
+++ b/spec/services/ai/content_moderation_labeler_spec.rb
@@ -28,9 +28,89 @@ RSpec.describe Ai::ContentModerationLabeler, type: :service do
         allow(ai_client).to receive(:call).and_raise(StandardError, "API Error")
       end
 
-      it "falls back to safe default" do
+      it "falls back to safe default after retries" do
         result = described_class.new(article).label
         expect(result).to eq("no_moderation_label")
+      end
+
+      it "retries exactly 2 times before falling back" do
+        described_class.new(article).label
+        expect(ai_client).to have_received(:call).exactly(3).times
+      end
+
+      it "logs retry attempts" do
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
+
+        described_class.new(article).label
+
+        expect(Rails.logger).to have_received(:error).with(/Content Moderation Labeling failed \(attempt 1\/3\)/)
+        expect(Rails.logger).to have_received(:info).with(/Retrying content moderation labeling \(attempt 2\/3\)/)
+        expect(Rails.logger).to have_received(:error).with(/Content Moderation Labeling failed \(attempt 2\/3\)/)
+        expect(Rails.logger).to have_received(:info).with(/Retrying content moderation labeling \(attempt 3\/3\)/)
+        expect(Rails.logger).to have_received(:error).with(/Content Moderation Labeling failed \(attempt 3\/3\)/)
+        expect(Rails.logger).to have_received(:error).with(/Content Moderation Labeling failed after 3 attempts, falling back to default/)
+      end
+    end
+
+    context "when AI succeeds after retries" do
+      before do
+        call_count = 0
+        allow(ai_client).to receive(:call) do
+          call_count += 1
+          if call_count < 3
+            raise StandardError, "Temporary API Error"
+          else
+            "okay_and_on_topic"
+          end
+        end
+      end
+
+      it "returns the correct label after successful retry" do
+        result = described_class.new(article).label
+        expect(result).to eq("okay_and_on_topic")
+      end
+
+      it "makes exactly 3 attempts before succeeding" do
+        described_class.new(article).label
+        expect(ai_client).to have_received(:call).exactly(3).times
+      end
+
+      it "logs retry attempts but not final fallback" do
+        allow(Rails.logger).to receive(:error)
+        allow(Rails.logger).to receive(:info)
+
+        described_class.new(article).label
+
+        expect(Rails.logger).to have_received(:error).with(/Content Moderation Labeling failed \(attempt 1\/3\)/)
+        expect(Rails.logger).to have_received(:info).with(/Retrying content moderation labeling \(attempt 2\/3\)/)
+        expect(Rails.logger).to have_received(:error).with(/Content Moderation Labeling failed \(attempt 2\/3\)/)
+        expect(Rails.logger).to have_received(:info).with(/Retrying content moderation labeling \(attempt 3\/3\)/)
+        expect(Rails.logger).not_to have_received(:error).with(/falling back to default/)
+      end
+    end
+
+    context "when AI succeeds on first retry" do
+      before do
+        call_count = 0
+        allow(ai_client).to receive(:call) do
+          call_count += 1
+          if call_count == 1
+            raise StandardError, "Temporary API Error"
+          else
+            "very_good_and_on_topic"
+          end
+        end
+      end
+
+      it "returns the correct label after first retry" do
+        result = described_class.new(article).label
+        expect(result).to eq("very_good_and_on_topic")
+      end
+
+      it "makes exactly 2 attempts" do
+        described_class.new(article).label
+        expect(ai_client).to have_received(:call).exactly(2).times
       end
     end
   end


### PR DESCRIPTION
- Implement 2 retry attempts before falling back to no_moderation_label
- Add comprehensive logging for retry attempts and failures
- Include tests for all retry scenarios and logging behavior
- Maintain existing fallback behavior after exhausting retries

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

