### PR TITLE
Add development fallbacks for redis scenarios

### DIFF
--- a/bin/db-reset
+++ b/bin/db-reset
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Usage:
+#   bin/db-reset [--clear-redis] [--skip-seed] [--seed-multiplier N]
+#
+# Drops, creates, migrates, and seeds the development database by default.
+# Options:
+#   --clear-redis         Also clears Redis DBs (sessions=1, cache=2, sidekiq=3) and Sidekiq queues.
+#   --skip-seed           Skip running db:seed.
+#   --seed-multiplier N   Set SEEDS_MULTIPLIER=N when seeding.
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT_DIR"
+
+CLEAR_REDIS=0
+SKIP_SEED=0
+SEEDS_MULTIPLIER=""
+for arg in "$@"; do
+  case "$arg" in
+    --clear-redis)
+      CLEAR_REDIS=1
+      shift
+      ;;
+    --skip-seed)
+      SKIP_SEED=1
+      shift
+      ;;
+    --seed-multiplier)
+      shift
+      SEEDS_MULTIPLIER=${1:-}
+      shift || true
+      ;;
+    *)
+      ;;
+  esac
+done
+
+echo "== Resetting database =="
+
+# Ensure Rails is available
+if ! command -v bin/rails >/dev/null 2>&1; then
+  echo "bin/rails not found" >&2
+  exit 1
+fi
+
+# Drop, create, migrate
+bin/rails db:drop db:create db:migrate
+
+# Seed unless skipped
+if [ "$SKIP_SEED" -eq 0 ]; then
+  if [ -n "$SEEDS_MULTIPLIER" ]; then
+    SEEDS_MULTIPLIER="$SEEDS_MULTIPLIER" bin/rails db:seed || true
+  else
+    bin/rails db:seed || true
+  fi
+fi
+
+if [ "$CLEAR_REDIS" -eq 1 ]; then
+  echo "== Clearing Redis (dev) and Sidekiq queues =="
+  # Use redis-cli if available; otherwise try via Rails runner
+  if command -v redis-cli >/dev/null 2>&1; then
+    # Sessions (db 1), Cache (db 2), Sidekiq (db 3)
+    for db in 1 2 3; do
+      redis-cli -n "$db" FLUSHDB || true
+    done
+  else
+    # Fallback: use Rails to clear queues and best-effort flush via Redis client
+    bin/rails runner "
+      begin
+        require 'redis'
+        [1,2,3].each do |db|
+          url = ENV.fetch('REDIS_URL', 'redis://localhost:6379')
+          uri = URI.parse(url)
+          uri.path = "/#{db}"
+          Redis.new(url: uri.to_s).flushdb
+        end
+      rescue => e
+        Rails.logger.warn("[dev] Redis flush fallback failed: #{e.message}")
+      end
+    "
+  fi
+
+  # Clear Sidekiq queues/retries/dead using Rails runner
+  bin/rails runner "
+    begin
+      Sidekiq::Queue.all.each(&:clear)
+      Sidekiq::RetrySet.new.clear
+      Sidekiq::DeadSet.new.clear
+      puts '[dev] Cleared Sidekiq queues, retries, and dead sets.'
+    rescue => e
+      warn \"[dev] Failed to clear Sidekiq sets: #{e.message}\"
+    end
+  "
+fi
+
+echo "== Database reset complete =="
+
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -169,7 +169,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_09_18_134444) do
     t.string "video_source_url"
     t.string "video_state"
     t.string "video_thumbnail_url"
-    t.index ["automod_label"], name: "index_articles_on_automod_label"
     t.index ["cached_label_list"], name: "index_articles_on_cached_label_list", using: :gin
     t.index ["cached_tag_list"], name: "index_articles_on_cached_tag_list", opclass: :gin_trgm_ops, using: :gin
     t.index ["canonical_url"], name: "index_articles_on_canonical_url", unique: true, where: "(published IS TRUE)"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This adds fallbacks in development for when redis is configured differently than expected. Should make it more robust in general to start the app locally.