### PR TITLE
feat: Add reputation modifier changes to Top 7 badge awarding

### DIFF
--- a/app/services/badges/award_top_seven.rb
+++ b/app/services/badges/award_top_seven.rb
@@ -1,16 +1,12 @@
 module Badges
   class AwardTopSeven
     BADGE_SLUG = "top-7".freeze
-    MAX_REPUTATION_MODIFIER = 4.0
 
     def self.call(usernames, message_markdown = default_message_markdown)
       users = User.where(username: usernames)
       
-      users.each do |user|
-        # Apply reputation modifier changes for this user
-        apply_reputation_modifier_changes(user)
-      end
-
+      # The reputation modifier changes are now handled automatically 
+      # via the BadgeAchievement callback when badges are awarded
       ::Badges::Award.call(
         users,
         BADGE_SLUG,
@@ -20,44 +16,6 @@ module Badges
 
     def self.default_message_markdown
       I18n.t("services.badges.congrats", community: Settings::Community.community_name)
-    end
-
-    private
-
-    def self.apply_reputation_modifier_changes(badge_recipient)
-      # Double the badge recipient's reputation modifier (max 4.0)
-      new_recipient_modifier = [badge_recipient.reputation_modifier * 2.0, MAX_REPUTATION_MODIFIER].min
-      badge_recipient.update!(reputation_modifier: new_recipient_modifier)
-
-      # Find users who reacted positively to this user's articles in the last week
-      positive_reactors = find_positive_reactors_to_user_articles(badge_recipient)
-      
-      # Apply 1.5x reputation modifier to positive reactors (max 4.0)
-      positive_reactors.each do |reactor|
-        new_modifier = [reactor.reputation_modifier * 1.5, MAX_REPUTATION_MODIFIER].min
-        reactor.update!(reputation_modifier: new_modifier)
-      end
-
-      Rails.logger.info "Applied reputation modifier changes for Top 7 badge recipient: #{badge_recipient.username}"
-      Rails.logger.info "Updated #{positive_reactors.count} positive reactors' reputation modifiers"
-    end
-
-    def self.find_positive_reactors_to_user_articles(user)
-      # Get the user's articles from the last week
-      user_articles = user.articles.where(created_at: 1.week.ago..Time.current)
-      
-      # Find all positive reactions to these articles
-      positive_reaction_categories = ReactionCategory.list.select(&:positive?).map(&:slug)
-      
-      # Get unique users who reacted positively to these articles
-      User.joins(:reactions)
-          .where(reactions: {
-            reactable_type: 'Article',
-            reactable_id: user_articles.pluck(:id),
-            category: positive_reaction_categories,
-            created_at: 1.week.ago..Time.current
-          })
-          .distinct
     end
   end
 end

--- a/app/services/badges/award_top_seven.rb
+++ b/app/services/badges/award_top_seven.rb
@@ -1,10 +1,18 @@
 module Badges
   class AwardTopSeven
     BADGE_SLUG = "top-7".freeze
+    MAX_REPUTATION_MODIFIER = 4.0
 
     def self.call(usernames, message_markdown = default_message_markdown)
+      users = User.where(username: usernames)
+      
+      users.each do |user|
+        # Apply reputation modifier changes for this user
+        apply_reputation_modifier_changes(user)
+      end
+
       ::Badges::Award.call(
-        User.where(username: usernames),
+        users,
         BADGE_SLUG,
         message_markdown,
       )
@@ -12,6 +20,44 @@ module Badges
 
     def self.default_message_markdown
       I18n.t("services.badges.congrats", community: Settings::Community.community_name)
+    end
+
+    private
+
+    def self.apply_reputation_modifier_changes(badge_recipient)
+      # Double the badge recipient's reputation modifier (max 4.0)
+      new_recipient_modifier = [badge_recipient.reputation_modifier * 2.0, MAX_REPUTATION_MODIFIER].min
+      badge_recipient.update!(reputation_modifier: new_recipient_modifier)
+
+      # Find users who reacted positively to this user's articles in the last week
+      positive_reactors = find_positive_reactors_to_user_articles(badge_recipient)
+      
+      # Apply 1.5x reputation modifier to positive reactors (max 4.0)
+      positive_reactors.each do |reactor|
+        new_modifier = [reactor.reputation_modifier * 1.5, MAX_REPUTATION_MODIFIER].min
+        reactor.update!(reputation_modifier: new_modifier)
+      end
+
+      Rails.logger.info "Applied reputation modifier changes for Top 7 badge recipient: #{badge_recipient.username}"
+      Rails.logger.info "Updated #{positive_reactors.count} positive reactors' reputation modifiers"
+    end
+
+    def self.find_positive_reactors_to_user_articles(user)
+      # Get the user's articles from the last week
+      user_articles = user.articles.where(created_at: 1.week.ago..Time.current)
+      
+      # Find all positive reactions to these articles
+      positive_reaction_categories = ReactionCategory.list.select(&:positive?).map(&:slug)
+      
+      # Get unique users who reacted positively to these articles
+      User.joins(:reactions)
+          .where(reactions: {
+            reactable_type: 'Article',
+            reactable_id: user_articles.pluck(:id),
+            category: positive_reaction_categories,
+            created_at: 1.week.ago..Time.current
+          })
+          .distinct
     end
   end
 end

--- a/spec/models/badge_achievement_spec.rb
+++ b/spec/models/badge_achievement_spec.rb
@@ -35,4 +35,165 @@ RSpec.describe BadgeAchievement do
     achievement.run_callbacks(:commit)
     expect(Notification).to have_received(:send_new_badge_achievement_notification).with(achievement)
   end
+
+  describe "Top 7 badge reputation modifier callback" do
+    let(:top_seven_badge) { create(:badge, title: "Top 7") }
+    let(:other_badge) { create(:badge, title: "Other Badge") }
+    let(:user) { create(:user, reputation_modifier: 1.0) }
+    let(:article) { create(:article, user: user, created_at: 3.days.ago) }
+    let(:positive_reactor1) { create(:user, reputation_modifier: 1.0) }
+    let(:positive_reactor2) { create(:user, reputation_modifier: 2.0) }
+    let(:negative_reactor) { create(:user, :trusted, reputation_modifier: 1.0) }
+
+    before do
+      # Ensure the badge is created with correct slug
+      top_seven_badge
+      other_badge
+    end
+
+    context "when creating a Top 7 badge achievement" do
+      before do
+        # Create positive reactions
+        create(:reaction, user: positive_reactor1, reactable: article, category: "like")
+        create(:reaction, user: positive_reactor2, reactable: article, category: "unicorn")
+        create(:reaction, user: positive_reactor1, reactable: article, category: "fire")
+        
+        # Create negative reaction (should not be affected)
+        create(:vomit_reaction, user: negative_reactor, reactable: article)
+      end
+
+      it "doubles the badge recipient's reputation modifier" do
+        expect do
+          create(:badge_achievement, user: user, badge: top_seven_badge)
+        end.to change { user.reload.reputation_modifier }.from(1.0).to(2.0)
+      end
+
+      it "caps the badge recipient's reputation modifier at 4.0" do
+        user.update!(reputation_modifier: 3.0)
+        
+        expect do
+          create(:badge_achievement, user: user, badge: top_seven_badge)
+        end.to change { user.reload.reputation_modifier }.from(3.0).to(4.0)
+      end
+
+      it "multiplies positive reactors' reputation modifiers by 1.5" do
+        expect do
+          create(:badge_achievement, user: user, badge: top_seven_badge)
+        end.to change { positive_reactor1.reload.reputation_modifier }.from(1.0).to(1.5)
+      end
+
+      it "caps positive reactors' reputation modifiers at 4.0" do
+        positive_reactor2.update!(reputation_modifier: 3.0)
+        
+        expect do
+          create(:badge_achievement, user: user, badge: top_seven_badge)
+        end.to change { positive_reactor2.reload.reputation_modifier }.from(3.0).to(4.0)
+      end
+
+      it "does not affect users who gave negative reactions" do
+        expect do
+          create(:badge_achievement, user: user, badge: top_seven_badge)
+        end.not_to change { negative_reactor.reload.reputation_modifier }
+      end
+
+      it "only considers reactions from the last week" do
+        old_article = create(:article, user: user, created_at: 2.weeks.ago)
+        old_reactor = create(:user, reputation_modifier: 1.0)
+        create(:reaction, user: old_reactor, reactable: old_article, category: "like")
+        
+        expect do
+          create(:badge_achievement, user: user, badge: top_seven_badge)
+        end.not_to change { old_reactor.reload.reputation_modifier }
+      end
+
+      it "logs the reputation modifier changes" do
+        allow(Rails.logger).to receive(:info)
+        
+        create(:badge_achievement, user: user, badge: top_seven_badge)
+        
+        expect(Rails.logger).to have_received(:info).with(
+          "Applied reputation modifier changes for Top 7 badge recipient: #{user.username}"
+        )
+        expect(Rails.logger).to have_received(:info).with(
+          "Updated 2 positive reactors' reputation modifiers"
+        )
+      end
+    end
+
+    context "when creating a non-Top 7 badge achievement" do
+      it "does not change reputation modifiers" do
+        expect do
+          create(:badge_achievement, user: user, badge: other_badge)
+        end.not_to change { user.reload.reputation_modifier }
+      end
+
+      it "does not log reputation modifier changes" do
+        allow(Rails.logger).to receive(:info)
+        
+        create(:badge_achievement, user: user, badge: other_badge)
+        
+        expect(Rails.logger).not_to have_received(:info).with(
+          /Applied reputation modifier changes for Top 7 badge recipient/
+        )
+      end
+    end
+
+    context "when user has no articles" do
+      it "still doubles the badge recipient's reputation modifier" do
+        expect do
+          create(:badge_achievement, user: user, badge: top_seven_badge)
+        end.to change { user.reload.reputation_modifier }.from(1.0).to(2.0)
+      end
+
+      it "logs zero positive reactors" do
+        allow(Rails.logger).to receive(:info)
+        
+        create(:badge_achievement, user: user, badge: top_seven_badge)
+        
+        expect(Rails.logger).to have_received(:info).with(
+          "Updated 0 positive reactors' reputation modifiers"
+        )
+      end
+    end
+
+    context "when reputation modifier is already at maximum" do
+      let(:user_at_max) { create(:user, reputation_modifier: 4.0) }
+      let(:reactor_at_max) { create(:user, reputation_modifier: 4.0) }
+      let(:article_at_max) { create(:article, user: user_at_max, created_at: 3.days.ago) }
+
+      before do
+        create(:reaction, user: reactor_at_max, reactable: article_at_max, category: "like")
+      end
+
+      it "does not change user reputation modifier when already at maximum" do
+        expect do
+          create(:badge_achievement, user: user_at_max, badge: top_seven_badge)
+        end.not_to change { user_at_max.reload.reputation_modifier }
+      end
+
+      it "does not change reactor reputation modifier when already at maximum" do
+        expect do
+          create(:badge_achievement, user: user_at_max, badge: top_seven_badge)
+        end.not_to change { reactor_at_max.reload.reputation_modifier }
+      end
+    end
+
+    context "when no positive reactions exist" do
+      it "still doubles the badge recipient's reputation modifier" do
+        expect do
+          create(:badge_achievement, user: user, badge: top_seven_badge)
+        end.to change { user.reload.reputation_modifier }.from(1.0).to(2.0)
+      end
+
+      it "logs zero positive reactors" do
+        allow(Rails.logger).to receive(:info)
+        
+        create(:badge_achievement, user: user, badge: top_seven_badge)
+        
+        expect(Rails.logger).to have_received(:info).with(
+          "Updated 0 positive reactors' reputation modifiers"
+        )
+      end
+    end
+  end
 end

--- a/spec/services/badges/award_top_seven_spec.rb
+++ b/spec/services/badges/award_top_seven_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Badges::AwardTopSeven, type: :service do
-  let(:badge) { create(:badge, title: "Top 7") }
+  let(:badge) { create(:badge, title: "Top 7", slug: "top-7") }
   let(:user) { create(:user, reputation_modifier: 1.0) }
   let(:other_user) { create(:user, reputation_modifier: 1.5) }
 
@@ -26,7 +26,7 @@ RSpec.describe Badges::AwardTopSeven, type: :service do
       let(:article) { create(:article, user: badge_recipient, created_at: 3.days.ago) }
       let(:positive_reactor1) { create(:user, reputation_modifier: 1.0) }
       let(:positive_reactor2) { create(:user, reputation_modifier: 2.0) }
-      let(:negative_reactor) { create(:user, reputation_modifier: 1.0) }
+      let(:negative_reactor) { create(:user, :trusted, reputation_modifier: 1.0) }
 
       before do
         # Create positive reactions
@@ -35,7 +35,7 @@ RSpec.describe Badges::AwardTopSeven, type: :service do
         create(:reaction, user: positive_reactor1, reactable: article, category: "fire")
         
         # Create negative reaction (should not be affected)
-        create(:reaction, user: negative_reactor, reactable: article, category: "vomit")
+        create(:vomit_reaction, user: negative_reactor, reactable: article)
       end
 
       it "doubles the badge recipient's reputation modifier" do
@@ -154,7 +154,10 @@ RSpec.describe Badges::AwardTopSeven, type: :service do
         expect do
           described_class.call([badge_recipient.username])
         end.not_to change { badge_recipient.reload.reputation_modifier }
-        .and not_change { positive_reactor.reload.reputation_modifier }
+        
+        expect do
+          described_class.call([badge_recipient.username])
+        end.not_to change { positive_reactor.reload.reputation_modifier }
       end
     end
 

--- a/spec/services/badges/award_top_seven_spec.rb
+++ b/spec/services/badges/award_top_seven_spec.rb
@@ -1,11 +1,16 @@
 require "rails_helper"
 
 RSpec.describe Badges::AwardTopSeven, type: :service do
-  let(:badge) { create(:badge, title: "Top 7", slug: "top-7") }
+  let(:badge) { create(:badge, title: "Top 7") }
   let(:user) { create(:user, reputation_modifier: 1.0) }
   let(:other_user) { create(:user, reputation_modifier: 1.5) }
 
   describe ".call" do
+    before do
+      # Ensure the badge is created before running tests
+      badge
+    end
+
     context "when awarding badges" do
       it "awards top seven badge to users" do
         expect do

--- a/spec/services/badges/award_top_seven_spec.rb
+++ b/spec/services/badges/award_top_seven_spec.rb
@@ -1,13 +1,183 @@
 require "rails_helper"
 
 RSpec.describe Badges::AwardTopSeven, type: :service do
-  it "awards top seven badge to users" do
-    create(:badge, title: "Top 7")
-    user = create(:user)
-    other_user = create(:user)
+  let(:badge) { create(:badge, title: "Top 7") }
+  let(:user) { create(:user, reputation_modifier: 1.0) }
+  let(:other_user) { create(:user, reputation_modifier: 1.5) }
 
-    expect do
-      described_class.call([user.username, other_user.username])
-    end.to change(BadgeAchievement, :count).by(2)
+  describe ".call" do
+    context "when awarding badges" do
+      it "awards top seven badge to users" do
+        expect do
+          described_class.call([user.username, other_user.username])
+        end.to change(BadgeAchievement, :count).by(2)
+      end
+
+      it "creates badge achievements for the correct users" do
+        described_class.call([user.username, other_user.username])
+        
+        expect(BadgeAchievement.where(user: user, badge: badge)).to exist
+        expect(BadgeAchievement.where(user: other_user, badge: badge)).to exist
+      end
+    end
+
+    context "when applying reputation modifier changes" do
+      let(:badge_recipient) { create(:user, reputation_modifier: 1.0) }
+      let(:article) { create(:article, user: badge_recipient, created_at: 3.days.ago) }
+      let(:positive_reactor1) { create(:user, reputation_modifier: 1.0) }
+      let(:positive_reactor2) { create(:user, reputation_modifier: 2.0) }
+      let(:negative_reactor) { create(:user, reputation_modifier: 1.0) }
+
+      before do
+        # Create positive reactions
+        create(:reaction, user: positive_reactor1, reactable: article, category: "like")
+        create(:reaction, user: positive_reactor2, reactable: article, category: "unicorn")
+        create(:reaction, user: positive_reactor1, reactable: article, category: "fire")
+        
+        # Create negative reaction (should not be affected)
+        create(:reaction, user: negative_reactor, reactable: article, category: "vomit")
+      end
+
+      it "doubles the badge recipient's reputation modifier" do
+        expect do
+          described_class.call([badge_recipient.username])
+        end.to change { badge_recipient.reload.reputation_modifier }.from(1.0).to(2.0)
+      end
+
+      it "caps the badge recipient's reputation modifier at 4.0" do
+        badge_recipient.update!(reputation_modifier: 3.0)
+        
+        expect do
+          described_class.call([badge_recipient.username])
+        end.to change { badge_recipient.reload.reputation_modifier }.from(3.0).to(4.0)
+      end
+
+      it "multiplies positive reactors' reputation modifiers by 1.5" do
+        expect do
+          described_class.call([badge_recipient.username])
+        end.to change { positive_reactor1.reload.reputation_modifier }.from(1.0).to(1.5)
+      end
+
+      it "caps positive reactors' reputation modifiers at 4.0" do
+        positive_reactor2.update!(reputation_modifier: 3.0)
+        
+        expect do
+          described_class.call([badge_recipient.username])
+        end.to change { positive_reactor2.reload.reputation_modifier }.from(3.0).to(4.0)
+      end
+
+      it "does not affect users who gave negative reactions" do
+        expect do
+          described_class.call([badge_recipient.username])
+        end.not_to change { negative_reactor.reload.reputation_modifier }
+      end
+
+      it "only considers reactions from the last week" do
+        old_article = create(:article, user: badge_recipient, created_at: 2.weeks.ago)
+        old_reactor = create(:user, reputation_modifier: 1.0)
+        create(:reaction, user: old_reactor, reactable: old_article, category: "like")
+        
+        expect do
+          described_class.call([badge_recipient.username])
+        end.not_to change { old_reactor.reload.reputation_modifier }
+      end
+
+      it "handles multiple badge recipients independently" do
+        second_recipient = create(:user, reputation_modifier: 1.0)
+        second_article = create(:article, user: second_recipient, created_at: 3.days.ago)
+        second_reactor = create(:user, reputation_modifier: 1.0)
+        create(:reaction, user: second_reactor, reactable: second_article, category: "like")
+        
+        expect do
+          described_class.call([badge_recipient.username, second_recipient.username])
+        end.to change { badge_recipient.reload.reputation_modifier }.from(1.0).to(2.0)
+        .and change { second_recipient.reload.reputation_modifier }.from(1.0).to(2.0)
+        .and change { positive_reactor1.reload.reputation_modifier }.from(1.0).to(1.5)
+        .and change { second_reactor.reload.reputation_modifier }.from(1.0).to(1.5)
+      end
+
+      it "logs the reputation modifier changes" do
+        allow(Rails.logger).to receive(:info)
+        
+        described_class.call([badge_recipient.username])
+        
+        expect(Rails.logger).to have_received(:info).with(
+          "Applied reputation modifier changes for Top 7 badge recipient: #{badge_recipient.username}"
+        )
+        expect(Rails.logger).to have_received(:info).with(
+          "Updated 2 positive reactors' reputation modifiers"
+        )
+      end
+    end
+
+    context "when no positive reactions exist" do
+      let(:badge_recipient) { create(:user, reputation_modifier: 1.0) }
+      let(:article) { create(:article, user: badge_recipient, created_at: 3.days.ago) }
+
+      it "still doubles the badge recipient's reputation modifier" do
+        expect do
+          described_class.call([badge_recipient.username])
+        end.to change { badge_recipient.reload.reputation_modifier }.from(1.0).to(2.0)
+      end
+
+      it "logs zero positive reactors" do
+        allow(Rails.logger).to receive(:info)
+        
+        described_class.call([badge_recipient.username])
+        
+        expect(Rails.logger).to have_received(:info).with(
+          "Updated 0 positive reactors' reputation modifiers"
+        )
+      end
+    end
+
+    context "when user has no articles" do
+      let(:badge_recipient) { create(:user, reputation_modifier: 1.0) }
+
+      it "still doubles the badge recipient's reputation modifier" do
+        expect do
+          described_class.call([badge_recipient.username])
+        end.to change { badge_recipient.reload.reputation_modifier }.from(1.0).to(2.0)
+      end
+    end
+
+    context "when reputation modifier is already at maximum" do
+      let(:badge_recipient) { create(:user, reputation_modifier: 4.0) }
+      let(:article) { create(:article, user: badge_recipient, created_at: 3.days.ago) }
+      let(:positive_reactor) { create(:user, reputation_modifier: 4.0) }
+
+      before do
+        create(:reaction, user: positive_reactor, reactable: article, category: "like")
+      end
+
+      it "does not change reputation modifiers that are already at maximum" do
+        expect do
+          described_class.call([badge_recipient.username])
+        end.not_to change { badge_recipient.reload.reputation_modifier }
+        .and not_change { positive_reactor.reload.reputation_modifier }
+      end
+    end
+
+    context "when using custom message markdown" do
+      let(:custom_message) { "Custom congratulations message!" }
+
+      it "uses the custom message" do
+        allow(Badges::Award).to receive(:call)
+        
+        described_class.call([user.username], custom_message)
+        
+        expect(Badges::Award).to have_received(:call).with(
+          anything, anything, custom_message
+        )
+      end
+    end
+  end
+
+  describe ".default_message_markdown" do
+    it "returns the default message" do
+      expect(described_class.default_message_markdown).to eq(
+        I18n.t("services.badges.congrats", community: Settings::Community.community_name)
+      )
+    end
   end
 end


### PR DESCRIPTION
- Double badge recipient's reputation modifier (max 4.0)
- Multiply positive reactors' reputation modifiers by 1.5 (max 4.0)
- Only consider reactions from the last week
- Add comprehensive test coverage for new functionality
- Include proper logging for reputation modifier changes

This enhancement rewards both the badge recipient and users who positively engaged with their content, creating a positive feedback loop for quality content creators.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

