### PR TITLE
Fix z-index issue with popover-billboard overlapping navbar

### DIFF
--- a/app/assets/stylesheets/billboards.scss
+++ b/app/assets/stylesheets/billboards.scss
@@ -66,7 +66,7 @@
 }
 
 .popover-billboard {
-  z-index: var(--z-popover);
+  z-index: 99;
   animation: popoverEnter 0.5s;
   box-shadow: 0 0 100px 60px rgba(0, 0, 0, 0.2) !important;
   max-height: calc(100vh - var(--header-height));


### PR DESCRIPTION
## Summary
Fixes #22244 - Changes popover-billboard z-index from 500 to 99 to prevent navbar overlap

## Description  
The popover-billboard element on the advertise page had a z-index of `var(--z-popover)` (500), which was higher than the navbar's z-index of `var(--z-sticky)` (100). This caused the 'View Sponsorship Overview' box to overlap the navbar when scrolling.

## Solution
Changed the z-index value to 99 in `app/assets/stylesheets/billboards.scss` to ensure the popover stays below the navbar while remaining visible above other content.

## Testing
- The change has been tested locally with Rails server running on port 3008
- The popover should now properly stay behind the navbar when scrolling

Co-Authored-By: Claude <noreply@anthropic.com>