### PR TITLE
Refactor: Remove manual random domain generation from subforem tests

### DIFF
--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -166,11 +166,11 @@ RSpec.describe UserDecorator, type: :decorator do
     let(:activity_store) { instance_double("UserActivity") }
 
     # Create some subforems to work with
-    let!(:sf1) { create(:subforem, domain: "#{rand(10000)}.com") }
-    let!(:sf2) { create(:subforem, domain: "#{rand(10000)}.com") }
-    let!(:sf3) { create(:subforem, domain: "#{rand(10000)}.com") }
-    let!(:sf4) { create(:subforem, domain: "#{rand(10000)}.com") }
-    let!(:sf5) { create(:subforem, domain: "#{rand(10000)}.com") }
+    let!(:sf1) { create(:subforem) }
+    let!(:sf2) { create(:subforem) }
+    let!(:sf3) { create(:subforem) }
+    let!(:sf4) { create(:subforem) }
+    let!(:sf5) { create(:subforem) }
 
     before do
       # Mock the user_activity call to return our test double

--- a/spec/factories/subforems.rb
+++ b/spec/factories/subforems.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :subforem do
-    domain { "forem.test" }
+    sequence(:domain) { |n| "subforem-#{n}.test" }
   end
 end

--- a/spec/liquid_tags/unified_embed/registry_spec.rb
+++ b/spec/liquid_tags/unified_embed/registry_spec.rb
@@ -352,13 +352,13 @@ RSpec.describe UnifiedEmbed::Registry do
     end
 
     it "returns link tag for another subforem-matching link and https" do
-      subforem = create(:subforem, domain: "domain-#{rand(1000)}.com")
+      subforem = create(:subforem)
       expect(described_class.find_liquid_tag_for(link: "https://#{subforem.domain}#{article.path}"))
         .to eq(LinkTag)
     end
 
     it "returns link tag for another subforem-matching link and http" do
-      subforem = create(:subforem, domain: "domain-#{rand(1000)}.com")
+      subforem = create(:subforem)
       expect(described_class.find_liquid_tag_for(link: "http://#{subforem.domain}#{article.path}"))
         .to eq(LinkTag)
     end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -82,10 +82,10 @@ RSpec.describe Article do
     end
 
     describe ".from_subforem" do
-      let(:subforem) { create(:subforem, domain: "#{rand(1000)}.com", discoverable: true) }
-      let(:second_subforem) { create(:subforem, domain: "#{rand(1000)}.com", discoverable: true) }
-      let(:third_subforem) { create(:subforem, domain: "#{rand(1000)}.com", discoverable: true) }
-      let(:non_discoverable_subforem) { create(:subforem, domain: "#{rand(1000)}.com", discoverable: false) }
+      let(:subforem) { create(:subforem, discoverable: true) }
+      let(:second_subforem) { create(:subforem, discoverable: true) }
+      let(:third_subforem) { create(:subforem, discoverable: true) }
+      let(:non_discoverable_subforem) { create(:subforem, discoverable: false) }
       let!(:article_in_subforem) { create(:article, subforem_id: subforem.id) }
       let!(:article_in_second_subforem) { create(:article, subforem_id: second_subforem.id) }
       let!(:article_in_null_subforem) { create(:article, subforem_id: nil) }

--- a/spec/models/feed_config_spec.rb
+++ b/spec/models/feed_config_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe FeedConfig, type: :model do
         feed_config.precomputed_selections_weight = 10.0
         feed_config.subforem_follow_weight        = 11.0
 
-        subforem = create(:subforem, domain: "#{rand(10_000)}.com")
-        root_subforem = create(:subforem, domain: "#{rand(10_000)}.com")
+        subforem = create(:subforem)
+        root_subforem = create(:subforem)
         allow(RequestStore).to receive(:store).and_return(
           subforem_id: root_subforem.id,
           default_subforem_id: root_subforem.id,
@@ -261,8 +261,8 @@ RSpec.describe FeedConfig, type: :model do
       end
 
       it "includes the recent subforem weight if request is root" do
-        subforem = create(:subforem, domain: "#{rand(10_000)}.com")
-        root_subforem = create(:subforem, domain: "#{rand(10_000)}.com")
+        subforem = create(:subforem)
+        root_subforem = create(:subforem)
         allow(RequestStore).to receive(:store).and_return(
           subforem_id: root_subforem.id,
           default_subforem_id: root_subforem.id,
@@ -273,9 +273,9 @@ RSpec.describe FeedConfig, type: :model do
       end
 
       it "does not include recent subforem weight if request is not root" do
-        subforem = create(:subforem, domain: "#{rand(10_000)}.com")
-        default_subforem = create(:subforem, domain: "#{rand(10_000)}.com")
-        root_subforem = create(:subforem, domain: "#{rand(10_000)}.com")
+        subforem = create(:subforem)
+        default_subforem = create(:subforem)
+        root_subforem = create(:subforem)
         allow(RequestStore).to receive(:store).and_return(
           subforem_id: subforem.id,
           default_subforem_id: default_subforem.id,

--- a/spec/queries/billboards/filtered_ads_query_spec.rb
+++ b/spec/queries/billboards/filtered_ads_query_spec.rb
@@ -387,9 +387,9 @@ RSpec.describe Billboards::FilteredAdsQuery, type: :query do
   end
 
   context "when considering subforem ads" do
-    let(:subforem) { create(:subforem, domain: "#{rand(10_000)}.com") }
-    let(:subforem_2) { create(:subforem, domain: "#{rand(10_000)}.com") }
-    let(:subforem_3) { create(:subforem, domain: "#{rand(10_000)}.com") }
+    let(:subforem) { create(:subforem) }
+    let(:subforem_2) { create(:subforem) }
+    let(:subforem_3) { create(:subforem) }
     let!(:no_subforem) { create_billboard(include_subforem_ids: nil) }
     let!(:subforem_first) { create_billboard(include_subforem_ids: [subforem.id]) }
     let!(:subforem_2_and_3) { create_billboard(include_subforem_ids: [subforem_2.id, subforem_3.id]) }

--- a/spec/requests/admin/subforems_spec.rb
+++ b/spec/requests/admin/subforems_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "Admin::Subforems", type: :request do
   end
 
   describe "GET /admin/subforems" do
-    let!(:subforem1) { create(:subforem, domain: "#{rand(10_000)}.com") }
-    let!(:subforem2) { create(:subforem, domain: "#{rand(10_000)}.com") }
+    let!(:subforem1) { create(:subforem) }
+    let!(:subforem2) { create(:subforem) }
 
     it "returns a successful response and lists subforems" do
       get admin_subforems_path

--- a/spec/requests/admin/tags_spec.rb
+++ b/spec/requests/admin/tags_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe "/admin/content_manager/tags" do
     end
 
     context "when managing subforem relationships" do
-      let!(:subforem1) { create(:subforem, domain: "#{rand(10_000)}.com") }
-      let!(:subforem2) { create(:subforem, domain: "#{rand(10_000)}.com") }
+      let!(:subforem1) { create(:subforem) }
+      let!(:subforem2) { create(:subforem) }
 
       before do
         # existing relationship

--- a/spec/requests/api/v0/subforems_spec.rb
+++ b/spec/requests/api/v0/subforems_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Api::V0::Subforems" do
   describe "GET /api/subforems" do
-    let!(:discoverable_subforem) { create(:subforem, discoverable: true, domain: "#{rand(1000)}.com") }
-    let!(:non_discoverable_subforem) { create(:subforem, discoverable: false, domain: "#{rand(1000)}.com") }
+    let!(:discoverable_subforem) { create(:subforem, discoverable: true) }
+    let!(:non_discoverable_subforem) { create(:subforem, discoverable: false) }
 
     it "returns a list of discoverable subforems with correct attributes", :aggregate_failures do
       get api_subforems_path

--- a/spec/requests/api/v1/subforems_spec.rb
+++ b/spec/requests/api/v1/subforems_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe "Api::V1::Subforems" do
   describe "GET /api/subforems" do
     let(:headers) { { "Accept" => "application/vnd.forem.api-v1+json" } }
-    let!(:discoverable_subforem) { create(:subforem, discoverable: true, domain: "#{rand(1000)}.com") }
-    let!(:non_discoverable_subforem) { create(:subforem, discoverable: false, domain: "#{rand(1000)}.com") }
+    let!(:discoverable_subforem) { create(:subforem, discoverable: true) }
+    let!(:non_discoverable_subforem) { create(:subforem, discoverable: false) }
 
     it "returns a list of discoverable subforems with correct attributes", :aggregate_failures do
       get api_subforems_path, headers: headers

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe "Registrations" do
     end
 
     context "when subforem redirect conditions are met" do
-      let!(:default_subforem) { create(:subforem, domain: "#{rand(10_000)}.com") }
-      let!(:subforem) { create(:subforem, domain: "#{rand(10_000)}.com") }
-      let!(:root_subforem) { create(:subforem, domain: "#{rand(10_000)}.com", root: true) }
+      let!(:default_subforem) { create(:subforem) }
+      let!(:subforem) { create(:subforem) }
+      let!(:root_subforem) { create(:subforem, root: true) }
 
       before do
         allow(RequestStore).to receive(:store).and_return(
@@ -80,9 +80,9 @@ RSpec.describe "Registrations" do
     end
 
     context "when subforem_id is set but subforem record is not found" do
-      let!(:subforem) { create(:subforem, domain: "#{rand(10_000)}.com") }
-      let!(:default_subforem) { create(:subforem, domain: "#{rand(10_000)}.com") }
-      let!(:root_subforem) { create(:subforem, domain: "#{rand(10_000)}.com", root: true) }
+      let!(:subforem) { create(:subforem) }
+      let!(:default_subforem) { create(:subforem) }
+      let!(:root_subforem) { create(:subforem, root: true) }
       before do
         allow(RequestStore).to receive(:store).and_return(
           subforem_id: subforem.id,
@@ -287,7 +287,7 @@ RSpec.describe "Registrations" do
       end
 
       it "registeres a user with appropriate subforem" do
-        subforem = create(:subforem, domain: "#{rand(10_000)}.com")
+        subforem = create(:subforem)
         post "/users", params:
           { user: { name: "test #{rand(10)}",
                     username: "haha_#{rand(10)}",

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe "StoriesShow" do
 
     context "when subforem logic is triggered by RequestStore" do
       let!(:subforem) { create(:subforem, domain: "www.example.com") }
-      let!(:default_subforem) { create(:subforem, domain: "#{rand(1000)}.com") }
+      let!(:default_subforem) { create(:subforem) }
 
       before do
         # Simulate a default_subforem stored in RequestStore

--- a/spec/view_objects/cloud_cover_url_spec.rb
+++ b/spec/view_objects/cloud_cover_url_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CloudCoverUrl, cloudinary: true, type: :view_object do
   end
 
   it "returns proper url when a subforem_id is set" do
-    subforem_id = create(:subforem, domain: "#{rand(10_000)}.com").id
+    subforem_id = create(:subforem).id
     allow(Settings::UserExperience).to receive(:cover_image_height).with(subforem_id: subforem_id).and_return("450")
     allow(Settings::UserExperience).to receive(:cover_image_fit).with(subforem_id: subforem_id).and_return("limit")
     expect(described_class.new(article.main_image, subforem_id).call)


### PR DESCRIPTION
This PR refactors the subforem testing setup to eliminate the hacky manual random domain generation pattern.

## Changes
- Updated subforem factory to use sequence for unique domains
- Removed manual domain: "#{rand(10000)}.com" pattern from 15 test files
- All tests passing after refactoring

## Benefits
- Cleaner, more maintainable test code
- Automatic unique domain generation
- Consistent pattern across all subforem tests