### PR TITLE
Replace prefetch with preload for critical home page resources

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,14 +3,14 @@
   <head>
     <% if user_signed_in? && current_page?(root_path) %>
       <% if params[:feed_type] == "discover" || params[:feed_type].blank? %>
-        <link rel="prefetch" href="/stories/feed/?page=1&type_of=discover">
+        <link rel="preload" href="/stories/feed/?page=1&type_of=discover" as="fetch" crossorigin="same-origin">
       <% elsif params[:feed_type] == "following" %>
-        <link rel="prefetch" href="/stories/feed/?page=1&type_of=following">
+        <link rel="preload" href="/stories/feed/?page=1&type_of=following" as="fetch" crossorigin="same-origin">
       <% end %>
-      <link rel="prefetch" href="/<%= ENV.fetch("BILLBOARD_URL_COMPONENT", "bb") %>/feed_first">
-      <link rel="prefetch" href="/<%= ENV.fetch("BILLBOARD_URL_COMPONENT", "bb") %>/feed_second">
-      <link rel="prefetch" href="/<%= ENV.fetch("BILLBOARD_URL_COMPONENT", "bb") %>/feed_third">
-      <link rel="prefetch" href="/sidebars/home">
+      <link rel="preload" href="/<%= ENV.fetch("BILLBOARD_URL_COMPONENT", "bb") %>/feed_first" as="fetch" crossorigin="same-origin">
+      <link rel="preload" href="/<%= ENV.fetch("BILLBOARD_URL_COMPONENT", "bb") %>/feed_second" as="fetch" crossorigin="same-origin">
+      <link rel="preload" href="/<%= ENV.fetch("BILLBOARD_URL_COMPONENT", "bb") %>/feed_third" as="fetch" crossorigin="same-origin">
+      <link rel="preload" href="/sidebars/home" as="fetch" crossorigin="same-origin">
     <% end %>
     <meta charset="utf-8">
     <% title = yield(:title) %>


### PR DESCRIPTION
## Problem
The home page was using  to load critical resources (stories feed, billboards, sidebar), but  loads resources with low priority only when the browser is idle. Since these resources are needed immediately when the home page loads, this was causing suboptimal performance.

## Solution
- Replace  with  for all critical home page resources
- Add proper  and  attributes
- These resources are now loaded with high priority immediately when the page starts loading

## Changes
-  endpoints (JSON data)
- Billboard endpoints , ,  (HTML content)
- Sidebar endpoint  (HTML content)

## Impact
- Improved perceived performance on home page
- Critical resources are available immediately when JavaScript needs them
- Better user experience with faster loading times

## Testing
- Verified HTML syntax is correct
- All preload attributes are properly formatted
- No linting errors introduced