### PR TITLE
Remove inefficient fragment caches

### DIFF
--- a/app/views/articles/_full_comment_area.html.erb
+++ b/app/views/articles/_full_comment_area.html.erb
@@ -1,76 +1,74 @@
-<% cache("whole-comment-area-#{@article.id}-#{@article.comments.cache_key_with_version}-#{@article.show_comments}-#{@discussion_lock&.updated_at}-#{@comments_order}-#{user_signed_in?}", expires_in: 2.hours) do %>
-  <section id="comments" data-follow-button-container="true" data-updated-at="<%= Time.current %>" class="text-padding mb-4 border-t-1 border-0 border-solid border-base-10">
-    <% if @article.show_comments %>
-      <header class="relative flex justify-between items-center mb-6">
-        <div class="flex items-center">
-          <h2 class="crayons-subtitle-1">
-            <%= t("views.articles.comments.subtitle.#{@comments_order}_html",
-                  num: tag.span(t("views.articles.comments.num", num: @comments_count), class: "js-comments-count", data: { comments_count: @comments_count })) %>
-          </h2>
-          <% if user_signed_in? %>
-            <button class="c-btn c-btn--ghost crayons-btn--icon-left" id="toggle-comments-sort-dropdown" aria-controls="comments-sort-dropdown-container" aria-expanded="false" aria-label="<%= t("views.articles.comments.sort_button.aria_label") %>" aria-haspopup="true">
-              <%= inline_svg_tag("expand.svg", aria_hidden: true, title: t("views.moderations.actions.admin.icon"), class: "mt-2") %>
-            </button>
-          <% end %>
-        </div>
-
+<section id="comments" data-follow-button-container="true" data-updated-at="<%= Time.current %>" class="text-padding mb-4 border-t-1 border-0 border-solid border-base-10">
+  <% if @article.show_comments %>
+    <header class="relative flex justify-between items-center mb-6">
+      <div class="flex items-center">
+        <h2 class="crayons-subtitle-1">
+          <%= t("views.articles.comments.subtitle.#{@comments_order}_html",
+                num: tag.span(t("views.articles.comments.num", num: @comments_count), class: "js-comments-count", data: { comments_count: @comments_count })) %>
+        </h2>
         <% if user_signed_in? %>
-          <nav class="crayons-dropdown p-4" id="comments-sort-dropdown-container" aria-labelledby="comments-sort-title">
-              <h3 id="comments-sort-title" class="mb-3"><%= t("views.articles.comments.sort.heading") %></h3>
-              <ul class="comments-sort-dropdown__list">
-                <%= render "comments/sort_option",
-                           sort_order: "top",
-                           sort_title: t("views.articles.comments.sort.title.top"),
-                           sort_description: t("views.articles.comments.sort.desc.top"),
-                           show_selected: @comments_order == "top" %>
-                <%= render "comments/sort_option",
-                           sort_order: "latest",
-                           sort_title: t("views.articles.comments.sort.title.latest"),
-                           sort_description: t("views.articles.comments.sort.desc.latest"),
-                           show_selected: @comments_order == "latest" %>
-                <%= render "comments/sort_option",
-                           sort_order: "oldest",
-                           sort_title: t("views.articles.comments.sort.title.oldest"),
-                           sort_description: t("views.articles.comments.sort.desc.oldest"),
-                           show_selected: @comments_order == "oldest" %>
-              </ul>
-          </nav>
+          <button class="c-btn c-btn--ghost crayons-btn--icon-left" id="toggle-comments-sort-dropdown" aria-controls="comments-sort-dropdown-container" aria-expanded="false" aria-label="<%= t("views.articles.comments.sort_button.aria_label") %>" aria-haspopup="true">
+            <%= inline_svg_tag("expand.svg", aria_hidden: true, title: t("views.moderations.actions.admin.icon"), class: "mt-2") %>
+          </button>
         <% end %>
-
-        <div id="comment-subscription" class="print-hidden">
-          <div class="crayons-btn-group">
-            <span class="crayons-btn crayons-btn--outlined"><%= t("views.articles.comments.subscribe") %></span>
-          </div>
-        </div>
-      </header>
-      <div id="billboard_delay_trigger"></div>
-      <div
-        id="comments-container"
-        data-testid="comments-container"
-        data-commentable-id="<%= @article.id %>"
-        data-commentable-type="Article"
-        data-has-recent-comment-activity="<%= @article.has_recent_comment_activity? %>">
-
-        <% if @discussion_lock %>
-          <%= render "/comments/discussion_lock_reason" %>
-        <% else %>
-          <%= render "/comments/form", commentable: @article, commentable_type: "Article" %>
-        <% end %>
-
-        <div class="comments" id="comment-trees-container">
-          <% if @article.comments_count > 0 %>
-            <% @current_comment_index = 0 %>
-            <%= render partial: "articles/comment_tree",
-                       collection: article_comment_tree(@article, @comments_to_show_count, @comments_order),
-                       as: :comment_node,
-                       cached: proc { |comment, _sub_comments| [comment, @comments_order, user_signed_in?] } %>
-          <% end %>
-        </div>
       </div>
 
-      <%= render "articles/comments_actions" %>
-    <% end %>
-  </section>
-  <%= render "comments/hide_comments_modal" %>
-<% end %>
+      <% if user_signed_in? %>
+        <nav class="crayons-dropdown p-4" id="comments-sort-dropdown-container" aria-labelledby="comments-sort-title">
+            <h3 id="comments-sort-title" class="mb-3"><%= t("views.articles.comments.sort.heading") %></h3>
+            <ul class="comments-sort-dropdown__list">
+              <%= render "comments/sort_option",
+                         sort_order: "top",
+                         sort_title: t("views.articles.comments.sort.title.top"),
+                         sort_description: t("views.articles.comments.sort.desc.top"),
+                         show_selected: @comments_order == "top" %>
+              <%= render "comments/sort_option",
+                         sort_order: "latest",
+                         sort_title: t("views.articles.comments.sort.title.latest"),
+                         sort_description: t("views.articles.comments.sort.desc.latest"),
+                         show_selected: @comments_order == "latest" %>
+              <%= render "comments/sort_option",
+                         sort_order: "oldest",
+                         sort_title: t("views.articles.comments.sort.title.oldest"),
+                         sort_description: t("views.articles.comments.sort.desc.oldest"),
+                         show_selected: @comments_order == "oldest" %>
+            </ul>
+        </nav>
+      <% end %>
+
+      <div id="comment-subscription" class="print-hidden">
+        <div class="crayons-btn-group">
+          <span class="crayons-btn crayons-btn--outlined"><%= t("views.articles.comments.subscribe") %></span>
+        </div>
+      </div>
+    </header>
+    <div id="billboard_delay_trigger"></div>
+    <div
+      id="comments-container"
+      data-testid="comments-container"
+      data-commentable-id="<%= @article.id %>"
+      data-commentable-type="Article"
+      data-has-recent-comment-activity="<%= @article.has_recent_comment_activity? %>">
+
+      <% if @discussion_lock %>
+        <%= render "/comments/discussion_lock_reason" %>
+      <% else %>
+        <%= render "/comments/form", commentable: @article, commentable_type: "Article" %>
+      <% end %>
+
+      <div class="comments" id="comment-trees-container">
+        <% if @article.comments_count > 0 %>
+          <% @current_comment_index = 0 %>
+          <%= render partial: "articles/comment_tree",
+                     collection: article_comment_tree(@article, @comments_to_show_count, @comments_order),
+                     as: :comment_node,
+                     cached: proc { |comment, _sub_comments| [comment, @comments_order, user_signed_in?] } %>
+        <% end %>
+      </div>
+    </div>
+
+    <%= render "articles/comments_actions" %>
+  <% end %>
+</section>
+<%= render "comments/hide_comments_modal" %>
 <% return if @warm_only %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -105,7 +105,7 @@
         <div id="audiocontent" data-podcast="">
           <%= yield(:audio) %>
         </div>
-        <% cache("main-side-bar-#{user_signed_in?}", expires_in: 5.minutes) do %>
+        <% cache("main-side-bar-#{user_signed_in?}", expires_in: 10.minutes) do %>
           <% if Subforem.cached_discoverable_ids.any? %>
             <%= render "layouts/main_side_bar" %>
           <% end %>

--- a/app/views/users/_comments_section.html.erb
+++ b/app/views/users/_comments_section.html.erb
@@ -1,58 +1,56 @@
-<% cache("user-profile-comments-#{@user.last_comment_at}-#{@user.id}-#{@comments.size}", expires_in: 2.days) do %>
-  <div class="profile-comment-card crayons-card mt-2 m:mt-0 mb-2">
-    <% if @comments.present? %>
-      <% if params[:view] == "comments" %>
-        <div class="crayons-card__header">
-          <h3 class="crayons-subtitle-2">
-            <% if high_number_of_comments?(@user.comments_count) %>
-              <%= t("views.users.comments.last.other") %>
-            <% else %>
-              <%= t("views.users.comments.all.other") %>
-            <% end %>
-          </h3>
-          <div class="crayons-card__actions">
-            <a href="<%= @user.path %>" class="crayons-link--branded fs-base">
-              <%= t("views.users.comments.view_last.other") %>
-            </a>
-          </div>
-        </div>
-      <% else %>
-        <div class="crayons-card__header">
-          <h3 class="crayons-subtitle-2">
+<div class="profile-comment-card crayons-card mt-2 m:mt-0 mb-2">
+  <% if @comments.present? %>
+    <% if params[:view] == "comments" %>
+      <div class="crayons-card__header">
+        <h3 class="crayons-subtitle-2">
+          <% if high_number_of_comments?(@user.comments_count) %>
             <%= t("views.users.comments.last.other") %>
-          </h3>
+          <% else %>
+            <%= t("views.users.comments.all.other") %>
+          <% end %>
+        </h3>
+        <div class="crayons-card__actions">
+          <a href="<%= @user.path %>" class="crayons-link--branded fs-base">
+            <%= t("views.users.comments.view_last.other") %>
+          </a>
         </div>
-      <% end %>
-    <% end %>
-    <% @comments.each do |comment| %>
-      <% if comment.commentable.present? && comment.commentable.published && !comment.deleted %>
-        <a href="<%= comment.path %>" class="profile-comment-row ">
-          <h4 class="fw-bold fs-base m-0 mb-1">
-            <%= truncate(comment.commentable.title, length: 75) %>
-          </h4>
-          <div class="flex items-center fs-s">
-            <p class="color-base-80">
-              <%= truncate(strip_tags(comment.processed_html), length: 64).html_safe %>
-            <p>
-            <small class="ml-2 color-base-60 fs-s comment-date whitespace-nowrap">
-              <time datetime="<%= comment.decorate.published_timestamp %>"><%= comment.readable_publish_date %></time>
-            </small>
-          </div>
-        </a>
-      <% end %>
-    <% end %>
-    <% if params[:view] != "comments" && high_number_of_comments?(@user.comments_count) %>
-      <div class="pt-3 pl-4 pb-3 pr-4">
-        <a href="<%= @user.path %>/comments" class="fs-base">
-          <%= t("views.users.comments.view_last.other") %>
-        </a>
       </div>
-    <% elsif params[:view] != "comments" && view_all_comments?(@user.comments_count) %>
-      <div class="py-3 px-4">
-        <a href="<%= @user.path %>/comments" class="fs-base">
-          <%= t("views.users.comments.view_all.other") %>
-        </a>
+    <% else %>
+      <div class="crayons-card__header">
+        <h3 class="crayons-subtitle-2">
+          <%= t("views.users.comments.last.other") %>
+        </h3>
       </div>
     <% end %>
-  </div>
-<% end %>
+  <% end %>
+  <% @comments.each do |comment| %>
+    <% if comment.commentable.present? && comment.commentable.published && !comment.deleted %>
+      <a href="<%= comment.path %>" class="profile-comment-row ">
+        <h4 class="fw-bold fs-base m-0 mb-1">
+          <%= truncate(comment.commentable.title, length: 75) %>
+        </h4>
+        <div class="flex items-center fs-s">
+          <p class="color-base-80">
+            <%= truncate(strip_tags(comment.processed_html), length: 64).html_safe %>
+          <p>
+          <small class="ml-2 color-base-60 fs-s comment-date whitespace-nowrap">
+            <time datetime="<%= comment.decorate.published_timestamp %>"><%= comment.readable_publish_date %></time>
+          </small>
+        </div>
+      </a>
+    <% end %>
+  <% end %>
+  <% if params[:view] != "comments" && high_number_of_comments?(@user.comments_count) %>
+    <div class="pt-3 pl-4 pb-3 pr-4">
+      <a href="<%= @user.path %>/comments" class="fs-base">
+        <%= t("views.users.comments.view_last.other") %>
+      </a>
+    </div>
+  <% elsif params[:view] != "comments" && view_all_comments?(@user.comments_count) %>
+    <div class="py-3 px-4">
+      <a href="<%= @user.path %>/comments" class="fs-base">
+        <%= t("views.users.comments.view_all.other") %>
+      </a>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
- Remove comment area cache that was invalidated on every comment activity
- Remove user profile comments cache that was invalidated on every user comment
- Remove 5-minute sidebar cache that was too short to be meaningful

These caches were write-heavy due to frequent invalidation from comment activity, making them inefficient with the 2-day edge cache strategy. Removing them reduces cache invalidation overhead while maintaining functionality.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

