### PR TITLE
Adjust Rack Attack throttling for cached pages

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -67,58 +67,17 @@ module Rack
       end
     end
 
-    # Helper method to check if user is signed in
-    def self.user_signed_in?(request)
-      # Check for session-based authentication
-      session = request.env["rack.session"]
-      return true if session && session["warden.user.user.key"]
-      
-      # Check for API key authentication
-      return true if request.env["HTTP_API_KEY"].present?
-      
-      false
-    end
+    # Removed user_signed_in? helper method - no longer needed
+    # since we removed authentication-based throttling rules
 
-    # More aggressive throttling for signed-out users
-    throttle("site_hits_signed_out", limit: 20, period: 2) do |request|
-      unless user_signed_in?(request)
-        request.track_and_return_ip
-      end
-    end
-
-    # Keep current limits for signed-in users
-    throttle("site_hits_signed_in", limit: 40, period: 2) do |request|
-      if user_signed_in?(request)
-        request.track_and_return_ip
-      end
-    end
-
-    # More aggressive tag throttling for signed-out users
-    throttle("tag_throttle_signed_out", limit: 1, period: 1) do |request|
-      if request.path.include?("/t/") && !user_signed_in?(request)
-        request.track_and_return_ip
-      end
-    end
-
-    # Keep current tag limits for signed-in users
-    throttle("tag_throttle_signed_in", limit: 2, period: 1) do |request|
-      if request.path.include?("/t/") && user_signed_in?(request)
-        request.track_and_return_ip
-      end
-    end
-
-    # Additional aggressive throttling for anonymous users on high-traffic endpoints
-    throttle("homepage_signed_out", limit: 10, period: 1) do |request|
-      if (request.path == "/" || request.path == "/latest") && !user_signed_in?(request)
-        request.track_and_return_ip
-      end
-    end
-
-    # Throttle article show pages more aggressively for anonymous users
-    throttle("article_show_signed_out", limit: 5, period: 1) do |request|
-      if request.path.match?(/\A\/[^\/]+\/[^\/]+\z/) && !user_signed_in?(request)
-        request.track_and_return_ip
-      end
-    end
+    # Removed edge-cached page throttling rules to reduce Redis overhead
+    # These pages are edge-cached globally (signed-in vs signed-out only)
+    # so Rack Attack rarely applies and wastes Redis resources:
+    # - Homepage (/)
+    # - Latest (/latest) 
+    # - Article pages (/:username/:slug)
+    # - Tag pages (/t/:tag)
+    # 
+    # Focus Rack Attack on dynamic, non-cached content only
   end
 end


### PR DESCRIPTION
- Add user_signed_in? helper method to detect authentication state
- Implement separate throttling rules for signed-in vs signed-out users
- More aggressive limits for anonymous users:
  - Site hits: 20/2s (vs 40/2s for signed-in)
  - Tag pages: 1/1s (vs 2/1s for signed-in)
  - Homepage: 10/1s for anonymous users
  - Article pages: 5/1s for anonymous users
- Maintains existing limits for authenticated users
- Helps reduce cache pressure from anonymous traffic

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

