### PR TITLE
Allow 'style' attribute for table alignment in markdown

### DIFF
--- a/app/services/markdown_processor.rb
+++ b/app/services/markdown_processor.rb
@@ -65,17 +65,17 @@ module MarkdownProcessor
   # contexts.
   module AllowedAttributes
     FEED = %w[alt class colspan data-conversation data-lang em height href id ref rel
-              rowspan size span src start strong title value width].freeze
+              rowspan size span src start strong title value width style].freeze
 
     PODCAST_SHOW = %w[alt class colspan data-conversation data-lang em height href id ref
-                      rel rowspan size span src start strong title value width].freeze
+                      rel rowspan size span src start strong title value width style].freeze
 
     BILLBOARD = %w[alt class height href src width].freeze
 
     RENDERED_MARKDOWN_SCRUBBER = %w[alt autoplay colspan controls data-conversation data-lang
                                     data-gif-video data-no-instant data-url href id loop muted name
                                     playsinline preload poster ref rel rowspan span src start title
-                                    type value].freeze
+                                    type value style].freeze
 
     MARKDOWN_PROCESSOR = %w[alt href src].freeze
 

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -672,4 +672,26 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
       expect(rendered_html).not_to include('alt="Image Description"')
   end
 
+  context "when rendering tables" do
+    it "preserves table alignment from markdown syntax" do
+      table_markdown = <<~MARKDOWN
+        | Left | Right | Center | Right |
+        |:-----|------:|:------:|------:|
+        | Apple | 100 | Test | 1000 |
+        | Banana | 200 | Demo | 20000 |
+      MARKDOWN
+
+      rendered_html = generate_and_parse_markdown(table_markdown)
+
+      # Check that the table is rendered
+      expect(rendered_html).to include("<table>")
+      expect(rendered_html).to include("<thead>")
+      expect(rendered_html).to include("<tbody>")
+
+      # Verify specific cells have correct alignment
+      expect(rendered_html).to match(%r{<th.*style="text-align:left;".*>Left</th>})
+      expect(rendered_html).to match(%r{<th.*style="text-align:right;".*>Right</th>})
+      expect(rendered_html).to match(%r{<th.*style="text-align:center;".*>Center</th>})
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes table alignment in Markdown tables. Previously, all table cells were left-aligned regardless of the alignment syntax used in the Markdown. The issue was that Redcarpet was correctly generating `style="text-align: left/right/center"` attributes, but the HTML sanitizer was stripping them out because `"style"` was not in the allowed attributes list.

## Related Tickets & Documents

Closes [#20618](https://github.com/forem/forem/issues/20618)

## QA Instructions, Screenshots, Recordings

1. Create a new article or comment with the following Markdown table:
```
| Column One | Column Two | Column Three | Column Four |
|------|------:|:--------:|------:|
| Lorem ipsum | 111 | centered | 666 |
| Consectetur | 222 | more text | 777 |
| Sed dotem | 333 | centered | 888 |
| Incididunt | 444 | stuff | 999 |
| Et dolore | 555 | centered | 000 |
```
2. Verify that:
   - First column is left-aligned
   - Second column is right-aligned  
   - Third column is center-aligned
   - Fourth column is right-aligned

<img width="571" height="307" alt="image" src="https://github.com/user-attachments/assets/310277fe-9188-4531-be98-c2150e4f81be" />


### UI accessibility checklist
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests