### PR TITLE
fix: Name has already been taken in actions_panel_helper_spec

### DIFF
--- a/spec/helpers/moderations/actions_panel_helper_spec.rb
+++ b/spec/helpers/moderations/actions_panel_helper_spec.rb
@@ -9,7 +9,7 @@ describe Moderations::ActionsPanelHelper do
     let(:admin) { create(:user, :admin) }
     let(:user) { create(:user) }
 
-    let(:article) { create(:article, tags: "tag2") }
+  let(:article) { create(:article, tags: tag2.name) }
 
     it "returns false if the last adjustment was made by a non-admin" do
       user.add_role(:tag_moderator, tag2)


### PR DESCRIPTION
I think the spec was trying to create tag with same name so I adjusted it to create two random alphanumeric names. I hope it fixes its failing

let me know if it was meant to be intentional