### PR TITLE
Remove admin-only flag condition for cover image generation

### DIFF
--- a/app/javascript/article-form/components/ArticleCoverImage.jsx
+++ b/app/javascript/article-form/components/ArticleCoverImage.jsx
@@ -38,8 +38,7 @@ const StandardImageUpload = ({
   onGenerateClick,
   aiAvailable,
 }) => {
-  const isAdmin = window.currentUser?.admin;
-  const showAiButton = isAdmin && aiAvailable;
+  const showAiButton = aiAvailable;
   
   return isUploadingImage ? null : (
     <Fragment>

--- a/app/javascript/article-form/components/__tests__/ArticleCoverImage.test.jsx
+++ b/app/javascript/article-form/components/__tests__/ArticleCoverImage.test.jsx
@@ -41,8 +41,8 @@ const resetNativeIOSCapabilities = () => {
 
 describe('<ArticleCoverImage />', () => {
   beforeEach(() => {
-    // Mock window.currentUser for admin checks
-    global.window.currentUser = { admin: true };
+    // Mock window.currentUser
+    global.window.currentUser = {};
   });
 
   afterEach(() => {
@@ -71,11 +71,11 @@ describe('<ArticleCoverImage />', () => {
 
   it('displays a generate with AI button when there is no main image', () => {
     const { getByTestId } = render(
-      <ArticleCoverImage mainImage="" onMainImageUrlChange={jest.fn()} coverImageHeight="420" coverImageCrop="no_crop" />,
+      <ArticleCoverImage mainImage="" onMainImageUrlChange={jest.fn()} coverImageHeight="420" coverImageCrop="no_crop" aiAvailable={true} />,
     );
     const generateButton = getByTestId('generate-ai-image-btn');
     expect(generateButton).toBeInTheDocument();
-    expect(generateButton.textContent).toContain('Generate with AI');
+    expect(generateButton.textContent).toContain('Generate Image');
   });
 
   describe('when an image is uploaded', () => {
@@ -219,6 +219,7 @@ describe('<ArticleCoverImage />', () => {
           onMainImageUrlChange={jest.fn()}
           coverImageHeight="420"
           coverImageCrop="no_crop"
+          aiAvailable={true}
         />,
       );
 
@@ -236,6 +237,7 @@ describe('<ArticleCoverImage />', () => {
           onMainImageUrlChange={jest.fn()}
           coverImageHeight="420"
           coverImageCrop="no_crop"
+          aiAvailable={true}
         />,
       );
 
@@ -260,6 +262,7 @@ describe('<ArticleCoverImage />', () => {
           onMainImageUrlChange={onMainImageUrlChange}
           coverImageHeight="420"
           coverImageCrop="no_crop"
+          aiAvailable={true}
         />,
       );
 
@@ -303,6 +306,7 @@ describe('<ArticleCoverImage />', () => {
           onMainImageUrlChange={jest.fn()}
           coverImageHeight="420"
           coverImageCrop="no_crop"
+          aiAvailable={true}
         />,
       );
 
@@ -330,6 +334,7 @@ describe('<ArticleCoverImage />', () => {
           onMainImageUrlChange={jest.fn()}
           coverImageHeight="420"
           coverImageCrop="no_crop"
+          aiAvailable={true}
         />,
       );
 
@@ -355,6 +360,7 @@ describe('<ArticleCoverImage />', () => {
           onMainImageUrlChange={jest.fn()}
           coverImageHeight="420"
           coverImageCrop="no_crop"
+          aiAvailable={true}
         />,
       );
 
@@ -383,6 +389,7 @@ describe('<ArticleCoverImage />', () => {
           onMainImageUrlChange={jest.fn()}
           coverImageHeight="420"
           coverImageCrop="no_crop"
+          aiAvailable={true}
         />,
       );
 
@@ -405,6 +412,7 @@ describe('<ArticleCoverImage />', () => {
           onMainImageUrlChange={jest.fn()}
           coverImageHeight="420"
           coverImageCrop="no_crop"
+          aiAvailable={true}
         />,
       );
 
@@ -424,23 +432,10 @@ describe('<ArticleCoverImage />', () => {
     });
   });
 
-  describe('when user is not an admin', () => {
-    beforeEach(() => {
-      global.window.currentUser = { admin: false };
-    });
-
-    it('does not show the generate AI image button', () => {
-      const { queryByTestId } = render(
-        <ArticleCoverImage mainImage="" onMainImageUrlChange={jest.fn()} coverImageHeight="420" coverImageCrop="no_crop" />,
-      );
-      expect(queryByTestId('generate-ai-image-btn')).not.toBeInTheDocument();
-    });
-  });
-
   describe('when rendered in native iOS with imageUpload support', () => {
     beforeAll(() => {
       stubNativeIOSCapabilities();
-      global.window.currentUser = { admin: true };
+      global.window.currentUser = {};
     });
 
     afterAll(() => {

--- a/app/policies/ai_image_generation_policy.rb
+++ b/app/policies/ai_image_generation_policy.rb
@@ -1,7 +1,7 @@
 class AiImageGenerationPolicy < ApplicationPolicy
   def create?
-    # Only admins can generate AI images
-    user.any_admin?
+    # All users can generate AI images (as long as they're not spam)
+    !user.spam
   end
 end
 

--- a/app/views/articles/_v2_form.html.erb
+++ b/app/views/articles/_v2_form.html.erb
@@ -101,6 +101,11 @@
               </label>
               <input id="cover-image-input" type="file" accept="image/*" class="w-100 h-100 absolute left-0 right-0 top-0 bottom-0 overflow-hidden opacity-0 cursor-pointer" data-max-file-size-mb="25">
             </button>
+            <% if ::AI_AVAILABLE %>
+              <button class="crayons-btn crayons-btn--outlined mr-2 whitespace-nowrap" data-testid="generate-ai-image-btn" style="min-height: 2.5rem; display: inline-flex; align-items: center;">
+                🍌 Generate Image
+              </button>
+            <% end %>
           </div>
           <div class="crayons-article-form__title">
             <textarea class="crayons-textfield crayons-textfield--ghost fs-3xl m:fs-4xl l:fs-5xl fw-bold s:fw-heavy lh-tight" type="text" id="article-form-title" placeholder="<%= t("views.editor.new_title") %>" autocomplete="off"><%= article.title %></textarea>

--- a/spec/requests/ai_image_generations_spec.rb
+++ b/spec/requests/ai_image_generations_spec.rb
@@ -2,8 +2,7 @@ require "rails_helper"
 
 RSpec.describe "AiImageGenerations" do
   describe "POST /ai_image_generations" do
-    let(:admin_user) { create(:user, :admin) }
-    let(:regular_user) { create(:user) }
+    let(:user) { create(:user) }
     let(:headers) { { "Content-Type": "application/json", Accept: "application/json" } }
     let(:valid_params) { { prompt: "A beautiful sunset over mountains" } }
     let(:image_url) { "https://example.com/generated-image.png" }
@@ -15,21 +14,9 @@ RSpec.describe "AiImageGenerations" do
       end
     end
 
-    context "when logged-in as non-admin" do
+    context "when logged-in" do
       before do
-        sign_in regular_user
-      end
-
-      it "does not allow non-admin users to generate images" do
-        expect do
-          post "/ai_image_generations", headers: headers, params: valid_params.to_json
-        end.to raise_error(Pundit::NotAuthorizedError)
-      end
-    end
-
-    context "when logged-in as admin" do
-      before do
-        sign_in admin_user
+        sign_in user
       end
 
       it "returns json" do
@@ -262,10 +249,10 @@ RSpec.describe "AiImageGenerations" do
     context "when rate limiting works" do
       let(:cache_store) { ActiveSupport::Cache.lookup_store(:redis_cache_store) }
       let(:cache) { Rails.cache }
-      let(:cache_key) { "#{admin_user.id}_ai_image_generation" }
+      let(:cache_key) { "#{user.id}_ai_image_generation" }
 
       before do
-        sign_in admin_user
+        sign_in user
         allow(Rails).to receive(:cache).and_return(cache_store)
         allow_any_instance_of(Ai::ImageGenerator).to receive(:generate).and_return(
           Ai::ImageGenerator::GenerationResult.new(url: image_url, text_response: nil)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Remove the experimental `admin?` condition for the image generation feature if the appropriate API key is available in the code