### PR TITLE
Make series unique on organization id alone

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,7 +4,8 @@ class Collection < ApplicationRecord
   belongs_to :user
   belongs_to :organization, optional: true
 
-  validates :slug, presence: true, uniqueness: { scope: [:user_id, :organization_id] }
+  validates :slug, presence: true
+  validate :slug_uniqueness_within_scope
 
   scope :non_empty, -> { joins(:articles).distinct }
 
@@ -12,8 +13,21 @@ class Collection < ApplicationRecord
 
   def self.find_series(slug, user, organization: nil)
     if organization.present?
-      Collection.find_or_create_by(slug: slug, user: user, organization: organization)
+      # For organization collections, find by slug and organization_id first (ignoring user_id)
+      # This ensures we reuse existing organization collections regardless of which user created them
+      existing_collection = Collection.find_by(slug: slug, organization_id: organization.id)
+      return existing_collection if existing_collection
+
+      # Create new collection with the provided user
+      # Handle potential race condition where another process created it between find_by and create
+      begin
+        Collection.create!(slug: slug, user: user, organization: organization)
+      rescue ActiveRecord::RecordNotUnique
+        # Another process created it, find it again
+        Collection.find_by!(slug: slug, organization_id: organization.id)
+      end
     else
+      # For personal collections, find by slug and user_id (no organization)
       Collection.find_or_create_by(slug: slug, user: user, organization_id: nil)
     end
   end
@@ -23,6 +37,24 @@ class Collection < ApplicationRecord
   end
 
   private
+
+  def slug_uniqueness_within_scope
+    scope = if organization_id.present?
+              Collection.where(slug: slug, organization_id: organization_id)
+            else
+              Collection.where(slug: slug, user_id: user_id, organization_id: nil)
+            end
+
+    scope = scope.where.not(id: id) if persisted?
+
+    if scope.exists?
+      if organization_id.present?
+        errors.add(:slug, "has already been taken for this organization")
+      else
+        errors.add(:slug, "has already been taken")
+      end
+    end
+  end
 
   def touch_articles
     articles.touch_all

--- a/db/migrate/20251120190926_update_collections_unique_index_for_organization_uniqueness.rb
+++ b/db/migrate/20251120190926_update_collections_unique_index_for_organization_uniqueness.rb
@@ -1,0 +1,54 @@
+class UpdateCollectionsUniqueIndexForOrganizationUniqueness < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    # Remove the old unique index that includes user_id
+    remove_index :collections,
+                 name: "index_collections_on_slug_and_user_id_and_organization_id",
+                 algorithm: :concurrently,
+                 if_exists: true
+
+    # Add partial unique index for organization collections: slug must be unique within organization_id
+    # This enforces that only one series can exist per slug per organization, regardless of user_id
+    ActiveRecord::Base.connection.execute(
+      <<~SQL
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "index_collections_on_slug_and_organization_id"
+        ON "collections"
+        USING btree ("slug", "organization_id")
+        WHERE "organization_id" IS NOT NULL;
+      SQL
+    )
+
+    # Add partial unique index for personal collections: slug must be unique within user_id
+    # This maintains the existing behavior for personal collections (no organization)
+    ActiveRecord::Base.connection.execute(
+      <<~SQL
+        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "index_collections_on_slug_and_user_id"
+        ON "collections"
+        USING btree ("slug", "user_id")
+        WHERE "organization_id" IS NULL;
+      SQL
+    )
+  end
+
+  def down
+    # Remove the partial indexes
+    ActiveRecord::Base.connection.execute(
+      <<~SQL
+        DROP INDEX CONCURRENTLY IF EXISTS "index_collections_on_slug_and_organization_id";
+      SQL
+    )
+    ActiveRecord::Base.connection.execute(
+      <<~SQL
+        DROP INDEX CONCURRENTLY IF EXISTS "index_collections_on_slug_and_user_id";
+      SQL
+    )
+
+    # Restore the old index
+    add_index :collections,
+              %i[slug user_id organization_id],
+              unique: true,
+              name: "index_collections_on_slug_and_user_id_and_organization_id",
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_11_19_174541) do
+ActiveRecord::Schema[7.0].define(version: 2025_11_20_190926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -389,7 +389,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_11_19_174541) do
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id"
     t.index ["organization_id"], name: "index_collections_on_organization_id"
-    t.index ["slug", "user_id", "organization_id"], name: "index_collections_on_slug_and_user_id_and_organization_id", unique: true
+    t.index ["slug", "organization_id"], name: "index_collections_on_slug_and_organization_id", unique: true, where: "(organization_id IS NOT NULL)"
+    t.index ["slug", "user_id"], name: "index_collections_on_slug_and_user_id", unique: true, where: "(organization_id IS NULL)"
     t.index ["user_id"], name: "index_collections_on_user_id"
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -10,7 +10,44 @@ RSpec.describe Collection do
     it { is_expected.to have_many(:articles).dependent(:nullify) }
 
     it { is_expected.to validate_presence_of(:slug) }
-    it { is_expected.to validate_uniqueness_of(:slug).scoped_to(%i[user_id organization_id]) }
+
+    describe "slug uniqueness" do
+      context "for personal collections (no organization)" do
+        it "enforces uniqueness within user_id" do
+          create(:collection, user: user, slug: "test-slug", organization: nil)
+          duplicate = build(:collection, user: user, slug: "test-slug", organization: nil)
+          expect(duplicate).not_to be_valid
+          expect(duplicate.errors[:slug]).to be_present
+        end
+
+        it "allows same slug for different users" do
+          other_user = create(:user)
+          create(:collection, user: user, slug: "test-slug", organization: nil)
+          other_collection = build(:collection, user: other_user, slug: "test-slug", organization: nil)
+          expect(other_collection).to be_valid
+        end
+      end
+
+      context "for organization collections" do
+        let(:organization) { create(:organization) }
+
+        it "enforces uniqueness within organization_id (not user_id)" do
+          create(:collection, user: user, slug: "test-slug", organization: organization)
+          # Even with a different user, same slug + organization should fail
+          other_user = create(:user)
+          duplicate = build(:collection, user: other_user, slug: "test-slug", organization: organization)
+          expect(duplicate).not_to be_valid
+          expect(duplicate.errors[:slug]).to include("has already been taken for this organization")
+        end
+
+        it "allows same slug for different organizations" do
+          other_organization = create(:organization)
+          create(:collection, user: user, slug: "test-slug", organization: organization)
+          other_collection = build(:collection, user: user, slug: "test-slug", organization: other_organization)
+          expect(other_collection).to be_valid
+        end
+      end
+    end
   end
 
   describe ".find_series" do
@@ -43,7 +80,21 @@ RSpec.describe Collection do
         end.to change(described_class, :count).by(1)
       end
 
-      it "returns an existing series for an organization" do
+      it "returns an existing series for an organization regardless of user_id" do
+        # Create a collection with one user
+        original_user = create(:user)
+        org_collection = create(:collection, user: original_user, organization: organization, slug: "test-series")
+        
+        # Try to find it with a different user - should return the existing collection
+        different_user = create(:user)
+        expect do
+          found_collection = described_class.find_series("test-series", different_user, organization: organization)
+          expect(found_collection).to eq(org_collection)
+          expect(found_collection.user_id).to eq(original_user.id) # Should still be the original user
+        end.not_to change(described_class, :count)
+      end
+
+      it "returns an existing series for an organization when called by the same user" do
         org_collection = create(:collection, user: user, organization: organization, slug: "test-series")
         expect do
           expect(described_class.find_series("test-series", user, organization: organization)).to eq(org_collection)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This makes slug uniqueness check for just organization id in that context — helps ensure multiple users in an org don't create the same series with different names.