### PR TITLE
feature(scroll-button): add back-to-top button (Stimulus controller, …

### DIFF
--- a/app/javascript/controllers/scroll_to_top_controller.js
+++ b/app/javascript/controllers/scroll_to_top_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from '@hotwired/stimulus';
+
+export class ScrollToTopController extends Controller {
+  static values = {
+    threshold: { type: Number, default: 300 }
+  };
+
+  connect() {
+    this.toggle();
+  }
+
+  toggle() {
+    const scrollPosition = window.scrollY || window.pageYOffset;
+    
+    if (scrollPosition > this.thresholdValue) {
+      this.element.classList.remove('hidden');
+      this.element.classList.add('visible');
+    } else {
+      this.element.classList.remove('visible');
+      this.element.classList.add('hidden');
+    }
+  }
+
+  scrollToTop() {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  }
+}
+
+export default ScrollToTopController;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -155,6 +155,72 @@
     <%= render "shared/subforem_selection_modal" %>
   <% end %>
   
+  <button
+    id="back-to-top-btn"
+    data-controller="scroll-to-top"
+    data-action="click->scroll-to-top#scrollToTop window@scroll->scroll-to-top#toggle"
+    class="hidden"
+    style="position: fixed; 
+           bottom: 20px; 
+           right: 20px; 
+           z-index: 9999; 
+           width: 48px; 
+           height: 48px; 
+           border-radius: 50%; 
+           background-color: rgba(0, 0, 0, 0.7); 
+           color: white; 
+           border: none; 
+           cursor: pointer; 
+           box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3); 
+           display: flex; 
+           align-items: center; 
+           justify-content: center; 
+           transition: opacity 0.3s ease, background-color 0.3s ease;"
+    onmouseover="this.style.backgroundColor='rgba(0, 0, 0, 0.9)'"
+    onmouseout="this.style.backgroundColor='rgba(0, 0, 0, 0.7)'"
+    aria-label="Back to top">
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <polyline points="18 15 12 9 6 15"></polyline>
+    </svg>
+  </button>
+
+  <script>
+    (function() {
+      const backToTopBtn = document.getElementById('back-to-top-btn');
+      
+      if (!backToTopBtn) return;
+
+      function toggleButton() {
+        const scrollPosition = window.scrollY || window.pageYOffset;
+        
+        if (scrollPosition > 300) {
+          backToTopBtn.classList.remove('hidden');
+          backToTopBtn.style.opacity = '1';
+          backToTopBtn.style.visibility = 'visible';
+        } else {
+          backToTopBtn.style.opacity = '0';
+          backToTopBtn.style.visibility = 'hidden';
+          setTimeout(() => {
+            if (window.scrollY <= 300) {
+              backToTopBtn.classList.add('hidden');
+            }
+          }, 300);
+        }
+      }
+
+      window.addEventListener('scroll', toggleButton);
+
+      backToTopBtn.addEventListener('click', function() {
+        window.scrollTo({
+          top: 0,
+          behavior: 'smooth'
+        });
+      });
+
+      toggleButton();
+    })();
+  </script>
+
   </body>
   </html>
 <% end %>

--- a/spec/system/scroll_to_top_spec.rb
+++ b/spec/system/scroll_to_top_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe "Scroll to Top Button", type: :system, js: true do
+  let(:user) { create(:user) }
+
+  before do
+    create_list(:article, 10, user: user, approved: true)
+    visit root_path
+  end
+
+  it "button exists and is initially hidden" do
+    expect(page).to have_css("#back-to-top-btn.hidden", visible: :all)
+  end
+
+  it "shows button when scrolling down and hides when scrolling up" do
+    page.execute_script("window.scrollTo(0, 500)")
+    page.execute_script("window.dispatchEvent(new Event('scroll'))")
+    sleep 0.5
+
+    expect(page).to have_css("#back-to-top-btn:not(.hidden)", visible: true)
+
+    page.execute_script("window.scrollTo(0, 0)")
+    page.execute_script("window.dispatchEvent(new Event('scroll'))")
+    sleep 0.5
+
+    expect(page).to have_css("#back-to-top-btn.hidden", visible: :all)
+  end
+
+  it "scrolls to top when button is clicked" do
+    page.execute_script("window.scrollTo(0, 1000)")
+    page.execute_script("window.dispatchEvent(new Event('scroll'))")
+    sleep 0.5
+
+    page.execute_script("document.getElementById('back-to-top-btn').classList.remove('hidden')")
+    
+    find("#back-to-top-btn").click
+    sleep 1
+
+    scroll_position = page.evaluate_script("window.scrollY")
+    expect(scroll_position).to be < 100
+  end
+end


### PR DESCRIPTION
This feature adds a “Scroll to Top” button that enhances navigation without interfering with the page layout.

The button is only displayed after the user scrolls down a certain distance (e.g., 300px), ensuring it does not appear unnecessarily.

It stays fixed in a corner of the screen, maintaining a clean visual design and avoiding obstruction of content.

The button fades in smoothly when triggered, preventing abrupt visual changes.

Clicking it triggers a smooth automatic scroll back to the top of the page for a better user experience.

(This was originally developed as part of a university project.)