### PR TITLE
Hide Moderate link from non-moderators in mobile view

### DIFF
--- a/app/assets/stylesheets/views/mod-actions.scss
+++ b/app/assets/stylesheets/views/mod-actions.scss
@@ -818,3 +818,12 @@
     height: 100%;
   }
 }
+
+// Hide moderate link for non-trusted users
+.only-mobile-menu-item.trusted-visible-block {
+  display: none !important;
+}
+
+body.trusted-status-true .only-mobile-menu-item.trusted-visible-block {
+  display: block !important;
+}

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -21,9 +21,8 @@
       </button>
 
       <div id="article-show-more-dropdown" class="crayons-dropdown side-bar left-2 right-2 m:right-auto m:left-100 s:left-auto mb-1 m:mb-0 top-unset bottom-100 m:top-0 m:bottom-unset">
-        <% article_for_policy = @article.is_a?(ArticleDecorator) ? @article.object : @article %>
-        <% if user_signed_in? && policy(article_for_policy).moderate? %>
-          <div class="only-mobile-menu-item">
+        <% if user_signed_in? %>
+          <div class="only-mobile-menu-item trusted-visible-block">
             <button class="mod-actions-menu-btn crayons-link crayons-link--block w-100 bg-transparent border-0 fw-bold">
               Moderate
             </button>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

**Issue:** The "Moderate" link in the mobile/narrow screen article actions dropdown was visible to all users (logged out and non-moderators), though unclickable.

**Fix:** Added policy check to only render the link for users with moderation permissions.

**No change** to desktop/full-width view which already works correctly via `trusted-visible-block` CSS.

## Related Tickets & Documents

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Mobile dropdown: "Moderate" link now only visible to moderators.

## Added/updated tests?

- [ ] No, and this is why: View-level authorization check. Existing `ArticlePolicy#moderate?` tests cover the logic.

## [optional] Are there any post deployment tasks we need to perform?
