### PR TITLE
Lower advertise form overlay below header

### DIFF
--- a/app/assets/stylesheets/views/advertise.scss
+++ b/app/assets/stylesheets/views/advertise.scss
@@ -1,0 +1,4 @@
+// Keep the advertise page form overlay below the global header/side nav while still above page content.
+#formOverlay.form-overlay {
+  z-index: calc(var(--z-sticky) - 1);
+}


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug Fix

## Description
Lower the `/advertise` form overlay so it sits below the global header/side nav (CSS override for `#formOverlay.form-overlay`). Blind fix: page content lives in CMS.

## Related Tickets & Documents
- Closes https://github.com/forem/forem/issues/22244
- Related: https://github.com/forem/forem/pull/22657 (drawer z-index). No conflict: that PR lifts the mobile drawer, this only adjusts the advertise overlay.

## QA Instructions
- Visit https://dev.to/advertise
- Open the sponsorship form overlay
- Confirm header and left nav remain above the overlay; overlay still above page content

## Added/updated tests?
- No