### PR TITLE
Subforem RSS Import Support

### DIFF
--- a/app/controllers/users/settings_controller.rb
+++ b/app/controllers/users/settings_controller.rb
@@ -47,7 +47,8 @@ module Users
     def import_articles_from_feed(users_setting)
       return if users_setting.feed_url.blank?
 
-      Feeds::ImportArticlesWorker.perform_async(users_setting.user_id)
+      subforem_id = RequestStore.store[:subforem_id]
+      Feeds::ImportArticlesWorker.perform_async([users_setting.user_id], nil, subforem_id)
     end
 
     def users_setting_params

--- a/spec/requests/user/user_settings_spec.rb
+++ b/spec/requests/user/user_settings_spec.rb
@@ -374,11 +374,11 @@ RSpec.describe "UserSettings" do
       end
 
       it "invokes Feeds::ImportArticlesWorker" do
-        allow(Feeds::ImportArticlesWorker).to receive(:perform_async).with(user.id)
+        allow(Feeds::ImportArticlesWorker).to receive(:perform_async)
 
         put users_settings_path(user.setting.id), params: { users_setting: { feed_url: feed_url } }
 
-        expect(Feeds::ImportArticlesWorker).to have_received(:perform_async).with(user.id)
+        expect(Feeds::ImportArticlesWorker).to have_received(:perform_async).with([user.id], nil, anything)
       end
     end
   end

--- a/spec/workers/feeds/import_articles_worker_spec.rb
+++ b/spec/workers/feeds/import_articles_worker_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe Feeds::ImportArticlesWorker, sidekiq: :inline, type: :worker do
 
         expect(Feeds::Import)
           .to have_received(:call)
-          .with(users_scope: User.where(id: [bob.id]), earlier_than: 4.hours.ago.iso8601)
+          .with(users_scope: User.where(id: [bob.id]), earlier_than: 4.hours.ago.iso8601, subforem_id: nil)
         expect(Feeds::Import)
           .not_to have_received(:call)
-          .with(users_scope: User.where(id: [alice.id]), earlier_than: 4.hours.ago.iso8601)
+          .with(users_scope: User.where(id: [alice.id]), earlier_than: 4.hours.ago.iso8601, subforem_id: nil)
       end
     end
 
@@ -38,6 +38,7 @@ RSpec.describe Feeds::ImportArticlesWorker, sidekiq: :inline, type: :worker do
       expect(Feeds::Import).to have_received(:call).with(
         users_scope: User.where(id: user.id),
         earlier_than: earlier_than.iso8601,
+        subforem_id: nil,
       )
     end
 
@@ -48,7 +49,7 @@ RSpec.describe Feeds::ImportArticlesWorker, sidekiq: :inline, type: :worker do
 
       worker.perform([user.id])
 
-      expect(Feeds::Import).to have_received(:call).with(users_scope: User.where(id: [user.id]), earlier_than: nil)
+      expect(Feeds::Import).to have_received(:call).with(users_scope: User.where(id: [user.id]), earlier_than: nil, subforem_id: nil)
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [x] Bug Fix

## Description

RSS imports publish to the subforem where the user saved feed settings (domain-aware). `subforem_id` is captured in settings, passed via the worker to import, and set on created articles. Removed root-subforem gating in the import filter.

## Added/updated tests?

- [x] Yes

