### PR TITLE
Fix org membership cache

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -185,7 +185,7 @@ class UsersController < ApplicationController
   def leave_org
     org = Organization.find_by(id: params[:organization_id])
     authorize org
-    OrganizationMembership.find_by(organization_id: org.id, user_id: current_user.id)&.delete
+    OrganizationMembership.find_by(organization_id: org.id, user_id: current_user.id)&.destroy
     flash[:settings_notice] = I18n.t("users_controller.left_org")
     redirect_to "/settings/organization/new"
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Fix cache invalidation when removing organization membership. Changed `OrganizationMembership.delete` to `.destroy` to ensure the `after_destroy` callback fires, which updates the user's `organization_info_updated_at` timestamp and invalidates the profile sidebar cache.

Previously, deleted org memberships would remain visible on user profiles for up to 2 days (cache TTL) because the callback was never triggered.

## Related Tickets & Documents

- Closes #22668