### PR TITLE
Add presence updating for users

### DIFF
--- a/app/controllers/ahoy/email_clicks_controller.rb
+++ b/app/controllers/ahoy/email_clicks_controller.rb
@@ -13,6 +13,9 @@ module Ahoy
       AhoyEmail::Utils.publish(:click, data)
       track_billboard if params[:bb].present?
       record_feed_event if @url.present?
+      
+      EmailMessage.find_by(token: @token)&.user&.update_presence!
+
       head :ok # Renders a blank response with a 200 OK status
     end
 

--- a/app/controllers/async_info_controller.rb
+++ b/app/controllers/async_info_controller.rb
@@ -6,6 +6,7 @@ class AsyncInfoController < ApplicationController
   def base_data
     flash.discard(:notice)
     if user_signed_in? && verify_state_of_user_session?
+      current_user.update_presence!
       @user = current_user.decorate
       respond_to do |format|
         format.json do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -699,6 +699,12 @@ class User < ApplicationRecord
   def bot?
     community_bot? || member_bot?
   end
+  
+  def update_presence!
+    return if last_presence_at.present? && last_presence_at > 1.hour.ago
+
+    update_column(:last_presence_at, Time.current)
+  end
 
   protected
 

--- a/db/migrate/20260127141307_add_last_presence_at_to_users.rb
+++ b/db/migrate/20260127141307_add_last_presence_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastPresenceAtToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :last_presence_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_12_30_120202) do
+ActiveRecord::Schema[7.0].define(version: 2026_01_27_141307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -447,9 +447,11 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_30_120202) do
     t.datetime "created_at", null: false
     t.text "processed_html", null: false
     t.bigint "tag_id"
+    t.bigint "trend_id"
     t.datetime "updated_at", null: false
     t.index ["article_id"], name: "index_context_notes_on_article_id"
     t.index ["tag_id"], name: "index_context_notes_on_tag_id"
+    t.index ["trend_id"], name: "index_context_notes_on_trend_id"
   end
 
   create_table "context_notifications", force: :cascade do |t|
@@ -826,6 +828,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_30_120202) do
 
   create_table "navigation_links", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.text "description"
     t.boolean "display_only_when_signed_in", default: false
     t.integer "display_to", default: 0, null: false
     t.string "icon"
@@ -1404,10 +1407,14 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_30_120202) do
   end
 
   create_table "tag_subforem_relationships", force: :cascade do |t|
+    t.string "bg_color_hex"
     t.datetime "created_at", null: false
+    t.string "pretty_name"
+    t.text "short_summary"
     t.bigint "subforem_id", null: false
     t.boolean "supported", default: true
     t.bigint "tag_id", null: false
+    t.string "text_color_hex"
     t.datetime "updated_at", null: false
     t.index ["subforem_id"], name: "index_tag_subforem_relationships_on_subforem_id"
     t.index ["tag_id"], name: "index_tag_subforem_relationships_on_tag_id"
@@ -1463,6 +1470,18 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_30_120202) do
     t.index ["social_preview_template"], name: "index_tags_on_social_preview_template"
     t.index ["supported"], name: "index_tags_on_supported"
     t.index ["taggings_count"], name: "index_tags_on_taggings_count"
+  end
+
+  create_table "trends", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expiry_date", null: false
+    t.text "full_content_description", null: false
+    t.text "public_description", null: false
+    t.string "short_title", null: false
+    t.bigint "subforem_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expiry_date"], name: "index_trends_on_expiry_date"
+    t.index ["subforem_id"], name: "index_trends_on_subforem_id"
   end
 
   create_table "tweets", force: :cascade do |t|
@@ -1624,6 +1643,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_30_120202) do
     t.datetime "last_moderation_notification", precision: nil, default: "2017-01-01 05:00:00"
     t.datetime "last_notification_activity", precision: nil
     t.string "last_onboarding_page"
+    t.datetime "last_presence_at"
     t.datetime "last_reacted_at", precision: nil
     t.datetime "last_sign_in_at", precision: nil
     t.inet "last_sign_in_ip"
@@ -1853,6 +1873,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_12_30_120202) do
   add_foreign_key "tag_subforem_relationships", "tags"
   add_foreign_key "taggings", "tags", on_delete: :cascade
   add_foreign_key "tags", "badges", on_delete: :nullify
+  add_foreign_key "trends", "subforems"
   add_foreign_key "tweets", "users", on_delete: :nullify
   add_foreign_key "user_activities", "users"
   add_foreign_key "user_blocks", "users", column: "blocked_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -804,6 +804,29 @@ RSpec.describe User do
     end
   end
 
+  describe "#update_presence!" do
+    context "when last_presence_at is nil" do
+      it "updates last_presence_at to current time" do
+        user.update_column(:last_presence_at, nil)
+        expect { user.update_presence! }.to change(user, :last_presence_at)
+      end
+    end
+
+    context "when last_presence_at is more than 1 hour ago" do
+      it "updates last_presence_at to current time" do
+        user.update_column(:last_presence_at, 2.hours.ago)
+        expect { user.update_presence! }.to change(user, :last_presence_at)
+      end
+    end
+
+    context "when last_presence_at is less than 1 hour ago" do
+      it "does not update last_presence_at" do
+        user.update_column(:last_presence_at, 30.minutes.ago)
+        expect { user.update_presence! }.not_to change(user, :last_presence_at)
+      end
+    end
+  end
+
   describe "#receives_follower_email_notifications?" do
     it "returns false if user has no email" do
       user.assign_attributes(email: nil)

--- a/spec/requests/ahoy/email_clicks_spec.rb
+++ b/spec/requests/ahoy/email_clicks_spec.rb
@@ -57,6 +57,14 @@ RSpec.describe "AhoyEmailClicks" do
                 hash_including(token: token, campaign: campaign, url: url, controller: controller))
         expect(FeedEvent.where(article_id: article.id, category: "click", context_type: "email").size).to be(1)
       end
+
+      it "updates the user's presence" do
+        user = create(:user, last_presence_at: 2.hours.ago)
+        create(:email_message, user: user, token: token)
+
+        expect { post ahoy_email_clicks_path, params: { t: token, c: campaign, u: url, s: signature } }
+          .to change { user.reload.last_presence_at }
+      end
     end
 
     context "with an invalid signature" do

--- a/spec/requests/async_info_spec.rb
+++ b/spec/requests/async_info_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe "AsyncInfo" do
         get "/async_info/base_data"
         expect(response.parsed_body["default_email_optin_allowed"]).to be(true)
       end
+
+      it "updates the user's presence" do
+        user = create(:user, last_presence_at: 2.hours.ago)
+        sign_in user
+
+        expect { get "/async_info/base_data" }.to change { user.reload.last_presence_at }
+      end
     end
   end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds the `last_presence_at` for a more all-encompassing field to better understand when someone last interacted. Will primarily be used to not send emails to long-inactive users etc.