### PR TITLE
Add baseline score for trusted orgs

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -917,7 +917,9 @@ class Article < ApplicationRecord
     badge_bonus_weight_sum = user.badges.sum(:bonus_weight)
     badge_reputation_bonus = Math.sqrt(badge_bonus_weight_sum).to_i
 
-    self.score = reactions.sum(:points) + spam_adjustment + negative_reaction_adjustment + base_subscriber_adjustment + user_featured_count_adjustment + user_negative_count_adjustment + context_note_adjustment + automod_label_adjustment + badge_reputation_bonus
+    organization_baseline_score = organization&.baseline_score || 0
+
+    self.score = reactions.sum(:points) + spam_adjustment + negative_reaction_adjustment + base_subscriber_adjustment + user_featured_count_adjustment + user_negative_count_adjustment + context_note_adjustment + automod_label_adjustment + badge_reputation_bonus + organization_baseline_score
     accepted_max = [max_score, user&.max_score.to_i].min
     accepted_max = [max_score, user&.max_score.to_i].max if accepted_max.zero?
     self.score = accepted_max if accepted_max.positive? && accepted_max < score

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -62,6 +62,7 @@ class Organization < ApplicationRecord
   validates :twitter_username, length: { maximum: 15 }
   validates :unspent_credits_count, presence: true
   validates :url, length: { maximum: 200 }, url: { allow_blank: true, no_local: true }
+  validates :baseline_score, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   unique_across_models :slug, length: { in: 2..30 }
 

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -118,6 +118,18 @@
   <% end %>
 </div>
 
+<div class="crayons-card p-6 mb-6">
+  <h3 class="crayons-subtitle-2 mb-4">Baseline Score</h3>
+  <p class="fs-s color-base-60 mb-4">
+    This score is added to every article published under this organization. 
+    Use this to give a visibility boost to trusted partners or official organizations.
+  </p>
+  <%= form_tag update_baseline_score_admin_organization_path(@organization), method: :patch, class: "flex items-center gap-2" do %>
+    <%= number_field_tag :baseline_score, @organization.baseline_score, class: "crayons-textfield w-25", min: 0 %>
+    <%= submit_tag "Update Score", class: "crayons-btn" %>
+  <% end %>
+</div>
+
 <%= render "activity" %>
 
 <% error_message = deletion_modal_error_message(@organization) %>

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -102,6 +102,7 @@ namespace :admin do
       member do
         patch "update_org_credits"
         patch "update_fully_trusted"
+        patch "update_baseline_score"
       end
     end
     resources :emails

--- a/db/migrate/20260128210141_add_baseline_score_to_organizations.rb
+++ b/db/migrate/20260128210141_add_baseline_score_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddBaselineScoreToOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :baseline_score, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_01_27_193756) do
+ActiveRecord::Schema[7.0].define(version: 2026_01_28_210141) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -902,6 +902,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_01_27_193756) do
 
   create_table "organizations", force: :cascade do |t|
     t.integer "articles_count", default: 0, null: false
+    t.integer "baseline_score", default: 0
     t.string "bg_color_hex"
     t.string "company_size"
     t.datetime "created_at", precision: nil, null: false

--- a/spec/models/article_organization_baseline_score_spec.rb
+++ b/spec/models/article_organization_baseline_score_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Article Organization Baseline Score", type: :model do
+  let(:organization) { create(:organization, baseline_score: 10) }
+  let(:user) { create(:user) }
+  let(:article) { create(:article, user: user, organization: organization) }
+
+  it "adds the organization baseline score to the article score" do
+    # Initial score calculation should include the baseline
+    article.update_score
+    
+    # We need to isolate the baseline score effect.
+    # Let's calculate what the score would be without the organization.
+    
+    article_without_org = create(:article, user: user, organization: nil)
+    article_without_org.update_score
+    base_score = article_without_org.score
+
+    # The difference should be the baseline score
+    # Note: There might be slight differences if other factors like spam/featured/etc apply, 
+    # but with fresh factories they should be identical except for the org.
+    # However, let's just check if the baseline score is component of the total.
+    
+    # To be more precise, let's update the organization baseline and see the score change.
+    initial_score = article.score
+    
+    organization.update(baseline_score: 50)
+    article.update_score
+    expect(article.score).to eq(initial_score + 40) # 50 - 10 = 40 increase
+  end
+
+  it "defaults to 0 if organization has no baseline score" do
+    organization.update(baseline_score: nil)
+    article.update_score
+    score_with_nil = article.score
+
+    organization.update(baseline_score: 0)
+    article.update_score
+    score_with_zero = article.score
+
+    expect(score_with_nil).to eq(score_with_zero)
+  end
+
+  it "does not affect articles without an organization" do
+    article_no_org = create(:article, user: user, organization: nil)
+    initial_score = article_no_org.score
+    
+    article_no_org.update_score
+    expect(article_no_org.score).to eq(initial_score)
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This adds the ability for an admin to add a "baseline score" for fully verified and trusted orgs to default put them above the indexable threshold. Posts can still be marked as low quality etc but this puts the default up a few points if applied.