### PR TITLE
Remove legacy cachebust functionality

### DIFF
--- a/app/services/edge_cache/bust_comment.rb
+++ b/app/services/edge_cache/bust_comment.rb
@@ -10,11 +10,6 @@ module EdgeCache
       EdgeCache::PurgeByKey.call(keys, fallback_paths: fallback_paths)
       bust_article_comment(commentable) if commentable.is_a?(Article)
       commentable.touch(:last_comment_at) if commentable.respond_to?(:last_comment_at)
-      ## Legacy commentable busting — can be removed after Feb 7
-      if commentable.is_a?(Article)
-        cache_bust = EdgeCache::Bust.new
-        cache_bust.call(commentable.path.to_s) if commentable&.path.present?
-      end
     end
 
     # bust commentable if it's an article


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This was kept around for extra cachebust coverage but can be removed safely as 99% of its use is done at this point