### PR TITLE
Add proper cache busts on billboard state changes

### DIFF
--- a/app/models/billboard.rb
+++ b/app/models/billboard.rb
@@ -88,6 +88,8 @@ class Billboard < ApplicationRecord
   after_save :refresh_audience_segment, if: :should_refresh_audience_segment?
   after_save :update_links_with_bb_param
   after_save :update_event_counts_when_taking_down, if: -> { being_taken_down? }
+  after_save :bust_billboard_cache, if: -> { being_taken_down? }
+  after_save :bust_home_page_cache, if: -> { home_feed_first_being_activated? }
 
   scope :approved_and_published, lambda {
                                    where(approved: true, published: true).where("expires_at IS NULL OR expires_at > ?", Time.current)
@@ -469,6 +471,23 @@ class Billboard < ApplicationRecord
 
     # Check if approved changed from true to false or published changed from true to false.
     (saved_change_to_approved? && !approved) || (saved_change_to_published? && !published)
+  end
+
+  def home_feed_first_being_activated?
+    return false unless placement_area == "feed_first"
+    return false unless approved && published
+
+    # Trigger if either approved or published just changed to true (from a prior different state)
+    (saved_change_to_approved? && !approved_before_last_save) ||
+      (saved_change_to_published? && !published_before_last_save)
+  end
+
+  def bust_billboard_cache
+    EdgeCache::PurgeByKey.call(record_key)
+  end
+
+  def bust_home_page_cache
+    EdgeCache::PurgeByKey.call("main_app_home_page", fallback_paths: "/")
   end
 
   def generate_billboard_name


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When a home-feed-first billboard is set to live we should purge the home page and when any billboard is taken down we should purge that billboard by record key.