### PR TITLE
Add API endpoint for agent session uploads

### DIFF
--- a/app/controllers/api/v1/agent_sessions_controller.rb
+++ b/app/controllers/api/v1/agent_sessions_controller.rb
@@ -1,0 +1,118 @@
+module Api
+  module V1
+    class AgentSessionsController < ApiController
+      before_action :authenticate_with_api_key!
+      before_action :set_agent_session, only: [:show]
+
+      def index
+        @agent_sessions = @user.agent_sessions.order(updated_at: :desc)
+        render json: @agent_sessions.map { |s| session_index_json(s) }
+      end
+
+      def show
+        render json: session_show_json(@agent_session)
+      end
+
+      def create
+        @agent_session = @user.agent_sessions.new(title: create_title)
+
+        content = extract_content
+        unless content
+          render json: { error: "Missing session content. Provide 'body' or 'session_file'.",
+                         status: 422 }, status: :unprocessable_entity
+          return
+        end
+
+        unless content.valid_encoding?
+          render json: { error: "File must be valid UTF-8 text", status: 422 }, status: :unprocessable_entity
+          return
+        end
+
+        if content.include?("\x00")
+          render json: { error: "Binary files are not supported", status: 422 }, status: :unprocessable_entity
+          return
+        end
+
+        if content.bytesize > AgentSession::MAX_RAW_DATA_SIZE
+          render json: { error: "Content too large (max 10MB)", status: 422 }, status: :unprocessable_entity
+          return
+        end
+
+        tool_name = params[:tool_name].presence
+        if tool_name.blank? || tool_name == "auto"
+          file = params[:session_file]
+          filename = file.respond_to?(:original_filename) ? file.original_filename : nil
+          detected_tool = AgentSessionParsers::AutoDetect.detect_tool(content, filename: filename)
+          @agent_session.parse_and_normalize!(content, detected_tool: detected_tool)
+        else
+          @agent_session.tool_name = tool_name
+          @agent_session.parse_and_normalize!(content)
+        end
+
+        if @agent_session.save
+          render json: session_show_json(@agent_session), status: :created
+        else
+          render json: { error: @agent_session.errors.full_messages.join(", "), status: 422 },
+                 status: :unprocessable_entity
+        end
+      rescue StandardError => e
+        Rails.logger.error("Agent session API parse error: #{e.class}: #{e.message}")
+        render json: { error: "Failed to parse session content. Please check the format and try again.", status: 422 },
+               status: :unprocessable_entity
+      end
+
+      private
+
+      def set_agent_session
+        @agent_session = @user.agent_sessions.find_by!(slug: params[:id])
+      rescue ActiveRecord::RecordNotFound
+        @agent_session = @user.agent_sessions.find(params[:id])
+      end
+
+      def create_title
+        params[:title].presence || "Session #{Time.current.strftime('%Y-%m-%d %H:%M')}"
+      end
+
+      def extract_content
+        if params[:session_file].respond_to?(:read)
+          params[:session_file].read.force_encoding("UTF-8")
+        elsif params[:body].present?
+          params[:body].to_s.force_encoding("UTF-8")
+        end
+      end
+
+      def session_index_json(session)
+        {
+          id: session.id,
+          slug: session.slug,
+          title: session.title,
+          tool_name: session.tool_name,
+          total_messages: session.total_messages,
+          published: session.published,
+          created_at: session.created_at.iso8601,
+          updated_at: session.updated_at.iso8601,
+          url: URL.url(agent_session_path(session))
+        }
+      end
+
+      def session_show_json(session)
+        {
+          id: session.id,
+          slug: session.slug,
+          title: session.title,
+          tool_name: session.tool_name,
+          total_messages: session.total_messages,
+          curated_count: session.curated_count,
+          published: session.published,
+          metadata: session.metadata,
+          messages: session.messages,
+          curated_selections: session.curated_selections,
+          slices: session.slices,
+          created_at: session.created_at.iso8601,
+          updated_at: session.updated_at.iso8601,
+          url: URL.url(agent_session_path(session))
+        }
+      end
+    end
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -34,6 +34,7 @@ namespace :followers do
   get :organizations
 end
 resources :readinglist, only: [:index]
+resources :agent_sessions, only: %i[index show create]
 
 get "/analytics/totals", to: "analytics#totals"
 get "/analytics/historical", to: "analytics#historical"

--- a/spec/requests/api/v1/agent_sessions_spec.rb
+++ b/spec/requests/api/v1/agent_sessions_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::AgentSessions" do
+  let(:user) { create(:user) }
+  let(:api_secret) { create(:api_secret, user: user) }
+  let(:headers) { { "content-type" => "application/json", "Accept" => "application/vnd.forem.api-v1+json" } }
+  let(:auth_headers) { headers.merge({ "api-key" => api_secret.secret }) }
+
+  let(:claude_code_jsonl) do
+    [
+      { type: "user", message: { role: "user", content: "Hello" }, uuid: "1",
+        timestamp: "2025-01-01T00:00:00Z", sessionId: "s1" }.to_json,
+      { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "Hi there" }] },
+        uuid: "2", timestamp: "2025-01-01T00:00:01Z", sessionId: "s1" }.to_json,
+    ].join("\n")
+  end
+
+  let(:normalized_data) do
+    {
+      "messages" => [
+        { "index" => 0, "role" => "user", "content" => [{ "type" => "text", "text" => "Hello" }] },
+        { "index" => 1, "role" => "assistant", "content" => [{ "type" => "text", "text" => "Hi there" }] },
+      ],
+      "metadata" => { "tool_name" => "claude_code", "total_messages" => 2 }
+    }
+  end
+
+  describe "POST /api/agent_sessions" do
+    it "returns 401 without authentication" do
+      post api_agent_sessions_path,
+           params: { title: "Test", body: claude_code_jsonl }.to_json,
+           headers: headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "creates a session from JSON body with auto-detection" do
+      post api_agent_sessions_path,
+           params: { title: "My Claude Session", body: claude_code_jsonl }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      json = response.parsed_body
+      expect(json["title"]).to eq("My Claude Session")
+      expect(json["tool_name"]).to eq("claude_code")
+      expect(json["total_messages"]).to be >= 1
+      expect(json["slug"]).to be_present
+      expect(json["url"]).to include("/agent_sessions/")
+    end
+
+    it "creates a session with explicit tool_name" do
+      post api_agent_sessions_path,
+           params: { title: "Codex Session", tool_name: "codex", body: claude_code_jsonl }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      json = response.parsed_body
+      expect(json["tool_name"]).to eq("codex")
+    end
+
+    it "auto-generates title when not provided" do
+      post api_agent_sessions_path,
+           params: { body: claude_code_jsonl }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      json = response.parsed_body
+      expect(json["title"]).to start_with("Session ")
+    end
+
+    it "returns 422 when body is missing" do
+      post api_agent_sessions_path,
+           params: { title: "No content" }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to include("Missing session content")
+    end
+
+    it "returns 422 when content is too large" do
+      large_body = "x" * (AgentSession::MAX_RAW_DATA_SIZE + 1)
+      post api_agent_sessions_path,
+           params: { title: "Too Big", body: large_body }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body["error"]).to include("too large")
+    end
+
+    it "returns 422 for invalid tool_name" do
+      post api_agent_sessions_path,
+           params: { title: "Bad Tool", tool_name: "invalid_tool", body: claude_code_jsonl }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "assigns the session to the authenticated user" do
+      post api_agent_sessions_path,
+           params: { title: "My Session", body: claude_code_jsonl }.to_json,
+           headers: auth_headers
+
+      expect(response).to have_http_status(:created)
+      session = AgentSession.last
+      expect(session.user_id).to eq(user.id)
+    end
+  end
+
+  describe "GET /api/agent_sessions" do
+    before do
+      AgentSession.create!(user: user, title: "Session A", tool_name: "claude_code", normalized_data: normalized_data)
+      AgentSession.create!(user: user, title: "Session B", tool_name: "codex", normalized_data: normalized_data)
+    end
+
+    it "returns 401 without authentication" do
+      get api_agent_sessions_path, headers: headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns the user's sessions" do
+      get api_agent_sessions_path, headers: auth_headers
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json.size).to eq(2)
+      expect(json.pluck("title")).to contain_exactly("Session A", "Session B")
+    end
+
+    it "does not return other users' sessions" do
+      other_user = create(:user)
+      AgentSession.create!(user: other_user, title: "Other Session", tool_name: "pi", normalized_data: normalized_data)
+
+      get api_agent_sessions_path, headers: auth_headers
+      json = response.parsed_body
+      expect(json.pluck("title")).not_to include("Other Session")
+    end
+  end
+
+  describe "GET /api/agent_sessions/:id" do
+    let!(:agent_session) do
+      AgentSession.create!(user: user, title: "My Session", tool_name: "claude_code", normalized_data: normalized_data)
+    end
+
+    it "returns 401 without authentication" do
+      get api_agent_session_path(agent_session), headers: headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it "returns the session by slug" do
+      get api_agent_session_path(agent_session.slug), headers: auth_headers
+      expect(response).to have_http_status(:ok)
+      json = response.parsed_body
+      expect(json["title"]).to eq("My Session")
+      expect(json["messages"]).to be_an(Array)
+    end
+
+    it "returns the session by id" do
+      get api_agent_session_path(agent_session.id), headers: auth_headers
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["title"]).to eq("My Session")
+    end
+
+    it "returns 404 for another user's session" do
+      other_user = create(:user)
+      other_session = AgentSession.create!(
+        user: other_user, title: "Other", tool_name: "codex", normalized_data: normalized_data,
+      )
+      get api_agent_session_path(other_session), headers: auth_headers
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a public V1 API for agent sessions, enabling external CLI tools (Claude Code, Codex, Copilot, Pi, etc.) to upload coding session transcripts programmatically using a DEV API key.

**New endpoints:**

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/agent_sessions` | Create a session from JSON body (`body` param) or multipart file upload (`session_file` param) |
| `GET` | `/api/agent_sessions` | List the authenticated user's sessions |
| `GET` | `/api/agent_sessions/:id` | Show a session by slug or numeric ID |

**Key details:**
- Authentication via `api-key` header (same as all other Forem V1 API endpoints)
- Sessions are scoped to the authenticated user — users can only see/create their own
- Tool name auto-detection from content (reuses existing `AgentSessionParsers::AutoDetect`)
- Supports all existing tool types: `claude_code`, `codex`, `gemini_cli`, `github_copilot`, `pi`, `opencode`, `cursor`
- Content validation: UTF-8, no binary, max 10MB (same as web upload)
- Sensitive data scrubbing runs automatically via `parse_and_normalize!`

**Example usage:**
```bash
curl -X POST "https://dev.to/api/agent_sessions" \
  -H "Content-Type: application/json" \
  -H "api-key: YOUR_KEY" \
  -d '{"title": "Bug fix session", "body": "...jsonl content..."}'
```

## Related Tickets & Documents

- Builds on the agent sessions feature from `feature/agent-sessions`
- Companion CLI plugin repo: `forem/forem-cli-plugin` (provides `/dev-upload` slash command for coding agents)

## QA Instructions, Screenshots, Recordings

**API testing (curl):**
1. Get a DEV API key from Settings > Extensions
2. Create a session:
   ```bash
   curl -X POST "http://localhost:3000/api/agent_sessions" \
     -H "Content-Type: application/json" \
     -H "api-key: YOUR_KEY" \
     -d '{"title": "Test session", "body": "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"Hello\"},\"uuid\":\"1\",\"timestamp\":\"2025-01-01T00:00:00Z\",\"sessionId\":\"s1\"}\n{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Hi\"}]},\"uuid\":\"2\",\"timestamp\":\"2025-01-01T00:00:01Z\",\"sessionId\":\"s1\"}"}'
   ```
3. Verify 201 response with `id`, `slug`, `url`, `tool_name`, `messages`
4. List sessions: `curl -H "api-key: KEY" http://localhost:3000/api/agent_sessions`
5. Show session: `curl -H "api-key: KEY" http://localhost:3000/api/agent_sessions/SLUG`
6. Verify 401 without api-key header
7. Verify another user's sessions are not visible (404)

**Automated tests:**
```bash
bundle exec rspec spec/requests/api/v1/agent_sessions_spec.rb
```

11 test cases covering: auth enforcement, creation (JSON body, explicit tool, auto-title), validation errors (missing body, too large, invalid tool), index, show by slug/id, and user isolation.

## Added/updated tests?

- [x] Yes

## [optional] Are there any post deployment tasks we need to perform?

No migrations or post-deploy tasks. This builds on the existing `agent_sessions` table from the parent branch.