### PR TITLE
Bust home cache more when billboards change

### DIFF
--- a/app/models/billboard.rb
+++ b/app/models/billboard.rb
@@ -44,6 +44,13 @@ class Billboard < ApplicationRecord
                                             "Digest Email Second"].freeze
 
   HOME_FEED_PLACEMENTS = %w[feed_first feed_second feed_third].freeze
+  HOME_PAGE_PLACEMENTS = %w[feed_first
+                            feed_second
+                            feed_third
+                            home_hero
+                            sidebar_right
+                            sidebar_right_second
+                            sidebar_right_third].freeze
 
   COLOR_HEX_REGEXP = /\A#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})\z/
 
@@ -89,7 +96,9 @@ class Billboard < ApplicationRecord
   after_save :update_links_with_bb_param
   after_save :update_event_counts_when_taking_down, if: -> { being_taken_down? }
   after_save :bust_billboard_cache, if: -> { being_taken_down? }
-  after_save :bust_home_page_cache, if: -> { home_feed_first_being_activated? }
+  after_save :bust_home_page_cache, if: -> { should_bust_home_page_cache? }
+  after_destroy :bust_billboard_cache, if: -> { approved && published }
+  after_destroy :bust_home_page_cache, if: -> { approved && published && HOME_PAGE_PLACEMENTS.include?(placement_area) }
 
   scope :approved_and_published, lambda {
                                    where(approved: true, published: true).where("expires_at IS NULL OR expires_at > ?", Time.current)
@@ -439,6 +448,8 @@ class Billboard < ApplicationRecord
     return unless expires_at.present? && expires_at < Time.current && approved?
 
     update_column(:approved, false)
+    bust_billboard_cache if published
+    bust_home_page_cache if published && HOME_PAGE_PLACEMENTS.include?(placement_area)
   end
 
   # Check if a user should be excluded from seeing this billboard based on survey completion
@@ -473,13 +484,21 @@ class Billboard < ApplicationRecord
     (saved_change_to_approved? && !approved) || (saved_change_to_published? && !published)
   end
 
-  def home_feed_first_being_activated?
-    return false unless placement_area == "feed_first"
-    return false unless approved && published
+  def should_bust_home_page_cache?
+    return false unless HOME_PAGE_PLACEMENTS.include?(placement_area) || HOME_PAGE_PLACEMENTS.include?(placement_area_before_last_save)
 
-    # Trigger if either approved or published just changed to true (from a prior different state)
-    (saved_change_to_approved? && !approved_before_last_save) ||
-      (saved_change_to_published? && !published_before_last_save)
+    content_fields = %w[body_markdown name placement_area color template render_mode]
+
+    was_active = approved_before_last_save && published_before_last_save
+    is_active = approved && published
+
+    # Bust if it is transitioning to active or inactive
+    return true if was_active != is_active
+
+    # Bust if it's currently active and content was updated
+    return true if is_active && content_fields.any? { |field| saved_change_to_attribute?(field) }
+
+    false
   end
 
   def bust_billboard_cache

--- a/spec/models/billboard_spec.rb
+++ b/spec/models/billboard_spec.rb
@@ -1004,6 +1004,24 @@ RSpec.describe Billboard do
       billboard.update_column(:expires_at, 1.day.ago)
       expect { billboard.check_and_handle_expiration }.to change { billboard.reload.approved }.from(true).to(false)
     end
+
+    it "busts caches if the billboard was published and on home page" do
+      billboard.update!(placement_area: "feed_first")
+      billboard.update_column(:expires_at, 1.day.ago)
+      allow(EdgeCache::PurgeByKey).to receive(:call)
+      billboard.check_and_handle_expiration
+      expect(EdgeCache::PurgeByKey).to have_received(:call).with(billboard.record_key)
+      expect(EdgeCache::PurgeByKey).to have_received(:call).with("main_app_home_page", fallback_paths: "/")
+    end
+
+    it "busts only billboard cache if the billboard was published but not on home page" do
+      billboard.update!(placement_area: "sidebar_left")
+      billboard.update_column(:expires_at, 1.day.ago)
+      allow(EdgeCache::PurgeByKey).to receive(:call)
+      billboard.check_and_handle_expiration
+      expect(EdgeCache::PurgeByKey).to have_received(:call).with(billboard.record_key)
+      expect(EdgeCache::PurgeByKey).not_to have_received(:call).with("main_app_home_page", fallback_paths: "/")
+    end
   end
 
   describe "scopes" do
@@ -1265,7 +1283,7 @@ RSpec.describe Billboard do
     end
   end
 
-  describe "#home_feed_first_being_activated?" do
+  describe "#should_bust_home_page_cache?" do
     let(:billboard) { create(:billboard, placement_area: "feed_first", approved: false, published: false) }
 
     it "busts home page cache when feed_first billboard is approved from unapproved state" do
@@ -1288,25 +1306,78 @@ RSpec.describe Billboard do
       expect(EdgeCache::PurgeByKey).to have_received(:call).with("main_app_home_page", fallback_paths: "/")
     end
 
-    it "does not bust cache when billboard is not feed_first" do
+    it "busts cache when billboard is being taken down (approved set to false)" do
+      billboard.update!(approved: true, published: true)
+      allow(EdgeCache::PurgeByKey).to receive(:call)
+      billboard.update!(approved: false)
+      expect(EdgeCache::PurgeByKey).to have_received(:call).with("main_app_home_page", fallback_paths: "/")
+    end
+
+    it "busts cache when billboard is being taken down (published set to false)" do
+      billboard.update!(approved: true, published: true)
+      allow(EdgeCache::PurgeByKey).to receive(:call)
+      billboard.update!(published: false)
+      expect(EdgeCache::PurgeByKey).to have_received(:call).with("main_app_home_page", fallback_paths: "/")
+    end
+
+    it "busts cache when active billboard content is updated" do
+      billboard.update!(approved: true, published: true)
+      allow(EdgeCache::PurgeByKey).to receive(:call)
+      billboard.update!(name: "Updated name")
+      expect(EdgeCache::PurgeByKey).to have_received(:call).with("main_app_home_page", fallback_paths: "/")
+    end
+
+    it "does not bust cache when active billboard unrelated attributes are updated" do
+      billboard.update!(approved: true, published: true)
+      allow(EdgeCache::PurgeByKey).to receive(:call)
+      billboard.update!(weight: 100)
+      expect(EdgeCache::PurgeByKey).not_to have_received(:call).with("main_app_home_page", fallback_paths: "/")
+    end
+
+    it "busts cache when placement_area is changed away from home page for an active billboard" do
+      billboard.update!(approved: true, published: true)
+      allow(EdgeCache::PurgeByKey).to receive(:call)
+      billboard.update!(placement_area: "post_sidebar")
+      expect(EdgeCache::PurgeByKey).to have_received(:call).with("main_app_home_page", fallback_paths: "/")
+    end
+
+    it "does not bust cache when billboard is not a home page placement and is activated" do
       sidebar_billboard = create(:billboard, placement_area: "sidebar_left", approved: false, published: false)
       allow(EdgeCache::PurgeByKey).to receive(:call)
       sidebar_billboard.update!(approved: true, published: true)
       expect(EdgeCache::PurgeByKey).not_to have_received(:call).with("main_app_home_page", fallback_paths: "/")
     end
 
-    it "does not bust cache when billboard is already approved and published and saved again" do
-      billboard.update!(approved: true, published: true)
+    it "does not bust cache when billboard is not a home page placement and content is updated" do
+      sidebar_billboard = create(:billboard, placement_area: "sidebar_left", approved: true, published: true)
       allow(EdgeCache::PurgeByKey).to receive(:call)
-      billboard.update!(name: "Updated name")
+      sidebar_billboard.update!(name: "Updated name")
+      expect(EdgeCache::PurgeByKey).not_to have_received(:call).with("main_app_home_page", fallback_paths: "/")
+    end
+  end
+
+  describe "after_destroy cache busting" do
+    it "busts billboard and home page cache for active home page billboard" do
+      billboard = create(:billboard, placement_area: "feed_first", approved: true, published: true)
+      allow(EdgeCache::PurgeByKey).to receive(:call)
+      billboard.destroy
+      expect(EdgeCache::PurgeByKey).to have_received(:call).with(billboard.record_key)
+      expect(EdgeCache::PurgeByKey).to have_received(:call).with("main_app_home_page", fallback_paths: "/")
+    end
+
+    it "busts billboard cache but not home page for active non-home page billboard" do
+      billboard = create(:billboard, placement_area: "sidebar_left", approved: true, published: true)
+      allow(EdgeCache::PurgeByKey).to receive(:call)
+      billboard.destroy
+      expect(EdgeCache::PurgeByKey).to have_received(:call).with(billboard.record_key)
       expect(EdgeCache::PurgeByKey).not_to have_received(:call).with("main_app_home_page", fallback_paths: "/")
     end
 
-    it "does not bust cache when billboard is being taken down (approved set to false)" do
-      billboard.update!(approved: true, published: true)
+    it "does not bust cache for inactive billboard" do
+      billboard = create(:billboard, placement_area: "feed_first", approved: false, published: true)
       allow(EdgeCache::PurgeByKey).to receive(:call)
-      billboard.update!(approved: false)
-      expect(EdgeCache::PurgeByKey).not_to have_received(:call).with("main_app_home_page", fallback_paths: "/")
+      billboard.destroy
+      expect(EdgeCache::PurgeByKey).not_to have_received(:call)
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Additional ways the home page cache clears on home billboard changes