### PR TITLE
Remove action bar in X's in-app browser

### DIFF
--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -164,6 +164,16 @@
   }
 }
 
+html.is-twitter-in-app {
+  .crayons-article-actions {
+    display: none !important;
+
+    @media (min-width: $breakpoint-m) {
+      display: grid !important; // Restore desktop layout if Twitter UA is faked/used on tablet
+    }
+  }
+}
+
 .crayons-reaction {
   --reaction-color: var(--button-ghost-color);
   --reaction-border: inset 0 0 0 0 transparent;

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -1,3 +1,8 @@
+<script>
+  if (/Twitter for (iPhone|iPad|Android)/i.test(navigator.userAgent)) {
+    document.documentElement.classList.add('is-twitter-in-app');
+  }
+</script>
 <div class="crayons-article-actions print-hidden">
   <div class="crayons-article-actions__inner">
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The reactions bar looks very goofy in the modern X in-app browser. This hides it in that context, where it's generally not useful anyway.