### PR TITLE
Add video_source_url to proper allow list

### DIFF
--- a/app/services/articles/attributes.rb
+++ b/app/services/articles/attributes.rb
@@ -2,7 +2,7 @@ module Articles
   class Attributes
     ATTRIBUTES = %i[archived body_markdown canonical_url description compellingness_score labels
                     edited_at main_image organization_id user_id published clickbait_score
-                    title video_thumbnail_url published_at co_author_ids_list].freeze
+                    title video_thumbnail_url published_at co_author_ids_list video_source_url].freeze
 
     attr_reader :attributes, :article_user, :organization
 

--- a/spec/services/articles/attributes_spec.rb
+++ b/spec/services/articles/attributes_spec.rb
@@ -23,11 +23,19 @@ RSpec.describe Articles::Attributes, type: :service do
       it "doesn't have attributes that were not passed" do
         expect(attrs_for_update.key?(:title)).to be false
         expect(attrs_for_update.key?(:video_thumbnail_url)).to be false
+        expect(attrs_for_update.key?(:video_source_url)).to be false
       end
 
       it "has passed attributes" do
         expect(attrs_for_update[:body_markdown]).to include("Hey this is the article")
         expect(attrs_for_update[:organization_id]).to eq(2)
+      end
+
+      it "allows video_source_url" do
+        video_attrs = few_attributes.merge(video_source_url: "https://youtube.com/watch?v=123")
+        attrs = described_class.new(video_attrs, user).for_update
+        expect(attrs.key?(:video_source_url)).to be true
+        expect(attrs[:video_source_url]).to eq("https://youtube.com/watch?v=123")
       end
     end
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Video was not updateable _after_ initial saving of the article. Now it is.