### PR TITLE
Z-Index Increase for the Emoji UI

### DIFF
--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -133,7 +133,7 @@
   background: var(--body-color-inverted);
   padding: var(--su-2);
   box-shadow: 0 -1px 5px rgba(0, 0, 0, 0.2);
-  // z-index: var(--z-sticky);
+  z-index: 9999; //Ensure this is the top most layer. This will fix the issue where if there is a lot of comments
 
   @media (min-width: $breakpoint-m) {
     border-radius: var(--radius-large);

--- a/app/views/articles/_actions.html.erb
+++ b/app/views/articles/_actions.html.erb
@@ -3,7 +3,7 @@
     document.documentElement.classList.add('is-twitter-in-app');
   }
 </script>
-<div class="crayons-article-actions print-hidden" style="z-index: 999;">
+<div class="crayons-article-actions print-hidden">
   <div class="crayons-article-actions__inner">
 
     <%= render partial: "articles/multiple_reactions" if @article.published? %>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update



## Description
Fixed the UI issue on the Emoji where you can see the "Like" button over the list of emojis as shown below:

### Before:
<img width="710" height="154" alt="Image" src="https://github.com/user-attachments/assets/5bed2ae6-dd05-4c08-998f-33fa6745a893" />

### After:
<img width="448" height="144" alt="image" src="https://github.com/user-attachments/assets/f6e01251-d031-40b5-96ac-787130f697e8" />

<br>
<br>
<br>
<br>

This also happen in the GIF. It is fixed now:

### Before:
<img width="758" height="241" alt="Image" src="https://github.com/user-attachments/assets/8afa3642-1250-4c4d-a931-cc41c6d4efb7" />

### After:
<img width="574" height="235" alt="image" src="https://github.com/user-attachments/assets/bfefdc39-a073-4cef-b687-247143325ef1" />



## Related Tickets & Documents

- Related Issue #22902
- Closes #22902 

## QA Instructions, Screenshots, Recordings

**_1. Go on any post on Dev.to._**

<br>

**_2. Inspect the element page and look for the class name "crayons-article-actions print-hidden"._**

<br>

**_3. Change the CSS._**

**Instead of:**
`z-index: var(z--sticky)`

**It should be:**
`z-index: 9999`

<img width="295" height="209" alt="image" src="https://github.com/user-attachments/assets/a7964e7b-905f-430f-822b-e7ded68dcb08" />

<br>
<br>
<br>

**_4. Comment out the z-index for this class below:_**
<img width="292" height="254" alt="image" src="https://github.com/user-attachments/assets/5f4cfd2d-5896-48a2-9e98-6293e850d4a0" />

<br>
<br>

**_5. Then scroll and it should be the highest z-index of the page._**

## What gif best describes this PR or how it makes you feel?

![dance](https://github.com/user-attachments/assets/3a843828-ead2-4635-905b-6e9d63150d20)