### PR TITLE
Add job title and company to user profiles

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -10,7 +10,7 @@ class Profile < ApplicationRecord
   after_commit :enqueue_profile_spam_check, on: :update, if: :profile_spam_check_triggered?
 
   validates :user_id, uniqueness: true
-  validates :location, :website_url, length: { maximum: 100 }
+  validates :location, :website_url, :job_title, :company, length: { maximum: 100 }
   validates :website_url, url: { allow_blank: true, no_local: true, schemes: %w[https http] }
   validates_with ProfileValidator
 
@@ -19,7 +19,7 @@ class Profile < ApplicationRecord
   # Static fields are columns on the profiles table; they have no relationship
   # to a ProfileField record. These are columns we can safely assume exist for
   # any profile on a given Forem.
-  STATIC_FIELDS = %w[summary location website_url].freeze
+  STATIC_FIELDS = %w[summary location website_url job_title company].freeze
 
   # Update the Rails cache with the currently available attributes.
   def self.refresh_attributes!
@@ -75,6 +75,8 @@ class Profile < ApplicationRecord
     saved_change_to_summary? ||
       saved_change_to_location? ||
       saved_change_to_website_url? ||
+      saved_change_to_job_title? ||
+      saved_change_to_company? ||
       saved_change_to_attribute?(:social_image) ||
       saved_change_to_data?
   end

--- a/app/views/admin/users/show/_profile.html.erb
+++ b/app/views/admin/users/show/_profile.html.erb
@@ -30,6 +30,11 @@
         <span class="color-accent-danger fw-medium"><%= t("views.admin.users.profile.not_member") %></span>
       <% end %>
     </div>
+    <% if @user.profile.job_title.present? || @user.profile.company.present? %>
+      <div class="fs-s color-base-70 mb-1">
+        <%= [@user.profile.job_title, @user.profile.company].compact_blank.join(" at ") %>
+      </div>
+    <% end %>
     <div>
       <ul class="flex flex-col s:flex-row gap-3 s:gap-6 flex-wrap">
         <li>

--- a/app/views/users/_profile.html.erb
+++ b/app/views/users/_profile.html.erb
@@ -108,6 +108,40 @@
         <span id="summary-characters"></span>/200
       </p>
     </div>
+
+    <div class="crayons-field">
+      <label class="crayons-field__label" for="profile[job_title]">
+        <%= t("views.users.profile_fields.job_title.label") %>
+      </label>
+      <%= f.text_field "profile[job_title]",
+                       maxlength: 100,
+                       value: profile.job_title,
+                       placeholder: t("views.users.profile_fields.job_title.placeholder"),
+                       class: "crayons-textfield",
+                       aria: { describedby: "job-title-description" },
+                       data: { character_span_id: "job-title-characters" } %>
+      <p id="job-title-description" class="crayons-field__description align-right">
+        <span class="screen-reader-only"><%= t("views.settings.characters") %></span>
+        <span id="job-title-characters"></span>/100
+      </p>
+    </div>
+
+    <div class="crayons-field">
+      <label class="crayons-field__label" for="profile[company]">
+        <%= t("views.users.profile_fields.company.label") %>
+      </label>
+      <%= f.text_field "profile[company]",
+                       maxlength: 100,
+                       value: profile.company,
+                       placeholder: t("views.users.profile_fields.company.placeholder"),
+                       class: "crayons-textfield",
+                       aria: { describedby: "company-description" },
+                       data: { character_span_id: "company-characters" } %>
+      <p id="company-description" class="crayons-field__description align-right">
+        <span class="screen-reader-only"><%= t("views.settings.characters") %></span>
+        <span id="company-characters"></span>/100
+      </p>
+    </div>
   </div>
 
   <% ProfileFieldGroup.non_empty_groups.each do |group| %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -77,6 +77,18 @@
 
           <p class="fs-base profile-header__bio m:fs-l color-base-90 mb-4 mx-auto max-w-100 m:max-w-75"><%= @user.tag_line.presence || [t("views.users.empty")].sample %></p>
 
+          <% if @user.profile.job_title.present? || @user.profile.company.present? %>
+            <p class="fs-base color-base-70 mb-2">
+              <% if @user.profile.job_title.present? && @user.profile.company.present? %>
+                <%= @user.profile.job_title %> at <%= @user.profile.company %>
+              <% elsif @user.profile.job_title.present? %>
+                <%= @user.profile.job_title %>
+              <% else %>
+                <%= @user.profile.company %>
+              <% end %>
+            </p>
+          <% end %>
+
           <div class="profile-header__meta">
             <% if @user.profile.location.present? %>
               <span class="profile-header__meta__item">

--- a/config/locales/views/users/en.yml
+++ b/config/locales/views/users/en.yml
@@ -45,6 +45,12 @@ en:
         website:
           label: Website URL
           placeholder: https://yoursite.com
+        job_title:
+          label: Job title
+          placeholder: Software Engineer
+        company:
+          label: Company
+          placeholder: Acme Inc.
         education: Education
         currently learning: Currently learning
         currently hacking on: Currently hacking on

--- a/config/locales/views/users/fr.yml
+++ b/config/locales/views/users/fr.yml
@@ -45,6 +45,12 @@ fr:
         website:
           label: Website URL
           placeholder: https://yoursite.com
+        job_title:
+          label: Titre du poste
+          placeholder: Ingénieur logiciel
+        company:
+          label: Entreprise
+          placeholder: Acme Inc.
         education: Education
         currently learning: Currently learning
         currently hacking on: Currently hacking on

--- a/config/locales/views/users/pt.yml
+++ b/config/locales/views/users/pt.yml
@@ -2,6 +2,23 @@
 pt:
   views:
     users:
+      profile_fields:
+        bio:
+          label: Bio
+          placeholder: Uma breve biografia...
+        display_email_on_profile: Exibir e-mail no perfil
+        location:
+          label: Localização
+          placeholder: São Paulo, Brasil
+        website:
+          label: URL do site
+          placeholder: https://seusite.com
+        job_title:
+          label: Cargo
+          placeholder: Engenheiro de software
+        company:
+          label: Empresa
+          placeholder: Acme Inc.
       profile:
         title: Perfil do Usuário
         bio: Biografia

--- a/db/migrate/20260308032335_add_job_title_and_company_to_profiles.rb
+++ b/db/migrate/20260308032335_add_job_title_and_company_to_profiles.rb
@@ -1,0 +1,6 @@
+class AddJobTitleAndCompanyToProfiles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :profiles, :job_title, :string
+    add_column :profiles, :company, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_08_120000) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_08_032335) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -31,9 +31,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_08_120000) do
     t.string "tool_name", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["slug"], name: "index_agent_sessions_on_slug", unique: true
     t.index ["tool_name"], name: "index_agent_sessions_on_tool_name"
     t.index ["user_id", "published"], name: "index_agent_sessions_on_user_id_and_published"
-    t.index ["user_id", "slug"], name: "index_agent_sessions_on_user_id_and_slug", unique: true
     t.index ["user_id"], name: "index_agent_sessions_on_user_id"
   end
 
@@ -897,21 +897,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_08_120000) do
     t.index ["slug"], name: "index_labels_on_slug", unique: true
   end
 
-  create_table "lead_submissions", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.string "email"
-    t.string "employer_name"
-    t.string "employment_title"
-    t.string "location"
-    t.string "name"
-    t.bigint "organization_lead_form_id", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.index ["organization_lead_form_id", "user_id"], name: "idx_lead_submissions_form_user_unique", unique: true
-    t.index ["organization_lead_form_id"], name: "index_lead_submissions_on_organization_lead_form_id"
-    t.index ["user_id"], name: "index_lead_submissions_on_user_id"
-  end
-
   create_table "media_sources", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "display_url", null: false
@@ -999,17 +984,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_08_120000) do
     t.index ["user_id", "organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_user_id_organization_id_notifiable_action", unique: true
   end
 
-  create_table "organization_lead_forms", force: :cascade do |t|
-    t.boolean "active", default: true, null: false
-    t.string "button_text", default: "Sign Up", null: false
-    t.datetime "created_at", null: false
-    t.text "description"
-    t.bigint "organization_id", null: false
-    t.string "title", null: false
-    t.datetime "updated_at", null: false
-    t.index ["organization_id"], name: "index_organization_lead_forms_on_organization_id"
-  end
-
   create_table "organization_memberships", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "invitation_token"
@@ -1026,7 +1000,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_08_120000) do
     t.integer "baseline_score", default: 0
     t.string "bg_color_hex"
     t.string "company_size"
-    t.string "cover_image"
     t.datetime "created_at", precision: nil, null: false
     t.integer "credits_count", default: 0, null: false
     t.text "cta_body_markdown"
@@ -1037,7 +1010,6 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_08_120000) do
     t.string "email"
     t.boolean "fully_trusted", default: false, null: false
     t.string "github_username"
-    t.jsonb "header_cta", default: {}, null: false
     t.integer "ideal_daily_promoted_billboard_impressions", default: 0, null: false
     t.datetime "last_article_at", precision: nil, default: "2017-01-01 05:00:00"
     t.datetime "latest_article_updated_at", precision: nil
@@ -1045,15 +1017,12 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_08_120000) do
     t.string "name"
     t.string "old_old_slug"
     t.string "old_slug"
-    t.text "page_markdown"
     t.integer "past_24_hours_promoted_billboard_impressions", default: 0, null: false
-    t.text "processed_page_html"
     t.string "profile_image"
     t.datetime "profile_updated_at", precision: nil, default: "2017-01-01 05:00:00"
     t.text "proof"
     t.string "secret"
     t.string "slug"
-    t.jsonb "social_links", default: {}, null: false
     t.integer "spent_credits_count", default: 0, null: false
     t.string "story"
     t.text "summary"
@@ -1989,14 +1958,11 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_08_120000) do
   add_foreign_key "github_repos", "users", on_delete: :cascade
   add_foreign_key "html_variants", "users", on_delete: :cascade
   add_foreign_key "identities", "users", on_delete: :cascade
-  add_foreign_key "lead_submissions", "organization_lead_forms", on_delete: :cascade
-  add_foreign_key "lead_submissions", "users", on_delete: :cascade
   add_foreign_key "mentions", "users", on_delete: :cascade
   add_foreign_key "notes", "users", column: "author_id", on_delete: :nullify
   add_foreign_key "notification_subscriptions", "users", on_delete: :cascade
   add_foreign_key "notifications", "organizations", on_delete: :cascade
   add_foreign_key "notifications", "users", on_delete: :cascade
-  add_foreign_key "organization_lead_forms", "organizations", on_delete: :cascade
   add_foreign_key "organization_memberships", "organizations", on_delete: :cascade
   add_foreign_key "organization_memberships", "users", on_delete: :cascade
   add_foreign_key "page_views", "articles", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_03_06_200919) do
+ActiveRecord::Schema[7.0].define(version: 2026_03_08_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -31,9 +31,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_06_200919) do
     t.string "tool_name", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index ["slug"], name: "index_agent_sessions_on_slug", unique: true
     t.index ["tool_name"], name: "index_agent_sessions_on_tool_name"
     t.index ["user_id", "published"], name: "index_agent_sessions_on_user_id_and_published"
+    t.index ["user_id", "slug"], name: "index_agent_sessions_on_user_id_and_slug", unique: true
     t.index ["user_id"], name: "index_agent_sessions_on_user_id"
   end
 
@@ -897,6 +897,21 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_06_200919) do
     t.index ["slug"], name: "index_labels_on_slug", unique: true
   end
 
+  create_table "lead_submissions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email"
+    t.string "employer_name"
+    t.string "employment_title"
+    t.string "location"
+    t.string "name"
+    t.bigint "organization_lead_form_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["organization_lead_form_id", "user_id"], name: "idx_lead_submissions_form_user_unique", unique: true
+    t.index ["organization_lead_form_id"], name: "index_lead_submissions_on_organization_lead_form_id"
+    t.index ["user_id"], name: "index_lead_submissions_on_user_id"
+  end
+
   create_table "media_sources", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "display_url", null: false
@@ -984,6 +999,17 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_06_200919) do
     t.index ["user_id", "organization_id", "notifiable_id", "notifiable_type", "action"], name: "index_notifications_user_id_organization_id_notifiable_action", unique: true
   end
 
+  create_table "organization_lead_forms", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.string "button_text", default: "Sign Up", null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.bigint "organization_id", null: false
+    t.string "title", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_organization_lead_forms_on_organization_id"
+  end
+
   create_table "organization_memberships", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "invitation_token"
@@ -1000,6 +1026,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_06_200919) do
     t.integer "baseline_score", default: 0
     t.string "bg_color_hex"
     t.string "company_size"
+    t.string "cover_image"
     t.datetime "created_at", precision: nil, null: false
     t.integer "credits_count", default: 0, null: false
     t.text "cta_body_markdown"
@@ -1010,6 +1037,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_06_200919) do
     t.string "email"
     t.boolean "fully_trusted", default: false, null: false
     t.string "github_username"
+    t.jsonb "header_cta", default: {}, null: false
     t.integer "ideal_daily_promoted_billboard_impressions", default: 0, null: false
     t.datetime "last_article_at", precision: nil, default: "2017-01-01 05:00:00"
     t.datetime "latest_article_updated_at", precision: nil
@@ -1017,12 +1045,15 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_06_200919) do
     t.string "name"
     t.string "old_old_slug"
     t.string "old_slug"
+    t.text "page_markdown"
     t.integer "past_24_hours_promoted_billboard_impressions", default: 0, null: false
+    t.text "processed_page_html"
     t.string "profile_image"
     t.datetime "profile_updated_at", precision: nil, default: "2017-01-01 05:00:00"
     t.text "proof"
     t.string "secret"
     t.string "slug"
+    t.jsonb "social_links", default: {}, null: false
     t.integer "spent_credits_count", default: 0, null: false
     t.string "story"
     t.text "summary"
@@ -1285,8 +1316,10 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_06_200919) do
   end
 
   create_table "profiles", force: :cascade do |t|
+    t.string "company"
     t.datetime "created_at", null: false
     t.jsonb "data", default: {}, null: false
+    t.string "job_title"
     t.string "location"
     t.string "social_image"
     t.text "summary"
@@ -1956,11 +1989,14 @@ ActiveRecord::Schema[7.0].define(version: 2026_03_06_200919) do
   add_foreign_key "github_repos", "users", on_delete: :cascade
   add_foreign_key "html_variants", "users", on_delete: :cascade
   add_foreign_key "identities", "users", on_delete: :cascade
+  add_foreign_key "lead_submissions", "organization_lead_forms", on_delete: :cascade
+  add_foreign_key "lead_submissions", "users", on_delete: :cascade
   add_foreign_key "mentions", "users", on_delete: :cascade
   add_foreign_key "notes", "users", column: "author_id", on_delete: :nullify
   add_foreign_key "notification_subscriptions", "users", on_delete: :cascade
   add_foreign_key "notifications", "organizations", on_delete: :cascade
   add_foreign_key "notifications", "users", on_delete: :cascade
+  add_foreign_key "organization_lead_forms", "organizations", on_delete: :cascade
   add_foreign_key "organization_memberships", "organizations", on_delete: :cascade
   add_foreign_key "organization_memberships", "users", on_delete: :cascade
   add_foreign_key "page_views", "articles", on_delete: :cascade

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -80,6 +80,42 @@ text of the printing and typesetting industry\r\nLorem Ipsum is simply dummy tex
       end
     end
 
+    describe "validating job_title" do
+      it "is valid if blank" do
+        profile.job_title = nil
+        expect(profile).to be_valid
+      end
+
+      it "is valid if short enough" do
+        profile.job_title = "Software Engineer"
+        expect(profile).to be_valid
+      end
+
+      it "is invalid if too long" do
+        profile.job_title = "x" * 101
+        expect(profile).not_to be_valid
+        expect(profile.errors_as_sentence).to include("Job title is too long")
+      end
+    end
+
+    describe "validating company" do
+      it "is valid if blank" do
+        profile.company = nil
+        expect(profile).to be_valid
+      end
+
+      it "is valid if short enough" do
+        profile.company = "Acme Inc."
+        expect(profile).to be_valid
+      end
+
+      it "is invalid if too long" do
+        profile.company = "x" * 101
+        expect(profile).not_to be_valid
+        expect(profile.errors_as_sentence).to include("Company is too long")
+      end
+    end
+
     describe "validating website_url" do
       it "is valid if blank" do
         profile.website_url = nil
@@ -120,6 +156,18 @@ text of the printing and typesetting industry\r\nLorem Ipsum is simply dummy tex
     it "enqueues a profile details cache bust when summary changes" do
       sidekiq_assert_enqueued_with(job: Users::BustProfileDetailsCacheWorker, args: [user.id]) do
         profile.update!(summary: "Updated bio")
+      end
+    end
+
+    it "enqueues a profile details cache bust when job_title changes" do
+      sidekiq_assert_enqueued_with(job: Users::BustProfileDetailsCacheWorker, args: [user.id]) do
+        profile.update!(job_title: "Software Engineer")
+      end
+    end
+
+    it "enqueues a profile details cache bust when company changes" do
+      sidekiq_assert_enqueued_with(job: Users::BustProfileDetailsCacheWorker, args: [user.id]) do
+        profile.update!(company: "Acme Inc.")
       end
     end
 

--- a/spec/requests/profiles_request_spec.rb
+++ b/spec/requests/profiles_request_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe "Profiles" do
           patch profile_path(profile), params: { profile: { location: new_location } }
         end.to change { profile.reload.location }.to(new_location)
       end
+
+      it "updates the profile job_title" do
+        expect do
+          patch profile_path(profile), params: { profile: { job_title: "Software Engineer" } }
+        end.to change { profile.reload.job_title }.to("Software Engineer")
+      end
+
+      it "updates the profile company" do
+        expect do
+          patch profile_path(profile), params: { profile: { company: "Acme Inc." } }
+        end.to change { profile.reload.company }.to("Acme Inc.")
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Adds `job_title` and `company` string columns to the `profiles` table as static fields
- Users can set these in Settings > Profile under the "Basic" section
- Displayed on public profile header (e.g. "Software Engineer at Acme Inc.") and in the admin user view
- Includes length validation (max 100 chars), cache busting, and i18n for en/fr/pt

## Test plan
- [x] Model specs pass for validation and cache busting of both fields
- [x] Request specs pass for updating job_title and company via profile form
- [ ] Manually verify fields appear in Settings > Profile
- [ ] Manually verify fields display on public profile page
- [ ] Manually verify fields display in admin user view