### PR TITLE
Flakey test fix: stub DEFAULT_KEY to prevent early return in spec

### DIFF
--- a/spec/services/articles/detect_code_block_languages_spec.rb
+++ b/spec/services/articles/detect_code_block_languages_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Articles::DetectCodeBlockLanguages, type: :service do
     end
 
     it "uses the lite Gemini model by default" do
+      stub_const("Ai::Base::DEFAULT_KEY", "fake-api-key")
       allow(Ai::Base).to receive(:new).and_return(ai_client)
 
       described_class.new(article).call


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fix potential for flakey test here