### PR TITLE
Fix admin Mark as Confirmed button submitting wrong form

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -499,6 +499,44 @@ module Admin
       end
     end
 
+    def confirm_pending_email
+      @user = User.find(params[:id])
+      old_email = @user.email
+      new_email = @user.unconfirmed_email
+
+      if new_email.present? && @user.update_columns(email: new_email, unconfirmed_email: nil, confirmed_at: Time.current)
+        Note.create(
+          author_id: current_user.id,
+          noteable_id: @user.id,
+          noteable_type: "User",
+          reason: "pending_email_confirmed",
+          content: "Pending email change confirmed by #{current_user.username}. Email changed from #{old_email} to #{new_email}",
+        )
+
+        respond_to do |format|
+          message = I18n.t("admin.users_controller.pending_email_confirmed")
+
+          format.html do
+            flash[:success] = message
+            redirect_back(fallback_location: admin_user_path(params[:id]))
+          end
+
+          format.js { render json: { result: message }, content_type: "application/json" }
+        end
+      else
+        message = I18n.t("admin.users_controller.pending_email_confirm_fail")
+
+        respond_to do |format|
+          format.html do
+            flash[:danger] = message
+            redirect_back(fallback_location: admin_user_path(params[:id]))
+          end
+
+          format.js { render json: { error: message }, content_type: "application/json", status: :service_unavailable }
+        end
+      end
+    end
+
     def unlock_access
       @user = User.find(params[:id])
       @user.unlock_access!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -267,6 +267,8 @@ class User < ApplicationRecord
   before_validation :set_username
   before_create :create_users_settings_and_notification_settings_records
   after_update :refresh_auto_audience_segments
+  after_update :create_email_change_note, if: :saved_change_to_unconfirmed_email?
+  after_update :create_password_change_note, if: :saved_change_to_encrypted_password?
   before_destroy :remove_from_mailchimp_newsletters, prepend: true
   before_destroy :destroy_follows, prepend: true
 
@@ -905,6 +907,24 @@ class User < ApplicationRecord
     return true if password == password_confirmation
 
     errors.add(:password, I18n.t("models.user.password_not_matched"))
+  end
+
+  def create_email_change_note
+    return unless unconfirmed_email.present?
+
+    Note.create(
+      noteable: self,
+      reason: "email_change_requested",
+      content: "User requested email change to #{unconfirmed_email}",
+    )
+  end
+
+  def create_password_change_note
+    Note.create(
+      noteable: self,
+      reason: "password_changed",
+      content: "User changed their password",
+    )
   end
 
   def confirmation_required?

--- a/app/views/admin/users/show/emails/_verification.html.erb
+++ b/app/views/admin/users/show/emails/_verification.html.erb
@@ -12,23 +12,17 @@
         <%= button_to "Mark as Confirmed", confirm_email_admin_user_path(@user), method: :post, class: "c-btn c-btn--primary whitespace-nowrap", form: { data: { confirm: "Are you sure you want to manually confirm this user's email?" } } %>
       </div>
     </div>
-  <% else %>
-    <%= form_with url: verify_email_ownership_admin_user_path(@user), local: true, class: "flex flex-col s:flex-row justify-between gap-4 s:items-center" do |f| %>
-      <% unless @last_email_verification_date %>
-        <div>
-          <h2 class="crayons-subtitle-1"><%= t("views.admin.users.emails.not_verified.subtitle") %></h2>
-          <p class="color-secondary"><%= t("views.admin.users.emails.not_verified.desc", user: @user.name) %></p>
-        </div>
-        <% if false # Not yet designed to be visible %>
-          <%= f.button t("views.admin.users.emails.manually_verify"), class: "c-btn c-btn--secondary whitespace-nowrap", value: "manual_verify" %>
-        <% end %>
-        <%= f.button t("views.admin.users.emails.verify"), class: "c-btn c-btn--secondary whitespace-nowrap", value: "send_verification_email" %>
-      <% else %>
-        <p>
-          <%= t("views.admin.users.emails.verified_html", time: tag.time(l(@last_email_verification_date, format: :email_verified), datetime: @last_email_verification_date.strftime("%Y-%m-%dT%H:%M:%S%z"), class: "fw-medium whitespace-nowrap")) %>
-        </p>
-        <%= f.button t("views.admin.users.emails.reverify"), class: "c-btn c-btn--secondary whitespace-nowrap" %>
-      <% end %>
-    <% end %>
+  <% end %>
+
+  <% if @user.unconfirmed_email.present? %>
+    <div class="flex flex-col s:flex-row justify-between gap-4 s:items-center mt-3">
+      <div>
+        <h2 class="crayons-subtitle-1"><%= t("views.admin.users.emails.pending_email.subtitle") %></h2>
+        <p class="color-secondary"><%= t("views.admin.users.emails.pending_email.desc", user: @user.name, email: @user.unconfirmed_email) %></p>
+      </div>
+      <div class="flex gap-2">
+        <%= button_to t("views.admin.users.emails.pending_email.confirm"), confirm_pending_email_admin_user_path(@user), method: :post, class: "c-btn c-btn--primary whitespace-nowrap", form: { data: { confirm: t("views.admin.users.emails.pending_email.confirm_dialog", email: @user.unconfirmed_email) } } %>
+      </div>
+    </div>
   <% end %>
 </div>

--- a/config/locales/controllers/admin/en.yml
+++ b/config/locales/controllers/admin/en.yml
@@ -207,6 +207,8 @@ en:
       tag_not_found: 'Tag "%{tag_name}" was not found'
       email_confirmed: Email confirmed!
       email_confirm_fail: Email confirmation failed.
+      pending_email_confirmed: Pending email change confirmed!
+      pending_email_confirm_fail: No pending email change to confirm.
     welcome_controller:
       thread_content: |
         ---

--- a/config/locales/controllers/admin/fr.yml
+++ b/config/locales/controllers/admin/fr.yml
@@ -207,6 +207,8 @@ fr:
       tag_not_found: 'Tag "%{tag_name}" non trouvée'
       email_confirmed: E-mail confirmé !
       email_confirm_fail: La confirmation de l'e-mail a échoué.
+      pending_email_confirmed: Changement d'e-mail en attente confirmé !
+      pending_email_confirm_fail: Aucun changement d'e-mail en attente à confirmer.
     welcome_controller:
       thread_content: |
         ---

--- a/config/locales/controllers/admin/pt.yml
+++ b/config/locales/controllers/admin/pt.yml
@@ -168,6 +168,8 @@ pt:
       manual_verification_sent: E-mail verificado manualmente!
       email_confirmed: E-mail confirmado!
       email_confirm_fail: A confirmação do e-mail falhou.
+      pending_email_confirmed: Mudança de e-mail pendente confirmada!
+      pending_email_confirm_fail: Nenhuma mudança de e-mail pendente para confirmar.
     welcome_controller:
       thread_content: |
         ---

--- a/config/locales/views/admin/en.yml
+++ b/config/locales/views/admin/en.yml
@@ -229,6 +229,11 @@ en:
           not_confirmed:
             subtitle: Email not confirmed
             desc: "%{user}'s email hasn't been confirmed yet."
+          pending_email:
+            subtitle: Pending email change
+            desc: "%{user} has requested to change their email to %{email}."
+            confirm: Confirm new email
+            confirm_dialog: "Are you sure you want to confirm this email change to %{email}?"
           not_verified:
             subtitle: Email not verified
             desc: "%{user}'s email hasn't been verified yet."

--- a/config/locales/views/admin/fr.yml
+++ b/config/locales/views/admin/fr.yml
@@ -218,6 +218,11 @@ fr:
           body: Body
           body_placeholder: What do you want to say?
           send_submit: Send email
+          pending_email:
+            subtitle: Changement d'e-mail en attente
+            desc: "%{user} a demandé à changer son e-mail pour %{email}."
+            confirm: Confirmer le nouvel e-mail
+            confirm_dialog: "Êtes-vous sûr de vouloir confirmer ce changement d'e-mail vers %{email} ?"
           not_verified:
             subtitle: Email not verified
             desc: "%{user}'s email hasn't been verified yet."

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -63,6 +63,7 @@ namespace :admin do
         post "verify_email_ownership"
         post "send_email_confirmation"
         post "confirm_email"
+        post "confirm_pending_email"
         patch "unlock_access"
         post "unpublish_all_articles"
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1244,6 +1244,40 @@ RSpec.describe User do
     end
   end
 
+  describe "#create_email_change_note" do
+    it "creates a note when unconfirmed_email is set" do
+      expect do
+        user.update(email: "changed@example.com")
+      end.to change(Note, :count).by(1)
+
+      note = user.notes.last
+      expect(note.reason).to eq("email_change_requested")
+      expect(note.content).to include("changed@example.com")
+      expect(note.author_id).to be_nil
+    end
+
+    it "does not create a note when unconfirmed_email is cleared" do
+      user.update_columns(unconfirmed_email: "old@example.com")
+
+      expect do
+        user.update_columns(unconfirmed_email: nil)
+      end.not_to change(Note, :count)
+    end
+  end
+
+  describe "#create_password_change_note" do
+    it "creates a note when password is changed" do
+      expect do
+        user.update(password: "newpassword123", password_confirmation: "newpassword123")
+      end.to change(Note, :count).by(1)
+
+      note = user.notes.last
+      expect(note.reason).to eq("password_changed")
+      expect(note.content).to eq("User changed their password")
+      expect(note.author_id).to be_nil
+    end
+  end
+
   describe "community_bots_for_subforem scope" do
     let(:subforem) { create(:subforem) }
     let!(:community_bot) { create(:user, type_of: :community_bot, onboarding_subforem_id: subforem.id) }

--- a/spec/requests/admin/users_spec.rb
+++ b/spec/requests/admin/users_spec.rb
@@ -471,6 +471,46 @@ end
     end
   end
 
+  describe "PATCH /admin/member_manager/users/:id/update_email" do
+    it "returns not found for non-existing users" do
+      expect do
+        patch update_email_admin_user_path(9999), params: { user: { email: "new@example.com" } }
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "updates the user's email" do
+      old_email = user.email
+
+      patch update_email_admin_user_path(user), params: { user: { email: "updated@example.com" } }
+
+      expect(user.reload.email).to eq("updated@example.com")
+      expect(response).to redirect_to(admin_user_path(user))
+      expect(flash[:success]).to be_present
+    end
+
+    it "creates an audit note recording the email change" do
+      old_email = user.email
+
+      expect do
+        patch update_email_admin_user_path(user), params: { user: { email: "updated@example.com" } }
+      end.to change(Note, :count).by(1)
+
+      note = user.notes.last
+      expect(note.reason).to eq("Update Email")
+      expect(note.content).to include(old_email)
+      expect(note.content).to include("updated@example.com")
+      expect(note.author_id).to eq(admin.id)
+    end
+
+    it "bypasses Devise reconfirmation" do
+      patch update_email_admin_user_path(user), params: { user: { email: "updated@example.com" } }
+
+      user.reload
+      expect(user.email).to eq("updated@example.com")
+      expect(user.unconfirmed_email).to be_nil
+    end
+  end
+
   describe "DELETE /admin/member_manager/users/:id/remove_identity" do
     let(:provider) { Authentication::Providers.available.first }
     let(:user) do
@@ -587,6 +627,69 @@ end
         note = unconfirmed_user.notes.last
         expect(note.reason).to eq("email_confirmed")
         expect(note.content).to include("manually confirmed by #{admin.username}")
+      end
+    end
+  end
+
+  describe "POST /admin/member_manager/users/:id/confirm_pending_email" do
+    let(:user_with_pending_email) do
+      u = create(:user, confirmed_at: Time.current)
+      u.update_columns(unconfirmed_email: "newemail@example.com")
+      u
+    end
+
+    context "when interacting via a browser" do
+      it "returns not found for non-existing users" do
+        expect do
+          post confirm_pending_email_admin_user_path(9999)
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      it "confirms the pending email change successfully" do
+        old_email = user_with_pending_email.email
+
+        post confirm_pending_email_admin_user_path(user_with_pending_email)
+
+        user_with_pending_email.reload
+        expect(user_with_pending_email.email).to eq("newemail@example.com")
+        expect(user_with_pending_email.unconfirmed_email).to be_nil
+        expect(user_with_pending_email.confirmed_at).to be_present
+        expect(response).to redirect_to(admin_user_path(user_with_pending_email))
+        expect(flash[:success]).to be_present
+      end
+
+      it "creates an audit note recording the email change" do
+        old_email = user_with_pending_email.email
+
+        expect do
+          post confirm_pending_email_admin_user_path(user_with_pending_email)
+        end.to change(Note, :count).by(1)
+
+        note = user_with_pending_email.notes.last
+        expect(note.reason).to eq("pending_email_confirmed")
+        expect(note.content).to include(old_email)
+        expect(note.content).to include("newemail@example.com")
+        expect(note.author_id).to eq(admin.id)
+      end
+
+      it "fails gracefully when there is no pending email" do
+        user_without_pending = create(:user, confirmed_at: Time.current)
+
+        post confirm_pending_email_admin_user_path(user_without_pending)
+
+        expect(flash[:danger]).to be_present
+      end
+    end
+
+    context "when interacting via AJAX" do
+      it "confirms the pending email change successfully" do
+        post confirm_pending_email_admin_user_path(user_with_pending_email), xhr: true
+
+        user_with_pending_email.reload
+        expect(user_with_pending_email.email).to eq("newemail@example.com")
+        expect(user_with_pending_email.unconfirmed_email).to be_nil
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["result"]).to be_present
       end
     end
   end


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

### Problem
Several issues with the admin email management panel:
1. The "Mark as Confirmed" button didn't work — it sent a confirmation email instead of directly confirming the user
2. Admins had no visibility into pending email changes (unconfirmed_email) and no way to resolve stuck reconfirmation flows without the Rails console (this can happen when a user changes their email but they're not getting the new email confirmation)
3. No audit trail for user-initiated email or password changes
4. The email verification section was unused

#### Changes

**Fix "Mark as Confirmed" button**
The button_to was nested inside the `send_email_confirmation form_with`. Nested `<form>` elements are invalid HTML, so browsers submitted the outer form instead. Separated them into independent forms.

**Show pending email changes in admin panel**
When a user changes their email in settings, Devise stores the new address in `unconfirmed_email` until confirmed. The admin panel now shows a "Pending email change" section displaying the pending address with a "Confirm new email" button.

**Admin action to confirm pending email**
New `confirm_pending_email` controller action that copies `unconfirmed_email` → `email`, clears `unconfirmed_email`, `sets confirmed_at`, and creates an audit Note — so admins can resolve stuck email changes without the console.

**Automatic Notes on user-initiated changes**
Added after_update callbacks on the User model that create Notes when:
•  A user requests an email change (sets `unconfirmed_emai`l)
•  A user changes their password

**Remove unused email verification section**
Removed the "Email not verified" / verification email section from the admin panel as it was not being used.

**Tests**
•  Request specs for `confirm_pending_email` (5 tests)
•  Request specs for `update_email` (4 tests)
•  Model specs for email/password change Note callbacks (3 tests)


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
