### PR TITLE
Fix RSS feed import destroying markdown formatting

### DIFF
--- a/app/services/feeds/assemble_article_markdown.rb
+++ b/app/services/feeds/assemble_article_markdown.rb
@@ -53,7 +53,7 @@ module Feeds
       raw_content = get_content
 
       unless html_content?(raw_content)
-        return raw_content.to_s.strip
+        return resolve_relative_image_urls(raw_content.to_s.strip)
       end
 
       cleaned_content = Feeds::CleanHtml.call(raw_content)
@@ -75,10 +75,40 @@ module Feeds
       @item.content || @item.summary
     end
 
+    def resolve_relative_image_urls(content)
+      # Fix relative src attributes in inline <img> tags
+      content = content.gsub(/(<img\s[^>]*?src=["'])([^"']+)(["'])/) do
+        prefix, path, suffix = Regexp.last_match(1), Regexp.last_match(2), Regexp.last_match(3)
+        if path.match?(%r{\Ahttps?://})
+          "#{prefix}#{path}#{suffix}"
+        else
+          resource = path.start_with?("/") ? base_url : @feed_source_url
+          "#{prefix}#{URI.join(resource, path)}#{suffix}"
+        end
+      end
+
+      # Fix relative URLs in markdown image syntax ![alt](/path)
+      content.gsub(/!\[([^\]]*)\]\(([^)]+)\)/) do
+        alt, path = Regexp.last_match(1), Regexp.last_match(2)
+        if path.match?(%r{\Ahttps?://})
+          "![#{alt}](#{path})"
+        else
+          resource = path.start_with?("/") ? base_url : @feed_source_url
+          "![#{alt}](#{URI.join(resource, path)})"
+        end
+      end
+    end
+
     def html_content?(content)
       return false if content.blank?
 
-      content.match?(/<\s*(p|div|h[1-6]|ul|ol|li|blockquote|pre|table|section|figure)[\s>]/i)
+      block_tag_count = content.scan(/<\s*(p|div|h[1-6]|ul|ol|li|blockquote|pre|table|section|figure)[\s>]/i).size
+      return false if block_tag_count.zero?
+
+      # If markdown paragraph breaks (blank lines) outnumber HTML block tags,
+      # the content is predominantly markdown with some inline HTML sprinkled in.
+      paragraph_breaks = content.scan(/\n\s*\n/).size
+      block_tag_count > paragraph_breaks
     end
 
     def thorough_parsing(content, feed_url)

--- a/lib/data_update_scripts/20260316120000_reprocess_markdown_feed_imports.rb
+++ b/lib/data_update_scripts/20260316120000_reprocess_markdown_feed_imports.rb
@@ -107,7 +107,11 @@ module DataUpdateScripts
     end
 
     def html_content?(content)
-      content.match?(/<\s*(p|div|h[1-6]|ul|ol|li|blockquote|pre|table|section|figure)[\s>]/i)
+      block_tag_count = content.scan(/<\s*(p|div|h[1-6]|ul|ol|li|blockquote|pre|table|section|figure)[\s>]/i).size
+      return false if block_tag_count.zero?
+
+      paragraph_breaks = content.scan(/\n\s*\n/).size
+      block_tag_count > paragraph_breaks
     end
 
     def log(message)

--- a/spec/services/feeds/assemble_article_markdown_spec.rb
+++ b/spec/services/feeds/assemble_article_markdown_spec.rb
@@ -101,6 +101,63 @@ RSpec.describe Feeds::AssembleArticleMarkdown, type: :service do
     end
   end
 
+  context "when markdown content has relative image URLs" do
+    let(:content) do
+      "### Post\n\n<img src=\"/content/blog/image.png\">\n\nMore text."
+    end
+
+    it "resolves relative img src to absolute URLs" do
+      body = feeds_assemble_article_markdown.call
+
+      expect(body).to include("<img src=\"https://feed.source/content/blog/image.png\">")
+      expect(body).not_to include("src=\"/content")
+    end
+  end
+
+  context "when markdown content has relative markdown image syntax" do
+    let(:content) do
+      "### Post\n\n![screenshot](/images/screenshot.png)\n\nMore text."
+    end
+
+    it "resolves relative markdown images to absolute URLs" do
+      body = feeds_assemble_article_markdown.call
+
+      expect(body).to include("![screenshot](https://feed.source/images/screenshot.png)")
+    end
+  end
+
+  context "when content is markdown with some inline HTML block tags" do
+    let(:content) do
+      <<~MARKDOWN
+        ### A Heading
+
+        Some paragraph text here.
+
+        Another paragraph with more text.
+
+        <p style="text-align: center"><a href="https://example.com">link</a></p>
+
+        ![](/images/photo.png)
+
+        More markdown text after the HTML.
+      MARKDOWN
+    end
+
+    it "treats as markdown and preserves formatting" do
+      body = feeds_assemble_article_markdown.call
+
+      expect(body).to include("### A Heading")
+      expect(body).to include("Some paragraph text here.")
+      expect(body).to include("More markdown text after the HTML.")
+    end
+
+    it "resolves relative image URLs" do
+      body = feeds_assemble_article_markdown.call
+
+      expect(body).to include("![](https://feed.source/images/photo.png)")
+    end
+  end
+
   context "when content is nil" do
     let(:item) do
       instance_double(


### PR DESCRIPTION
## Summary
- RSS feeds serving markdown or plain text content (e.g. workbrew.com/blog/rss.xml) had their formatting destroyed during import -- the pipeline assumed all feed content was HTML and ran it through Nokogiri + ReverseMarkdown, which collapsed whitespace and removed markdown structure, producing one unformatted block of text
- Added `html_content?` detection using a ratio heuristic: if markdown paragraph breaks (blank lines) outnumber HTML block tags, content is treated as markdown. This handles mixed-content feeds (mostly markdown with some inline HTML) correctly
- For markdown content, relative image URLs in both `<img>` tags and `![](path)` syntax are resolved to absolute URLs
- Removed dead code fallback to `item.description` (method does not exist on `Feedjira::Parser::RSSEntry`)

## Data migration
- Added `ReprocessMarkdownFeedImports` data update script (`lib/data_update_scripts/`) that automatically runs post-deploy
- Finds all **draft** feed-imported articles, re-fetches their original RSS feeds, and re-assembles any with markdown content using the fixed pipeline
- Only touches unpublished drafts to avoid overwriting user edits on published articles
- Articles whose entries are no longer in the current feed are safely skipped

## Test plan
- [x] Specs for HTML content (existing HTML-to-markdown pipeline unchanged)
- [x] Specs for pure markdown content (preserved as-is)
- [x] Specs for mixed content -- markdown with inline HTML block tags (treated as markdown)
- [x] Specs for relative image URL resolution (both `<img>` and markdown syntax)
- [x] Specs for plain text, inline-only HTML, and nil content edge cases
- [x] All 12 specs pass, plus 25 existing feed import specs
- [x] Live import of https://workbrew.com/blog/rss.xml -- 48 articles imported with correct formatting and resolved image URLs
- [x] Data migration tested: mangled article body, ran script, confirmed formatting and image URLs restored