### PR TITLE
Add ENV var for disable notification cleanup

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -227,6 +227,7 @@ class Notification < ApplicationRecord
   end
 
   def cleanup_old_notifications
+    return if ENV["DISABLE_USER_NOTIFICATION_CLEANUP"] == "true"
     return unless user_id
     return unless rand(10).zero?
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -648,6 +648,16 @@ RSpec.describe Notification do
       Rails.cache.delete("cleanup_user_notifications_#{user.id}")
     end
 
+    it "does not enqueue a cleanup job if DISABLE_USER_NOTIFICATION_CLEANUP is true" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("DISABLE_USER_NOTIFICATION_CLEANUP").and_return("true")
+      
+      notification = build(:notification, user: user)
+      expect do
+        notification.send(:cleanup_old_notifications)
+      end.not_to change(Notifications::CleanupUserWorker.jobs, :size)
+    end
+
     it "enqueues a cleanup job 10% of the time and throttles via cache" do
       allow_any_instance_of(described_class).to receive(:rand).with(10).and_return(0)
       


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
Recently pushed a change to do per-user notification cleanup. This adds the ability to turn it off, primarily to deal with a situation of too many deleted rows at once for postgres vacuum.