### PR TITLE
Fix mobile footer and billboard cutoff by fixed reaction bar

### DIFF
--- a/app/assets/stylesheets/billboards.scss
+++ b/app/assets/stylesheets/billboards.scss
@@ -129,11 +129,13 @@
       padding-left: var(--su-4);
     }
   }
+}
+
+html:not(.is-twitter-in-app) .stories-show .popover-billboard {
   @media (max-width: $breakpoint-m - 1) {
     bottom: calc(56px + env(safe-area-inset-bottom, 0px)) !important;
   }
 }
-
 // Adjust popover-billboard position when main sidebar is visible
 body[data-side-nav-visible='true']:not(.hidden-shell) {
   .popover-billboard {

--- a/app/assets/stylesheets/views/footer.scss
+++ b/app/assets/stylesheets/views/footer.scss
@@ -30,12 +30,10 @@
   background: var(--footer-bg);
   color: var(--footer-color);
   padding: var(--footer-padding);
-  padding-bottom: calc(var(--footer-padding) + 56px + env(safe-area-inset-bottom, 0px));
   text-align: center;
 
   @media (min-width: $breakpoint-m) {
     --footer-padding: var(--su-8);
-    padding-bottom: var(--footer-padding);
   }
 
   &__container {
@@ -45,6 +43,12 @@
     display: flex;
     flex-direction: column;
     gap: var(--su-2);
+  }
+}
+
+.stories-show ~ .crayons-footer {
+  @media (max-width: $breakpoint-m - 1) {
+    padding-bottom: calc(var(--footer-padding) + 56px);
   }
 }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
On mobile viewports (<768px), the fixed-position article reaction bar (`.crayons-article-actions`) at `bottom: 0` overlaps content at the bottom of the screen.

**Fix 1 — Footer (mobile web, tested):** Added `padding-bottom` clearance to `.crayons-footer` via `.stories-show ~ .crayons-footer` sibling selector, scoped to article pages only. Resets at `$breakpoint-m`.

**Fix 2 — Billboard (app, untested locally):** Offset `.popover-billboard` bottom position to clear the reaction bar, scoped to article pages via `html:not(.is-twitter-in-app) .stories-show .popover-billboard` so it only applies when the reaction bar is actually visible.

![image](https://github.com/user-attachments/assets/61ad9235-0c09-4b74-a3b7-cf2f534f2d47)

![image](https://github.com/user-attachments/assets/a5ecd217-63d9-4dc4-b94a-f23450423886)


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
