### PR TITLE
Add max offset to sitemaps

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -3,6 +3,7 @@ class SitemapsController < ApplicationController
 
   SITEMAP_REGEX = /\Asitemap-(?<date_string>[A-Z][a-z][a-z]-\d{4})\.xml\z/
   RESULTS_LIMIT = Rails.env.production? ? 750 : 5
+  MAX_OFFSET = 250 * RESULTS_LIMIT
 
   def show
     if params[:sitemap].start_with? "sitemap-index"
@@ -24,13 +25,13 @@ class SitemapsController < ApplicationController
     set_surrogate_controls(Time.current)
     @articles_count = Article.published.from_subforem
       .where("score >= ?", Settings::UserExperience.index_minimum_score).size
-    @articles_count = 200_000 if @articles_count > 200_000
+    @articles_count = MAX_OFFSET if @articles_count > MAX_OFFSET
     @page_limit = RESULTS_LIMIT
     @view_template = "index"
   end
 
   def resource_sitemap(resource)
-    return not_found if offset > 200_000
+    return not_found if offset > MAX_OFFSET
 
     case resource
     when "users"

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -90,8 +90,8 @@ RSpec.describe "Sitemaps" do
         expect(response.body).not_to include(Article.order("published_at DESC").last.path)
       end
 
-      it "renders not found if over 200_000 offset" do
-        expect { get "/sitemap-posts-45000.xml" }.to raise_error(ActiveRecord::RecordNotFound)
+      it "renders not found if over max offset" do
+        expect { get "/sitemap-posts-251.xml" }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it "renders 'recent' version of surrogate control" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
This prevents the infinite crawling via sitemap which is not the intended behavior. Will still allow for almost 200k lookback which is plenty.