### PR TITLE
Ensure connection clear on Rails timeout

### DIFF
--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -3,8 +3,10 @@ if Rails.env.development? && ENV["RACK_TIMEOUT_WAIT_TIMEOUT"].nil?
   ENV["RACK_TIMEOUT_SERVICE_TIMEOUT"] = "100000"
 end
 
-Rack::Timeout.unregister_state_change_observer(:logger) if Rails.env.development?
-Rack::Timeout::Logger.disable
+if defined?(Rack::Timeout)
+  Rack::Timeout.unregister_state_change_observer(:logger) if Rails.env.development?
+  Rack::Timeout::Logger.disable
+end
 
 if defined?(Rack::Timeout) && defined?(ActiveRecord::Base)
   Rack::Timeout.register_state_change_observer(:clear_db_connections_on_timeout) do |env|


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Kill Rails connections to the DB in event of a timeout, to prevent lingering connections.