### PR TITLE
Fix triple backticks mid-line incorrectly terminating fenced code blocks - Fixes #8044

### DIFF
--- a/app/services/markdown_processor/parser.rb
+++ b/app/services/markdown_processor/parser.rb
@@ -132,11 +132,15 @@ module MarkdownProcessor
     end
 
     def escape_liquid_tags_in_codeblock(content)
-      # Escape codeblocks, code spans, and inline code
-      content.gsub(/[[:space:]]*~{3}.*?~{3}|[[:space:]]*`{3}.*?`{3}|`{2}.+?`{2}|`{1}.+?`{1}/m) do |codeblock|
+      # Escape fenced code blocks, code spans, and inline code.
+      # Fences (``` or ~~~) must appear at the start of a line to be treated as
+      # block delimiters, preventing lines like `/// ``` ` from terminating a block.
+      content.gsub(/^[[:blank:]]*(~{3,}|`{3,})[^\n]*\n.*?^[[:blank:]]*\1[[:blank:]]*$|`{2}.+?`{2}|`{1}.+?`{1}/m) do |codeblock|
+        next codeblock unless codeblock.match?(/(\{%|\{\{)/)
+
         codeblock.gsub!("{% endraw %}", "{----% endraw %----}")
         codeblock.gsub!("{% raw %}", "{----% raw %----}")
-        if codeblock.match?(/[[:space:]]*`{3}/)
+        if codeblock.match?(/\A[[:blank:]]*(~{3,}|`{3,})/)
           "\n{% raw %}\n#{codeblock}\n{% endraw %}\n"
         else
           "{% raw %}#{codeblock}{% endraw %}"

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
     expect(number_of_triple_backticks).to eq(2)
   end
 
+  it "does not treat triple backticks mid-line as a fence boundary" do
+    markdown = <<~MARKDOWN
+      ```rust
+      /// # Example
+      ///
+      /// ```
+      /// let foo = "foo";
+      /// assert_eq!(foo, "foo");
+      /// ```
+      ```
+
+      ## heading after code block
+    MARKDOWN
+    output = generate_and_parse_markdown(markdown)
+    expect(output).to include("let foo")
+    expect(output).to include("heading after code block")
+  end
+
   xit "allows more than 1 codeblock written separately" do
     code_block = "~~~\n Hello my name is  \n~~~   \n ```\n whatever too \n```"
     number_of_code_blocks = generate_and_parse_markdown(code_block).scan("<code>").count

--- a/spec/services/markdown_processor/parser_spec.rb
+++ b/spec/services/markdown_processor/parser_spec.rb
@@ -95,8 +95,9 @@ RSpec.describe MarkdownProcessor::Parser, type: :service do
       ## heading after code block
     MARKDOWN
     output = generate_and_parse_markdown(markdown)
-    expect(output).to include("let foo")
-    expect(output).to include("heading after code block")
+    doc = Nokogiri::HTML.fragment(output)
+    expect(doc.at_css("code").text).to include("let foo")
+    expect(doc.at_css("h2").text).to include("heading after code block")
   end
 
   xit "allows more than 1 codeblock written separately" do


### PR DESCRIPTION
**What type of PR is this?**
- [x] `Bug Fix`

**Description**
Fixes markdown parsing where triple backticks preceded by other characters were incorrectly treated as fenced code block boundaries. 

Updated `MarkdownProcessor::Parser#escape_liquid_tags_in_codeblock` to only treat fences at line start as block delimiters, and added a regression spec for the reported case so headings/content after the block render correctly.

**Related Tickets & Documents**
- Related Issue #8044
- Closes #8044

**Added/updated tests?**
- [x] `Yes`