### PR TITLE
Strip extra line breaks from comments to fix new ltag issue

### DIFF
--- a/app/liquid_tags/liquid_tag_base.rb
+++ b/app/liquid_tags/liquid_tag_base.rb
@@ -93,9 +93,9 @@ class LiquidTagBase < Liquid::Tag
 
     out_payload = CGI.escapeHTML(data)
 
-    output << "\n<!-- FOREM_LTAG_START:#{out_payload} -->\n"
+    output << "<!-- FOREM_LTAG_START:#{out_payload} -->"
     super
-    output << "\n<!-- FOREM_LTAG_END:#{out_payload} -->\n"
+    output << "<!-- FOREM_LTAG_END:#{out_payload} -->"
   end
 
   private


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes formatting issue in comments