### PR TITLE
fix(github-embed-23055): resolve relative GitHub README image URLs

### DIFF
--- a/app/liquid_tags/github_tag/github_readme_tag.rb
+++ b/app/liquid_tags/github_tag/github_readme_tag.rb
@@ -88,7 +88,8 @@ class GithubTag
         element["src"] = "" if attribute == "src" && element.attributes[attribute].blank?
 
         path = element.attributes[attribute].value
-        next if path[0, 4] == "http" # Skip absolute URLs
+        next if path.blank? # Skip missing/empty attributes — avoids bogus rewrite to .../HEAD/
+        next if path.start_with?("http", "//", "data:", "mailto:") # Skip absolute/non-relative URLs
 
         # Handle different types of relative paths
         if path.start_with?("/")

--- a/spec/liquid_tags/github_tag/github_readme_tag_spec.rb
+++ b/spec/liquid_tags/github_tag/github_readme_tag_spec.rb
@@ -164,6 +164,43 @@ RSpec.describe GithubTag::GithubReadmeTag, type: :liquid_tag, vcr: true do
         expect(result).to include('href="https://github.com/owner/repo/blob/main/README.md"')
         expect(result).not_to include("raw.githubusercontent.com")
       end
+
+      it "does not rewrite an img with a blank src to a bogus raw.githubusercontent.com URL" do
+        html = '<img src="">'
+        result = tag.send(:clean_relative_path!, html, repo_url)
+        expect(result).not_to include("raw.githubusercontent.com")
+        expect(result).not_to include("/HEAD/")
+      end
+
+      it "does not rewrite an img with no src attribute to a bogus raw.githubusercontent.com URL" do
+        html = "<img>"
+        result = tag.send(:clean_relative_path!, html, repo_url)
+        expect(result).not_to include("raw.githubusercontent.com")
+        expect(result).not_to include("/HEAD/")
+      end
+
+      it "does not rewrite a protocol-relative img src (//cdn.example.com/img.png)" do
+        html = '<img src="//cdn.example.com/img.png">'
+        result = tag.send(:clean_relative_path!, html, repo_url)
+        expect(result).to include('src="//cdn.example.com/img.png"')
+        expect(result).not_to include("raw.githubusercontent.com")
+        expect(result).not_to include("/HEAD/")
+      end
+
+      it "does not rewrite a data: URI img src" do
+        html = '<img src="data:image/png;base64,abc123">'
+        result = tag.send(:clean_relative_path!, html, repo_url)
+        expect(result).to include('src="data:image/png;base64,abc123"')
+        expect(result).not_to include("raw.githubusercontent.com")
+        expect(result).not_to include("/HEAD/")
+      end
+
+      it "does not rewrite a mailto: href to a github path" do
+        html = '<a href="mailto:user@example.com">Email</a>'
+        result = tag.send(:clean_relative_path!, html, repo_url)
+        expect(result).to include('href="mailto:user@example.com"')
+        expect(result).not_to include("github.com/owner/repo/mailto")
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
- Fix relative image paths in GitHub embed rendering
- Add tests to verify correct img src rewriting
- Add tests to verify non-rewriting for absolute/root-relative paths

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #23055 

## QA Instructions, Screenshots, Recordings

_Follow better instructions in issue #23055 to reproduce._
_Tested with Chrome Dev._
_Reproducible with any GitHub embed having relative img in README._
_Create post > paste gh embed > observe._

### Before
<img width="757" height="454" alt="Screenshot 2026-03-30 at 10 33 35 PM" src="https://github.com/user-attachments/assets/2b622dce-7238-4253-826c-ae240e767339" />

### After
<img width="757" height="461" alt="Screenshot 2026-03-30 at 10 34 34 PM" src="https://github.com/user-attachments/assets/10bf26d3-0bfd-4bbf-b5d0-317a762e4816" />

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
Nope. Pretty straightforward cure for my OCD.

## [optional] What gif best describes this PR or how it makes you feel?

![this-is-fine-its-fine](https://github.com/user-attachments/assets/012eaef7-d0c8-4c67-a20e-63f9c6ee0fe2)
Really... but what do you guys think about using OG instead of the `README` for the GH embed?? 😆 