### PR TITLE
Hide quickie subforem form if env var present

### DIFF
--- a/app/views/articles/_quickie_form.html.erb
+++ b/app/views/articles/_quickie_form.html.erb
@@ -17,7 +17,7 @@
       <div class="fs-xs color-base-60">
         <%= t("views.stories.status_hint_html") %>
       </div>
-    <% elsif @article && Subforem.cached_postable_array.any? %>
+    <% elsif !ENV["DISABLE_MAIN_SIDE_BAR"] && @article && Subforem.cached_postable_array.any? %>
       <input value="<%= @article.cached_tag_list %>" autocomplete="off" type="hidden" name="article[tag_list]" id="article_tag_list">
       <div>
         <select name="article[subforem_id]" id="article_subforem_id" class="crayons-select">


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Let's re-use the sidebar env var and hide the quickie dropdown like we hide the sidebar subforems if we don't want them displayed.