### PR TITLE
Analytics Charts - brush zoom, top engagers, followers ratio, dark mode fixes

### DIFF
--- a/app/controllers/concerns/api/analytics_controller.rb
+++ b/app/controllers/concerns/api/analytics_controller.rb
@@ -34,6 +34,15 @@ module Api
       render json: data.to_json
     end
 
+    def top_contributors
+      analytics = AnalyticsService.new(
+        @owner,
+        start_date: params[:start], end_date: params[:end], article_id: params[:article_id],
+      )
+      data = analytics.top_contributors
+      render json: data.to_json
+    end
+
     private
 
     def authorize_user_organization

--- a/app/controllers/concerns/api/analytics_controller.rb
+++ b/app/controllers/concerns/api/analytics_controller.rb
@@ -43,6 +43,15 @@ module Api
       render json: data.to_json
     end
 
+    def follower_engagement
+      analytics = AnalyticsService.new(
+        @owner,
+        start_date: params[:start], end_date: params[:end],
+      )
+      data = analytics.follower_engagement
+      render json: data.to_json
+    end
+
     private
 
     def authorize_user_organization

--- a/app/javascript/analytics/__tests__/dashboard.test.js
+++ b/app/javascript/analytics/__tests__/dashboard.test.js
@@ -447,4 +447,66 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
     const card = document.getElementById('followers-card');
     expect(card.querySelector('.follower-engagement')).toBeNull();
   });
+
+  test('charts show empty state message when historical data is empty', async () => {
+    callHistoricalAPI.mockResolvedValue({});
+    callTotalsAPI.mockResolvedValue({
+      comments: { total: 0 },
+      reactions: { total: 0, like: 0, readinglist: 0, unicorn: 0, exploding_head: 0, raised_hands: 0, fire: 0, unique_reactors: 0 },
+      page_views: { total: 0, average_read_time_in_seconds: 0 },
+      follows: { total: 0 },
+    });
+    callReferrersAPI.mockResolvedValue({ domains: [] });
+
+    initCharts({});
+    await flushPromises();
+
+    ['readers-chart', 'reactions-chart', 'comments-chart', 'followers-chart'].forEach((id) => {
+      const el = document.getElementById(id);
+      expect(el.innerHTML).toContain('dashboard_analytics_no_data');
+    });
+
+    // No ApexCharts instances should be created for main charts
+    const mainChartCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type !== 'donut');
+    expect(mainChartCalls.length).toBe(0);
+  });
+
+  test('referrers show empty state when no domains', async () => {
+    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
+    callTotalsAPI.mockResolvedValue(mockTotalsData);
+    callReferrersAPI.mockResolvedValue({ domains: [] });
+
+    initCharts({});
+    await flushPromises();
+
+    const container = document.getElementById('referrers-container');
+    expect(container.innerHTML).toContain('dashboard_analytics_no_referrers');
+
+    // Referrer chart should be cleared, no donut rendered
+    const donutCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type === 'donut');
+    expect(donutCalls.length).toBe(0);
+  });
+
+  test('cards show zero values when data is empty', async () => {
+    callHistoricalAPI.mockResolvedValue({});
+    callTotalsAPI.mockResolvedValue({
+      comments: { total: 0 },
+      reactions: { total: 0, like: 0, readinglist: 0, unicorn: 0, exploding_head: 0, raised_hands: 0, fire: 0, unique_reactors: 0 },
+      page_views: { total: 0, average_read_time_in_seconds: 0 },
+      follows: { total: 0 },
+    });
+    callReferrersAPI.mockResolvedValue({ domains: [] });
+
+    initCharts({});
+    await flushPromises();
+
+    const readersCard = document.getElementById('readers-card');
+    expect(readersCard.innerHTML).toContain('0');
+
+    const reactionsCard = document.getElementById('reactions-card');
+    expect(reactionsCard.innerHTML).toContain('0');
+
+    const commentsCard = document.getElementById('comments-card');
+    expect(commentsCard.innerHTML).toContain('0');
+  });
 });

--- a/app/javascript/analytics/__tests__/dashboard.test.js
+++ b/app/javascript/analytics/__tests__/dashboard.test.js
@@ -26,6 +26,7 @@ jest.mock('../client', () => ({
   callHistoricalAPI: jest.fn(),
   callTotalsAPI: jest.fn(),
   callReferrersAPI: jest.fn(),
+  callTopContributorsAPI: jest.fn(),
 }));
 
 // Build sample historical data spanning 120 days
@@ -57,6 +58,10 @@ const mockTotalsData = {
   follows: { total: 15 },
 };
 const mockReferrersData = { domains: [{ domain: 'google.com', count: 100 }] };
+const mockTopContributorsData = [
+  { user_id: 1, username: 'alice', name: 'Alice', profile_image: '/img/alice.png', reactions_count: 5, comments_count: 2, score: 11 },
+  { user_id: 2, username: 'bob', name: 'Bob', profile_image: '/img/bob.png', reactions_count: 3, comments_count: 0, score: 3 },
+];
 
 function setupDOM() {
   document.body.innerHTML = `
@@ -80,11 +85,12 @@ function setupDOM() {
     <div class="charts-container"><div id="followers-chart"><div class="analytics-loading crayons-scaffold-loading"></div></div></div>
     <div id="referrers-chart"><div class="analytics-loading crayons-scaffold-loading"></div></div>
     <table><tbody id="referrers-container"></tbody></table>
+    <div id="top-contributors-container"><div class="analytics-loading crayons-scaffold-loading"></div></div>
   `;
 }
 
 describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
-  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI } = require('../client');
+  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI, callTopContributorsAPI } = require('../client');
 
   beforeEach(() => {
     // Reset shared window state between tests
@@ -96,6 +102,7 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
     callHistoricalAPI.mockResolvedValue(mockHistoricalData);
     callTotalsAPI.mockResolvedValue(mockTotalsData);
     callReferrersAPI.mockResolvedValue(mockReferrersData);
+    callTopContributorsAPI.mockResolvedValue(mockTopContributorsData);
   });
 
   async function flushPromises() {
@@ -256,7 +263,7 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
 });
 
 describe('Analytics Dashboard – Async Chart Loading', () => {
-  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI } = require('../client');
+  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI, callTopContributorsAPI } = require('../client');
 
   beforeEach(() => {
     // Reset shared window state between tests
@@ -265,6 +272,7 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
     MockApexCharts.mockClear();
     mockRender.mockClear();
     mockDestroy.mockClear();
+    callTopContributorsAPI.mockResolvedValue([]);
   });
 
   async function flushPromises() {
@@ -351,6 +359,7 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
     callHistoricalAPI.mockRejectedValue(new Error('API error'));
     callTotalsAPI.mockRejectedValue(new Error('API error'));
     callReferrersAPI.mockResolvedValue(mockReferrersData);
+    callTopContributorsAPI.mockResolvedValue([]);
 
     initCharts({});
     await flushPromises();
@@ -358,5 +367,52 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
     // Referrers should still render
     const referrersContainer = document.getElementById('referrers-container');
     expect(referrersContainer.innerHTML).toContain('google.com');
+  });
+
+  test('top contributors panel renders async with ranked list', async () => {
+    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
+    callTotalsAPI.mockResolvedValue(mockTotalsData);
+    callReferrersAPI.mockResolvedValue(mockReferrersData);
+    callTopContributorsAPI.mockResolvedValue(mockTopContributorsData);
+
+    initCharts({});
+    await flushPromises();
+
+    const container = document.getElementById('top-contributors-container');
+    expect(container.innerHTML).toContain('alice');
+    expect(container.innerHTML).toContain('bob');
+    // Alice should appear before Bob (higher score)
+    expect(container.innerHTML.indexOf('alice')).toBeLessThan(container.innerHTML.indexOf('bob'));
+  });
+
+  test('top contributors shows empty message when no data', async () => {
+    callTopContributorsAPI.mockResolvedValue([]);
+
+    initCharts({});
+    await flushPromises();
+
+    const container = document.getElementById('top-contributors-container');
+    expect(container.innerHTML).toContain('top_contributors_empty');
+  });
+
+  test('stale top contributors response is discarded after navigation', async () => {
+    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
+    callTotalsAPI.mockResolvedValue(mockTotalsData);
+    callReferrersAPI.mockResolvedValue(mockReferrersData);
+
+    let resolveContributors;
+    callTopContributorsAPI.mockReturnValue(new Promise((r) => { resolveContributors = r; }));
+
+    initCharts({});
+    // Simulate navigation — call initCharts again which bumps generation
+    callTopContributorsAPI.mockResolvedValue([]);
+    initCharts({});
+
+    resolveContributors(mockTopContributorsData);
+    await flushPromises();
+
+    const container = document.getElementById('top-contributors-container');
+    // Should NOT have rendered the stale data — only the empty message from the second call
+    expect(container.innerHTML).not.toContain('alice');
   });
 });

--- a/app/javascript/analytics/__tests__/dashboard.test.js
+++ b/app/javascript/analytics/__tests__/dashboard.test.js
@@ -68,17 +68,17 @@ function setupDOM() {
       </ul>
     </div>
     <div class="summary-stats">
-      <div><div id="readers-card" class="py-3"></div></div>
-      <div><div id="reactions-card" class="py-3"></div></div>
-      <div><div id="comments-card" class="py-3"></div></div>
-      <div><div id="bookmarks-card" class="py-3"></div></div>
-      <div><div id="followers-card" class="py-3"></div></div>
+      <div><div id="readers-card" class="py-3"><div class="analytics-loading crayons-scaffold-loading"></div></div></div>
+      <div><div id="reactions-card" class="py-3"><div class="analytics-loading crayons-scaffold-loading"></div></div></div>
+      <div><div id="comments-card" class="py-3"><div class="analytics-loading crayons-scaffold-loading"></div></div></div>
+      <div><div id="bookmarks-card" class="py-3"><div class="analytics-loading crayons-scaffold-loading"></div></div></div>
+      <div><div id="followers-card" class="py-3"><div class="analytics-loading crayons-scaffold-loading"></div></div></div>
     </div>
-    <div class="charts-container"><div id="readers-chart"></div></div>
-    <div class="charts-container"><div id="reactions-chart"></div></div>
-    <div class="charts-container"><div id="comments-chart"></div></div>
-    <div class="charts-container"><div id="followers-chart"></div></div>
-    <div id="referrers-chart"></div>
+    <div class="charts-container"><div id="readers-chart"><div class="analytics-loading crayons-scaffold-loading"></div></div></div>
+    <div class="charts-container"><div id="reactions-chart"><div class="analytics-loading crayons-scaffold-loading"></div></div></div>
+    <div class="charts-container"><div id="comments-chart"><div class="analytics-loading crayons-scaffold-loading"></div></div></div>
+    <div class="charts-container"><div id="followers-chart"><div class="analytics-loading crayons-scaffold-loading"></div></div></div>
+    <div id="referrers-chart"><div class="analytics-loading crayons-scaffold-loading"></div></div>
     <table><tbody id="referrers-container"></tbody></table>
   `;
 }
@@ -87,6 +87,8 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
   const { callHistoricalAPI, callTotalsAPI, callReferrersAPI } = require('../client');
 
   beforeEach(() => {
+    // Reset shared window state between tests
+    window._analyticsState = { activeCharts: {}, apiGeneration: 0 };
     setupDOM();
     MockApexCharts.mockClear();
     mockRender.mockClear();
@@ -146,9 +148,11 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
     expect(mainCalls.length).toBe(4);
     expect(brushCalls.length).toBe(4);
 
-    // Main charts should use datetime x-axis
+    // Main charts should use datetime x-axis with initial zoom range
     mainCalls.forEach(([, opts]) => {
       expect(opts.xaxis.type).toBe('datetime');
+      expect(opts.xaxis.min).toBeDefined();
+      expect(opts.xaxis.max).toBeDefined();
       expect(opts.chart.zoom.enabled).toBe(true);
       expect(opts.chart.toolbar.show).toBe(true);
     });
@@ -248,5 +252,111 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
     expect(document.getElementById('brush-reactions-chart')).toBeNull();
     expect(document.getElementById('brush-comments-chart')).toBeNull();
     expect(document.getElementById('brush-followers-chart')).toBeNull();
+  });
+});
+
+describe('Analytics Dashboard – Async Chart Loading', () => {
+  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI } = require('../client');
+
+  beforeEach(() => {
+    // Reset shared window state between tests
+    window._analyticsState = { activeCharts: {}, apiGeneration: 0 };
+    setupDOM();
+    MockApexCharts.mockClear();
+    mockRender.mockClear();
+    mockDestroy.mockClear();
+  });
+
+  async function flushPromises() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  test('charts render when historical resolves even if totals is still pending', async () => {
+    let resolveTotals;
+    const totalsPromise = new Promise((resolve) => { resolveTotals = resolve; });
+    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
+    callTotalsAPI.mockReturnValue(totalsPromise);
+    callReferrersAPI.mockResolvedValue(mockReferrersData);
+
+    initCharts({});
+    await flushPromises();
+
+    // Charts should be rendered (from historical)
+    const chartCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type !== 'donut');
+    expect(chartCalls.length).toBeGreaterThan(0);
+
+    // Cards should show data (from historical, without totals)
+    expect(document.getElementById('readers-card').innerHTML).not.toContain('analytics-loading');
+
+    // Now resolve totals — cards should update with extra info
+    resolveTotals(mockTotalsData);
+    await flushPromises();
+
+    expect(document.getElementById('reactions-card').innerHTML).toContain('unique reactors');
+  });
+
+  test('referrers load independently of historical and totals', async () => {
+    let resolveHistorical;
+    const historicalPromise = new Promise((resolve) => { resolveHistorical = resolve; });
+    callHistoricalAPI.mockReturnValue(historicalPromise);
+    callTotalsAPI.mockResolvedValue(mockTotalsData);
+    callReferrersAPI.mockResolvedValue(mockReferrersData);
+
+    initCharts({});
+    await flushPromises();
+
+    // Referrers should be rendered even though historical hasn't resolved
+    const referrersContainer = document.getElementById('referrers-container');
+    expect(referrersContainer.innerHTML).toContain('google.com');
+
+    // Charts should NOT be rendered yet
+    const chartCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type !== 'donut');
+    // Only the donut chart should exist at this point
+    const donutCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type === 'donut');
+    expect(donutCalls.length).toBe(1);
+
+    // Now resolve historical — charts appear
+    resolveHistorical(mockHistoricalData);
+    await flushPromises();
+
+    const allChartCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type !== 'donut');
+    expect(allChartCalls.length).toBeGreaterThan(0);
+  });
+
+  test('loading placeholders are shown before data arrives', async () => {
+    let resolveHistorical;
+    const historicalPromise = new Promise((resolve) => { resolveHistorical = resolve; });
+    callHistoricalAPI.mockReturnValue(historicalPromise);
+    callTotalsAPI.mockReturnValue(new Promise(() => {}));
+    callReferrersAPI.mockReturnValue(new Promise(() => {}));
+
+    initCharts({});
+    // Don't flush — let promises stay pending
+
+    // Placeholders should be visible in chart containers
+    expect(document.getElementById('readers-chart').querySelector('.analytics-loading')).not.toBeNull();
+    expect(document.getElementById('reactions-chart').querySelector('.analytics-loading')).not.toBeNull();
+
+    // Resolve historical to clear chart placeholders
+    resolveHistorical(mockHistoricalData);
+    await flushPromises();
+
+    // Chart containers should no longer have placeholders (replaced by ApexCharts)
+    // The innerHTML is cleared by drawChart before rendering
+    expect(document.getElementById('readers-chart').querySelector('.analytics-loading')).toBeNull();
+  });
+
+  test('chart errors do not prevent referrer rendering', async () => {
+    callHistoricalAPI.mockRejectedValue(new Error('API error'));
+    callTotalsAPI.mockRejectedValue(new Error('API error'));
+    callReferrersAPI.mockResolvedValue(mockReferrersData);
+
+    initCharts({});
+    await flushPromises();
+
+    // Referrers should still render
+    const referrersContainer = document.getElementById('referrers-container');
+    expect(referrersContainer.innerHTML).toContain('google.com');
   });
 });

--- a/app/javascript/analytics/__tests__/dashboard.test.js
+++ b/app/javascript/analytics/__tests__/dashboard.test.js
@@ -27,6 +27,7 @@ jest.mock('../client', () => ({
   callTotalsAPI: jest.fn(),
   callReferrersAPI: jest.fn(),
   callTopContributorsAPI: jest.fn(),
+  callFollowerEngagementAPI: jest.fn(),
 }));
 
 // Build sample historical data spanning 120 days
@@ -62,6 +63,7 @@ const mockTopContributorsData = [
   { user_id: 1, username: 'alice', name: 'Alice', profile_image: '/img/alice.png', reactions_count: 5, comments_count: 2, score: 11 },
   { user_id: 2, username: 'bob', name: 'Bob', profile_image: '/img/bob.png', reactions_count: 3, comments_count: 0, score: 3 },
 ];
+const mockFollowerEngagementData = { total_followers: 200, engaged_followers: 30, ratio: 15.0 };
 
 function setupDOM() {
   document.body.innerHTML = `
@@ -90,7 +92,7 @@ function setupDOM() {
 }
 
 describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
-  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI, callTopContributorsAPI } = require('../client');
+  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI, callTopContributorsAPI, callFollowerEngagementAPI } = require('../client');
 
   beforeEach(() => {
     // Reset shared window state between tests
@@ -103,6 +105,7 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
     callTotalsAPI.mockResolvedValue(mockTotalsData);
     callReferrersAPI.mockResolvedValue(mockReferrersData);
     callTopContributorsAPI.mockResolvedValue(mockTopContributorsData);
+    callFollowerEngagementAPI.mockResolvedValue(mockFollowerEngagementData);
   });
 
   async function flushPromises() {
@@ -263,7 +266,7 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
 });
 
 describe('Analytics Dashboard – Async Chart Loading', () => {
-  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI, callTopContributorsAPI } = require('../client');
+  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI, callTopContributorsAPI, callFollowerEngagementAPI } = require('../client');
 
   beforeEach(() => {
     // Reset shared window state between tests
@@ -273,6 +276,7 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
     mockRender.mockClear();
     mockDestroy.mockClear();
     callTopContributorsAPI.mockResolvedValue([]);
+    callFollowerEngagementAPI.mockResolvedValue({ total_followers: 0, engaged_followers: 0, ratio: 0.0 });
   });
 
   async function flushPromises() {
@@ -414,5 +418,33 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
     const container = document.getElementById('top-contributors-container');
     // Should NOT have rendered the stale data — only the empty message from the second call
     expect(container.innerHTML).not.toContain('alice');
+  });
+
+  test('follower engagement ratio renders on followers card', async () => {
+    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
+    callTotalsAPI.mockResolvedValue(mockTotalsData);
+    callReferrersAPI.mockResolvedValue(mockReferrersData);
+    callFollowerEngagementAPI.mockResolvedValue(mockFollowerEngagementData);
+
+    initCharts({});
+    await flushPromises();
+
+    const card = document.getElementById('followers-card');
+    const engagement = card.querySelector('.follower-engagement');
+    expect(engagement).not.toBeNull();
+    expect(engagement.textContent).toContain('follower_engagement_ratio');
+  });
+
+  test('follower engagement does not render when no followers', async () => {
+    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
+    callTotalsAPI.mockResolvedValue(mockTotalsData);
+    callReferrersAPI.mockResolvedValue(mockReferrersData);
+    callFollowerEngagementAPI.mockResolvedValue({ total_followers: 0, engaged_followers: 0, ratio: 0.0 });
+
+    initCharts({});
+    await flushPromises();
+
+    const card = document.getElementById('followers-card');
+    expect(card.querySelector('.follower-engagement')).toBeNull();
   });
 });

--- a/app/javascript/analytics/__tests__/dashboard.test.js
+++ b/app/javascript/analytics/__tests__/dashboard.test.js
@@ -1,0 +1,252 @@
+import { initCharts } from '../dashboard';
+
+// Mock locale utility
+jest.mock('@utilities/locale', () => ({
+  locale: jest.fn((key, opts = {}) => {
+    if (key === 'core.dashboard_analytics_avg_read_time') return `avg. read time ${opts.seconds}s`;
+    if (key === 'core.dashboard_analytics_unique_reactors') return `${opts.count} unique reactors`;
+    return key.split('.').pop();
+  }),
+}));
+
+// Capture ApexCharts constructor calls
+const mockRender = jest.fn().mockResolvedValue(undefined);
+const mockDestroy = jest.fn();
+const MockApexCharts = jest.fn().mockImplementation(() => ({
+  render: mockRender,
+  destroy: mockDestroy,
+}));
+
+jest.mock('apexcharts', () => ({
+  __esModule: true,
+  default: MockApexCharts,
+}));
+
+jest.mock('../client', () => ({
+  callHistoricalAPI: jest.fn(),
+  callTotalsAPI: jest.fn(),
+  callReferrersAPI: jest.fn(),
+}));
+
+// Build sample historical data spanning 120 days
+function buildHistoricalData(days) {
+  const data = {};
+  const now = new Date();
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(now);
+    d.setDate(d.getDate() - i);
+    const key = d.toISOString().split('T')[0];
+    data[key] = {
+      comments: { total: Math.floor(Math.random() * 5) },
+      reactions: {
+        total: 5, like: 3, readinglist: 1, unicorn: 1,
+        exploding_head: 0, raised_hands: 0, fire: 0,
+      },
+      page_views: { total: 50 + i, average_read_time_in_seconds: 30 },
+      follows: { total: i % 10 === 0 ? 1 : 0 },
+    };
+  }
+  return data;
+}
+
+const mockHistoricalData = buildHistoricalData(120);
+const mockTotalsData = {
+  comments: { total: 50 },
+  reactions: { total: 100, like: 60, readinglist: 10, unicorn: 20, exploding_head: 5, raised_hands: 3, fire: 2, unique_reactors: 25 },
+  page_views: { total: 5000, average_read_time_in_seconds: 35 },
+  follows: { total: 15 },
+};
+const mockReferrersData = { domains: [{ domain: 'google.com', count: 100 }] };
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <div class="crayons-tabs crayons-tabs--analytics">
+      <ul class="crayons-tabs__list">
+        <li><button class="crayons-tabs__item crayons-tabs__item--current" id="week-button" aria-current="page">Week</button></li>
+        <li><button class="crayons-tabs__item" id="month-button">Month</button></li>
+        <li><button class="crayons-tabs__item" id="infinity-button">Infinity</button></li>
+      </ul>
+    </div>
+    <div class="summary-stats">
+      <div><div id="readers-card" class="py-3"></div></div>
+      <div><div id="reactions-card" class="py-3"></div></div>
+      <div><div id="comments-card" class="py-3"></div></div>
+      <div><div id="bookmarks-card" class="py-3"></div></div>
+      <div><div id="followers-card" class="py-3"></div></div>
+    </div>
+    <div class="charts-container"><div id="readers-chart"></div></div>
+    <div class="charts-container"><div id="reactions-chart"></div></div>
+    <div class="charts-container"><div id="comments-chart"></div></div>
+    <div class="charts-container"><div id="followers-chart"></div></div>
+    <div id="referrers-chart"></div>
+    <table><tbody id="referrers-container"></tbody></table>
+  `;
+}
+
+describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
+  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI } = require('../client');
+
+  beforeEach(() => {
+    setupDOM();
+    MockApexCharts.mockClear();
+    mockRender.mockClear();
+    mockDestroy.mockClear();
+    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
+    callTotalsAPI.mockResolvedValue(mockTotalsData);
+    callReferrersAPI.mockResolvedValue(mockReferrersData);
+  });
+
+  async function flushPromises() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  test('week/month charts use category x-axis without brush', async () => {
+    initCharts({});
+    await flushPromises();
+
+    // 4 main charts (readers, reactions, comments, followers) + 1 donut (referrers)
+    const calls = MockApexCharts.mock.calls;
+    const mainChartCalls = calls.filter(([, opts]) => opts.chart.type !== 'donut');
+
+    mainChartCalls.forEach(([, opts]) => {
+      // Should use categories, not datetime
+      expect(opts.xaxis.type).toBeUndefined();
+      expect(opts.xaxis.categories).toBeDefined();
+      // Should not have brush config
+      expect(opts.chart.brush).toBeUndefined();
+      // Zoom should be disabled
+      expect(opts.chart.zoom.enabled).toBe(false);
+    });
+
+    // No brush divs should exist
+    expect(document.getElementById('brush-readers-chart')).toBeNull();
+    expect(document.getElementById('brush-reactions-chart')).toBeNull();
+    expect(document.getElementById('brush-comments-chart')).toBeNull();
+    expect(document.getElementById('brush-followers-chart')).toBeNull();
+  });
+
+  test('infinity charts use datetime x-axis with brush navigators', async () => {
+    initCharts({});
+    await flushPromises();
+    MockApexCharts.mockClear();
+
+    // Click infinity button
+    document.getElementById('infinity-button').click();
+    await flushPromises();
+
+    const calls = MockApexCharts.mock.calls;
+
+    // Find main chart calls (have chart.id starting with 'main-')
+    const mainCalls = calls.filter(([, opts]) => opts.chart.id && opts.chart.id.startsWith('main-'));
+    // Find brush chart calls (have chart.brush.enabled)
+    const brushCalls = calls.filter(([, opts]) => opts.chart.brush && opts.chart.brush.enabled);
+
+    // Should have 4 main charts and 4 brush charts
+    expect(mainCalls.length).toBe(4);
+    expect(brushCalls.length).toBe(4);
+
+    // Main charts should use datetime x-axis
+    mainCalls.forEach(([, opts]) => {
+      expect(opts.xaxis.type).toBe('datetime');
+      expect(opts.chart.zoom.enabled).toBe(true);
+      expect(opts.chart.toolbar.show).toBe(true);
+    });
+
+    // Brush charts should target correct main charts
+    const brushTargets = brushCalls.map(([, opts]) => opts.chart.brush.target).sort();
+    expect(brushTargets).toEqual([
+      'main-comments-chart',
+      'main-followers-chart',
+      'main-reactions-chart',
+      'main-readers-chart',
+    ]);
+
+    // Brush charts should have datetime x-axis
+    brushCalls.forEach(([, opts]) => {
+      expect(opts.xaxis.type).toBe('datetime');
+      expect(opts.chart.selection.enabled).toBe(true);
+    });
+
+    // Brush divs should exist in DOM
+    expect(document.getElementById('brush-readers-chart')).not.toBeNull();
+    expect(document.getElementById('brush-reactions-chart')).not.toBeNull();
+    expect(document.getElementById('brush-comments-chart')).not.toBeNull();
+    expect(document.getElementById('brush-followers-chart')).not.toBeNull();
+  });
+
+  test('brush selection defaults to last 90 days of data', async () => {
+    initCharts({});
+    await flushPromises();
+    MockApexCharts.mockClear();
+
+    document.getElementById('infinity-button').click();
+    await flushPromises();
+
+    const brushCalls = MockApexCharts.mock.calls.filter(
+      ([, opts]) => opts.chart.brush && opts.chart.brush.enabled,
+    );
+
+    const labels = Object.keys(mockHistoricalData);
+    const lastTimestamp = new Date(labels[labels.length - 1]).getTime();
+    const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+    const expectedMin = lastTimestamp - ninetyDaysMs;
+
+    brushCalls.forEach(([, opts]) => {
+      const { min, max } = opts.chart.selection.xaxis;
+      // Selection max should be the last data point
+      expect(max).toBe(lastTimestamp);
+      // Selection min should be ~90 days before the last data point
+      // (may be clamped to first data point if data < 90 days)
+      const firstTimestamp = new Date(labels[0]).getTime();
+      expect(min).toBe(Math.max(firstTimestamp, expectedMin));
+    });
+  });
+
+  test('infinity series data uses [timestamp, value] pairs', async () => {
+    initCharts({});
+    await flushPromises();
+    MockApexCharts.mockClear();
+
+    document.getElementById('infinity-button').click();
+    await flushPromises();
+
+    const mainCalls = MockApexCharts.mock.calls.filter(
+      ([, opts]) => opts.chart.id && opts.chart.id.startsWith('main-'),
+    );
+
+    mainCalls.forEach(([, opts]) => {
+      opts.series.forEach((s) => {
+        s.data.forEach((point) => {
+          // Each data point should be a [timestamp, value] pair
+          expect(Array.isArray(point)).toBe(true);
+          expect(point.length).toBe(2);
+          expect(typeof point[0]).toBe('number'); // timestamp
+          expect(typeof point[1]).toBe('number'); // value
+        });
+      });
+    });
+  });
+
+  test('switching from infinity back to week cleans up brush charts', async () => {
+    initCharts({});
+    await flushPromises();
+
+    // Switch to infinity
+    document.getElementById('infinity-button').click();
+    await flushPromises();
+
+    // Brush divs should exist
+    expect(document.getElementById('brush-readers-chart')).not.toBeNull();
+
+    // Switch back to week
+    document.getElementById('week-button').click();
+    await flushPromises();
+
+    // Brush divs should be removed
+    expect(document.getElementById('brush-readers-chart')).toBeNull();
+    expect(document.getElementById('brush-reactions-chart')).toBeNull();
+    expect(document.getElementById('brush-comments-chart')).toBeNull();
+    expect(document.getElementById('brush-followers-chart')).toBeNull();
+  });
+});

--- a/app/javascript/analytics/client.js
+++ b/app/javascript/analytics/client.js
@@ -58,3 +58,14 @@ export function callTopContributorsAPI(
     { organizationId, articleId },
   );
 }
+
+export function callFollowerEngagementAPI(
+  date,
+  { organizationId },
+) {
+  return callAnalyticsAPI(
+    '/api/analytics/follower_engagement',
+    date,
+    { organizationId },
+  );
+}

--- a/app/javascript/analytics/client.js
+++ b/app/javascript/analytics/client.js
@@ -47,3 +47,14 @@ export function callTotalsAPI(
     { organizationId, articleId },
   );
 }
+
+export function callTopContributorsAPI(
+  date,
+  { organizationId, articleId },
+) {
+  return callAnalyticsAPI(
+    '/api/analytics/top_contributors',
+    date,
+    { organizationId, articleId },
+  );
+}

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -473,29 +473,84 @@ function renderTopContributors(data) {
   const container = document.getElementById('top-contributors-container');
   if (!container) return;
 
+  container.innerHTML = '';
+
   if (!data || data.length === 0) {
-    container.innerHTML = `<p class="color-base-60 fs-s p-4">${locale('core.top_contributors_empty')}</p>`;
+    const emptyMsg = document.createElement('p');
+    emptyMsg.className = 'color-base-60 fs-s p-4';
+    emptyMsg.textContent = locale('core.top_contributors_empty');
+    container.appendChild(emptyMsg);
     return;
   }
 
-  const rows = data.map((contributor, index) => {
-    return `
-      <div class="flex items-center gap-3 py-3 ${index > 0 ? 'border-t-1 border-base-10' : ''}">
-        <span class="color-base-50 fs-s fw-bold" style="min-width:1.75rem;text-align:right">${index + 1}</span>
-        <img class="crayons-avatar crayons-avatar--l" src="${contributor.profile_image}" alt="${contributor.username}" width="40" height="40" loading="lazy" />
-        <div class="flex-1 min-w-0">
-          <a href="/${contributor.username}" class="fw-bold fs-base block truncate color-base-90">${contributor.name || contributor.username}</a>
-          <div class="flex items-center gap-3 mt-1">
-            ${contributor.reactions_count > 0 ? `<span class="fs-s color-base-70"><span style="color:#4bc0c0">&#x2764;&#xFE0F;</span> <strong>${contributor.reactions_count}</strong> ${locale('core.top_contributors_reactions')}</span>` : ''}
-            ${contributor.comments_count > 0 ? `<span class="fs-s color-base-70"><span style="color:#9d39e9">&#x1F4AC;</span> <strong>${contributor.comments_count}</strong> ${locale('core.top_contributors_comments')}</span>` : ''}
-          </div>
-        </div>
-      </div>`;
-  }).join('');
+  const note = document.createElement('p');
+  note.className = 'fs-xs color-base-50 mt-0 mb-3';
+  note.style.fontStyle = 'italic';
+  note.textContent = locale('core.top_contributors_weight_note');
+  container.appendChild(note);
 
-  container.innerHTML = `
-    <p class="fs-xs color-base-50 mt-0 mb-3" style="font-style:italic">${locale('core.top_contributors_weight_note')}</p>
-    ${rows}`;
+  data.forEach((contributor, index) => {
+    const row = document.createElement('div');
+    row.className = `flex items-center gap-3 py-3${index > 0 ? ' border-t-1 border-base-10' : ''}`;
+
+    const rank = document.createElement('span');
+    rank.className = 'color-base-50 fs-s fw-bold';
+    rank.style.minWidth = '1.75rem';
+    rank.style.textAlign = 'right';
+    rank.textContent = index + 1;
+    row.appendChild(rank);
+
+    const avatar = document.createElement('img');
+    avatar.className = 'crayons-avatar crayons-avatar--l';
+    avatar.src = contributor.profile_image;
+    avatar.alt = contributor.username;
+    avatar.width = 40;
+    avatar.height = 40;
+    avatar.loading = 'lazy';
+    row.appendChild(avatar);
+
+    const info = document.createElement('div');
+    info.className = 'flex-1 min-w-0';
+
+    const nameLink = document.createElement('a');
+    nameLink.href = `/${contributor.username}`;
+    nameLink.className = 'fw-bold fs-base block truncate color-base-90';
+    nameLink.textContent = contributor.name || contributor.username;
+    info.appendChild(nameLink);
+
+    const counts = document.createElement('div');
+    counts.className = 'flex items-center gap-3 mt-1';
+
+    if (contributor.reactions_count > 0) {
+      const rSpan = document.createElement('span');
+      rSpan.className = 'fs-s color-base-70';
+      const rIcon = document.createElement('span');
+      rIcon.style.color = '#4bc0c0';
+      rIcon.textContent = '\u2764\uFE0F';
+      const rStrong = document.createElement('strong');
+      rStrong.textContent = contributor.reactions_count;
+      rSpan.appendChild(rIcon);
+      rSpan.append(' ', rStrong, ' ', locale('core.top_contributors_reactions'));
+      counts.appendChild(rSpan);
+    }
+
+    if (contributor.comments_count > 0) {
+      const cSpan = document.createElement('span');
+      cSpan.className = 'fs-s color-base-70';
+      const cIcon = document.createElement('span');
+      cIcon.style.color = '#9d39e9';
+      cIcon.textContent = '\uD83D\uDCAC';
+      const cStrong = document.createElement('strong');
+      cStrong.textContent = contributor.comments_count;
+      cSpan.appendChild(cIcon);
+      cSpan.append(' ', cStrong, ' ', locale('core.top_contributors_comments'));
+      counts.appendChild(cSpan);
+    }
+
+    info.appendChild(counts);
+    row.appendChild(info);
+    container.appendChild(row);
+  });
 }
 
 function showLoadingPlaceholders() {

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -1,4 +1,4 @@
-import { callHistoricalAPI, callReferrersAPI, callTotalsAPI } from './client';
+import { callHistoricalAPI, callReferrersAPI, callTotalsAPI, callTopContributorsAPI } from './client';
 import { locale } from '@utilities/locale';
 
 // Window-level state survives esbuild IIFE re-execution during InstantClick
@@ -469,6 +469,35 @@ function renderReferrers(data) {
   drawReferrerChart(data);
 }
 
+function renderTopContributors(data) {
+  const container = document.getElementById('top-contributors-container');
+  if (!container) return;
+
+  if (!data || data.length === 0) {
+    container.innerHTML = `<p class="color-base-60 fs-s p-4">${locale('core.top_contributors_empty')}</p>`;
+    return;
+  }
+
+  const rows = data.map((contributor, index) => {
+    return `
+      <div class="flex items-center gap-3 py-3 ${index > 0 ? 'border-t-1 border-base-10' : ''}">
+        <span class="color-base-50 fs-s fw-bold" style="min-width:1.75rem;text-align:right">${index + 1}</span>
+        <img class="crayons-avatar crayons-avatar--l" src="${contributor.profile_image}" alt="${contributor.username}" width="40" height="40" loading="lazy" />
+        <div class="flex-1 min-w-0">
+          <a href="/${contributor.username}" class="fw-bold fs-base block truncate color-base-90">${contributor.name || contributor.username}</a>
+          <div class="flex items-center gap-3 mt-1">
+            ${contributor.reactions_count > 0 ? `<span class="fs-s color-base-70"><span style="color:#4bc0c0">&#x2764;&#xFE0F;</span> <strong>${contributor.reactions_count}</strong> ${locale('core.top_contributors_reactions')}</span>` : ''}
+            ${contributor.comments_count > 0 ? `<span class="fs-s color-base-70"><span style="color:#9d39e9">&#x1F4AC;</span> <strong>${contributor.comments_count}</strong> ${locale('core.top_contributors_comments')}</span>` : ''}
+          </div>
+        </div>
+      </div>`;
+  }).join('');
+
+  container.innerHTML = `
+    <p class="fs-xs color-base-50 mt-0 mb-3" style="font-style:italic">${locale('core.top_contributors_weight_note')}</p>
+    ${rows}`;
+}
+
 function showLoadingPlaceholders() {
   const cardIds = ['readers-card', 'reactions-card', 'comments-card', 'bookmarks-card', 'followers-card'];
   cardIds.forEach((id) => {
@@ -558,6 +587,20 @@ function callAnalyticsAPI(date, timeRangeLabel, { organizationId, articleId }) {
       if (generation !== _state.apiGeneration) return;
       showErrorsOnReferrers();
     });
+
+  // Top contributors panel (user/org dashboard only — container may not exist for articles)
+  if (document.getElementById('top-contributors-container')) {
+    callTopContributorsAPI(date, { organizationId, articleId })
+      .then((data) => {
+        if (generation !== _state.apiGeneration) return;
+        renderTopContributors(data);
+      })
+      .catch((_err) => {
+        if (generation !== _state.apiGeneration) return;
+        const el = document.getElementById('top-contributors-container');
+        if (el) el.innerHTML = '';
+      });
+  }
 }
 
 function drawWeekCharts({ organizationId, articleId }) {

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -11,6 +11,10 @@ if (!window._analyticsState) {
 const activeCharts = window._analyticsState.activeCharts;
 const _state = window._analyticsState;
 
+function isDarkMode() {
+  return document.body.classList.contains('dark-theme');
+}
+
 function resetActive(activeButton) {
   const buttons = document.querySelectorAll(
     '.crayons-tabs--analytics .crayons-tabs__item',
@@ -158,12 +162,15 @@ function drawChart({ id, chartType = 'line', showPoints = true, labels, series, 
     legend: {
       position: 'top',
     },
+    theme: {
+      mode: isDarkMode() ? 'dark' : 'light',
+    },
     tooltip: {
       shared: true,
       intersect: false,
     },
     grid: {
-      borderColor: '#e7e7e7',
+      borderColor: isDarkMode() ? '#333' : '#e7e7e7',
     },
   };
 
@@ -236,8 +243,11 @@ function drawChart({ id, chartType = 'line', showPoints = true, labels, series, 
         stroke: { width: 1, curve: 'smooth' },
         legend: { show: false },
         dataLabels: { enabled: false },
+        theme: {
+          mode: isDarkMode() ? 'dark' : 'light',
+        },
         grid: {
-          borderColor: '#e7e7e7',
+          borderColor: isDarkMode() ? '#333' : '#e7e7e7',
           padding: { left: 10, right: 10 },
         },
       };
@@ -401,6 +411,9 @@ function drawReferrerChart(data) {
         easing: 'easeinout',
         speed: 400,
       },
+    },
+    theme: {
+      mode: isDarkMode() ? 'dark' : 'light',
     },
     series,
     labels,

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -1,4 +1,4 @@
-import { callHistoricalAPI, callReferrersAPI, callTotalsAPI, callTopContributorsAPI } from './client';
+import { callHistoricalAPI, callReferrersAPI, callTotalsAPI, callTopContributorsAPI, callFollowerEngagementAPI } from './client';
 import { locale } from '@utilities/locale';
 
 // Window-level state survives esbuild IIFE re-execution during InstantClick
@@ -86,7 +86,9 @@ function writeCards(data, timeRangeLabel, totals) {
   commentCard.innerHTML = cardHTML(comments, `${locale('core.dashboard_analytics_comments')} ${timeRangeLabel}`);
   bookmarkCard.innerHTML = cardHTML(bookmarks, `${locale('core.dashboard_analytics_bookmarks')} ${timeRangeLabel}`);
   if (followersCard) {
+    const engagementEl = followersCard.querySelector('.follower-engagement');
     followersCard.innerHTML = cardHTML(sumAnalytics(data, 'follows'), `${locale('core.dashboard_analytics_followers')} ${timeRangeLabel}`);
+    if (engagementEl) followersCard.appendChild(engagementEl);
   }
 }
 
@@ -566,6 +568,24 @@ function renderTopContributors(data) {
   });
 }
 
+function renderFollowerEngagement(data) {
+  const card = document.getElementById('followers-card');
+  if (!card) return;
+
+  // Remove any previous engagement line
+  const existing = card.querySelector('.follower-engagement');
+  if (existing) existing.remove();
+
+  if (!data || data.total_followers === 0) return;
+
+  const p = document.createElement('p');
+  p.className = 'follower-engagement color-base-60 fs-s';
+  p.appendChild(document.createTextNode(locale('core.follower_engagement_ratio', { ratio: data.ratio })));
+  p.appendChild(document.createElement('br'));
+  p.appendChild(document.createTextNode(locale('core.follower_engagement_detail', { engaged: data.engaged_followers, total: data.total_followers })));
+  card.appendChild(p);
+}
+
 function showLoadingPlaceholders() {
   const cardIds = ['readers-card', 'reactions-card', 'comments-card', 'bookmarks-card', 'followers-card'];
   cardIds.forEach((id) => {
@@ -668,6 +688,16 @@ function callAnalyticsAPI(date, timeRangeLabel, { organizationId, articleId }) {
         const el = document.getElementById('top-contributors-container');
         if (el) el.innerHTML = '';
       });
+  }
+
+  // Follower engagement ratio (user/org dashboard only)
+  if (document.getElementById('followers-card')) {
+    callFollowerEngagementAPI(date, { organizationId })
+      .then((data) => {
+        if (generation !== _state.apiGeneration) return;
+        renderFollowerEngagement(data);
+      })
+      .catch(() => {});
   }
 }
 

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -1,7 +1,15 @@
 import { callHistoricalAPI, callReferrersAPI, callTotalsAPI } from './client';
 import { locale } from '@utilities/locale';
 
-const activeCharts = {};
+// Window-level state survives esbuild IIFE re-execution during InstantClick
+// navigation. Without this, each script re-execution creates a new closure scope
+// with empty charts/counter, and the on('change') handler (bound to the first
+// scope) can't reach later scopes' charts — breaking brush/zoom bindings.
+if (!window._analyticsState) {
+  window._analyticsState = { activeCharts: {}, apiGeneration: 0 };
+}
+const activeCharts = window._analyticsState.activeCharts;
+const _state = window._analyticsState;
 
 function resetActive(activeButton) {
   const buttons = document.querySelectorAll(
@@ -85,10 +93,20 @@ function drawChart({ id, chartType = 'line', showPoints = true, labels, series, 
   // Convert labels to timestamps for infinity mode (enables datetime x-axis + brush)
   const timestamps = isInfinity ? labels.map((l) => new Date(l).getTime()) : null;
 
+  // Calculate 90-day selection window for infinity mode (used by both main chart and brush)
+  let selMin, selMax;
+  if (isInfinity && timestamps && timestamps.length > 0) {
+    const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+    selMin = Math.max(timestamps[0], timestamps[timestamps.length - 1] - ninetyDaysMs);
+    selMax = timestamps[timestamps.length - 1];
+  }
+
   // X-axis: datetime for infinity (brush support), categories for week/month
   const xaxisConfig = isInfinity
     ? {
         type: 'datetime',
+        min: selMin,
+        max: selMax,
         labels: { datetimeUTC: false, style: { fontSize: '11px' } },
       }
     : {
@@ -158,10 +176,7 @@ function drawChart({ id, chartType = 'line', showPoints = true, labels, series, 
   }
 
   import('apexcharts').then(({ default: ApexCharts }) => {
-    // Destroy existing charts (main + brush)
-    if (activeCharts[id]) {
-      activeCharts[id].destroy();
-    }
+    // Destroy existing charts (brush first, then main — order matters for ApexCharts registry)
     if (activeCharts[brushId]) {
       activeCharts[brushId].destroy();
       delete activeCharts[brushId];
@@ -169,22 +184,24 @@ function drawChart({ id, chartType = 'line', showPoints = true, labels, series, 
     const existingBrushEl = document.getElementById(brushId);
     if (existingBrushEl) existingBrushEl.remove();
 
+    if (activeCharts[id]) {
+      activeCharts[id].destroy();
+      delete activeCharts[id];
+    }
+
     const el = document.getElementById(id);
     if (!el) return;
     el.innerHTML = '';
     const chart = new ApexCharts(el, options);
-    chart.render();
     activeCharts[id] = chart;
 
-    // Render brush navigator for infinity mode
-    if (isInfinity && timestamps.length > 0) {
+    // Render main chart, then brush — brush must bind after main is in the registry
+    chart.render().then(() => {
+      if (!isInfinity || !timestamps || timestamps.length === 0) return;
+
       const brushEl = document.createElement('div');
       brushEl.id = brushId;
       el.parentNode.insertBefore(brushEl, el.nextSibling);
-
-      const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
-      const selMin = Math.max(timestamps[0], timestamps[timestamps.length - 1] - ninetyDaysMs);
-      const selMax = timestamps[timestamps.length - 1];
 
       const brushOptions = {
         chart: {
@@ -228,7 +245,7 @@ function drawChart({ id, chartType = 'line', showPoints = true, labels, series, 
       const brushChart = new ApexCharts(brushEl, brushOptions);
       brushChart.render();
       activeCharts[brushId] = brushChart;
-    }
+    });
   });
 }
 
@@ -452,6 +469,24 @@ function renderReferrers(data) {
   drawReferrerChart(data);
 }
 
+function showLoadingPlaceholders() {
+  const cardIds = ['readers-card', 'reactions-card', 'comments-card', 'bookmarks-card', 'followers-card'];
+  cardIds.forEach((id) => {
+    const el = document.getElementById(id);
+    if (el && !el.querySelector('.analytics-loading')) {
+      el.innerHTML = '<div class="analytics-loading crayons-scaffold-loading w-75 h-0 py-4 mx-auto my-3"></div>';
+    }
+  });
+
+  const chartIds = ['readers-chart', 'reactions-chart', 'comments-chart', 'followers-chart', 'referrers-chart'];
+  chartIds.forEach((id) => {
+    const el = document.getElementById(id);
+    if (el && !el.querySelector('.analytics-loading')) {
+      el.innerHTML = '<div class="analytics-loading crayons-scaffold-loading w-100 mx-auto" style="height:200px"></div>';
+    }
+  });
+}
+
 function removeCardElements() {
   const el = document.getElementsByClassName('summary-stats')[0];
   el && el.remove();
@@ -474,24 +509,55 @@ function showErrorsOnReferrers() {
 }
 
 function callAnalyticsAPI(date, timeRangeLabel, { organizationId, articleId }) {
-  Promise.all([
-    callHistoricalAPI(date, { organizationId, articleId }),
-    callTotalsAPI(date, { organizationId, articleId }),
-  ])
-    .then(([data, totals]) => {
-      writeCards(data, timeRangeLabel, totals);
+  const generation = ++_state.apiGeneration;
+
+  // Destroy existing charts before showing placeholders to clean ApexCharts registry
+  Object.keys(activeCharts).forEach((key) => {
+    activeCharts[key].destroy();
+    delete activeCharts[key];
+  });
+  document.querySelectorAll('[id^="brush-"]').forEach((el) => el.remove());
+
+  showLoadingPlaceholders();
+
+  // Single historical fetch, shared by charts and cards
+  const historicalPromise = callHistoricalAPI(date, { organizationId, articleId });
+
+  // Historical data → draw charts as soon as available
+  historicalPromise
+    .then((data) => {
+      if (generation !== _state.apiGeneration) return;
+      writeCards(data, timeRangeLabel, null);
       drawCharts(data, timeRangeLabel);
     })
     .catch((_err) => {
-      removeCardElements();
+      if (generation !== _state.apiGeneration) return;
       showErrorsOnCharts();
+    });
+
+  // Totals → update cards with extra info (avg read time, unique reactors)
+  callTotalsAPI(date, { organizationId, articleId })
+    .then((totals) => {
+      if (generation !== _state.apiGeneration) return;
+      // Re-render cards once totals arrive (historical likely already resolved)
+      historicalPromise.then((data) => {
+        if (generation !== _state.apiGeneration) return;
+        writeCards(data, timeRangeLabel, totals);
+      });
+    })
+    .catch((_err) => {
+      // Cards already rendered from historical; totals failure is non-critical
     });
 
   callReferrersAPI(date, { organizationId, articleId })
     .then((data) => {
+      if (generation !== _state.apiGeneration) return;
       renderReferrers(data);
     })
-    .catch((_err) => showErrorsOnReferrers());
+    .catch((_err) => {
+      if (generation !== _state.apiGeneration) return;
+      showErrorsOnReferrers();
+    });
 }
 
 function drawWeekCharts({ organizationId, articleId }) {
@@ -515,21 +581,44 @@ function drawInfinityCharts({ organizationId, articleId }) {
   callAnalyticsAPI(beginningOfTime, '', { organizationId, articleId });
 }
 
+export function destroyCharts() {
+  // Invalidate any in-flight API responses
+  _state.apiGeneration++;
+  Object.keys(activeCharts).forEach((key) => {
+    activeCharts[key].destroy();
+    delete activeCharts[key];
+  });
+  // Remove dynamically created brush elements
+  document.querySelectorAll('[id^="brush-"]').forEach((el) => el.remove());
+}
+
 export function initCharts({ organizationId, articleId }) {
+  // Destroy any leftover charts from previous navigation
+  destroyCharts();
+
   const weekButton = document.getElementById('week-button');
-  weekButton.addEventListener(
+  const monthButton = document.getElementById('month-button');
+  const infinityButton = document.getElementById('infinity-button');
+
+  // Replace elements to remove all old event listeners cleanly
+  const newWeek = weekButton.cloneNode(true);
+  const newMonth = monthButton.cloneNode(true);
+  const newInfinity = infinityButton.cloneNode(true);
+  weekButton.replaceWith(newWeek);
+  monthButton.replaceWith(newMonth);
+  infinityButton.replaceWith(newInfinity);
+
+  newWeek.addEventListener(
     'click',
     drawWeekCharts.bind(null, { organizationId, articleId }),
   );
 
-  const monthButton = document.getElementById('month-button');
-  monthButton.addEventListener(
+  newMonth.addEventListener(
     'click',
     drawMonthCharts.bind(null, { organizationId, articleId }),
   );
 
-  const infinityButton = document.getElementById('infinity-button');
-  infinityButton.addEventListener(
+  newInfinity.addEventListener(
     'click',
     drawInfinityCharts.bind(null, { organizationId, articleId }),
   );

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -263,6 +263,17 @@ function drawChart({ id, chartType = 'line', showPoints = true, labels, series, 
 
 function drawCharts(data, timeRangeLabel) {
   const labels = Object.keys(data);
+
+  if (labels.length === 0) {
+    ['reactions-chart', 'comments-chart', 'readers-chart', 'followers-chart'].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) {
+        el.innerHTML = `<p class="color-base-60 fs-s m-5 text-center">${locale('core.dashboard_analytics_no_data')}</p>`;
+      }
+    });
+    return;
+  }
+
   const parsedData = Object.entries(data).map((date) => date[1]);
   const comments = parsedData.map((date) => date.comments.total);
   const reactions = parsedData.map((date) => date.reactions.total);
@@ -456,6 +467,14 @@ function drawReferrerChart(data) {
 
 function renderReferrers(data) {
   const container = document.getElementById('referrers-container');
+
+  if (!data.domains || data.domains.length === 0) {
+    container.innerHTML = `<tr><td colspan="2" class="color-base-60 fs-s p-4 text-center">${locale('core.dashboard_analytics_no_referrers')}</td></tr>`;
+    const chartEl = document.getElementById('referrers-chart');
+    if (chartEl) chartEl.innerHTML = '';
+    return;
+  }
+
   const tableBody = data.domains
     .filter((referrer) => referrer.domain)
     .map((referrer) => {

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -78,31 +78,51 @@ function writeCards(data, timeRangeLabel, totals) {
   }
 }
 
-function drawChart({ id, chartType = 'line', showPoints = true, labels, series, colors, strokeDashArray, fillOptions, dataLabels, yaxis }) {
+function drawChart({ id, chartType = 'line', showPoints = true, labels, series, colors, strokeDashArray, fillOptions, dataLabels, yaxis, isInfinity = false }) {
+  const brushId = `brush-${id}`;
+  const mainChartId = `main-${id}`;
+
+  // Convert labels to timestamps for infinity mode (enables datetime x-axis + brush)
+  const timestamps = isInfinity ? labels.map((l) => new Date(l).getTime()) : null;
+
+  // X-axis: datetime for infinity (brush support), categories for week/month
+  const xaxisConfig = isInfinity
+    ? {
+        type: 'datetime',
+        labels: { datetimeUTC: false, style: { fontSize: '11px' } },
+      }
+    : {
+        categories: labels,
+        labels: {
+          rotate: -45,
+          rotateAlways: false,
+          hideOverlappingLabels: true,
+          style: { fontSize: '11px' },
+        },
+        tickAmount: Math.min(labels.length, 14),
+      };
+
+  // For infinity, pair values with timestamps: [[ts, val], ...]
+  const chartSeries = isInfinity
+    ? series.map((s) => ({ ...s, data: s.data.map((val, i) => [timestamps[i], val]) }))
+    : series;
+
   const options = {
     chart: {
+      ...(isInfinity ? { id: mainChartId } : {}),
       type: chartType,
       height: 320,
-      toolbar: { show: false },
-      zoom: { enabled: false },
+      toolbar: { show: isInfinity, autoSelected: 'zoom' },
+      zoom: { enabled: isInfinity },
       animations: {
         enabled: true,
         easing: 'easeinout',
         speed: 400,
       },
     },
-    series,
+    series: chartSeries,
     colors,
-    xaxis: {
-      categories: labels,
-      labels: {
-        rotate: -45,
-        rotateAlways: false,
-        hideOverlappingLabels: true,
-        style: { fontSize: '11px' },
-      },
-      tickAmount: Math.min(labels.length, 14),
-    },
+    xaxis: xaxisConfig,
     yaxis: yaxis || {
       min: 0,
       labels: {
@@ -138,10 +158,16 @@ function drawChart({ id, chartType = 'line', showPoints = true, labels, series, 
   }
 
   import('apexcharts').then(({ default: ApexCharts }) => {
-    const currentChart = activeCharts[id];
-    if (currentChart) {
-      currentChart.destroy();
+    // Destroy existing charts (main + brush)
+    if (activeCharts[id]) {
+      activeCharts[id].destroy();
     }
+    if (activeCharts[brushId]) {
+      activeCharts[brushId].destroy();
+      delete activeCharts[brushId];
+    }
+    const existingBrushEl = document.getElementById(brushId);
+    if (existingBrushEl) existingBrushEl.remove();
 
     const el = document.getElementById(id);
     if (!el) return;
@@ -149,6 +175,60 @@ function drawChart({ id, chartType = 'line', showPoints = true, labels, series, 
     const chart = new ApexCharts(el, options);
     chart.render();
     activeCharts[id] = chart;
+
+    // Render brush navigator for infinity mode
+    if (isInfinity && timestamps.length > 0) {
+      const brushEl = document.createElement('div');
+      brushEl.id = brushId;
+      el.parentNode.insertBefore(brushEl, el.nextSibling);
+
+      const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+      const selMin = Math.max(timestamps[0], timestamps[timestamps.length - 1] - ninetyDaysMs);
+      const selMax = timestamps[timestamps.length - 1];
+
+      const brushOptions = {
+        chart: {
+          type: 'area',
+          height: 100,
+          brush: {
+            target: mainChartId,
+            enabled: true,
+          },
+          selection: {
+            enabled: true,
+            xaxis: { min: selMin, max: selMax },
+          },
+          toolbar: { show: false },
+          animations: { enabled: false },
+        },
+        series: [{ name: chartSeries[0].name, data: chartSeries[0].data }],
+        colors: [colors[0]],
+        xaxis: {
+          type: 'datetime',
+          labels: { datetimeUTC: false, style: { fontSize: '10px' } },
+          axisBorder: { show: false },
+        },
+        yaxis: {
+          min: 0,
+          labels: { show: false },
+        },
+        fill: {
+          type: 'gradient',
+          gradient: { opacityFrom: 0.3, opacityTo: 0.05 },
+        },
+        stroke: { width: 1, curve: 'smooth' },
+        legend: { show: false },
+        dataLabels: { enabled: false },
+        grid: {
+          borderColor: '#e7e7e7',
+          padding: { left: 10, right: 10 },
+        },
+      };
+
+      const brushChart = new ApexCharts(brushEl, brushOptions);
+      brushChart.render();
+      activeCharts[brushId] = brushChart;
+    }
   });
 }
 
@@ -174,13 +254,16 @@ function drawCharts(data, timeRangeLabel) {
     return acc;
   }, []);
 
+  // Infinity mode: brush navigator + datetime x-axis
+  const isInfinity = timeRangeLabel === '';
   // When timeRange is "Infinity" we hide the points to avoid over-crowding the UI
-  const showPoints = timeRangeLabel !== '';
+  const showPoints = !isInfinity;
 
   drawChart({
     id: 'reactions-chart',
     showPoints,
     labels,
+    isInfinity,
     colors: ['#4bc0c0', '#e56464', '#9d39e9', '#f59e0b', '#10b981', '#ef4444', '#0a85ff'],
     // dashArray: 0 = solid for first 6 series, 5 = dashed for Bookmarks (last)
     strokeDashArray: [0, 0, 0, 0, 0, 0, 5],
@@ -199,6 +282,7 @@ function drawCharts(data, timeRangeLabel) {
     id: 'comments-chart',
     showPoints,
     labels,
+    isInfinity,
     colors: ['#4bc0c0'],
     series: [{ name: 'Comments', data: comments }],
   });
@@ -207,6 +291,7 @@ function drawCharts(data, timeRangeLabel) {
     id: 'readers-chart',
     showPoints,
     labels,
+    isInfinity,
     colors: ['#9d39e9', '#10b981'],
     strokeDashArray: [0, 4],
     series: [
@@ -233,6 +318,7 @@ function drawCharts(data, timeRangeLabel) {
     chartType: 'area',
     showPoints: false,
     labels,
+    isInfinity,
     colors: ['#f59e0b'],
     series: [{ name: 'Total Followers', data: cumulativeFollowers }],
     fillOptions: {

--- a/app/javascript/packs/analyticsDashboard.js
+++ b/app/javascript/packs/analyticsDashboard.js
@@ -1,4 +1,4 @@
-import { initCharts } from '../analytics/dashboard';
+import { initCharts, destroyCharts } from '../analytics/dashboard';
 
 function renderOrgData() {
   const organizationsArray = Array.from(
@@ -15,6 +15,9 @@ function renderOrgData() {
 }
 
 function initDashboard() {
+  // Guard: only run on analytics pages (script re-executes on every InstantClick navigation)
+  if (!document.getElementById('week-button')) return;
+
   const organizationsMenu = document.getElementsByClassName('organization')[0];
 
   if (!organizationsMenu) {
@@ -22,6 +25,16 @@ function initDashboard() {
   } else {
     renderOrgData();
   }
+}
+
+// Register InstantClick cleanup ONCE — prevents stale ApexCharts global registry entries
+// after DOM swap. The on('change') handler runs while old DOM is still intact, ensuring
+// .destroy() properly deregisters charts. Script re-execution handles re-init via initDashboard().
+if (window.InstantClick && !window._analyticsChangeRegistered) {
+  window._analyticsChangeRegistered = true;
+  window.InstantClick.on('change', () => {
+    destroyCharts();
+  });
 }
 
 initDashboard();

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -68,6 +68,71 @@ class AnalyticsService
     { domains: domains }
   end
 
+  # Returns top contributors who engaged with the user/org's articles
+  # via reactions (excl. bookmarks) and comments, excluding self-interactions.
+  # Comments are weighted 3x, reactions 1x.
+  def top_contributors(limit: 20)
+    article_ids = article_data.ids
+    return [] if article_ids.empty?
+
+    # Determine author IDs to exclude self-interactions
+    author_ids = article_data.distinct.pluck(:user_id)
+
+    # Reactions (excl readinglist/self) → weight 1
+    reactions_sql = Reaction.for_analytics
+      .where(reactable_id: article_ids, reactable_type: "Article")
+      .where.not(category: "readinglist")
+      .where.not(user_id: author_ids)
+    reactions_sql = reactions_sql.where(created_at: start_date..end_date) if start_date && end_date
+    reactions_query = reactions_sql
+      .select("user_id, COUNT(*) AS reactions_count, 0 AS comments_count, COUNT(*) AS score")
+      .group(:user_id)
+
+    # Comments (excl self, score > 0) → weight 6
+    # Comments carry more weight than reactions because they require
+    # significantly more effort and drive meaningful discussion.
+    comments_sql = Comment
+      .where(commentable_id: article_ids, commentable_type: "Article")
+      .where("score > 0")
+      .where.not(user_id: author_ids)
+    comments_sql = comments_sql.where(created_at: start_date..end_date) if start_date && end_date
+    comments_query = comments_sql
+      .select("user_id, 0 AS reactions_count, COUNT(*) AS comments_count, COUNT(*) * 6 AS score")
+      .group(:user_id)
+
+    # UNION and aggregate
+    union_sql = "(" \
+      "#{reactions_query.to_sql}" \
+      " UNION ALL " \
+      "#{comments_query.to_sql}" \
+    ")"
+
+    rows = ActiveRecord::Base.connection.select_all(
+      "SELECT user_id, SUM(reactions_count)::int AS reactions_count, " \
+      "SUM(comments_count)::int AS comments_count, SUM(score)::int AS score " \
+      "FROM #{union_sql} AS combined " \
+      "GROUP BY user_id ORDER BY score DESC, user_id ASC LIMIT #{limit.to_i}",
+    )
+
+    user_ids = rows.map { |r| r["user_id"] }
+    users_by_id = User.where(id: user_ids).index_by(&:id)
+
+    rows.filter_map do |row|
+      user = users_by_id[row["user_id"]]
+      next unless user
+
+      {
+        user_id: user.id,
+        username: user.username,
+        name: user.name,
+        profile_image: user.profile_image_90,
+        reactions_count: row["reactions_count"],
+        comments_count: row["comments_count"],
+        score: row["score"]
+      }
+    end
+  end
+
   private
 
   attr_reader(

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -135,6 +135,47 @@ class AnalyticsService
     end
   end
 
+  # Returns what percentage of followers engaged (reacted or commented)
+  # with the user/org's articles in the given period.
+  def follower_engagement
+    follower_scope = Follow
+      .where(followable_type: user_or_org.class.name, followable_id: user_or_org.id)
+      .where(blocked: false)
+
+    total_followers = follower_scope.count
+    return { total_followers: 0, engaged_followers: 0, ratio: 0.0 } if total_followers.zero?
+    return { total_followers: total_followers, engaged_followers: 0, ratio: 0.0 } unless article_data.exists?
+
+    follower_ids_subquery = follower_scope.select(:follower_id)
+    article_ids_subquery = article_data.select(:id)
+
+    # Followers who reacted (excl readinglist)
+    reacting_scope = Reaction.for_analytics
+      .where(reactable_id: article_ids_subquery, reactable_type: "Article")
+      .where.not(category: "readinglist")
+      .where(user_id: follower_ids_subquery)
+    reacting_scope = reacting_scope.where(created_at: start_date..end_date) if start_date && end_date
+
+    # Followers who commented (score > 0)
+    commenting_scope = Comment
+      .where(commentable_id: article_ids_subquery, commentable_type: "Article")
+      .where("score > 0")
+      .where(user_id: follower_ids_subquery)
+    commenting_scope = commenting_scope.where(created_at: start_date..end_date) if start_date && end_date
+
+    engaged_count = ActiveRecord::Base.connection.select_value(
+      "SELECT COUNT(DISTINCT user_id) FROM (" \
+      "#{reacting_scope.select(:user_id).to_sql} UNION ALL #{commenting_scope.select(:user_id).to_sql}" \
+      ") AS engaged",
+    ).to_i
+
+    {
+      total_followers: total_followers,
+      engaged_followers: engaged_count,
+      ratio: (engaged_count.to_f / total_followers * 100).round(1)
+    }
+  end
+
   private
 
   attr_reader(

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -72,15 +72,17 @@ class AnalyticsService
   # via reactions (excl. bookmarks) and comments, excluding self-interactions.
   # Comments are weighted 6x, reactions 1x.
   def top_contributors(limit: 20)
-    article_ids = article_data.ids
-    return [] if article_ids.empty?
+    return [] unless article_data.exists?
+
+    # Use subqueries to avoid loading all IDs into memory for large datasets
+    article_ids_subquery = article_data.select(:id)
 
     # Determine author IDs to exclude self-interactions
     author_ids = article_data.distinct.pluck(:user_id)
 
     # Reactions (excl readinglist/self) → weight 1
     reactions_sql = Reaction.for_analytics
-      .where(reactable_id: article_ids, reactable_type: "Article")
+      .where(reactable_id: article_ids_subquery, reactable_type: "Article")
       .where.not(category: "readinglist")
       .where.not(user_id: author_ids)
     reactions_sql = reactions_sql.where(created_at: start_date..end_date) if start_date && end_date
@@ -92,7 +94,7 @@ class AnalyticsService
     # Comments carry more weight than reactions because they require
     # significantly more effort and drive meaningful discussion.
     comments_sql = Comment
-      .where(commentable_id: article_ids, commentable_type: "Article")
+      .where(commentable_id: article_ids_subquery, commentable_type: "Article")
       .where("score > 0")
       .where.not(user_id: author_ids)
     comments_sql = comments_sql.where(created_at: start_date..end_date) if start_date && end_date

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -70,7 +70,7 @@ class AnalyticsService
 
   # Returns top contributors who engaged with the user/org's articles
   # via reactions (excl. bookmarks) and comments, excluding self-interactions.
-  # Comments are weighted 3x, reactions 1x.
+  # Comments are weighted 6x, reactions 1x.
   def top_contributors(limit: 20)
     article_ids = article_data.ids
     return [] if article_ids.empty?

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -117,8 +117,8 @@
     </div>
   </div>
 <% else %>
-  <div class="graphs my-2">
-    <div class="graphs__col crayons-card mx-5">
+  <div class="grid xl:grid-cols-2 gap-4 mx-5">
+    <div class="crayons-card p-2 overflow-auto" style="max-height:600px">
       <h2 class="mt-5 mx-5"><%= t("views.stats.traffic.text") %></h2>
       <div id="referrers-chart"><div class="analytics-loading crayons-scaffold-loading w-100 mx-auto" style="height:150px"></div></div>
       <table class="w-100 m-auto crayons-table">
@@ -131,5 +131,13 @@
         <tbody id="referrers-container"></tbody>
       </table>
     </div>
+    <% unless @article %>
+      <div class="crayons-card p-4 overflow-auto" style="max-height:600px">
+        <h2 class="crayons-subtitle mb-2"><%= t("views.stats.top_contributors.heading") %></h2>
+        <div id="top-contributors-container">
+          <div class="analytics-loading crayons-scaffold-loading w-100 mx-auto" style="height:150px"></div>
+        </div>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -14,20 +14,20 @@
 
 <div class="summary-stats">
   <div class="summary-stats__col crayons-card mx-5">
-    <div id="readers-card" class="py-3"></div>
+    <div id="readers-card" class="py-3"><div class="analytics-loading crayons-scaffold-loading w-75 h-0 py-4 mx-auto my-3"></div></div>
   </div>
   <div class="summary-stats__col crayons-card mx-5">
-    <div id="reactions-card" class="py-3"></div>
+    <div id="reactions-card" class="py-3"><div class="analytics-loading crayons-scaffold-loading w-75 h-0 py-4 mx-auto my-3"></div></div>
   </div>
   <div class="summary-stats__col crayons-card mx-5">
-    <div id="comments-card" class="py-3"></div>
+    <div id="comments-card" class="py-3"><div class="analytics-loading crayons-scaffold-loading w-75 h-0 py-4 mx-auto my-3"></div></div>
   </div>
   <div class="summary-stats__col crayons-card mx-5">
-    <div id="bookmarks-card" class="py-3"></div>
+    <div id="bookmarks-card" class="py-3"><div class="analytics-loading crayons-scaffold-loading w-75 h-0 py-4 mx-auto my-3"></div></div>
   </div>
   <% unless @article %>
     <div class="summary-stats__col crayons-card mx-5">
-      <div id="followers-card" class="py-3"></div>
+      <div id="followers-card" class="py-3"><div class="analytics-loading crayons-scaffold-loading w-75 h-0 py-4 mx-auto my-3"></div></div>
     </div>
   <% end %>
 </div>
@@ -37,7 +37,7 @@
     <h2 class="mt-5 mx-5"><%= t("views.stats.readers") %></h2>
     <p class="mx-5 color-base-60 fs-xs"><em><%= t("views.stats.readers_description") %></em></p>
     <div class="charts-container">
-      <div id="readers-chart"></div>
+      <div id="readers-chart"><div class="analytics-loading crayons-scaffold-loading w-100 mx-auto" style="height:200px"></div></div>
     </div>
   </div>
 </div>
@@ -47,7 +47,7 @@
     <h2 class="mt-5 mx-5"><%= t("views.stats.reactions") %></h2>
     <p class="mx-5 color-base-60 fs-xs"><em>Bookmarks not included in Total</em></p>
     <div class="charts-container">
-      <div id="reactions-chart"></div>
+      <div id="reactions-chart"><div class="analytics-loading crayons-scaffold-loading w-100 mx-auto" style="height:200px"></div></div>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@
     <div class="graphs__col crayons-card mx-5">
       <h2 class="mt-5 mx-5"><%= t("views.stats.comments") %></h2>
       <div class="charts-container">
-        <div id="comments-chart"></div>
+        <div id="comments-chart"><div class="analytics-loading crayons-scaffold-loading w-100 mx-auto" style="height:200px"></div></div>
       </div>
     </div>
   </div>
@@ -66,13 +66,13 @@
     <div class="graphs__col crayons-card">
       <h2 class="mt-5 mx-5"><%= t("views.stats.comments") %></h2>
       <div class="charts-container">
-        <div id="comments-chart"></div>
+        <div id="comments-chart"><div class="analytics-loading crayons-scaffold-loading w-100 mx-auto" style="height:200px"></div></div>
       </div>
     </div>
     <div class="graphs__col crayons-card">
       <h2 class="mt-5 mx-5"><%= t("views.stats.followers") %></h2>
       <div class="charts-container">
-        <div id="followers-chart"></div>
+        <div id="followers-chart"><div class="analytics-loading crayons-scaffold-loading w-100 mx-auto" style="height:200px"></div></div>
       </div>
     </div>
   </div>
@@ -82,7 +82,7 @@
   <div class="grid xl:grid-cols-2 gap-4 mx-5">
     <div class="crayons-card p-2 overflow-auto" style="max-height:600px">
       <h2 class="mt-5 mx-5"><%= t("views.stats.traffic.text") %></h2>
-      <div id="referrers-chart"></div>
+      <div id="referrers-chart"><div class="analytics-loading crayons-scaffold-loading w-100 mx-auto" style="height:150px"></div></div>
       <table class="w-100 m-auto crayons-table">
         <thead>
           <tr>
@@ -120,7 +120,7 @@
   <div class="graphs my-2">
     <div class="graphs__col crayons-card mx-5">
       <h2 class="mt-5 mx-5"><%= t("views.stats.traffic.text") %></h2>
-      <div id="referrers-chart"></div>
+      <div id="referrers-chart"><div class="analytics-loading crayons-scaffold-loading w-100 mx-auto" style="height:150px"></div></div>
       <table class="w-100 m-auto crayons-table">
         <thead>
           <tr>

--- a/babel.config.js
+++ b/babel.config.js
@@ -37,6 +37,7 @@ module.exports = function (api) {
     plugins: [
       isEndToEnd && ['istanbul'],
       '@babel/plugin-syntax-dynamic-import',
+      isTestEnv && '@babel/plugin-transform-dynamic-import',
       isTestEnv && '@babel/plugin-transform-modules-commonjs',
       '@babel/plugin-transform-destructuring',
       [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,8 @@ en:
     top_contributors_reactions: reactions
     top_contributors_comments: comments
     top_contributors_weight_note: Comments carry more weight
+    follower_engagement_ratio: "%{ratio}% of followers engaged"
+    follower_engagement_detail: "(%{engaged} of %{total})"
     stats_by: by
     editor_new_title: New post title here...
     editor_body_placeholder: Write your post content here...

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,10 @@ en:
     dashboard_analytics_unique_reactors: from %{count} unique users
     dashboard_analytics_bookmarks: Bookmarks
     dashboard_analytics_followers: New Followers
+    top_contributors_empty: No engagers found for this period.
+    top_contributors_reactions: reactions
+    top_contributors_comments: comments
+    top_contributors_weight_note: Comments carry more weight
     stats_by: by
     editor_new_title: New post title here...
     editor_body_placeholder: Write your post content here...

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,8 @@ en:
     top_contributors_weight_note: Comments carry more weight
     follower_engagement_ratio: "%{ratio}% of followers engaged"
     follower_engagement_detail: "(%{engaged} of %{total})"
+    dashboard_analytics_no_data: No data available for this period
+    dashboard_analytics_no_referrers: No traffic sources yet
     stats_by: by
     editor_new_title: New post title here...
     editor_body_placeholder: Write your post content here...

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -51,6 +51,8 @@ fr:
     top_contributors_reactions: réactions
     top_contributors_comments: commentaires
     top_contributors_weight_note: Les commentaires ont plus de poids
+    follower_engagement_ratio: "%{ratio}% des abonnés engagés"
+    follower_engagement_detail: "(%{engaged} sur %{total})"
     stats_by: par
     editor_new_title: Nouveau titre d'article ici...
     editor_body_placeholder: Écrivez le contenu de votre article ici...

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -47,6 +47,10 @@ fr:
     dashboard_analytics_unique_reactors: de %{count} utilisateurs uniques
     dashboard_analytics_bookmarks: Favoris
     dashboard_analytics_followers: Nouveaux Abonnés
+    top_contributors_empty: Aucun contributeur trouvé pour cette période.
+    top_contributors_reactions: réactions
+    top_contributors_comments: commentaires
+    top_contributors_weight_note: Les commentaires ont plus de poids
     stats_by: par
     editor_new_title: Nouveau titre d'article ici...
     editor_body_placeholder: Écrivez le contenu de votre article ici...

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -53,6 +53,8 @@ fr:
     top_contributors_weight_note: Les commentaires ont plus de poids
     follower_engagement_ratio: "%{ratio}% des abonnés engagés"
     follower_engagement_detail: "(%{engaged} sur %{total})"
+    dashboard_analytics_no_data: Aucune donnée disponible pour cette période
+    dashboard_analytics_no_referrers: Pas encore de sources de trafic
     stats_by: par
     editor_new_title: Nouveau titre d'article ici...
     editor_body_placeholder: Écrivez le contenu de votre article ici...

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -53,6 +53,8 @@ pt:
     top_contributors_weight_note: Comentários têm mais peso
     follower_engagement_ratio: "%{ratio}% dos seguidores engajados"
     follower_engagement_detail: "(%{engaged} de %{total})"
+    dashboard_analytics_no_data: Nenhum dado disponível para este período
+    dashboard_analytics_no_referrers: Ainda sem fontes de tráfego
     stats_by: por
     editor_new_title: Novo título do post aqui...
     editor_body_placeholder: Escreva o conteúdo do seu post aqui...

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -47,6 +47,10 @@ pt:
     dashboard_analytics_unique_reactors: de %{count} usuários únicos
     dashboard_analytics_bookmarks: Favoritos
     dashboard_analytics_followers: Novos Seguidores
+    top_contributors_empty: Nenhum contribuidor encontrado para este período.
+    top_contributors_reactions: reações
+    top_contributors_comments: comentários
+    top_contributors_weight_note: Comentários têm mais peso
     stats_by: por
     editor_new_title: Novo título do post aqui...
     editor_body_placeholder: Escreva o conteúdo do seu post aqui...

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -51,6 +51,8 @@ pt:
     top_contributors_reactions: reações
     top_contributors_comments: comentários
     top_contributors_weight_note: Comentários têm mais peso
+    follower_engagement_ratio: "%{ratio}% dos seguidores engajados"
+    follower_engagement_detail: "(%{engaged} de %{total})"
     stats_by: por
     editor_new_title: Novo título do post aqui...
     editor_body_placeholder: Escreva o conteúdo do seu post aqui...

--- a/config/locales/views/misc/en.yml
+++ b/config/locales/views/misc/en.yml
@@ -112,6 +112,8 @@ en:
         views: Views
       reactions_history: "Reactions History"
       by: by
+      top_contributors:
+        heading: Top Engagers
     sticky:
       joined: Joined
       default_cta: Learn more

--- a/config/locales/views/misc/fr.yml
+++ b/config/locales/views/misc/fr.yml
@@ -112,6 +112,8 @@ fr:
         views: Views
       reactions_history: "Historique des réactions"
       by: par
+      top_contributors:
+        heading: Meilleurs participants
     sticky:
       joined: Rejoint
       default_cta: Learn more

--- a/config/locales/views/misc/pt.yml
+++ b/config/locales/views/misc/pt.yml
@@ -112,6 +112,8 @@ pt:
         views: Views
       reactions_history: "Histórico de Reações"
       by: por
+      top_contributors:
+        heading: Principais Engajadores
     sticky:
       joined: Joined
       default_cta: Learn more

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -40,6 +40,7 @@ get "/analytics/historical", to: "analytics#historical"
 get "/analytics/past_day", to: "analytics#past_day"
 get "/analytics/referrers", to: "analytics#referrers"
 get "/analytics/top_contributors", to: "analytics#top_contributors"
+get "/analytics/follower_engagement", to: "analytics#follower_engagement"
 
 resources :health_checks, only: [] do
   collection do

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -39,6 +39,7 @@ get "/analytics/totals", to: "analytics#totals"
 get "/analytics/historical", to: "analytics#historical"
 get "/analytics/past_day", to: "analytics#past_day"
 get "/analytics/referrers", to: "analytics#referrers"
+get "/analytics/top_contributors", to: "analytics#top_contributors"
 
 resources :health_checks, only: [] do
   collection do

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@babel/plugin-proposal-class-properties": "^7.16.0",
     "@babel/plugin-proposal-export-default-from": "^7.23.3",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+    "@babel/plugin-transform-dynamic-import": "^7.23.3",
     "@babel/plugin-transform-private-methods": "^7.24.1",
     "@babel/plugin-transform-react-jsx": "^7.22.15",
     "@babel/preset-env": "^7.23.3",

--- a/spec/requests/api/v0/analytics_spec.rb
+++ b/spec/requests/api/v0/analytics_spec.rb
@@ -42,4 +42,8 @@ RSpec.describe "Api::V0::Analytics" do
   describe "GET /api/analytics/referrers" do
     include_examples "GET /api/analytics/:endpoint authorization examples", "referrers"
   end
+
+  describe "GET /api/analytics/top_contributors" do
+    include_examples "GET /api/analytics/:endpoint authorization examples", "top_contributors"
+  end
 end

--- a/spec/requests/api/v0/analytics_spec.rb
+++ b/spec/requests/api/v0/analytics_spec.rb
@@ -46,4 +46,8 @@ RSpec.describe "Api::V0::Analytics" do
   describe "GET /api/analytics/top_contributors" do
     include_examples "GET /api/analytics/:endpoint authorization examples", "top_contributors"
   end
+
+  describe "GET /api/analytics/follower_engagement" do
+    include_examples "GET /api/analytics/:endpoint authorization examples", "follower_engagement"
+  end
 end

--- a/spec/requests/api/v1/analytics_spec.rb
+++ b/spec/requests/api/v1/analytics_spec.rb
@@ -69,4 +69,13 @@ RSpec.describe "Api::V1::Analytics" do
       expect(response).to have_http_status(:unauthorized)
     end
   end
+
+  describe "GET /api/analytics/follower_engagement" do
+    include_examples "GET /api/analytics/:endpoint authorization examples", "follower_engagement"
+
+    it "returns 401 when unauthenticated" do
+      get "/api/analytics/follower_engagement", headers: { "Accept" => "application/vnd.forem.api-v1+json" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
 end

--- a/spec/requests/api/v1/analytics_spec.rb
+++ b/spec/requests/api/v1/analytics_spec.rb
@@ -60,4 +60,13 @@ RSpec.describe "Api::V1::Analytics" do
       expect(response).to have_http_status(:unauthorized)
     end
   end
+
+  describe "GET /api/analytics/top_contributors" do
+    include_examples "GET /api/analytics/:endpoint authorization examples", "top_contributors"
+
+    it "returns 401 when unauthenticated" do
+      get "/api/analytics/top_contributors", headers: { "Accept" => "application/vnd.forem.api-v1+json" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
 end

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -570,4 +570,100 @@ RSpec.describe AnalyticsService, type: :service do
       expect(result).to include(:user_id, :username, :name, :profile_image, :reactions_count, :comments_count, :score)
     end
   end
+
+  describe "#follower_engagement" do
+    let(:analytics_service) { described_class.new(user) }
+    let(:follower) { create(:user) }
+
+    before do
+      create(:follow, follower: follower, followable: user, blocked: false)
+    end
+
+    it "returns zero ratio when user has no followers" do
+      other_user = create(:user)
+      create(:article, user: other_user, published: true)
+      service = described_class.new(other_user)
+      result = service.follower_engagement
+      expect(result).to eq({ total_followers: 0, engaged_followers: 0, ratio: 0.0 })
+    end
+
+    it "returns zero engaged when follower has not interacted" do
+      result = analytics_service.follower_engagement
+      expect(result[:total_followers]).to eq(1)
+      expect(result[:engaged_followers]).to eq(0)
+      expect(result[:ratio]).to eq(0.0)
+    end
+
+    it "counts a follower who reacted" do
+      create(:reaction, reactable: article, category: :like, user: follower)
+      result = analytics_service.follower_engagement
+      expect(result[:total_followers]).to eq(1)
+      expect(result[:engaged_followers]).to eq(1)
+      expect(result[:ratio]).to eq(100.0)
+    end
+
+    it "counts a follower who commented" do
+      create(:comment, commentable: article, user: follower, score: 1)
+      result = analytics_service.follower_engagement
+      expect(result[:engaged_followers]).to eq(1)
+    end
+
+    it "counts a follower with both reaction and comment only once" do
+      create(:reaction, reactable: article, category: :like, user: follower)
+      create(:comment, commentable: article, user: follower, score: 1)
+      result = analytics_service.follower_engagement
+      expect(result[:engaged_followers]).to eq(1)
+    end
+
+    it "excludes readinglist reactions" do
+      create(:reaction, reactable: article, category: :readinglist, user: follower)
+      result = analytics_service.follower_engagement
+      expect(result[:engaged_followers]).to eq(0)
+    end
+
+    it "excludes low-score comments" do
+      create(:comment, commentable: article, user: follower, score: 0)
+      result = analytics_service.follower_engagement
+      expect(result[:engaged_followers]).to eq(0)
+    end
+
+    it "excludes blocked followers" do
+      blocked_follower = create(:user)
+      create(:follow, follower: blocked_follower, followable: user, blocked: true)
+      create(:reaction, reactable: article, category: :like, user: blocked_follower)
+      result = analytics_service.follower_engagement
+      expect(result[:total_followers]).to eq(1) # only the non-blocked follower
+    end
+
+    it "does not count non-followers" do
+      non_follower = create(:user)
+      create(:reaction, reactable: article, category: :like, user: non_follower)
+      result = analytics_service.follower_engagement
+      expect(result[:engaged_followers]).to eq(0)
+    end
+
+    it "calculates correct ratio with multiple followers" do
+      follower2 = create(:user)
+      follower3 = create(:user)
+      create(:follow, follower: follower2, followable: user, blocked: false)
+      create(:follow, follower: follower3, followable: user, blocked: false)
+      create(:reaction, reactable: article, category: :like, user: follower)
+      result = analytics_service.follower_engagement
+      expect(result[:total_followers]).to eq(3)
+      expect(result[:engaged_followers]).to eq(1)
+      expect(result[:ratio]).to eq(33.3)
+    end
+
+    it "works with organization owner" do
+      create(:organization_membership, user: user, organization: organization)
+      org_article = create(:article, user: user, organization: organization, published: true)
+      org_follower = create(:user)
+      create(:follow, follower: org_follower, followable: organization, blocked: false)
+      create(:reaction, reactable: org_article, category: :like, user: org_follower)
+      service = described_class.new(organization)
+      result = service.follower_engagement
+      expect(result[:total_followers]).to eq(1)
+      expect(result[:engaged_followers]).to eq(1)
+    end
+  end
 end

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -549,7 +549,7 @@ RSpec.describe AnalyticsService, type: :service do
       user_a = create(:user)
       user_b = create(:user)
       create(:reaction, reactable: article, category: :like, user: user_a)
-      create(:comment, commentable: article, user: user_b, score: 1) # score 3
+      create(:comment, commentable: article, user: user_b, score: 1) # score 6
       result = analytics_service.top_contributors
       expect(result.first[:username]).to eq(user_b.username)
     end

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -481,4 +481,93 @@ RSpec.describe AnalyticsService, type: :service do
       end
     end
   end
+
+  describe "#top_contributors" do
+    let(:analytics_service) { described_class.new(user) }
+    let(:contributor) { create(:user) }
+
+    it "returns an empty array when there are no articles" do
+      other_user = create(:user)
+      service = described_class.new(other_user)
+      expect(service.top_contributors).to eq([])
+    end
+
+    it "excludes self-reactions from results" do
+      create(:reaction, reactable: article, category: :like, user: user)
+      expect(analytics_service.top_contributors).to eq([])
+    end
+
+    it "excludes readinglist reactions" do
+      create(:reaction, reactable: article, category: :readinglist, user: contributor)
+      expect(analytics_service.top_contributors).to eq([])
+    end
+
+    it "includes non-readinglist reactions from other users" do
+      create(:reaction, reactable: article, category: :like, user: contributor)
+      result = analytics_service.top_contributors
+      expect(result.length).to eq(1)
+      expect(result.first[:username]).to eq(contributor.username)
+      expect(result.first[:reactions_count]).to eq(1)
+      expect(result.first[:comments_count]).to eq(0)
+      expect(result.first[:score]).to eq(1)
+    end
+
+    it "weights comments at 6x" do
+      create(:comment, commentable: article, user: contributor, score: 1)
+      result = analytics_service.top_contributors
+      expect(result.first[:comments_count]).to eq(1)
+      expect(result.first[:score]).to eq(6)
+    end
+
+    it "excludes comments with score <= 0" do
+      create(:comment, commentable: article, user: contributor, score: 0)
+      expect(analytics_service.top_contributors).to eq([])
+    end
+
+    it "excludes self-comments" do
+      create(:comment, commentable: article, user: user, score: 1)
+      expect(analytics_service.top_contributors).to eq([])
+    end
+
+    it "combines reactions and comments for the same user" do
+      create(:reaction, reactable: article, category: :like, user: contributor)
+      create(:comment, commentable: article, user: contributor, score: 1)
+      result = analytics_service.top_contributors
+      expect(result.length).to eq(1)
+      expect(result.first[:reactions_count]).to eq(1)
+      expect(result.first[:comments_count]).to eq(1)
+      expect(result.first[:score]).to eq(7) # 1 + 6
+    end
+
+    it "respects the limit parameter" do
+      3.times { |i| create(:reaction, reactable: article, category: :like, user: create(:user)) }
+      result = analytics_service.top_contributors(limit: 2)
+      expect(result.length).to eq(2)
+    end
+
+    it "orders by score descending" do
+      user_a = create(:user)
+      user_b = create(:user)
+      create(:reaction, reactable: article, category: :like, user: user_a)
+      create(:comment, commentable: article, user: user_b, score: 1) # score 3
+      result = analytics_service.top_contributors
+      expect(result.first[:username]).to eq(user_b.username)
+    end
+
+    it "works with organization owner" do
+      create(:organization_membership, user: user, organization: organization)
+      org_article = create(:article, user: user, organization: organization, published: true)
+      create(:reaction, reactable: org_article, category: :like, user: contributor)
+      service = described_class.new(organization)
+      result = service.top_contributors
+      expect(result.length).to eq(1)
+      expect(result.first[:username]).to eq(contributor.username)
+    end
+
+    it "returns profile data for each contributor" do
+      create(:reaction, reactable: article, category: :like, user: contributor)
+      result = analytics_service.top_contributors.first
+      expect(result).to include(:user_id, :username, :name, :profile_image, :reactions_count, :comments_count, :score)
+    end
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -6984,6 +6984,7 @@ __metadata:
     "@babel/plugin-proposal-export-default-from": "npm:^7.23.3"
     "@babel/plugin-proposal-object-rest-spread": "npm:^7.20.7"
     "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
+    "@babel/plugin-transform-dynamic-import": "npm:^7.23.3"
     "@babel/plugin-transform-private-methods": "npm:^7.24.1"
     "@babel/plugin-transform-react-jsx": "npm:^7.22.15"
     "@babel/preset-env": "npm:^7.23.3"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Closes #23122. Supersedes #23141.

**Async loading & InstantClick resilience:**
- Each panel (charts, cards, referrers, engagers) renders independently as its API resolves. Shimmer placeholders in the interim.
- Generation counter discards stale responses on rapid tab switches.
- Chart state moved to `window._analyticsState` to survive InstantClick soft nav; `on('change')` cleanup registered once to prevent ApexCharts registry leaks.

**Top Engagers panel:**
- `GET /api/analytics/top_contributors` — UNION of reactions (×1) and comments (×6), excluding self-interactions, readinglist, and low-score comments. Uses subquery for article IDs.
- Rendered via DOM API (`createElement`/`textContent`) to avoid XSS from user-controlled fields.
- Split-row layout alongside Traffic Sources on user/org dashboards. i18n for en/fr/pt.

**Follower Engagement Ratio:**
- `GET /api/analytics/follower_engagement` (v0 + v1 auth) — UNION of reacting + commenting followers with subquery pattern (no large IN lists).
- Excludes blocked followers, readinglist reactions, low-score comments. Date-filtered when start/end params present.
- Renders ratio + detail count on separate lines below the followers card. `writeCards` preserves engagement element across card re-renders.
- i18n for en/fr/pt (`follower_engagement_ratio` + `follower_engagement_detail`).

**Dark mode charts:**
- ApexCharts `theme.mode` and grid color now respond to `body.dark-theme`.

***Empty state handling***
- Added user-friendly messages when analytics data is empty instead of leaving sections in a loading/blank state
- Charts display "No data available for this period" when historical data returns no date keys
- Traffic sources display "No traffic sources yet" when referrer domains array is empty, clearing the donut chart placeholder
- Added i18n keys for en, fr, and pt locales

### UI accessibility checklist

- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [x] Color contrast tested?

## Added/updated tests?

- [x] Yes

**Jest:** Brush/zoom, async loading, error isolation, placeholders, top engagers render/empty/stale discard, follower engagement render/zero-followers.

Added 3 Jest tests covering empty state scenarios: empty charts, empty referrers, and zero-value cards

**RSpec:** `AnalyticsService#top_contributors` (10 cases), `#follower_engagement` (10 cases), v0/v1 auth examples for both new endpoints.