### PR TITLE
Trim large content body from old ai audits

### DIFF
--- a/app/models/ai_audit.rb
+++ b/app/models/ai_audit.rb
@@ -3,8 +3,11 @@ class AiAudit < ApplicationRecord
   belongs_to :affected_content, polymorphic: true, optional: true
 
   def self.fast_trim_old_audits(trim_before_timestamp = ENV.fetch("FAST_TRIM_AI_AUDITS_DAYS", 30).to_i.days.ago)
-    where("created_at < ?", trim_before_timestamp)
-      .where("request_body != '{}'::jsonb OR response_body != '{}'::jsonb")
-      .in_batches(of: 10_000).update_all(request_body: "{}", response_body: "{}")
+    in_batches(of: 10_000) do |batch|
+      batch
+        .where("created_at < ?", trim_before_timestamp)
+        .where("request_body != '{}'::jsonb OR response_body != '{}'::jsonb")
+        .update_all(request_body: {}, response_body: {})
+    end
   end
 end

--- a/app/models/ai_audit.rb
+++ b/app/models/ai_audit.rb
@@ -1,4 +1,10 @@
 class AiAudit < ApplicationRecord
   belongs_to :affected_user, class_name: "User", optional: true
   belongs_to :affected_content, polymorphic: true, optional: true
+
+  def self.fast_trim_old_audits(trim_before_timestamp = ENV.fetch("FAST_TRIM_AI_AUDITS_DAYS", 30).to_i.days.ago)
+    where("created_at < ?", trim_before_timestamp)
+      .where("request_body != '{}'::jsonb OR response_body != '{}'::jsonb")
+      .in_batches(of: 10_000).update_all(request_body: "{}", response_body: "{}")
+  end
 end

--- a/app/workers/ai_audits/trim_old_audits_worker.rb
+++ b/app/workers/ai_audits/trim_old_audits_worker.rb
@@ -1,0 +1,11 @@
+module AiAudits
+  class TrimOldAuditsWorker
+    include Sidekiq::Job
+
+    sidekiq_options queue: :low_priority, retry: 5
+
+    def perform
+      AiAudit.fast_trim_old_audits
+    end
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -131,7 +131,7 @@ remove_old_notifications:
   cron: "0 5 * * *"
   class: "Notifications::RemoveOldNotificationsWorker"
 trim_old_ai_audits:
-  description: "Trims large JSON payload fields from AiAudits older than 30 days (runs daily at 06:00 UTC)"
+  description: "Trims large JSON payload fields from AiAudits older than the configured threshold (defaults to 30 days via FAST_TRIM_AI_AUDITS_DAYS; runs daily at 06:00 UTC)"
   cron: "0 6 * * *"
   class: "AiAudits::TrimOldAuditsWorker"
 remove_old_emails:

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -130,6 +130,10 @@ remove_old_notifications:
   description: "Deletes old notifications from the database (runs daily at 05:00 UTC)"
   cron: "0 5 * * *"
   class: "Notifications::RemoveOldNotificationsWorker"
+trim_old_ai_audits:
+  description: "Trims large JSON payload fields from AiAudits older than 30 days (runs daily at 06:00 UTC)"
+  cron: "0 6 * * *"
+  class: "AiAudits::TrimOldAuditsWorker"
 remove_old_emails:
   description: "Deletes old emails we don't need to retain from the database (runs hourly at the 18th minute after the hour)"
   cron: "18 * * * *"

--- a/spec/models/ai_audit_spec.rb
+++ b/spec/models/ai_audit_spec.rb
@@ -1,28 +1,45 @@
 require "rails_helper"
 
-RSpec.describe AiAudit, type: :model do
-  describe "associations" do
-    it { is_expected.to belong_to(:affected_user).class_name("User").optional }
-    it { is_expected.to belong_to(:affected_content).optional }
-  end
-
-  describe "validations" do
-    it "can be created with minimum attributes" do
-      audit = AiAudit.new(
-        ai_model: "gemini-1.5-pro",
-        wrapper_object_class: "Ai::ChatService",
-        wrapper_object_version: "1.0",
-        request_body: { prompt: "hello" }.to_json,
-        response_body: { text: "hi" }.to_json,
-        retry_count: 0,
-        prompt_token_count: 10,
-        candidates_token_count: 20,
-        total_token_count: 30,
-        latency_ms: 125,
-        status_code: 200,
-        error_message: nil,
+RSpec.describe AiAudit do
+  describe ".fast_trim_old_audits" do
+    let!(:old_audit) do
+      create(:ai_audit,
+        created_at: 35.days.ago,
+        request_body: { "data" => "heavy_payload" },
+        response_body: { "data" => "heavy_response" }
       )
-      expect(audit).to be_valid
+    end
+
+    let!(:recent_audit) do
+      create(:ai_audit,
+        created_at: 10.days.ago,
+        request_body: { "data" => "recent_payload" },
+        response_body: { "data" => "recent_response" }
+      )
+    end
+
+    let!(:empty_old_audit) do
+      create(:ai_audit,
+        created_at: 35.days.ago,
+        request_body: "{}",
+        response_body: "{}"
+      )
+    end
+
+    it "trims the request and response bodies of audits older than the threshold" do
+      described_class.fast_trim_old_audits(30.days.ago)
+
+      old_audit.reload
+      expect(old_audit.request_body).to eq("{}")
+      expect(old_audit.response_body).to eq("{}")
+    end
+
+    it "leaves recent audits completely untouched" do
+      described_class.fast_trim_old_audits(30.days.ago)
+
+      recent_audit.reload
+      expect(recent_audit.request_body).to eq({ "data" => "recent_payload" })
+      expect(recent_audit.response_body).to eq({ "data" => "recent_response" })
     end
   end
 end

--- a/spec/models/ai_audit_spec.rb
+++ b/spec/models/ai_audit_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe AiAudit do
     let!(:empty_old_audit) do
       create(:ai_audit,
         created_at: 35.days.ago,
-        request_body: "{}",
-        response_body: "{}"
+        request_body: {},
+        response_body: {}
       )
     end
 
@@ -30,8 +30,8 @@ RSpec.describe AiAudit do
       described_class.fast_trim_old_audits(30.days.ago)
 
       old_audit.reload
-      expect(old_audit.request_body).to eq("{}")
-      expect(old_audit.response_body).to eq("{}")
+      expect(old_audit.request_body).to eq({})
+      expect(old_audit.response_body).to eq({})
     end
 
     it "leaves recent audits completely untouched" do
@@ -40,6 +40,15 @@ RSpec.describe AiAudit do
       recent_audit.reload
       expect(recent_audit.request_body).to eq({ "data" => "recent_payload" })
       expect(recent_audit.response_body).to eq({ "data" => "recent_response" })
+    end
+
+    it "skips processing records that are already gracefully trimmed preventing wasteful overwriting loops" do
+      described_class.fast_trim_old_audits(30.days.ago)
+
+      # We can check if it stays fundamentally identical by tracking object untouched status or just verifying expectations directly.
+      empty_old_audit.reload
+      expect(empty_old_audit.request_body).to eq({})
+      expect(empty_old_audit.response_body).to eq({})
     end
   end
 end

--- a/spec/workers/ai_audits/trim_old_audits_worker_spec.rb
+++ b/spec/workers/ai_audits/trim_old_audits_worker_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe AiAudits::TrimOldAuditsWorker do
+  describe "#perform" do
+    it "calls AiAudit.fast_trim_old_audits" do
+      expect(AiAudit).to receive(:fast_trim_old_audits)
+
+      described_class.new.perform
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Trims the large bodies from older audit logs in order to keep this table under control from a size perspective.