### PR TITLE
Allow admin to mofidy context note

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -6,16 +6,19 @@ module Admin
       Audit::Logger.log(:moderator, current_user, params.dup)
     end
 
-    ARTICLES_ALLOWED_PARAMS = %i[featured
-                                 social_image
-                                 body_markdown
-                                 approved
-                                 email_digest_eligible
-                                 main_image_background_hex_color
-                                 user_id
-                                 max_score
-                                 co_author_ids_list
-                                 published_at].freeze
+    ARTICLES_ALLOWED_PARAMS = [
+      :featured,
+      :social_image,
+      :body_markdown,
+      :approved,
+      :email_digest_eligible,
+      :main_image_background_hex_color,
+      :user_id,
+      :max_score,
+      :co_author_ids_list,
+      :published_at,
+      { context_notes_attributes: %i[id body_markdown] }
+    ].freeze
 
     def index
       case params[:state]

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -185,6 +185,8 @@ class Article < ApplicationRecord
   has_many :rating_votes, dependent: :destroy
   has_many :tag_adjustments
   has_many :context_notes, dependent: :delete_all
+  accepts_nested_attributes_for :context_notes
+
   has_many :top_comments,
            lambda {
              where(comments: { score: 11.. }, ancestry: nil, hidden_by_commentable_user: false, deleted: false)

--- a/app/views/admin/articles/_article_item.html.erb
+++ b/app/views/admin/articles/_article_item.html.erb
@@ -175,7 +175,21 @@
           </label>
           <input id="max_score_<%= article.id %>" class="crayons-textfield" type="number" name="article[max_score]" value="<%= article.max_score %>">
         </div>
+        </div>
       </div>
+      <% if article.context_notes.any? %>
+        <div class="flex">
+          <div class="crayons-field w-100">
+            <label class="crayons-field__label">Context Notes</label>
+            <%= f.fields_for :context_notes do |cn_form| %>
+              <div class="mb-3 w-100">
+                <span class="fs-s color-secondary mb-1 block">Context tag: <%= cn_form.object.tag&.name || "None" %></span>
+                <%= cn_form.text_area :body_markdown, class: "crayons-textfield w-100 p-2", rows: 3 %>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
       <% if article.published? %>
         <div class="flex">
           <div class="crayons-field">

--- a/spec/requests/admin/articles_spec.rb
+++ b/spec/requests/admin/articles_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe "/admin/content_manager/articles" do
       end.to change { article.reload.published_at }.to(DateTime.parse(updated_published_at.to_s))
     end
 
+    it "allows an Admin to update an article's context_notes" do
+      context_note = create(:context_note, article: article, body_markdown: "Original markdown note that is long enough")
+      
+      expect do
+        patch admin_article_path(article.id), params: { article: { context_notes_attributes: { "0" => { id: context_note.id, body_markdown: "Updated markdown note that is long enough" } } } }
+      end.to change { context_note.reload.body_markdown }.to("Updated markdown note that is long enough")
+    end
+
     it "creates an audit log on update" do
       Audit::Subscribe.listen(:moderator)
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Admins can edit any context notes that are present