### PR TITLE
Exclude article ids on billboards linking to that article

### DIFF
--- a/app/models/billboard.rb
+++ b/app/models/billboard.rb
@@ -91,6 +91,7 @@ class Billboard < ApplicationRecord
            :validate_expiration_approval
 
   before_save :process_markdown
+  before_save :update_exclude_article_ids
   before_save :update_content_updated_at_if_needed
   after_save :generate_billboard_name
   after_save :refresh_audience_segment, if: :should_refresh_audience_segment?
@@ -471,6 +472,37 @@ class Billboard < ApplicationRecord
     return unless content_fields.any? { |field| will_save_change_to_attribute?(field) }
     
     self.content_updated_at = Time.current
+  end
+
+  def update_exclude_article_ids
+    return if body_markdown.blank? || !body_markdown_changed?
+
+    extracted_paths = []
+
+    if processed_html.present?
+      full_html = "<html><head></head><body>#{processed_html}</body></html>"
+      doc = Nokogiri::HTML(full_html)
+
+      doc.css("a").each do |link|
+        href = link["href"]
+        next unless href.present? && href.start_with?("http", "/")
+
+        begin
+          uri = URI.parse(href)
+          path = uri.path
+          if path.present? && path != "/"
+            extracted_paths << path.chomp("/").downcase
+          end
+        rescue URI::InvalidURIError
+          next
+        end
+      end
+    end
+
+    if extracted_paths.any?
+      found_article_ids = Article.where(path: extracted_paths).pluck(:id)
+      self.exclude_article_ids = (self.exclude_article_ids.to_a + found_article_ids).uniq if found_article_ids.any?
+    end
   end
 
   def update_event_counts_when_taking_down

--- a/app/models/billboard.rb
+++ b/app/models/billboard.rb
@@ -477,32 +477,46 @@ class Billboard < ApplicationRecord
   def update_exclude_article_ids
     return if body_markdown.blank? || !body_markdown_changed?
 
-    extracted_paths = []
+    old_paths = extract_internal_article_paths(processed_html_was)
+    new_paths = extract_internal_article_paths(processed_html)
 
-    if processed_html.present?
-      full_html = "<html><head></head><body>#{processed_html}</body></html>"
-      doc = Nokogiri::HTML(full_html)
+    removed_paths = old_paths - new_paths
+    added_paths = new_paths - old_paths
 
-      doc.css("a").each do |link|
-        href = link["href"]
-        next unless href.present? && href.start_with?("http", "/")
+    removed_ids = removed_paths.any? ? Article.where(path: removed_paths).pluck(:id) : []
+    added_ids = added_paths.any? ? Article.where(path: added_paths).pluck(:id) : []
 
-        begin
-          uri = URI.parse(href)
-          path = uri.path
-          if path.present? && path != "/"
-            extracted_paths << path.chomp("/").downcase
-          end
-        rescue URI::InvalidURIError
-          next
-        end
+    current_ids = self.exclude_article_ids.to_a
+    self.exclude_article_ids = ((current_ids - removed_ids) + added_ids).uniq
+  end
+
+  def extract_internal_article_paths(html)
+    return [] if html.blank?
+
+    paths = []
+    doc = Nokogiri::HTML("<html><body>#{html}</body></html>")
+    
+    internal_hosts = [
+      nil,
+      ApplicationConfig["APP_DOMAIN"],
+      URI.parse(URL.url).host
+    ].compact.uniq
+
+    doc.css("a").each do |link|
+      href = link["href"]
+      next unless href.present? && href.start_with?("http", "/")
+
+      begin
+        uri = URI.parse(href)
+        next unless internal_hosts.include?(uri.host)
+
+        path = uri.path
+        paths << path.chomp("/").downcase if path.present? && path != "/"
+      rescue URI::InvalidURIError
+        next
       end
     end
-
-    if extracted_paths.any?
-      found_article_ids = Article.where(path: extracted_paths).pluck(:id)
-      self.exclude_article_ids = (self.exclude_article_ids.to_a + found_article_ids).uniq if found_article_ids.any?
-    end
+    paths.uniq
   end
 
   def update_event_counts_when_taking_down

--- a/spec/models/billboard_spec.rb
+++ b/spec/models/billboard_spec.rb
@@ -592,11 +592,23 @@ RSpec.describe Billboard do
   describe "#update_exclude_article_ids" do
     let(:article) { create(:article) }
 
-    it "automatically extracts article IDs from links in the billboard content" do
-      # Set up the billboard with a link to the article
-      billboard = build(:billboard, body_markdown: "Check out this great post: [link](https://dev.to#{article.path})")
+    it "automatically extracts article IDs from relative links in the billboard content" do
+      billboard = build(:billboard, body_markdown: "Check out this great post: [link](#{article.path})")
       
       expect { billboard.save! }.to change { billboard.exclude_article_ids }.from([]).to([article.id])
+    end
+
+    it "automatically extracts article IDs from absolute links matching the app domain" do
+      app_url = URI.parse(URL.url)
+      billboard = build(:billboard, body_markdown: "Check out this great post: [link](#{app_url}#{article.path})")
+      
+      expect { billboard.save! }.to change { billboard.exclude_article_ids }.from([]).to([article.id])
+    end
+
+    it "does not parse links from external domains" do
+      billboard = build(:billboard, body_markdown: "Check out this great post: [link](https://external-domain.com#{article.path})")
+      
+      expect { billboard.save! }.not_to change { billboard.exclude_article_ids }
     end
     
     it "does not add invalid paths" do
@@ -605,15 +617,25 @@ RSpec.describe Billboard do
       expect { billboard.save! }.not_to change { billboard.exclude_article_ids }
     end
 
+    it "removes IDs of linked articles if they are removed from the markdown" do
+      billboard = create(:billboard, body_markdown: "Check out this great post: [link](#{article.path})")
+      expect(billboard.exclude_article_ids).to eq([article.id])
+
+      expect {
+        billboard.update!(body_markdown: "Never mind, no links here!")
+      }.to change { billboard.exclude_article_ids }.from([article.id]).to([])
+    end
+
     it "only runs when the body_markdown is changed" do
-      billboard = create(:billboard, body_markdown: "Check out this great post: [link](https://dev.to#{article.path})")
+      billboard = create(:billboard, body_markdown: "Check out this great post: [link](#{article.path})")
       
-      allow(Nokogiri).to receive(:HTML).and_call_original
+      allow(Article).to receive(:where).and_call_original
       
       # Now save without changing markdown
       billboard.update!(name: "A different name")
       
-      expect(Nokogiri).not_to have_received(:HTML)
+      expect(Article).not_to have_received(:where)
+      expect(billboard.exclude_article_ids).to eq([article.id])
     end
   end
 

--- a/spec/models/billboard_spec.rb
+++ b/spec/models/billboard_spec.rb
@@ -589,6 +589,34 @@ RSpec.describe Billboard do
     end
   end
 
+  describe "#update_exclude_article_ids" do
+    let(:article) { create(:article) }
+
+    it "automatically extracts article IDs from links in the billboard content" do
+      # Set up the billboard with a link to the article
+      billboard = build(:billboard, body_markdown: "Check out this great post: [link](https://dev.to#{article.path})")
+      
+      expect { billboard.save! }.to change { billboard.exclude_article_ids }.from([]).to([article.id])
+    end
+    
+    it "does not add invalid paths" do
+      billboard = build(:billboard, body_markdown: "Check out this great post: [link](/not-a-real-path)")
+      
+      expect { billboard.save! }.not_to change { billboard.exclude_article_ids }
+    end
+
+    it "only runs when the body_markdown is changed" do
+      billboard = create(:billboard, body_markdown: "Check out this great post: [link](https://dev.to#{article.path})")
+      
+      allow(Nokogiri).to receive(:HTML).and_call_original
+      
+      # Now save without changing markdown
+      billboard.update!(name: "A different name")
+      
+      expect(Nokogiri).not_to have_received(:HTML)
+    end
+  end
+
   describe "when a stale audience segment is associated" do
     let(:audience_segment) do
       Timecop.travel(5.days.ago) do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
I thought this had already been implemented, but it's missing. Billboards that link to articles should not show up on that article.