### PR TITLE
Add event countdown on event showpage

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -16,10 +16,13 @@
     </div>
 
     <div class="stream-grid">
-        <div class="video-wrapper">
+        <div class="video-wrapper" style="position: relative; background: #000; overflow: hidden; border-radius: var(--radius); min-height: 300px; display: flex; align-items: center; justify-content: center;">
             <% if @event.primary_stream_url.present? %>
-              <iframe src="<%= @event.primary_stream_url %>" frameborder="0" allowfullscreen="true" scrolling="no" title="Event Stream" loading="lazy">
-              </iframe>
+              <div class="overlay-post absolute inset-0 z-10 flex flex-col items-center justify-center hidden" id="overlay-post-<%= @event.id %>" style="background: #000; color: #fff; width: 100%; height: 100%;">
+                <div class="text-xl mb-2 fw-medium">Stream starts in…</div>
+                <div id="countdown-post-<%= @event.id %>" class="tabular-nums text-4xl fw-bold">--:--:--</div>
+              </div>
+              <div class="player-container-post w-100 h-100" id="player-container-post-<%= @event.id %>" style="width: 100%; height: 100%;"></div>
             <% else %>
               <div class="crayons-card p-8 text-center flex items-center justify-center h-100 w-100">
                 <p class="color-base-60">Stream URL not configured.</p>
@@ -94,5 +97,54 @@
               </article>
           <% end %>
       </div>
+    <% end %>
+
+    <% if @event.primary_stream_url.present? %>
+      <script>
+        (function() {
+          const TARGET_TIME = new Date(<%= @event.start_time.iso8601.to_json.html_safe %>).getTime();
+          const IFRAME_SRC = <%= @event.primary_stream_url.to_json.html_safe %>;
+          const IS_FORCED_LIVE = <%= params[:state] == 'forced_live' %>;
+
+          const overlay = document.getElementById("overlay-post-<%= @event.id %>");
+          const countdownEl = document.getElementById("countdown-post-<%= @event.id %>");
+          const playerContainer = document.getElementById("player-container-post-<%= @event.id %>");
+          let timerId;
+
+          function update() {
+            const now = Date.now();
+
+            if (now >= TARGET_TIME || IS_FORCED_LIVE) {
+              clearInterval(timerId);
+              if (overlay) overlay.classList.add("hidden");
+
+              if (playerContainer && !playerContainer.querySelector("iframe")) {
+                const iframe = document.createElement("iframe");
+                iframe.src = IFRAME_SRC;
+                iframe.allowFullscreen = true;
+                iframe.setAttribute("frameborder", "0");
+                iframe.setAttribute("scrolling", "no");
+                iframe.style.width = "100%";
+                iframe.style.height = "100%";
+                playerContainer.appendChild(iframe);
+              }
+              return;
+            }
+
+            if (overlay) overlay.classList.remove("hidden");
+            
+            if (countdownEl) {
+              const diffSeconds = Math.max(0, Math.floor((TARGET_TIME - now) / 1000));
+              const hours = String(Math.floor(diffSeconds / 3600)).padStart(2, "0");
+              const minutes = String(Math.floor((diffSeconds % 3600) / 60)).padStart(2, "0");
+              const seconds = String(diffSeconds % 60).padStart(2, "0");
+              countdownEl.textContent = `${hours}:${minutes}:${seconds}`;
+            }
+          }
+
+          timerId = setInterval(update, 1000);
+          update();
+        })();
+      </script>
     <% end %>
 </div>

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe "Events", type: :request do
         expect(response.body).to include(published_event.title)
       end
 
+      context "when forced_live state is passed" do
+        it "renders the show view indicating that forced live mode is enabled" do
+          get event_path(published_event.event_name_slug, published_event.event_variation_slug), params: { state: "forced_live" }
+          
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("IS_FORCED_LIVE = true;")
+        end
+      end
+
       context "when the event has associated articles via tags" do
         let(:tag) { create(:tag, name: "awstest") }
         let(:article) { create(:article, title: "A Custom Event Article", tag_list: tag.name, published: true) }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add countdown to event show page like billboards