### PR TITLE
Personalization for email digest article selection

### DIFF
--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -5,6 +5,8 @@ class EmailDigestArticleCollector
   ARTICLES_TO_SEND = "EmailDigestArticleCollector#articles_to_send".freeze
   RESULTS_COUNT = 7 # Winner of digest_count_03_18 field test
   CLICK_LOOKBACK = 30
+  DIGEST_ARTICLE_COLUMNS = %i[title description path cached_user cached_tag_list
+                              subforem_id comment_score comments_count].freeze
 
   def initialize(user, force_send: false)
     @user = user
@@ -12,112 +14,16 @@ class EmailDigestArticleCollector
   end
 
   def articles_to_send
-    # rubocop:disable Metrics/BlockLength
-    order = Arel.sql("(((score + comment_score) * ((feed_success_score * 12) + 0.1)) - (clickbait_score * 2)) DESC")
     instrument ARTICLES_TO_SEND, tags: { user_id: @user.id } do
       return [] unless @force_send || should_receive_email?
 
-      articles = if @user.cached_followed_tag_names.any?
-                   # Set subforem context for followed subforems or default
-                   set_subforem_context
-
-                   articles_query = @user.followed_articles
-                     .select(:title, :description, :path, :cached_user, :cached_tag_list, :subforem_id, :comment_score, :comments_count)
-                     .published
-                     .full_posts
-                     .where("published_at > ?", cutoff_date)
-                     .where(email_digest_eligible: true)
-                     .not_authored_by(@user.id)
-                     .where("score > ?", 8)
-
-                   # Only filter by subforem if we're not skipping subforem filtering
-                   articles_query = articles_query.where(subforem_id: @subforem_ids) unless @skip_subforem_filtering
-
-                   articles_query.order(order).limit(RESULTS_COUNT)
-                 else
-                   tags = @user.cached_followed_tag_names_or_recent_tags
-                   # Set subforem context for followed subforems or default
-                   set_subforem_context
-
-                   articles_query = if @skip_subforem_filtering
-                                      # If skipping subforem filtering, get articles from anywhere
-                                      Article.select(
-                                        :title, :description, :path, :cached_user, :cached_tag_list, :subforem_id, :comment_score, :comments_count
-                                      )
-                                        .published
-                                        .full_posts
-                                        .where("published_at > ?", cutoff_date)
-                                        .where(email_digest_eligible: true)
-                                        .not_authored_by(@user.id)
-                                        .where("score > ?", 11)
-                                        .merge(Article.featured.or(Article.cached_tagged_with_any(tags)))
-                                        .order(order)
-                                        .limit(RESULTS_COUNT)
-                                    else
-                                      # Normal logic with subforem filtering and tags
-                                      Article.select(
-                                        :title, :description, :path, :cached_user, :cached_tag_list, :subforem_id, :comment_score, :comments_count
-                                      )
-                                        .published
-                                        .full_posts
-                                        .where("published_at > ?", cutoff_date)
-                                        .where(email_digest_eligible: true)
-                                        .not_authored_by(@user.id)
-                                        .where("score > ?", 11)
-                                        .where(subforem_id: @subforem_ids)
-                                        .order(order)
-                                        .limit(RESULTS_COUNT)
-                                        .merge(Article.featured.or(Article.cached_tagged_with_any(tags)))
-                                    end
-                 end
-
-      # Fallback if there are not enough articles
-      if articles.length < 3
-        if @skip_subforem_filtering
-          # If we're skipping subforem filtering, get articles from anywhere
-          articles_query = Article.select(:title, :description, :path, :cached_user, :cached_tag_list, :subforem_id, :comment_score, :comments_count)
-            .published
-            .full_posts
-            .where("published_at > ?", cutoff_date)
-            .where(email_digest_eligible: true)
-            .where("score > ?", 11)
-        else
-          # For fallback, include both followed subforems and default subforem
-          fallback_subforem_ids = @subforem_ids.dup
-          default_subforem_id = Subforem.cached_default_id
-          if default_subforem_id && fallback_subforem_ids.exclude?(default_subforem_id)
-            fallback_subforem_ids << default_subforem_id
-          end
-
-          articles_query = Article.select(:title, :description, :path, :cached_user, :cached_tag_list, :subforem_id, :comment_score, :comments_count)
-            .published
-            .full_posts
-            .where("published_at > ?", cutoff_date)
-            .where(email_digest_eligible: true)
-            .where("score > ?", 11)
-            .where(subforem_id: fallback_subforem_ids)
-        end
-
-        articles = articles_query.not_authored_by(@user.id)
-          .order(order)
-          .limit(RESULTS_COUNT)
-
-        if @user.cached_antifollowed_tag_names.any?
-          articles = articles.not_cached_tagged_with_any(@user.cached_antifollowed_tag_names)
-        end
+      if Settings::UserExperience.feed_strategy == "configured"
+        articles = personalized_articles
+        return articles if articles
       end
 
-      # Ensure we operate on an array to avoid relation-slicing surprises
-      articles = articles.to_a
-
-      # Pop second article to front if the first article is the same as the last email
-      if articles.any? && last_email_includes_title_in_subject?(articles.first.title)
-        articles = articles.rotate(1)
-      end
-
-      articles.length < 3 ? [] : articles
+      legacy_articles
     end
-    # rubocop:enable Metrics/BlockLength
   end
 
   def should_receive_email?
@@ -132,6 +38,140 @@ class EmailDigestArticleCollector
   end
 
   private
+
+  # rubocop:disable Metrics/PerceivedComplexity
+  def legacy_articles
+    order = Arel.sql("(((score + comment_score) * ((feed_success_score * 12) + 0.1)) - (clickbait_score * 2)) DESC")
+    articles = if @user.cached_followed_tag_names.any?
+                 # Set subforem context for followed subforems or default
+                 set_subforem_context
+
+                 articles_query = @user.followed_articles
+                   .select(*DIGEST_ARTICLE_COLUMNS)
+                   .published
+                   .full_posts
+                   .where("published_at > ?", cutoff_date)
+                   .where(email_digest_eligible: true)
+                   .not_authored_by(@user.id)
+                   .where("score > ?", 8)
+
+                 # Only filter by subforem if we're not skipping subforem filtering
+                 articles_query = articles_query.where(subforem_id: @subforem_ids) unless @skip_subforem_filtering
+
+                 articles_query.order(order).limit(RESULTS_COUNT)
+               else
+                 tags = @user.cached_followed_tag_names_or_recent_tags
+                 # Set subforem context for followed subforems or default
+                 set_subforem_context
+
+                 articles_query = if @skip_subforem_filtering
+                                    # If skipping subforem filtering, get articles from anywhere
+                                    Article.select(*DIGEST_ARTICLE_COLUMNS)
+                                      .published
+                                      .full_posts
+                                      .where("published_at > ?", cutoff_date)
+                                      .where(email_digest_eligible: true)
+                                      .not_authored_by(@user.id)
+                                      .where("score > ?", 11)
+                                      .merge(Article.featured.or(Article.cached_tagged_with_any(tags)))
+                                      .order(order)
+                                      .limit(RESULTS_COUNT)
+                                  else
+                                    # Normal logic with subforem filtering and tags
+                                    Article.select(*DIGEST_ARTICLE_COLUMNS)
+                                      .published
+                                      .full_posts
+                                      .where("published_at > ?", cutoff_date)
+                                      .where(email_digest_eligible: true)
+                                      .not_authored_by(@user.id)
+                                      .where("score > ?", 11)
+                                      .where(subforem_id: @subforem_ids)
+                                      .order(order)
+                                      .limit(RESULTS_COUNT)
+                                      .merge(Article.featured.or(Article.cached_tagged_with_any(tags)))
+                                  end
+               end
+
+    # Fallback if there are not enough articles
+    if articles.length < 3
+      if @skip_subforem_filtering
+        # If we're skipping subforem filtering, get articles from anywhere
+        articles_query = Article.select(*DIGEST_ARTICLE_COLUMNS)
+          .published
+          .full_posts
+          .where("published_at > ?", cutoff_date)
+          .where(email_digest_eligible: true)
+          .where("score > ?", 11)
+      else
+        # For fallback, include both followed subforems and default subforem
+        fallback_subforem_ids = @subforem_ids.dup
+        default_subforem_id = Subforem.cached_default_id
+        if default_subforem_id && fallback_subforem_ids.exclude?(default_subforem_id)
+          fallback_subforem_ids << default_subforem_id
+        end
+
+        articles_query = Article.select(*DIGEST_ARTICLE_COLUMNS)
+          .published
+          .full_posts
+          .where("published_at > ?", cutoff_date)
+          .where(email_digest_eligible: true)
+          .where("score > ?", 11)
+          .where(subforem_id: fallback_subforem_ids)
+      end
+
+      articles = articles_query.not_authored_by(@user.id)
+        .order(order)
+        .limit(RESULTS_COUNT)
+
+      if @user.cached_antifollowed_tag_names.any?
+        articles = articles.not_cached_tagged_with_any(@user.cached_antifollowed_tag_names)
+      end
+    end
+
+    # Ensure we operate on an array to avoid relation-slicing surprises
+    articles = articles.to_a
+
+    # Pop second article to front if the first article is the same as the last email
+    if articles.any? && last_email_includes_title_in_subject?(articles.first.title)
+      articles = articles.rotate(1)
+    end
+
+    articles.length < 3 ? [] : articles
+  end
+  # rubocop:enable Metrics/PerceivedComplexity
+
+  def personalized_articles
+    feed_config = FeedConfig.order(feed_success_score: :desc).first
+    return unless feed_config
+
+    set_subforem_context
+
+    score_sql = feed_config.score_sql(@user)
+
+    articles_query = Article
+      .select(*DIGEST_ARTICLE_COLUMNS)
+      .published
+      .full_posts
+      .where("published_at > ?", cutoff_date)
+      .where(email_digest_eligible: true)
+      .not_authored_by(@user.id)
+      .order(Arel.sql("#{score_sql} DESC"))
+      .limit(RESULTS_COUNT)
+
+    articles_query = articles_query.where(subforem_id: @subforem_ids) unless @skip_subforem_filtering
+
+    blocked_ids = UserBlock.cached_blocked_ids_for_blocker(@user.id)
+    articles_query = articles_query.where.not(user_id: blocked_ids) if blocked_ids.any?
+
+    hidden_tags = @user.cached_antifollowed_tag_names
+    articles_query = articles_query.not_cached_tagged_with_any(hidden_tags) if hidden_tags.any?
+
+    articles = articles_query.to_a
+    articles = articles.rotate(1) if articles.any? && last_email_includes_title_in_subject?(articles.first.title)
+    articles.length >= 3 ? articles : nil
+  rescue StandardError
+    nil
+  end
 
   def set_subforem_context
     # Get user's followed subforems from UserActivity

--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -17,7 +17,8 @@ class EmailDigestArticleCollector
     instrument ARTICLES_TO_SEND, tags: { user_id: @user.id } do
       return [] unless @force_send || should_receive_email?
 
-      if Settings::UserExperience.feed_strategy == "configured"
+      if FeatureFlag.enabled?(:personalized_email_digests) &&
+          Settings::UserExperience.feed_strategy == "configured"
         articles = personalized_articles
         return articles if articles
       end

--- a/spec/services/email_digest_article_collector_spec.rb
+++ b/spec/services/email_digest_article_collector_spec.rb
@@ -294,6 +294,7 @@ RSpec.describe EmailDigestArticleCollector, type: :service do
       let(:feed_config) { create(:feed_config) }
 
       before do
+        FeatureFlag.enable(:personalized_email_digests)
         allow(Settings::UserExperience).to receive(:feed_strategy).and_return("configured")
         allow(FeedConfig).to receive(:order).and_return(instance_double(ActiveRecord::Relation, first: feed_config))
         allow(feed_config).to receive(:score_sql).and_return("articles.score")
@@ -343,6 +344,18 @@ RSpec.describe EmailDigestArticleCollector, type: :service do
 
       it "skips personalized path when feed_strategy is not 'configured'" do
         allow(Settings::UserExperience).to receive(:feed_strategy).and_return("basic")
+        allow(FeedConfig).to receive(:order).and_call_original
+
+        other_user = create(:user)
+        create_list(:article, 3, score: 40, featured: true, email_digest_eligible: true,
+                                 subforem: default_subforem, user: other_user)
+        described_class.new(user).articles_to_send
+
+        expect(FeedConfig).not_to have_received(:order)
+      end
+
+      it "skips personalized path when feature flag is disabled" do
+        FeatureFlag.disable(:personalized_email_digests)
         allow(FeedConfig).to receive(:order).and_call_original
 
         other_user = create(:user)

--- a/spec/services/email_digest_article_collector_spec.rb
+++ b/spec/services/email_digest_article_collector_spec.rb
@@ -135,7 +135,8 @@ RSpec.describe EmailDigestArticleCollector, type: :service do
                                  tag_list: "career", user: other_user, featured: true)
         create_list(:article, 3, public_reactions_count: 40, score: 40, subforem: default_subforem,
                                  tag_list: "productivity", user: other_user, featured: true)
-        create_list(:article, 2, public_reactions_count: 40, score: 40, subforem: create(:subforem, domain: "other.test"),
+        other_subforem = create(:subforem, domain: "other.test")
+        create_list(:article, 2, public_reactions_count: 40, score: 40, subforem: other_subforem,
                                  tag_list: "ruby", user: other_user, featured: true)
 
         articles = described_class.new(user).articles_to_send
@@ -286,6 +287,144 @@ RSpec.describe EmailDigestArticleCollector, type: :service do
         result = described_class.new(user).articles_to_send
 
         expect(result.first.title).to eq articles.first.title
+      end
+    end
+
+    context "with personalized selection via FeedConfig" do
+      let(:feed_config) { create(:feed_config) }
+
+      before do
+        allow(Settings::UserExperience).to receive(:feed_strategy).and_return("configured")
+        allow(FeedConfig).to receive(:order).and_return(instance_double(ActiveRecord::Relation, first: feed_config))
+        allow(feed_config).to receive(:score_sql).and_return("articles.score")
+      end
+
+      it "returns personalized articles when FeedConfig produces >= 3 eligible results" do
+        other_user = create(:user)
+        create_list(:article, 4, score: 40, featured: true, email_digest_eligible: true,
+                                 subforem: default_subforem, user: other_user)
+
+        articles = described_class.new(user).articles_to_send
+        expect(articles.length).to be >= 3
+      end
+
+      it "falls back to legacy selection when personalized result has < 3 articles" do
+        other_user = create(:user)
+        # Only 2 eligible articles → personalized returns nil → legacy path runs
+        create_list(:article, 2, score: 40, featured: true, email_digest_eligible: true,
+                                 subforem: default_subforem, user: other_user)
+        # Add a 3rd article that the legacy path can also find
+        create(:article, score: 40, featured: true, email_digest_eligible: true,
+                         subforem: default_subforem, user: other_user)
+
+        articles = described_class.new(user).articles_to_send
+        expect(articles.length).to be >= 3
+      end
+
+      it "falls back to legacy selection when personalized path raises" do
+        other_user = create(:user)
+        create_list(:article, 3, score: 40, featured: true, email_digest_eligible: true,
+                                 subforem: default_subforem, user: other_user)
+        allow(feed_config).to receive(:score_sql).and_raise(StandardError, "boom")
+
+        articles = described_class.new(user).articles_to_send
+        expect(articles.length).to be >= 3
+      end
+
+      it "falls back to legacy selection when no FeedConfig exists" do
+        allow(FeedConfig).to receive(:order).and_return(instance_double(ActiveRecord::Relation, first: nil))
+        other_user = create(:user)
+        create_list(:article, 3, score: 40, featured: true, email_digest_eligible: true,
+                                 subforem: default_subforem, user: other_user)
+
+        articles = described_class.new(user).articles_to_send
+        expect(articles.length).to be >= 3
+      end
+
+      it "skips personalized path when feed_strategy is not 'configured'" do
+        allow(Settings::UserExperience).to receive(:feed_strategy).and_return("basic")
+        allow(FeedConfig).to receive(:order).and_call_original
+
+        other_user = create(:user)
+        create_list(:article, 3, score: 40, featured: true, email_digest_eligible: true,
+                                 subforem: default_subforem, user: other_user)
+        described_class.new(user).articles_to_send
+
+        expect(FeedConfig).not_to have_received(:order)
+      end
+
+      it "never includes the user's own articles" do
+        own_articles = create_list(:article, 5, score: 40, featured: true, email_digest_eligible: true,
+                                                subforem: default_subforem, user: user)
+        other_user = create(:user)
+        create_list(:article, 3, score: 30, featured: true, email_digest_eligible: true,
+                                 subforem: default_subforem, user: other_user)
+
+        articles = described_class.new(user).articles_to_send
+        own_paths = own_articles.map(&:path)
+        expect(articles.none? { |a| own_paths.include?(a.path) }).to be true
+      end
+
+      it "never includes digest-ineligible articles" do
+        other_user = create(:user)
+        ineligible = create_list(:article, 3, score: 40, email_digest_eligible: false,
+                                              subforem: default_subforem, user: other_user)
+        create_list(:article, 3, score: 30, email_digest_eligible: true, featured: true,
+                                 subforem: default_subforem, user: other_user)
+
+        articles = described_class.new(user).articles_to_send
+        ineligible_paths = ineligible.map(&:path)
+        expect(articles.none? { |a| ineligible_paths.include?(a.path) }).to be true
+      end
+
+      it "never includes articles from blocked authors" do
+        blocked_author = create(:user)
+        create(:user_block, blocker: user, blocked: blocked_author, config: "default")
+        allow(UserBlock).to receive(:cached_blocked_ids_for_blocker).with(user.id).and_return([blocked_author.id])
+
+        blocked_articles = create_list(:article, 3, score: 40, featured: true, email_digest_eligible: true,
+                                                    subforem: default_subforem, user: blocked_author)
+        other_user = create(:user)
+        create_list(:article, 3, score: 30, featured: true, email_digest_eligible: true,
+                                 subforem: default_subforem, user: other_user)
+
+        articles = described_class.new(user).articles_to_send
+        blocked_paths = blocked_articles.map(&:path)
+        expect(articles.none? { |a| blocked_paths.include?(a.path) }).to be true
+      end
+
+      it "bumps the second article to the top when the first matches the last email subject" do
+        other_user = create(:user)
+        articles = (1..5).map do |i|
+          create(:article, score: 100 - i, featured: true, email_digest_eligible: true,
+                           subforem: default_subforem, user: other_user)
+        end
+
+        Ahoy::Message.create(mailer: "DigestMailer#digest_email",
+                             user_id: user.id, sent_at: 25.hours.ago,
+                             clicked_at: 20.hours.ago,
+                             subject: articles.first.title)
+
+        result = described_class.new(user).articles_to_send
+        expect(result.first.title).to eq articles.second.title
+        expect(result.last.title).to eq articles.first.title
+      end
+
+      it "never includes articles tagged with antifollowed tags" do
+        other_user = create(:user)
+        antifollowed_articles = create_list(:article, 3, score: 40, featured: true, email_digest_eligible: true,
+                                                         tag_list: "ruby", subforem: default_subforem, user: other_user)
+        create_list(:article, 3, score: 30, featured: true, email_digest_eligible: true,
+                                 tag_list: "python", subforem: default_subforem, user: other_user)
+
+        tag = Tag.find_by(name: "ruby") || create(:tag, name: "ruby")
+        user.follow(tag)
+        user.follows.find_by(followable: tag).update!(explicit_points: -999)
+        allow(user).to receive(:cached_antifollowed_tag_names).and_return(["ruby"])
+
+        articles = described_class.new(user).articles_to_send
+        antifollowed_paths = antifollowed_articles.map(&:path)
+        expect(articles.none? { |a| antifollowed_paths.include?(a.path) }).to be true
       end
     end
   end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change enables personalization for the email digest, using FeedConfig scoring like `Articles::Feeds::Custom` does for homepage feeds if `Settings::UserExperience.feed_strategy` is set to `"configured"`. If not enough articles are available or if any errors occur, article selection falls back to the current mechanism.

## Related Tickets & Documents

[JIRA ticket](https://mlhacks.atlassian.net/browse/DEV-3636)

## QA Instructions, Screenshots, Recordings

Backend change only.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None.