### PR TITLE
Decouple web and sidekiq pool sizes

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,13 +17,13 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # http://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("DATABASE_POOL_SIZE") { ENV.fetch("RAILS_MAX_THREADS", 5).to_i } %>
+  # Web dynos will default to 5 connections, perfectly matching Puma threads
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5).to_i %>
   connect_timeout: 6
   checkout_timeout: 10
   idle_timeout: 60
-  reaping_frequency: <%= ENV.fetch("REAPING_FREQUENCY", 40).to_i %>
+  # Sweeps for dead thread connections every 10 seconds instead of 40
+  reaping_frequency: <%= ENV.fetch("REAPING_FREQUENCY", 10).to_i %>
   variables:
       statement_timeout: <%= ENV.fetch("STATEMENT_TIMEOUT", 2500).to_i %>
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -25,6 +25,27 @@ module Sidekiq
 end
 
 Sidekiq.configure_server do |config|
+  # Grab the concurrency passed to Sidekiq (defaults to 16 if not set)
+  sidekiq_concurrency = ENV.fetch("SIDEKIQ_CONCURRENCY", 16).to_i
+
+  # Adjust Sidekiq's internal concurrency
+  config.concurrency = sidekiq_concurrency if config.respond_to?(:concurrency=)
+
+  config.on(:startup) do
+    # Disconnect the default Rails pool (which booted at 5 from RAILS_MAX_THREADS)
+    ActiveRecord::Base.connection_pool.disconnect!
+
+    # Create a new configuration hash with the correct pool size
+    db_config = Rails.application.config.database_configuration[Rails.env].merge(
+      'pool' => sidekiq_concurrency
+    )
+
+    # Re-establish the database connection with the new pool size
+    ActiveRecord::Base.establish_connection(db_config)
+    
+    Rails.logger.info("Sidekiq DB Pool re-established with size: #{sidekiq_concurrency}")
+  end
+
   # @mstruve/@sre: sidekiq-cron still uses the removed poll_interval
   # to determine how often to poll for jobs so we should manually set it
   # https://github.com/ondrejbartas/sidekiq-cron/issues/254

--- a/spec/initializers/sidekiq_spec.rb
+++ b/spec/initializers/sidekiq_spec.rb
@@ -34,4 +34,37 @@ RSpec.describe "Sidekiq Initializer" do
     strategy = Sidekiq::Throttled::Registry.get(Emails::BatchCustomSendWorker)
     expect(strategy).to be_a(Sidekiq::Throttled::Strategy)
   end
+
+  describe "Database Pool Decoupling" do
+    it "reconnects to the database with SIDEKIQ_CONCURRENCY upon Sidekiq startup" do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("SIDEKIQ_CONCURRENCY", 16).and_return("25")
+
+      startup_blocks = []
+      
+      # Since Sidekiq.configure_server blocks only yield when Sidekiq is running as a server,
+      # we bypass the internal state check and manually yield a mock to capture the `.on(:startup)` hook.
+      allow(Sidekiq).to receive(:configure_server).and_wrap_original do |original_method, &block|
+        config_mock = double("SidekiqConfig").as_null_object
+        allow(config_mock).to receive(:on) # allow other hooks like :shutdown
+        allow(config_mock).to receive(:on).with(:startup) { |&startup| startup_blocks << startup }
+        block.call(config_mock)
+      end
+
+      load initializer_path
+
+      our_block = startup_blocks.find { |b| b.source_location[0].include?("config/initializers/sidekiq.rb") }
+      expect(our_block).not_to be_nil, "Expected config.on(:startup) loop to be defined"
+
+      pool_mock = double("ConnectionPool")
+      expect(pool_mock).to receive(:disconnect!)
+      allow(ActiveRecord::Base).to receive(:connection_pool).and_return(pool_mock)
+      
+      expected_db_config = Rails.application.config.database_configuration[Rails.env].merge('pool' => 25)
+      expect(ActiveRecord::Base).to receive(:establish_connection).with(expected_db_config)
+      
+      # Simulate Sidekiq boot completing and triggering our specific startup hook
+      our_block.call
+    end
+  end
 end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Decouple sidekiq from web threads and pool size