### PR TITLE
Allow for manual live event broadcast finishing

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -36,6 +36,17 @@ module Admin
       redirect_to admin_events_path, notice: "Event destroyed successfully."
     end
 
+    def end_broadcast
+      @event = Event.find(params[:id])
+      
+      if @event.update(broadcast_ended_at: Time.current)
+        Events::ManageBroadcastBillboardsWorker.perform_async
+        redirect_to admin_event_path(@event), notice: "Broadcast manually ended. Billboards are being deactivated locally."
+      else
+        redirect_to admin_event_path(@event), alert: "Failed to end broadcast."
+      end
+    end
+
     private
 
     def set_event
@@ -54,6 +65,7 @@ module Admin
         :end_time, 
         :type_of,
         :broadcast_config,
+        :manual_broadcast_end,
         :user_id, 
         :organization_id, 
         :tag_list,

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -142,6 +142,14 @@
       })();
     </script>
 
+    <div class="crayons-field crayons-field--checkbox mt-4">
+      <%= form.check_box :manual_broadcast_end, class: "crayons-checkbox" %>
+      <%= form.label :manual_broadcast_end, class: "crayons-field__label" do %>
+        Manually End Broadcast (Overrides End Time)
+        <p class="crayons-field__description">If checked, the background worker will NOT tear down the billboards when End Time is reached. You must manually press "End Broadcast" on the details page.</p>
+      <% end %>
+    </div>
+
     <div class="crayons-field crayons-field--checkbox">
       <%= form.check_box :published, class: "crayons-checkbox" %>
       <%= form.label :published, class: "crayons-field__label" do %>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -30,6 +30,17 @@
             <span class="c-indicator c-indicator--warning">Draft</span>
           <% end %>
         </li>
+        <% if @event.manual_broadcast_end? %>
+          <li>
+            <strong>Manual Termination:</strong>
+            <% if @event.broadcast_ended_at.present? %>
+               <span class="c-indicator">Closed</span>
+               <span class="text-xs opacity-75">(<%= @event.broadcast_ended_at.to_fs(:short) %>)</span>
+            <% else %>
+               <span class="c-indicator c-indicator--warning">Holding: Waiting for trigger</span>
+            <% end %>
+          </li>
+        <% end %>
         <li><strong>Event Type:</strong> <%= @event.type_of.titleize %></li>
         <li><strong>Broadcast Config:</strong> <%= @event.broadcast_config.titleize %></li>
         <li>
@@ -60,9 +71,14 @@
 
   <div class="flex items-center justify-between mb-6">
     <h2 class="text-2xl font-bold">Generated Billboards</h2>
-    <% if @event.live_stream? %>
-      <button id="toggle-stream-btn" class="c-btn c-btn--secondary c-btn--sm">Test Stream Transition</button>
-    <% end %>
+    <div class="flex items-center gap-2">
+      <% if @event.manual_broadcast_end? && @event.broadcast_ended_at.nil? && @event.published? %>
+        <%= button_to "End Broadcast", end_broadcast_admin_event_path(@event), method: :patch, form: { data: { turbo: false } }, data: { confirm: "Are you sure? This will tear down all active billboards." }, class: "c-btn c-btn--danger c-btn--sm" %>
+      <% end %>
+      <% if @event.live_stream? %>
+        <button id="toggle-stream-btn" class="c-btn c-btn--secondary c-btn--sm">Test Stream Transition</button>
+      <% end %>
+    </div>
   </div>
   
   <% if @event.billboards.any? %>

--- a/app/workers/events/manage_broadcast_billboards_worker.rb
+++ b/app/workers/events/manage_broadcast_billboards_worker.rb
@@ -6,9 +6,16 @@ module Events
     def perform
       # Look for all active broadcasts
       # An active broadcast event is one where the current time falls 
-      # between start_time - 15 minutes and end_time + 5 minutes allowing wiggle room
+      # between start_time - 15 minutes and end_time - 5 minutes
       active_events = Event.published.where.not(broadcast_config: 0)
-                           .where("start_time <= ? AND end_time >= ?", Time.current + 15.minutes, Time.current - 5.minutes)
+                           .where(
+                             "start_time <= :start_cutoff AND (" \
+                               "end_time >= :end_cutoff OR " \
+                               "(manual_broadcast_end = true AND broadcast_ended_at IS NULL)" \
+                             ")",
+                             start_cutoff: Time.current + 15.minutes,
+                             end_cutoff: Time.current + 5.minutes
+                           )
                            .pluck(:id)
 
       # We must turn ON billboards for active events, and OFF for ALL OTHER EXPIRED event broadcasts.
@@ -31,9 +38,9 @@ module Events
       billboards_to_disable = billboards_to_disable.where.not(event_id: active_events) if active_events.any?
       
       newly_disabled_count = 0
-      billboards_to_disable.where(approved: true).find_each do |bb|
+      billboards_to_disable.where("approved = true OR published = true").find_each do |bb|
         # This update triggers bust_billboard_cache naturally
-        bb.update!(approved: false) 
+        bb.update!(approved: false, published: false) 
         newly_disabled_count += 1
       end
       EdgeCache::PurgeByKey.call("main_app_home_page", fallback_paths: "/") if newly_disabled_count > 0

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -136,7 +136,11 @@ namespace :admin do
       resource :moderator, only: %i[create destroy], module: "tags"
     end
     resources :surveys
-    resources :events
+    resources :events do
+      member do
+        patch :end_broadcast
+      end
+    end
   end
 
   scope :customization do

--- a/db/migrate/20260421160606_add_manual_broadcast_end_to_events.rb
+++ b/db/migrate/20260421160606_add_manual_broadcast_end_to_events.rb
@@ -1,0 +1,6 @@
+class AddManualBroadcastEndToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :manual_broadcast_end, :boolean, default: false, null: false
+    add_column :events, :broadcast_ended_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_09_173612) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_21_160606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -670,6 +670,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_09_173612) do
 
   create_table "events", force: :cascade do |t|
     t.integer "broadcast_config", default: 0
+    t.datetime "broadcast_ended_at"
     t.string "cached_tag_list"
     t.datetime "created_at", null: false
     t.jsonb "data", default: {}
@@ -677,6 +678,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_09_173612) do
     t.datetime "end_time", null: false
     t.string "event_name_slug", null: false
     t.string "event_variation_slug", null: false
+    t.boolean "manual_broadcast_end", default: false, null: false
     t.bigint "organization_id"
     t.string "primary_stream_url"
     t.boolean "published", default: false

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -86,5 +86,32 @@ RSpec.describe "Admin::Events", type: :request do
         expect(response.body).to include("prohibited this event from being saved")
       end
     end
+
+    context "with manual_broadcast_end config" do
+      let(:attributes_with_manual) { valid_attributes.merge(manual_broadcast_end: true) }
+      it "permits and sets the manual_broadcast_end flag" do
+        post admin_events_path, params: { event: attributes_with_manual }
+        expect(Event.last.manual_broadcast_end).to eq(true)
+      end
+    end
+  end
+
+  describe "PATCH /admin/content_manager/events/:id/end_broadcast" do
+    let(:event) { create(:event, manual_broadcast_end: true, broadcast_ended_at: nil) }
+
+    context "when logged in as an admin" do
+      before { login_as(super_admin) }
+
+      it "updates broadcast_ended_at and enqueues the worker" do
+        allow(Events::ManageBroadcastBillboardsWorker).to receive(:perform_async)
+        
+        patch end_broadcast_admin_event_path(event)
+        
+        expect(response).to redirect_to(admin_event_path(event))
+        expect(flash[:notice]).to include("Broadcast manually ended")
+        expect(event.reload.broadcast_ended_at).to be_within(1.second).of(Time.current)
+        expect(Events::ManageBroadcastBillboardsWorker).to have_received(:perform_async)
+      end
+    end
   end
 end

--- a/spec/workers/events/manage_broadcast_billboards_worker_spec.rb
+++ b/spec/workers/events/manage_broadcast_billboards_worker_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Events::ManageBroadcastBillboardsWorker, type: :worker do
 
       expect(active_billboard.reload.approved).to eq(true)
       expect(past_billboard.reload.approved).to eq(false)
+      expect(past_billboard.reload.published).to eq(false)
       expect(future_billboard.reload.approved).to eq(false)
+      expect(future_billboard.reload.published).to eq(false)
       
       # Standard billboards remain untouched
       expect(standard_billboard.reload.approved).to eq(true)
@@ -52,16 +54,40 @@ RSpec.describe Events::ManageBroadcastBillboardsWorker, type: :worker do
       end
 
       let(:border_end_event) do
-        create(:event, start_time: 2.hours.ago, end_time: 6.minutes.ago, broadcast_config: "global_broadcast", published: true)
+        create(:event, start_time: 2.hours.ago, end_time: 4.minutes.from_now, broadcast_config: "global_broadcast", published: true)
       end
 
-      let!(:border_start_bb) { create(:billboard, event: border_start_event, approved: false) }
-      let!(:border_end_bb) { create(:billboard, event: border_end_event, approved: true) }
+      let!(:border_start_bb) { create(:billboard, event: border_start_event, approved: false, published: true) }
+      let!(:border_end_bb) { create(:billboard, event: border_end_event, approved: true, published: true) }
 
       it "approves exactly within 15 bounds, and disables exactly after 5 boundary limits" do
         described_class.new.perform
         expect(border_start_bb.reload.approved).to eq(true) # <= 15.minutes
-        expect(border_end_bb.reload.approved).to eq(false) # <= -5.minutes (6.minutes.ago is completely expired)
+        expect(border_end_bb.reload.approved).to eq(false) # <= 5.minutes before end time (4.minutes.from_now fails condition)
+        expect(border_end_bb.reload.published).to eq(false)
+      end
+    end
+
+    context "with manual broadcast termination" do
+      let(:holding_event) do
+        create(:event, start_time: 2.hours.ago, end_time: 1.hour.ago, broadcast_config: "global_broadcast", published: true, manual_broadcast_end: true, broadcast_ended_at: nil)
+      end
+      let!(:holding_billboard) { create(:billboard, event: holding_event, approved: true, published: true) }
+
+      let(:terminated_event) do
+        create(:event, start_time: 2.hours.ago, end_time: 1.hour.ago, broadcast_config: "global_broadcast", published: true, manual_broadcast_end: true, broadcast_ended_at: 30.minutes.ago)
+      end
+      let!(:terminated_billboard) { create(:billboard, event: terminated_event, approved: true, published: true) }
+
+      it "keeps billboards approved past end_time if manual_broadcast_end is true and broadcast_ended_at is nil" do
+        described_class.new.perform
+        expect(holding_billboard.reload.approved).to eq(true)
+      end
+
+      it "unapproves and unpublishes billboards if broadcast_ended_at is present" do
+        described_class.new.perform
+        expect(terminated_billboard.reload.approved).to eq(false)
+        expect(terminated_billboard.reload.published).to eq(false)
       end
     end
   end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Allow for a broadcasted event to be set to end manually instead of having it automatically end at the set time.