### PR TITLE
FIX: clear video_source_url and video fields when user removes cover …

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -325,13 +325,17 @@ class ArticlesController < ApplicationController
                        ]
                      end
 
-    # Allow video_source_url if it's a valid YouTube, Mux, or Twitch URL
+    # Allow video_source_url if it's blank (user is clearing it) or a valid YouTube, Mux, or Twitch URL
     video_url = params.dig("article", "video_source_url")
-    if video_url.present?
-      youtube_pattern = /\Ahttps?:\/\/(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)/
-      mux_pattern = /\Ahttps?:\/\/player\.mux\.com\//
-      twitch_pattern = /\Ahttps?:\/\/(www\.)?twitch\.tv\/videos\//
-      allowed_params << :video_source_url if video_url.match?(youtube_pattern) || video_url.match?(mux_pattern) || video_url.match?(twitch_pattern)
+    if params["article"].key?("video_source_url")
+      if video_url.blank?
+        allowed_params << :video_source_url
+      else
+        youtube_pattern = /\Ahttps?:\/\/(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)/
+        mux_pattern = /\Ahttps?:\/\/player\.mux\.com\//
+        twitch_pattern = /\Ahttps?:\/\/(www\.)?twitch\.tv\/videos\//
+        allowed_params << :video_source_url if video_url.match?(youtube_pattern) || video_url.match?(mux_pattern) || video_url.match?(twitch_pattern)
+      end
     end
 
     # NOTE: the organization logic is still a little counter intuitive but this should

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1064,7 +1064,10 @@ class Article < ApplicationRecord
   end
 
   def generate_video_embed_url
-    return if video_source_url.blank?
+    if video_source_url.blank?
+      self.video = nil
+      return
+    end
 
     if video_source_url.include?("youtube.com") || video_source_url.include?("youtu.be")
       begin

--- a/spec/requests/articles/articles_update_spec.rb
+++ b/spec/requests/articles/articles_update_spec.rb
@@ -191,6 +191,17 @@ RSpec.describe "ArticlesUpdate" do
     expect(article.reload.video_thumbnail_url).to include "https://i.imgur.com/HPiu7N4.jpg"
   end
 
+  it "clears video_source_url and video when an empty video_source_url is submitted" do
+    article.update_columns(video_source_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                           video: "https://www.youtube.com/embed/dQw4w9WgXcQ")
+    put "/articles/#{article.id}", params: {
+      article: { title: article.title, body_markdown: article.body_markdown, video_source_url: "" }
+    }
+    article.reload
+    expect(article.video_source_url).to be_blank
+    expect(article.video).to be_nil
+  end
+
   context "when setting published_at in editor v2" do
     let(:tomorrow) { 1.day.from_now }
     let(:published_at) { "#{tomorrow.strftime('%d.%m.%Y')} 18:00" }


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [x] Bug Fix
- [ ] Feature
- [ ] Optimization
- [ ] Documentation Update

## Description

When a user edits an article and removes the cover video by clearing the **Cover Video Link** field, the video is not removed after saving. It persists in both the UI and the database.

**Root cause — two problems working together:**

**1. Controller was silently ignoring the empty value**

`video_source_url` was only added to permitted params when the value was `present?`. When the user cleared the field and submitted an empty string, the controller saw nothing and excluded the field from the update entirely — the old value was never touched.

**2. Model was not clearing the embed URL**

`generate_video_embed_url` returned early when `video_source_url` was blank without clearing the `video` field, leaving the old embed URL in the database even if the source URL had been cleared.

**Changes made:**
- Permit `video_source_url` when the key is present in params (including blank values) so clearing the field is passed through to the updater
- Clear `self.video` in `generate_video_embed_url` when `video_source_url` is blank so the embed URL is removed alongside the source URL
- Add regression test covering the full removal flow via the HTTP layer

## Related Tickets & Documents

- Closes #23118

## QA Instructions, Screenshots, Recordings

**To reproduce the bug (before this fix):**
1. Create a post and add a YouTube URL in the Cover Video Link field
2. Save the post
3. Edit the post and clear the Cover Video Link field
4. Save again — the video is still there

**To verify the fix:**
1. Follow the same steps above — the video should be removed after saving
2. Run the regression test:

```
bundle exec rspec spec/requests/articles/articles_update_spec.rb -e "clears video_source_url"
```

Tested locally on macOS with Ruby 3.3.0, Rails 7.0.8.7.

## Added/updated tests?

- [x] Yes — added a regression test in `spec/requests/articles/articles_update_spec.rb` that sets a YouTube video on an article, submits an update with a blank `video_source_url`, and asserts both `video_source_url` and `video` are cleared after saving.
