### PR TITLE
FIX: use :video factory trait in videos specs so tests actually pass

### DIFF
--- a/spec/requests/api/v0/videos_spec.rb
+++ b/spec/requests/api/v0/videos_spec.rb
@@ -4,11 +4,9 @@ RSpec.describe "Api::V0::Videos" do
   let(:user) { create(:user, created_at: 1.month.ago) }
 
   def create_article(article_params = {})
-    default_params = {
-      user: user, video: "https://example.com", video_thumbnail_url: "https://example.com", title: "video-#{rand(10_000)}",
-    }
-    params = default_params.merge(article_params)
-    create(:article, params)
+    article = create(:article, :video, user: user, title: "video-#{rand(10_000)}")
+    article.update_columns(article_params) if article_params.any?
+    article
   end
 
   describe "GET /api/videos" do
@@ -22,11 +20,11 @@ RSpec.describe "Api::V0::Videos" do
 
     it "does not return unpublished video articles" do
       article = create_article
-      article.update(published: false)
+      article.update_columns(published: false)
 
       get api_videos_path
 
-      expect(response.parsed_body.size).to eq(1)
+      expect(response.parsed_body.size).to eq(0)
     end
 
     it "does not return regular articles without videos" do
@@ -73,12 +71,7 @@ RSpec.describe "Api::V0::Videos" do
     end
 
     it "supports pagination" do
-      3.times do
-        create(
-          :article,
-          user: user, video: "https://example.com", video_thumbnail_url: "https://example.com", title: "video-#{rand(10_000)}"
-        )
-      end
+      3.times { create(:article, :video, user: user, title: "video-#{rand(10_000)}") }
 
       get api_videos_path, params: { page: 1, per_page: 2 }
       expect(response.parsed_body.length).to eq(2)
@@ -92,12 +85,7 @@ RSpec.describe "Api::V0::Videos" do
       allow(ApplicationConfig).to receive(:[]).with("APP_PROTOCOL").and_return("http://")
       allow(ApplicationConfig).to receive(:[]).with("API_PER_PAGE_MAX").and_return(2)
 
-      3.times do
-        create(
-          :article,
-          user: user, video: "https://example.com", video_thumbnail_url: "https://example.com", title: "video-#{rand(10_000)}"
-        )
-      end
+      3.times { create(:article, :video, user: user, title: "video-#{rand(10_000)}") }
 
       get api_videos_path, params: { per_page: 10 }
       expect(response.parsed_body.count).to eq(2)

--- a/spec/requests/api/v1/videos_spec.rb
+++ b/spec/requests/api/v1/videos_spec.rb
@@ -6,11 +6,9 @@ RSpec.describe "Api::V1::Videos" do
   let(:headers) { { "Accept" => "application/vnd.forem.api-v1+json" } }
 
   def create_article(article_params = {})
-    default_params = {
-      user: user, video: "https://example.com", video_thumbnail_url: "https://example.com", title: "video-#{rand(10_000)}"
-    }
-    params = default_params.merge(article_params)
-    create(:article, params)
+    article = create(:article, :video, user: user, title: "video-#{rand(10_000)}")
+    article.update_columns(article_params) if article_params.any?
+    article
   end
 
   describe "GET /api/videos" do
@@ -24,11 +22,11 @@ RSpec.describe "Api::V1::Videos" do
 
     it "does not return unpublished video articles" do
       article = create_article
-      article.update(published: false)
+      article.update_columns(published: false)
 
       get api_videos_path, headers: headers
 
-      expect(response.parsed_body.size).to eq(1)
+      expect(response.parsed_body.size).to eq(0)
     end
 
     it "does not return regular articles without videos" do
@@ -75,12 +73,7 @@ RSpec.describe "Api::V1::Videos" do
     end
 
     it "supports pagination" do
-      3.times do
-        create(
-          :article,
-          user: user, video: "https://example.com", video_thumbnail_url: "https://example.com", title: "video-#{rand(10_000)}"
-        )
-      end
+      3.times { create(:article, :video, user: user, title: "video-#{rand(10_000)}") }
 
       get api_videos_path, params: { page: 1, per_page: 2 }, headers: headers
       expect(response.parsed_body.length).to eq(2)
@@ -94,12 +87,7 @@ RSpec.describe "Api::V1::Videos" do
       allow(ApplicationConfig).to receive(:[]).with("APP_PROTOCOL").and_return("http://")
       allow(ApplicationConfig).to receive(:[]).with("API_PER_PAGE_MAX").and_return(2)
 
-      3.times do
-        create(
-          :article,
-          user: user, video: "https://example.com", video_thumbnail_url: "https://example.com", title: "video-#{rand(10_000)}"
-        )
-      end
+      3.times { create(:article, :video, user: user, title: "video-#{rand(10_000)}") }
 
       get api_videos_path, params: { per_page: 10 }, headers: headers
       expect(response.parsed_body.count).to eq(2)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

All 7 tests in `spec/requests/api/v0/videos_spec.rb` were failing because
the `create_article` helper passed `video:` and `video_thumbnail_url:` directly
to `create(:article, ...)`. Article callbacks cleared those fields during save,
so `Article.with_video` found nothing and every test returned 0 results.

Three problems fixed:

1. **`create_article` helper used the wrong factory approach**

   Passing `video:` directly to `create(:article, ...)` does not work because
   article callbacks clear the `video` field during save. Switched to the `:video`
   factory trait which sets the field via `update_columns` after create, bypassing
   the callbacks that clear it. Applied the same fix to all inline article creates
   in the pagination and per-page tests.

2. **`article.update(published: false)` triggered a real HTTP request**

   Calling `update` runs all callbacks including `fetch_video_duration`, which
   makes a real HTTP request blocked by WebMock in the test environment, causing
   a `WebMock::NetConnectNotAllowedError`. Switched to `update_columns` to bypass
   callbacks when unpublishing in tests.

3. **Wrong assertion on the unpublished test**

   The "does not return unpublished video articles" test asserted `eq(1)` but the
   article was unpublished — the correct expectation is `eq(0)`.

## Related Tickets & Documents

- No linked issue — these are pre-existing test failures on `forem/main`

## QA Instructions, Screenshots, Recordings

To reproduce the original failures (before this fix):

```bash
bundle exec rspec spec/requests/api/v0/videos_spec.rb
# 7 failures, all returning 0 results
```

To verify the fix:

```bash
bundle exec rspec spec/requests/api/v0/videos_spec.rb spec/requests/api/v1/videos_spec.rb
# 18 examples, 0 failures
```

Tested locally on macOS with Ruby 3.3.0, Rails 7.0.8.7.

## Added/updated tests?

- [x] No — fixed existing broken tests, no new tests added
