### PR TITLE
Fix CodePen tag validation for single-ID CodePen 2.0 editor URLs

### DIFF
--- a/app/liquid_tags/codepen_tag.rb
+++ b/app/liquid_tags/codepen_tag.rb
@@ -10,7 +10,7 @@ class CodepenTag < LiquidTagBase
   REGISTRY_REGEXP =
     %r{\Ahttps?://codepen\.io/(?:
       (?:team/)?#{USERNAME_REGEXP}/(?:pen|embed)(?:/preview)?/#{PEN_ID_REGEXP}|
-      editor/#{USERNAME_REGEXP}/(?:pen|embed)(?:/preview)?/#{EDITOR_PEN_ID_REGEXP}/#{PEN_ID_REGEXP}
+      editor/#{USERNAME_REGEXP}/(?:pen|embed)(?:/preview)?/#{EDITOR_PEN_ID_REGEXP}(?:/#{PEN_ID_REGEXP})?
     )/?\z}x
 
   def initialize(_tag_name, link, _parse_context)

--- a/spec/liquid_tags/codepen_tag_spec.rb
+++ b/spec/liquid_tags/codepen_tag_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe CodepenTag, type: :liquid_tag do
     let(:codepen_editor_link) do
       "https://codepen.io/editor/alvaromontoro/pen/019d657e-d7bc-746a-9bc3-4df2244c97cc/24ac30a5aad27b2b927702d3557c6e70"
     end
+    let(:codepen_editor_single_id_link) do
+      "https://codepen.io/editor/alvaromontoro/pen/019d657e-d7bc-746a-9bc3-4df2244c97cc"
+    end
     let(:codepen_link_with_default_tab) { "https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result" }
     let(:codepen_link_with_theme_id) { "https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148" }
     let(:codepen_link_with_preview_indicator) { "https://codepen.io/propjockey/pen/preview/dyVMgBg" }
@@ -82,6 +85,15 @@ RSpec.describe CodepenTag, type: :liquid_tag do
       expect(liquid.render).to include("<iframe")
         .and include(
           'src="https://codepen.io/editor/alvaromontoro/embed/019d657e-d7bc-746a-9bc3-4df2244c97cc/24ac30a5aad27b2b927702d3557c6e70?height=600&default-tab=result&embed-version=2"',
+        )
+    end
+
+    it "accepts CodePen 2.0 editor link with only the editor pen ID" do
+      liquid = generate_new_liquid(codepen_editor_single_id_link)
+
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/editor/alvaromontoro/embed/019d657e-d7bc-746a-9bc3-4df2244c97cc?height=600&default-tab=result&embed-version=2"',
         )
     end
 


### PR DESCRIPTION
## Description

Forem currently supports classic CodePen URLs and one form of CodePen 2.0 editor URLs, but rejects newer editor URLs that contain only a single editor pen ID.

This causes valid embeds like:

`https://codepen.io/editor/<username>/pen/<editor_id>`

to fail with "Invalid CodePen URL".

## Changes

- Update CodePen URL validation to accept single-ID CodePen 2.0 editor URLs
- Preserve support for existing classic and two-ID editor URL formats
- Add regression test coverage for the single-ID editor URL format

## Testing

- Added spec coverage for a valid single-ID CodePen 2.0 editor URL

> Note: Tests were not executed locally due to environment constraints.