### PR TITLE
Fix video cover not removed when editing article

### DIFF
--- a/app/javascript/article-form/articleForm.jsx
+++ b/app/javascript/article-form/articleForm.jsx
@@ -383,6 +383,7 @@ export class ArticleForm extends Component {
     const payload = {
       ...this.state,
       published: true,
+      video_thumbnail_url: this.state.videoSourceUrl ? this.state.video_thumbnail_url : null,
     };
 
     submitArticle({
@@ -401,6 +402,7 @@ export class ArticleForm extends Component {
     const payload = {
       ...this.state,
       published: false,
+      video_thumbnail_url: this.state.videoSourceUrl ? this.state.video_thumbnail_url : null,
     };
 
     submitArticle({


### PR DESCRIPTION
## 🐛 Description

When editing an article with a video cover, removing the video and saving does not remove the video cover.

This happens because the frontend does not send a clearing value for `video_thumbnail_url`, so the backend retains the previous value.

## ✅ Fix

- Explicitly send `video_thumbnail_url: null` when video is removed
- Ensures backend properly clears the video cover

## 💡 Result

Removing a video cover now correctly updates the article state.