### PR TITLE
Add sidekiq memory killer

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,6 +5,7 @@ require "sidekiq/worker_retries_exhausted_reporter"
 require "sidekiq/sidekiq_connection_cleanup"
 require "sidekiq/transaction_safe_rescue"
 require "sidekiq/throttled"
+require "sidekiq/memory_killer"
 
 module Sidekiq
   module Cron
@@ -78,6 +79,7 @@ Sidekiq.configure_server do |config|
     chain.add SidekiqUniqueJobs::Middleware::Client
     chain.add SidekiqUniqueJobs::Middleware::Server
     chain.add Sidekiq::SidekiqConnectionCleanup
+    chain.add Sidekiq::MemoryKiller
   end
 
   SidekiqUniqueJobs::Server.configure(config)

--- a/lib/sidekiq/memory_killer.rb
+++ b/lib/sidekiq/memory_killer.rb
@@ -21,10 +21,11 @@ module Sidekiq
       rss_kb = extract_memory_kb
       return if rss_kb <= 0
 
-      rss_mb = rss_kb / 1024
+      max_rss_kb = @max_rss_mb * 1024
 
-      if rss_mb > @max_rss_mb
+      if rss_kb > max_rss_kb
         @terminating = true
+        rss_mb = (rss_kb / 1024.0).round(2)
         ::Rails.logger.warn("SidekiqMemoryKiller: Memory usage #{rss_mb}MB exceeds max #{@max_rss_mb}MB. Sending SIGTERM to PID #{::Process.pid}.")
         # Send SIGTERM to the current process to gracefully shut down Sidekiq.
         # It will stop accepting new jobs, finish current ones, and then exit.
@@ -42,7 +43,8 @@ module Sidekiq
       end
       
       `ps -o rss= -p #{::Process.pid}`.strip.to_i
-    rescue StandardError
+    rescue StandardError => e
+      ::Rails.logger.error("SidekiqMemoryKiller: Error checking memory in extract_memory_kb: #{e.message}")
       0
     end
   end

--- a/lib/sidekiq/memory_killer.rb
+++ b/lib/sidekiq/memory_killer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  class MemoryKiller
+    def initialize
+      @max_rss_mb = ENV.fetch("SIDEKIQ_MEMORY_KILLER_MAX_MB", 1024).to_i
+      @enabled = ENV["SIDEKIQ_MEMORY_KILLER_ENABLED"] == "true"
+    end
+
+    def call(worker, job, queue)
+      yield
+    ensure
+      check_and_kill! if @enabled
+    end
+
+    private
+
+    def check_and_kill!
+      rss_kb = extract_memory_kb
+      rss_mb = rss_kb / 1024
+
+      if rss_mb > @max_rss_mb
+        ::Rails.logger.warn("SidekiqMemoryKiller: Memory usage #{rss_mb}MB exceeds max #{@max_rss_mb}MB. Sending SIGTERM to PID #{::Process.pid}.")
+        # Send SIGTERM to the current process to gracefully shut down Sidekiq.
+        # It will stop accepting new jobs, finish current ones, and then exit.
+        ::Process.kill("TERM", ::Process.pid)
+      end
+    rescue StandardError => e
+      ::Rails.logger.error("SidekiqMemoryKiller: Failed to check memory: #{e.message}")
+    end
+
+    def extract_memory_kb
+      `ps -o rss= -p #{::Process.pid}`.strip.to_i
+    end
+  end
+end

--- a/lib/sidekiq/memory_killer.rb
+++ b/lib/sidekiq/memory_killer.rb
@@ -3,23 +3,28 @@
 module Sidekiq
   class MemoryKiller
     def initialize
-      @max_rss_mb = ENV.fetch("SIDEKIQ_MEMORY_KILLER_MAX_MB", 1024).to_i
+      max_rss_env = ENV.fetch("SIDEKIQ_MEMORY_KILLER_MAX_MB", "1024").to_s
+      @max_rss_mb = max_rss_env.to_i > 0 ? max_rss_env.to_i : 1024
       @enabled = ENV["SIDEKIQ_MEMORY_KILLER_ENABLED"] == "true"
+      @terminating = false
     end
 
     def call(worker, job, queue)
       yield
     ensure
-      check_and_kill! if @enabled
+      check_and_kill! if @enabled && !@terminating
     end
 
     private
 
     def check_and_kill!
       rss_kb = extract_memory_kb
+      return if rss_kb <= 0
+
       rss_mb = rss_kb / 1024
 
       if rss_mb > @max_rss_mb
+        @terminating = true
         ::Rails.logger.warn("SidekiqMemoryKiller: Memory usage #{rss_mb}MB exceeds max #{@max_rss_mb}MB. Sending SIGTERM to PID #{::Process.pid}.")
         # Send SIGTERM to the current process to gracefully shut down Sidekiq.
         # It will stop accepting new jobs, finish current ones, and then exit.
@@ -30,7 +35,15 @@ module Sidekiq
     end
 
     def extract_memory_kb
+      if File.exist?("/proc/self/status")
+        status = ::File.read("/proc/self/status")
+        rss_line = status.each_line.find { |line| line.start_with?("VmRSS:") }
+        return rss_line.split[1].to_i if rss_line
+      end
+      
       `ps -o rss= -p #{::Process.pid}`.strip.to_i
+    rescue StandardError
+      0
     end
   end
 end

--- a/spec/lib/sidekiq/memory_killer_spec.rb
+++ b/spec/lib/sidekiq/memory_killer_spec.rb
@@ -14,12 +14,13 @@ RSpec.describe Sidekiq::MemoryKiller do
 
   describe "#call" do
     it "yields to the block" do
+      stub_const("ENV", ENV.to_hash.merge("SIDEKIQ_MEMORY_KILLER_ENABLED" => "false"))
       expect { |b| middleware.call(worker, job, queue, &b) }.to yield_control
     end
 
     context "when disabled via ENV" do
       before do
-        middleware.instance_variable_set(:@enabled, false)
+        stub_const("ENV", ENV.to_hash.merge("SIDEKIQ_MEMORY_KILLER_ENABLED" => "false"))
       end
 
       it "does not check memory" do
@@ -30,8 +31,7 @@ RSpec.describe Sidekiq::MemoryKiller do
 
     context "when enabled via ENV" do
       before do
-        middleware.instance_variable_set(:@enabled, true)
-        middleware.instance_variable_set(:@max_rss_mb, 1024)
+        stub_const("ENV", ENV.to_hash.merge("SIDEKIQ_MEMORY_KILLER_ENABLED" => "true", "SIDEKIQ_MEMORY_KILLER_MAX_MB" => "1024"))
       end
 
       it "checks memory" do

--- a/spec/lib/sidekiq/memory_killer_spec.rb
+++ b/spec/lib/sidekiq/memory_killer_spec.rb
@@ -1,0 +1,77 @@
+require "rails_helper"
+require "sidekiq/memory_killer"
+
+RSpec.describe Sidekiq::MemoryKiller do
+  let(:middleware) { described_class.new }
+  let(:worker) { double("worker") }
+  let(:job) { { "class" => "SomeWorker" } }
+  let(:queue) { "default" }
+  let(:yield_block) { -> {} }
+
+  before do
+    allow(Process).to receive(:kill).with("TERM", Process.pid)
+  end
+
+  describe "#call" do
+    it "yields to the block" do
+      expect { |b| middleware.call(worker, job, queue, &b) }.to yield_control
+    end
+
+    context "when disabled via ENV" do
+      before do
+        middleware.instance_variable_set(:@enabled, false)
+      end
+
+      it "does not check memory" do
+        expect(middleware).not_to receive(:check_and_kill!)
+        middleware.call(worker, job, queue, &yield_block)
+      end
+    end
+
+    context "when enabled via ENV" do
+      before do
+        middleware.instance_variable_set(:@enabled, true)
+        middleware.instance_variable_set(:@max_rss_mb, 1024)
+      end
+
+      it "checks memory" do
+        expect(middleware).to receive(:extract_memory_kb).and_return(500000)
+        middleware.call(worker, job, queue, &yield_block)
+      end
+
+      context "when memory is below the limit" do
+        before do
+          # Return ~500 MB
+          allow(middleware).to receive(:extract_memory_kb).and_return(512000)
+        end
+
+        it "does not kill the process" do
+          expect(Process).not_to receive(:kill)
+          middleware.call(worker, job, queue, &yield_block)
+        end
+      end
+
+      context "when memory exceeds the limit" do
+        it "logs a warning and kills the process with SIGTERM" do
+          expect(middleware).to receive(:extract_memory_kb).and_return(1536000)
+          expect(::Rails.logger).to receive(:warn)
+          expect(::Process).to receive(:kill).with("TERM", ::Process.pid)
+          
+          middleware.call(worker, job, queue, &yield_block)
+        end
+      end
+
+      context "when the memory check raises an error" do
+        before do
+          allow(middleware).to receive(:extract_memory_kb).and_raise(StandardError, "ps command failed")
+          allow(::Rails.logger).to receive(:error)
+        end
+
+        it "rescues the error, logs it, and does not crash the worker" do
+          expect(::Rails.logger).to receive(:error).with(/SidekiqMemoryKiller: Failed to check memory: ps command failed/)
+          expect { middleware.call(worker, job, queue, &yield_block) }.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
A feature to kill sidekiq workers if we run out of memory so that we don't have to over-provision. We want to monitor process-level memory consumption and gracefully terminate the Sidekiq process.