### PR TITLE
Fix analytics dashboard 'Failed to fetch chart data' error

### DIFF
--- a/app/controllers/api/v0/analytics_controller.rb
+++ b/app/controllers/api/v0/analytics_controller.rb
@@ -11,7 +11,7 @@ module Api
       before_action :authenticate_with_api_key_or_current_user!
       before_action :authorize_user_organization
       before_action :load_owner
-      before_action :validate_date_params, only: [:historical]
+      before_action :validate_date_params, only: %i[historical dashboard]
     end
   end
 end

--- a/app/controllers/api/v1/analytics_controller.rb
+++ b/app/controllers/api/v1/analytics_controller.rb
@@ -11,7 +11,7 @@ module Api
       before_action :authenticate_with_api_key_or_current_user!
       before_action :authorize_user_organization
       before_action :load_owner
-      before_action :validate_date_params, only: [:historical]
+      before_action :validate_date_params, only: %i[historical dashboard]
     end
   end
 end

--- a/app/controllers/concerns/api/analytics_controller.rb
+++ b/app/controllers/concerns/api/analytics_controller.rb
@@ -57,20 +57,22 @@ module Api
     # per-IP Rack::Attack api_throttle (3 GETs/sec), halves middleware overhead,
     # and gives the client a consistent point-in-time snapshot across panels.
     def dashboard
-      dated = AnalyticsService.new(
-        @owner,
-        start_date: params[:start], end_date: params[:end], article_id: params[:article_id],
-      )
-      all_time = AnalyticsService.new(@owner, article_id: analytics_params[:article_id])
-
       cache_key = [
-        "analytics-dashboard-v1",
+        "analytics-dashboard",
         params[:start], params[:end],
         @owner.class.name, @owner.id,
         params[:article_id]
       ].join("-")
 
       data = Rails.cache.fetch(cache_key, expires_in: 7.days) do
+        # Construct services lazily inside the cache block: AnalyticsService#initialize
+        # runs load_data, so building them on cache hits would defeat the cache.
+        dated = AnalyticsService.new(
+          @owner,
+          start_date: params[:start], end_date: params[:end], article_id: params[:article_id],
+        )
+        all_time = AnalyticsService.new(@owner, article_id: analytics_params[:article_id])
+
         {
           historical: dated.grouped_by_day,
           totals: all_time.totals,

--- a/app/controllers/concerns/api/analytics_controller.rb
+++ b/app/controllers/concerns/api/analytics_controller.rb
@@ -52,6 +52,37 @@ module Api
       render json: data.to_json
     end
 
+    # Bundled endpoint: returns every payload the analytics dashboard UI needs
+    # in a single response. Consolidating into one request avoids tripping the
+    # per-IP Rack::Attack api_throttle (3 GETs/sec), halves middleware overhead,
+    # and gives the client a consistent point-in-time snapshot across panels.
+    def dashboard
+      dated = AnalyticsService.new(
+        @owner,
+        start_date: params[:start], end_date: params[:end], article_id: params[:article_id],
+      )
+      all_time = AnalyticsService.new(@owner, article_id: analytics_params[:article_id])
+
+      cache_key = [
+        "analytics-dashboard-v1",
+        params[:start], params[:end],
+        @owner.class.name, @owner.id,
+        params[:article_id]
+      ].join("-")
+
+      data = Rails.cache.fetch(cache_key, expires_in: 7.days) do
+        {
+          historical: dated.grouped_by_day,
+          totals: all_time.totals,
+          referrers: dated.referrers,
+          top_contributors: dated.top_contributors,
+          follower_engagement: dated.follower_engagement
+        }
+      end
+
+      render json: data.to_json
+    end
+
     private
 
     def authorize_user_organization

--- a/app/javascript/analytics/__tests__/client.test.js
+++ b/app/javascript/analytics/__tests__/client.test.js
@@ -1,0 +1,167 @@
+import fetchMock from 'jest-fetch-mock';
+import {
+  withRetry,
+  callHistoricalAPI,
+  callReferrersAPI,
+  callTotalsAPI,
+  callTopContributorsAPI,
+  callFollowerEngagementAPI,
+  callDashboardAPI,
+} from '../client';
+
+/* global globalThis */
+
+describe('analytics/client', () => {
+  beforeAll(() => {
+    globalThis.fetch = fetchMock;
+  });
+
+  beforeEach(() => {
+    fetchMock.resetMocks();
+  });
+
+  afterAll(() => {
+    delete globalThis.fetch;
+  });
+
+  describe('withRetry', () => {
+    it('resolves without retry when fn succeeds on the first try', async () => {
+      const fn = jest.fn().mockResolvedValue('ok');
+
+      await expect(withRetry(fn, { baseDelayMs: 0 })).resolves.toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries once on TypeError and resolves on the second attempt', async () => {
+      const fn = jest
+        .fn()
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockResolvedValueOnce('ok');
+
+      await expect(withRetry(fn, { baseDelayMs: 0 })).resolves.toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects with the final error after exhausting retries', async () => {
+      const fn = jest.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+      await expect(withRetry(fn, { baseDelayMs: 0 })).rejects.toThrow('Failed to fetch');
+      expect(fn).toHaveBeenCalledTimes(2); // initial + 1 retry
+    });
+
+    it('does NOT retry on non-TypeError (e.g. 4xx/5xx from handleFetchAPIErrors)', async () => {
+      const fn = jest.fn().mockRejectedValue(new Error('Not Found'));
+
+      await expect(withRetry(fn, { baseDelayMs: 0 })).rejects.toThrow('Not Found');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('honors a custom maxRetries count', async () => {
+      const fn = jest.fn().mockRejectedValue(new TypeError('network down'));
+
+      await expect(
+        withRetry(fn, { maxRetries: 3, baseDelayMs: 0 }),
+      ).rejects.toThrow('network down');
+      expect(fn).toHaveBeenCalledTimes(4); // initial + 3 retries
+    });
+  });
+
+  describe('call*API URL construction', () => {
+    const date = new Date('2024-05-01T12:00:00Z');
+
+    beforeEach(() => {
+      fetchMock.mockResponseOnce(JSON.stringify({ ok: true }));
+    });
+
+    it('callHistoricalAPI hits the historical endpoint with start+org+article params', async () => {
+      await callHistoricalAPI(date, { organizationId: 42, articleId: 7 });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/analytics/historical?start=2024-05-01&organization_id=42&article_id=7',
+      );
+    });
+
+    it('callReferrersAPI hits the referrers endpoint', async () => {
+      await callReferrersAPI(date, {});
+
+      expect(fetchMock).toHaveBeenCalledWith('/api/analytics/referrers?start=2024-05-01');
+    });
+
+    it('callTotalsAPI hits the totals endpoint', async () => {
+      await callTotalsAPI(date, { organizationId: 99 });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/analytics/totals?start=2024-05-01&organization_id=99',
+      );
+    });
+
+    it('callTopContributorsAPI hits the top_contributors endpoint', async () => {
+      await callTopContributorsAPI(date, { articleId: 5 });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/analytics/top_contributors?start=2024-05-01&article_id=5',
+      );
+    });
+
+    it('callFollowerEngagementAPI hits the follower_engagement endpoint', async () => {
+      await callFollowerEngagementAPI(date, { organizationId: 3 });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/analytics/follower_engagement?start=2024-05-01&organization_id=3',
+      );
+    });
+
+    it('callDashboardAPI hits the dashboard endpoint with start+org+article params', async () => {
+      await callDashboardAPI(date, { organizationId: 42, articleId: 7 });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/analytics/dashboard?start=2024-05-01&organization_id=42&article_id=7',
+      );
+    });
+
+    it('callDashboardAPI works with no context args', async () => {
+      await callDashboardAPI(date);
+
+      expect(fetchMock).toHaveBeenCalledWith('/api/analytics/dashboard?start=2024-05-01');
+    });
+  });
+
+  describe('call*API error + retry integration', () => {
+    const date = new Date('2024-05-01T12:00:00Z');
+
+    it('parses the response JSON on success', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ stat: 123 }));
+
+      await expect(callHistoricalAPI(date, {})).resolves.toEqual({ stat: 123 });
+    });
+
+    it('retries once on network failure and resolves on the second attempt', async () => {
+      fetchMock
+        .mockRejectOnce(new TypeError('Failed to fetch'))
+        .mockResponseOnce(JSON.stringify({ stat: 'recovered' }));
+
+      await expect(callHistoricalAPI(date, {})).resolves.toEqual({ stat: 'recovered' });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects with API error message from JSON body on 4xx (no retry)', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      await expect(callHistoricalAPI(date, {})).rejects.toThrow('Unauthorized');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects with statusText on non-JSON 5xx response (no retry)', async () => {
+      fetchMock.mockResponseOnce('<html>500</html>', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      await expect(callHistoricalAPI(date, {})).rejects.toThrow('Internal Server Error');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/javascript/analytics/__tests__/dashboard.retry.test.js
+++ b/app/javascript/analytics/__tests__/dashboard.retry.test.js
@@ -1,0 +1,179 @@
+/**
+ * Retry-button UX tests for the analytics dashboard error UI.
+ *
+ * When the bundled /api/analytics/dashboard request fails, we render a
+ * user-clickable "Retry" button that re-invokes the currently-active time
+ * range (week/month/infinity). An automatic 1x retry on network-level
+ * TypeErrors lives in `./client`.
+ */
+
+jest.mock('@utilities/locale', () => ({
+  locale: jest.fn((key, opts = {}) => {
+    if (key === 'core.dashboard_analytics_avg_read_time') return `avg. read time ${opts.seconds}s`;
+    if (key === 'core.dashboard_analytics_unique_reactors') return `${opts.count} unique reactors`;
+    return key.split('.').pop();
+  }),
+}));
+
+const mockRender = jest.fn().mockResolvedValue(undefined);
+const mockDestroy = jest.fn();
+const MockApexCharts = jest.fn().mockImplementation(() => ({
+  render: mockRender,
+  destroy: mockDestroy,
+}));
+
+jest.mock('apexcharts', () => ({
+  __esModule: true,
+  default: MockApexCharts,
+}));
+
+jest.mock('../client', () => ({
+  callDashboardAPI: jest.fn(),
+}));
+
+const { initCharts } = require('../dashboard');
+const { callDashboardAPI } = require('../client');
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <div class="crayons-tabs crayons-tabs--analytics">
+      <ul class="crayons-tabs__list">
+        <li><button class="crayons-tabs__item crayons-tabs__item--current" id="week-button" aria-current="page">Week</button></li>
+        <li><button class="crayons-tabs__item" id="month-button">Month</button></li>
+        <li><button class="crayons-tabs__item" id="infinity-button">Infinity</button></li>
+      </ul>
+    </div>
+    <div class="summary-stats">
+      <div><div id="readers-card"></div></div>
+      <div><div id="reactions-card"></div></div>
+      <div><div id="comments-card"></div></div>
+      <div><div id="bookmarks-card"></div></div>
+      <div><div id="followers-card"></div></div>
+    </div>
+    <div class="charts-container"><div id="readers-chart"></div></div>
+    <div class="charts-container"><div id="reactions-chart"></div></div>
+    <div class="charts-container"><div id="comments-chart"></div></div>
+    <div class="charts-container"><div id="followers-chart"></div></div>
+    <div id="referrers-chart"></div>
+    <table><tbody id="referrers-container"></tbody></table>
+    <div id="top-contributors-container"></div>
+  `;
+}
+
+// Resolve after currently-queued microtasks so rejected promises have had a
+// chance to propagate through dashboard's .catch handlers.
+function flushMicrotasks() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('Analytics Dashboard – error UI Retry button', () => {
+  beforeEach(() => {
+    window._analyticsState = { activeCharts: {}, apiGeneration: 0 };
+    setupDOM();
+    jest.clearAllMocks();
+  });
+
+  describe('when callDashboardAPI fails', () => {
+    beforeEach(() => {
+      callDashboardAPI.mockRejectedValue(new Error('boom'));
+    });
+
+    it('renders a Retry button in each chart container and the referrers container', async () => {
+      initCharts({ organizationId: null, articleId: null });
+      await flushMicrotasks();
+
+      ['reactions-chart', 'comments-chart', 'readers-chart', 'followers-chart'].forEach((id) => {
+        const container = document.getElementById(id);
+        expect(container).not.toBeNull();
+        expect(container.textContent).toContain('Failed to fetch chart data');
+        expect(container.querySelector('[data-analytics-retry]')).not.toBeNull();
+      });
+
+      const referrers = document.getElementById('referrers-container');
+      expect(referrers.textContent).toContain('Failed to fetch referrer data');
+      expect(referrers.querySelector('[data-analytics-retry]')).not.toBeNull();
+    });
+
+    it('clicking Retry re-invokes the active range (week by default)', async () => {
+      initCharts({ organizationId: null, articleId: null });
+      await flushMicrotasks();
+
+      expect(callDashboardAPI).toHaveBeenCalledTimes(1);
+
+      const retryBtn = document
+        .getElementById('reactions-chart')
+        .querySelector('[data-analytics-retry]');
+      expect(retryBtn).not.toBeNull();
+      retryBtn.click();
+      await flushMicrotasks();
+
+      expect(callDashboardAPI).toHaveBeenCalledTimes(2);
+    });
+
+    it('clicking Retry from the referrers container re-invokes the active range', async () => {
+      initCharts({ organizationId: null, articleId: null });
+      await flushMicrotasks();
+
+      expect(callDashboardAPI).toHaveBeenCalledTimes(1);
+
+      const retryBtn = document
+        .getElementById('referrers-container')
+        .querySelector('[data-analytics-retry]');
+      expect(retryBtn).not.toBeNull();
+      retryBtn.click();
+      await flushMicrotasks();
+
+      expect(callDashboardAPI).toHaveBeenCalledTimes(2);
+    });
+
+    it('clicking Retry after switching to Infinity re-invokes Infinity range', async () => {
+      initCharts({ organizationId: 42, articleId: null });
+      await flushMicrotasks();
+
+      // Switch to Infinity
+      document.getElementById('infinity-button').click();
+      await flushMicrotasks();
+
+      // Most recent call should use the 2019-04-01 "beginning of time" date.
+      const infinityCall = callDashboardAPI.mock.calls[callDashboardAPI.mock.calls.length - 1];
+      expect(infinityCall[0].toISOString().split('T')[0]).toBe('2019-04-01');
+      expect(infinityCall[1]).toEqual({ organizationId: 42, articleId: null });
+
+      const callsBeforeRetry = callDashboardAPI.mock.calls.length;
+      const retryBtn = document
+        .getElementById('reactions-chart')
+        .querySelector('[data-analytics-retry]');
+      retryBtn.click();
+      await flushMicrotasks();
+
+      const retryCall = callDashboardAPI.mock.calls[callDashboardAPI.mock.calls.length - 1];
+      expect(callDashboardAPI.mock.calls.length).toBe(callsBeforeRetry + 1);
+      expect(retryCall[0].toISOString().split('T')[0]).toBe('2019-04-01');
+    });
+  });
+
+  it('binds each Retry button exactly once even if showErrors runs multiple times', async () => {
+    callDashboardAPI.mockRejectedValue(new Error('boom'));
+
+    initCharts({ organizationId: null, articleId: null });
+    await flushMicrotasks();
+
+    const retryBtn = document
+      .getElementById('reactions-chart')
+      .querySelector('[data-analytics-retry]');
+
+    retryBtn.click();
+    await flushMicrotasks();
+
+    // After click → second call → that call also fails → error UI re-renders.
+    // The original button is replaced; the new one should be clickable.
+    const newRetryBtn = document
+      .getElementById('reactions-chart')
+      .querySelector('[data-analytics-retry]');
+    expect(newRetryBtn).not.toBeNull();
+    const callsBefore = callDashboardAPI.mock.calls.length;
+    newRetryBtn.click();
+    await flushMicrotasks();
+    expect(callDashboardAPI.mock.calls.length).toBe(callsBefore + 1);
+  });
+});

--- a/app/javascript/analytics/__tests__/dashboard.test.js
+++ b/app/javascript/analytics/__tests__/dashboard.test.js
@@ -23,11 +23,7 @@ jest.mock('apexcharts', () => ({
 }));
 
 jest.mock('../client', () => ({
-  callHistoricalAPI: jest.fn(),
-  callTotalsAPI: jest.fn(),
-  callReferrersAPI: jest.fn(),
-  callTopContributorsAPI: jest.fn(),
-  callFollowerEngagementAPI: jest.fn(),
+  callDashboardAPI: jest.fn(),
 }));
 
 // Build sample historical data spanning 120 days
@@ -65,6 +61,17 @@ const mockTopContributorsData = [
 ];
 const mockFollowerEngagementData = { total_followers: 200, engaged_followers: 30, ratio: 15.0 };
 
+function bundle(overrides = {}) {
+  return {
+    historical: mockHistoricalData,
+    totals: mockTotalsData,
+    referrers: mockReferrersData,
+    top_contributors: mockTopContributorsData,
+    follower_engagement: mockFollowerEngagementData,
+    ...overrides,
+  };
+}
+
 function setupDOM() {
   document.body.innerHTML = `
     <div class="crayons-tabs crayons-tabs--analytics">
@@ -91,47 +98,37 @@ function setupDOM() {
   `;
 }
 
+async function flushPromises() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
-  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI, callTopContributorsAPI, callFollowerEngagementAPI } = require('../client');
+  const { callDashboardAPI } = require('../client');
 
   beforeEach(() => {
-    // Reset shared window state between tests
     window._analyticsState = { activeCharts: {}, apiGeneration: 0 };
     setupDOM();
     MockApexCharts.mockClear();
     mockRender.mockClear();
     mockDestroy.mockClear();
-    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
-    callTotalsAPI.mockResolvedValue(mockTotalsData);
-    callReferrersAPI.mockResolvedValue(mockReferrersData);
-    callTopContributorsAPI.mockResolvedValue(mockTopContributorsData);
-    callFollowerEngagementAPI.mockResolvedValue(mockFollowerEngagementData);
+    callDashboardAPI.mockResolvedValue(bundle());
   });
-
-  async function flushPromises() {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
 
   test('week/month charts use category x-axis without brush', async () => {
     initCharts({});
     await flushPromises();
 
-    // 4 main charts (readers, reactions, comments, followers) + 1 donut (referrers)
     const calls = MockApexCharts.mock.calls;
     const mainChartCalls = calls.filter(([, opts]) => opts.chart.type !== 'donut');
 
     mainChartCalls.forEach(([, opts]) => {
-      // Should use categories, not datetime
       expect(opts.xaxis.type).toBeUndefined();
       expect(opts.xaxis.categories).toBeDefined();
-      // Should not have brush config
       expect(opts.chart.brush).toBeUndefined();
-      // Zoom should be disabled
       expect(opts.chart.zoom.enabled).toBe(false);
     });
 
-    // No brush divs should exist
     expect(document.getElementById('brush-readers-chart')).toBeNull();
     expect(document.getElementById('brush-reactions-chart')).toBeNull();
     expect(document.getElementById('brush-comments-chart')).toBeNull();
@@ -143,22 +140,16 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
     await flushPromises();
     MockApexCharts.mockClear();
 
-    // Click infinity button
     document.getElementById('infinity-button').click();
     await flushPromises();
 
     const calls = MockApexCharts.mock.calls;
-
-    // Find main chart calls (have chart.id starting with 'main-')
     const mainCalls = calls.filter(([, opts]) => opts.chart.id && opts.chart.id.startsWith('main-'));
-    // Find brush chart calls (have chart.brush.enabled)
     const brushCalls = calls.filter(([, opts]) => opts.chart.brush && opts.chart.brush.enabled);
 
-    // Should have 4 main charts and 4 brush charts
     expect(mainCalls.length).toBe(4);
     expect(brushCalls.length).toBe(4);
 
-    // Main charts should use datetime x-axis with initial zoom range
     mainCalls.forEach(([, opts]) => {
       expect(opts.xaxis.type).toBe('datetime');
       expect(opts.xaxis.min).toBeDefined();
@@ -167,7 +158,6 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
       expect(opts.chart.toolbar.show).toBe(true);
     });
 
-    // Brush charts should target correct main charts
     const brushTargets = brushCalls.map(([, opts]) => opts.chart.brush.target).sort();
     expect(brushTargets).toEqual([
       'main-comments-chart',
@@ -176,13 +166,11 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
       'main-readers-chart',
     ]);
 
-    // Brush charts should have datetime x-axis
     brushCalls.forEach(([, opts]) => {
       expect(opts.xaxis.type).toBe('datetime');
       expect(opts.chart.selection.enabled).toBe(true);
     });
 
-    // Brush divs should exist in DOM
     expect(document.getElementById('brush-readers-chart')).not.toBeNull();
     expect(document.getElementById('brush-reactions-chart')).not.toBeNull();
     expect(document.getElementById('brush-comments-chart')).not.toBeNull();
@@ -208,10 +196,7 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
 
     brushCalls.forEach(([, opts]) => {
       const { min, max } = opts.chart.selection.xaxis;
-      // Selection max should be the last data point
       expect(max).toBe(lastTimestamp);
-      // Selection min should be ~90 days before the last data point
-      // (may be clamped to first data point if data < 90 days)
       const firstTimestamp = new Date(labels[0]).getTime();
       expect(min).toBe(Math.max(firstTimestamp, expectedMin));
     });
@@ -232,11 +217,10 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
     mainCalls.forEach(([, opts]) => {
       opts.series.forEach((s) => {
         s.data.forEach((point) => {
-          // Each data point should be a [timestamp, value] pair
           expect(Array.isArray(point)).toBe(true);
           expect(point.length).toBe(2);
-          expect(typeof point[0]).toBe('number'); // timestamp
-          expect(typeof point[1]).toBe('number'); // value
+          expect(typeof point[0]).toBe('number');
+          expect(typeof point[1]).toBe('number');
         });
       });
     });
@@ -246,18 +230,14 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
     initCharts({});
     await flushPromises();
 
-    // Switch to infinity
     document.getElementById('infinity-button').click();
     await flushPromises();
 
-    // Brush divs should exist
     expect(document.getElementById('brush-readers-chart')).not.toBeNull();
 
-    // Switch back to week
     document.getElementById('week-button').click();
     await flushPromises();
 
-    // Brush divs should be removed
     expect(document.getElementById('brush-readers-chart')).toBeNull();
     expect(document.getElementById('brush-reactions-chart')).toBeNull();
     expect(document.getElementById('brush-comments-chart')).toBeNull();
@@ -265,132 +245,89 @@ describe('Analytics Dashboard – Brush/Zoom for Infinity', () => {
   });
 });
 
-describe('Analytics Dashboard – Async Chart Loading', () => {
-  const { callHistoricalAPI, callTotalsAPI, callReferrersAPI, callTopContributorsAPI, callFollowerEngagementAPI } = require('../client');
+describe('Analytics Dashboard – Bundled Endpoint Rendering', () => {
+  const { callDashboardAPI } = require('../client');
 
   beforeEach(() => {
-    // Reset shared window state between tests
     window._analyticsState = { activeCharts: {}, apiGeneration: 0 };
     setupDOM();
     MockApexCharts.mockClear();
     mockRender.mockClear();
     mockDestroy.mockClear();
-    callTopContributorsAPI.mockResolvedValue([]);
-    callFollowerEngagementAPI.mockResolvedValue({ total_followers: 0, engaged_followers: 0, ratio: 0.0 });
+    callDashboardAPI.mockReset();
   });
 
-  async function flushPromises() {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-
-  test('charts render when historical resolves even if totals is still pending', async () => {
-    let resolveTotals;
-    const totalsPromise = new Promise((resolve) => { resolveTotals = resolve; });
-    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
-    callTotalsAPI.mockReturnValue(totalsPromise);
-    callReferrersAPI.mockResolvedValue(mockReferrersData);
+  test('issues exactly ONE dashboard API call per initCharts', async () => {
+    callDashboardAPI.mockResolvedValue(bundle());
 
     initCharts({});
     await flushPromises();
 
-    // Charts should be rendered (from historical)
-    const chartCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type !== 'donut');
-    expect(chartCalls.length).toBeGreaterThan(0);
+    expect(callDashboardAPI).toHaveBeenCalledTimes(1);
+  });
 
-    // Cards should show data (from historical, without totals)
+  test('renders cards, charts, referrers, top contributors, and followers from single response', async () => {
+    callDashboardAPI.mockResolvedValue(bundle());
+
+    initCharts({});
+    await flushPromises();
+
+    // Cards populated (no more loading placeholders)
     expect(document.getElementById('readers-card').innerHTML).not.toContain('analytics-loading');
-
-    // Now resolve totals — cards should update with extra info
-    resolveTotals(mockTotalsData);
-    await flushPromises();
-
     expect(document.getElementById('reactions-card').innerHTML).toContain('unique reactors');
-  });
 
-  test('referrers load independently of historical and totals', async () => {
-    let resolveHistorical;
-    const historicalPromise = new Promise((resolve) => { resolveHistorical = resolve; });
-    callHistoricalAPI.mockReturnValue(historicalPromise);
-    callTotalsAPI.mockResolvedValue(mockTotalsData);
-    callReferrersAPI.mockResolvedValue(mockReferrersData);
-
-    initCharts({});
-    await flushPromises();
-
-    // Referrers should be rendered even though historical hasn't resolved
+    // Referrers rendered
     const referrersContainer = document.getElementById('referrers-container');
     expect(referrersContainer.innerHTML).toContain('google.com');
 
-    // Charts should NOT be rendered yet
+    // Top contributors rendered
+    const topContribContainer = document.getElementById('top-contributors-container');
+    expect(topContribContainer.innerHTML).toContain('alice');
+    expect(topContribContainer.innerHTML).toContain('bob');
+    expect(topContribContainer.innerHTML.indexOf('alice')).toBeLessThan(topContribContainer.innerHTML.indexOf('bob'));
+
+    // Follower engagement rendered
+    const followerCard = document.getElementById('followers-card');
+    expect(followerCard.querySelector('.follower-engagement')).not.toBeNull();
+
+    // Charts rendered
     const chartCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type !== 'donut');
-    // Only the donut chart should exist at this point
-    const donutCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type === 'donut');
-    expect(donutCalls.length).toBe(1);
-
-    // Now resolve historical — charts appear
-    resolveHistorical(mockHistoricalData);
-    await flushPromises();
-
-    const allChartCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type !== 'donut');
-    expect(allChartCalls.length).toBeGreaterThan(0);
+    expect(chartCalls.length).toBeGreaterThan(0);
   });
 
   test('loading placeholders are shown before data arrives', async () => {
-    let resolveHistorical;
-    const historicalPromise = new Promise((resolve) => { resolveHistorical = resolve; });
-    callHistoricalAPI.mockReturnValue(historicalPromise);
-    callTotalsAPI.mockReturnValue(new Promise(() => {}));
-    callReferrersAPI.mockReturnValue(new Promise(() => {}));
+    let resolve;
+    callDashboardAPI.mockReturnValue(new Promise((r) => { resolve = r; }));
 
     initCharts({});
-    // Don't flush — let promises stay pending
+    // Don't flush — promise stays pending
 
-    // Placeholders should be visible in chart containers
     expect(document.getElementById('readers-chart').querySelector('.analytics-loading')).not.toBeNull();
     expect(document.getElementById('reactions-chart').querySelector('.analytics-loading')).not.toBeNull();
 
-    // Resolve historical to clear chart placeholders
-    resolveHistorical(mockHistoricalData);
+    resolve(bundle());
     await flushPromises();
 
-    // Chart containers should no longer have placeholders (replaced by ApexCharts)
-    // The innerHTML is cleared by drawChart before rendering
     expect(document.getElementById('readers-chart').querySelector('.analytics-loading')).toBeNull();
   });
 
-  test('chart errors do not prevent referrer rendering', async () => {
-    callHistoricalAPI.mockRejectedValue(new Error('API error'));
-    callTotalsAPI.mockRejectedValue(new Error('API error'));
-    callReferrersAPI.mockResolvedValue(mockReferrersData);
-    callTopContributorsAPI.mockResolvedValue([]);
+  test('shows error UI on both charts and referrers when the request fails', async () => {
+    callDashboardAPI.mockRejectedValue(new Error('boom'));
 
     initCharts({});
     await flushPromises();
 
-    // Referrers should still render
+    ['readers-chart', 'reactions-chart', 'comments-chart', 'followers-chart'].forEach((id) => {
+      const el = document.getElementById(id);
+      expect(el.textContent).toContain('Failed to fetch chart data');
+    });
+
     const referrersContainer = document.getElementById('referrers-container');
-    expect(referrersContainer.innerHTML).toContain('google.com');
-  });
-
-  test('top contributors panel renders async with ranked list', async () => {
-    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
-    callTotalsAPI.mockResolvedValue(mockTotalsData);
-    callReferrersAPI.mockResolvedValue(mockReferrersData);
-    callTopContributorsAPI.mockResolvedValue(mockTopContributorsData);
-
-    initCharts({});
-    await flushPromises();
-
-    const container = document.getElementById('top-contributors-container');
-    expect(container.innerHTML).toContain('alice');
-    expect(container.innerHTML).toContain('bob');
-    // Alice should appear before Bob (higher score)
-    expect(container.innerHTML.indexOf('alice')).toBeLessThan(container.innerHTML.indexOf('bob'));
+    expect(referrersContainer.textContent).toContain('Failed to fetch referrer data');
   });
 
   test('top contributors shows empty message when no data', async () => {
-    callTopContributorsAPI.mockResolvedValue([]);
+    callDashboardAPI.mockResolvedValue(bundle({ top_contributors: [] }));
 
     initCharts({});
     await flushPromises();
@@ -399,32 +336,27 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
     expect(container.innerHTML).toContain('top_contributors_empty');
   });
 
-  test('stale top contributors response is discarded after navigation', async () => {
-    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
-    callTotalsAPI.mockResolvedValue(mockTotalsData);
-    callReferrersAPI.mockResolvedValue(mockReferrersData);
-
-    let resolveContributors;
-    callTopContributorsAPI.mockReturnValue(new Promise((r) => { resolveContributors = r; }));
+  test('stale response is discarded after navigation', async () => {
+    let resolveStale;
+    callDashboardAPI
+      .mockReturnValueOnce(new Promise((r) => { resolveStale = r; }))
+      .mockResolvedValueOnce(bundle({ top_contributors: [] }));
 
     initCharts({});
-    // Simulate navigation — call initCharts again which bumps generation
-    callTopContributorsAPI.mockResolvedValue([]);
+    // Simulate navigation — second initCharts bumps generation
     initCharts({});
+    await flushPromises();
 
-    resolveContributors(mockTopContributorsData);
+    // Resolve the first (stale) call after navigation — it must be ignored
+    resolveStale(bundle());
     await flushPromises();
 
     const container = document.getElementById('top-contributors-container');
-    // Should NOT have rendered the stale data — only the empty message from the second call
     expect(container.innerHTML).not.toContain('alice');
   });
 
   test('follower engagement ratio renders on followers card', async () => {
-    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
-    callTotalsAPI.mockResolvedValue(mockTotalsData);
-    callReferrersAPI.mockResolvedValue(mockReferrersData);
-    callFollowerEngagementAPI.mockResolvedValue(mockFollowerEngagementData);
+    callDashboardAPI.mockResolvedValue(bundle());
 
     initCharts({});
     await flushPromises();
@@ -436,10 +368,9 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
   });
 
   test('follower engagement does not render when no followers', async () => {
-    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
-    callTotalsAPI.mockResolvedValue(mockTotalsData);
-    callReferrersAPI.mockResolvedValue(mockReferrersData);
-    callFollowerEngagementAPI.mockResolvedValue({ total_followers: 0, engaged_followers: 0, ratio: 0.0 });
+    callDashboardAPI.mockResolvedValue(bundle({
+      follower_engagement: { total_followers: 0, engaged_followers: 0, ratio: 0.0 },
+    }));
 
     initCharts({});
     await flushPromises();
@@ -449,14 +380,16 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
   });
 
   test('charts show empty state message when historical data is empty', async () => {
-    callHistoricalAPI.mockResolvedValue({});
-    callTotalsAPI.mockResolvedValue({
-      comments: { total: 0 },
-      reactions: { total: 0, like: 0, readinglist: 0, unicorn: 0, exploding_head: 0, raised_hands: 0, fire: 0, unique_reactors: 0 },
-      page_views: { total: 0, average_read_time_in_seconds: 0 },
-      follows: { total: 0 },
-    });
-    callReferrersAPI.mockResolvedValue({ domains: [] });
+    callDashboardAPI.mockResolvedValue(bundle({
+      historical: {},
+      totals: {
+        comments: { total: 0 },
+        reactions: { total: 0, like: 0, readinglist: 0, unicorn: 0, exploding_head: 0, raised_hands: 0, fire: 0, unique_reactors: 0 },
+        page_views: { total: 0, average_read_time_in_seconds: 0 },
+        follows: { total: 0 },
+      },
+      referrers: { domains: [] },
+    }));
 
     initCharts({});
     await flushPromises();
@@ -466,15 +399,12 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
       expect(el.innerHTML).toContain('dashboard_analytics_no_data');
     });
 
-    // No ApexCharts instances should be created for main charts
     const mainChartCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type !== 'donut');
     expect(mainChartCalls.length).toBe(0);
   });
 
   test('referrers show empty state when no domains', async () => {
-    callHistoricalAPI.mockResolvedValue(mockHistoricalData);
-    callTotalsAPI.mockResolvedValue(mockTotalsData);
-    callReferrersAPI.mockResolvedValue({ domains: [] });
+    callDashboardAPI.mockResolvedValue(bundle({ referrers: { domains: [] } }));
 
     initCharts({});
     await flushPromises();
@@ -482,31 +412,27 @@ describe('Analytics Dashboard – Async Chart Loading', () => {
     const container = document.getElementById('referrers-container');
     expect(container.innerHTML).toContain('dashboard_analytics_no_referrers');
 
-    // Referrer chart should be cleared, no donut rendered
     const donutCalls = MockApexCharts.mock.calls.filter(([, opts]) => opts.chart.type === 'donut');
     expect(donutCalls.length).toBe(0);
   });
 
   test('cards show zero values when data is empty', async () => {
-    callHistoricalAPI.mockResolvedValue({});
-    callTotalsAPI.mockResolvedValue({
-      comments: { total: 0 },
-      reactions: { total: 0, like: 0, readinglist: 0, unicorn: 0, exploding_head: 0, raised_hands: 0, fire: 0, unique_reactors: 0 },
-      page_views: { total: 0, average_read_time_in_seconds: 0 },
-      follows: { total: 0 },
-    });
-    callReferrersAPI.mockResolvedValue({ domains: [] });
+    callDashboardAPI.mockResolvedValue(bundle({
+      historical: {},
+      totals: {
+        comments: { total: 0 },
+        reactions: { total: 0, like: 0, readinglist: 0, unicorn: 0, exploding_head: 0, raised_hands: 0, fire: 0, unique_reactors: 0 },
+        page_views: { total: 0, average_read_time_in_seconds: 0 },
+        follows: { total: 0 },
+      },
+      referrers: { domains: [] },
+    }));
 
     initCharts({});
     await flushPromises();
 
-    const readersCard = document.getElementById('readers-card');
-    expect(readersCard.innerHTML).toContain('0');
-
-    const reactionsCard = document.getElementById('reactions-card');
-    expect(reactionsCard.innerHTML).toContain('0');
-
-    const commentsCard = document.getElementById('comments-card');
-    expect(commentsCard.innerHTML).toContain('0');
+    expect(document.getElementById('readers-card').innerHTML).toContain('0');
+    expect(document.getElementById('reactions-card').innerHTML).toContain('0');
+    expect(document.getElementById('comments-card').innerHTML).toContain('0');
   });
 });

--- a/app/javascript/analytics/client.js
+++ b/app/javascript/analytics/client.js
@@ -1,5 +1,23 @@
 import { handleFetchAPIErrors } from '../utilities/http';
 
+// Retry a promise-returning fn on transient network failures only.
+// A `TypeError` from fetch signals a network/DNS/CORS-level failure (no HTTP
+// response was received). Errors from handleFetchAPIErrors — 4xx/5xx — are
+// regular `Error` instances with actionable messages and should surface
+// immediately rather than being retried silently.
+export function withRetry(fn, { maxRetries = 1, baseDelayMs = 300 } = {}) {
+  const attempt = (n) =>
+    fn().catch((err) => {
+      if (n >= maxRetries || !(err instanceof TypeError)) {
+        throw err;
+      }
+      return new Promise((resolve) => {
+        setTimeout(resolve, baseDelayMs * 2 ** n);
+      }).then(() => attempt(n + 1));
+    });
+  return attempt(0);
+}
+
 function callAnalyticsAPI(path, date, { organizationId, articleId }) {
   let url = `${path}?start=${date.toISOString().split('T')[0]}`;
 
@@ -10,9 +28,11 @@ function callAnalyticsAPI(path, date, { organizationId, articleId }) {
     url = `${url}&article_id=${articleId}`;
   }
 
-  return fetch(url)
-    .then(handleFetchAPIErrors)
-    .then((response) => response.json());
+  return withRetry(() =>
+    fetch(url)
+      .then(handleFetchAPIErrors)
+      .then((response) => response.json()),
+  );
 }
 
 export function callHistoricalAPI(
@@ -67,5 +87,21 @@ export function callFollowerEngagementAPI(
     '/api/analytics/follower_engagement',
     date,
     { organizationId },
+  );
+}
+
+// Bundled endpoint that returns historical + totals + referrers +
+// top_contributors + follower_engagement in a single response. Used by the
+// analytics dashboard to avoid issuing 5 parallel GETs (which systematically
+// tripped the Rack::Attack api_throttle of 3 requests/sec per IP and caused
+// "Failed to fetch chart data" errors in production).
+export function callDashboardAPI(
+  date,
+  { organizationId, articleId } = {},
+) {
+  return callAnalyticsAPI(
+    '/api/analytics/dashboard',
+    date,
+    { organizationId, articleId },
   );
 }

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -659,7 +659,9 @@ function showErrorsOnReferrers() {
   if (chartEl) chartEl.innerHTML = '';
   const container = document.getElementById('referrers-container');
   if (container) {
-    container.outerHTML = `<div class="m-5" id="referrers-container"><p>Failed to fetch referrer data. If this error persists for a minute, you can try to disable adblock etc. on this page or site.</p>${retryButtonHTML()}</div>`;
+    // referrers-container is a <tbody>; preserve it and inject a valid table row
+    // so the surrounding <table> markup stays well-formed.
+    container.innerHTML = `<tr><td colspan="2" class="p-5"><p>Failed to fetch referrer data. If this error persists for a minute, you can try to disable adblock etc. on this page or site.</p>${retryButtonHTML()}</td></tr>`;
   }
   bindRetryButtons();
 }

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -1,4 +1,4 @@
-import { callHistoricalAPI, callReferrersAPI, callTotalsAPI, callTopContributorsAPI, callFollowerEngagementAPI } from './client';
+import { callDashboardAPI } from './client';
 import { locale } from '@utilities/locale';
 
 // Window-level state survives esbuild IIFE re-execution during InstantClick
@@ -628,20 +628,40 @@ function removeCardElements() {
   el && el.remove();
 }
 
+function retryButtonHTML() {
+  return '<button type="button" class="crayons-btn crayons-btn--secondary mt-2" data-analytics-retry>Retry</button>';
+}
+
+function bindRetryButtons(root = document) {
+  root.querySelectorAll('[data-analytics-retry]').forEach((btn) => {
+    if (btn.dataset.analyticsRetryBound === 'true') return;
+    btn.dataset.analyticsRetryBound = 'true';
+    btn.addEventListener('click', () => {
+      if (typeof _state.lastDraw === 'function') {
+        _state.lastDraw(_state.lastContext || {});
+      }
+    });
+  });
+}
+
 function showErrorsOnCharts() {
   const target = ['reactions-chart', 'comments-chart', 'readers-chart', 'followers-chart'];
   target.forEach((id) => {
     const el = document.getElementById(id);
     if (!el) return;
-    el.outerHTML = `<p class="m-5" id="${id}">Failed to fetch chart data. If this error persists for a minute, you can try to disable adblock etc. on this page or site.</p>`;
+    el.outerHTML = `<div class="m-5" id="${id}"><p>Failed to fetch chart data. If this error persists for a minute, you can try to disable adblock etc. on this page or site.</p>${retryButtonHTML()}</div>`;
   });
+  bindRetryButtons();
 }
 
 function showErrorsOnReferrers() {
   const chartEl = document.getElementById('referrers-chart');
   if (chartEl) chartEl.innerHTML = '';
-  document.getElementById('referrers-container').outerHTML =
-    '<p class="m-5" id="referrers-container">Failed to fetch referrer data. If this error persists for a minute, you can try to disable adblock etc. on this page or site.</p>';
+  const container = document.getElementById('referrers-container');
+  if (container) {
+    container.outerHTML = `<div class="m-5" id="referrers-container"><p>Failed to fetch referrer data. If this error persists for a minute, you can try to disable adblock etc. on this page or site.</p>${retryButtonHTML()}</div>`;
+  }
+  bindRetryButtons();
 }
 
 function callAnalyticsAPI(date, timeRangeLabel, { organizationId, articleId }) {
@@ -656,71 +676,37 @@ function callAnalyticsAPI(date, timeRangeLabel, { organizationId, articleId }) {
 
   showLoadingPlaceholders();
 
-  // Single historical fetch, shared by charts and cards
-  const historicalPromise = callHistoricalAPI(date, { organizationId, articleId });
-
-  // Historical data → draw charts as soon as available
-  historicalPromise
+  // Single bundled request: /api/analytics/dashboard returns all five panels
+  // (historical, totals, referrers, top_contributors, follower_engagement) in
+  // one response. This replaces 5 parallel GETs that systematically tripped
+  // the Rack::Attack api_throttle (3 GET/sec per IP) and caused "Failed to
+  // fetch chart data" errors in production.
+  callDashboardAPI(date, { organizationId, articleId })
     .then((data) => {
       if (generation !== _state.apiGeneration) return;
-      writeCards(data, timeRangeLabel, null);
-      drawCharts(data, timeRangeLabel);
+
+      writeCards(data.historical, timeRangeLabel, data.totals);
+      drawCharts(data.historical, timeRangeLabel);
+      renderReferrers(data.referrers);
+
+      if (document.getElementById('top-contributors-container')) {
+        renderTopContributors(data.top_contributors);
+      }
+
+      if (document.getElementById('followers-card')) {
+        renderFollowerEngagement(data.follower_engagement);
+      }
     })
     .catch((_err) => {
       if (generation !== _state.apiGeneration) return;
       showErrorsOnCharts();
-    });
-
-  // Totals → update cards with extra info (avg read time, unique reactors)
-  callTotalsAPI(date, { organizationId, articleId })
-    .then((totals) => {
-      if (generation !== _state.apiGeneration) return;
-      // Re-render cards once totals arrive (historical likely already resolved)
-      historicalPromise.then((data) => {
-        if (generation !== _state.apiGeneration) return;
-        writeCards(data, timeRangeLabel, totals);
-      });
-    })
-    .catch((_err) => {
-      // Cards already rendered from historical; totals failure is non-critical
-    });
-
-  callReferrersAPI(date, { organizationId, articleId })
-    .then((data) => {
-      if (generation !== _state.apiGeneration) return;
-      renderReferrers(data);
-    })
-    .catch((_err) => {
-      if (generation !== _state.apiGeneration) return;
       showErrorsOnReferrers();
     });
-
-  // Top contributors panel (user/org dashboard only — container may not exist for articles)
-  if (document.getElementById('top-contributors-container')) {
-    callTopContributorsAPI(date, { organizationId, articleId })
-      .then((data) => {
-        if (generation !== _state.apiGeneration) return;
-        renderTopContributors(data);
-      })
-      .catch((_err) => {
-        if (generation !== _state.apiGeneration) return;
-        const el = document.getElementById('top-contributors-container');
-        if (el) el.innerHTML = '';
-      });
-  }
-
-  // Follower engagement ratio (user/org dashboard only)
-  if (document.getElementById('followers-card')) {
-    callFollowerEngagementAPI(date, { organizationId })
-      .then((data) => {
-        if (generation !== _state.apiGeneration) return;
-        renderFollowerEngagement(data);
-      })
-      .catch(() => {});
-  }
 }
 
 function drawWeekCharts({ organizationId, articleId }) {
+  _state.lastDraw = drawWeekCharts;
+  _state.lastContext = { organizationId, articleId };
   resetActive(document.getElementById('week-button'));
   const oneWeekAgo = new Date();
   oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
@@ -728,6 +714,8 @@ function drawWeekCharts({ organizationId, articleId }) {
 }
 
 function drawMonthCharts({ organizationId, articleId }) {
+  _state.lastDraw = drawMonthCharts;
+  _state.lastContext = { organizationId, articleId };
   resetActive(document.getElementById('month-button'));
   const oneMonthAgo = new Date();
   oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
@@ -735,6 +723,8 @@ function drawMonthCharts({ organizationId, articleId }) {
 }
 
 function drawInfinityCharts({ organizationId, articleId }) {
+  _state.lastDraw = drawInfinityCharts;
+  _state.lastContext = { organizationId, articleId };
   resetActive(document.getElementById('infinity-button'));
   // April 1st is when the DEV analytics feature went into place
   const beginningOfTime = new Date('2019-04-01');

--- a/app/javascript/utilities/http/__tests__/errors.test.js
+++ b/app/javascript/utilities/http/__tests__/errors.test.js
@@ -1,0 +1,63 @@
+import { handleFetchAPIErrors } from '../errors';
+
+describe('handleFetchAPIErrors', () => {
+  const buildResponse = ({ ok, status = 200, statusText = '', jsonValue, jsonError }) => ({
+    ok,
+    status,
+    statusText,
+    json: () => (jsonError ? Promise.reject(jsonError) : Promise.resolve(jsonValue)),
+  });
+
+  it('returns the response unchanged when ok', () => {
+    const response = buildResponse({ ok: true, status: 200, statusText: 'OK' });
+
+    expect(handleFetchAPIErrors(response)).toBe(response);
+  });
+
+  it('rejects with the API-provided error message when body is JSON with an error field', async () => {
+    const response = buildResponse({
+      ok: false,
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      jsonValue: { error: 'Invalid parameters' },
+    });
+
+    await expect(handleFetchAPIErrors(response)).rejects.toThrow('Invalid parameters');
+  });
+
+  it('falls back to statusText when JSON body has no error field', async () => {
+    const response = buildResponse({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      jsonValue: {},
+    });
+
+    await expect(handleFetchAPIErrors(response)).rejects.toThrow('Internal Server Error');
+  });
+
+  it('falls back to statusText when the response body is not valid JSON', async () => {
+    const response = buildResponse({
+      ok: false,
+      status: 502,
+      statusText: 'Bad Gateway',
+      jsonError: new SyntaxError('Unexpected token < in JSON'),
+    });
+
+    await expect(handleFetchAPIErrors(response)).rejects.toThrow('Bad Gateway');
+  });
+
+  it('returns a rejected promise rather than throwing synchronously', () => {
+    const response = buildResponse({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      jsonValue: { error: 'boom' },
+    });
+
+    // Must not throw synchronously — callers chain .then/.catch on the result.
+    const result = handleFetchAPIErrors(response);
+    expect(result).toBeInstanceOf(Promise);
+    return expect(result).rejects.toThrow('boom');
+  });
+});

--- a/app/javascript/utilities/http/errors.js
+++ b/app/javascript/utilities/http/errors.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line consistent-return
 export function handleFetchAPIErrors(response) {
   // pass along a correct response
   if (response.ok) {
@@ -6,16 +5,15 @@ export function handleFetchAPIErrors(response) {
   }
 
   // API errors contain the error message in {"error": "error message"}
-  // but they could be unhandled 500 errors
-  try {
-    response.json().then((data) => {
-      throw new Error(data.error);
-    });
-  } catch (e) {
-    if (e instanceof SyntaxError) {
+  // but they could be unhandled non-JSON errors (e.g. 5xx HTML). Chain on
+  // the json() promise so any parse/throw rejects the returned promise —
+  // a surrounding sync try/catch cannot catch async throws.
+  return response.json().then(
+    (data) => {
+      throw new Error(data.error || response.statusText);
+    },
+    () => {
       throw new Error(response.statusText);
-    } else {
-      throw e;
-    }
-  }
+    },
+  );
 }

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -41,6 +41,7 @@ get "/analytics/past_day", to: "analytics#past_day"
 get "/analytics/referrers", to: "analytics#referrers"
 get "/analytics/top_contributors", to: "analytics#top_contributors"
 get "/analytics/follower_engagement", to: "analytics#follower_engagement"
+get "/analytics/dashboard", to: "analytics#dashboard"
 
 resources :health_checks, only: [] do
   collection do

--- a/spec/requests/api/v0/analytics_spec.rb
+++ b/spec/requests/api/v0/analytics_spec.rb
@@ -50,4 +50,8 @@ RSpec.describe "Api::V0::Analytics" do
   describe "GET /api/analytics/follower_engagement" do
     include_examples "GET /api/analytics/:endpoint authorization examples", "follower_engagement"
   end
+
+  describe "GET /api/analytics/dashboard" do
+    include_examples "GET /api/analytics/:endpoint authorization examples", "dashboard", "&start=2019-03-29"
+  end
 end

--- a/spec/requests/api/v1/analytics_spec.rb
+++ b/spec/requests/api/v1/analytics_spec.rb
@@ -89,11 +89,12 @@ RSpec.describe "Api::V1::Analytics" do
 
     context "when authenticated" do
       let(:user) { create(:user) }
+      let(:v1_headers) { { "Accept" => "application/vnd.forem.api-v1+json" } }
 
       before { sign_in user }
 
       it "returns all five panels in a single response" do
-        get "/api/analytics/dashboard?start=2019-03-29"
+        get "/api/analytics/dashboard?start=2019-03-29", headers: v1_headers
 
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body.keys).to match_array(
@@ -102,14 +103,14 @@ RSpec.describe "Api::V1::Analytics" do
       end
 
       it "rejects requests missing the start parameter" do
-        get "/api/analytics/dashboard"
+        get "/api/analytics/dashboard", headers: v1_headers
 
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.parsed_body["error"]).to eq("Required 'start' parameter is missing")
       end
 
       it "rejects requests with malformed date parameters" do
-        get "/api/analytics/dashboard?start=2019/3/29"
+        get "/api/analytics/dashboard?start=2019/3/29", headers: v1_headers
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
@@ -117,11 +118,11 @@ RSpec.describe "Api::V1::Analytics" do
       it "serves the second request from cache" do
         allow(Rails.cache).to receive(:fetch).and_call_original
 
-        get "/api/analytics/dashboard?start=2019-03-29"
-        get "/api/analytics/dashboard?start=2019-03-29"
+        get "/api/analytics/dashboard?start=2019-03-29", headers: v1_headers
+        get "/api/analytics/dashboard?start=2019-03-29", headers: v1_headers
 
         expect(Rails.cache).to have_received(:fetch).twice.with(
-          a_string_starting_with("analytics-dashboard-v1-"),
+          a_string_starting_with("analytics-dashboard-"),
           hash_including(expires_in: 7.days),
         )
       end

--- a/spec/requests/api/v1/analytics_spec.rb
+++ b/spec/requests/api/v1/analytics_spec.rb
@@ -78,4 +78,53 @@ RSpec.describe "Api::V1::Analytics" do
       expect(response).to have_http_status(:unauthorized)
     end
   end
+
+  describe "GET /api/analytics/dashboard" do
+    include_examples "GET /api/analytics/:endpoint authorization examples", "dashboard", "&start=2019-03-29"
+
+    it "returns 401 when unauthenticated" do
+      get "/api/analytics/dashboard", headers: { "Accept" => "application/vnd.forem.api-v1+json" }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    context "when authenticated" do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it "returns all five panels in a single response" do
+        get "/api/analytics/dashboard?start=2019-03-29"
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.keys).to match_array(
+          %w[historical totals referrers top_contributors follower_engagement],
+        )
+      end
+
+      it "rejects requests missing the start parameter" do
+        get "/api/analytics/dashboard"
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.parsed_body["error"]).to eq("Required 'start' parameter is missing")
+      end
+
+      it "rejects requests with malformed date parameters" do
+        get "/api/analytics/dashboard?start=2019/3/29"
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "serves the second request from cache" do
+        allow(Rails.cache).to receive(:fetch).and_call_original
+
+        get "/api/analytics/dashboard?start=2019-03-29"
+        get "/api/analytics/dashboard?start=2019-03-29"
+
+        expect(Rails.cache).to have_received(:fetch).twice.with(
+          a_string_starting_with("analytics-dashboard-v1-"),
+          hash_including(expires_in: 7.days),
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix
- [x] Optimization

## Description

**Issue:** Analytics dashboard logs `429 (Too Many Requests)` on two of its `/api/analytics/*` calls plus an uncaught `SyntaxError: "Retry later" is not valid JSON` on page load in production.

**Cause:** The dashboard fires 5 parallel `GET /api/analytics/*` requests; `Rack::Attack` throttles `GET /api/*` to 3/sec per IP, so 2 always 429. The `SyntaxError` is from `handleFetchAPIErrors` trying to JSON-parse Rack::Attack's plain-text `"Retry later"` body.

**Fix:** New bundled `GET /api/analytics/dashboard` endpoint (V0 + V1) returns all five payloads in one cached response — frontend now makes 1 request instead of 5. Also fixed `handleFetchAPIErrors` to handle non-JSON error bodies cleanly.

**Why it should work:** 1 request can't trip a 3/sec throttle. Can't fully confirm until it's on prod since unable to reproduce 429's locally.

## Tests

- [x] Yes

Backend specs for new endpoint on V0 + V1: 172 examples / 0 failures. Frontend tests for the bundled client, error handler, and Retry UX: 49 passed / 0 failed. No new regressions in the full Jest suite.

## Post-deploy

Verify on prod: no more 429s on `/api/analytics/*` in Rack::Attack / Datadog, DevTools shows 1 `GET /api/analytics/dashboard` per tab switch.