### PR TITLE
Generate article summaries with Gemini

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -322,6 +322,8 @@ class Article < ApplicationRecord
 
   after_update_commit :update_dependent_embeds_if_key_info_changed
 
+  after_update_commit :regenerate_summary_if_content_changed
+
   # The trigger `update_reading_list_document` is used to keep the `articles.reading_list_document` column updated.
   #
   # Its body is inserted in a PostgreSQL trigger function and that joins the columns values
@@ -972,6 +974,7 @@ class Article < ApplicationRecord
                    hotness_score: BlackBox.article_hotness_score(self))
 
     trigger_freeform_context_note_generation
+    trigger_summary_generation
   end
 
   def trigger_freeform_context_note_generation
@@ -981,6 +984,27 @@ class Article < ApplicationRecord
     return if context_notes.exists?
     
     Articles::GenerateFreeformContextNoteWorker.perform_async(id)
+  end
+
+  def trigger_summary_generation
+    return unless Ai::Base::DEFAULT_KEY.present?
+    return if score < 50 || comment_score < 25
+    return if ai_summary.present?
+
+    Articles::GenerateSummaryWorker.perform_async(id)
+  end
+
+  # This is specifically for regenerating an existing summary when body or title
+  # change. First-time generation is still done by trigger_summary_generation
+  # when eligible after score computation.
+  def regenerate_summary_if_content_changed
+    return unless Ai::Base::DEFAULT_KEY.present?
+    return unless published?
+    return unless saved_change_to_body_markdown? || saved_change_to_title?
+    return if score < 50 || comment_score < 25
+    return if ai_summary.blank?
+
+    Articles::GenerateSummaryWorker.perform_async(id)
   end
 
   def co_author_ids_list

--- a/app/services/ai/article_summary_generator.rb
+++ b/app/services/ai/article_summary_generator.rb
@@ -1,0 +1,94 @@
+module Ai
+  class ArticleSummaryGenerator
+    VERSION = "1.0".freeze
+    MAX_RETRIES = 2
+    MIN_WORDS = 50
+    MAX_WORDS = 60
+    ARTICLE_BODY_CHAR_LIMIT = 4000
+
+    def initialize(article)
+      @article = article
+      @ai_client = Ai::Base.new(wrapper: self, affected_content: @article)
+    end
+
+    def call
+      return unless @article
+
+      retries = 0
+      extra_emphasis = ""
+
+      begin
+        prompt = build_prompt(extra_emphasis)
+        response = @ai_client.call(prompt)
+        return if response.blank?
+
+        summary = response.strip.gsub(/^["']|["']$/, "")
+        word_count = summary.split(/\s+/).size
+
+        unless (MIN_WORDS..MAX_WORDS).cover?(word_count)
+          raise "Summary invalid word count: #{word_count} (expected #{MIN_WORDS}-#{MAX_WORDS})"
+        end
+
+        @article.update_columns(ai_summary: summary,
+                                ai_summary_prompt_version: VERSION,
+                                ai_summary_generated_at: Time.current,
+                                updated_at: Time.current)
+      rescue StandardError => e
+        if retries < MAX_RETRIES
+          retries += 1
+          extra_emphasis = "RETRY: Your previous response had the wrong word count. You MUST produce between #{MIN_WORDS} and #{MAX_WORDS} words. Count carefully."
+          retry
+        else
+          Rails.logger.error("Article Summary Generation failed for article #{@article.id}: #{e.message}")
+        end
+      end
+    end
+
+    private
+
+    def build_prompt(extra_emphasis)
+      article_text = @article.body_markdown.to_s[0...ARTICLE_BODY_CHAR_LIMIT]
+
+      <<~PROMPT
+        You are writing a short summary that will appear under the title of a
+        published article. Write in a neutral, descriptive voice, like a
+        magazine dek or a book-jacket blurb. State the substance of the piece
+        directly, without narration.
+
+        Article Title: "#{@article.title}"
+        Article Content (truncated):
+        #{article_text}
+
+        Voice and framing:
+        - NEUTRAL perspective. Not first person, not third-party descriptive.
+        - Do NOT use "I", "we", "my", "our". This is not the author speaking.
+        - Do NOT use "the article", "the post", "this piece", "this essay",
+          "the author", "the writer", or ANY other meta-reference to the article
+          itself or whoever wrote it.
+        - Do NOT use phrases like "explores", "argues", "considers",
+          "posits", "concludes", "contends" when they would be attached to
+          a meta-subject like "this piece" or "the article".
+        - Just present the ideas, claims, or questions directly, as
+          standalone statements.
+        - Bad (third-party):  "The article considers whether modern AI would
+          have accelerated web development."
+        - Bad (first person): "I wonder whether modern AI would have
+          accelerated web development."
+        - Good (neutral):     "If modern AI had emerged a decade earlier,
+          would it have accelerated web development or merely entrenched
+          existing patterns?"
+
+        Length and form:
+        - MUST be between #{MIN_WORDS} and #{MAX_WORDS} words. Rewrite the
+          summary until it fits that window.
+        - Plain prose in complete sentences. No markdown, lists, or headings.
+        - Do not repeat the title verbatim.
+        - Avoid clickbait or sensational language.
+
+        Respond ONLY with the summary text, no preamble or explanation.
+
+        #{extra_emphasis}
+      PROMPT
+    end
+  end
+end

--- a/app/workers/articles/generate_summary_worker.rb
+++ b/app/workers/articles/generate_summary_worker.rb
@@ -1,0 +1,21 @@
+module Articles
+  class GenerateSummaryWorker
+    include Sidekiq::Job
+    include Sidekiq::Throttled::Job
+
+    sidekiq_throttle(concurrency: { limit: 3 })
+
+    sidekiq_options queue: :low_priority, lock: :until_executing, on_conflict: :replace
+
+    def perform(article_id)
+      return unless Ai::Base::DEFAULT_KEY.present?
+
+      article = Article.find_by(id: article_id)
+      return unless article
+
+      return if article.score < 50 || article.comment_score < 25
+
+      Ai::ArticleSummaryGenerator.new(article).call
+    end
+  end
+end

--- a/db/migrate/20260422102533_add_ai_summary_to_articles.rb
+++ b/db/migrate/20260422102533_add_ai_summary_to_articles.rb
@@ -1,0 +1,13 @@
+class AddAiSummaryToArticles < ActiveRecord::Migration[7.0]
+  def up
+    add_column :articles, :ai_summary, :text
+    add_column :articles, :ai_summary_prompt_version, :string
+    add_column :articles, :ai_summary_generated_at, :datetime
+  end
+
+  def down
+    remove_column :articles, :ai_summary_generated_at
+    remove_column :articles, :ai_summary_prompt_version
+    remove_column :articles, :ai_summary
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_21_160606) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_22_102533) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -125,6 +125,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_04_21_160606) do
   end
 
   create_table "articles", force: :cascade do |t|
+    t.text "ai_summary"
+    t.datetime "ai_summary_generated_at"
+    t.string "ai_summary_prompt_version"
     t.boolean "any_comments_hidden", default: false
     t.boolean "approved", default: false
     t.boolean "archived", default: false

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -2674,6 +2674,98 @@ RSpec.describe Article do
     end
   end
 
+  describe "#trigger_summary_generation" do
+    let(:article) { create(:article) }
+
+    before do
+      stub_const("Ai::Base::DEFAULT_KEY", "some_key")
+      allow(Articles::GenerateSummaryWorker).to receive(:perform_async)
+    end
+
+    it "bails if Ai::Base::DEFAULT_KEY is not present" do
+      stub_const("Ai::Base::DEFAULT_KEY", nil)
+      article.update_columns(score: 50, comment_score: 25)
+      article.trigger_summary_generation
+      expect(Articles::GenerateSummaryWorker).not_to have_received(:perform_async)
+    end
+
+    it "bails if score is less than 50" do
+      article.update_columns(score: 49, comment_score: 25)
+      article.trigger_summary_generation
+      expect(Articles::GenerateSummaryWorker).not_to have_received(:perform_async)
+    end
+
+    it "bails if comment_score is less than 25" do
+      article.update_columns(score: 50, comment_score: 24)
+      article.trigger_summary_generation
+      expect(Articles::GenerateSummaryWorker).not_to have_received(:perform_async)
+    end
+
+    it "bails if the article already has a summary" do
+      article.update_columns(score: 50, comment_score: 25, ai_summary: "done")
+      article.trigger_summary_generation
+      expect(Articles::GenerateSummaryWorker).not_to have_received(:perform_async)
+    end
+
+    it "calls the worker when conditions are met" do
+      article.update_columns(score: 50, comment_score: 25)
+      article.trigger_summary_generation
+      expect(Articles::GenerateSummaryWorker).to have_received(:perform_async).with(article.id)
+    end
+  end
+
+  describe "#regenerate_summary_if_content_changed" do
+    let(:article) do
+      create(:article).tap do |a|
+        a.update_columns(
+          score: 60, comment_score: 30, published_at: 1.day.ago, published: true,
+          ai_summary: "existing summary text",
+          ai_summary_prompt_version: Ai::ArticleSummaryGenerator::VERSION,
+        )
+      end
+    end
+
+    before do
+      stub_const("Ai::Base::DEFAULT_KEY", "some_key")
+      allow(Articles::GenerateSummaryWorker).to receive(:perform_async)
+    end
+
+    it "enqueues a forced regeneration when body_markdown changes" do
+      article.update!(body_markdown: "#{article.body_markdown} edited")
+      expect(Articles::GenerateSummaryWorker).to have_received(:perform_async).with(article.id)
+    end
+
+    it "does not enqueue when a non-content attribute changes" do
+      article.update!(cached_tag_list: "ruby, rails")
+      expect(Articles::GenerateSummaryWorker).not_to have_received(:perform_async)
+    end
+
+    it "does not enqueue when no existing summary is stored" do
+      article.update_columns(ai_summary: nil, ai_summary_prompt_version: nil)
+      article.update!(body_markdown: "#{article.body_markdown} edited")
+      expect(Articles::GenerateSummaryWorker).not_to have_received(:perform_async)
+    end
+
+    it "does not enqueue when article is not eligible" do
+      article.update_columns(score: 10, comment_score: 5)
+      article.update!(body_markdown: "#{article.body_markdown} edited")
+      expect(Articles::GenerateSummaryWorker).not_to have_received(:perform_async)
+    end
+
+    it "does not enqueue when article is unpublished" do
+      draft_body = "---\ntitle: Draft\npublished: false\n---\n\nbody text"
+      draft = create(:article, body_markdown: draft_body)
+      draft.update_columns(
+        score: 60, comment_score: 30,
+        ai_summary: "existing", ai_summary_prompt_version: Ai::ArticleSummaryGenerator::VERSION,
+      )
+
+      draft.update!(body_markdown: "---\ntitle: Draft\npublished: false\n---\n\nedited body")
+
+      expect(Articles::GenerateSummaryWorker).not_to have_received(:perform_async)
+    end
+  end
+
   describe "#feed_source_url and canonical_url must be unique for published articles" do
     let(:url) { "http://www.example.com" }
 

--- a/spec/services/ai/article_summary_generator_spec.rb
+++ b/spec/services/ai/article_summary_generator_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe Ai::ArticleSummaryGenerator, type: :service do
+  let(:article) { create(:article) }
+  let(:ai_client) { instance_double(Ai::Base) }
+  let(:generator) { described_class.new(article) }
+
+  before do
+    allow(Ai::Base).to receive(:new).and_return(ai_client)
+  end
+
+  def words_of(count)
+    Array.new(count) { |i| "word#{i}" }.join(" ")
+  end
+
+  describe "#call" do
+    it "writes summary and metadata when AI returns a valid-length response" do
+      summary = words_of(55)
+      allow(ai_client).to receive(:call).and_return(summary)
+      original_updated_at = article.updated_at
+
+      Timecop.freeze(1.hour.from_now) do
+        generator.call
+      end
+
+      article.reload
+      expect(article.ai_summary).to eq(summary)
+      expect(article.ai_summary_prompt_version).to eq(Ai::ArticleSummaryGenerator::VERSION)
+      expect(article.ai_summary_generated_at).to be_present
+      expect(article.updated_at).to be > original_updated_at
+    end
+
+    it "strips surrounding quotes that the AI may have added" do
+      allow(ai_client).to receive(:call).and_return("\"#{words_of(55)}\"")
+
+      generator.call
+
+      expect(article.reload.ai_summary).to eq(words_of(55))
+    end
+
+    it "returns without writing if response is blank" do
+      allow(ai_client).to receive(:call).and_return("")
+
+      expect { generator.call }.not_to change { article.reload.ai_summary }
+    end
+
+    it "retries and succeeds when first response has invalid word count" do
+      too_short = words_of(20)
+      valid = words_of(55)
+      allow(ai_client).to receive(:call).and_return(too_short, valid)
+
+      generator.call
+
+      expect(article.reload.ai_summary).to eq(valid)
+      expect(ai_client).to have_received(:call).twice
+    end
+
+    it "retries up to MAX_RETRIES and fails gracefully" do
+      too_long = words_of(100)
+      allow(ai_client).to receive(:call).and_return(too_long)
+
+      expect { generator.call }.not_to change { article.reload.ai_summary }
+      expect(ai_client).to have_received(:call).exactly(Ai::ArticleSummaryGenerator::MAX_RETRIES + 1).times
+    end
+
+    it "defines a VERSION constant for audit logging" do
+      expect(described_class::VERSION).to be_a(String)
+      expect(described_class::VERSION).not_to be_empty
+    end
+  end
+end

--- a/spec/workers/articles/generate_summary_worker_spec.rb
+++ b/spec/workers/articles/generate_summary_worker_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Articles::GenerateSummaryWorker, type: :worker do
+  describe "#perform" do
+    let(:article) { create(:article) }
+    let(:generator_instance) { instance_double(Ai::ArticleSummaryGenerator, call: true) }
+
+    before do
+      stub_const("Ai::Base::DEFAULT_KEY", "some_key")
+      allow(Ai::ArticleSummaryGenerator).to receive(:new).with(article).and_return(generator_instance)
+    end
+
+    it "bails if Ai::Base::DEFAULT_KEY is not present" do
+      stub_const("Ai::Base::DEFAULT_KEY", nil)
+      expect(Ai::ArticleSummaryGenerator).not_to receive(:new)
+      described_class.new.perform(article.id)
+    end
+
+    it "bails if article is not found" do
+      expect(Ai::ArticleSummaryGenerator).not_to receive(:new)
+      described_class.new.perform(0)
+    end
+
+    it "bails if score is less than 50" do
+      article.update_columns(score: 49, comment_score: 25)
+
+      described_class.new.perform(article.id)
+      expect(generator_instance).not_to have_received(:call)
+    end
+
+    it "bails if comment_score is less than 25" do
+      article.update_columns(score: 50, comment_score: 24)
+
+      described_class.new.perform(article.id)
+      expect(generator_instance).not_to have_received(:call)
+    end
+
+    it "calls the generator when conditions are met" do
+      article.update_columns(score: 50, comment_score: 25)
+
+      described_class.new.perform(article.id)
+      expect(generator_instance).to have_received(:call)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change adds article summaries generated by Gemini. A 50–60 word summary is generated and stored on every article that crosses the engagement threshold (score >= 50, comment_score >= 25), along with the prompt version and generation date.

Generation is triggered from the score calculation pipeline and runs in the background via Articles::GenerateSummaryWorker (throttled to 3 concurrent Gemini calls). The summary is also regenerated automatically when an eligible article's body or title changes.

#### Caveats
- Summaries are generated based on scores, so newly published articles will not automatically be summarized.
- Long articles are truncated at 4,000 characters before prompting.
- No budget monitoring or enforcement added. Deferred to a platform-wide AI spend framework.
- No backfill is done so existing articles will not get summaries.
- For now, no tooling is provided to refresh stale summaries when the prompt changes. If the prompt is improved, only articles edited afterward will pick it up.

## Related Tickets & Documents

[DEV-3637](https://mlhacks.atlassian.net/browse/DEV-3637)

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### UI accessibility checklist

N/A

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

DB migration to add columns.
