### PR TITLE
fix: bypass CDN optimization for SVG images

### DIFF
--- a/app/services/images/optimizer.rb
+++ b/app/services/images/optimizer.rb
@@ -2,6 +2,7 @@ module Images
   module Optimizer
     def self.call(img_src, **kwargs)
       return img_src if img_src.blank? || img_src.starts_with?("/")
+      return img_src if img_src.match?(/\.svg(\?.*)?$/i)
 
       if imgproxy_enabled?
         imgproxy(img_src, **kwargs)

--- a/spec/services/images/optimizer_spec.rb
+++ b/spec/services/images/optimizer_spec.rb
@@ -17,6 +17,24 @@ RSpec.describe Images::Optimizer, type: :service do
       expect(described_class.call(relative_asset_path)).to eq(relative_asset_path)
     end
 
+    it "does nothing when given an SVG url even when a CDN is enabled", :aggregate_failures do
+      allow(described_class).to receive_messages(cloudinary_enabled?: true, imgproxy_enabled?: false)
+      svg_url = "https://example.com/logo.svg"
+      expect(described_class.call(svg_url)).to eq(svg_url)
+      expect(described_class).not_to have_received(:cloudinary)
+      expect(described_class).not_to have_received(:cloudflare)
+      expect(described_class).not_to have_received(:imgproxy)
+    end
+
+    it "does nothing when given an SVG url with query params even when a CDN is enabled", :aggregate_failures do
+      allow(described_class).to receive_messages(cloudinary_enabled?: true, imgproxy_enabled?: false)
+      svg_url = "https://example.com/icon.svg?v=abc123"
+      expect(described_class.call(svg_url)).to eq(svg_url)
+      expect(described_class).not_to have_received(:cloudinary)
+      expect(described_class).not_to have_received(:cloudflare)
+      expect(described_class).not_to have_received(:imgproxy)
+    end
+
     it "does nothing when given nil" do
       expect(described_class.call(nil)).to be_nil
     end


### PR DESCRIPTION
## Summary

Fixes #22908

SVG files are vector graphics and should not be passed through raster CDN pipelines. The current `Images::Optimizer.call` method routes **all** external image URLs through whichever CDN backend is enabled (Cloudflare, Cloudinary, or imgproxy). Each of these services applies transformations such as `format: auto` (Cloudflare/Cloudinary) or resizing (imgproxy) that convert SVG content to raster formats (WebP/PNG), breaking vector images entirely.

## Root Cause

```ruby
# app/services/images/optimizer.rb
def self.call(img_src, **kwargs)
  return img_src if img_src.blank? || img_src.starts_with?("/")
  # Only skips relative paths — SVG URLs still get routed to CDN
  ...
end
```

Cloudflare's CDN applies `format: "auto"` which instructs the CDN to serve the image in the most optimal raster format (WebP/AVIF). SVGs passed through this pipeline come back as broken raster images. The same problem applies to Cloudinary (`fetch_format: "auto"`) and imgproxy.

## Fix

Add an early return for SVG URLs **before** any CDN backend is invoked:

```ruby
return img_src if img_src.match?(/\.svg(\?.*)?$/i)
```

This correctly handles:
- Plain SVG URLs: `https://example.com/logo.svg`
- SVG URLs with query parameters: `https://example.com/icon.svg?v=abc123`
- Case-insensitive extension matching: `.SVG`

## Testing

Added two new specs to `spec/services/images/optimizer_spec.rb`:
- Verifies a plain SVG URL is returned unchanged and no CDN backend is called
- Verifies an SVG URL with query parameters is returned unchanged and no CDN backend is called

## Before / After

| Scenario | Before | After |
|---|---|---|
| PNG/JPG/GIF image | Routes through CDN ✅ | Routes through CDN ✅ |
| SVG image | Routes through CDN → broken ❌ | Returned as-is ✅ |
| Relative path (/assets/…) | Returned as-is ✅ | Returned as-is ✅ |
