### PR TITLE
fix: allow recently published articles to be indexed during grace period

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -56,6 +56,10 @@ class Article < ApplicationRecord
 
   MAX_TAG_LIST_SIZE = 4
 
+  # New articles are exempt from the index_minimum_score check for this long,
+  # giving them time to accumulate reactions before score-based noindex kicks in.
+  INDEXING_GRACE_PERIOD = 2.days
+
   # Filter out anything that isn't a word, space, punctuation mark,
   # recognized emoji, and other auxiliary marks.
   # See: https://github.com/forem/forem/pull/16787#issuecomment-1062044359
@@ -859,9 +863,10 @@ class Article < ApplicationRecord
   def skip_indexing?
     # should the article be skipped indexed by crawlers?
     # true if unpublished, or spammy,
-    # or low score, and not featured
+    # or low score (and not featured and past the publishing grace period), or
+    # published before minimum date
     !published ||
-      (score < Settings::UserExperience.index_minimum_score && !featured) ||
+      (score < Settings::UserExperience.index_minimum_score && !featured && past_indexing_grace_period?) ||
       published_at.to_i < Settings::UserExperience.index_minimum_date.to_i ||
       score < -1
   end
@@ -869,7 +874,7 @@ class Article < ApplicationRecord
   def skip_indexing_reason
     return "unpublished" unless published
     return "negative_score" if score < -1
-    return "below_minimum_score" if score < Settings::UserExperience.index_minimum_score && !featured
+    return "below_minimum_score" if score < Settings::UserExperience.index_minimum_score && !featured && past_indexing_grace_period?
     return "below_minimum_date" if published_at.to_i < Settings::UserExperience.index_minimum_date.to_i
 
     "indexed"
@@ -1632,6 +1637,10 @@ class Article < ApplicationRecord
   end
 
   private
+
+  def past_indexing_grace_period?
+    published_at.present? && published_at < INDEXING_GRACE_PERIOD.ago
+  end
 
   def admin_published_user?
     return false unless user

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -2957,7 +2957,7 @@ RSpec.describe Article do
     end
 
     context "when the article has score below minimum and is not featured" do
-      let(:article) { build(:published_article, featured: false, score: 2, published_at: 1.day.ago) }
+      let(:article) { build(:published_article, featured: false, score: 2, published_at: 3.days.ago) }
 
       before do
         allow(Settings::UserExperience).to receive_messages(index_minimum_score: 10,
@@ -2966,6 +2966,19 @@ RSpec.describe Article do
 
       it "returns true" do
         expect(article.skip_indexing?).to be true
+      end
+    end
+
+    context "when the article has score below minimum but was published within the grace period" do
+      let(:article) { build(:published_article, featured: false, score: 2, published_at: 1.day.ago) }
+
+      before do
+        allow(Settings::UserExperience).to receive_messages(index_minimum_score: 10,
+                                                            index_minimum_date: 1.week.ago)
+      end
+
+      it "returns false (allows indexing during grace period)" do
+        expect(article.skip_indexing?).to be false
       end
     end
 
@@ -3036,6 +3049,7 @@ RSpec.describe Article do
       article.published = true
       article.score = 3
       article.featured = false
+      article.published_at = 3.days.ago
       expect(article.skip_indexing_reason).to eq("below_minimum_score")
     end
 


### PR DESCRIPTION
## Summary

Fixes #22968

Newly published articles can receive a `noindex` meta tag immediately after publishing when a Forem admin has raised `Settings::UserExperience.index_minimum_score` above its default of `0`. New articles start with `score = 0` and, if that is below the configured minimum, are flagged as `skip_indexing? == true` before any search engine has had a chance to crawl them.

## Root Cause

```ruby
# app/models/article.rb
def skip_indexing?
  !published ||
    (score < Settings::UserExperience.index_minimum_score && !featured) ||
    ...
end
```

The score check applies **immediately** on publish. A brand-new article has had no time to receive reactions that would raise its score, so it is unfairly penalised by the same threshold that correctly suppresses low-quality older content.

## Fix

Introduce a 2-day `INDEXING_GRACE_PERIOD` constant. The score-based `noindex` check is gated behind a `past_indexing_grace_period?` predicate so articles published within the last 48 hours are always allowed to be indexed, regardless of their current score:

```ruby
INDEXING_GRACE_PERIOD = 2.days

def skip_indexing?
  !published ||
    (score < Settings::UserExperience.index_minimum_score && !featured && past_indexing_grace_period?) ||
    published_at.to_i < Settings::UserExperience.index_minimum_date.to_i ||
    score < -1
end

def past_indexing_grace_period?
  published_at.present? && published_at < INDEXING_GRACE_PERIOD.ago
end
```

The `score < -1` spam guard is **not** affected by the grace period — articles that are quickly downvoted into negative territory are still excluded from indexing immediately.

`skip_indexing_reason` is updated in parallel to keep the diagnostic helper consistent.

## Behaviour Matrix

| Condition | Before | After |
|---|---|---|
| Published < 2 days ago, low score | noindex ❌ | indexed ✅ |
| Published ≥ 2 days ago, low score, not featured | noindex ✅ | noindex ✅ |
| Published < 2 days ago, score < -1 (spam) | noindex ✅ | noindex ✅ |
| Published, score meets threshold | indexed ✅ | indexed ✅ |
| Unpublished | noindex ✅ | noindex ✅ |

## Testing

- Updated the existing "score below minimum" spec to use `published_at: 3.days.ago` (past the grace period) so the test remains accurate.
- Added a new context: **"when the article has score below minimum but was published within the grace period"** — verifies `skip_indexing?` returns `false`.
- Updated `skip_indexing_reason` spec for `below_minimum_score` to explicitly set `published_at: 3.days.ago`.
