### PR TITLE
fix: refresh notification json_data paths on username change

### DIFF
--- a/app/services/notifications/update_json_data_for_user.rb
+++ b/app/services/notifications/update_json_data_for_user.rb
@@ -1,0 +1,193 @@
+# Rebuilds json_data on notifications that contain stale paths after a username change.
+#
+# When a user changes their username, notification records still hold the old
+# denormalized paths (e.g. "/old_username/comment/abc"). This service finds all
+# affected notifications and refreshes their json_data using the canonical data
+# builder methods in the Notifications module.
+#
+# Affected notifications fall into two categories:
+#   1. Notifications whose notifiable is owned by the user (their articles and
+#      comments contain the username in the path).
+#   2. Notifications where the user appears as the actor stored in
+#      json_data["user"] (e.g. someone commented on another user's article).
+#
+# For category 2 we fall back to a jsonb containment query because there is no
+# indexed column linking the actor to the notification row.
+module Notifications
+  class UpdateJsonDataForUser
+    BATCH_SIZE = 1000
+
+    delegate :article_data, :comment_data, :user_data, :organization_data, to: Notifications
+
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      update_notifiable_owned_notifications
+      update_comment_on_user_articles_notifications
+      update_actor_notifications
+    end
+
+    private
+
+    attr_reader :user
+
+    # Category 1: Notifications where the user authored the notifiable.
+    # We can query these efficiently via the polymorphic notifiable association.
+    def update_notifiable_owned_notifications
+      user.articles.find_each do |article|
+        refresh_notifications_for(article)
+      end
+
+      user.comments.find_each do |comment|
+        refresh_notifications_for(comment)
+      end
+    end
+
+    # Category 1b: Notifications for comments left on the user's articles.
+    # These comment notifications embed the article's path in json_data["comment"]["commentable"].
+    # When the article author changes username, those paths become stale even though
+    # the comment's author is a different user.
+    def update_comment_on_user_articles_notifications
+      user.articles.find_each do |article|
+        comment_ids = Comment.where(commentable_type: "Article", commentable_id: article.id)
+          .where.not(user_id: user.id)
+          .pluck(:id)
+
+        next if comment_ids.blank?
+
+        Notification
+          .where(notifiable_type: "Comment", notifiable_id: comment_ids)
+          .find_each(batch_size: BATCH_SIZE) do |notification|
+            comment = Comment.find_by(id: notification.notifiable_id)
+            next unless comment
+
+            notification.update_column(:json_data, build_comment_json_data(comment))
+          end
+      end
+    end
+
+    # Category 2: Notifications where the user appears as the actor in json_data.
+    # This uses a jsonb path query to find notifications where the user's id
+    # is stored as the actor in json_data["user"]["id"].
+    #
+    # Covers:
+    #   - Reaction notifications (action: "Reaction") where the user reacted on
+    #     someone else's content (notifiable is someone else's Article/Comment)
+    #   - Follow notifications (notifiable_type: "Follow")
+    #   - Mention notifications (notifiable_type: "Mention")
+    #   - Any other notification type where the user appears as the actor
+    #
+    # Some of these notifications may have been refreshed by category 1/1b above.
+    # The redundancy is harmless and simplifies the query logic.
+    def update_actor_notifications
+      Notification
+        .where("json_data->'user'->>'id' = ?", user.id.to_s)
+        .find_each(batch_size: BATCH_SIZE) do |notification|
+          refresh_actor_notification(notification)
+        end
+    end
+
+    def refresh_notifications_for(notifiable)
+      scope = Notification.where(
+        notifiable_id: notifiable.id,
+        notifiable_type: notifiable.class.name,
+      )
+
+      case notifiable
+      when Article
+        refresh_article_notifications(scope, notifiable)
+      when Comment
+        refresh_comment_notifications(scope, notifiable)
+      end
+    end
+
+    def refresh_article_notifications(scope, article)
+      scope.find_each(batch_size: BATCH_SIZE) do |notification|
+        new_json_data = build_article_json_data(article, notification.action)
+        notification.update_column(:json_data, new_json_data)
+      end
+    end
+
+    def refresh_comment_notifications(scope, comment)
+      scope.find_each(batch_size: BATCH_SIZE) do |notification|
+        new_json_data = build_comment_json_data(comment)
+        notification.update_column(:json_data, new_json_data)
+      end
+    end
+
+    # For actor notifications, we rebuild from the notifiable when possible.
+    # When the notifiable no longer exists (e.g. deleted), we update only the
+    # user portion of the existing json_data.
+    def refresh_actor_notification(notification)
+      new_json_data = rebuild_actor_json_data(notification)
+      notification.update_column(:json_data, new_json_data)
+    rescue StandardError => e
+      # Gracefully handle errors without halting the batch
+      Rails.logger.warn(
+        "Notifications::UpdateJsonDataForUser: skipping notification #{notification.id}: #{e.message}",
+      )
+    end
+
+    def rebuild_actor_json_data(notification)
+      notifiable = notification.notifiable
+
+      return update_user_in_json_data(notification) unless notifiable.present?
+
+      case notifiable
+      when Article
+        build_article_json_data(notifiable, notification.action)
+      when Comment
+        build_comment_json_data(notifiable)
+      when Mention
+        build_mention_json_data(notifiable)
+      else
+        # For Follow, Reaction (aggregated), and other types, update the user
+        # portion. Reaction notifications have aggregated_siblings that would
+        # require the full Reactions::Send logic to rebuild; updating just the
+        # primary user data is a pragmatic middle ground.
+        update_user_in_json_data(notification)
+      end
+    end
+
+    def build_article_json_data(article, action)
+      data = {
+        user: user_data(article.user),
+        article: article_data(article),
+      }
+      data[:organization] = organization_data(article.organization) if article.organization
+      data
+    end
+
+    def build_comment_json_data(comment)
+      {
+        user: user_data(comment.user),
+        comment: comment_data(comment),
+      }
+    end
+
+    def build_mention_json_data(mention)
+      data = { user: user_data(mention.mentionable.user) }
+
+      case mention.mentionable_type
+      when "Comment"
+        data[:comment] = comment_data(mention.mentionable)
+      when "Article"
+        data[:article] = article_data(mention.mentionable)
+      end
+
+      data
+    end
+
+    def update_user_in_json_data(notification)
+      new_json_data = notification.json_data.deep_dup
+      new_json_data["user"] = user_data(user).deep_stringify_keys
+      new_json_data
+    end
+  end
+end

--- a/app/services/notifications/update_json_data_for_user.rb
+++ b/app/services/notifications/update_json_data_for_user.rb
@@ -156,9 +156,10 @@ module Notifications
     end
 
     def build_article_json_data(article, action)
+      article.reload
       data = {
         user: user_data(article.user),
-        article: article_data(article),
+        article: fresh_article_data(article),
       }
       data[:organization] = organization_data(article.organization) if article.organization
       data
@@ -167,8 +168,35 @@ module Notifications
     def build_comment_json_data(comment)
       {
         user: user_data(comment.user),
-        comment: comment_data(comment),
+        comment: fresh_comment_data(comment),
       }
+    end
+
+    # Notifications.article_data uses article.path which is a stored column
+    # that goes stale after a username change until the article is resaved
+    # (ResaveArticlesWorker runs asynchronously). Override with the correct
+    # path computed from the current username.
+    def fresh_article_data(article)
+      article_data(article).tap do |data|
+        data[:path] = computed_article_path(article)
+      end
+    end
+
+    def fresh_comment_data(comment)
+      comment_data(comment).tap do |data|
+        commentable = comment.commentable
+        next unless commentable.is_a?(Article)
+
+        data[:commentable][:path] = computed_article_path(commentable)
+      end
+    end
+
+    def computed_article_path(article)
+      if article.organization
+        "/#{article.organization.slug}/#{article.slug}"
+      else
+        "/#{article.user.username}/#{article.slug}"
+      end
     end
 
     def build_mention_json_data(mention)

--- a/app/services/users/update.rb
+++ b/app/services/users/update.rb
@@ -36,9 +36,9 @@ module Users
     def call
       if update_successful?
         @success = true
-        @user.touch(:profile_updated_at)
         conditionally_resave_articles
         conditionally_refresh_notification_paths
+        @user.touch(:profile_updated_at)
       else
         errors.concat(@profile.errors.full_messages)
         errors.concat(@user.errors.full_messages)

--- a/app/services/users/update.rb
+++ b/app/services/users/update.rb
@@ -38,6 +38,7 @@ module Users
         @success = true
         @user.touch(:profile_updated_at)
         conditionally_resave_articles
+        conditionally_refresh_notification_paths
       else
         errors.concat(@profile.errors.full_messages)
         errors.concat(@user.errors.full_messages)
@@ -125,6 +126,13 @@ module Users
       @updated_user_attributes.any_key?(user_fields) ||
         @updated_profile_attributes.any_key?(CORE_PROFILE_FIELDS) ||
         @updated_users_setting_attributes.any_key?(CORE_SETTINGS_FIELDS)
+    end
+
+    def conditionally_refresh_notification_paths
+      return unless @user.saved_change_to_username?
+      return if @user.spam_or_suspended?
+
+      Notifications::UpdateJsonDataForUserWorker.perform_async(@user.id)
     end
   end
 end

--- a/app/workers/notifications/update_json_data_for_user_worker.rb
+++ b/app/workers/notifications/update_json_data_for_user_worker.rb
@@ -1,0 +1,14 @@
+module Notifications
+  class UpdateJsonDataForUserWorker
+    include Sidekiq::Job
+
+    sidekiq_options queue: :low_priority, retry: 10, lock: :until_executing
+
+    def perform(user_id)
+      user = User.find_by(id: user_id)
+      return unless user
+
+      Notifications::UpdateJsonDataForUser.call(user)
+    end
+  end
+end

--- a/spec/services/notifications/update_json_data_for_user_spec.rb
+++ b/spec/services/notifications/update_json_data_for_user_spec.rb
@@ -48,8 +48,13 @@ RSpec.describe Notifications::UpdateJsonDataForUser, type: :service do
       let(:comment) { create(:comment, commentable: article, user: commenter) }
 
       it "updates comment notification json_data with the new comment path" do
-        Notifications::NewComment::Send.call(comment)
-        notification = Notification.find_by(notifiable: comment, user: reader)
+        notification = create(:notification,
+                              notifiable: comment,
+                              user: reader,
+                              json_data: {
+                                user: Notifications.user_data(commenter),
+                                comment: Notifications.comment_data(comment)
+                              })
 
         old_comment_path = notification.json_data["comment"]["path"]
         expect(old_comment_path).to include(commenter.username)
@@ -104,8 +109,13 @@ RSpec.describe Notifications::UpdateJsonDataForUser, type: :service do
       let(:comment) { create(:comment, commentable: article, user: commenter) }
 
       it "updates the commentable path in comment notifications" do
-        Notifications::NewComment::Send.call(comment)
-        notification = Notification.find_by(notifiable: comment, user: author)
+        notification = create(:notification,
+                              notifiable: comment,
+                              user: author,
+                              json_data: {
+                                user: Notifications.user_data(commenter),
+                                comment: Notifications.comment_data(comment)
+                              })
 
         # The commentable path in the notification should contain the author's username
         expect(notification.json_data["comment"]["commentable"]["path"]).to include("old_username")

--- a/spec/services/notifications/update_json_data_for_user_spec.rb
+++ b/spec/services/notifications/update_json_data_for_user_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe Notifications::UpdateJsonDataForUser, type: :service do
+  let(:author)  { create(:user, username: "old_username") }
+  let(:reader)  { create(:user) }
+  let(:commenter) { create(:user) }
+
+  describe "#call" do
+    context "when the user authored an article with notifications" do
+      let(:article) { create(:article, user: author) }
+
+      it "updates article notification json_data with the new user path" do
+        notification = create(:notification, notifiable: article, user: reader, action: "Published",
+                                             json_data: { user: Notifications.user_data(author), article: Notifications.article_data(article) })
+
+        old_path = notification.json_data["user"]["path"]
+        expect(old_path).to eq("/old_username")
+
+        author.update!(username: "new_username")
+        described_class.call(author)
+
+        notification.reload
+        expect(notification.json_data["user"]["path"]).to eq("/new_username")
+        expect(notification.json_data["user"]["username"]).to eq("new_username")
+        expect(notification.json_data["article"]["path"]).to include("new_username")
+      end
+
+      it "updates organization data when article belongs to an org" do
+        org = create(:organization)
+        article = create(:article, user: author, organization: org)
+        notification = create(:notification, notifiable: article, user: reader, action: "Published",
+                                             json_data: { user: Notifications.user_data(author),
+                                                          article: Notifications.article_data(article),
+                                                          organization: Notifications.organization_data(org) })
+
+        author.update!(username: "new_username")
+        described_class.call(author)
+
+        notification.reload
+        expect(notification.json_data["user"]["path"]).to eq("/new_username")
+        expect(notification.json_data["article"]["path"]).to include("new_username")
+        expect(notification.json_data["organization"]["id"]).to eq(org.id)
+      end
+    end
+
+    context "when the user authored a comment with notifications" do
+      let(:article) { create(:article, user: reader) }
+      let(:comment) { create(:comment, commentable: article, user: commenter) }
+
+      it "updates comment notification json_data with the new comment path" do
+        Notifications::NewComment::Send.call(comment)
+        notification = Notification.find_by(notifiable: comment, user: reader)
+
+        old_comment_path = notification.json_data["comment"]["path"]
+        expect(old_comment_path).to include(commenter.username)
+
+        commenter.update!(username: "renamed_commenter")
+        described_class.call(commenter)
+
+        notification.reload
+        expect(notification.json_data["comment"]["path"]).to include("renamed_commenter")
+        expect(notification.json_data["user"]["username"]).to eq("renamed_commenter")
+      end
+    end
+
+    context "when the user appears as the actor in non-Article/Comment notifications" do
+      let(:article) { create(:article, user: reader) }
+      let(:comment) { create(:comment, commentable: article, user: commenter) }
+      let(:mention) { create(:mention, user: reader, mentionable: comment) }
+
+      it "updates mention notification json_data when user is the mentionable author" do
+        Notifications::NewMention::Send.call(mention)
+        notification = Notification.find_by(notifiable: mention)
+
+        expect(notification.json_data["user"]["username"]).to eq(commenter.username)
+
+        commenter.update!(username: "renamed_commenter")
+        described_class.call(commenter)
+
+        notification.reload
+        expect(notification.json_data["user"]["username"]).to eq("renamed_commenter")
+        expect(notification.json_data["user"]["path"]).to eq("/renamed_commenter")
+      end
+    end
+
+    context "when the user has milestone notifications" do
+      let(:article) { create(:article, user: author) }
+
+      it "updates article paths in milestone notifications" do
+        notification = create(:notification, notifiable: article, user: author,
+                                             action: "Milestone::Reaction::64",
+                                             json_data: { article: Notifications.article_data(article) })
+
+        author.update!(username: "new_username")
+        described_class.call(author)
+
+        notification.reload
+        expect(notification.json_data["article"]["path"]).to include("new_username")
+      end
+    end
+
+    context "when comments are left on the user's article by someone else" do
+      let(:article) { create(:article, user: author) }
+      let(:comment) { create(:comment, commentable: article, user: commenter) }
+
+      it "updates the commentable path in comment notifications" do
+        Notifications::NewComment::Send.call(comment)
+        notification = Notification.find_by(notifiable: comment, user: author)
+
+        # The commentable path in the notification should contain the author's username
+        expect(notification.json_data["comment"]["commentable"]["path"]).to include("old_username")
+
+        author.update!(username: "new_username")
+        described_class.call(author)
+
+        notification.reload
+        # The commentable path should now reflect the author's new username
+        expect(notification.json_data["comment"]["commentable"]["path"]).to include("new_username")
+        # The commenter's data should remain unchanged (they didn't change username)
+        expect(notification.json_data["user"]["username"]).to eq(commenter.username)
+      end
+    end
+
+    context "when notifications have no json_data" do
+      let(:article) { create(:article, user: author) }
+
+      it "does not raise errors for notifications without json_data" do
+        notification = create(:notification, notifiable: article, user: reader, action: "Published")
+
+        expect { described_class.call(author) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/services/notifications/update_json_data_for_user_spec.rb
+++ b/spec/services/notifications/update_json_data_for_user_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Notifications::UpdateJsonDataForUser, type: :service do
 
         notification.reload
         expect(notification.json_data["user"]["path"]).to eq("/new_username")
-        expect(notification.json_data["article"]["path"]).to include("new_username")
+        # Org article paths use the org slug, not the username
+        expect(notification.json_data["article"]["path"]).to include(org.slug)
         expect(notification.json_data["organization"]["id"]).to eq(org.id)
       end
     end

--- a/spec/services/users/update_spec.rb
+++ b/spec/services/users/update_spec.rb
@@ -120,6 +120,30 @@ RSpec.describe Users::Update, type: :service do
       end
     end
 
+    it "enqueues notification path update job when changing username" do
+      sidekiq_assert_enqueued_with(
+        job: Notifications::UpdateJsonDataForUserWorker,
+        args: [user.id],
+        queue: "low_priority",
+      ) do
+        described_class.call(user, user: { username: "#{user.username}_changed" })
+      end
+    end
+
+    it "does not enqueue notification path update job for a suspended user" do
+      suspended_user = create(:user, :suspended)
+
+      expect do
+        described_class.call(suspended_user, user: { username: "#{suspended_user.username}_changed" })
+      end.not_to change(Notifications::UpdateJsonDataForUserWorker.jobs, :size)
+    end
+
+    it "does not enqueue notification path update job when changing non-username fields" do
+      expect do
+        described_class.call(user, user: { name: "#{user.name} changed" })
+      end.not_to change(Notifications::UpdateJsonDataForUserWorker.jobs, :size)
+    end
+
     it "enqueues resave articles job when changing profile_image" do
       profile_image = fixture_file_upload("800x600.jpg")
 

--- a/spec/workers/notifications/update_json_data_for_user_worker_spec.rb
+++ b/spec/workers/notifications/update_json_data_for_user_worker_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Notifications::UpdateJsonDataForUserWorker do
+  let(:worker) { described_class.new }
+
+  describe "#perform" do
+    it "does not call the service when user is not found" do
+      allow(Notifications::UpdateJsonDataForUser).to receive(:call)
+
+      worker.perform(-1)
+
+      expect(Notifications::UpdateJsonDataForUser).not_to have_received(:call)
+    end
+
+    it "calls the service when user is found" do
+      user = create(:user)
+
+      allow(Notifications::UpdateJsonDataForUser).to receive(:call)
+
+      worker.perform(user.id)
+
+      expect(Notifications::UpdateJsonDataForUser).to have_received(:call).with(user)
+    end
+  end
+end


### PR DESCRIPTION
When a user changes their username, notification records retain stale denormalized paths in their `json_data` column. Paths like `/old_username/comment/abc` (from `Comment#path`), `/old_username/slug` (from `Article#path`), and `/old_username` (from `User#path`) become 404s when users click notification links.

**What changed:**

Added a new service `Notifications::UpdateJsonDataForUser` that rebuilds stale json_data when a username changes. It handles three categories of affected notifications:

1. **Notifications where the user authored the notifiable** (their articles and comments) — queried via `notifiable_id`/`notifiable_type`
2. **Comment notifications on the user's articles** — these embed the article's path in `json_data["comment"]["commentable"]["path"]` and become stale when the article author changes username
3. **Notifications where the user appears as the actor** (`json_data["user"]`) — found via PostgreSQL jsonb query, covers mentions, follows, reactions

The service reuses the existing canonical data builders (`Notifications.user_data`, `Notifications.article_data`, `Notifications.comment_data`) rather than doing string replacement, so the rebuilt json_data is always consistent with what would be created fresh.

Processing is batched with `find_each(batch_size: 1000)` and runs asynchronously via `Notifications::UpdateJsonDataForUserWorker` on the `low_priority` queue.

**Architecture decision:**

Three approaches were considered:
1. Bulk string-replace paths in json_data — fragile, could corrupt data in unexpected contexts
2. **Refresh json_data from source of truth (chosen)** — robust, reuses canonical builders, consistent with `Notifications::Update`
3. Refactor to lazy-load paths from live objects (store IDs not denormalized data) — best long-term but a massive refactor touching every notification view, serializer, and frontend component

**How to reproduce:** Change a user's username. Click any old notification link that references the article/comment path. Before this fix: 404. After: correct path.

Closes #3234