### PR TITLE
Fix CodePen 2.0 editor URLs with single UUID

### DIFF
--- a/app/liquid_tags/codepen_tag.rb
+++ b/app/liquid_tags/codepen_tag.rb
@@ -6,11 +6,11 @@ class CodepenTag < LiquidTagBase
   PEN_ID_REGEXP = "[a-zA-Z0-9]{5,32}".freeze
   # CodePen 2.0 editor IDs are UUID-like and can include dashes.
   EDITOR_PEN_ID_REGEXP = "[a-zA-Z0-9-]{5,36}".freeze
-  # CodePen 2.0 editor URLs include both the editor pen ID and the classic pen hash.
+  # CodePen 2.0 editor URLs may have a classic pen hash appended, but it's optional.
   REGISTRY_REGEXP =
     %r{\Ahttps?://codepen\.io/(?:
       (?:team/)?#{USERNAME_REGEXP}/(?:pen|embed)(?:/preview)?/#{PEN_ID_REGEXP}|
-      editor/#{USERNAME_REGEXP}/(?:pen|embed)(?:/preview)?/#{EDITOR_PEN_ID_REGEXP}/#{PEN_ID_REGEXP}
+      editor/#{USERNAME_REGEXP}/(?:pen|embed)(?:/preview)?/#{EDITOR_PEN_ID_REGEXP}(?:/#{PEN_ID_REGEXP})?
     )/?\z}x
 
   def initialize(_tag_name, link, _parse_context)

--- a/spec/liquid_tags/codepen_tag_spec.rb
+++ b/spec/liquid_tags/codepen_tag_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe CodepenTag, type: :liquid_tag do
     let(:codepen_editor_link) do
       "https://codepen.io/editor/alvaromontoro/pen/019d657e-d7bc-746a-9bc3-4df2244c97cc/24ac30a5aad27b2b927702d3557c6e70"
     end
+    let(:codepen_editor_link_single_uuid) do
+      "https://codepen.io/editor/Vaniel-John-Cornelio/pen/019dc28a-3250-7767-85c2-98e0573b8629"
+    end
     let(:codepen_link_with_default_tab) { "https://codepen.io/twhite96/pen/XKqrJX default-tab=js,result" }
     let(:codepen_link_with_theme_id) { "https://codepen.io/propjockey/pen/dyVMgBg theme-id=40148" }
     let(:codepen_link_with_preview_indicator) { "https://codepen.io/propjockey/pen/preview/dyVMgBg" }
@@ -82,6 +85,15 @@ RSpec.describe CodepenTag, type: :liquid_tag do
       expect(liquid.render).to include("<iframe")
         .and include(
           'src="https://codepen.io/editor/alvaromontoro/embed/019d657e-d7bc-746a-9bc3-4df2244c97cc/24ac30a5aad27b2b927702d3557c6e70?height=600&default-tab=result&embed-version=2"',
+        )
+    end
+
+    it "accepts CodePen 2.0 editor link with single UUID (no appended hash)" do
+      liquid = generate_new_liquid(codepen_editor_link_single_uuid)
+
+      expect(liquid.render).to include("<iframe")
+        .and include(
+          'src="https://codepen.io/editor/Vaniel-John-Cornelio/embed/019dc28a-3250-7767-85c2-98e0573b8629?height=600&default-tab=result&embed-version=2"',
         )
     end
 


### PR DESCRIPTION
Closes #23111

## Summary

- Newer CodePen 2.0 editor URLs only contain a single UUID (no trailing classic pen hash), causing validation to fail
- Made the second ID segment optional in `REGISTRY_REGEXP`: `(?:/#{PEN_ID_REGEXP})?`
- Existing dual-ID editor URLs continue to work

## Test plan

- [ ] `{% codepen https://codepen.io/editor/USERNAME/pen/UUID %}` no longer raises "Invalid CodePen URL"
- [ ] Existing classic and dual-ID editor URLs still accepted