### PR TITLE
fix(dashboard): exclude archived posts from pagination count

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -49,9 +49,11 @@ class DashboardsController < ApplicationController
     @reactions_count = @articles.sum(&:public_reactions_count)
     @comments_count = @articles.sum(&:comments_count)
     @page_views_count = @articles.sum(&:page_views_count)
+    @has_archived_posts = @articles.any?(&:archived)
 
-    @articles = @articles.includes(:collection).sorting(params[:sort]).decorate
-    @articles = Kaminari.paginate_array(@articles).page(params[:page]).per(ARTICLES_PER_PAGE)
+    @articles = @articles.includes(:collection).sorting(params[:sort])
+    @articles = @articles.where(archived: params[:filter] == "archived")
+    @articles = Kaminari.paginate_array(@articles.decorate).page(params[:page]).per(ARTICLES_PER_PAGE)
     @collections_count = target.collections.non_empty.count
   end
 

--- a/app/views/dashboards/_dashboard_article_row.html.erb
+++ b/app/views/dashboards/_dashboard_article_row.html.erb
@@ -1,4 +1,4 @@
-<div class="dashboard-story js-dashboard-story spec__dashboard-story single-article <%= "story-unpublished" unless article.published %> <%= "js-dashboard-story story-archived hidden" if article.archived %>">
+<div class="dashboard-story js-dashboard-story spec__dashboard-story single-article <%= "story-unpublished" unless article.published %>">
   <div class="dashboard-story__title">
     <h3 class="flex items-center">
       <% if article.archived %>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -13,8 +13,12 @@
           <% else %>
             <%= link_to t("views.dashboard.posts.statuses"), "/dashboard?state=status", class: "crayons-btn crayons-btn--outlined whitespace-nowrap" %>
           <% end %>
-          <% if @articles.any?(&:archived) %>
-            <%= link_to t("views.dashboard.posts.archived"), "javascript:;", id: "toggleArchivedLink", class: "crayons-btn crayons-btn--outlined whitespace-nowrap" %>
+          <% if @has_archived_posts %>
+            <% if params[:filter] == "archived" %>
+              <%= link_to t("views.dashboard.posts.full"), "/dashboard", class: "crayons-btn crayons-btn--outlined whitespace-nowrap" %>
+            <% else %>
+              <%= link_to t("views.dashboard.posts.archived"), "/dashboard?filter=archived", class: "crayons-btn crayons-btn--outlined whitespace-nowrap" %>
+            <% end %>
           <% end %>
           <% if @articles.any? %>
             <%= select_tag "dashboard_sort", options_for_select(sort_options, params[:sort]), "aria-label": t("views.dashboard.posts.option.aria_label"), class: "crayons-select w-auto" %>
@@ -67,4 +71,4 @@
   </div>
 </main>
 
-<%= javascript_include_tag "archivedPostFilters", "dashboards/convertCoauthorIdsToUsernameInputs", defer: true %>
+<%= javascript_include_tag "dashboards/convertCoauthorIdsToUsernameInputs", defer: true %>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -95,6 +95,30 @@ RSpec.describe "Dashboards" do
         expect(response.body).not_to include "pagination"
       end
 
+      it "excludes archived posts from pagination count" do
+        # Create 30 articles, then archive 26 of them.
+        # Before the fix, all 30 counted toward pagination, so page 1
+        # would show only 4 non-archived posts (or none if archived were hidden).
+        # After the fix, only the 4 non-archived posts are paginated.
+        articles = create_list(:article, 30, user: user)
+        articles.first(26).each { |a| a.update_column(:archived, true) }
+
+        get "/dashboard"
+        expect(response.body).not_to include "pagination"
+      end
+
+      it "shows archived posts when filter=archived param is present" do
+        articles = create_list(:article, 5, user: user)
+        articles.first(3).each { |a| a.update_column(:archived, true) }
+
+        get "/dashboard", params: { filter: "archived" }
+        archived_titles = articles.first(3).map { |a| CGI.escapeHTML(a.title) }
+        non_archived_titles = articles.last(2).map { |a| CGI.escapeHTML(a.title) }
+
+        archived_titles.each { |title| expect(response.body).to include(title) }
+        non_archived_titles.each { |title| expect(response.body).not_to include(title) }
+      end
+
       it "renders a link to analytics dashboard" do
         get dashboard_path
 


### PR DESCRIPTION
## Summary

When users archive posts from their dashboard, the archived posts are hidden via CSS but still count toward the 25-per-page pagination limit. If a user archives enough posts, they get completely empty pages and must navigate to later pages to see their remaining visible posts.

**Root cause**: The controller fetches all articles (including archived), applies pagination on the full set, and the view hides archived posts with CSS. The pagination count includes hidden posts.

**Fix**: Filter archived posts at the database level before pagination. Replace the client-side JavaScript toggle with a server-side `filter=archived` query parameter.

Closes #22903

## How to reproduce

1. Create 30+ posts on your dev.to account
2. Archive 26+ of them
3. Visit `/dashboard`
4. **Before fix**: Page 1 shows very few (or zero) posts, with pagination links visible
5. **After fix**: Page 1 shows 25 non-archived posts (or all of them if fewer than 25)

## What changed

- `app/controllers/dashboards_controller.rb` — Added `.where(archived: params[:filter] == "archived")` before pagination. Added `@has_archived_posts` to track if user has archived posts.
- `app/views/dashboards/show.html.erb` — "Show archived" link now navigates to `?filter=archived` instead of using JS toggle. Removed `archivedPostFilters` JS include.
- `app/views/dashboards/_dashboard_article_row.html.erb` — Removed CSS-based hiding of archived rows (now handled server-side).

## Trade-offs

The archived posts toggle is no longer a client-side show/hide but a separate server-rendered view (`?filter=archived`). This trades instant toggling for correct pagination. The UX is arguably clearer: users see either their active posts or their archived posts, not a mix with invisible gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)