### PR TITLE
Fix: Enhance article management by busting author profile cache on unpublish and destroy actions

### DIFF
--- a/app/services/articles/destroyer.rb
+++ b/app/services/articles/destroyer.rb
@@ -3,6 +3,8 @@ module Articles
     module_function
 
     def call(article)
+      author = article.user
+
       # comments will automatically lose the connection to their article once `.destroy` is called,
       # due to the `dependent: nullify` clause, so to remove their notifications,
       # we need to cache the ids in advance
@@ -12,9 +14,11 @@ module Articles
 
       Notification.remove_all(notifiable_ids: article.id, notifiable_type: "Article")
 
-      return if article_comments_ids.blank?
+      unless article_comments_ids.blank?
+        Notification.remove_all(notifiable_ids: article_comments_ids, notifiable_type: "Comment")
+      end
 
-      Notification.remove_all(notifiable_ids: article_comments_ids, notifiable_type: "Comment")
+      EdgeCache::BustUser.call(author)
     end
   end
 end

--- a/app/services/articles/updater.rb
+++ b/app/services/articles/updater.rb
@@ -19,7 +19,11 @@ module Articles
       if success
         user.rate_limiter.track_limit_by_action(:article_update)
 
-        remove_all_notifications if became_unpublished?
+        if became_unpublished?
+          remove_all_notifications
+          bust_author_profile_cache
+        end
+
         send_to_mentioned_users_and_followers if remains_published?
         refresh_auto_audience_segments if became_published?
         complete_onboarding_first_post if became_published?
@@ -90,6 +94,10 @@ module Articles
 
       Notification.remove_all(notifiable_ids: article.mentions.ids,
                               notifiable_type: "Mention")
+    end
+
+    def bust_author_profile_cache
+      EdgeCache::BustUser.call(article.user)
     end
   end
 end

--- a/spec/requests/articles/articles_admin_unpublish_spec.rb
+++ b/spec/requests/articles/articles_admin_unpublish_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "ArticlesAdminUnpublish" do
 
   it "removes the related notifications when unpublishing" do
     expect(article.published).to be true
+    allow(EdgeCache::BustUser).to receive(:call)
     create(:notification, notifiable: article, action: "Published")
     expect do
       patch "/articles/#{article.id}/admin_unpublish", params: {
@@ -31,5 +32,6 @@ RSpec.describe "ArticlesAdminUnpublish" do
         slug: article.slug
       }
     end.to change(Notification, :count).by(-1)
+    expect(EdgeCache::BustUser).to have_received(:call).with(user)
   end
 end

--- a/spec/requests/articles/articles_destroy_spec.rb
+++ b/spec/requests/articles/articles_destroy_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe "ArticlesDestroy" do
       end.to change(Notification, :count).by(-1)
     end
 
+    it "busts the author profile cache" do
+      allow(EdgeCache::BustUser).to receive(:call)
+
+      delete "/articles/#{article.id}"
+
+      expect(EdgeCache::BustUser).to have_received(:call).with(user)
+    end
+
     it "doesn't destroy another person's article" do
       article2 = create(:article, user_id: create(:user).id)
       expect do

--- a/spec/requests/articles/articles_update_spec.rb
+++ b/spec/requests/articles/articles_update_spec.rb
@@ -172,6 +172,8 @@ RSpec.describe "ArticlesUpdate" do
 
   it "removes all published notifications if unpublished" do
     user2.follow(user)
+    allow(EdgeCache::BustUser).to receive(:call)
+
     sidekiq_perform_enqueued_jobs do
       Notification.send_to_followers(article, "Published")
     end
@@ -181,6 +183,7 @@ RSpec.describe "ArticlesUpdate" do
       article: { body_markdown: article.body_markdown.gsub("published: true", "published: false"), version: "v1" }
     }
     expect(article.notifications.size).to eq 0
+    expect(EdgeCache::BustUser).to have_received(:call).with(user)
   end
 
   it "changes video_thumbnail_url effectively" do

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe "UserProfiles" do
       expect(response.body).to include "Pinned"
     end
 
+    it "does not render unpublished pinned stories" do
+      unpublished_article = create(:article, user: user, published: false, published_at: nil, title: "Unpublished Pinned Story")
+      create(:profile_pin, pinnable: unpublished_article, profile: user)
+
+      get "/#{user.username}"
+
+      expect(response.body).not_to include("Unpublished Pinned Story")
+    end
+
     context "when has articles" do
       before do
         create(:article, user: user, title: "Super Article", published: true, type_of: "full_post")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes a bug where a deleted post can still appear as pinned on an author's profile and dashboard. Previously, clicking on this stale link resulted in a `404 Page Not Found` error. 

**Root Cause:**
The issue was caused by a stale cache. Pinned stories are correctly resolved from existing published `Article` rows, meaning a hard-deleted record should disappear naturally. However, the deletion flow did not invalidate all profile-cache surfaces quickly enough, allowing stale HTML to continue referencing the deleted post.

**Implementation:**
To fix this, I hooked into Forem's existing cache-busting pattern. The article deletion flow (via `Articles::Destroyer`) now ensures that `EdgeCache::BustUser.call(author)` is triggered. This busts the author's profile cache upon deletion, so the profile and dashboard immediately stop serving the stale pinned link. 

**Trade-offs:**
I considered explicitly removing profile pins on article deletion, but chose cache-busting as the primary fix. It directly addresses the broken user experience (stale link visibility) while remaining minimal, consistent with existing Forem infrastructure, and avoiding risky broad refactors to pin rendering logic.

## Related Tickets & Documents

- Related Issue: If the post is pinned and you delete, the post still pinned but you can't access #23191
- Closes #23191

## QA Instructions, Screenshots, Recordings

**How to test:**
1. Navigate to your dashboard and **Pin** a published post.
2. Verify the post appears as pinned on your user profile and dashboard.
3. Edit and **Delete** that pinned post.
4. Navigate back to your user profile and dashboard.
5. **Verify** that the post no longer appears in the pinned section and the UI reflects the current state immediately.

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

*(Note: No new UI elements were added; this is a backend cache invalidation fix).*

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

**Testing Details:**
Added regression coverage in `spec/requests/articles/articles_destroy_spec.rb` to confirm the intended behavior:
* Deleting an article successfully triggers author profile cache busting (`expect(EdgeCache::BustUser).to have_received(:call).with(user)`).
* This protects against future regressions where article deletion and profile cache invalidation might drift apart.