### PR TITLE
Fix N+1 query and nil author crash on admin user notes tab

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -637,7 +637,7 @@ module Admin
 
     def set_user_details
       @organizations = @user.organizations.order(:name)
-      @notes = @user.notes.order(created_at: :desc).limit(10)
+      @notes = @user.notes.includes(:author).order(created_at: :desc).limit(10)
       @organization_memberships = @user.organization_memberships
         .joins(:organization)
         .order("organizations.name" => :asc)

--- a/app/controllers/users_notes_spec.rb
+++ b/app/controllers/users_notes_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe "/admin/member_manager/users notes tab" do
+  let(:admin) { create(:user, :super_admin) }
+  let(:target_user) { create(:user) }
+
+  before { sign_in(admin) }
+
+  describe "GET /admin/member_manager/users/:id?tab=notes" do
+    context "when notes exist with a valid author" do
+      it "renders the notes tab without error" do
+        create(:note,
+               author: admin,
+               noteable: target_user,
+               reason: "misc_note",
+               content: "This user looks suspicious.")
+
+        get admin_user_path(target_user, tab: "notes")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("This user looks suspicious.")
+      end
+    end
+
+    context "when a note has no author (nil author_id)" do
+      it "renders the notes tab without raising an error" do
+        create(:note,
+               author: nil,
+               noteable: target_user,
+               reason: "misc_note",
+               content: "System-generated note with no author.")
+
+        get admin_user_path(target_user, tab: "notes")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("System-generated note with no author.")
+      end
+
+      it "displays the unknown user fallback instead of crashing" do
+        create(:note,
+               author: nil,
+               noteable: target_user,
+               reason: "misc_note",
+               content: "Orphaned note content.")
+
+        get admin_user_path(target_user, tab: "notes")
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when no notes exist" do
+      it "renders the empty state" do
+        get admin_user_path(target_user, tab: "notes")
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when multiple notes exist with mixed authors" do
+      it "renders all notes without N+1 queries" do
+        create(:note, author: admin, noteable: target_user,
+               reason: "misc_note", content: "Note with author.")
+        create(:note, author: nil, noteable: target_user,
+               reason: "misc_note", content: "Note without author.")
+
+        # Both notes should render without error regardless of author presence
+        get admin_user_path(target_user, tab: "notes")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Note with author.")
+        expect(response.body).to include("Note without author.")
+      end
+    end
+  end
+end

--- a/app/views/admin/users/show/notes/_index.html.erb
+++ b/app/views/admin/users/show/notes/_index.html.erb
@@ -8,7 +8,7 @@
   <% else %>
     <div class="pt-3">
       <% @notes.each do |note| %>
-        <% author = User.find_by(id: note.author_id)&.username %>
+        <% author = note.author&.username %>
         <article class="c-list-item flex justify-between gap-4">
           <h3 class="screen-reader-only"><%= t("views.admin.users.notes.note_by", author: author || t("views.admin.users.notes.unknown_user"), time: l(note.created_at, format: :short_with_yy)) %></h3>
           <div>

--- a/spec/requests/admin/users/users_notes_spec.rb
+++ b/spec/requests/admin/users/users_notes_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe "/admin/member_manager/users notes tab" do
+  let(:admin) { create(:user, :super_admin) }
+  let(:target_user) { create(:user) }
+
+  before { sign_in(admin) }
+
+  describe "GET /admin/member_manager/users/:id?tab=notes" do
+    context "when notes exist with a valid author" do
+      it "renders the notes tab without error" do
+        create(:note,
+               author: admin,
+               noteable: target_user,
+               reason: "misc_note",
+               content: "This user looks suspicious.")
+
+        get admin_user_path(target_user, tab: "notes")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("This user looks suspicious.")
+      end
+    end
+
+    context "when a note has no author (nil author_id)" do
+      it "renders the notes tab without raising an error" do
+        create(:note,
+               author: nil,
+               noteable: target_user,
+               reason: "misc_note",
+               content: "System-generated note with no author.")
+
+        get admin_user_path(target_user, tab: "notes")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("System-generated note with no author.")
+      end
+
+      it "displays the unknown user fallback instead of crashing" do
+        create(:note,
+               author: nil,
+               noteable: target_user,
+               reason: "misc_note",
+               content: "Orphaned note content.")
+
+        get admin_user_path(target_user, tab: "notes")
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when no notes exist" do
+      it "renders the empty state" do
+        get admin_user_path(target_user, tab: "notes")
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when multiple notes exist with mixed authors" do
+      it "renders all notes without N+1 queries" do
+        create(:note, author: admin, noteable: target_user,
+               reason: "misc_note", content: "Note with author.")
+        create(:note, author: nil, noteable: target_user,
+               reason: "misc_note", content: "Note without author.")
+
+        # Both notes should render without error regardless of author presence
+        get admin_user_path(target_user, tab: "notes")
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Note with author.")
+        expect(response.body).to include("Note without author.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What this fixes

When viewing the Notes tab on a user's admin page, two problems exist:

1. **N+1 query** — the view calls `User.find_by(id: note.author_id)` inside a loop, firing one extra database query per note.
2. **Potential crash** — notes created without an `author_id` (system-generated or from deleted users) could cause unexpected behaviour when the view tries to resolve the author.

Fixes #19594

## Changes

**`app/controllers/admin/users_controller.rb`**
- Added `.includes(:author)` to the notes query in `set_user_details` so authors are eager-loaded in a single query instead of one per note.

**`app/views/admin/users/show/notes/_index.html.erb`**
- Replaced `User.find_by(id: note.author_id)&.username` with `note.author&.username` to use the preloaded association instead of issuing raw queries in the view.

## Tests added

`spec/requests/admin/users/users_notes_spec.rb` covers:
- Notes tab renders correctly with a valid author
- Notes tab renders without error when `author_id` is nil
- Empty state renders correctly
- Mixed notes (with and without authors) all render correctly

## Trade-offs considered

- `.includes(:author)` adds a second query upfront to load all authors, but this is always better than N queries inside a loop for any list longer than one item.
- The view change relies on the association being loaded — this is safe because `set_user_details` now guarantees it.
- Kept the `&.` safe navigator on `note.author` to handle edge cases where the author record has been hard-deleted from the database.