### PR TITLE
Fix orphaned profile pins blocking new pins

### DIFF
--- a/app/controllers/profile_pins_controller.rb
+++ b/app/controllers/profile_pins_controller.rb
@@ -2,6 +2,8 @@ class ProfilePinsController < ApplicationController
   before_action :authenticate_user!, only: %i[create update]
 
   def create
+    remove_orphaned_profile_pins
+
     @profile_pin = ProfilePin.new
     @profile_pin.profile_id = current_user.id
     @profile_pin.profile_type = "User"
@@ -34,5 +36,12 @@ class ProfilePinsController < ApplicationController
     cache_bust = EdgeCache::Bust.new
     cache_bust.call(current_user.path)
     cache_bust.call("#{current_user.path}?i=i")
+  end
+
+  def remove_orphaned_profile_pins
+    current_user.profile_pins.where(pinnable_type: "Article").where.not(
+      pinnable_id: Article.unscoped.select(:id),
+    ).delete_all
+    current_user.profile_pins.reset
   end
 end

--- a/app/models/profile_pin.rb
+++ b/app/models/profile_pin.rb
@@ -1,6 +1,3 @@
-# @note When we destroy the related article (via pinnable), it's using
-#       dependent: :delete for the relationship.  That means no
-#       before/after destroy callbacks will be called on this object.
 class ProfilePin < ApplicationRecord
   belongs_to :pinnable, polymorphic: true
   belongs_to :profile, polymorphic: true
@@ -14,7 +11,7 @@ class ProfilePin < ApplicationRecord
   private
 
   def only_five_pins_per_profile
-    errors.add(:base, I18n.t("models.profile_pin.only_five")) if profile.profile_pins.size > 4
+    errors.add(:base, I18n.t("models.profile_pin.only_five")) if profile.profile_pins.count > 4
   end
 
   def pinnable_belongs_to_profile

--- a/app/services/users/delete_articles.rb
+++ b/app/services/users/delete_articles.rb
@@ -15,6 +15,8 @@ module Users
           comment.delete
         end
         article.discussion_lock&.delete
+        # `article.delete` bypasses the association's `dependent: :delete_all` cleanup.
+        article.profile_pins.delete_all
         article.delete
         article.purge
       end

--- a/spec/requests/profile_pins_spec.rb
+++ b/spec/requests/profile_pins_spec.rb
@@ -29,6 +29,28 @@ RSpec.describe "ProfilePins" do
       end
       expect(user.reload.profile_pins.size).to eq(5)
     end
+
+    it "ignores orphaned pins when enforcing the five pin limit" do
+      [article, article2, article3, article4, article5].each do |pinned_article|
+        post "/profile_pins", params: {
+          profile_pin: { pinnable_id: pinned_article.id }
+        }
+      end
+
+      Article.delete(article.id)
+
+      post "/profile_pins", params: {
+        profile_pin: { pinnable_id: article6.id }
+      }
+
+      expect(user.reload.profile_pins.pluck(:pinnable_id)).to contain_exactly(
+        article2.id,
+        article3.id,
+        article4.id,
+        article5.id,
+        article6.id,
+      )
+    end
   end
 
   describe "PUT /profile_pins/:id" do # delete

--- a/spec/services/users/delete_articles_spec.rb
+++ b/spec/services/users/delete_articles_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Users::DeleteArticles, type: :service do
     end.to change(DiscussionLock, :count).from(1).to(0)
   end
 
+  context "when pinned articles exist" do
+    let!(:profile_pin) { create(:profile_pin, profile: user, pinnable: article) }
+
+    it "deletes pinned article references with the article" do
+      expect do
+        described_class.call(user)
+      end.to change(ProfilePin, :count).from(1).to(0)
+    end
+  end
+
   context "with comments" do
     before do
       allow(EdgeCache::BustComment).to receive(:call)


### PR DESCRIPTION
## Summary

- Remove orphaned article pins before creating a new profile pin so deleted articles do not keep consuming a user's five-pin limit.
- Clean up profile pins in `Users::DeleteArticles`, where `article.delete` bypasses association cleanup.
- Add request and service regression coverage for orphaned pin handling.

## Test plan

- [ ] `bundle exec rspec spec/requests/profile_pins_spec.rb`
- [ ] `bundle exec rspec spec/services/users/delete_articles_spec.rb`