### PR TITLE
Fix/profile post count after deletion

### DIFF
--- a/app/services/edge_cache/bust_article.rb
+++ b/app/services/edge_cache/bust_article.rb
@@ -17,6 +17,7 @@ module EdgeCache
 
       bust_home_pages(cache_bust, article)
       bust_tag_pages(cache_bust, article)
+      bust_user_profile_pages(article)
     end
 
     def self.bust_home_pages(cache_bust, article)
@@ -72,5 +73,11 @@ module EdgeCache
     end
 
     private_class_method :bust_tag_pages
+
+    def self.bust_user_profile_pages(article)
+
+    end
+
+    private_class_method :bust_user_profile_pages
   end
 end

--- a/app/services/edge_cache/bust_article.rb
+++ b/app/services/edge_cache/bust_article.rb
@@ -75,7 +75,7 @@ module EdgeCache
     private_class_method :bust_tag_pages
 
     def self.bust_user_profile_pages(article)
-
+      EdgeCache::PurgeByKey.call(article.user.profile_cache_keys)
     end
 
     private_class_method :bust_user_profile_pages

--- a/app/services/edge_cache/bust_article.rb
+++ b/app/services/edge_cache/bust_article.rb
@@ -75,6 +75,8 @@ module EdgeCache
     private_class_method :bust_tag_pages
 
     def self.bust_user_profile_pages(article)
+      return unless article.user
+      
       EdgeCache::PurgeByKey.call(article.user.profile_cache_keys)
     end
 

--- a/app/services/edge_cache/bust_article.rb
+++ b/app/services/edge_cache/bust_article.rb
@@ -76,8 +76,11 @@ module EdgeCache
 
     def self.bust_user_profile_pages(article)
       return unless article.user
-      
-      EdgeCache::PurgeByKey.call(article.user.profile_cache_keys)
+
+      EdgeCache::PurgeByKey.call(
+        article.user.profile_cache_keys,
+        fallback_paths: article.user.profile_cache_bust_paths,
+      )
     end
 
     private_class_method :bust_user_profile_pages

--- a/spec/services/edge_cache/bust_article_spec.rb
+++ b/spec/services/edge_cache/bust_article_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe EdgeCache::BustArticle, type: :service do
     allow(cache_bust).to receive(:call)
     allow(described_class).to receive(:bust_home_pages)
     allow(described_class).to receive(:bust_tag_pages)
-    allow(described_class).to receive(:bust_user_profile_pages)
   end
 
   it "defines TIMEFRAMES" do
@@ -28,6 +27,7 @@ RSpec.describe EdgeCache::BustArticle, type: :service do
   end
 
   it "busts the cache" do
+    allow(described_class).to receive(:bust_user_profile_pages)
     described_class.call(article)
     expect(article).to have_received(:purge).once
     allow(article.user).to receive(:purge)

--- a/spec/services/edge_cache/bust_article_spec.rb
+++ b/spec/services/edge_cache/bust_article_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe EdgeCache::BustArticle, type: :service do
     allow(cache_bust).to receive(:call)
     allow(described_class).to receive(:bust_home_pages)
     allow(described_class).to receive(:bust_tag_pages)
+    allow(described_class).to receive(:bust_user_profile_pages)
   end
 
   it "defines TIMEFRAMES" do
@@ -32,6 +33,7 @@ RSpec.describe EdgeCache::BustArticle, type: :service do
     allow(article.user).to receive(:purge)
     expect(described_class).to have_received(:bust_home_pages).with(cache_bust, article).once
     expect(described_class).to have_received(:bust_tag_pages).with(cache_bust, article).once
+    expect(described_class).to have_received(:bust_user_profile_pages).with(article).once
   end
 
   context "when an article is part of an organization" do

--- a/spec/services/edge_cache/bust_article_spec.rb
+++ b/spec/services/edge_cache/bust_article_spec.rb
@@ -41,7 +41,10 @@ RSpec.describe EdgeCache::BustArticle, type: :service do
 
     described_class.call(article)
 
-    expect(EdgeCache::PurgeByKey).to have_received(:call).with(article.user.profile_cache_keys).once
+    expect(EdgeCache::PurgeByKey).to have_received(:call).with(
+      article.user.profile_cache_keys,
+      fallback_paths: article.user.profile_cache_bust_paths
+    ).once
   end
 
   it "does not raise when article has no user" do

--- a/spec/services/edge_cache/bust_article_spec.rb
+++ b/spec/services/edge_cache/bust_article_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe EdgeCache::BustArticle, type: :service do
     expect(described_class).to have_received(:bust_user_profile_pages).with(article).once
   end
 
+  it "busts user profile pages" do
+    allow(EdgeCache::PurgeByKey).to receive(:call)
+
+    described_class.call(article)
+
+    expect(EdgeCache::PurgeByKey).to have_received(:call).with(article.user.profile_cache_keys).once
+  end
+
   context "when an article is part of an organization" do
     it "busts the organization slug" do
       organization = create(:organization)

--- a/spec/services/edge_cache/bust_article_spec.rb
+++ b/spec/services/edge_cache/bust_article_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe EdgeCache::BustArticle, type: :service do
     expect(EdgeCache::PurgeByKey).to have_received(:call).with(article.user.profile_cache_keys).once
   end
 
+  it "does not raise when article has no user" do
+    article_without_user = create(:article)
+    article_without_user.user = nil
+    allow(EdgeCache::PurgeByKey).to receive(:call)
+
+    expect { described_class.call(article_without_user) }.not_to raise_error
+  end
+
   context "when an article is part of an organization" do
     it "busts the organization slug" do
       organization = create(:organization)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
**Bug:** Deleting an article leaves the user profile page stale — the deleted post remains visible and the post count doesn't update. Reproducible in production; not locally without Fastly configured.

**Root cause:** EdgeCache::BustArticle calls article.user&.purge which purges the CDN cache under the key users/:id. However, the profile page is cached under surrogate keys users/:id/profile_identity, users/:id/profile_details, and users/:id/profile_image. These keys never match, so the profile page cache is never invalidated on article deletion.

**Fix:** Added bust_user_profile_pages which calls EdgeCache::PurgeByKey.call with the user's profile_cache_keys, ensuring the correct surrogate keys are purged on deletion.

**Tests:** Added tests asserting bust_user_profile_pages is called on article deletion, that EdgeCache::PurgeByKey receives the correct keys, and that nil users are handled gracefully.

**Note:** This issue can only be verified in a production-like environment with Fastly configured.

## Related Tickets & Documents
- Related issue #16394 
- Closes #16863

## QA Instructions, Screenshots, Recordings

To test this fix:
1. Create and publish a post.
2. Note the number of posts in the user stats side bar on the left side of the profile page. It should say "1 post published" if you have one post, for example.
3. Locate the newly created post in your list of posts. Since it's a new post, it should be at the top of the list.
5. Delete the post.
6. Note the number of posts in the user stats side bar. It should be decremented by 1.
7. Ensure that the new post no longer appears in the list.

### UI accessibility checklist
- No UI changes in this PR.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Are there any post deployment tasks we need to perform?
No

## What gif best describes this PR or how it makes you feel?

![Clear your cache](https://y.yarn.co/bee344e3-4658-43e5-a120-694573e600f3_text.gif)
