### PR TITLE
Fix/stale pinned links on dashboard

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -303,6 +303,7 @@ class Article < ApplicationRecord
   before_save :detect_language
   before_create :create_password
   before_destroy :before_destroy_actions, prepend: true
+  after_commit :bust_cache_after_destroy, on: :destroy
 
   after_save :create_conditional_autovomits
   after_save :bust_cache
@@ -1672,6 +1673,10 @@ class Article < ApplicationRecord
 
     self.class.bust_cached_admin_published_with("welcome", subforem_id: subforem_id)
     self.class.bust_cached_admin_published_with("welcome")
+  end
+
+  def bust_cache_after_destroy
+    EdgeCache::BustArticle.call(self)
   end
 
   def should_add_urls_from_title?

--- a/app/services/articles/destroyer.rb
+++ b/app/services/articles/destroyer.rb
@@ -8,13 +8,19 @@ module Articles
       # we need to cache the ids in advance
       article_comments_ids = article.comments.ids
 
-      article.destroy!
+        # create a lightweight copy to use for cache purging after destroy
+        virtual_article = Article.new(article.attributes)
 
-      Notification.remove_all(notifiable_ids: article.id, notifiable_type: "Article")
+        article.destroy!
 
-      return if article_comments_ids.blank?
+        # purge any edge caches that reference this article (and related records)
+        EdgeCache::BustArticle.call(virtual_article)
 
-      Notification.remove_all(notifiable_ids: article_comments_ids, notifiable_type: "Comment")
+        Notification.remove_all(notifiable_ids: article.id, notifiable_type: "Article")
+
+        return if article_comments_ids.blank?
+
+        Notification.remove_all(notifiable_ids: article_comments_ids, notifiable_type: "Comment")
     end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Problem: 
Pinned articles could remain visible on a user's dashboard/profile after the underlying Article was deleted, producing a 404 when clicked.

Root cause: 
Edge/CDN cached profile/dashboard HTML was not reliably invalidated after article deletion. Some deletion flows purged cache too early (before dependent profile_pins were removed) or skipped purging entirely (e.g., flows that call delete and skip callbacks). Because cached HTML still contained the pinned link, the UI showed the dead link until the cache expired or was purged.

Fix:
Model-level: Add a post-commit purge so cache is invalidated after the DB transaction completes: after_commit :bust_cache_after_destroy, on: :destroy and def bust_cache_after_destroy; EdgeCache::BustArticle.call(self); end in Article.
Service-level: Ensure the controller/service delete path purges the same targets immediately after destroy by calling EdgeCache::BustArticle with a lightweight copy of the article attributes (so purge keys can be computed even after the AR instance is destroyed).

Files changed:
article.rb — added after_commit + bust_cache_after_destroy.
destroyer.rb — call EdgeCache::BustArticle.call(virtual_article) after article.destroy!.

## Related Tickets & Documents
- Closes #23191 

## QA Instructions, Screenshots, Recordings

Reproduce
1. Sign in as a user and create + publish an article (or use an existing published article).
2. Pin the article to your profile (use the dashboard pin button).
3. From the dashboard, delete the article (use the Delete action).

Verify (expected)
- After deletion and a page refresh, the pinned entry should no longer appear on the dashboard/profile.
- Clicking the (previous) pinned entry should not be possible — there should be no stale link to a 404 page.

Extra checks
- Test both UI delete (ArticlesController#destroy) and any mass-delete/cleanup flows that use delete (e.g., Users::DeleteArticles), because delete bypasses callbacks and must explicitly call purge (those flows already call EdgeCache::BustArticle).
- If you have a Fastly/OpenResty staging setup, verify the CDN-served page is updated after the purge (allow a few seconds for propagation).


_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: the change is a lifecycle/caching hook that requires careful test setup (committed transactions / CDN stub).
- [ ] I need help with writing tests

