### PR TITLE
Add popup comment cue message

### DIFF
--- a/app/assets/stylesheets/views/comments.scss
+++ b/app/assets/stylesheets/views/comments.scss
@@ -307,3 +307,94 @@
     }
   }
 }
+
+.comment-cue-sentinel {
+  position: relative;
+  display: block;
+  height: 0;
+}
+
+.comment-cue-popup {
+  position: absolute;
+  bottom: -65px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--modal-bg);
+  border: var(--modal-border);
+  color: var(--text-color);
+  border-radius: var(--radius-large-auto);
+  box-shadow: var(--shadow-2);
+  padding: var(--su-5) var(--su-8) var(--su-5) var(--su-5);
+  font-size: var(--fs-base);
+  line-height: var(--lh-base);
+  min-width: 280px;
+  max-width: 360px;
+  width: calc(100vw - 32px);
+  animation: comment-cue-popup-in 0.4s ease-out;
+
+  &--leaving {
+    animation: comment-cue-popup-out 0.3s ease-in;
+  }
+
+  &__message {
+    margin: 0;
+  }
+
+  &__close {
+    position: absolute;
+    top: var(--su-2);
+    right: var(--su-2);
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    color: var(--base-60);
+    opacity: 0.8;
+    font-size: var(--fs-xl);
+    line-height: 1;
+    padding: var(--su-1) var(--su-2);
+    border-radius: 6px;
+
+    &:hover,
+    &:focus {
+      background-color: var(--base-10);
+      color: var(--base-80);
+    }
+  }
+}
+
+@keyframes comment-cue-popup-in {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 30px);
+  }
+  25% {
+    transform: translate(-50%, -20px);
+  }
+  60% {
+    opacity: 1;
+    transform: translate(-50%, 7px);
+  }
+  100% {
+    transform: translate(-50%, 0);
+  }
+}
+
+@keyframes comment-cue-popup-out {
+  0% {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  20% {
+    transform: translate(-50%, 5px);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -25px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .comment-cue-popup {
+    animation: none;
+  }
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -504,7 +504,8 @@ module ApplicationHelper
   end
 
   def enabled_global_feature_flags
-    RequestStore.store[:enabled_global_feature_flags] ||=
+    RequestStore.store[:enabled_global_feature_flags] ||= MemoryFirstCache.fetch("enabled_global_feature_flags", redis_expires_in: 10.minutes) do
       FeatureFlag.all.select { |_, state| state == :on }.keys.join(" ")
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -502,4 +502,9 @@ module ApplicationHelper
 
     content_tag(name, class: dom_class, **kwargs, &block)
   end
+
+  def enabled_global_feature_flags
+    RequestStore.store[:enabled_global_feature_flags] ||=
+      FeatureFlag.all.select { |_, state| state == :on }.keys.join(" ")
+  end
 end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -73,4 +73,16 @@ module ArticlesHelper
   def active_threads(...)
     Articles::ActiveThreadsQuery.call(...)
   end
+
+  def comment_cue_message(count)
+    count = count.to_i
+    bucket = if count.zero?
+               :zero
+             elsif count <= 10
+               :few
+             else
+               :many
+             end
+    t("views.articles.comment_cue.#{bucket}")
+  end
 end

--- a/app/javascript/commentCue/CommentCuePopup.jsx
+++ b/app/javascript/commentCue/CommentCuePopup.jsx
@@ -1,0 +1,56 @@
+import { h } from 'preact';
+import { useEffect, useRef, useState } from 'preact/hooks';
+
+export function CommentCuePopup({ message, closeLabel, onDismiss }) {
+  const [leaving, setLeaving] = useState(false);
+  const popupRef = useRef(null);
+
+  const beginDismiss = () => setLeaving(true);
+
+  useEffect(() => {
+    if (leaving) return undefined;
+
+    const onKey = (e) => {
+      if (e.key === 'Escape') beginDismiss();
+    };
+    const onClick = (e) => {
+      if (popupRef.current && !popupRef.current.contains(e.target)) beginDismiss();
+    };
+
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onClick);
+
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onClick);
+    };
+  }, [leaving]);
+
+  useEffect(() => {
+    if (!leaving) return undefined;
+
+    const finish = () => onDismiss();
+    popupRef.current.addEventListener('animationend', finish, { once: true });
+
+    return () => popupRef.current.removeEventListener('animationend', finish);
+  }, [leaving, onDismiss]);
+
+  return (
+    <div
+      ref={popupRef}
+      class={`comment-cue-popup${leaving ? ' comment-cue-popup--leaving' : ''}`}
+      role="status"
+      aria-live="polite"
+    >
+      <p class="comment-cue-popup__message">{message}</p>
+      <button
+        type="button"
+        class="comment-cue-popup__close"
+        aria-label={closeLabel}
+        onClick={beginDismiss}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/app/javascript/commentCue/__tests__/CommentCuePopup.test.jsx
+++ b/app/javascript/commentCue/__tests__/CommentCuePopup.test.jsx
@@ -1,0 +1,67 @@
+import { h } from 'preact';
+import { axe } from 'jest-axe';
+import '@testing-library/jest-dom';
+import { render, fireEvent } from '@testing-library/preact';
+import { CommentCuePopup } from '../CommentCuePopup';
+
+function renderPopup(overrides = {}) {
+  const onDismiss = overrides.onDismiss || jest.fn();
+  const result = render(
+    <CommentCuePopup
+      message="Jump in!"
+      closeLabel="Dismiss"
+      onDismiss={onDismiss}
+      {...overrides}
+    />,
+  );
+  return { ...result, onDismiss };
+}
+
+function finishLeaveAnimation(container) {
+  const popup = container.querySelector('.comment-cue-popup--leaving');
+  if (popup) fireEvent.animationEnd(popup);
+}
+
+describe('CommentCuePopup', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders the popup with the message', () => {
+    const { getByText, getByLabelText } = renderPopup();
+    expect(getByText('Jump in!')).toBeInTheDocument();
+    expect(getByLabelText('Dismiss')).toBeInTheDocument();
+  });
+
+  it('has no a11y violations', async () => {
+    const { container } = renderPopup();
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it('calls onDismiss after the leave animation when the close button is clicked', () => {
+    const { getByLabelText, container, onDismiss } = renderPopup();
+    fireEvent.click(getByLabelText('Dismiss'));
+    expect(onDismiss).not.toHaveBeenCalled();
+    finishLeaveAnimation(container);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDismiss after the leave animation when Escape is pressed', () => {
+    const { container, onDismiss } = renderPopup();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onDismiss).not.toHaveBeenCalled();
+    finishLeaveAnimation(container);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDismiss after the leave animation on click outside the popup', () => {
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    const { container, onDismiss } = renderPopup();
+    fireEvent.mouseDown(outside);
+    expect(onDismiss).not.toHaveBeenCalled();
+    finishLeaveAnimation(container);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/javascript/packs/__tests__/commentCuePopup.test.jsx
+++ b/app/javascript/packs/__tests__/commentCuePopup.test.jsx
@@ -1,0 +1,70 @@
+import { init } from '../commentCuePopup';
+
+function buildPage({ flag = 'comment_cue_popup', message = 'Jump in!' } = {}) {
+  document.body.innerHTML = `
+    <div id="article-wrapper">
+      <div id="article-body"
+           data-article-id="42"
+           data-cue-message="${message}"
+           data-cue-close-label="Dismiss"></div>
+    </div>
+  `;
+  document.body.dataset.globalFeatureFlagsEnabled = flag;
+}
+
+describe('comment cue init', () => {
+  let observerSpy;
+  let observeMock;
+  let disconnectMock;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    delete document.body.dataset.globalFeatureFlagsEnabled;
+    sessionStorage.clear();
+    observeMock = jest.fn();
+    disconnectMock = jest.fn();
+    observerSpy = jest.fn(function MockIO(callback) {
+      this.callback = callback;
+      this.observe = observeMock;
+      this.disconnect = disconnectMock;
+    });
+    global.IntersectionObserver = observerSpy;
+  });
+
+  it('does nothing when the global flag is absent', () => {
+    buildPage({ flag: 'something_else' });
+    init();
+    expect(observerSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the article was already dismissed in this session', () => {
+    buildPage();
+    sessionStorage.setItem('commentCueDismissed:42', '1');
+    init();
+    expect(observerSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the article body is missing', () => {
+    document.body.dataset.globalFeatureFlagsEnabled = 'comment_cue_popup';
+    init();
+    expect(observerSpy).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no message is provided', () => {
+    buildPage({ message: '' });
+    init();
+    expect(observerSpy).not.toHaveBeenCalled();
+  });
+
+  it('appends a sentinel to the article wrapper and observes it', () => {
+    buildPage();
+    init();
+    expect(observerSpy).toHaveBeenCalledTimes(1);
+    const wrapper = document.getElementById('article-wrapper');
+    const sentinel = wrapper.querySelector('.comment-cue-sentinel');
+    expect(sentinel).not.toBeNull();
+    expect(sentinel.parentElement).toBe(wrapper);
+    expect(wrapper.lastElementChild).toBe(sentinel);
+    expect(observeMock).toHaveBeenCalledWith(sentinel);
+  });
+});

--- a/app/javascript/packs/commentCuePopup.jsx
+++ b/app/javascript/packs/commentCuePopup.jsx
@@ -1,0 +1,61 @@
+import { h, render } from 'preact';
+import { CommentCuePopup } from '../commentCue/CommentCuePopup';
+
+const FLAG_NAME = 'comment_cue_popup';
+const STORAGE_PREFIX = 'commentCueDismissed:';
+
+export function init() {
+  const flags = document.body.dataset.globalFeatureFlagsEnabled || '';
+  if (!flags.split(' ').includes(FLAG_NAME)) return;
+
+  const articleBody = document.querySelector('#article-body');
+  if (!articleBody) return;
+
+  const storageKey = `${STORAGE_PREFIX}${articleBody.dataset.articleId}`;
+  if (window.sessionStorage.getItem(storageKey)) return;
+
+  const message = articleBody.dataset.cueMessage;
+  const closeLabel = articleBody.dataset.cueCloseLabel || 'Dismiss';
+  if (!message) return;
+
+  // Position a sentinel at the bottom of the article section to serve as both
+  // the IntersectionObserver target and the popup's positioned ancestor
+  const sentinel = document.createElement('div');
+  sentinel.className = 'comment-cue-sentinel';
+  sentinel.setAttribute('aria-hidden', 'true');
+  // Append to the parent, so the popup is rendered below any billboards
+  articleBody.parentElement.appendChild(sentinel);
+
+  const dismiss = () => {
+    window.sessionStorage.setItem(storageKey, '1');
+    render(null, sentinel);
+    sentinel.remove();
+  };
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+
+        observer.disconnect();
+        render(
+          <CommentCuePopup
+            message={message}
+            closeLabel={closeLabel}
+            onDismiss={dismiss}
+          />,
+          sentinel,
+        );
+        return;
+      }
+    },
+    { rootMargin: '0px 0px -100px 0px' },
+  );
+  observer.observe(sentinel);
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -14,9 +14,9 @@
 
 <%= render "shared/webcomponents_loader_script" %>
 <% if user_signed_in? && @article.type_of != "fullscreen_embed" %>
-  <%= javascript_include_tag "webShare", "articlePage", "articleSignedIn", "articleModerationTools", "commentDropdowns", defer: true %>
+  <%= javascript_include_tag "webShare", "articlePage", "articleSignedIn", "articleModerationTools", "commentDropdowns", "commentCuePopup", defer: true %>
 <% elsif @article.type_of != "fullscreen_embed" %>
-  <%= javascript_include_tag "webShare", "articlePage", "commentDropdowns", defer: true %>
+  <%= javascript_include_tag "webShare", "articlePage", "commentDropdowns", "commentCuePopup", defer: true %>
 <% end %>
 
 <% unless internal_navigation? || user_signed_in? %>
@@ -226,7 +226,12 @@
                 <%= @context_note.processed_html.html_safe %>
               </div>
             <% end %>
-            <div class="crayons-article__body text-styles spec__body" data-article-id="<%= @article.id %>" id="article-body">
+            <div class="crayons-article__body text-styles spec__body" data-article-id="<%= @article.id %>"
+              <% if FeatureFlag.enabled?(:comment_cue_popup) %>
+                data-cue-message="<%= comment_cue_message(@comments_count) %>"
+                data-cue-close-label="<%= t("views.articles.comment_cue.close") %>"
+              <% end %>
+              id="article-body">
               <% if @article.type_of == "status" && @article.processed_html_final.present? %>
                 <% if user_signed_in? %>
                   <div class="pt-2">

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -14,9 +14,13 @@
 
 <%= render "shared/webcomponents_loader_script" %>
 <% if user_signed_in? && @article.type_of != "fullscreen_embed" %>
-  <%= javascript_include_tag "webShare", "articlePage", "articleSignedIn", "articleModerationTools", "commentDropdowns", "commentCuePopup", defer: true %>
+  <%= javascript_include_tag "webShare", "articlePage", "articleSignedIn", "articleModerationTools", "commentDropdowns", defer: true %>
 <% elsif @article.type_of != "fullscreen_embed" %>
-  <%= javascript_include_tag "webShare", "articlePage", "commentDropdowns", "commentCuePopup", defer: true %>
+  <%= javascript_include_tag "webShare", "articlePage", "commentDropdowns", defer: true %>
+<% end %>
+
+<% if @article.type_of != "fullscreen_embed" && FeatureFlag.enabled?(:comment_cue_popup) %>
+  <%= javascript_include_tag "commentCuePopup", defer: true %>
 <% end %>
 
 <% unless internal_navigation? || user_signed_in? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -85,7 +85,8 @@
       data-algolia-search-key="<%= j(Settings::General.algolia_search_only_api_key) if feature_flag_enabled?(:algolia_frontend) %>"
       data-algolia-display="<%= j(Settings::General.display_algolia_branding) %>"
       data-dynamic-url-component="<%= ENV.fetch("BILLBOARD_URL_COMPONENT", "bb") %>"
-      data-ga4-tracking-id="<%= j(Settings::General.ga_analytics_4_id) %>">
+      data-ga4-tracking-id="<%= j(Settings::General.ga_analytics_4_id) %>"
+      data-global-feature-flags-enabled="<%= j(enabled_global_feature_flags) %>">
       <%# Repeat of stylesheets in <head> to fix rendering glitch: https://github.com/forem/forem/issues/12377 %>
       
       <%# First script to run no matter what %>

--- a/config/locales/views/articles/en.yml
+++ b/config/locales/views/articles/en.yml
@@ -26,6 +26,11 @@ en:
           oldest_html: Oldest comments %{num}
         num: "(%{num})"
         subscribe: Subscribe
+      comment_cue:
+        zero: It's quiet in here... almost too quiet. Be the trendsetter and start the conversation!
+        few: A few folks are already chatting. Don't leave them hanging—add your two cents!
+        many: The comment section is popping off. 🔥 Jump in and have your say!
+        close: Dismiss
       conduct:
         aria_label: Conduct controls
         code: Code of Conduct

--- a/config/locales/views/articles/fr.yml
+++ b/config/locales/views/articles/fr.yml
@@ -26,6 +26,11 @@ fr:
           oldest_html: Oldest comments %{num}
         num: "(%{num})"
         subscribe: Subscribe
+      comment_cue:
+        zero: C'est bien calme ici... presque trop calme. Soyez le premier à lancer la conversation !
+        few: Quelques personnes discutent déjà. Ne les laissez pas en plan—donnez votre avis !
+        many: La section commentaires s'enflamme. 🔥 Sautez dans la mêlée et dites ce que vous en pensez !
+        close: Fermer
       conduct:
         aria_label: Conduct controls
         code: Code of Conduct

--- a/config/locales/views/articles/pt.yml
+++ b/config/locales/views/articles/pt.yml
@@ -26,6 +26,11 @@ pt:
           oldest_html: Comentários mais antigos %{num}
         num: "(%{num})"
         subscribe: Inscrever
+      comment_cue:
+        zero: Está silencioso por aqui... quase silencioso demais. Seja o pioneiro e inicie a conversa!
+        few: Algumas pessoas já estão conversando. Não as deixe na mão—dê sua opinião!
+        many: A seção de comentários está bombando. 🔥 Entre na conversa e dê seu pitaco!
+        close: Fechar
       conduct:
         aria_label: Controles de conduta
         code: Código de Conduta

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -568,7 +568,11 @@ RSpec.describe ApplicationHelper do
   end
 
   describe "#enabled_global_feature_flags" do
-    before { RequestStore.store[:enabled_global_feature_flags] = nil }
+    before do
+      RequestStore.store[:enabled_global_feature_flags] = nil
+      MemoryFirstCache.clear
+      Rails.cache.delete("enabled_global_feature_flags")
+    end
 
     it "returns a space-separated list of globally enabled flag names" do
       allow(FeatureFlag).to receive(:all).and_return(

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -566,4 +566,27 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe "#enabled_global_feature_flags" do
+    before { RequestStore.store[:enabled_global_feature_flags] = nil }
+
+    it "returns a space-separated list of globally enabled flag names" do
+      allow(FeatureFlag).to receive(:all).and_return(
+        { foo: :on, bar: :off, baz: :on },
+      )
+      expect(helper.enabled_global_feature_flags.split).to contain_exactly("foo", "baz")
+    end
+
+    it "returns an empty string when no flags are enabled" do
+      allow(FeatureFlag).to receive(:all).and_return({ foo: :off })
+      expect(helper.enabled_global_feature_flags).to eq("")
+    end
+
+    it "memoizes the result on RequestStore" do
+      allow(FeatureFlag).to receive(:all).and_return({ foo: :on })
+      helper.enabled_global_feature_flags
+      helper.enabled_global_feature_flags
+      expect(FeatureFlag).to have_received(:all).once
+    end
+  end
 end

--- a/spec/helpers/articles_helper_spec.rb
+++ b/spec/helpers/articles_helper_spec.rb
@@ -69,4 +69,30 @@ describe ArticlesHelper do
       expect(helper.utc_iso_timestamp(nil)).to be_nil
     end
   end
+
+  describe ".comment_cue_message" do
+    it "returns the zero-comment copy when count is 0" do
+      expect(helper.comment_cue_message(0))
+        .to eq(I18n.t("views.articles.comment_cue.zero"))
+    end
+
+    it "returns the few-comments copy for 1..10" do
+      [1, 5, 10].each do |count|
+        expect(helper.comment_cue_message(count))
+          .to eq(I18n.t("views.articles.comment_cue.few"))
+      end
+    end
+
+    it "returns the many-comments copy when count exceeds 10" do
+      [11, 50, 999].each do |count|
+        expect(helper.comment_cue_message(count))
+          .to eq(I18n.t("views.articles.comment_cue.many"))
+      end
+    end
+
+    it "treats nil as zero comments" do
+      expect(helper.comment_cue_message(nil))
+        .to eq(I18n.t("views.articles.comment_cue.zero"))
+    end
+  end
 end

--- a/spec/requests/stories_show_spec.rb
+++ b/spec/requests/stories_show_spec.rb
@@ -304,5 +304,27 @@ RSpec.describe "StoriesShow" do
       expect(response.body).to redirect_to org.path
       expect(response).to have_http_status(:moved_permanently)
     end
+
+    context "with comment cue popup data attributes" do
+      it "renders cue data attributes when the flag is fully enabled globally" do
+        allow(FeatureFlag).to receive(:enabled?).and_call_original
+        allow(FeatureFlag).to receive(:enabled?).with(:comment_cue_popup).and_return(true)
+
+        get article.path
+
+        expect(response.body).to include("data-cue-message=")
+        expect(response.body).to include("data-cue-close-label=")
+      end
+
+      it "omits cue data attributes when the flag is off" do
+        allow(FeatureFlag).to receive(:enabled?).and_call_original
+        allow(FeatureFlag).to receive(:enabled?).with(:comment_cue_popup).and_return(false)
+
+        get article.path
+
+        expect(response.body).not_to include("data-cue-message=")
+        expect(response.body).not_to include("data-cue-close-label=")
+      end
+    end
   end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change adds the option to show an animated popup message prompting the user to comment on an article when they scroll to the end. The message displayed varies depending on the number of current comments.

To enable the feature:
```ruby
FeatureFlag.enable(:comment_cue_popup)
```

Pressing escape, closing the popup, or clicking outside it will dismiss the popup. Once dismissed, the popup will no longer be shown the next time the article is viewed. Dismiss state can be reset on the JS console:
```javascript
sessionStorage.removeItem('commentCueDismissed:<article-id>');
```

## Related Tickets & Documents

- [DEV-3553](https://mlhacks.atlassian.net/browse/DEV-3553)

## QA Instructions, Screenshots, Recordings

<img width="897" height="421" alt="image" src="https://github.com/user-attachments/assets/15885dda-a6d0-44f8-8247-a7e2a491d3e3" />

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
