### PR TITLE
fix: user profile cache is busted after article deletion to evict stale pinned-article cards

### DIFF
--- a/app/services/articles/destroyer.rb
+++ b/app/services/articles/destroyer.rb
@@ -7,8 +7,15 @@ module Articles
       # due to the `dependent: nullify` clause, so to remove their notifications,
       # we need to cache the ids in advance
       article_comments_ids = article.comments.ids
+      user = article.user
 
       article.destroy!
+
+      # BustCacheWorker looks up the article by ID after deletion and returns early
+      # when it can't find it, so article.user.purge inside EdgeCache::BustArticle is
+      # never called.  Explicitly bust the user's profile cache here so that any
+      # pinned-article cards pointing to the just-deleted post are evicted.
+      EdgeCache::BustUser.call(user)
 
       Notification.remove_all(notifiable_ids: article.id, notifiable_type: "Article")
 

--- a/spec/services/articles/destroyer_spec.rb
+++ b/spec/services/articles/destroyer_spec.rb
@@ -15,4 +15,11 @@ RSpec.describe Articles::Destroyer, type: :service do
       described_class.call(article)
     end
   end
+
+  it "busts the author's profile cache so stale pinned-article cards are evicted" do
+    user = article.user
+    allow(EdgeCache::BustUser).to receive(:call)
+    described_class.call(article)
+    expect(EdgeCache::BustUser).to have_received(:call).with(user)
+  end
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Problem: 
When a user deletes an article that is pinned to their profile, the pinned card remains visible on their public profile page (served from CDN cache) and links to a 404 page.

Root cause: 
`Articles::BustCacheWorker` is scheduled *before* the article is deleted (inside `before_destroy:before_destroy_actions`).  By the time Sidekiq runs that job, the article row is already gone - `Article.find_by(id: …)` returns `nil` and the worker returns early.  Because `EdgeCache::BustArticle` is never called, `article.user.purge` (which invalidates the author's CDN-cached profile page) is never executed.  The `profile_pins` DB rows **are** correctly removed by the `dependent: :delete_all` association, so the database is clean; only the CDN-cached profile page is stale.

Fix:
In `Articles::Destroyer`, save the `user` reference before `article.destroy!`, then call `EdgeCache::BustUser.call(user)` immediately after.  This mirrors the pattern already used in `Users::DeleteArticles` (which also manually compensates
for skipped callbacks) and ensures the author's profile CDN cache is evicted regardless of when the async bust worker runs.

Tradeoffs:
The extra `EdgeCache::BustUser` call adds one synchronous CDN purge per article deletion.  This is negligible; article deletion is a low-frequency, user-initiated action.

## Related Tickets & Documents
- Closes #23191 

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: the change is a lifecycle/caching hook that requires careful test setup (committed transactions / CDN stub).
- [ ] I need help with writing tests

## What gif best describes this PR or how it makes you feel?

![too_easy_spongebob](https://media1.tenor.com/m/-LHzJmfwj2kAAAAC/spongebob-too-easy.gif)
