### PR TITLE
fix: db seed crash

### DIFF
--- a/app/lib/seeder.rb
+++ b/app/lib/seeder.rb
@@ -34,6 +34,7 @@ class Seeder
       yield
     else
       puts "  #{@counter}. #{plural} already exist. Skipping."
+      klass.all
     end
   end
 

--- a/spec/lib/seeder_spec.rb
+++ b/spec/lib/seeder_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Seeder, type: :lib do
+  describe "#create_if_none" do
+    let(:seeder) { described_class.new }
+
+    it "returns existing records when class data already exists" do
+      user = create(:user)
+
+      result = seeder.create_if_none(User, 10) do
+        raise "create_if_none should not execute the block when records exist"
+      end
+
+      expect(result).to be_a(ActiveRecord::Relation)
+      expect(result).to include(user)
+    end
+  end
+end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Problem: 
Running `bin/rails db:seed` more than once can crash with:

`NoMethodError: undefined method 'limit' for nil`

This happens in the badge-seeding section when iterating over `users_in_random_order.limit(10)`.

Root cause: 
`users_in_random_order` is assigned from `Seeder#create_if_none(User, ...)` in `db/seeds.rb`.
When users already exist, `create_if_none` skips its block and implicitly returns `nil`.
Any downstream code that expects a relation and calls methods like `limit` on the return value can crash on seed reruns.

Fix:
Updated `Seeder#create_if_none` to return `klass.all` when records already exist.
This keeps rerunnable seed flows safe and callers that capture `create_if_none` return values receive an `ActiveRecord::Relation` instead of `nil` in the "already exists" path.

Added regression coverage in `spec/lib/seeder_spec.rb` to verify `create_if_none` returns existing records (and does not execute the block) when class data is already present.

Tradeoffs (optional):
This broadens `create_if_none` semantics from "possibly nil" to "relation on skip path".
The change is intentionally minimal and aligns with idempotent seed expectations while avoiding heavier `db/seeds.rb` restructuring.

## Related Tickets & Documents
- Closes #23104 

Forem contribution references:
- https://developers.forem.com/contributing-guide/forem
- https://github.com/forem/forem#contributing

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## QA Instructions, Screenshots, Recordings

Reproduce
1. Run `bin/rails db:schema:load` on a local setup.
2. Run `bin/rails db:seed` once (creates users and other seed data).
3. Run `bin/rails db:seed` again.

Verify (expected)
- The second seed run does not crash with `undefined method 'limit' for nil`.
- Badge seeding path can safely evaluate user iteration.
- Seeding remains idempotent in the user-creation skip path.

Notes
- In this environment, targeted spec execution was blocked by local toolchain mismatch (Ruby 3.4.9 vs Gemfile 3.3.0).
- Once using project Ruby 3.3.0 and dependencies installed, run: `bundle exec rspec spec/lib/seeder_spec.rb`

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: the change is a lifecycle/caching hook that requires careful test setup (committed transactions / CDN stub).
- [ ] I need help with writing tests

