### PR TITLE
Show generated article summary in email digest

### DIFF
--- a/app/services/email_digest_article_collector.rb
+++ b/app/services/email_digest_article_collector.rb
@@ -6,7 +6,7 @@ class EmailDigestArticleCollector
   RESULTS_COUNT = 7 # Winner of digest_count_03_18 field test
   CLICK_LOOKBACK = 30
   DIGEST_ARTICLE_COLUMNS = %i[title description path cached_user cached_tag_list
-                              subforem_id comment_score comments_count].freeze
+                              subforem_id comment_score comments_count ai_summary].freeze
 
   def initialize(user, force_send: false)
     @user = user

--- a/app/views/mailers/digest_mailer/digest_email.html.erb
+++ b/app/views/mailers/digest_mailer/digest_email.html.erb
@@ -62,7 +62,7 @@
               <div style="padding: 4px 8px;">
                 <a href="<%= article_url(article) %>?context=digest" style="text-decoration: none; font-weight: 600; color:#111111; font-size: 18px; line-height: 1.4; display:block; letter-spacing: -0.01em;"><%= article.title.strip %></a>
                 <p style="margin-top: 8px; margin-bottom: 0px; font-size: 15px; color: #555555; line-height: 1.5;">
-                  <%= truncate(article.description, length: 180) %>
+                  <%= article.ai_summary.presence || truncate(article.description, length: 180) %>
                 </p>
               </div>
             </td>

--- a/spec/mailers/digest_mailer_spec.rb
+++ b/spec/mailers/digest_mailer_spec.rb
@@ -33,6 +33,24 @@ RSpec.describe DigestMailer do
       expect(smtpapi_header["category"]).to include("Digest Email")
     end
 
+    it "renders the article ai_summary when present" do
+      article.update_columns(ai_summary: "An AI generated summary of the article.",
+                             description: "Original description text.")
+
+      email = described_class.with(user: user, articles: [article]).digest_email
+
+      expect(email.body.encoded).to include("An AI generated summary of the article.")
+      expect(email.body.encoded).not_to include("Original description text.")
+    end
+
+    it "falls back to the truncated description when ai_summary is blank" do
+      article.update_columns(ai_summary: nil, description: "Fallback description text.")
+
+      email = described_class.with(user: user, articles: [article]).digest_email
+
+      expect(email.body.encoded).to include("Fallback description text.")
+    end
+
     it "includes billboard html in body" do
       bb_1 = create(:billboard, placement_area: "digest_first", published: true, approved: true)
       bb_2 = create(:billboard, placement_area: "digest_second", published: true, approved: true)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This change displays AI-generated summaries for articles in the email digest. The current descriptions will be shown if summaries are not available.

## Related Tickets & Documents

[DEV-3638](https://mlhacks.atlassian.net/browse/DEV-3638)

## QA Instructions, Screenshots, Recordings

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None
