### PR TITLE
Prevent Honeybadger notifications for OAuth::Unauthorized and OmniAuth::NoSessionError exceptions

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -42,7 +42,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       
       if error.class.name == "OmniAuth::Strategies::OAuth2::CallbackError"
         is_expected_oauth_error = error.message.include?("nonce_mismatch") || error.message.include?("csrf_detected")
-      elsif error.class.name == "OAuth2::Error"
+      elsif error.class.name == "OAuth2::Error" || error.class.name == "OAuth::Unauthorized" || error.class.name == "OmniAuth::NoSessionError"
         is_expected_oauth_error = true # These are all expired/invalid HTTP token grants natively raised by remote provider APIs
       elsif error.class.name == "StandardError"
         is_expected_oauth_error = error.message.include?("access_token was nil")

--- a/spec/requests/omniauth_callbacks_failure_spec.rb
+++ b/spec/requests/omniauth_callbacks_failure_spec.rb
@@ -62,6 +62,32 @@ RSpec.describe "OmniAuth Callbacks Failure", type: :request do
     expect(response).to redirect_to(new_user_session_url)
   end
 
+  it "does not notify Honeybadger on OAuth::Unauthorized" do
+    response_double = double("HTTPResponse", code: 401, message: "Unauthorized")
+    error = Object.const_defined?("OAuth::Unauthorized") ? OAuth::Unauthorized.new(response_double) : StandardError.new("fallback")
+    allow(error).to receive(:class).and_return(double(name: "OAuth::Unauthorized"))
+    omniauth_setup_authentication_error(error)
+    omniauth_setup_invalid_credentials(:twitter)
+
+    post "/users/auth/twitter"
+    follow_redirect!
+
+    expect(Honeybadger).not_to have_received(:notify)
+    expect(response).to redirect_to(new_user_session_url)
+  end
+
+  it "does not notify Honeybadger on OmniAuth::NoSessionError" do
+    error = OmniAuth::NoSessionError.new("Session Expired")
+    omniauth_setup_authentication_error(error)
+    omniauth_setup_invalid_credentials(:twitter)
+
+    post "/users/auth/twitter"
+    follow_redirect!
+
+    expect(Honeybadger).not_to have_received(:notify)
+    expect(response).to redirect_to(new_user_session_url)
+  end
+
   it "does not notify Honeybadger on StandardError with 'access_token was nil'" do
     error = StandardError.new("access_token was nil when checking expiration")
     omniauth_setup_authentication_error(error)


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Don't raise expected errors like this