### PR TITLE
Remove uniqueness validation from LinkedDomain host attribute

### DIFF
--- a/app/models/linked_domain.rb
+++ b/app/models/linked_domain.rb
@@ -8,7 +8,7 @@ class LinkedDomain < ApplicationRecord
 
   has_many :webpage_references, dependent: :destroy
 
-  validates :host, presence: true, uniqueness: true
+  validates :host, presence: true
 
   before_save :apply_manual_setting_limits
 

--- a/spec/models/linked_domain_spec.rb
+++ b/spec/models/linked_domain_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe LinkedDomain, type: :model do
   describe "validations" do
     subject { LinkedDomain.new(host: "example.com") }
 
-    before { LinkedDomain.create!(host: "example.com") }
-
     it { is_expected.to validate_presence_of(:host) }
   end
 

--- a/spec/models/linked_domain_spec.rb
+++ b/spec/models/linked_domain_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe LinkedDomain, type: :model do
     before { LinkedDomain.create!(host: "example.com") }
 
     it { is_expected.to validate_presence_of(:host) }
-    it { is_expected.to validate_uniqueness_of(:host) }
   end
 
   describe "enums" do


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The Bug: The worker was encountering a PG::NotNullViolation on linked_domain_id when performing a bulk insert via WebpageReference.insert_all(references_to_insert). This meant that domain.id was nil inside the loop. This happened because domain = LinkedDomain.find_or_create_by_url(url) was returning an unpersisted object with validation errors, rather than the existing record.

The Root Cause: In LinkedDomain.find_or_create_by_url, it uses Rails' create_or_find_by(host: host). This method is designed for high-concurrency environments and relies on the database's unique constraint (which Forem has on linked_domains.host). When the INSERT hits a uniqueness conflict, the database natively raises an ActiveRecord::RecordNotUnique exception, which create_or_find_by internally rescues to perform a find_by and return the existing record.

However, LinkedDomain had an application-level validation: validates :host, uniqueness: true. When create_or_find_by was called, Rails evaluated the uniqueness validation before executing the INSERT. The validation detected the duplicate and failed the save, returning the unpersisted LinkedDomain object with errors (and a nil ID). Because the INSERT never happened, RecordNotUnique was never raised, and the fallback find_by was never triggered!

The Fix: I simply removed uniqueness: true from the validates :host rule in app/models/linked_domain.rb and the corresponding RSpec expectation in linked_domain_spec.rb. Since host is guaranteed unique by the database index, the application-level validation was not only redundant but actively breaking the create_or_find_by logic.

Now, create_or_find_by works natively as intended, and SyncWebpageReferencesWorker will successfully retrieve domain.id and pass the batch inserts.

