### PR TITLE
Sanitize omniauth.origin URLs to prevent open redirects by stripping host information

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -251,6 +251,9 @@ class ApplicationController < ActionController::Base
       signin_param = { "signin" => "true" } # the "signin" param is used by the service worker
 
       uri = Addressable::URI.parse(path)
+      uri.scheme = nil
+      uri.host = nil
+      uri.port = nil
       uri.query_values = if uri.query_values
                            # Ignore i=i (internal navigation) param
                            uri.query_values.except("i").merge(signin_param)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -254,6 +254,8 @@ class ApplicationController < ActionController::Base
       uri.scheme = nil
       uri.host = nil
       uri.port = nil
+      uri.path = "/" if uri.path.blank?
+      uri.path = "/#{uri.path}" unless uri.path.start_with?("/")
       uri.query_values = if uri.query_values
                            # Ignore i=i (internal navigation) param
                            uri.query_values.except("i").merge(signin_param)

--- a/spec/controllers/concerns/omniauth_redirect_spec.rb
+++ b/spec/controllers/concerns/omniauth_redirect_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe "Omniauth redirect", type: :request do
     expect(path).not_to include("i=i")
     expect(path).to end_with("/settings?signin=true")
   end
+
+  it "strips the host from external omniauth.origin URLs to prevent open redirects" do
+    mock_env = { "omniauth.origin" => "https://github.com/settings?signin=true", "warden" => mock_warden }
+    mock_request = OpenStruct.new(env: mock_env)
+    allow(controller).to receive(:request).and_return(mock_request)
+
+    path = controller.after_sign_in_path_for(user)
+    expect(path).to eq("/settings?signin=true")
+  end
 end
 # rubocop:enable Style/OpenStructUse
 # rubocop:enable Performance/OpenStruct


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Fixes unsafe url redirect bug
