### PR TITLE
Add OpenCode agent sessions

### DIFF
--- a/app/assets/images/agent-opencode.svg
+++ b/app/assets/images/agent-opencode.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M8.4 17.4H19.2V21H4.8V13.8H8.4V17.4ZM15.6 10.2V13.8H8.4V10.2H15.6ZM19.2 10.2H15.6V6.6H4.8V3H19.2V10.2Z" fill="#F59E0B"/>
+</svg>

--- a/app/helpers/agent_sessions_helper.rb
+++ b/app/helpers/agent_sessions_helper.rb
@@ -4,6 +4,7 @@ module AgentSessionsHelper
     "codex" => { bg: "#10A37F", label: "Codex", svg: "agent-codex.svg" },
     "gemini_cli" => { bg: "#4285F4", label: "Gemini CLI", svg: "agent-gemini-cli.svg" },
     "github_copilot" => { bg: "#333", label: "GitHub Copilot", svg: "agent-github-copilot.svg" },
+    "opencode" => { bg: "#F59E0B", label: "OpenCode", svg: "agent-opencode.svg" },
     "pi" => { bg: "#EF4444", label: "Pi", svg: "agent-pi.svg" }
   }.freeze
 

--- a/app/javascript/agentSessionParsers/__tests__/autoDetect.test.js
+++ b/app/javascript/agentSessionParsers/__tests__/autoDetect.test.js
@@ -48,6 +48,14 @@ describe('autoDetect', () => {
       expect(detectTool(content)).toBe('gemini_cli');
     });
 
+    it('detects OpenCode CLI exports', () => {
+      const content = JSON.stringify({
+        info: { id: 'ses_123', title: 'OpenCode session' },
+        messages: [{ info: { role: 'user' }, parts: [{ type: 'text', text: 'hi' }] }],
+      });
+      expect(detectTool(content)).toBe('opencode');
+    });
+
     it('detects claude_code when sessionId present (even with messages)', () => {
       // sessionId on first line triggers JSONL detection branch
       const content = JSON.stringify({ sessionId: 's1', messages: [{ role: 'user', content: 'hi' }] });

--- a/app/javascript/agentSessionParsers/__tests__/autoDetect.test.js
+++ b/app/javascript/agentSessionParsers/__tests__/autoDetect.test.js
@@ -56,6 +56,22 @@ describe('autoDetect', () => {
       expect(detectTool(content)).toBe('opencode');
     });
 
+    it('detects empty OpenCode CLI exports', () => {
+      const content = JSON.stringify({
+        info: { id: 'ses_123', title: 'Empty OpenCode session' },
+        messages: [],
+      });
+      expect(detectTool(content)).toBe('opencode');
+    });
+
+    it('does not detect OpenCode when the session id has an unexpected format', () => {
+      const content = JSON.stringify({
+        info: { id: 'session_123', title: 'OpenCode-like session' },
+        messages: [{ info: { role: 'user' }, parts: [{ type: 'text', text: 'hi' }] }],
+      });
+      expect(detectTool(content)).toBe('gemini_cli');
+    });
+
     it('detects claude_code when sessionId present (even with messages)', () => {
       // sessionId on first line triggers JSONL detection branch
       const content = JSON.stringify({ sessionId: 's1', messages: [{ role: 'user', content: 'hi' }] });

--- a/app/javascript/agentSessionParsers/__tests__/opencode.test.js
+++ b/app/javascript/agentSessionParsers/__tests__/opencode.test.js
@@ -1,0 +1,45 @@
+import { parse } from '../opencode';
+
+describe('opencode parser', () => {
+  it('parses OpenCode CLI JSON exports', () => {
+    const input = JSON.stringify({
+      info: {
+        id: 'ses_123',
+        title: 'OpenCode session',
+        directory: '/workspace/project',
+        time: { created: 1778005777747, updated: 1778005780228 },
+      },
+      messages: [
+        {
+          info: {
+            role: 'user',
+            time: { created: 1778005777747 },
+            model: { providerID: 'google', modelID: 'gemini-3-flash-preview' },
+          },
+          parts: [{ type: 'text', text: 'Hello OpenCode' }],
+        },
+        {
+          info: { role: 'assistant', time: { created: 1778005780228 } },
+          parts: [
+            { type: 'reasoning', text: 'Thinking through the task' },
+            { type: 'tool', tool: 'bash', callID: 'call_1', state: { input: { command: 'ls' }, output: 'file.txt' } },
+            { type: 'text', text: 'Done' },
+          ],
+        },
+      ],
+    });
+
+    const result = parse(input);
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].role).toBe('user');
+    expect(result.messages[0].content[0].text).toBe('Hello OpenCode');
+    expect(result.messages[1].role).toBe('assistant');
+    expect(result.messages[1].content[1].type).toBe('tool_call');
+    expect(result.messages[1].content[1].name).toBe('bash');
+    expect(result.metadata.tool_name).toBe('opencode');
+    expect(result.metadata.session_id).toBe('ses_123');
+    expect(result.metadata.model).toBe('google/gemini-3-flash-preview');
+  });
+
+});

--- a/app/javascript/agentSessionParsers/__tests__/opencode.test.js
+++ b/app/javascript/agentSessionParsers/__tests__/opencode.test.js
@@ -42,4 +42,106 @@ describe('opencode parser', () => {
     expect(result.metadata.model).toBe('google/gemini-3-flash-preview');
   });
 
+  it('extracts model metadata from assistant message info fields', () => {
+    const result = parse(JSON.stringify({
+      info: { id: 'ses_123' },
+      messages: [
+        {
+          info: {
+            role: 'assistant',
+            providerID: 'anthropic',
+            modelID: 'claude-sonnet-4-5',
+          },
+          parts: [{ type: 'text', text: 'hello' }],
+        },
+      ],
+    }));
+
+    expect(result.messages[0].model).toBe('anthropic/claude-sonnet-4-5');
+    expect(result.metadata.model).toBe('anthropic/claude-sonnet-4-5');
+  });
+
+  it('handles empty message exports', () => {
+    const result = parse(JSON.stringify({
+      info: { id: 'ses_123' },
+      messages: [],
+    }));
+
+    expect(result.messages).toHaveLength(0);
+    expect(result.metadata.tool_name).toBe('opencode');
+    expect(result.metadata.total_messages).toBe(0);
+  });
+
+  it('skips messages with unknown roles', () => {
+    const result = parse(JSON.stringify({
+      info: { id: 'ses_123' },
+      messages: [
+        { info: { role: 'system' }, parts: [{ type: 'text', text: 'ignored' }] },
+        { info: { role: 'user' }, parts: [{ type: 'text', text: 'kept' }] },
+      ],
+    }));
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].content[0].text).toBe('kept');
+  });
+
+  it('skips messages without content blocks', () => {
+    const result = parse(JSON.stringify({
+      info: { id: 'ses_123' },
+      messages: [
+        { info: { role: 'user' }, parts: [] },
+        { info: { role: 'assistant' }, parts: [{ type: 'text', text: 'response' }] },
+      ],
+    }));
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe('assistant');
+  });
+
+  it('handles tool parts without state', () => {
+    const result = parse(JSON.stringify({
+      info: { id: 'ses_123' },
+      messages: [
+        { info: { role: 'assistant' }, parts: [{ type: 'tool', tool: 'bash', callID: 'call_1' }] },
+      ],
+    }));
+
+    const block = result.messages[0].content[0];
+    expect(block.type).toBe('tool_call');
+    expect(block.name).toBe('bash');
+    expect(block.input).toBeUndefined();
+    expect(block.output).toBeUndefined();
+  });
+
+  it('renders file attachment parts as text blocks', () => {
+    const result = parse(JSON.stringify({
+      info: { id: 'ses_123' },
+      messages: [
+        { info: { role: 'user' }, parts: [{ type: 'file', filename: 'notes.md' }] },
+      ],
+    }));
+
+    expect(result.messages[0].content[0].text).toBe('[File attachment: notes.md]');
+  });
+
+  it('omits missing optional metadata fields', () => {
+    const result = parse(JSON.stringify({
+      info: { id: 'ses_123' },
+      messages: [
+        { info: { role: 'user' }, parts: [{ type: 'text', text: 'hello' }] },
+      ],
+    }));
+
+    expect(result.metadata.session_id).toBe('ses_123');
+    expect(result.metadata).not.toHaveProperty('title');
+    expect(result.metadata).not.toHaveProperty('working_directory');
+    expect(result.metadata).not.toHaveProperty('model');
+    expect(result.metadata).not.toHaveProperty('start_time');
+    expect(result.metadata).not.toHaveProperty('end_time');
+  });
+
+  it('throws on malformed JSON input', () => {
+    expect(() => parse('{not json')).toThrow(SyntaxError);
+  });
+
 });

--- a/app/javascript/agentSessionParsers/autoDetect.js
+++ b/app/javascript/agentSessionParsers/autoDetect.js
@@ -83,11 +83,12 @@ export function detectTool(content) {
 }
 
 function isOpenCodeExport(data) {
+  // OpenCode CLI export session IDs currently use the ses_ prefix.
   return data && typeof data === 'object' && !Array.isArray(data) &&
     data.info && typeof data.info === 'object' &&
     typeof data.info.id === 'string' && data.info.id.startsWith('ses_') &&
     Array.isArray(data.messages) &&
-    data.messages.some(m => m?.info && Array.isArray(m.parts));
+    data.messages.every(m => m?.info && Array.isArray(m.parts));
 }
 
 function detectJsonlTool(firstRecord) {

--- a/app/javascript/agentSessionParsers/autoDetect.js
+++ b/app/javascript/agentSessionParsers/autoDetect.js
@@ -2,6 +2,7 @@
 import * as claudeCode from './claudeCode.js';
 import * as codex from './codex.js';
 import * as geminiCli from './geminiCli.js';
+import * as opencode from './opencode.js';
 import * as pi from './pi.js';
 import * as githubCopilot from './githubCopilot.js';
 
@@ -9,6 +10,7 @@ const PARSER_MAP = {
   claude_code: claudeCode,
   codex: codex,
   gemini_cli: geminiCli,
+  opencode: opencode,
   pi: pi,
   github_copilot: githubCopilot,
 };
@@ -50,6 +52,9 @@ export function detectTool(content) {
       // Gemini: has session_metadata type
       if (firstRecord.type === 'session_metadata') return 'gemini_cli';
 
+      // OpenCode CLI export: { info: { id, ... }, messages: [{ info, parts }] }
+      if (isOpenCodeExport(firstRecord)) return 'opencode';
+
       // JSONL-based agents (Claude Code, Pi, etc.)
       if ('sessionId' in firstRecord || 'version' in firstRecord ||
           'parentId' in firstRecord || 'parentUuid' in firstRecord ||
@@ -64,6 +69,8 @@ export function detectTool(content) {
   // Try full JSON parse (Gemini CLI uses single JSON object)
   try {
     const data = JSON.parse(content);
+    if (isOpenCodeExport(data)) return 'opencode';
+
     if (data && typeof data === 'object' && !Array.isArray(data) && !('parentId' in data)) {
       return 'gemini_cli';
     }
@@ -73,6 +80,14 @@ export function detectTool(content) {
 
   // Default fallback
   return 'claude_code';
+}
+
+function isOpenCodeExport(data) {
+  return data && typeof data === 'object' && !Array.isArray(data) &&
+    data.info && typeof data.info === 'object' &&
+    typeof data.info.id === 'string' && data.info.id.startsWith('ses_') &&
+    Array.isArray(data.messages) &&
+    data.messages.some(m => m?.info && Array.isArray(m.parts));
 }
 
 function detectJsonlTool(firstRecord) {

--- a/app/javascript/agentSessionParsers/opencode.js
+++ b/app/javascript/agentSessionParsers/opencode.js
@@ -1,0 +1,98 @@
+import {
+  buildResult, buildMessage, textBlock, toolCallBlock,
+  truncateOutput, truncateStr,
+} from './base.js';
+
+export function parse(rawContent) {
+  const data = JSON.parse(rawContent);
+  const messages = [];
+
+  for (const message of data.messages || []) {
+    const role = normalizeRole(message.info?.role);
+    if (!role) continue;
+
+    const contentBlocks = extractContentBlocks(message.parts || []);
+    if (contentBlocks.length === 0) continue;
+
+    messages.push(buildMessage({
+      role,
+      contentBlocks,
+      timestamp: timestampFromTime(message.info?.time),
+      model: modelName(message.info?.model),
+    }));
+  }
+
+  return buildResult(messages, extractMetadata(data, messages));
+}
+
+function normalizeRole(role) {
+  if (role === 'user') return 'user';
+  if (role === 'assistant') return 'assistant';
+  return null;
+}
+
+function extractContentBlocks(parts) {
+  const blocks = [];
+
+  for (const part of parts) {
+    switch (part.type) {
+      case 'text':
+      case 'reasoning':
+        if (part.text) blocks.push(textBlock(part.text));
+        break;
+      case 'tool':
+        blocks.push(toolCallBlock({
+          name: part.tool || 'tool_call',
+          input: formatToolInput(part.state?.input),
+          output: formatToolOutput(part.state?.output),
+          toolCallId: part.callID,
+        }));
+        break;
+      case 'file':
+        blocks.push(textBlock(`[File attachment: ${part.filename || part.mime || 'file'}]`));
+        break;
+    }
+  }
+
+  return blocks;
+}
+
+function formatToolInput(input) {
+  if (input == null) return undefined;
+  if (typeof input === 'string') return truncateStr(input, 200);
+  return truncateStr(JSON.stringify(input), 200);
+}
+
+function formatToolOutput(output) {
+  if (output == null) return undefined;
+  if (typeof output === 'string') return truncateOutput(output);
+  return truncateOutput(JSON.stringify(output));
+}
+
+function timestampFromTime(time) {
+  if (!time?.created) return undefined;
+  return new Date(time.created).toISOString();
+}
+
+function modelName(model) {
+  if (!model) return undefined;
+  return [model.providerID, model.modelID].filter(Boolean).join('/');
+}
+
+function extractMetadata(data, messages) {
+  const meta = {
+    tool_name: 'opencode',
+    total_messages: messages.length,
+  };
+
+  if (data.info?.id) meta.session_id = data.info.id;
+  if (data.info?.title) meta.title = data.info.title;
+  if (data.info?.directory) meta.working_directory = data.info.directory;
+  if (data.info?.time?.created) meta.start_time = new Date(data.info.time.created).toISOString();
+  if (data.info?.time?.updated) meta.end_time = new Date(data.info.time.updated).toISOString();
+
+  const model = data.messages?.find(m => m.info?.model)?.info?.model;
+  if (model) meta.model = modelName(model);
+
+  return meta;
+}

--- a/app/javascript/agentSessionParsers/opencode.js
+++ b/app/javascript/agentSessionParsers/opencode.js
@@ -18,7 +18,7 @@ export function parse(rawContent) {
       role,
       contentBlocks,
       timestamp: timestampFromTime(message.info?.time),
-      model: modelName(message.info?.model),
+      model: modelName(message.info?.model || message.info),
     }));
   }
 
@@ -91,7 +91,9 @@ function extractMetadata(data, messages) {
   if (data.info?.time?.created) meta.start_time = new Date(data.info.time.created).toISOString();
   if (data.info?.time?.updated) meta.end_time = new Date(data.info.time.updated).toISOString();
 
-  const model = data.messages?.find(m => m.info?.model)?.info?.model;
+  const model = data.messages
+    ?.map(m => m.info?.model || m.info)
+    .find(m => m?.providerID || m?.modelID);
   if (model) meta.model = modelName(model);
 
   return meta;

--- a/app/models/agent_session.rb
+++ b/app/models/agent_session.rb
@@ -1,5 +1,5 @@
 class AgentSession < ApplicationRecord
-  TOOL_NAMES = %w[claude_code codex gemini_cli github_copilot pi].freeze
+  TOOL_NAMES = %w[claude_code codex gemini_cli github_copilot opencode pi].freeze
   MAX_CURATED_DATA_SIZE = 10.megabytes
   RAW_FILE_RETENTION_DAYS = 90
 

--- a/app/views/agent_sessions/new.html.erb
+++ b/app/views/agent_sessions/new.html.erb
@@ -26,6 +26,7 @@
         <option value="claude_code">Claude Code</option>
         <option value="codex">Codex (OpenAI)</option>
         <option value="gemini_cli">Gemini CLI</option>
+        <option value="opencode">OpenCode</option>
         <option value="pi">Pi</option>
         <option value="github_copilot">GitHub Copilot</option>
       </select>
@@ -65,6 +66,8 @@
           <dd><code>~/.codex/sessions/YYYY/MM/DD/*.jsonl</code></dd>
           <dt>Gemini CLI</dt>
           <dd><code>~/.gemini/tmp/session-*.json</code></dd>
+          <dt>OpenCode</dt>
+          <dd>Use <code>/export</code> in OpenCode, then upload the exported file.</dd>
           <dt>Pi</dt>
           <dd><code>~/.pi/agent/sessions/&lt;project&gt;/*.jsonl</code></dd>
           <dt>GitHub Copilot</dt>
@@ -247,9 +250,15 @@
   function formatToolName(tool) {
     var names = {
       claude_code: 'Claude Code', codex: 'Codex', gemini_cli: 'Gemini CLI',
-      pi: 'Pi', github_copilot: 'GitHub Copilot'
+      opencode: 'OpenCode', pi: 'Pi', github_copilot: 'GitHub Copilot'
     };
     return names[tool] || tool;
+  }
+
+  function isGeneratedSessionTitle(title) {
+    var values = ['claude_code', 'codex', 'gemini_cli', 'opencode', 'pi', 'github_copilot']
+      .map(function(tool) { return formatToolName(tool) + ' Session'; });
+    return values.indexOf(title) !== -1;
   }
 
   // Parse button
@@ -360,6 +369,11 @@
           : 'No secrets found');
 
         parsedResult = result;
+
+        if (result.metadata && result.metadata.title && isGeneratedSessionTitle(titleInput.value.trim())) {
+          titleInput.value = result.metadata.title;
+        }
+
         setStep('done', 'done', '<%= j t("views.agent_sessions.ready_to_curate", default: "Ready to curate") %>');
         setProgress(100);
 

--- a/app/views/agent_sessions/new.html.erb
+++ b/app/views/agent_sessions/new.html.erb
@@ -67,7 +67,7 @@
           <dt>Gemini CLI</dt>
           <dd><code>~/.gemini/tmp/session-*.json</code></dd>
           <dt>OpenCode</dt>
-          <dd>Use <code>/export</code> in OpenCode, then upload the exported file.</dd>
+          <dd>Run <code>opencode export &lt;session-id&gt; &gt; opencode-session.json</code>, then upload the exported file.</dd>
           <dt>Pi</dt>
           <dd><code>~/.pi/agent/sessions/&lt;project&gt;/*.jsonl</code></dd>
           <dt>GitHub Copilot</dt>

--- a/spec/views/agent_sessions/new.html.erb_spec.rb
+++ b/spec/views/agent_sessions/new.html.erb_spec.rb
@@ -23,9 +23,10 @@ RSpec.describe "agent_sessions/new" do
     expect(help_text).to include("Pi")
   end
 
-  it "uses OpenCode as the generated display label" do
+  it "renders OpenCode as the upload option label" do
     render
 
-    expect(rendered).to include("opencode: 'OpenCode'")
+    option = Capybara.string(rendered).find("select#session-tool option[value='opencode']")
+    expect(option.text).to eq("OpenCode")
   end
 end

--- a/spec/views/agent_sessions/new.html.erb_spec.rb
+++ b/spec/views/agent_sessions/new.html.erb_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "agent_sessions/new" do
+  it "renders a manual upload option for every supported agent tool" do
+    render
+
+    options = Capybara.string(rendered).all("select#session-tool option").map { |option| option[:value] }
+
+    expect(options).to include("auto")
+    expect(options).to include(*AgentSession::TOOL_NAMES)
+  end
+
+  it "renders session file location help for every supported agent tool" do
+    render
+
+    help_text = Capybara.string(rendered).find(".agent-session-paths", visible: false).text(:all)
+
+    expect(help_text).to include("Claude Code")
+    expect(help_text).to include("Codex (OpenAI)")
+    expect(help_text).to include("Gemini CLI")
+    expect(help_text).to include("GitHub Copilot")
+    expect(help_text).to include("OpenCode")
+    expect(help_text).to include("Pi")
+  end
+
+  it "uses OpenCode as the generated display label" do
+    render
+
+    expect(rendered).to include("opencode: 'OpenCode'")
+  end
+end

--- a/spec/views/agent_sessions/new.html.erb_spec.rb
+++ b/spec/views/agent_sessions/new.html.erb_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "agent_sessions/new" do
     expect(help_text).to include("Gemini CLI")
     expect(help_text).to include("GitHub Copilot")
     expect(help_text).to include("OpenCode")
+    expect(help_text).to include("opencode export <session-id> > opencode-session.json")
     expect(help_text).to include("Pi")
   end
 

--- a/swagger/v1/api_v1.json
+++ b/swagger/v1/api_v1.json
@@ -87,6 +87,7 @@
                       "codex",
                       "gemini_cli",
                       "github_copilot",
+                      "opencode",
                       "pi"
                     ]
                   }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adds OpenCode as a supported Agent Sessions upload source. This includes:
- Adding `opencode` as a valid `AgentSession` tool name.
- Adding an OpenCode parser for CLI JSON exports from `opencode export <session-id>`.
- Adding OpenCode auto-detection for exported sessions.
- Adding OpenCode to the upload dropdown, help text, helper metadata, icon set, and Swagger enum.
- Adding focused parser, auto-detection, and upload view specs.

## Related Tickets & Documents
- Finally getting back around to #22895

## QA Instructions, Screenshots, Recordings
Test with an OpenCode CLI export:
```bash
opencode export <session-id> > opencode-session.json
```

Then:
1. Go to /agent_sessions/new.
2. Choose Auto-detect or OpenCode.
3. Upload opencode-session.json.
4. Confirm the session parses successfully.
5. Confirm messages, tool calls, file attachment placeholders, metadata, and title import correctly.
6. Save the curated session.


Manual smoke testing was performed locally with a real OpenCode export.

### UI accessibility checklist
- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [ ] Checked with axe DevTools (https://www.deque.com/axe/) and addressed Critical and Serious issues?
- [ ] Color contrast tested?
 
No new custom interactive controls were added. The upload option uses the existing native `<select>` flow.

## Added/updated tests?
- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

## Tested with:

```bash
yarn jest app/javascript/agentSessionParsers/__tests__/opencode.test.js app/javascript/agentSessionParsers/__tests__/autoDetect.test.js
RAILS_ENV=test DATABASE_URL_TEST=postgres://postgres:postgres@127.0.0.1:5432/Forem_test bundle exec rspec spec/views/agent_sessions/new.html.erb_spec.rb
```
_Auto detect OpenCode sessions. Full Screenshot_
<img width="500" alt="Auto detect OpenCode sessions. Full Screenshot" src="https://github.com/user-attachments/assets/53a3ab85-311d-449d-9c5f-a32ab0f58df5" />
_Listed in the dropdown menu_
<img width="250" alt="Listed in the dropdown menu" src="https://github.com/user-attachments/assets/9e76f4fe-0439-4199-9473-cf23df4fe15f" />
_Instructions for exports/finding files_
<img width="250" alt="Instructions for exports/finding files" src="https://github.com/user-attachments/assets/b3d4cedc-379d-426d-b92f-98c55e2859c8" />