### PR TITLE
Fix agent session redaction accuracy

### DIFF
--- a/app/controllers/agent_sessions_controller.rb
+++ b/app/controllers/agent_sessions_controller.rb
@@ -144,9 +144,7 @@ class AgentSessionsController < ApplicationController
     @agent_session.tool_name = tool_name.presence || curated.dig("metadata", "tool_name") || "claude_code"
     @agent_session.curated_data = result.scrubbed_data
     @agent_session.s3_key = create_params[:s3_key] if create_params[:s3_key].present?
-    @agent_session.session_metadata = result.scrubbed_data.fetch("metadata", {}).merge(
-      "redactions" => result.redactions.map { |r| { "name" => r.pattern_name, "count" => r.match_count } },
-    )
+    @agent_session.session_metadata = session_metadata_from_scrub_result(result)
 
     if params[:agent_session]&.key?(:slices)
       @agent_session.slices = parse_create_slices_param
@@ -188,11 +186,19 @@ class AgentSessionsController < ApplicationController
     curated = raw.is_a?(String) ? JSON.parse(raw, max_nesting: 50) : raw.to_unsafe_h
     result = AgentSessionParsers::SensitiveDataScrubber.scrub(curated)
     @agent_session.curated_data = result.scrubbed_data
-    @agent_session.session_metadata = result.scrubbed_data.fetch("metadata", {}).merge(
-      "redactions" => result.redactions.map { |r| { "name" => r.pattern_name, "count" => r.match_count } },
-    )
+    @agent_session.session_metadata = session_metadata_from_scrub_result(result)
   rescue JSON::ParserError
     # Ignore invalid JSON — validation will catch it
+  end
+
+  def session_metadata_from_scrub_result(result)
+    metadata = result.scrubbed_data.fetch("metadata", {}) || {}
+    metadata_redactions = metadata["redactions"].presence ||
+      AgentSessionParsers::RedactionMetadata.from_messages(result.scrubbed_data["messages"])
+
+    metadata.merge(
+      "redactions" => AgentSessionParsers::RedactionMetadata.merge(metadata_redactions, result.redactions),
+    )
   end
 
   def parse_curated_data_param

--- a/app/controllers/api/v1/agent_sessions_controller.rb
+++ b/app/controllers/api/v1/agent_sessions_controller.rb
@@ -91,9 +91,7 @@ module Api
         @agent_session.tool_name = params[:tool_name].presence || curated.dig("metadata", "tool_name") || "claude_code"
         @agent_session.curated_data = result.scrubbed_data
         @agent_session.s3_key = params[:s3_key] if params[:s3_key].present?
-        @agent_session.session_metadata = result.scrubbed_data.fetch("metadata", {}).merge(
-          "redactions" => result.redactions.map { |r| { "name" => r.pattern_name, "count" => r.match_count } },
-        )
+        @agent_session.session_metadata = session_metadata_from_scrub_result(result)
 
         save_and_respond
       rescue JSON::ParserError
@@ -104,6 +102,16 @@ module Api
         @agent_session.tool_name = params[:tool_name].presence || "claude_code"
         @agent_session.s3_key = params[:s3_key]
         save_and_respond
+      end
+
+      def session_metadata_from_scrub_result(result)
+        metadata = result.scrubbed_data.fetch("metadata", {}) || {}
+        metadata_redactions = metadata["redactions"].presence ||
+          AgentSessionParsers::RedactionMetadata.from_messages(result.scrubbed_data["messages"])
+
+        metadata.merge(
+          "redactions" => AgentSessionParsers::RedactionMetadata.merge(metadata_redactions, result.redactions),
+        )
       end
 
       def save_and_respond

--- a/app/javascript/agentSessionParsers/__tests__/sensitiveDataScrubber.test.js
+++ b/app/javascript/agentSessionParsers/__tests__/sensitiveDataScrubber.test.js
@@ -19,6 +19,28 @@ describe('sensitiveDataScrubber', () => {
       expect(result.redactions[0].pattern_name).toBe('GitHub Token');
     });
 
+    it('redacts GitHub fine-grained tokens', () => {
+      const token = 'github_pat_' + 'a'.repeat(22) + '_' + 'b'.repeat(29) + '_' + 'c'.repeat(29);
+      const result = scrub(makeData('My token is ' + token));
+      expect(result.scrubbed_data.messages[0].content[0].text).toContain('[REDACTED]');
+      expect(result.scrubbed_data.messages[0].content[0].text).not.toContain(token);
+      expect(result.redactions.some(r => r.pattern_name === 'GitHub Fine-Grained Token')).toBe(true);
+    });
+
+    it('does not redact masked GitHub fine-grained token placeholders', () => {
+      const token = 'github_pat_' + 'a'.repeat(22) + '_' + '*'.repeat(35);
+      const result = scrub(makeData('Masked token: ' + token));
+      expect(result.scrubbed_data.messages[0].content[0].text).toContain(token);
+      expect(result.redactions.some(r => r.pattern_name === 'GitHub Fine-Grained Token')).toBe(false);
+    });
+
+    it('records redaction counts on individual messages', () => {
+      const result = scrub(makeData('My token is ghp_abcdefghijklmnopqrstuvwxyz1234567890'));
+      expect(result.scrubbed_data.messages[0].metadata.redactions).toEqual([
+        { pattern_name: 'GitHub Token', match_count: 1 },
+      ]);
+    });
+
     it('redacts AWS access keys', () => {
       const result = scrub(makeData('Key: AKIAIOSFODNN7EXAMPLE'));
       expect(result.scrubbed_data.messages[0].content[0].text).toContain('[REDACTED]');
@@ -34,6 +56,21 @@ describe('sensitiveDataScrubber', () => {
     it('redacts Stripe keys', () => {
       const result = scrub(makeData('sk_live_' + 'a'.repeat(25)));
       expect(result.scrubbed_data.messages[0].content[0].text).toContain('[REDACTED]');
+    });
+
+    it('redacts Heroku API keys when explicitly labeled', () => {
+      const key = '01234567-89ab-cdef-0123-456789abcdef';
+      const result = scrub(makeData('HEROKU_API_KEY=' + key));
+      expect(result.scrubbed_data.messages[0].content[0].text).toContain('[REDACTED]');
+      expect(result.scrubbed_data.messages[0].content[0].text).not.toContain(key);
+      expect(result.redactions.some(r => r.pattern_name === 'Heroku API Key')).toBe(true);
+    });
+
+    it('does not redact unrelated UUIDs just because Heroku is mentioned', () => {
+      const uuid = '01234567-89ab-cdef-0123-456789abcdef';
+      const result = scrub(makeData('Review Heroku deploy logs for session ' + uuid));
+      expect(result.scrubbed_data.messages[0].content[0].text).toContain(uuid);
+      expect(result.redactions.some(r => r.pattern_name === 'Heroku API Key')).toBe(false);
     });
 
     it('redacts private key headers', () => {

--- a/app/javascript/agentSessionParsers/sensitiveDataScrubber.js
+++ b/app/javascript/agentSessionParsers/sensitiveDataScrubber.js
@@ -23,7 +23,7 @@ const PATTERNS = [
   { name: 'GitHub Token',
     regex: /(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}/g },
   { name: 'GitHub Fine-Grained Token',
-    regex: /github_pat_[A-Za-z0-9_]{22,}/g },
+    regex: /github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9_]{59,}/g },
   { name: 'GitLab Token',
     regex: /glpat-[A-Za-z0-9\-_]{20,}/g },
   { name: 'Bitbucket Token',
@@ -33,8 +33,7 @@ const PATTERNS = [
   { name: 'Travis CI Token',
     regex: /travis-token\s*[=:]\s*[A-Za-z0-9]{22}/g },
   { name: 'Heroku API Key',
-    regex: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/g,
-    context: /heroku/i },
+    regex: /(?:heroku[_\s-]*(?:api[_\s-]*)?key|heroku[_\s-]*token)\s*[=:]\s*["']?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}["']?/gi },
   { name: 'Vercel Token',
     regex: /vercel_[A-Za-z0-9]{24}/g },
   { name: 'Netlify Token',
@@ -156,22 +155,30 @@ export function scrubText(text) {
 
 function scrubMessage(message, redactionCounts) {
   const content = message.content || [];
+  const messageRedactionCounts = {};
+
   for (const block of content) {
     const isToolOutput = block.type === 'tool_call';
 
     if (block.text) {
-      block.text = scrubTextField(block.text, false, redactionCounts);
+      block.text = scrubTextField(block.text, false, redactionCounts, messageRedactionCounts);
     }
     if (block.input) {
-      block.input = scrubTextField(String(block.input), isToolOutput, redactionCounts);
+      block.input = scrubTextField(String(block.input), isToolOutput, redactionCounts, messageRedactionCounts);
     }
     if (block.output) {
-      block.output = scrubTextField(String(block.output), true, redactionCounts);
+      block.output = scrubTextField(String(block.output), true, redactionCounts, messageRedactionCounts);
     }
+  }
+
+  const messageRedactions = Object.entries(messageRedactionCounts)
+    .map(([name, count]) => ({ pattern_name: name, match_count: count }));
+  if (messageRedactions.length > 0) {
+    message.metadata = { ...(message.metadata || {}), redactions: messageRedactions };
   }
 }
 
-function scrubTextField(text, isToolOutput, redactionCounts) {
+function scrubTextField(text, isToolOutput, redactionCounts, messageRedactionCounts = {}) {
   for (const pattern of PATTERNS) {
     if (isToolOutput && SKIP_IN_TOOL_OUTPUT.has(pattern.name)) continue;
     if (pattern.context && !pattern.context.test(text)) continue;
@@ -180,6 +187,7 @@ function scrubTextField(text, isToolOutput, redactionCounts) {
     pattern.regex.lastIndex = 0;
     text = text.replace(pattern.regex, () => {
       redactionCounts[pattern.name] = (redactionCounts[pattern.name] || 0) + 1;
+      messageRedactionCounts[pattern.name] = (messageRedactionCounts[pattern.name] || 0) + 1;
       return REDACTED_LABEL;
     });
   }

--- a/app/javascript/packs/agentSessionCurator.js
+++ b/app/javascript/packs/agentSessionCurator.js
@@ -453,7 +453,11 @@
         var curatedMsgs = messages.filter(function(m) { return curatedIndices.has(m.index); });
         var curatedDataObj = {
           messages: curatedMsgs,
-          metadata: { total_messages: messages.length, curated_indices: Array.from(curated).sort(function(a,b){ return a-b; }) }
+          metadata: {
+            total_messages: messages.length,
+            curated_indices: Array.from(curated).sort(function(a,b){ return a-b; }),
+            redactions: redactionsForMessages(curatedMsgs)
+          }
         };
         var payload = { agent_session: { curated_data: JSON.stringify(curatedDataObj), slices: slices } };
 
@@ -478,6 +482,23 @@
           btn.textContent = 'Save';
           alert('Error saving curation');
         });
+      });
+    }
+
+    function redactionsForMessages(messages) {
+      var counts = {};
+      (messages || []).forEach(function(msg) {
+        var redactions = msg.metadata && msg.metadata.redactions;
+        (redactions || []).forEach(function(r) {
+          var name = r.name || r.pattern_name;
+          var count = Number(r.count || r.match_count || 0);
+          if (!name || count <= 0) return;
+          counts[name] = (counts[name] || 0) + count;
+        });
+      });
+
+      return Object.keys(counts).map(function(name) {
+        return { name: name, count: counts[name] };
       });
     }
 

--- a/app/services/agent_session_parsers/redaction_metadata.rb
+++ b/app/services/agent_session_parsers/redaction_metadata.rb
@@ -1,0 +1,43 @@
+module AgentSessionParsers
+  class RedactionMetadata
+    def self.merge(metadata_redactions, scrubber_redactions)
+      counts = Hash.new(0)
+
+      Array(metadata_redactions).each do |redaction|
+        name = redaction["name"] || redaction["pattern_name"]
+        count = redaction["count"] || redaction["match_count"]
+        name = name.to_s.strip
+        count = count.to_i
+
+        counts[name] += count if name.present? && count.positive?
+      end
+
+      scrubber_redactions.each do |redaction|
+        counts[redaction.pattern_name] += redaction.match_count.to_i
+      end
+
+      counts
+        .sort_by { |_, count| -count }
+        .map { |name, count| { "name" => name, "count" => count } }
+    end
+
+    def self.from_messages(messages)
+      counts = Hash.new(0)
+
+      Array(messages).each do |message|
+        Array(message.dig("metadata", "redactions")).each do |redaction|
+          name = redaction["name"] || redaction["pattern_name"]
+          count = redaction["count"] || redaction["match_count"]
+          name = name.to_s.strip
+          count = count.to_i
+
+          counts[name] += count if name.present? && count.positive?
+        end
+      end
+
+      counts
+        .sort_by { |_, count| -count }
+        .map { |name, count| { "name" => name, "count" => count } }
+    end
+  end
+end

--- a/app/services/agent_session_parsers/sensitive_data_scrubber.rb
+++ b/app/services/agent_session_parsers/sensitive_data_scrubber.rb
@@ -18,13 +18,13 @@ module AgentSessionParsers
 
       # === Code hosting & CI/CD ===
       { name: "GitHub Token", regex: /(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}/ },
-      { name: "GitHub Fine-Grained Token", regex: /github_pat_[A-Za-z0-9_]{22,}/ },
+      { name: "GitHub Fine-Grained Token", regex: /github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9_]{59,}/ },
       { name: "GitLab Token", regex: /glpat-[A-Za-z0-9\-_]{20,}/ },
       { name: "Bitbucket Token", regex: /ATBB[A-Za-z0-9]{32,}/ },
       { name: "CircleCI Token", regex: /circle-token\s*[=:]\s*[A-Za-z0-9]{40}/ },
       { name: "Travis CI Token", regex: /travis-token\s*[=:]\s*[A-Za-z0-9]{22}/ },
-      { name: "Heroku API Key", regex: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/,
-        context: /heroku/i },
+      { name: "Heroku API Key",
+        regex: /(?:heroku[_\s-]*(?:api[_\s-]*)?key|heroku[_\s-]*token)\s*[=:]\s*["']?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}["']?/i }, # rubocop:disable Layout/LineLength
       { name: "Vercel Token", regex: /vercel_[A-Za-z0-9]{24}/ },
       { name: "Netlify Token", regex: /netlify_[A-Za-z0-9]{40,}/ },
 

--- a/app/views/agent_sessions/new.html.erb
+++ b/app/views/agent_sessions/new.html.erb
@@ -445,7 +445,8 @@
       messages: curatedMessages,
       metadata: Object.assign({}, parsedResult.metadata || {}, {
         total_messages: parsedResult.messages.length,
-        curated_indices: curationData.curated
+        curated_indices: curationData.curated,
+        redactions: redactionsForMessages(curatedMessages)
       })
     };
 
@@ -498,6 +499,23 @@
         saveBtn.textContent = '<%= j t("views.agent_sessions.save_and_upload", default: "Save & Upload") %>';
       }
       alert('Error saving session: ' + (err.message || 'Network error'));
+    });
+  }
+
+  function redactionsForMessages(messages) {
+    var counts = {};
+    (messages || []).forEach(function(msg) {
+      var redactions = msg.metadata && msg.metadata.redactions;
+      (redactions || []).forEach(function(r) {
+        var name = r.name || r.pattern_name;
+        var count = Number(r.count || r.match_count || 0);
+        if (!name || count <= 0) return;
+        counts[name] = (counts[name] || 0) + count;
+      });
+    });
+
+    return Object.keys(counts).map(function(name) {
+      return { name: name, count: counts[name] };
     });
   }
 

--- a/spec/requests/agent_sessions_create_spec.rb
+++ b/spec/requests/agent_sessions_create_spec.rb
@@ -70,6 +70,25 @@ RSpec.describe "AgentSessions#create" do
       expect(text).not_to include("ghp_")
     end
 
+    it "preserves client-side redaction counts from already scrubbed uploads" do
+      data_with_client_redaction = valid_curated_data.deep_dup
+      data_with_client_redaction["messages"][0]["content"][0]["text"] = "My key is [REDACTED]"
+      data_with_client_redaction["metadata"]["redactions"] = [{ "name" => "GitHub Token", "count" => 1 }]
+
+      post agent_sessions_path, params: {
+        agent_session: {
+          title: "Client Scrubbed Session",
+          tool_name: "claude_code",
+          curated_data: data_with_client_redaction.to_json,
+        }
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      session = AgentSession.last
+      expect(session.redactions).to eq([{ "name" => "GitHub Token", "count" => 1 }])
+      expect(session.total_redactions).to eq(1)
+    end
+
     it "rejects invalid curated_data structure" do
       post agent_sessions_path, params: {
         agent_session: {
@@ -221,6 +240,29 @@ RSpec.describe "AgentSessions#create" do
       expect(response).to have_http_status(:ok)
       agent_session.reload
       expect(agent_session.curated_data["messages"].size).to eq(1)
+    end
+
+    it "preserves per-message redaction counts when updating already scrubbed curated_data" do
+      new_curated = {
+        "messages" => [
+          {
+            "index" => 0,
+            "role" => "user",
+            "content" => [{ "type" => "text", "text" => "My key is [REDACTED]" }],
+            "metadata" => { "redactions" => [{ "pattern_name" => "GitHub Token", "match_count" => 1 }] },
+          },
+        ],
+        "metadata" => { "total_messages" => 2, "curated_indices" => [0] }
+      }
+
+      patch agent_session_path(agent_session), params: {
+        agent_session: { curated_data: new_curated.to_json }
+      }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      agent_session.reload
+      expect(agent_session.redactions).to eq([{ "name" => "GitHub Token", "count" => 1 }])
+      expect(agent_session.total_redactions).to eq(1)
     end
   end
 end

--- a/spec/services/agent_session_parsers/redaction_metadata_spec.rb
+++ b/spec/services/agent_session_parsers/redaction_metadata_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe AgentSessionParsers::RedactionMetadata do
+  describe ".merge" do
+    it "preserves client-side redaction counts" do
+      result = described_class.merge(
+        [{ "name" => "GitHub Token", "count" => 2 }],
+        [],
+      )
+
+      expect(result).to eq([{ "name" => "GitHub Token", "count" => 2 }])
+    end
+
+    it "accepts JavaScript scrubber redaction keys" do
+      result = described_class.merge(
+        [{ "pattern_name" => "Home Directory", "match_count" => 1 }],
+        [],
+      )
+
+      expect(result).to eq([{ "name" => "Home Directory", "count" => 1 }])
+    end
+
+    it "combines client and server redaction counts" do
+      redaction = Struct.new(:pattern_name, :match_count)
+      result = described_class.merge(
+        [{ "name" => "GitHub Token", "count" => 1 }],
+        [redaction.new("GitHub Token", 2), redaction.new("AWS Access Key", 1)],
+      )
+
+      expect(result).to eq([
+        { "name" => "GitHub Token", "count" => 3 },
+        { "name" => "AWS Access Key", "count" => 1 },
+      ])
+    end
+  end
+
+  describe ".from_messages" do
+    it "aggregates redactions from message metadata" do
+      result = described_class.from_messages([
+        { "metadata" => { "redactions" => [{ "pattern_name" => "GitHub Token", "match_count" => 1 }] } },
+        { "metadata" => { "redactions" => [{ "name" => "GitHub Token", "count" => 2 }] } },
+        { "metadata" => { "redactions" => [{ "name" => "Home Directory", "count" => 1 }] } },
+      ])
+
+      expect(result).to eq([
+        { "name" => "GitHub Token", "count" => 3 },
+        { "name" => "Home Directory", "count" => 1 },
+      ])
+    end
+  end
+end

--- a/spec/services/agent_session_parsers/sensitive_data_scrubber_spec.rb
+++ b/spec/services/agent_session_parsers/sensitive_data_scrubber_spec.rb
@@ -27,6 +27,27 @@ RSpec.describe AgentSessionParsers::SensitiveDataScrubber do
       expect(text).not_to include("ghp_ABCDEFGHIJKLMNOP")
     end
 
+    it "redacts GitHub fine-grained tokens" do
+      token = "github_pat_#{'a' * 22}_#{'b' * 29}_#{'c' * 29}"
+      data = build_normalized("token: #{token}")
+      result = described_class.scrub(data)
+      text = result.scrubbed_data["messages"][0]["content"][0]["text"]
+
+      expect(text).to include("[REDACTED]")
+      expect(text).not_to include(token)
+      expect(result.redactions.map(&:pattern_name)).to include("GitHub Fine-Grained Token")
+    end
+
+    it "does not redact masked GitHub fine-grained token placeholders" do
+      token = "github_pat_#{'a' * 22}_#{'*' * 35}"
+      data = build_normalized("Masked token: #{token}")
+      result = described_class.scrub(data)
+      text = result.scrubbed_data["messages"][0]["content"][0]["text"]
+
+      expect(text).to include(token)
+      expect(result.redactions.map(&:pattern_name)).not_to include("GitHub Fine-Grained Token")
+    end
+
     it "redacts Stripe secret keys" do
       # Build key via interpolation so the literal doesn't trigger GitHub push protection
       stripe_key = "sk_live_#{'a1b2c3d4e5' * 3}"
@@ -65,6 +86,27 @@ RSpec.describe AgentSessionParsers::SensitiveDataScrubber do
       result = described_class.scrub(data)
       text = result.scrubbed_data["messages"][0]["content"][0]["text"]
       expect(text).not_to include("sk-ant-")
+    end
+
+    it "redacts Heroku API keys when explicitly labeled" do
+      key = "01234567-89ab-cdef-0123-456789abcdef"
+      data = build_normalized("HEROKU_API_KEY=#{key}")
+      result = described_class.scrub(data)
+      text = result.scrubbed_data["messages"][0]["content"][0]["text"]
+
+      expect(text).to include("[REDACTED]")
+      expect(text).not_to include(key)
+      expect(result.redactions.map(&:pattern_name)).to include("Heroku API Key")
+    end
+
+    it "does not redact unrelated UUIDs just because Heroku is mentioned" do
+      uuid = "01234567-89ab-cdef-0123-456789abcdef"
+      data = build_normalized("Review Heroku deploy logs for session #{uuid}")
+      result = described_class.scrub(data)
+      text = result.scrubbed_data["messages"][0]["content"][0]["text"]
+
+      expect(text).to include(uuid)
+      expect(result.redactions.map(&:pattern_name)).not_to include("Heroku API Key")
     end
 
     it "redacts Slack tokens" do


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes Agent Sessions redaction accuracy in two areas:

- Preserves client-side redaction counts after saving curated sessions.
  - Keeps saved redaction counts scoped to the messages that were actually selected and stored.
  - Merges preserved client-side counts with any additional server-side scrubber counts.
- Particularly for OpenCode sessions:
  - Reduces false positives for Heroku API keys caused by unrelated UUIDs near Heroku text.
  - Reduces false positives for already-masked GitHub fine-grained token placeholders.

Previously, the upload UI could show redactions during curation, but saving the session could persist `0` redactions because the server re-scrubbed already-redacted content. This change carries per-message redaction metadata through the curation flow so saved sessions retain accurate redaction counts.

## Related Tickets & Documents

- Related Issue #22895
- Closes N/A

## QA Instructions, Screenshots, Recordings

Manual smoke test performed locally with a real Agent Session upload.

To test manually:

1. Go to `/agent_sessions/new`.
2. Upload an agent session file that contains redacted or redactable content.
3. Confirm the upload UI reports automatic redactions during curation.
4. Deselect one or more messages containing redactions.
5. Save the curated session.
6. Confirm saved redaction counts match only the selected/saved messages.
7. Confirm unrelated UUIDs near Heroku text are not counted as Heroku API keys.
8. Confirm masked `github_pat_...****` placeholders are not counted as GitHub fine-grained tokens.

Expected result from the local smoke test with the OpenCode fixture after these fixes:

```text
9 items automatically redacted — 5 Home Directory, 3 Email Address, 1 IPv4 Address
```

### UI accessibility checklist

_If your PR includes UI changes, please utilize this checklist:_

- [x] Semantic HTML implemented?
- [x] Keyboard operability supported?
- [ ] Checked with [axe DevTools](https://www.deque.com/axe/) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

No new custom interactive controls were added. This changes redaction metadata/count behavior in the existing upload and curation flows.

_For more info, check out the
[Forem Accessibility Docs](https://developers.forem.com/frontend/accessibility)._

## Added/updated tests?

_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

Tested with:

```bash
yarn jest app/javascript/agentSessionParsers/__tests__/sensitiveDataScrubber.test.js
```

```bash
RAILS_ENV=test DATABASE_URL_TEST=postgres://postgres:postgres@127.0.0.1:5432/Forem_test bundle exec rspec spec/services/agent_session_parsers/sensitive_data_scrubber_spec.rb spec/services/agent_session_parsers/redaction_metadata_spec.rb spec/requests/agent_sessions_create_spec.rb
```

Results:

- JavaScript scrubber specs: `18 passed`
- Ruby service/request specs: `37 examples, 0 failures`