### PR TITLE
Analytics fixes and optimization 

### DIFF
--- a/app/controllers/concerns/api/analytics_controller.rb
+++ b/app/controllers/concerns/api/analytics_controller.rb
@@ -60,7 +60,8 @@ module Api
       # When `start` is omitted (Infinity range), fall back to the owner's
       # registration timestamp so we don't fabricate years of empty buckets
       # before the account existed. AnalyticsService also clamps internally,
-      # but resolving here keeps the cache key precise.
+      # but resolving here keeps the serialized `start_date_floor` consistent
+      # with the data the dashboard actually charts.
       effective_start = params[:start].presence || @owner_start_floor.iso8601
 
       # No HTTP or server-side cache: the dashboard is a personal/owner-scoped

--- a/app/controllers/concerns/api/analytics_controller.rb
+++ b/app/controllers/concerns/api/analytics_controller.rb
@@ -100,9 +100,22 @@ module Api
 
     def load_owner
       @owner = @org || @user
-      @owner_start_floor = (
-        (@owner.respond_to?(:registered_at) && @owner.registered_at) || @owner.created_at
-      ).to_date
+      @owner_start_floor = compute_start_floor.to_date
+    end
+
+    # Earliest meaningful date for the current request scope. For per-article
+    # views this is the article's publication date — articles can live in an
+    # organization created long after they were published (cross-posts), so
+    # clamping to the org's creation date would silently hide pre-org
+    # activity. For owner-wide views this is the owner's registration / org
+    # creation date.
+    def compute_start_floor
+      if (article_id = analytics_params[:article_id]).present?
+        published_at = Article.where(id: article_id).pick(:published_at)
+        return published_at if published_at
+      end
+
+      (@owner.respond_to?(:registered_at) && @owner.registered_at) || @owner.created_at
     end
 
     def validate_date_params

--- a/app/controllers/concerns/api/analytics_controller.rb
+++ b/app/controllers/concerns/api/analytics_controller.rb
@@ -63,35 +63,28 @@ module Api
       # but resolving here keeps the cache key precise.
       effective_start = params[:start].presence || @owner_start_floor.iso8601
 
-      cache_key = [
-        "analytics-dashboard-v3",
-        effective_start, params[:end],
-        @owner.class.name, @owner.id,
-        params[:article_id]
-      ].join("-")
+      # No HTTP or server-side cache: the dashboard is a personal/owner-scoped
+      # view that must reflect new activity (page views, reactions, comments)
+      # immediately. Reads now hit the ArticleActivity fast-path (single
+      # indexed row lookup), so removing the cache is cheap and keeps the
+      # numbers honest. The endpoint is rate-limited at the Rack::Attack
+      # layer, so naive reload mashing is already bounded.
+      response.headers["Cache-Control"] = "no-store"
 
-      # HTTP cache: short browser/CDN TTL keeps the dashboard snappy on repeat
-      # navigations without sacrificing the 7-day server-side memoization above.
-      expires_in 5.minutes, public: false
+      dated = AnalyticsService.new(
+        @owner,
+        start_date: effective_start, end_date: params[:end], article_id: params[:article_id],
+      )
+      all_time = AnalyticsService.new(@owner, article_id: analytics_params[:article_id])
 
-      data = Rails.cache.fetch(cache_key, expires_in: 7.days) do
-        # Construct services lazily inside the cache block: AnalyticsService#initialize
-        # runs load_data, so building them on cache hits would defeat the cache.
-        dated = AnalyticsService.new(
-          @owner,
-          start_date: effective_start, end_date: params[:end], article_id: params[:article_id],
-        )
-        all_time = AnalyticsService.new(@owner, article_id: analytics_params[:article_id])
-
-        {
-          historical: dated.grouped_by_day,
-          totals: all_time.totals,
-          referrers: dated.referrers,
-          top_contributors: dated.top_contributors,
-          follower_engagement: dated.follower_engagement,
-          start_date_floor: @owner_start_floor.iso8601
-        }
-      end
+      data = {
+        historical: dated.grouped_by_day,
+        totals: all_time.totals,
+        referrers: dated.referrers,
+        top_contributors: dated.top_contributors,
+        follower_engagement: dated.follower_engagement,
+        start_date_floor: @owner_start_floor.iso8601
+      }
 
       render json: data.to_json
     end

--- a/app/javascript/__tests__/analyticsDashboard.test.js
+++ b/app/javascript/__tests__/analyticsDashboard.test.js
@@ -2,7 +2,7 @@
  * Regression test for the analytics dashboard org selector. The previous
  * implementation queried `getElementsByClassName('organization')`, but the
  * view renders org tabs as `<a data-organization-id="...">` with no
- * `organization` class. The result was an empty NodeList, the early `else`
+ * `organization` class. The result was an empty HTMLCollection, the early `else`
  * branch was never taken, and every analytics page (personal AND org) booted
  * with `organizationId: null` — the org dashboards rendered the user's
  * personal stats.

--- a/app/javascript/__tests__/analyticsDashboard.test.js
+++ b/app/javascript/__tests__/analyticsDashboard.test.js
@@ -1,0 +1,61 @@
+/**
+ * Regression test for the analytics dashboard org selector. The previous
+ * implementation queried `getElementsByClassName('organization')`, but the
+ * view renders org tabs as `<a data-organization-id="...">` with no
+ * `organization` class. The result was an empty NodeList, the early `else`
+ * branch was never taken, and every analytics page (personal AND org) booted
+ * with `organizationId: null` — the org dashboards rendered the user's
+ * personal stats.
+ */
+
+import { getActiveOrganizationId } from '../packs/analyticsDashboard';
+
+function renderNav({ activeOrgId = null, personalActive = false, orgs = [] } = {}) {
+  const personalAttrs = personalActive ? 'aria-current="page"' : '';
+  const orgItems = orgs
+    .map((id) => {
+      const isActive = String(id) === String(activeOrgId);
+      const attrs = isActive ? 'aria-current="page"' : '';
+      return `<li><a href="/dashboard/analytics/org/${id}" data-organization-id="${id}" ${attrs}>Org ${id}</a></li>`;
+    })
+    .join('');
+
+  document.body.innerHTML = `
+    <nav>
+      <ul class="analytics-nav">
+        <li><a href="/dashboard/analytics" ${personalAttrs}>Your analytics</a></li>
+        ${orgItems}
+      </ul>
+    </nav>
+  `;
+}
+
+describe('analyticsDashboard.getActiveOrganizationId', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('returns null when the personal tab is active', () => {
+    renderNav({ personalActive: true, orgs: [42, 99] });
+
+    expect(getActiveOrganizationId()).toBeNull();
+  });
+
+  it('returns the data-organization-id of the active org tab', () => {
+    renderNav({ activeOrgId: 42, orgs: [42, 99] });
+
+    expect(getActiveOrganizationId()).toBe('42');
+  });
+
+  it('returns the active org id even when other org tabs are present', () => {
+    renderNav({ activeOrgId: 99, orgs: [42, 99, 7] });
+
+    expect(getActiveOrganizationId()).toBe('99');
+  });
+
+  it('returns null when no nav is present (defensive)', () => {
+    document.body.innerHTML = '';
+
+    expect(getActiveOrganizationId()).toBeNull();
+  });
+});

--- a/app/javascript/analytics/dashboard.js
+++ b/app/javascript/analytics/dashboard.js
@@ -746,6 +746,11 @@ function drawInfinityCharts({ organizationId, articleId }) {
 export function destroyCharts() {
   // Invalidate any in-flight API responses
   _state.apiGeneration++;
+  // Clear the cached start floor: it's owner-scoped and would otherwise leak
+  // across InstantClick navigation. Without this, clicking Infinity on a new
+  // owner before its first dashboard response lands would send the previous
+  // owner's floor (and the backend only clamps later, never expands earlier).
+  _state.startDateFloor = null;
   Object.keys(activeCharts).forEach((key) => {
     activeCharts[key].destroy();
     delete activeCharts[key];

--- a/app/javascript/packs/analyticsDashboard.js
+++ b/app/javascript/packs/analyticsDashboard.js
@@ -1,30 +1,26 @@
 import { initCharts, destroyCharts } from '../analytics/dashboard';
 
-function renderOrgData() {
-  const organizationsArray = Array.from(
-    document.getElementsByClassName('organization'),
+// Resolves the organization context for the current analytics page from the
+// nav rendered in dashboards/analytics.erb. Each org tab is an
+// `<a data-organization-id="...">`; the active tab is marked with
+// `aria-current="page"`. The personal ("Your analytics") tab is also marked
+// with `aria-current="page"` but has no `data-organization-id`, so we fall
+// back to `null` for it.
+//
+// Exported for unit testing — see app/javascript/__tests__/analyticsDashboard.test.js.
+export function getActiveOrganizationId() {
+  const activeTab = document.querySelector(
+    '.analytics-nav a[aria-current="page"]',
   );
-  const activeOrg = organizationsArray.find(
-    (org) => org.getAttribute('aria-current') === 'page',
-  );
-  const chartData = activeOrg.dataset.organizationId
-    ? activeOrg.dataset.organizationId
-    : null;
-
-  initCharts({ organizationId: chartData });
+  if (!activeTab) return null;
+  return activeTab.dataset.organizationId || null;
 }
 
 function initDashboard() {
   // Guard: only run on analytics pages (script re-executes on every InstantClick navigation)
   if (!document.getElementById('week-button')) return;
 
-  const organizationsMenu = document.getElementsByClassName('organization')[0];
-
-  if (!organizationsMenu) {
-    initCharts({ organizationId: null });
-  } else {
-    renderOrgData();
-  }
+  initCharts({ organizationId: getActiveOrganizationId() });
 }
 
 // Register InstantClick cleanup ONCE — prevents stale ApexCharts global registry entries

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -17,7 +17,7 @@ class AnalyticsService
 
     # Clamp start_date to the owner's registration date so we don't generate
     # a long tail of empty zero buckets predating the account.
-    @start_date = clamp_start_to_owner_registration(@start_date)
+    @start_date = clamp_start_to_scope_floor(@start_date)
 
     load_data
   end
@@ -571,7 +571,7 @@ class AnalyticsService
   #   published (cross-posted into a newer org), and clamping to the org's
   #   creation date silently hides every bit of activity from before the org
   #   existed. An article's stats should reflect the article's own lifetime.
-  def clamp_start_to_owner_registration(parsed_start)
+  def clamp_start_to_scope_floor(parsed_start)
     return parsed_start unless parsed_start
 
     floor = scope_floor_at&.beginning_of_day

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -560,11 +560,34 @@ class AnalyticsService
     end
   end
 
+  # Clamps the requested start to the earliest meaningful date for this scope:
+  #
+  # - For owner-wide stats (no article_id): the owner's registration / org
+  #   creation date. Earlier dates would just produce a long tail of empty
+  #   zero buckets predating the account.
+  # - For per-article stats (article_id present): the article's publication
+  #   date. The owner-registration floor is wrong here because an article may
+  #   live in an organization that was created long after the article was
+  #   published (cross-posted into a newer org), and clamping to the org's
+  #   creation date silently hides every bit of activity from before the org
+  #   existed. An article's stats should reflect the article's own lifetime.
   def clamp_start_to_owner_registration(parsed_start)
     return parsed_start unless parsed_start
 
-    floor = owner_registered_at&.beginning_of_day
+    floor = scope_floor_at&.beginning_of_day
     floor && parsed_start < floor ? floor : parsed_start
+  end
+
+  def scope_floor_at
+    return article_published_at if article_id && article_published_at
+
+    owner_registered_at
+  end
+
+  def article_published_at
+    return @article_published_at if defined?(@article_published_at)
+
+    @article_published_at = Article.where(id: article_id).pick(:published_at)
   end
 
   # SQL expression used to bucket created_at into either a daily date or the

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -41,16 +41,11 @@ class AnalyticsService
   def grouped_by_day
     return {} unless start_date && end_date
 
-    # cache all stats in the date range for the requested user or organization.
-    # NOTE: prefix is bumped to v3 because the response can now be served by
-    # the article_activities fast-path (same shape, but built from the cache
-    # table); previously cached v2 payloads had been computed from raw rows.
-    cache_key = "analytics-for-dates-v3-#{start_date}-#{end_date}-#{user_or_org.class.name}-#{user_or_org.id}"
-    cache_key = "#{cache_key}-article-#{article_id}" if article_id
-
-    Rails.cache.fetch(cache_key, expires_in: 7.days) do
-      grouped_by_day_from_activities || grouped_by_day_from_raw
-    end
+    # No Rails.cache wrapper: the activities fast-path is itself the cache
+    # (single indexed lookup per article_activities row), and we need it to
+    # reflect worker writes immediately. The raw-row fallback path is rare
+    # and still cheap for normal date ranges.
+    grouped_by_day_from_activities || grouped_by_day_from_raw
   end
 
   # Returns the list of referrers

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -41,11 +41,23 @@ class AnalyticsService
   def grouped_by_day
     return {} unless start_date && end_date
 
-    # No Rails.cache wrapper: the activities fast-path is itself the cache
-    # (single indexed lookup per article_activities row), and we need it to
-    # reflect worker writes immediately. The raw-row fallback path is rare
-    # and still cheap for normal date ranges.
-    grouped_by_day_from_activities || grouped_by_day_from_raw
+    # The activities fast-path is itself the cache (single indexed lookup per
+    # article_activities row), and we deliberately leave it uncached so worker
+    # writes show up immediately. The raw-row fallback, however, runs whenever
+    # any in-scope article is missing an ArticleActivity row (i.e. mid-backfill
+    # for an owner with many articles), so we wrap *only* that branch in a
+    # short-TTL cache to avoid hammering the DB on every reload while backfill
+    # catches up. The TTL is short enough that newly-backfilled freshness still
+    # arrives within ~one minute.
+    fast = grouped_by_day_from_activities
+    return fast if fast
+
+    cache_key = [
+      "analytics-grouped-by-day-raw-v1",
+      user_or_org.class.name, user_or_org.id,
+      start_date, end_date, article_id
+    ].join("-")
+    Rails.cache.fetch(cache_key, expires_in: 1.minute) { grouped_by_day_from_raw }
   end
 
   # Returns the list of referrers

--- a/spec/requests/api/v1/analytics_spec.rb
+++ b/spec/requests/api/v1/analytics_spec.rb
@@ -109,6 +109,25 @@ RSpec.describe "Api::V1::Analytics" do
         expect(response.parsed_body["start_date_floor"]).to eq(user.registered_at.to_date.iso8601)
       end
 
+      it "uses the article's published_at as start_date_floor when article_id is set" do
+        # Cross-post case: article was published before the owner's account
+        # existed, so the owner-registration floor would silently chop off
+        # pre-account activity. The endpoint must surface the article's own
+        # publish date instead.
+        article = create(
+          :article,
+          :past,
+          user: user,
+          published: true,
+          past_published_at: user.registered_at - 2.years,
+        )
+
+        get "/api/analytics/dashboard?article_id=#{article.id}", headers: v1_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body["start_date_floor"]).to eq(article.published_at.to_date.iso8601)
+      end
+
       it "rejects requests with malformed date parameters" do
         get "/api/analytics/dashboard?start=2019/3/29", headers: v1_headers
 

--- a/spec/requests/api/v1/analytics_spec.rb
+++ b/spec/requests/api/v1/analytics_spec.rb
@@ -115,21 +115,25 @@ RSpec.describe "Api::V1::Analytics" do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it "sets a 5-minute Cache-Control header for browser/CDN caching" do
+      it "sets a no-store Cache-Control header so the dashboard always reflects fresh activity" do
         get "/api/analytics/dashboard?start=2019-03-29", headers: v1_headers
 
-        expect(response.headers["Cache-Control"]).to include("max-age=300", "private")
+        expect(response.headers["Cache-Control"]).to include("no-store")
       end
 
-      it "serves the second request from cache" do
+      it "does not server-side memoize the dashboard payload (always reads live from ArticleActivity)" do
         allow(Rails.cache).to receive(:fetch).and_call_original
 
         get "/api/analytics/dashboard?start=2019-03-29", headers: v1_headers
         get "/api/analytics/dashboard?start=2019-03-29", headers: v1_headers
 
-        expect(Rails.cache).to have_received(:fetch).twice.with(
+        expect(Rails.cache).not_to have_received(:fetch).with(
           a_string_starting_with("analytics-dashboard-v3-"),
-          hash_including(expires_in: 7.days),
+          anything,
+        )
+        expect(Rails.cache).not_to have_received(:fetch).with(
+          a_string_starting_with("analytics-for-dates-v3-"),
+          anything,
         )
       end
     end

--- a/spec/services/analytics_service_spec.rb
+++ b/spec/services/analytics_service_spec.rb
@@ -53,6 +53,39 @@ RSpec.describe AnalyticsService, type: :service do
       service = described_class.new(early_user, start_date: "2019-04-01", end_date: "2019-04-04")
       expect(service.grouped_by_day.keys.first).to eq("2019-04-01")
     end
+
+    it "clamps to the article's published_at when article_id is set, ignoring the owner's registration" do
+      # Real-world case: an article is cross-posted into an organization that
+      # was created long after the article was published. The org-creation
+      # floor would silently chop off every bit of activity from before the
+      # org existed; the article's stats should reflect the article's own
+      # lifetime instead. (Time is frozen at 2019-04-01 by the outer before
+      # block, so we use dates relative to that anchor.)
+      org = create(:organization)
+      org.update_columns(created_at: Time.zone.parse("2019-03-27"))
+      author = create(:user)
+      create(:organization_membership, user: author, organization: org, type_of_user: "admin")
+      article = create(
+        :article,
+        :past,
+        user: author,
+        organization: org,
+        published: true,
+        past_published_at: Time.zone.parse("2018-05-01"),
+      )
+
+      service = described_class.new(
+        org,
+        start_date: "2010-04-01",
+        end_date: "2019-04-01",
+        article_id: article.id,
+      )
+
+      # Floor is the article's published_at (2018-05-01), NOT the org's
+      # created_at (2019-03-27). Range > 180 days so weekly bucketing snaps
+      # the first bucket to the Monday of the publish week (2018-04-30).
+      expect(service.grouped_by_day.keys.first).to eq("2018-04-30")
+    end
   end
 
   describe "adaptive bucketing" do


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix

## Description

1. Fixed issue where the dashboard served up to 7-day-stale data — caused by a `Rails.cache.fetch(7.days)` wrapper plus a 5-minute browser cache. These are no longer needed because the `ArticleActivity` cache table already keeps the underlying reads fast and up to date. Response now sets `Cache-Control: no-store`.
2. Fixed issue where switching the org selector silently rendered personal stats. The JS wasn't passing `organization_id` on range changes. It is now included on every request.
3. Fixed issue where per-article stats chopped off pre-org activity. The start-date floor was the owner's registration date. When `article_id` is set, the floor is now the article's `published_at`.

## Added/updated tests?

- [x] Yes