### PR TITLE
Fix Comment.propTypes typo in CommentsList

### DIFF
--- a/app/javascript/articles/components/CommentsList.jsx
+++ b/app/javascript/articles/components/CommentsList.jsx
@@ -48,14 +48,14 @@ export const CommentsList = ({ comments = [], articlePath, totalCount }) => {
 
 CommentsList.displayName = 'CommentsList';
 
-CommentsList.propTypes = PropTypes.shape({
+const commentShape = PropTypes.shape({
   name: PropTypes.string.isRequired,
   profile_image_90: PropTypes.string.isRequired,
   published_at_int: PropTypes.number.isRequired,
 });
 
 CommentsList.propTypes = {
-  comments: PropTypes.arrayOf(CommentsList.propTypes).isRequired,
+  comments: PropTypes.arrayOf(commentShape).isRequired,
   articlePath: PropTypes.string.isRequired,
   totalCount: PropTypes.number.isRequired,
 };

--- a/app/javascript/articles/components/CommentsList.jsx
+++ b/app/javascript/articles/components/CommentsList.jsx
@@ -48,14 +48,14 @@ export const CommentsList = ({ comments = [], articlePath, totalCount }) => {
 
 CommentsList.displayName = 'CommentsList';
 
-Comment.propTypes = PropTypes.shape({
+CommentsList.propTypes = PropTypes.shape({
   name: PropTypes.string.isRequired,
   profile_image_90: PropTypes.string.isRequired,
   published_at_int: PropTypes.number.isRequired,
 });
 
 CommentsList.propTypes = {
-  comments: PropTypes.arrayOf(Comment.propTypes).isRequired,
+  comments: PropTypes.arrayOf(CommentsList.propTypes).isRequired,
   articlePath: PropTypes.string.isRequired,
   totalCount: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

In `app/javascript/articles/components/CommentsList.jsx`, the comment shape was assigned to `Comment.propTypes`. `Comment` is not imported or defined locally, so it resolves to the DOM `Comment` interface (the constructor for HTML comment nodes), and the assignment mutates a browser global by attaching a `propTypes` property to it.

Rename the assignment target to `CommentsList.propTypes` so the shape stays scoped to this component. Functionally the resulting `CommentsList.propTypes` object is unchanged (the shape is captured in the next assignment's RHS before being overwritten), but the DOM `Comment` global is no longer touched.

## Related Tickets & Documents

- Closes #23264

## QA Instructions, Screenshots, Recordings

No behavior change. Verify by inspecting `window.Comment.propTypes` in the browser console on a page that loads `CommentsList` — it should now be `undefined` instead of a `PropTypes.shape(...)`.

## Added/updated tests?

- [x] No, and this is why: this is a non-functional rename of a propTypes assignment target; there is no observable behavior to cover with a regression test.