### PR TITLE
Align Sidekiq client Redis db with server in development

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -107,6 +107,25 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
+  # Keep the client (Rails app / runner / specs) on the same Redis database the
+  # server consumes from. The `Sidekiq.configure_server` block above remaps the
+  # URL to db `/3` in development so it doesn't collide with Rails.cache /
+  # Rack::Attack / RequestStore data sitting in db `/0`. Without the matching
+  # override here, enqueues silently land in `/0` while the worker daemon polls
+  # `/3` — jobs pile up forever and never run.
+  sidekiq_url = ApplicationConfig["REDIS_SIDEKIQ_URL"] || ApplicationConfig["REDIS_URL"] || "redis://localhost:6379"
+  if Rails.env.development?
+    begin
+      require "uri"
+      uri = URI.parse(sidekiq_url)
+      uri.path = "/3" if uri.path.nil? || uri.path == "" || uri.path == "/"
+      sidekiq_url = uri.to_s
+    rescue URI::InvalidURIError
+      # fall through with the original url
+    end
+  end
+  config.redis = { url: sidekiq_url }
+
   config.client_middleware do |chain|
     chain.add SidekiqUniqueJobs::Middleware::Client
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -25,6 +25,25 @@ module Sidekiq
   end
 end
 
+# In development, point Sidekiq at Redis db `/3` so its queues / locks /
+# scheduled set don't collide with other Redis-backed consumers in the default
+# `/0` (Rails.cache when configured with redis_cache_store, Rack::Attack, etc.).
+# Used by both `configure_server` and `configure_client` below — keep them in
+# sync via this single helper so the two never drift.
+SIDEKIQ_REDIS_URL = lambda do
+  url = ApplicationConfig["REDIS_SIDEKIQ_URL"] || ApplicationConfig["REDIS_URL"] || "redis://localhost:6379"
+  return url unless Rails.env.development?
+
+  begin
+    require "uri"
+    uri = URI.parse(url)
+    uri.path = "/3" if uri.path.nil? || uri.path == "" || uri.path == "/"
+    uri.to_s
+  rescue URI::InvalidURIError
+    url
+  end
+end
+
 Sidekiq.configure_server do |config|
   # Grab the concurrency passed to Sidekiq (defaults to 16 if not set)
   sidekiq_concurrency = ENV.fetch("SIDEKIQ_CONCURRENCY", 16).to_i
@@ -56,19 +75,9 @@ Sidekiq.configure_server do |config|
   # every 30 seconds which the gem defaults to
   config[:poll_interval] = 10
 
-  sidekiq_url = ApplicationConfig["REDIS_SIDEKIQ_URL"] || ApplicationConfig["REDIS_URL"] || "redis://localhost:6379"
-  if Rails.env.development?
-    begin
-      require "uri"
-      uri = URI.parse(sidekiq_url)
-      uri.path = "/3" if uri.path.nil? || uri.path == "" || uri.path == "/"
-      sidekiq_url = uri.to_s
-    rescue URI::InvalidURIError
-    end
-  end
   # On Heroku this configuration is overridden and Sidekiq will point at the redis
   # instance given by the ENV variable REDIS_PROVIDER
-  config.redis = { url: sidekiq_url }
+  config.redis = { url: SIDEKIQ_REDIS_URL.call }
 
   config.server_middleware do |chain|
     # sidekiq-throttled wires itself up when `require "sidekiq/throttled"` is loaded:
@@ -108,23 +117,10 @@ end
 
 Sidekiq.configure_client do |config|
   # Keep the client (Rails app / runner / specs) on the same Redis database the
-  # server consumes from. The `Sidekiq.configure_server` block above remaps the
-  # URL to db `/3` in development so it doesn't collide with Rails.cache /
-  # Rack::Attack / RequestStore data sitting in db `/0`. Without the matching
-  # override here, enqueues silently land in `/0` while the worker daemon polls
-  # `/3` — jobs pile up forever and never run.
-  sidekiq_url = ApplicationConfig["REDIS_SIDEKIQ_URL"] || ApplicationConfig["REDIS_URL"] || "redis://localhost:6379"
-  if Rails.env.development?
-    begin
-      require "uri"
-      uri = URI.parse(sidekiq_url)
-      uri.path = "/3" if uri.path.nil? || uri.path == "" || uri.path == "/"
-      sidekiq_url = uri.to_s
-    rescue URI::InvalidURIError
-      # fall through with the original url
-    end
-  end
-  config.redis = { url: sidekiq_url }
+  # server consumes from — see SIDEKIQ_REDIS_URL above. Without this, dev
+  # enqueues silently land in `/0` while the worker daemon polls `/3` and jobs
+  # pile up forever.
+  config.redis = { url: SIDEKIQ_REDIS_URL.call }
 
   config.client_middleware do |chain|
     chain.add SidekiqUniqueJobs::Middleware::Client


### PR DESCRIPTION
## Description

In development, `Sidekiq.configure_server` overrides the Redis URL to db `/3` (to avoid colliding with `Rails.cache` etc. on `/0`), but `Sidekiq.configure_client` was missing the same override. So the web process enqueued into `/0` while the Sidekiq daemon polled `/3` — every job from web/rake/specs silently piled up and never ran.

Fix: mirror the same `/3` override into `configure_client`. Dev only; production untouched.