### PR TITLE
Fix broken shields.io badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   </a>
   <img src="https://img.shields.io/github/commit-activity/w/forem/forem" alt="GitHub commit activity">
   <a href="https://github.com/forem/forem/issues?q=is%3Aissue+is%3Aopen+label%3A%22ready+for+dev%22">
-    <img src="https://img.shields.io/github/issues/forem/forem/ready for dev" alt="GitHub issues ready for dev">
+    <img src="https://img.shields.io/github/issues/forem/forem/ready%20for%20dev" alt="GitHub issues ready for dev">
   </a>
   <a href="https://gitpod.io/#https://github.com/forem/forem">
     <img src="https://img.shields.io/badge/setup-automated-blue?logo=gitpod" alt="GitPod badge">


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

The "GitHub issues ready for dev" badge in `README.md` has raw spaces in its shields.io image URL:

```
https://img.shields.io/github/issues/forem/forem/ready for dev
```

shields.io can't resolve URLs with raw whitespace, so the image silently fails to load. The adjacent `<a href>` already URL-encodes the same string (`label%3A%22ready+for+dev%22`), so the fix is to encode the spaces in the `<img src>` too.

After the fix the URL returns `200 OK` with the SVG badge:

```
https://img.shields.io/github/issues/forem/forem/ready%20for%20dev
```

## Related Tickets & Documents

None — spotted while reading the README.

## QA Instructions, Screenshots, Recordings

Open the rendered README on GitHub (or any markdown viewer). The "GitHub issues ready for dev" badge now renders with the issue count instead of failing to load.

## Added/updated tests?

- [x] No, and this is why: README rendering is not covered by automated tests, and the change is a one-character URL encoding fix with no runtime behaviour to assert.