### PR TITLE
fix quickie embed engulfing paginated stories (#23266)

### DIFF
--- a/app/assets/javascripts/initializers/initScrolling.js
+++ b/app/assets/javascripts/initializers/initScrolling.js
@@ -392,7 +392,7 @@ function insertArticles(articles) {
   });
 
   var singleArticles = document.querySelectorAll(
-    '.single-article, .crayons-story',
+    '.single-article:not(.ltag__link--embedded *), .crayons-story:not(.ltag__link--embedded *)',
   );
   var lastElement = singleArticles[singleArticles.length - 1];
   insertAfter(newNode, lastElement);

--- a/spec/system/articles/feeds/quickie_embed_engulf_spec.rb
+++ b/spec/system/articles/feeds/quickie_embed_engulf_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+# Regression for forem/forem#23266: initScrolling.js (lines 394-396) anchors
+# pagination on `querySelectorAll('.single-article, .crayons-story')`'s last
+# match, which can be a quickie's embed inner card — dropping `.paged-stories`
+# inside `.ltag__link--embedded`.
+RSpec.describe "Quickie embed feed engulfment (#23266)", :js do
+  before do
+    # Page-of-1 keeps the quickie alone on page 1 (so its embed is the
+    # trailing `.crayons-story`) and spills `target` to page 2.
+    stub_const("Article::DEFAULT_FEED_PAGINATION_WINDOW_SIZE", 1)
+
+    # /latest applies both filters (stories_controller.rb:370-373).
+    min_score = [Settings::UserExperience.home_feed_minimum_score,
+                 Settings::UserExperience.index_minimum_score].max + 1
+    user = create(:user)
+
+    # Embed target + page-2 content (older than the quickie).
+    target = create(:article, :past, past_published_at: 10.hours.ago, score: min_score, user: user)
+
+    # Build directly: the factory's `title` transient only writes to
+    # body_markdown frontmatter, but `add_urls_from_title_to_body`
+    # (article.rb:1702) needs a URL in the title *column* to inject the embed.
+    quickie = Article.new(
+      user: user,
+      type_of: "status",
+      title: "Look at this #{URL.article(target)}",
+      body_markdown: "",
+      main_image: nil,
+      published: true,
+    )
+    quickie.save!
+    quickie.update_columns(published_at: 1.hour.ago, score: min_score)
+  end
+
+  it "does not nest paginated feed cards inside the quickie embed" do
+    visit "/latest"
+
+    expect(page).to have_css(".ltag__link--embedded", wait: 5)
+    # Guard against vacuous pass: pagination must have fired.
+    expect(page).to have_css(".paged-stories", wait: 10, visible: :all)
+
+    # `visible: :all` because the embed's CSS hides engulfed descendants.
+    expect(page).to have_no_css(".ltag__link--embedded .paged-stories", visible: :all)
+  end
+end


### PR DESCRIPTION
  ## What type of PR is this? (check all applicable)

  - [x] Bug Fix

  ## Description

  `querySelectorAll('.single-article, .crayons-story')` in
  `initScrolling.js` (pagination-anchor lookup) also matched the
  SSR embed preview inside `.ltag__link--embedded`. When a quickie's
  embed was the trailing `.crayons-story` in the DOM, the next
  paginated batch was inserted inside the embed instead of after the
  feed — causing the indent / engulfment seen in #23266.

  Fix: exclude descendants of `.ltag__link--embedded` from that
  selector so the anchor always lands on a top-level feed card.

  ## Related Tickets & Documents

  - Closes #23266

  ## QA Instructions, Screenshots, Recordings

  1. Seed `/latest` so a quickie containing an embed sits at the
     bottom of page 1 (e.g. shrink `Article::DEFAULT_FEED_PAGINATION_WINDOW_SIZE`
     or order timestamps so the quickie is the last `.crayons-story`
     on page 1).
  2. Scroll to trigger infinite scroll.
  3. Before fix: `.paged-stories` is inserted inside
     `article.crayons-story > … > .ltag__link--embedded`, visually
     nesting later feed cards under the quickie embed.
  4. After fix: `.paged-stories` is appended at the feed root, after
     the last top-level card.
     
     I also managed to reproduce locally. Before fix:
     <img width="588" height="567" alt="forem_repro_1" src="https://github.com/user-attachments/assets/2ff138ab-cc08-46b0-9a7e-3caf08e363b7" />
     After:
<img width="692" height="597" alt="forem_repro_2" src="https://github.com/user-attachments/assets/3ee4f59d-81a7-41c4-ba09-5d532836bd5c" />



  ## Added/updated tests?

  - [x] Yes — `spec/system/articles/feeds/quickie_embed_engulf_spec.rb`
    (added in the prior commit, fails on `main`, passes with this
    selector change).
