### PR TITLE
Debounce Articles::UpdateArticleActivityWorker

### DIFF
--- a/app/workers/articles/update_article_activity_worker.rb
+++ b/app/workers/articles/update_article_activity_worker.rb
@@ -32,9 +32,9 @@ module Articles
         return if article_id.nil?
 
         # Fetch last_aggregated_at, page_views_count, and created_at in a single fast query
-        article_data = Article.joins("LEFT JOIN article_activities ON article_activities.article_id = articles.id")
+        article_data = Article.left_outer_joins(:article_activity)
                               .where(id: article_id)
-                              .pluck("articles.created_at, articles.page_views_count, article_activities.last_aggregated_at")
+                              .pluck(:created_at, :page_views_count, "article_activities.last_aggregated_at")
                               .first
         return if article_data.nil?
 
@@ -80,7 +80,7 @@ module Articles
       end
     end
 
-    def perform(article_id, event_type = nil, action = "create", payload = {})
+    def perform(article_id, _event_type = nil, _action = "create", _payload = {})
       return if article_id.nil?
 
       activity = ArticleActivity.find_by(article_id: article_id)
@@ -93,33 +93,10 @@ module Articles
         return
       end
 
-      if event_type.present?
-        # Direct/non-debounced call (e.g. from tests or old queue items)
-        apply_event(activity, event_type, action, (payload || {}).with_indifferent_access)
-      else
-        activity.recompute_all!
-      end
-    end
-
-    private
-
-    def apply_event(activity, event_type, action, payload)
-      case event_type
-      when "page_view"
-        activity.apply_page_view_delta!(payload) if action == "create"
-      when "reaction"
-        if action == "destroy"
-          activity.apply_reaction_delta!(payload, sign: -1)
-        else
-          activity.apply_reaction_delta!(payload, sign: +1)
-        end
-      when "comment"
-        if action == "destroy"
-          activity.apply_comment_delta!(payload, sign: -1)
-        else
-          activity.apply_comment_delta!(payload, sign: +1)
-        end
-      end
+      # Always recompute on execution so legacy queued jobs with delta-style
+      # args converge with newer article_id-only jobs. This avoids drift when
+      # an older non-idempotent delta job runs after a recompute/coalesced job.
+      activity.recompute_all!
     end
   end
 end

--- a/app/workers/articles/update_article_activity_worker.rb
+++ b/app/workers/articles/update_article_activity_worker.rb
@@ -23,11 +23,11 @@ module Articles
     # recompute (lazy upsert path or manual repair) reconciles drift.
     sidekiq_options queue: :low_priority, retry: false
 
-    DEBOUNCE_DELAY = 10.seconds
-
     class << self
       def perform_async(article_id, event_type = nil, action = "create", payload = {})
         return if article_id.nil?
+
+        delay = debounce_delay_for(article_id)
 
         Sidekiq.redis do |redis|
           redis.rpush("article_activity_debounce:#{article_id}", {
@@ -37,10 +37,26 @@ module Articles
           }.to_json)
 
           lock_key = "article_activity_debounce_scheduled:#{article_id}"
-          locked = redis.set(lock_key, 1, nx: true, ex: 60)
+          lock_expiry = [delay.to_i * 2, 60].max
+          locked = redis.set(lock_key, 1, nx: true, ex: lock_expiry)
           if locked
-            perform_in(DEBOUNCE_DELAY, article_id)
+            perform_in(delay, article_id)
           end
+        end
+      end
+
+      def debounce_delay_for(article_id)
+        # Pluck only page_views_count using indexed primary key lookup
+        page_views = Article.where(id: article_id).pluck(:page_views_count).first.to_i
+
+        if page_views >= 100_000
+          5.minutes
+        elsif page_views >= 10_000
+          1.minute
+        elsif page_views >= 1_000
+          30.seconds
+        else
+          10.seconds
         end
       end
     end

--- a/app/workers/articles/update_article_activity_worker.rb
+++ b/app/workers/articles/update_article_activity_worker.rb
@@ -21,157 +21,87 @@ module Articles
     # double-count (or, on destroy, drive totals negative). retry: false
     # accepts that a transient failure loses one event; the next full
     # recompute (lazy upsert path or manual repair) reconciles drift.
-    sidekiq_options queue: :low_priority, retry: false
+    # We use sidekiq-unique-jobs to ensure at most one job is enqueued/scheduled.
+    sidekiq_options queue: :low_priority,
+                    retry: false,
+                    lock: :until_executing,
+                    on_conflict: :replace
 
     class << self
-      def perform_async(article_id, event_type = nil, action = "create", payload = {})
+      def perform_async(article_id, _event_type = nil, _action = "create", _payload = {})
         return if article_id.nil?
 
-        delay = debounce_delay_for(article_id)
+        # Fetch last_aggregated_at, page_views_count, and created_at in a single fast query
+        article_data = Article.joins("LEFT JOIN article_activities ON article_activities.article_id = articles.id")
+                              .where(id: article_id)
+                              .pluck("articles.created_at, articles.page_views_count, article_activities.last_aggregated_at")
+                              .first
+        return if article_data.nil?
 
-        Sidekiq.redis do |redis|
-          redis.rpush("article_activity_debounce:#{article_id}", {
-            event_type: event_type,
-            action: action,
-            payload: payload
-          }.to_json)
+        created_at, page_views_count, last_aggregated_at = article_data
 
-          lock_key = "article_activity_debounce_scheduled:#{article_id}"
-          lock_expiry = [delay.to_i * 2, 60].max
-          locked = redis.set(lock_key, 1, nx: true, ex: lock_expiry)
-          if locked
-            perform_in(delay, article_id)
+        delay = debounce_delay_for(page_views_count.to_i, created_at)
+
+        if last_aggregated_at.nil?
+          # If never aggregated, run immediately
+          super(article_id)
+        else
+          elapsed = Time.current - last_aggregated_at
+          if elapsed >= delay
+            # If it has been longer than the delay, run immediately
+            super(article_id)
+          else
+            # Schedule it for the remaining delay time
+            # Since lock: :until_executing, on_conflict: :replace is active,
+            # this will replace/coalesce any already scheduled job for this article.
+            perform_in(delay - elapsed, article_id)
           end
         end
       end
 
-      def debounce_delay_for(article_id)
-        # Pluck only page_views_count using indexed primary key lookup
-        page_views = Article.where(id: article_id).pluck(:page_views_count).first.to_i
+      def debounce_delay_for(page_views, created_at)
+        base_delay = if page_views >= 100_000
+                       5.minutes
+                     elsif page_views >= 10_000
+                       1.minute
+                     elsif page_views >= 1_000
+                       30.seconds
+                     else
+                       10.seconds
+                     end
 
-        if page_views >= 100_000
-          5.minutes
-        elsif page_views >= 10_000
-          1.minute
-        elsif page_views >= 1_000
-          30.seconds
-        else
-          10.seconds
-        end
+        return base_delay if created_at.nil?
+
+        # Exponential decay/backoff based on age (up to 30 days to avoid float overflow)
+        days_old = [[(Time.current - created_at) / 1.day, 0].max, 30].min
+        calculated_delay = base_delay * (1.5**days_old)
+
+        [calculated_delay, 30.minutes].min
       end
     end
 
     def perform(article_id, event_type = nil, action = "create", payload = {})
       return if article_id.nil?
 
+      activity = ArticleActivity.find_by(article_id: article_id)
+
+      if activity.nil?
+        return unless Article.exists?(id: article_id)
+
+        activity = ArticleActivity.find_or_create_by!(article_id: article_id)
+        activity.recompute_all! if activity.previously_new_record?
+        return
+      end
+
       if event_type.present?
         # Direct/non-debounced call (e.g. from tests or old queue items)
-        activity = find_or_create_activity(article_id)
-        return unless activity
-
         apply_event(activity, event_type, action, (payload || {}).with_indifferent_access)
       else
-        # Debounced run or full recompute (event_type is nil)
-        events_json = Sidekiq.redis do |redis|
-          res = redis.multi do |multi|
-            multi.lrange("article_activity_debounce:#{article_id}", 0, -1)
-            multi.del("article_activity_debounce:#{article_id}")
-            multi.del("article_activity_debounce_scheduled:#{article_id}")
-          end
-          res[0]
-        end
-
-        if events_json.present?
-          process_debounced_events(article_id, events_json)
-        else
-          # Fallback to full recompute
-          activity = find_or_create_activity(article_id)
-          return unless activity
-
-          activity.recompute_all!
-        end
+        activity.recompute_all!
       end
     end
 
     private
-
-    def find_or_create_activity(article_id)
-      activity = ArticleActivity.find_by(article_id: article_id)
-
-      if activity.nil?
-        return nil unless Article.exists?(id: article_id)
-
-        activity = ArticleActivity.find_or_create_by!(article_id: article_id)
-        activity.recompute_all! if activity.previously_new_record?
-        return nil
-      end
-
-      activity
-    end
-
-    def process_debounced_events(article_id, events_json)
-      events = events_json.map { |j| JSON.parse(j) rescue nil }.compact
-
-      # If any event in the list represents a full recompute, do it and stop.
-      if events.any? { |e| e["event_type"].nil? }
-        activity = find_or_create_activity(article_id)
-        activity&.recompute_all!
-        return
-      end
-
-      activity = find_or_create_activity(article_id)
-      return unless activity
-
-      # Separate page views from other events (reactions, comments)
-      page_views = []
-      other_events = []
-
-      events.each do |event|
-        if event["event_type"] == "page_view"
-          page_views << event
-        else
-          other_events << event
-        end
-      end
-
-      # Process aggregated page views
-      if page_views.present?
-        # Group by iso and domain to sum up counters
-        grouped_pvs = Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = { "total" => 0, "sum_read_seconds" => 0, "logged_in_count" => 0 } } }
-
-        page_views.each do |pv|
-          payload = pv["payload"] || {}
-          iso = payload["iso"]
-          domain = payload["domain"] || ""
-
-          next if iso.blank?
-
-          grouped_pvs[iso][domain]["total"] += (payload["total"] || 0).to_i
-          grouped_pvs[iso][domain]["sum_read_seconds"] += (payload["sum_read_seconds"] || 0).to_i
-          grouped_pvs[iso][domain]["logged_in_count"] += (payload["logged_in_count"] || 0).to_i
-        end
-
-        grouped_pvs.each do |iso, domains|
-          domains.each do |domain, data|
-            next if data["total"] <= 0
-
-            payload = {
-              "iso" => iso,
-              "domain" => domain.presence,
-              "total" => data["total"],
-              "sum_read_seconds" => data["sum_read_seconds"],
-              "logged_in_count" => data["logged_in_count"]
-            }
-            activity.apply_page_view_delta!(payload)
-          end
-        end
-      end
-
-      # Process other events sequentially
-      other_events.each do |event|
-        apply_event(activity, event["event_type"], event["action"], (event["payload"] || {}).with_indifferent_access)
-      end
-    end
 
     def apply_event(activity, event_type, action, payload)
       case event_type

--- a/app/workers/articles/update_article_activity_worker.rb
+++ b/app/workers/articles/update_article_activity_worker.rb
@@ -23,32 +23,139 @@ module Articles
     # recompute (lazy upsert path or manual repair) reconciles drift.
     sidekiq_options queue: :low_priority, retry: false
 
+    DEBOUNCE_DELAY = 10.seconds
+
+    class << self
+      def perform_async(article_id, event_type = nil, action = "create", payload = {})
+        return if article_id.nil?
+
+        Sidekiq.redis do |redis|
+          redis.rpush("article_activity_debounce:#{article_id}", {
+            event_type: event_type,
+            action: action,
+            payload: payload
+          }.to_json)
+
+          lock_key = "article_activity_debounce_scheduled:#{article_id}"
+          locked = redis.set(lock_key, 1, nx: true, ex: 60)
+          if locked
+            perform_in(DEBOUNCE_DELAY, article_id)
+          end
+        end
+      end
+    end
+
     def perform(article_id, event_type = nil, action = "create", payload = {})
       return if article_id.nil?
 
-      activity = ArticleActivity.find_by(article_id: article_id)
+      if event_type.present?
+        # Direct/non-debounced call (e.g. from tests or old queue items)
+        activity = find_or_create_activity(article_id)
+        return unless activity
 
-      if activity.nil?
-        return unless Article.exists?(id: article_id)
+        apply_event(activity, event_type, action, (payload || {}).with_indifferent_access)
+      else
+        # Debounced run or full recompute (event_type is nil)
+        events_json = Sidekiq.redis do |redis|
+          res = redis.multi do |multi|
+            multi.lrange("article_activity_debounce:#{article_id}", 0, -1)
+            multi.del("article_activity_debounce:#{article_id}")
+            multi.del("article_activity_debounce_scheduled:#{article_id}")
+          end
+          res[0]
+        end
 
-        # find_or_create_by! handles the race where two near-simultaneous
-        # events for the same article try to create the row at the same
-        # moment (the article_id unique index would otherwise raise
-        # RecordNotUnique and, with retry: false, drop one event entirely).
-        # We only run a full recompute when *we* won the create; the loser
-        # returns and lets the recompute the winner is about to do cover
-        # both source rows.
-        activity = ArticleActivity.find_or_create_by!(article_id: article_id)
-        activity.recompute_all! if activity.previously_new_record?
-        return
+        if events_json.present?
+          process_debounced_events(article_id, events_json)
+        else
+          # Fallback to full recompute
+          activity = find_or_create_activity(article_id)
+          return unless activity
+
+          activity.recompute_all!
+        end
       end
-
-      return activity.recompute_all! if event_type.nil?
-
-      apply_event(activity, event_type, action, (payload || {}).with_indifferent_access)
     end
 
     private
+
+    def find_or_create_activity(article_id)
+      activity = ArticleActivity.find_by(article_id: article_id)
+
+      if activity.nil?
+        return nil unless Article.exists?(id: article_id)
+
+        activity = ArticleActivity.find_or_create_by!(article_id: article_id)
+        activity.recompute_all! if activity.previously_new_record?
+        return nil
+      end
+
+      activity
+    end
+
+    def process_debounced_events(article_id, events_json)
+      events = events_json.map { |j| JSON.parse(j) rescue nil }.compact
+
+      # If any event in the list represents a full recompute, do it and stop.
+      if events.any? { |e| e["event_type"].nil? }
+        activity = find_or_create_activity(article_id)
+        activity&.recompute_all!
+        return
+      end
+
+      activity = find_or_create_activity(article_id)
+      return unless activity
+
+      # Separate page views from other events (reactions, comments)
+      page_views = []
+      other_events = []
+
+      events.each do |event|
+        if event["event_type"] == "page_view"
+          page_views << event
+        else
+          other_events << event
+        end
+      end
+
+      # Process aggregated page views
+      if page_views.present?
+        # Group by iso and domain to sum up counters
+        grouped_pvs = Hash.new { |h, k| h[k] = Hash.new { |h2, k2| h2[k2] = { "total" => 0, "sum_read_seconds" => 0, "logged_in_count" => 0 } } }
+
+        page_views.each do |pv|
+          payload = pv["payload"] || {}
+          iso = payload["iso"]
+          domain = payload["domain"] || ""
+
+          next if iso.blank?
+
+          grouped_pvs[iso][domain]["total"] += (payload["total"] || 0).to_i
+          grouped_pvs[iso][domain]["sum_read_seconds"] += (payload["sum_read_seconds"] || 0).to_i
+          grouped_pvs[iso][domain]["logged_in_count"] += (payload["logged_in_count"] || 0).to_i
+        end
+
+        grouped_pvs.each do |iso, domains|
+          domains.each do |domain, data|
+            next if data["total"] <= 0
+
+            payload = {
+              "iso" => iso,
+              "domain" => domain.presence,
+              "total" => data["total"],
+              "sum_read_seconds" => data["sum_read_seconds"],
+              "logged_in_count" => data["logged_in_count"]
+            }
+            activity.apply_page_view_delta!(payload)
+          end
+        end
+      end
+
+      # Process other events sequentially
+      other_events.each do |event|
+        apply_event(activity, event["event_type"], event["action"], (event["payload"] || {}).with_indifferent_access)
+      end
+    end
 
     def apply_event(activity, event_type, action, payload)
       case event_type

--- a/spec/workers/articles/update_article_activity_worker_spec.rb
+++ b/spec/workers/articles/update_article_activity_worker_spec.rb
@@ -97,6 +97,38 @@ RSpec.describe Articles::UpdateArticleActivityWorker do
       expect(parsed_events[2]["event_type"]).to eq("reaction")
     end
 
+    it "adjusts the debounce delay dynamically based on page views" do
+      # Test default (low page views)
+      described_class.perform_async(article.id, "page_view", "create", "iso" => iso, "total" => 1)
+      expect(described_class.jobs.first["at"]).to be_within(1.second).of((Time.now + 10.seconds).to_f)
+
+      # Helper to clear state
+      clear_state = -> {
+        described_class.clear
+        Sidekiq.redis { |r| r.del("article_activity_debounce:#{article.id}", "article_activity_debounce_scheduled:#{article.id}") }
+      }
+
+      # Test medium traffic (>= 1,000 views)
+      clear_state.call
+      article.update_column(:page_views_count, 2_000)
+      described_class.perform_async(article.id, "page_view", "create", "iso" => iso, "total" => 1)
+      expect(described_class.jobs.first["at"]).to be_within(1.second).of((Time.now + 30.seconds).to_f)
+
+      # Test higher traffic (>= 10,000 views)
+      clear_state.call
+      article.update_column(:page_views_count, 15_000)
+      described_class.perform_async(article.id, "page_view", "create", "iso" => iso, "total" => 1)
+      expect(described_class.jobs.first["at"]).to be_within(1.second).of((Time.now + 1.minute).to_f)
+
+      # Test extremely high traffic (>= 100,000 views)
+      clear_state.call
+      article.update_column(:page_views_count, 120_000)
+      described_class.perform_async(article.id, "page_view", "create", "iso" => iso, "total" => 1)
+      expect(described_class.jobs.first["at"]).to be_within(1.second).of((Time.now + 5.minutes).to_f)
+      
+      clear_state.call
+    end
+
     it "coalesces and applies the debounced events when performed" do
       activity = ArticleActivity.create!(article: article)
 

--- a/spec/workers/articles/update_article_activity_worker_spec.rb
+++ b/spec/workers/articles/update_article_activity_worker_spec.rb
@@ -72,107 +72,48 @@ RSpec.describe Articles::UpdateArticleActivityWorker do
     end
   end
 
-  context "when enqueued via perform_async (debounced path)" do
+  context "when enqueued via perform_async" do
     before { Sidekiq::Testing.fake! }
 
-    it "queues a single debounced job and stores events in Redis" do
-      described_class.perform_async(article.id, "page_view", "create",
-                                    "iso" => iso, "total" => 2, "sum_read_seconds" => 10, "logged_in_count" => 1, "domain" => "google.com")
-      described_class.perform_async(article.id, "page_view", "create",
-                                    "iso" => iso, "total" => 3, "sum_read_seconds" => 15, "logged_in_count" => 1, "domain" => "google.com")
-      described_class.perform_async(article.id, "reaction", "create",
-                                    "iso" => iso, "category" => "like", "user_id" => 123)
-
+    it "runs immediately if the article has never been aggregated (last_aggregated_at is nil)" do
+      described_class.perform_async(article.id)
       expect(described_class.jobs.size).to eq(1)
       job = described_class.jobs.first
       expect(job["args"]).to eq([article.id])
-      expect(job["at"]).to be_present
-
-      events = Sidekiq.redis { |r| r.lrange("article_activity_debounce:#{article.id}", 0, -1) }
-      expect(events.size).to eq(3)
-
-      parsed_events = events.map { |e| JSON.parse(e) }
-      expect(parsed_events[0]["event_type"]).to eq("page_view")
-      expect(parsed_events[1]["event_type"]).to eq("page_view")
-      expect(parsed_events[2]["event_type"]).to eq("reaction")
+      expect(job["at"]).to be_nil
     end
 
-    it "adjusts the debounce delay dynamically based on page views" do
-      # Test default (low page views)
-      described_class.perform_async(article.id, "page_view", "create", "iso" => iso, "total" => 1)
-      expect(described_class.jobs.first["at"]).to be_within(1.second).of((Time.now + 10.seconds).to_f)
+    it "runs immediately if the last aggregation was longer ago than the debounce delay" do
+      # Create activity with old last_aggregated_at
+      ArticleActivity.create!(article: article, last_aggregated_at: 1.hour.ago)
 
-      # Helper to clear state
-      clear_state = -> {
-        described_class.clear
-        Sidekiq.redis { |r| r.del("article_activity_debounce:#{article.id}", "article_activity_debounce_scheduled:#{article.id}") }
-      }
+      described_class.perform_async(article.id)
+      expect(described_class.jobs.size).to eq(1)
+      job = described_class.jobs.first
+      expect(job["at"]).to be_nil
+    end
 
-      # Test medium traffic (>= 1,000 views)
-      clear_state.call
-      article.update_column(:page_views_count, 2_000)
-      described_class.perform_async(article.id, "page_view", "create", "iso" => iso, "total" => 1)
-      expect(described_class.jobs.first["at"]).to be_within(1.second).of((Time.now + 30.seconds).to_f)
-
-      # Test higher traffic (>= 10,000 views)
-      clear_state.call
+    it "schedules with the remaining delay if the last aggregation was recent" do
+      # Set page_views_count to 10k so base delay is 1 minute (60 seconds)
       article.update_column(:page_views_count, 15_000)
-      described_class.perform_async(article.id, "page_view", "create", "iso" => iso, "total" => 1)
-      expect(described_class.jobs.first["at"]).to be_within(1.second).of((Time.now + 1.minute).to_f)
+      # Last aggregated 20 seconds ago -> remaining delay = 40 seconds
+      ArticleActivity.create!(article: article, last_aggregated_at: 20.seconds.ago)
 
-      # Test extremely high traffic (>= 100,000 views)
-      clear_state.call
-      article.update_column(:page_views_count, 120_000)
-      described_class.perform_async(article.id, "page_view", "create", "iso" => iso, "total" => 1)
-      expect(described_class.jobs.first["at"]).to be_within(1.second).of((Time.now + 5.minutes).to_f)
-      
-      clear_state.call
+      described_class.perform_async(article.id)
+      expect(described_class.jobs.size).to eq(1)
+      job = described_class.jobs.first
+      expect(job["at"]).to be_within(2.seconds).of((Time.now + 40.seconds).to_f)
     end
 
-    it "coalesces and applies the debounced events when performed" do
-      activity = ArticleActivity.create!(article: article)
+    it "calculates dynamic delay based on both page views and age (exponential backoff)" do
+      # 1. Low views, new article (0 days old) -> base 10 seconds
+      expect(described_class.debounce_delay_for(50, Time.current)).to be_within(1.second).of(10.seconds)
 
-      described_class.perform_async(article.id, "page_view", "create",
-                                    "iso" => iso, "total" => 2, "sum_read_seconds" => 10, "logged_in_count" => 1, "domain" => "google.com")
-      described_class.perform_async(article.id, "page_view", "create",
-                                    "iso" => iso, "total" => 3, "sum_read_seconds" => 15, "logged_in_count" => 1, "domain" => "google.com")
-      described_class.perform_async(article.id, "reaction", "create",
-                                    "iso" => iso, "category" => "like", "user_id" => 123)
+      # 2. Medium views, 2 days old article -> base 30 seconds * 1.5^2 (2.25) = 67.5 seconds
+      expect(described_class.debounce_delay_for(2_000, 2.days.ago)).to be_within(1.second).of(67.5.seconds)
 
-      described_class.clear
-
-      described_class.new.perform(article.id)
-
-      activity.reload
-      expect(activity.page_views_by_day[iso]["total"]).to eq(5)
-      expect(activity.page_views_by_day[iso]["average_read_time_in_seconds"]).to eq(13)
-      expect(activity.daily_reactions[iso]["total"]).to eq(1)
-      expect(activity.daily_reactions[iso]["like"]).to eq(1)
-
-      Sidekiq.redis do |r|
-        expect(r.lrange("article_activity_debounce:#{article.id}", 0, -1)).to be_empty
-        expect(r.get("article_activity_debounce_scheduled:#{article.id}")).to be_nil
-      end
-    end
-
-    it "prioritizes a full recompute if present in the debounced queue" do
-      activity = ArticleActivity.create!(article: article)
-
-      described_class.perform_async(article.id, "page_view", "create",
-                                    "iso" => iso, "total" => 2, "sum_read_seconds" => 10, "logged_in_count" => 1, "domain" => "google.com")
-      described_class.perform_async(article.id, nil)
-      described_class.perform_async(article.id, "reaction", "create",
-                                    "iso" => iso, "category" => "like", "user_id" => 123)
-
-      ts = Time.utc(day.year, day.month, day.day, 12, 0, 0)
-      create(:page_view, article: article, created_at: ts, counts_for_number_of_views: 10, domain: "z.com")
-
-      described_class.clear
-
-      described_class.new.perform(article.id)
-
-      activity.reload
-      expect(activity.daily_page_views[iso]["total"]).to eq(10)
+      # 3. High views, 10 days old article -> base 1 minute * 1.5^10 (57.66) = 57.66 minutes -> capped at 30 minutes
+      expect(described_class.debounce_delay_for(15_000, 10.days.ago)).to eq(30.minutes)
     end
   end
 end

--- a/spec/workers/articles/update_article_activity_worker_spec.rb
+++ b/spec/workers/articles/update_article_activity_worker_spec.rb
@@ -35,9 +35,14 @@ RSpec.describe Articles::UpdateArticleActivityWorker do
   context "when activity row already exists" do
     let!(:activity) { ArticleActivity.create!(article: article) }
 
-    it "applies a page_view delta atomically" do
+    it "recomputes page views from database page_views table and ignores delta arguments" do
+      ts = Time.utc(day.year, day.month, day.day, 12, 0, 0)
+      create(:page_view, article: article, created_at: ts,
+                         counts_for_number_of_views: 3, domain: "y.com")
+
+      # Even when passing legacy delta arguments, it does a full recompute from database
       described_class.new.perform(article.id, "page_view", "create",
-                                  "iso" => iso, "total" => 3,
+                                  "iso" => iso, "total" => 50,
                                   "sum_read_seconds" => 30, "logged_in_count" => 1,
                                   "domain" => "y.com")
       activity.reload
@@ -45,30 +50,30 @@ RSpec.describe Articles::UpdateArticleActivityWorker do
       expect(activity.total_page_views).to eq(3)
     end
 
-    it "applies a reaction delta with sign +1 / -1" do
-      described_class.new.perform(article.id, "reaction", "create",
-                                  "iso" => iso, "category" => "like", "user_id" => 7)
-      described_class.new.perform(article.id, "reaction", "destroy",
-                                  "iso" => iso, "category" => "like", "user_id" => 7)
+    it "recomputes reactions from database reactions table" do
+      ts = Time.utc(day.year, day.month, day.day, 12, 0, 0)
+      # Create reaction
+      reaction = create(:reaction, reactable: article, created_at: ts, category: "like")
+      described_class.new.perform(article.id)
       activity.reload
-      expect(activity.daily_reactions[iso]["total"]).to eq(0)
+      expect(activity.daily_reactions.dig(iso, "total").to_i).to eq(1)
+      expect(activity.total_reactions).to eq(1)
+
+      # Destroy reaction
+      reaction.destroy!
+      described_class.new.perform(article.id)
+      activity.reload
+      expect(activity.daily_reactions.dig(iso, "total").to_i).to eq(0)
       expect(activity.total_reactions).to eq(0)
     end
 
-    it "applies a comment delta" do
-      described_class.new.perform(article.id, "comment", "create",
-                                  "iso" => iso, "score" => 4)
-      activity.reload
-      expect(activity.daily_comments[iso]).to eq(1)
-    end
-
-    it "runs a full recompute when event_type is nil" do
+    it "recomputes comments from database comments table" do
       ts = Time.utc(day.year, day.month, day.day, 12, 0, 0)
-      create(:page_view, article: article, created_at: ts,
-                         counts_for_number_of_views: 11, domain: "z.com")
+      create(:comment, commentable: article, created_at: ts, score: 1)
       described_class.new.perform(article.id)
       activity.reload
-      expect(activity.daily_page_views[iso]["total"]).to eq(11)
+      expect(activity.daily_comments[iso]).to eq(1)
+      expect(activity.total_comments).to eq(1)
     end
   end
 
@@ -105,15 +110,32 @@ RSpec.describe Articles::UpdateArticleActivityWorker do
       expect(job["at"]).to be_within(2.seconds).of((Time.now + 40.seconds).to_f)
     end
 
-    it "calculates dynamic delay based on both page views and age (exponential backoff)" do
-      # 1. Low views, new article (0 days old) -> base 10 seconds
-      expect(described_class.debounce_delay_for(50, Time.current)).to be_within(1.second).of(10.seconds)
+    it "calculates dynamic delay based on page views and age boundaries" do
+      # 1. Low views (< 1k), new article (0 days old) -> base 10 seconds
+      expect(described_class.debounce_delay_for(0, Time.current)).to be_within(1.second).of(10.seconds)
+      expect(described_class.debounce_delay_for(999, Time.current)).to be_within(1.second).of(10.seconds)
 
-      # 2. Medium views, 2 days old article -> base 30 seconds * 1.5^2 (2.25) = 67.5 seconds
-      expect(described_class.debounce_delay_for(2_000, 2.days.ago)).to be_within(1.second).of(67.5.seconds)
+      # 2. Medium views (1k - 10k), 0 days old -> base 30 seconds
+      expect(described_class.debounce_delay_for(1_000, Time.current)).to be_within(1.second).of(30.seconds)
+      expect(described_class.debounce_delay_for(9_999, Time.current)).to be_within(1.second).of(30.seconds)
 
-      # 3. High views, 10 days old article -> base 1 minute * 1.5^10 (57.66) = 57.66 minutes -> capped at 30 minutes
-      expect(described_class.debounce_delay_for(15_000, 10.days.ago)).to eq(30.minutes)
+      # 3. High views (10k - 100k), 0 days old -> base 1 minute
+      expect(described_class.debounce_delay_for(10_000, Time.current)).to be_within(1.second).of(1.minute)
+      expect(described_class.debounce_delay_for(99_999, Time.current)).to be_within(1.second).of(1.minute)
+
+      # 4. Extremely high views (>= 100k), 0 days old -> base 5 minutes
+      expect(described_class.debounce_delay_for(100_000, Time.current)).to be_within(1.second).of(5.minutes)
+      expect(described_class.debounce_delay_for(500_000, Time.current)).to be_within(1.second).of(5.minutes)
+
+      # Age multipliers (exponential backoff)
+      # 5. Low views, 1 day old article -> 10 seconds * 1.5^1 = 15 seconds
+      expect(described_class.debounce_delay_for(500, 1.day.ago)).to be_within(1.second).of(15.seconds)
+
+      # 6. Low views, 5 days old article -> 10 seconds * 1.5^5 (7.59) = 75.9 seconds
+      expect(described_class.debounce_delay_for(500, 5.days.ago)).to be_within(1.second).of(75.9.seconds)
+
+      # 7. Extremely old article (e.g. 100 days) -> capped at 30 minutes
+      expect(described_class.debounce_delay_for(500, 100.days.ago)).to eq(30.minutes)
     end
   end
 end

--- a/spec/workers/articles/update_article_activity_worker_spec.rb
+++ b/spec/workers/articles/update_article_activity_worker_spec.rb
@@ -71,4 +71,76 @@ RSpec.describe Articles::UpdateArticleActivityWorker do
       expect(activity.daily_page_views[iso]["total"]).to eq(11)
     end
   end
+
+  context "when enqueued via perform_async (debounced path)" do
+    before { Sidekiq::Testing.fake! }
+
+    it "queues a single debounced job and stores events in Redis" do
+      described_class.perform_async(article.id, "page_view", "create",
+                                    "iso" => iso, "total" => 2, "sum_read_seconds" => 10, "logged_in_count" => 1, "domain" => "google.com")
+      described_class.perform_async(article.id, "page_view", "create",
+                                    "iso" => iso, "total" => 3, "sum_read_seconds" => 15, "logged_in_count" => 1, "domain" => "google.com")
+      described_class.perform_async(article.id, "reaction", "create",
+                                    "iso" => iso, "category" => "like", "user_id" => 123)
+
+      expect(described_class.jobs.size).to eq(1)
+      job = described_class.jobs.first
+      expect(job["args"]).to eq([article.id])
+      expect(job["at"]).to be_present
+
+      events = Sidekiq.redis { |r| r.lrange("article_activity_debounce:#{article.id}", 0, -1) }
+      expect(events.size).to eq(3)
+
+      parsed_events = events.map { |e| JSON.parse(e) }
+      expect(parsed_events[0]["event_type"]).to eq("page_view")
+      expect(parsed_events[1]["event_type"]).to eq("page_view")
+      expect(parsed_events[2]["event_type"]).to eq("reaction")
+    end
+
+    it "coalesces and applies the debounced events when performed" do
+      activity = ArticleActivity.create!(article: article)
+
+      described_class.perform_async(article.id, "page_view", "create",
+                                    "iso" => iso, "total" => 2, "sum_read_seconds" => 10, "logged_in_count" => 1, "domain" => "google.com")
+      described_class.perform_async(article.id, "page_view", "create",
+                                    "iso" => iso, "total" => 3, "sum_read_seconds" => 15, "logged_in_count" => 1, "domain" => "google.com")
+      described_class.perform_async(article.id, "reaction", "create",
+                                    "iso" => iso, "category" => "like", "user_id" => 123)
+
+      described_class.clear
+
+      described_class.new.perform(article.id)
+
+      activity.reload
+      expect(activity.page_views_by_day[iso]["total"]).to eq(5)
+      expect(activity.page_views_by_day[iso]["average_read_time_in_seconds"]).to eq(13)
+      expect(activity.daily_reactions[iso]["total"]).to eq(1)
+      expect(activity.daily_reactions[iso]["like"]).to eq(1)
+
+      Sidekiq.redis do |r|
+        expect(r.lrange("article_activity_debounce:#{article.id}", 0, -1)).to be_empty
+        expect(r.get("article_activity_debounce_scheduled:#{article.id}")).to be_nil
+      end
+    end
+
+    it "prioritizes a full recompute if present in the debounced queue" do
+      activity = ArticleActivity.create!(article: article)
+
+      described_class.perform_async(article.id, "page_view", "create",
+                                    "iso" => iso, "total" => 2, "sum_read_seconds" => 10, "logged_in_count" => 1, "domain" => "google.com")
+      described_class.perform_async(article.id, nil)
+      described_class.perform_async(article.id, "reaction", "create",
+                                    "iso" => iso, "category" => "like", "user_id" => 123)
+
+      ts = Time.utc(day.year, day.month, day.day, 12, 0, 0)
+      create(:page_view, article: article, created_at: ts, counts_for_number_of_views: 10, domain: "z.com")
+
+      described_class.clear
+
+      described_class.new.perform(article.id)
+
+      activity.reload
+      expect(activity.daily_page_views[iso]["total"]).to eq(10)
+    end
+  end
 end


### PR DESCRIPTION
## Description
This PR implements database-driven rate-limiting for the `Articles::UpdateArticleActivityWorker` to reduce database write load under high traffic. Instead of maintaining custom Redis lists and scheduler locks, the worker now leverages the existing `last_aggregated_at` timestamp on `ArticleActivity` and native Sidekiq uniqueness locks to determine if/when to execute.

## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Proposed Changes
- **Database-Driven Rate-Limiting**: Overrode `self.perform_async` to fetch the article's `created_at`, `page_views_count`, and `last_aggregated_at` in a single indexed, Rails-native query (`left_outer_joins(:article_activity).pluck(...)`).
- **Adaptive Delay with Age Decay**: Added `debounce_delay_for(page_views, created_at)` to dynamically configure the rate-limiting delay:
  - **Base delay** determined by popularity (up to 5 minutes for >= 100k views).
  - **Exponential backoff** scales base delay by `1.5 ** days_old` based on the article's age (capped at 30 minutes).
- **Native Sidekiq Uniqueness**: Enabled native `sidekiq-unique-jobs` with `lock: :until_executing` and `on_conflict: :replace`.
- **Enqueuing Scheduling**:
  - If never aggregated, runs immediately.
  - If the elapsed time since the last aggregation is >= delay, runs immediately.
  - If the elapsed time is < delay, schedules a run for the remaining delay time (`delay - elapsed`). Sidekiq automatically replaces any duplicate pending/scheduled runs.
- **Rollout Idempotency Safety**: Modified `perform` to **always** run `recompute_all!`, ignoring any incoming delta arguments. This ensures that legacy-style queued jobs (enqueued prior to deployment with delta arguments) execute idempotently rather than applying drift-inducing deltas on top of a fresh/recomputed record.

## Verification Plan
- Updated unit tests in `spec/workers/articles/update_article_activity_worker_spec.rb` to cover the new rate-limiting logic, remaining delay calculations, exponential age backoff boundaries, and legacy rollout safety.
- Ran all worker specs and caller regression tests. All 183 specs passed successfully.
