### PR TITLE
Fix EOFError in SetSubforem middleware on empty multipart requests

### DIFF
--- a/app/lib/middlewares/set_subforem.rb
+++ b/app/lib/middlewares/set_subforem.rb
@@ -8,7 +8,7 @@ module Middlewares
     def call(env)
       request = Rack::Request.new(env)
 
-      domain = request.params["passed_domain"].presence || request.host
+      domain = request.GET["passed_domain"].presence || request.host
       RequestStore.store[:default_subforem_id]     = Subforem.cached_default_id
       RequestStore.store[:subforem_id]             = Subforem.cached_id_by_domain(domain)
       RequestStore.store[:root_subforem_id]        = Subforem.cached_root_id

--- a/spec/lib/middlewares/set_subforem_spec.rb
+++ b/spec/lib/middlewares/set_subforem_spec.rb
@@ -115,6 +115,21 @@ RSpec.describe Middlewares::SetSubforem do
         expect(RequestStore.store[:subforem_domain]).to eq("override.example.com")
       end
     end
+
+    context "when a request has an empty body and a multipart Content-Type header" do
+      let(:env) do
+        Rack::MockRequest.env_for(
+          "https://actual.example.com/articles",
+          "CONTENT_TYPE" => "multipart/form-data; boundary=----WebKitFormBoundaryE199uG4vT6",
+          "CONTENT_LENGTH" => "100",
+          :input => ""
+        )
+      end
+
+      it "does not raise EOFError" do
+        expect { middleware.call(env) }.not_to raise_error
+      end
+    end
   end
 end
 


### PR DESCRIPTION
### What's the deal?
In production, requests (including GET requests) sent with a `Content-Type: multipart/form-data` header but having an empty or truncated body raise an `EOFError: bad content body` from Rack's multipart parser inside the early-stage `SetSubforem` middleware.

This happens because the middleware was calling `request.params["passed_domain"]`. Calling `Rack::Request#params` merges query parameters and POST parameters. If a request indicates a multipart content type, calling `params` triggers the multipart parser to read the body stream. When the stream is empty/invalid, Rack raises `EOFError`.

### How was it fixed?
Since `passed_domain` is expected as a GET query parameter in the URL, we changed `request.params` to `request.GET`. This avoids parsing the request body entirely inside the middleware, resolving the error.

A regression test simulating an empty-body multipart request has been added to verify the fix.
