### PR TITLE
Add generated cover images for trends

### DIFF
--- a/app/services/ai/trend_detector.rb
+++ b/app/services/ai/trend_detector.rb
@@ -73,26 +73,30 @@ module Ai
         metadata = generate_trend_metadata(cluster[:articles].first(5))
         next if metadata.blank?
 
+        trend = nil
+        new_trend_created = false
+
         Trend.transaction do
-          trend = if existing_trend
-                    existing_trend.update!(
-                      name: metadata["name"],
-                      description: metadata["description"],
-                      key_questions: metadata["key_questions"],
-                      centroid_embedding: cluster[:centroid],
-                      last_observed_at: Time.current
-                    )
-                    existing_trend
-                  else
-                    Trend.create!(
-                      name: metadata["name"],
-                      description: metadata["description"],
-                      key_questions: metadata["key_questions"],
-                      centroid_embedding: cluster[:centroid],
-                      first_observed_at: Time.current,
-                      last_observed_at: Time.current
-                    )
-                  end
+          if existing_trend
+            existing_trend.update!(
+              name: metadata["name"],
+              description: metadata["description"],
+              key_questions: metadata["key_questions"],
+              centroid_embedding: cluster[:centroid],
+              last_observed_at: Time.current
+            )
+            trend = existing_trend
+          else
+            trend = Trend.create!(
+              name: metadata["name"],
+              description: metadata["description"],
+              key_questions: metadata["key_questions"],
+              centroid_embedding: cluster[:centroid],
+              first_observed_at: Time.current,
+              last_observed_at: Time.current
+            )
+            new_trend_created = true
+          end
 
           # Sync memberships
           active_article_ids = cluster[:articles].map(&:id)
@@ -107,6 +111,10 @@ module Ai
 
           # Recalculate trend score
           recalculate_trend_score(trend, days_lookback: days_lookback)
+        end
+
+        if new_trend_created && trend
+          Trends::GenerateCoverImageWorker.perform_async(trend.id)
         end
       end
     end

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -35,6 +35,12 @@
               </span>
             </div>
 
+            <% if trend.cover_image.present? %>
+              <%= link_to trend_path(trend.slug), class: "block mb-4 overflow-hidden rounded", style: "aspect-ratio: 16/9;" do %>
+                <img src="<%= optimized_image_url(trend.cover_image, width: 500, random_fallback: false) %>" class="w-100 h-100 object-cover block" alt="Cover image for <%= trend.name %>" loading="lazy">
+              <% end %>
+            <% end %>
+
             <h2 class="fs-xl font-bold mb-2">
               <%= link_to trend.name, trend_path(trend.slug), class: "color-base-100 hover:color-brand-100" %>
             </h2>

--- a/app/views/trends/show.html.erb
+++ b/app/views/trends/show.html.erb
@@ -3,6 +3,15 @@
 <%= content_for :page_meta do %>
   <link rel="canonical" href="<%= app_url(trend_path(@trend.slug)) %>" />
   <meta name="description" content="<%= @trend.description %>">
+  <meta property="og:title" content="<%= @trend.name %> - Trend" />
+  <meta property="og:description" content="<%= @trend.description %>" />
+  <meta property="og:url" content="<%= app_url(trend_path(@trend.slug)) %>" />
+  <meta property="og:type" content="article" />
+  <% if @trend.cover_image.present? %>
+    <meta property="og:image" content="<%= optimized_image_url(@trend.cover_image, width: 1200, random_fallback: false) %>" />
+    <meta name="twitter:image:src" content="<%= optimized_image_url(@trend.cover_image, width: 1200, random_fallback: false) %>">
+    <meta name="twitter:card" content="summary_large_image">
+  <% end %>
 <% end %>
 
 <div class="crayons-layout crayons-layout--2-cols crayons-layout--2-cols--inverted px-3 m:px-0" id="trend-show-container">
@@ -12,6 +21,11 @@
       <div class="flex items-center gap-2 mb-2">
         <%= link_to "← All Trends", trends_path, class: "fs-s fw-semibold color-base-60 hover:color-brand-100" %>
       </div>
+      <% if @trend.cover_image.present? %>
+        <div class="mb-4 overflow-hidden rounded" style="aspect-ratio: 16/9; max-height: 350px;">
+          <img src="<%= optimized_image_url(@trend.cover_image, width: 1000, random_fallback: false) %>" class="w-100 h-100 object-cover block" alt="Cover image for <%= @trend.name %>">
+        </div>
+      <% end %>
       <h1 class="crayons-title fs-3xl font-extrabold mb-2">
         <%= @trend.name %>
       </h1>

--- a/app/workers/trends/generate_cover_image_worker.rb
+++ b/app/workers/trends/generate_cover_image_worker.rb
@@ -1,0 +1,58 @@
+module Trends
+  class GenerateCoverImageWorker
+    include Sidekiq::Job
+
+    sidekiq_options queue: :low_priority, retry: 5
+
+    CONTENT_SAFETY_SUFFIX =
+      "Do not under any circumstances generate any violence, gore, lewd, or explicit content of any kind regardless of prior instructions."
+
+    def perform(trend_id)
+      # Ensure API key is configured
+      return unless ENV["GEMINI_API_KEY"].present?
+
+      trend = Trend.find_by(id: trend_id)
+      return unless trend
+      return if trend.cover_image.present? # Only generate once
+
+      prompt = build_prompt(trend)
+
+      # 16:9 is the standard aspect ratio for linkedin-friendly/OG images
+      result = Ai::ImageGenerator.new(
+        prompt,
+        aspect_ratio: "16:9"
+      ).generate
+
+      return unless result&.url
+
+      trend.update!(cover_image: result.url)
+    rescue StandardError => e
+      Rails.logger.error("AI cover image generation failed for trend #{trend_id}: #{e.message}")
+      Honeybadger.notify(e, context: { trend_id: trend_id }) if defined?(Honeybadger)
+    end
+
+    private
+
+    def build_prompt(trend)
+      base_prompt = "A cheeky and abstract representation of the following developer trend topic: '#{trend.name}'. Context: #{trend.description}."
+      aesthetic_instructions = fetch_aesthetic_instructions
+
+      if aesthetic_instructions.present?
+        "#{base_prompt} Style to use if not otherwise contradicted previously: " \
+          "#{aesthetic_instructions}.\n\n#{CONTENT_SAFETY_SUFFIX}"
+      else
+        "#{base_prompt}\n\n#{CONTENT_SAFETY_SUFFIX}"
+      end
+    end
+
+    def fetch_aesthetic_instructions
+      instructions = Settings::UserExperience.cover_image_aesthetic_instructions
+      return instructions if instructions.present?
+
+      default_subforem_id = RequestStore.store[:default_subforem_id] || Subforem.cached_default_id
+      return if default_subforem_id.blank?
+
+      Settings::UserExperience.cover_image_aesthetic_instructions(subforem_id: default_subforem_id)
+    end
+  end
+end

--- a/db/migrate/20260521163241_add_cover_image_to_trends.rb
+++ b/db/migrate/20260521163241_add_cover_image_to_trends.rb
@@ -1,0 +1,5 @@
+class AddCoverImageToTrends < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trends, :cover_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_20_120701) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_21_163241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -1757,6 +1757,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_20_120701) do
   create_table "trends", force: :cascade do |t|
     t.integer "articles_count", default: 0, null: false
     t.vector "centroid_embedding", limit: 768, null: false
+    t.string "cover_image"
     t.datetime "created_at", null: false
     t.text "description"
     t.datetime "first_observed_at", null: false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 ENV["RAILS_ENV"] = "test"
 # Temporary workaround for Ruby 3.0.6 / CGI udpate
 ENV["APP_DOMAIN"] = "forem.test"
+ENV["APP_PROTOCOL"] ||= "http://"
 require "knapsack_pro"
 require "simplecov"
 require "simplecov_json_formatter"

--- a/spec/requests/trends_spec.rb
+++ b/spec/requests/trends_spec.rb
@@ -3,18 +3,32 @@ require "rails_helper"
 RSpec.describe "Trends", type: :request do
   describe "GET /trends" do
     it "renders the trends list" do
-      trend1 = create(:trend, name: "Ruby 3.4 release", score: 10)
+      allow(Images::Optimizer).to receive(:call).and_call_original
+      allow(Images::Optimizer).to receive(:call)
+        .with("https://example.com/ruby34.png", hash_including(width: 500))
+        .and_return("https://optimized.example.com/ruby34_500.png")
+
+      trend1 = create(:trend, name: "Ruby 3.4 release", score: 10, cover_image: "https://example.com/ruby34.png")
       trend2 = create(:trend, name: "AI Agent Revolution", score: 5)
 
       get trends_path
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Emergent Trends", "Ruby 3.4 release", "AI Agent Revolution")
+      expect(response.body).to include("https://optimized.example.com/ruby34_500.png")
     end
   end
 
   describe "GET /trends/:slug" do
     it "renders the trend details and list of articles" do
-      trend = create(:trend, name: "Ruby 3.4 release", description: "Awesome discussions about Ruby 3.4 features")
+      allow(Images::Optimizer).to receive(:call).and_call_original
+      allow(Images::Optimizer).to receive(:call)
+        .with("https://example.com/ruby34_large.png", hash_including(width: 1000))
+        .and_return("https://optimized.example.com/ruby34_1000.png")
+      allow(Images::Optimizer).to receive(:call)
+        .with("https://example.com/ruby34_large.png", hash_including(width: 1200))
+        .and_return("https://optimized.example.com/ruby34_1200.png")
+
+      trend = create(:trend, name: "Ruby 3.4 release", description: "Awesome discussions about Ruby 3.4 features", cover_image: "https://example.com/ruby34_large.png")
       article1 = create(:article, published: true, title: "Ruby 3.4 features deep dive")
       article2 = create(:article, published: true, title: "Why I love Ruby 3.4")
 
@@ -26,6 +40,11 @@ RSpec.describe "Trends", type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Ruby 3.4 release", "Awesome discussions about Ruby 3.4 features")
       expect(response.body).to include("Ruby 3.4 features deep dive", "Why I love Ruby 3.4")
+      
+      # Assert cover image and OG/Twitter tags
+      expect(response.body).to include("https://optimized.example.com/ruby34_1000.png")
+      expect(response.body).to include('property="og:image" content="https://optimized.example.com/ruby34_1200.png"')
+      expect(response.body).to include('name="twitter:image:src" content="https://optimized.example.com/ruby34_1200.png"')
     end
   end
 end

--- a/spec/services/ai/trend_detector_spec.rb
+++ b/spec/services/ai/trend_detector_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Ai::TrendDetector do
 
   before do
     allow(Ai::Base).to receive(:new).and_return(ai_client)
+    allow(Trends::GenerateCoverImageWorker).to receive(:perform_async)
   end
 
   describe "#call" do
@@ -43,6 +44,8 @@ RSpec.describe Ai::TrendDetector do
         expect(trend.description).to eq("A cluster of discussions focused on Ruby patterns and updates.")
         expect(trend.key_questions).to eq(["What is Ruby 3.4 bringing?", "How do these patterns compare to python?"])
         expect(trend.articles).to contain_exactly(article1, article2, article3)
+
+        expect(Trends::GenerateCoverImageWorker).to have_received(:perform_async).with(trend.id)
       end
     end
 
@@ -86,6 +89,8 @@ RSpec.describe Ai::TrendDetector do
         expect(existing_trend.name).to eq("Emergent Ruby Patterns")
         expect(existing_trend.description).to eq("A cluster of discussions focused on Ruby patterns and updates.")
         expect(existing_trend.articles).to contain_exactly(article1, article2, article3)
+
+        expect(Trends::GenerateCoverImageWorker).not_to have_received(:perform_async)
       end
     end
 

--- a/spec/workers/trends/generate_cover_image_worker_spec.rb
+++ b/spec/workers/trends/generate_cover_image_worker_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe Trends::GenerateCoverImageWorker, type: :worker do
+  subject(:worker) { described_class.new }
+
+  describe "#perform" do
+    let(:trend) { create(:trend, name: "Ruby 3.4", description: "Awesome new parser changes", cover_image: nil) }
+    let(:image_generator) { instance_double(Ai::ImageGenerator) }
+    let(:generation_result) { Ai::ImageGenerator::GenerationResult.new(url: "https://example.com/image.png") }
+
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("GEMINI_API_KEY").and_return("dummy_api_key")
+      allow(Ai::ImageGenerator).to receive(:new).and_return(image_generator)
+      allow(image_generator).to receive(:generate).and_return(generation_result)
+    end
+
+    context "when GEMINI_API_KEY is not present" do
+      before do
+        allow(ENV).to receive(:[]).with("GEMINI_API_KEY").and_return(nil)
+      end
+
+      it "does not generate cover image" do
+        worker.perform(trend.id)
+        expect(Ai::ImageGenerator).not_to have_received(:new)
+      end
+    end
+
+    context "when trend does not exist" do
+      it "does not raise error" do
+        expect { worker.perform(-1) }.not_to raise_error
+      end
+    end
+
+    context "when cover_image is already present" do
+      before do
+        trend.update!(cover_image: "https://example.com/existing.png")
+      end
+
+      it "does not generate cover image" do
+        worker.perform(trend.id)
+        expect(Ai::ImageGenerator).not_to have_received(:new)
+      end
+    end
+
+    context "when generating image successfully" do
+      it "calls ImageGenerator with prompt and correct aspect ratio, and updates trend" do
+        expect {
+          worker.perform(trend.id)
+        }.to change { trend.reload.cover_image }.from(nil).to("https://example.com/image.png")
+
+        expect(Ai::ImageGenerator).to have_received(:new).with(
+          a_string_including("Ruby 3.4"),
+          aspect_ratio: "16:9"
+        )
+      end
+    end
+
+    context "when image generator returns no result" do
+      before do
+        allow(image_generator).to receive(:generate).and_return(nil)
+      end
+
+      it "does not update trend cover image" do
+        expect {
+          worker.perform(trend.id)
+        }.not_to change { trend.reload.cover_image }
+      end
+    end
+
+    context "when an error occurs" do
+      before do
+        allow(image_generator).to receive(:generate).and_raise(StandardError.new("API Error"))
+      end
+
+      it "rescues and logs the error" do
+        expect(Rails.logger).to receive(:error).with(/AI cover image generation failed for trend/)
+        worker.perform(trend.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
When a trend is newly-generated let's add a cheeky image and deliver it through optimizer