### PR TITLE
Tune AI trend detector thresholds: similarity to 0.90, match to 0.98

### DIFF
--- a/app/services/ai/trend_detector.rb
+++ b/app/services/ai/trend_detector.rb
@@ -6,7 +6,7 @@ module Ai
       @ai_client = Ai::Base.new(wrapper: self)
     end
 
-    def call(days_lookback: 7, similarity_threshold: 0.82, match_threshold: 0.92, min_articles: 10, min_score: nil)
+    def call(days_lookback: 7, similarity_threshold: 0.90, match_threshold: 0.98, min_articles: 10, min_score: nil)
       min_score ||= Settings::UserExperience.index_minimum_score.to_i
 
       articles = Article.published

--- a/spec/services/ai/trend_detector_spec.rb
+++ b/spec/services/ai/trend_detector_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Ai::TrendDetector do
         }.not_to change(Trend, :count)
       end
 
-      it "creates a new trend under the default match_threshold of 0.92" do
+      it "creates a new trend under the default match_threshold of 0.98" do
         expect {
           detector.call(min_articles: 3, min_score: 10)
         }.to change(Trend, :count).by(1)


### PR DESCRIPTION
This PR tunes the AI trend detector parameters to make the system more likely to capture distinct trends rather than coalescing too many separate ideas or updates into the same trend.

Specifically, it:
1. Bumps `similarity_threshold` to `0.90` (from `0.82`) to tighten Leader Clustering, resulting in more, smaller, and more specific clusters.
2. Bumps `match_threshold` to `0.98` (from `0.92`) to require a closer semantic match before updating an existing trend, increasing the likelihood of creating new trends.
3. Updates the default `match_threshold` assertion description in the test suite to match.