### PR TITLE
Hide pending org invitations from user profile and bust caches

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -303,7 +303,7 @@ class UsersController < ApplicationController
   private
 
   def handle_organization_tab
-    @organizations = @current_user.organizations.order(name: :asc)
+    @organizations = @current_user.member_organizations.order(name: :asc)
     @organization = Organization.new
   end
 

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -13,7 +13,8 @@ class OrganizationMembership < ApplicationRecord
 
   before_create :generate_invitation_token, if: -> { type_of_user == "pending" && invitation_token.blank? }
 
-  after_save    :update_user_organization_info_updated_at, if: :saved_change_to_type_of_user?
+  after_create  :update_user_organization_info_updated_at
+  after_update  :update_user_organization_info_updated_at, if: :saved_change_to_type_of_user?
   after_destroy :update_user_organization_info_updated_at
 
   after_commit :bust_cache

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -13,7 +13,7 @@ class OrganizationMembership < ApplicationRecord
 
   before_create :generate_invitation_token, if: -> { type_of_user == "pending" && invitation_token.blank? }
 
-  after_create  :update_user_organization_info_updated_at
+  after_save    :update_user_organization_info_updated_at, if: :saved_change_to_type_of_user?
   after_destroy :update_user_organization_info_updated_at
 
   after_commit :bust_cache

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -9,7 +9,7 @@
             grid_class: "grid-cols-3 s:grid-cols-4 m:grid-cols-2"
           } %>
     <% end %>
-    <% if @user.organizations.present? %>
+    <% if @user.member_organizations.present? %>
       <div class="crayons-card crayons-card--secondary crayons-layout__content">
         <header class="crayons-card__header">
           <h3 class="crayons-subtitle-3 spec-org-titles"><%= t("views.users.side.org") %></h3>
@@ -17,7 +17,7 @@
         <div>
           <%# it's unlikely that a user will belong to enough organizations to cause a performance issue here %>
           <%# More info regarding the `.present?/.each` pattern: https://www.speedshop.co/2019/01/10/three-activerecord-mistakes.html %>
-          <% @user.organizations.each do |organization| %>
+          <% @user.member_organizations.each do |organization| %>
             <a href="/<%= organization.slug %>" class="flex items-center crayons-link crayons-link--contentful">
               <span class="crayons-logo crayons-logo--l mr-2 shrink-0">
                 <img src="<%= organization.profile_image_url_for(length: 90) %>" alt="<%= organization.name %> profile image" class="crayons-logo__image" loading="lazy" />

--- a/spec/models/organization_membership_spec.rb
+++ b/spec/models/organization_membership_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe OrganizationMembership do
     it "updates the membership" do
       expect { membership.confirm! }.to change { membership.reload.type_of_user }.from("pending").to("member")
     end
+
+    it "touches the user's organization_info_updated_at so profile caches refresh" do
+      membership.user.update_column(:organization_info_updated_at, 1.day.ago)
+      previous_timestamp = membership.user.reload.organization_info_updated_at
+      membership.confirm!
+      expect(membership.user.reload.organization_info_updated_at).to be > previous_timestamp
+    end
   end
 
   describe "invitation_token generation" do

--- a/spec/requests/user/user_profile_spec.rb
+++ b/spec/requests/user/user_profile_spec.rb
@@ -98,6 +98,20 @@ RSpec.describe "UserProfiles" do
       expect(response.body.split("Whoaaaa").first).to include "crayons-layout__sidebar-left"
     end
 
+    context "when user has organization memberships" do
+      it "does not list pending invitations as organizations on the profile sidebar" do
+        create(:organization_membership, user: user, organization: organization, type_of_user: "pending")
+        get "/#{user.username}"
+        expect(response.body).not_to include(CGI.escapeHTML(organization.name))
+      end
+
+      it "lists accepted organizations on the profile sidebar" do
+        create(:organization_membership, user: user, organization: organization, type_of_user: "member")
+        get "/#{user.username}"
+        expect(response.body).to include(CGI.escapeHTML(organization.name))
+      end
+    end
+
     it "does not render special display header elements naively" do
       user.profile.update(location: "hawaii")
       get "/#{user.username}"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Pending org invitees showed up as members on their public profile, and after accepting, the org sometimes failed to appear there for up to 2 days.

Causes:
1. The sidebar rendered `@user.organizations`, which includes pending memberships.
2. The sidebar fragment cache only busted on membership create/destroy, not on `pending → member` transitions.

Fix:
- Sidebar and Settings → Organization tab now use `@user.member_organizations`.
- `OrganizationMembership` touches `organization_info_updated_at` on any `type_of_user` change.
- Regression specs for both.

## Related Tickets & Documents

- Closes #23277 

## Added/updated tests?

- [x] Yes