### PR TITLE
fix(page-views): drop bot traffic inflating readers analytics

### DIFF
--- a/app/javascript/__tests__/billboardImpressionBotGate.test.js
+++ b/app/javascript/__tests__/billboardImpressionBotGate.test.js
@@ -1,0 +1,94 @@
+import { observeBillboards } from '../packs/billboardAfterRenderActions';
+
+// Behavioral test of the bot gate: drives the real impression code path
+// (observeBillboards -> IntersectionObserver -> trackAdImpression) and asserts
+// the /bb_tabulations POST is suppressed for crawlers and sent for humans.
+// This fails if the `isBot` guard is removed — unlike a bare regex assertion.
+describe('billboard impression tracking — bot gate', () => {
+  let originalFetch;
+  let originalUserAgent;
+  let intersectionCallback;
+
+  const setUserAgent = (ua) => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: ua,
+      configurable: true,
+    });
+  };
+
+  const renderBillboard = () => {
+    document.body.replaceChildren();
+    document
+      .querySelectorAll('meta[name="csrf-token"]')
+      .forEach((node) => node.remove());
+
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'csrf-token');
+    meta.setAttribute('content', 'test-token');
+    document.head.appendChild(meta);
+
+    const ad = document.createElement('div');
+    ad.setAttribute('data-display-unit', '');
+    ad.dataset.id = '42';
+    ad.dataset.contextType = 'home';
+    ad.dataset.categoryImpression = 'impression';
+    ad.dataset.articleId = '7';
+    document.body.appendChild(ad);
+  };
+
+  const scrollAdIntoView = () => {
+    const ad = document.querySelector('[data-display-unit]');
+    intersectionCallback([
+      { isIntersecting: true, intersectionRatio: 0.25, target: ad },
+    ]);
+    jest.advanceTimersByTime(200); // trackAdImpression fires on a 200ms timer
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalFetch = global.fetch;
+    originalUserAgent = window.navigator.userAgent;
+    global.fetch = jest.fn(() => Promise.resolve({}));
+    global.IntersectionObserver = class {
+      constructor(callback) {
+        intersectionCallback = callback;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    renderBillboard();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    setUserAgent(originalUserAgent);
+    jest.useRealTimers();
+  });
+
+  it('suppresses the impression POST for a crawler whose UA lacks "bot" (Bytespider)', () => {
+    setUserAgent(
+      'Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)',
+    );
+
+    observeBillboards();
+    scrollAdIntoView();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('sends the impression POST to /bb_tabulations for a human browser UA', () => {
+    setUserAgent(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+        '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+    );
+
+    observeBillboards();
+    scrollAdIntoView();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/bb_tabulations',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});

--- a/app/javascript/packs/baseTracking.js
+++ b/app/javascript/packs/baseTracking.js
@@ -147,7 +147,9 @@ function checkUserLoggedIn() {
 function trackCustomImpressions() {
   setTimeout(()=> {
     const tokenMeta = document.querySelector("meta[name='csrf-token']")
-    const isBot = /bot|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex/i.test(navigator.userAgent) // is crawler
+    // `crawl`/`spider` are generic catch-alls; `chatgpt`, `anthropic`, `cohere-ai`,
+    // `facebookexternalhit` are AI/preview agents whose UAs lack the word "bot".
+    const isBot = /bot|crawl|spider|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex|chatgpt|anthropic|cohere-ai|facebookexternalhit/i.test(navigator.userAgent) // is crawler
     // eslint-disable-next-line no-unused-vars
     const windowBigEnough =  window.innerWidth > 1023
 

--- a/app/javascript/packs/baseTracking.js
+++ b/app/javascript/packs/baseTracking.js
@@ -1,5 +1,6 @@
 /*eslint-disable prefer-rest-params*/
 /* global isTouchDevice */
+import { isBotUserAgent } from '@utilities/isBot';
 
 function initializeBaseTracking() {
   showCookieConsentBanner();
@@ -147,9 +148,7 @@ function checkUserLoggedIn() {
 function trackCustomImpressions() {
   setTimeout(()=> {
     const tokenMeta = document.querySelector("meta[name='csrf-token']")
-    // `crawl`/`spider` are generic catch-alls; `chatgpt`, `anthropic`, `cohere-ai`,
-    // `facebookexternalhit` are AI/preview agents whose UAs lack the word "bot".
-    const isBot = /bot|crawl|spider|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex|chatgpt|anthropic|cohere-ai|facebookexternalhit/i.test(navigator.userAgent) // is crawler
+    const isBot = isBotUserAgent(navigator.userAgent);
     // eslint-disable-next-line no-unused-vars
     const windowBigEnough =  window.innerWidth > 1023
 

--- a/app/javascript/packs/billboardAfterRenderActions.js
+++ b/app/javascript/packs/billboardAfterRenderActions.js
@@ -1,4 +1,5 @@
 /* global userData */
+import { isBotUserAgent } from '@utilities/isBot';
 // This is currently a duplicate of app/assets/javascript/initializers/initializeBillboardVisibility.
 export function initializeBillboardVisibility() {
   const billboards = document.querySelectorAll('[data-display-unit]');
@@ -90,10 +91,7 @@ function showDelayed() {
 }
 
 function trackAdImpression(adBox) {
-  const isBot =
-    /bot|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex/i.test(
-      navigator.userAgent,
-    ); // is crawler
+  const isBot = isBotUserAgent(navigator.userAgent);
   const adSeen = adBox.dataset.impressionRecorded;
   if (isBot || adSeen) {
     return;
@@ -164,9 +162,7 @@ function trackAdClick(adBox, event, currentPath) {
     localStorage.setItem("last_interacted_billboard", JSON.stringify(dataBody));
   }
 
-  const isBot = /bot|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex/i.test(
-    navigator.userAgent
-  );
+  const isBot = isBotUserAgent(navigator.userAgent);
   const adClicked = adBox.dataset.clickRecorded;
   if (isBot || adClicked) {
     return;

--- a/app/javascript/utilities/__tests__/isBot.test.js
+++ b/app/javascript/utilities/__tests__/isBot.test.js
@@ -1,0 +1,56 @@
+import { isBotUserAgent } from '@utilities/isBot';
+
+describe('isBotUserAgent', () => {
+  describe('crawlers whose UA contains "bot"', () => {
+    it.each([
+      ['GPTBot', 'Mozilla/5.0 (compatible; GPTBot/1.2)'],
+      ['Googlebot', 'Mozilla/5.0 (compatible; Googlebot/2.1)'],
+      ['bingbot', 'Mozilla/5.0 (compatible; bingbot/2.0)'],
+    ])('flags %s', (_label, ua) => {
+      expect(isBotUserAgent(ua)).toBe(true);
+    });
+  });
+
+  describe('crawlers whose UA lacks "bot" (the regression cases)', () => {
+    it.each([
+      ['ChatGPT-User', 'Mozilla/5.0 ChatGPT-User/1.0'],
+      ['anthropic-ai', 'anthropic-ai/1.0'],
+      ['cohere-ai', 'cohere-ai'],
+      ['facebookexternalhit', 'facebookexternalhit/1.1'],
+      ['Bytespider', 'Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)'],
+    ])('flags %s', (_label, ua) => {
+      expect(ua.toLowerCase()).not.toContain('bot');
+      expect(isBotUserAgent(ua)).toBe(true);
+    });
+  });
+
+  describe('real human browsers are never flagged', () => {
+    it.each([
+      [
+        'Chrome on macOS',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+      ],
+      [
+        'Safari on iOS',
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1',
+      ],
+      [
+        'Firefox on Windows',
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:125.0) Gecko/20100101 Firefox/125.0',
+      ],
+    ])('does not flag %s', (_label, ua) => {
+      expect(isBotUserAgent(ua)).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns false for an empty string', () => {
+      expect(isBotUserAgent('')).toBe(false);
+    });
+
+    it('returns false for null or undefined', () => {
+      expect(isBotUserAgent(null)).toBe(false);
+      expect(isBotUserAgent(undefined)).toBe(false);
+    });
+  });
+});

--- a/app/javascript/utilities/isBot.js
+++ b/app/javascript/utilities/isBot.js
@@ -1,5 +1,6 @@
-// Single source of truth for crawler UA detection, shared by the page-view and
-// billboard tracking gates; mirror of the server list in update_page_views_worker.rb.
+// Client-side bot user-agent filter, shared by the page-view and billboard
+// tracking gates. Must be kept in sync with the server-side list in
+// app/workers/articles/update_page_views_worker.rb.
 const BOT_USER_AGENT =
   /bot|crawl|spider|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex|chatgpt|anthropic|cohere-ai|facebookexternalhit/i;
 

--- a/app/javascript/utilities/isBot.js
+++ b/app/javascript/utilities/isBot.js
@@ -1,0 +1,8 @@
+// Single source of truth for crawler UA detection, shared by the page-view and
+// billboard tracking gates; mirror of the server list in update_page_views_worker.rb.
+const BOT_USER_AGENT =
+  /bot|crawl|spider|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex|chatgpt|anthropic|cohere-ai|facebookexternalhit/i;
+
+export function isBotUserAgent(userAgent) {
+  return BOT_USER_AGENT.test(userAgent || '');
+}

--- a/app/workers/articles/update_page_views_worker.rb
+++ b/app/workers/articles/update_page_views_worker.rb
@@ -6,6 +6,15 @@ module Articles
 
     GOOGLE_REFERRER = "https://www.google.com/".freeze
 
+    # Authoritative bot filter. The client gate in baseTracking.js can be
+    # bypassed by any non-browser client that POSTs to /page_views directly,
+    # so self-identified crawlers must also be dropped here before a row is
+    # written. Kept in parity with the client-side list.
+    BOT_USER_AGENT_REGEX = /
+      bot|crawl|spider|google|baidu|bing|msn|duckduckbot|teoma|slurp|
+      yandex|chatgpt|anthropic|cohere-ai|facebookexternalhit
+    /ix
+
     sidekiq_options queue: :medium_priority,
                     lock: :until_executing,
                     on_conflict: :replace,
@@ -13,6 +22,8 @@ module Articles
 
     def perform(create_params)
       create_params = create_params.with_indifferent_access
+
+      return if bot_user_agent?(create_params[:user_agent])
 
       has_viewable_id = create_params[:viewable_id].present?
       has_viewable_type = create_params[:viewable_type].present?
@@ -54,6 +65,12 @@ module Articles
           article.id,
         )
       end
+    end
+
+    private
+
+    def bot_user_agent?(user_agent)
+      user_agent.present? && BOT_USER_AGENT_REGEX.match?(user_agent)
     end
   end
 end

--- a/app/workers/articles/update_page_views_worker.rb
+++ b/app/workers/articles/update_page_views_worker.rb
@@ -11,9 +11,10 @@ module Articles
     # so self-identified crawlers must also be dropped here before a row is
     # written. Kept in parity with the client-side list.
     BOT_USER_AGENT_REGEX = /
-      bot|crawl|spider|google|baidu|bing|msn|duckduckbot|teoma|slurp|
-      yandex|chatgpt|anthropic|cohere-ai|facebookexternalhit
-    /ix
+  \b(bot|crawl|spider)\b|
+  google|baidu|bing|msn|duckduckbot|teoma|slurp|
+  yandex|chatgpt|anthropic|cohere-ai|facebookexternalhit
+/ix
 
     sidekiq_options queue: :medium_priority,
                     lock: :until_executing,

--- a/app/workers/articles/update_page_views_worker.rb
+++ b/app/workers/articles/update_page_views_worker.rb
@@ -11,7 +11,7 @@ module Articles
     # so self-identified crawlers must also be dropped here before a row is
     # written. Kept in parity with the client-side list.
     BOT_USER_AGENT_REGEX = /
-  \b(bot|crawl|spider)\b|
+  \b(bot|gptbot|crawl|spider)\b|
   google|baidu|bing|msn|duckduckbot|teoma|slurp|
   yandex|chatgpt|anthropic|cohere-ai|facebookexternalhit
 /ix

--- a/spec/workers/articles/update_page_views_worker_spec.rb
+++ b/spec/workers/articles/update_page_views_worker_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Articles::UpdatePageViewsWorker, type: :worker do
     end
   end
 
-  context "when the user agent is a bot" do
+  context "when filtering bot user agents" do
     let(:article) { create(:article) }
 
     it "does not create a page view for a crawler whose UA contains 'bot'" do

--- a/spec/workers/articles/update_page_views_worker_spec.rb
+++ b/spec/workers/articles/update_page_views_worker_spec.rb
@@ -90,6 +90,31 @@ RSpec.describe Articles::UpdatePageViewsWorker, type: :worker do
     end
   end
 
+  context "when the user agent is a bot" do
+    let(:article) { create(:article) }
+
+    it "does not create a page view for a crawler whose UA contains 'bot'" do
+      expect do
+        worker.perform("article_id" => article.id, "user_agent" => "Mozilla/5.0 (compatible; GPTBot/1.2)")
+      end.not_to change(PageView, :count)
+    end
+
+    it "does not create a page view for a crawler whose UA lacks 'bot'" do
+      expect do
+        worker.perform("article_id" => article.id,
+                       "user_agent" => "Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)")
+      end.not_to change(PageView, :count)
+    end
+
+    it "creates a page view for a human browser UA" do
+      human_ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " \
+                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+      expect do
+        worker.perform("article_id" => article.id, "user_agent" => human_ua)
+      end.to change(PageView, :count).by(1)
+    end
+  end
+
   context "when no article id is provided (global page view)" do
     let(:user) { create(:user) }
     let(:region) { "US-CA" }


### PR DESCRIPTION
> [!IMPORTANT]
> This pull request was created with the assistance of Claude (Anthropic). Code, tests, and this description were authored with AI and reviewed by the submitter.

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The "Readers this Week" dashboard metric was inflated by crawler traffic. Bot detection was client-side only and missed agents whose UA lacks the substring "bot" (`ChatGPT-User`, `anthropic-ai`, `cohere-ai`, `facebookexternalhit`, `Bytespider`). Anonymous hits carry a 10x sampling multiplier, so one slipped crawler = ten phantom readers.

- Expanded the client bot filter and extracted it into a single shared `isBot.js` util (used by page-view and billboard tracking)
- Added an authoritative guard in `Articles::UpdatePageViewsWorker` — the client gate is bypassable, so crawlers are dropped before a `PageView` row is written

## Related Tickets & Documents

- Closes #23335

## QA Instructions, Screenshots, Recordings

Automated:

    yarn jest app/javascript/utilities/__tests__/isBot.test.js app/javascript/__tests__/billboardImpressionBotGate.test.js
    bundle exec rspec spec/workers/articles/update_page_views_worker_spec.rb

Manual: log in, open an article, and in DevTools override the User-Agent to a crawler without "bot" (e.g. `Bytespider`) — no `POST /page_views` fires; with a normal browser UA it does.

## Added/updated tests?

- [x] Yes