### PR TITLE
Reaction Number is now aligned to the Reaction Icons

### DIFF
--- a/app/assets/stylesheets/views/article.scss
+++ b/app/assets/stylesheets/views/article.scss
@@ -247,8 +247,9 @@ html.is-twitter-in-app {
     color: var(--base-70);
     font-size: var(--fs-s);
     display: inline-flex;
+    align-items: center;
     margin-left: 0px;
-    padding-right: var(--su-1);
+    // padding-right: var(--su-1);
     min-width: var(--su-6);
 
     @media (min-width: $breakpoint-m) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update





## Description

This is a small PR where the number initially wasn't align to the reaction icons as shown below.

<img width="49" height="276" alt="image" src="https://github.com/user-attachments/assets/37fb5e73-5153-4a0b-8768-d90eb17b8dcc" />


**This PR fixes it by removing the padding and add center alignment (though it is not needed. Adding it just in case) shown below:**

<img width="40" height="222" alt="image" src="https://github.com/user-attachments/assets/459247ff-2d08-4882-b6cc-e8a093cec1f4" />





## What gif best describes this PR or how it makes you feel?

<img width="498" height="281" alt="mha" src="https://github.com/user-attachments/assets/f7ed51fa-a26a-47f6-b094-46924bd6a9df" />

