### PR TITLE
Restore original Host header from Fastly/proxy

### DIFF
--- a/app/lib/middlewares/restore_original_host.rb
+++ b/app/lib/middlewares/restore_original_host.rb
@@ -1,0 +1,32 @@
+module Middlewares
+  class RestoreOriginalHost
+    VALID_HOST_REGEXP = /\A[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,}\z/i
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      # Fastly-Orig-Host is set by Fastly to the client's original Host header.
+      original_host = env["HTTP_FASTLY_ORIG_HOST"].presence
+
+      # Allow X-Forwarded-Host ONLY in non-production environments to prevent spoofing in production
+      if !Rails.env.production?
+        original_host ||= env["HTTP_X_FORWARDED_HOST"]&.split(",")&.first&.strip.presence
+      end
+
+      if original_host && valid_host?(original_host)
+        env["HTTP_HOST"] = original_host
+      end
+
+      @app.call(env)
+    end
+
+    private
+
+    def valid_host?(host)
+      host_without_port = host.split(":").first
+      host_without_port.match?(VALID_HOST_REGEXP) || host_without_port == "localhost"
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,13 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-Dotenv::Railtie.load if Rails.env.test? || Rails.env.development?
+if Rails.env.test? || Rails.env.development?
+  if defined?(Dotenv::Rails)
+    Dotenv::Rails.load
+  elsif defined?(Dotenv::Railtie)
+    Dotenv::Railtie.load
+  end
+end
 
 module PracticalDeveloper
   class Application < Rails::Application

--- a/config/initializers/middlewares.rb
+++ b/config/initializers/middlewares.rb
@@ -1,7 +1,9 @@
+require_relative "../../app/lib/middlewares/restore_original_host"
 require_relative "../../app/lib/middlewares/set_cookie_domain"
 require_relative "../../app/lib/middlewares/set_subforem"
 require_relative "../../app/lib/middlewares/set_time_zone"
 
+Rails.configuration.middleware.use(Middlewares::RestoreOriginalHost)
 Rails.configuration.middleware.use(Middlewares::SetCookieDomain) if Rails.env.production?
 
 # Include middleware to ensure timezone for browser requests for Capybara specs

--- a/spec/lib/middlewares/restore_original_host_spec.rb
+++ b/spec/lib/middlewares/restore_original_host_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe Middlewares::RestoreOriginalHost, type: :middleware do
+  let(:app) { ->(env) { [200, env, "OK"] } }
+  let(:middleware) { described_class.new(app) }
+
+  context "when HTTP_FASTLY_ORIG_HOST is present" do
+    it "overrides HTTP_HOST with the value of HTTP_FASTLY_ORIG_HOST" do
+      env = {
+        "HTTP_HOST" => "practicaldev.herokuapp.com",
+        "HTTP_FASTLY_ORIG_HOST" => "mlh.forem.wtf"
+      }
+      _status, result_env, _body = middleware.call(env)
+
+      expect(result_env["HTTP_HOST"]).to eq("mlh.forem.wtf")
+    end
+  end
+
+  context "when HTTP_X_FORWARDED_HOST is present and HTTP_FASTLY_ORIG_HOST is absent" do
+    before do
+      allow(Rails.env).to receive(:production?).and_return(false)
+    end
+
+    it "overrides HTTP_HOST with the value of HTTP_X_FORWARDED_HOST" do
+      env = {
+        "HTTP_HOST" => "practicaldev.herokuapp.com",
+        "HTTP_X_FORWARDED_HOST" => "mlh.forem.wtf"
+      }
+      _status, result_env, _body = middleware.call(env)
+
+      expect(result_env["HTTP_HOST"]).to eq("mlh.forem.wtf")
+    end
+
+    it "takes the first host when HTTP_X_FORWARDED_HOST has comma-separated values" do
+      env = {
+        "HTTP_HOST" => "practicaldev.herokuapp.com",
+        "HTTP_X_FORWARDED_HOST" => "mlh.forem.wtf, practicaldev.herokuapp.com"
+      }
+      _status, result_env, _body = middleware.call(env)
+
+      expect(result_env["HTTP_HOST"]).to eq("mlh.forem.wtf")
+    end
+  end
+
+  context "when HTTP_X_FORWARDED_HOST is present but environment is production" do
+    before do
+      allow(Rails.env).to receive(:production?).and_return(true)
+    end
+
+    it "does not override HTTP_HOST to prevent host spoofing" do
+      env = {
+        "HTTP_HOST" => "practicaldev.herokuapp.com",
+        "HTTP_X_FORWARDED_HOST" => "mlh.forem.wtf"
+      }
+      _status, result_env, _body = middleware.call(env)
+
+      expect(result_env["HTTP_HOST"]).to eq("practicaldev.herokuapp.com")
+    end
+  end
+
+  context "when both HTTP_FASTLY_ORIG_HOST and HTTP_X_FORWARDED_HOST are present" do
+    it "prioritizes HTTP_FASTLY_ORIG_HOST" do
+      env = {
+        "HTTP_HOST" => "practicaldev.herokuapp.com",
+        "HTTP_FASTLY_ORIG_HOST" => "fastly-orig.com",
+        "HTTP_X_FORWARDED_HOST" => "forwarded.com"
+      }
+      _status, result_env, _body = middleware.call(env)
+
+      expect(result_env["HTTP_HOST"]).to eq("fastly-orig.com")
+    end
+  end
+
+  context "when neither HTTP_FASTLY_ORIG_HOST nor HTTP_X_FORWARDED_HOST is present" do
+    it "does not change HTTP_HOST" do
+      env = {
+        "HTTP_HOST" => "practicaldev.herokuapp.com"
+      }
+      _status, result_env, _body = middleware.call(env)
+
+      expect(result_env["HTTP_HOST"]).to eq("practicaldev.herokuapp.com")
+    end
+  end
+
+  describe "host validation" do
+    it "allows valid hostnames and localhost" do
+      %w[mlh.forem.wtf sub-domain.example.com localhost localhost:3000].each do |valid_host|
+        env = {
+          "HTTP_HOST" => "practicaldev.herokuapp.com",
+          "HTTP_FASTLY_ORIG_HOST" => valid_host
+        }
+        _status, result_env, _body = middleware.call(env)
+        expect(result_env["HTTP_HOST"]).to eq(valid_host)
+      end
+    end
+
+    it "rejects invalid hostnames (containing spaces, control characters, or invalid syntax)" do
+      ["invalid host", "host\nname", "host;name", "http://host.com"].each do |invalid_host|
+        env = {
+          "HTTP_HOST" => "practicaldev.herokuapp.com",
+          "HTTP_FASTLY_ORIG_HOST" => invalid_host
+        }
+        _status, result_env, _body = middleware.call(env)
+        expect(result_env["HTTP_HOST"]).to eq("practicaldev.herokuapp.com")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Restores original client-facing Host header from HTTP_FASTLY_ORIG_HOST or HTTP_X_FORWARDED_HOST. Fixes routing constraints for custom organization domains when HTTP Host header is overridden at the CDN edge to satisfy Heroku router.