### PR TITLE
Sync Fastly VCL Host override logic to codebase

### DIFF
--- a/config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl
+++ b/config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl
@@ -4,7 +4,21 @@ sub vcl_recv {
   } else {
     set req.http.X-Loggedin = "logged-out";
   }
+  
+  # 1. Capture the original custom domain host header BEFORE we override it.
+  # This is critical for Forem's cache isolation (Vary: X-Req-Host).
   set req.http.X-Req-Host = req.http.Host;
+
+  # 2. Safely override the Host header only for custom domains.
+  # We do NOT touch the host header if it is already dev.to or www.dev.to.
+  if (req.http.Host != "dev.to" && req.http.Host != "www.dev.to" && req.http.Host != "practicaldev.herokuapp.com") {
+    # Set X-Forwarded-Host so Rails/Forem can read the custom domain
+    if (!req.http.X-Forwarded-Host) {
+      set req.http.X-Forwarded-Host = req.http.Host;
+    }
+    # Rewrite the Host header to match the Heroku application domain
+    set req.http.Host = "practicaldev.herokuapp.com";
+  }
 }
 
 sub vcl_fetch {
@@ -15,7 +29,9 @@ sub vcl_fetch {
       set beresp.http.Vary = "X-Loggedin";
     }
   }
-  if (req.http.Host == "dev.to") {
+  
+  # 3. Check if the original request was for dev.to (stored in X-Req-Host)
+  if (req.http.X-Req-Host == "dev.to" || req.http.X-Req-Host == "www.dev.to") {
     if (beresp.http.Vary && beresp.http.Vary ~ "X-Req-Host") {
       set beresp.http.Vary = regsub(beresp.http.Vary, "(,?\\s*X-Req-Host)", "");
       set beresp.http.Vary = regsub(beresp.http.Vary, "^,\\s*", "");
@@ -25,6 +41,7 @@ sub vcl_fetch {
       }
     }
   } else {
+    # For custom domains, vary cache on X-Req-Host to prevent cache collisions
     if (beresp.http.Vary !~ "X-Req-Host") {
       if (beresp.http.Vary) {
         set beresp.http.Vary = beresp.http.Vary ", X-Req-Host";


### PR DESCRIPTION
This PR adds the Host override logic (which directs custom domains to Heroku using practicaldev.herokuapp.com but preserves the client-facing Host under X-Forwarded-Host) directly to the VCL snippet in the codebase. This ensures subsequent deployments do not overwrite/revert our Fastly configuration.