### PR TITLE
Explicitly set Fastly-Orig-Host header in VCL

### DIFF
--- a/config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl
+++ b/config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl
@@ -8,6 +8,7 @@ sub vcl_recv {
   # 1. Capture the original custom domain host header BEFORE we override it.
   # This is critical for Forem's cache isolation (Vary: X-Req-Host).
   set req.http.X-Req-Host = req.http.Host;
+  set req.http.Fastly-Orig-Host = req.http.Host;
 
   # 2. Safely override the Host header only for custom domains.
   # We do NOT touch the host header if it is already dev.to or www.dev.to.


### PR DESCRIPTION
This PR adds the explicit setting of the HTTP header 'Fastly-Orig-Host' in the VCL snippet before Host is overridden. This allows our production Rails middleware to read and restore the original custom domain host header securely.