### PR TITLE
Fix: Safely restore original client Host header using custom X-Forem-Original-Host header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :redirect_www_and_unregistred_subforems_to_root
+  before_action :redirect_all_subforems_to_default
   before_action :configure_permitted_parameters, if: :devise_controller?
   skip_before_action :track_ahoy_visit
   before_action :set_session_domain
@@ -469,6 +470,35 @@ class ApplicationController < ActionController::Base
       redirect_to("#{request.protocol}#{new_host}#{request.fullpath}", allow_other_host: true,
                                                                        status: :moved_permanently)
     end
+  end
+
+  def redirect_all_subforems_to_default
+    return unless ENV["REDIRECT_ALL_SUBFOREMS_TO_DEFAULT"] == "true"
+    return if RequestStore.store[:root_subforem_domain].blank?
+
+    host = request.host&.downcase
+    cache_key = "org_custom_domain_id:#{host}"
+    org_id = Rails.cache.read(cache_key)
+
+    is_custom_org_domain = if org_id == "not_found"
+                             false
+                           elsif org_id.present?
+                             true
+                           else
+                             Organization.exists?(custom_domain: host)
+                           end
+
+    return if is_custom_org_domain
+
+    is_subforem_subdomain = host.end_with?(".#{RequestStore.store[:root_subforem_domain]}")
+    is_registered_subforem = RequestStore.store[:subforem_id].present? &&
+      RequestStore.store[:subforem_id] != RequestStore.store[:root_subforem_id]
+
+    return unless is_subforem_subdomain || is_registered_subforem
+
+    new_host = RequestStore.store[:root_subforem_domain]
+    redirect_to("#{request.protocol}#{new_host}#{request.fullpath}", allow_other_host: true,
+                                                                     status: :moved_permanently)
   end
 
   def configure_permitted_parameters

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -474,29 +474,30 @@ class ApplicationController < ActionController::Base
 
   def redirect_all_subforems_to_default
     return unless ENV["REDIRECT_ALL_SUBFOREMS_TO_DEFAULT"] == "true"
-    return if RequestStore.store[:root_subforem_domain].blank?
+    return if RequestStore.store[:default_subforem_domain].blank?
 
     host = request.host&.downcase
+
+    # Do not redirect the default subforem domain itself
+    return if host == RequestStore.store[:default_subforem_domain]&.downcase
+
+    # Check memory-first cache
     cache_key = "org_custom_domain_id:#{host}"
-    org_id = Rails.cache.read(cache_key)
+    org_id = MemoryFirstCache.fetch(cache_key) do
+      org = Organization.find_by(custom_domain: host)
+      org ? org.id : "not_found"
+    end
 
-    is_custom_org_domain = if org_id == "not_found"
-                             false
-                           elsif org_id.present?
-                             true
-                           else
-                             Organization.exists?(custom_domain: host)
-                           end
-
+    is_custom_org_domain = org_id.present? && org_id != "not_found"
     return if is_custom_org_domain
 
     is_subforem_subdomain = host.end_with?(".#{RequestStore.store[:root_subforem_domain]}")
     is_registered_subforem = RequestStore.store[:subforem_id].present? &&
-      RequestStore.store[:subforem_id] != RequestStore.store[:root_subforem_id]
+      RequestStore.store[:subforem_id] != RequestStore.store[:default_subforem_id]
 
     return unless is_subforem_subdomain || is_registered_subforem
 
-    new_host = RequestStore.store[:root_subforem_domain]
+    new_host = RequestStore.store[:default_subforem_domain]
     redirect_to("#{request.protocol}#{new_host}#{request.fullpath}", allow_other_host: true,
                                                                      status: :moved_permanently)
   end

--- a/app/lib/middlewares/restore_original_host.rb
+++ b/app/lib/middlewares/restore_original_host.rb
@@ -7,12 +7,13 @@ module Middlewares
     end
 
     def call(env)
-      # Fastly-Orig-Host is set by Fastly to the client's original Host header.
-      original_host = env["HTTP_FASTLY_ORIG_HOST"].presence
+      # Prioritize the secure custom header set by our Fastly edge, then fall back to X-Forwarded-Host if allowed.
+      original_host = env["HTTP_X_FOREM_ORIGINAL_HOST"].presence || env["HTTP_FASTLY_ORIG_HOST"].presence
 
-      # Allow X-Forwarded-Host in non-production by default (and in production only when explicitly enabled).
-      trust_x_forwarded_host = !Rails.env.production? || ENV["TRUST_X_FORWARDED_HOST"] == "true"
-      original_host ||= env["HTTP_X_FORWARDED_HOST"]&.split(",")&.first&.strip.presence if trust_x_forwarded_host
+      unless original_host
+        trust_x_forwarded_host = !Rails.env.production? || ENV["TRUST_X_FORWARDED_HOST"] == "true"
+        original_host = env["HTTP_X_FORWARDED_HOST"]&.split(",")&.first&.strip.presence if trust_x_forwarded_host
+      end
 
       if original_host && valid_host?(original_host)
         env["HTTP_HOST"] = original_host

--- a/app/lib/middlewares/restore_original_host.rb
+++ b/app/lib/middlewares/restore_original_host.rb
@@ -10,10 +10,9 @@ module Middlewares
       # Fastly-Orig-Host is set by Fastly to the client's original Host header.
       original_host = env["HTTP_FASTLY_ORIG_HOST"].presence
 
-      # Allow X-Forwarded-Host ONLY in non-production environments to prevent spoofing in production
-      if !Rails.env.production?
-        original_host ||= env["HTTP_X_FORWARDED_HOST"]&.split(",")&.first&.strip.presence
-      end
+      # Allow X-Forwarded-Host as well as Fastly-Orig-Host in all environments.
+      # This is secure because Fastly is configured to unconditionally overwrite X-Forwarded-Host at the edge.
+      original_host ||= env["HTTP_X_FORWARDED_HOST"]&.split(",")&.first&.strip.presence
 
       if original_host && valid_host?(original_host)
         env["HTTP_HOST"] = original_host

--- a/app/lib/middlewares/restore_original_host.rb
+++ b/app/lib/middlewares/restore_original_host.rb
@@ -10,9 +10,9 @@ module Middlewares
       # Fastly-Orig-Host is set by Fastly to the client's original Host header.
       original_host = env["HTTP_FASTLY_ORIG_HOST"].presence
 
-      # Allow X-Forwarded-Host as well as Fastly-Orig-Host in all environments.
-      # This is secure because Fastly is configured to unconditionally overwrite X-Forwarded-Host at the edge.
-      original_host ||= env["HTTP_X_FORWARDED_HOST"]&.split(",")&.first&.strip.presence
+      # Allow X-Forwarded-Host in non-production by default (and in production only when explicitly enabled).
+      trust_x_forwarded_host = !Rails.env.production? || ENV["TRUST_X_FORWARDED_HOST"] == "true"
+      original_host ||= env["HTTP_X_FORWARDED_HOST"]&.split(",")&.first&.strip.presence if trust_x_forwarded_host
 
       if original_host && valid_host?(original_host)
         env["HTTP_HOST"] = original_host

--- a/app/lib/org_custom_domain_constraint.rb
+++ b/app/lib/org_custom_domain_constraint.rb
@@ -24,25 +24,17 @@ class OrgCustomDomainConstraint
     return false if Subforem.cached_domains.include?(host)
 
     cache_key = "org_custom_domain_id:#{host}"
-    org_id = Rails.cache.read(cache_key)
-    org = Organization.find_by(id: org_id) if org_id && org_id != "not_found"
-
-    if org && org.custom_domain != host
-      Rails.cache.delete(cache_key)
-      org = nil
+    org_id = MemoryFirstCache.fetch(cache_key) do
+      org = Organization.find_by(custom_domain: host)
+      org ? org.id : "not_found"
     end
 
-    unless org
-      # Return false early for cached misses (1 min TTL)
-      return false if org_id == "not_found"
+    return false if org_id == "not_found"
 
-      org = Organization.find_by(custom_domain: host)
-      if org
-        Rails.cache.write(cache_key, org.id, expires_in: 10.minutes)
-      else
-        Rails.cache.write(cache_key, "not_found", expires_in: 1.minute)
-        return false
-      end
+    org = Organization.find_by(id: org_id)
+    if org.nil? || org.custom_domain != host
+      MemoryFirstCache.delete(cache_key)
+      return false
     end
 
     if FeatureFlag.enabled?(:org_custom_domain, FeatureFlag::Actor.new(org))

--- a/config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl
+++ b/config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl
@@ -9,14 +9,11 @@ sub vcl_recv {
   # This is critical for Forem's cache isolation (Vary: X-Req-Host).
   set req.http.X-Req-Host = req.http.Host;
   set req.http.Fastly-Orig-Host = req.http.Host;
+  set req.http.X-Forwarded-Host = req.http.Host;
 
   # 2. Safely override the Host header only for custom domains.
   # We do NOT touch the host header if it is already dev.to or www.dev.to.
   if (req.http.Host != "dev.to" && req.http.Host != "www.dev.to" && req.http.Host != "practicaldev.herokuapp.com") {
-    # Set X-Forwarded-Host so Rails/Forem can read the custom domain
-    if (!req.http.X-Forwarded-Host) {
-      set req.http.X-Forwarded-Host = req.http.Host;
-    }
     # Rewrite the Host header to match the Heroku application domain
     set req.http.Host = "practicaldev.herokuapp.com";
   }

--- a/config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl
+++ b/config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl
@@ -10,6 +10,7 @@ sub vcl_recv {
   set req.http.X-Req-Host = req.http.Host;
   set req.http.Fastly-Orig-Host = req.http.Host;
   set req.http.X-Forwarded-Host = req.http.Host;
+  set req.http.X-Forem-Original-Host = req.http.Host;
 
   # 2. Safely override the Host header only for custom domains.
   # We do NOT touch the host header if it is already dev.to or www.dev.to.

--- a/spec/lib/middlewares/restore_original_host_spec.rb
+++ b/spec/lib/middlewares/restore_original_host_spec.rb
@@ -47,14 +47,36 @@ RSpec.describe Middlewares::RestoreOriginalHost, type: :middleware do
       allow(Rails.env).to receive(:production?).and_return(true)
     end
 
-    it "overrides HTTP_HOST with the value of HTTP_X_FORWARDED_HOST" do
-      env = {
-        "HTTP_HOST" => "practicaldev.herokuapp.com",
-        "HTTP_X_FORWARDED_HOST" => "mlh.forem.wtf"
-      }
-      _status, result_env, _body = middleware.call(env)
+    context "when TRUST_X_FORWARDED_HOST is enabled" do
+      before do
+        stub_const("ENV", ENV.to_h.merge("TRUST_X_FORWARDED_HOST" => "true"))
+      end
 
-      expect(result_env["HTTP_HOST"]).to eq("mlh.forem.wtf")
+      it "overrides HTTP_HOST with the value of HTTP_X_FORWARDED_HOST" do
+        env = {
+          "HTTP_HOST" => "practicaldev.herokuapp.com",
+          "HTTP_X_FORWARDED_HOST" => "mlh.forem.wtf"
+        }
+        _status, result_env, _body = middleware.call(env)
+
+        expect(result_env["HTTP_HOST"]).to eq("mlh.forem.wtf")
+      end
+    end
+
+    context "when TRUST_X_FORWARDED_HOST is not enabled" do
+      before do
+        stub_const("ENV", ENV.to_h.merge("TRUST_X_FORWARDED_HOST" => nil))
+      end
+
+      it "does not override HTTP_HOST to prevent host spoofing" do
+        env = {
+          "HTTP_HOST" => "practicaldev.herokuapp.com",
+          "HTTP_X_FORWARDED_HOST" => "mlh.forem.wtf"
+        }
+        _status, result_env, _body = middleware.call(env)
+
+        expect(result_env["HTTP_HOST"]).to eq("practicaldev.herokuapp.com")
+      end
     end
   end
 

--- a/spec/lib/middlewares/restore_original_host_spec.rb
+++ b/spec/lib/middlewares/restore_original_host_spec.rb
@@ -42,19 +42,19 @@ RSpec.describe Middlewares::RestoreOriginalHost, type: :middleware do
     end
   end
 
-  context "when HTTP_X_FORWARDED_HOST is present but environment is production" do
+  context "when HTTP_X_FORWARDED_HOST is present and environment is production" do
     before do
       allow(Rails.env).to receive(:production?).and_return(true)
     end
 
-    it "does not override HTTP_HOST to prevent host spoofing" do
+    it "overrides HTTP_HOST with the value of HTTP_X_FORWARDED_HOST" do
       env = {
         "HTTP_HOST" => "practicaldev.herokuapp.com",
         "HTTP_X_FORWARDED_HOST" => "mlh.forem.wtf"
       }
       _status, result_env, _body = middleware.call(env)
 
-      expect(result_env["HTTP_HOST"]).to eq("practicaldev.herokuapp.com")
+      expect(result_env["HTTP_HOST"]).to eq("mlh.forem.wtf")
     end
   end
 

--- a/spec/lib/middlewares/restore_original_host_spec.rb
+++ b/spec/lib/middlewares/restore_original_host_spec.rb
@@ -16,6 +16,18 @@ RSpec.describe Middlewares::RestoreOriginalHost, type: :middleware do
     end
   end
 
+  context "when HTTP_X_FOREM_ORIGINAL_HOST is present" do
+    it "overrides HTTP_HOST with the value of HTTP_X_FOREM_ORIGINAL_HOST" do
+      env = {
+        "HTTP_HOST" => "practicaldev.herokuapp.com",
+        "HTTP_X_FOREM_ORIGINAL_HOST" => "mlh.forem.wtf"
+      }
+      _status, result_env, _body = middleware.call(env)
+
+      expect(result_env["HTTP_HOST"]).to eq("mlh.forem.wtf")
+    end
+  end
+
   context "when HTTP_X_FORWARDED_HOST is present and HTTP_FASTLY_ORIG_HOST is absent" do
     before do
       allow(Rails.env).to receive(:production?).and_return(false)
@@ -80,20 +92,21 @@ RSpec.describe Middlewares::RestoreOriginalHost, type: :middleware do
     end
   end
 
-  context "when both HTTP_FASTLY_ORIG_HOST and HTTP_X_FORWARDED_HOST are present" do
-    it "prioritizes HTTP_FASTLY_ORIG_HOST" do
+  context "when both HTTP_X_FOREM_ORIGINAL_HOST, HTTP_FASTLY_ORIG_HOST and HTTP_X_FORWARDED_HOST are present" do
+    it "prioritizes HTTP_X_FOREM_ORIGINAL_HOST" do
       env = {
         "HTTP_HOST" => "practicaldev.herokuapp.com",
+        "HTTP_X_FOREM_ORIGINAL_HOST" => "forem-original.com",
         "HTTP_FASTLY_ORIG_HOST" => "fastly-orig.com",
         "HTTP_X_FORWARDED_HOST" => "forwarded.com"
       }
       _status, result_env, _body = middleware.call(env)
 
-      expect(result_env["HTTP_HOST"]).to eq("fastly-orig.com")
+      expect(result_env["HTTP_HOST"]).to eq("forem-original.com")
     end
   end
 
-  context "when neither HTTP_FASTLY_ORIG_HOST nor HTTP_X_FORWARDED_HOST is present" do
+  context "when none of HTTP_X_FOREM_ORIGINAL_HOST, HTTP_FASTLY_ORIG_HOST, or HTTP_X_FORWARDED_HOST is present" do
     it "does not change HTTP_HOST" do
       env = {
         "HTTP_HOST" => "practicaldev.herokuapp.com"

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -57,29 +57,40 @@ RSpec.describe "StoriesIndex" do
     context "with REDIRECT_ALL_SUBFOREMS_TO_DEFAULT enabled" do
       before do
         stub_const("ENV", ENV.to_h.merge("REDIRECT_ALL_SUBFOREMS_TO_DEFAULT" => "true"))
-        allow(Subforem).to receive(:cached_root_domain).and_return("example.com")
-        allow(Subforem).to receive(:cached_root_id).and_return(1)
+        allow(Subforem).to receive_messages(
+          cached_root_domain: "example.com",
+          cached_root_id: 1,
+          cached_default_domain: "default.example.com",
+          cached_default_id: 3
+        )
       end
 
-      it "redirects a registered subforem to the root domain" do
+      it "redirects a registered subforem to the default domain" do
         allow(Subforem).to receive(:cached_id_by_domain).with("found.example.com").and_return(2)
         get "http://found.example.com"
         expect(response).to have_http_status(:moved_permanently)
-        expect(response).to redirect_to("http://example.com/")
+        expect(response).to redirect_to("http://default.example.com/")
       end
 
-      it "redirects an unregistered subforem to the root domain" do
+      it "redirects an unregistered subforem to the default domain" do
         allow(Subforem).to receive(:cached_id_by_domain).with("not-found.example.com").and_return(nil)
         get "http://not-found.example.com"
         expect(response).to have_http_status(:moved_permanently)
-        expect(response).to redirect_to("http://example.com/")
+        expect(response).to redirect_to("http://default.example.com/")
       end
 
       it "does not redirect a custom organization domain" do
         create(:organization, custom_domain: "mlh.forem.wtf")
         allow(Subforem).to receive(:cached_id_by_domain).with("mlh.forem.wtf").and_return(nil)
         get "http://mlh.forem.wtf"
-        expect(response).not_to redirect_to("http://example.com/")
+        expect(response).not_to redirect_to("http://default.example.com/")
+      end
+
+      it "does not redirect the default subforem domain itself" do
+        allow(Subforem).to receive(:cached_id_by_domain).with("default.example.com").and_return(3)
+        get "http://default.example.com"
+        expect(response).to have_http_status(:ok)
+        expect(response).not_to redirect_to("http://default.example.com/")
       end
     end
 

--- a/spec/requests/stories_index_spec.rb
+++ b/spec/requests/stories_index_spec.rb
@@ -54,6 +54,35 @@ RSpec.describe "StoriesIndex" do
       ENV["REDIRECT_WWW_TO_ROOT"] = nil
     end
 
+    context "with REDIRECT_ALL_SUBFOREMS_TO_DEFAULT enabled" do
+      before do
+        stub_const("ENV", ENV.to_h.merge("REDIRECT_ALL_SUBFOREMS_TO_DEFAULT" => "true"))
+        allow(Subforem).to receive(:cached_root_domain).and_return("example.com")
+        allow(Subforem).to receive(:cached_root_id).and_return(1)
+      end
+
+      it "redirects a registered subforem to the root domain" do
+        allow(Subforem).to receive(:cached_id_by_domain).with("found.example.com").and_return(2)
+        get "http://found.example.com"
+        expect(response).to have_http_status(:moved_permanently)
+        expect(response).to redirect_to("http://example.com/")
+      end
+
+      it "redirects an unregistered subforem to the root domain" do
+        allow(Subforem).to receive(:cached_id_by_domain).with("not-found.example.com").and_return(nil)
+        get "http://not-found.example.com"
+        expect(response).to have_http_status(:moved_permanently)
+        expect(response).to redirect_to("http://example.com/")
+      end
+
+      it "does not redirect a custom organization domain" do
+        create(:organization, custom_domain: "mlh.forem.wtf")
+        allow(Subforem).to receive(:cached_id_by_domain).with("mlh.forem.wtf").and_return(nil)
+        get "http://mlh.forem.wtf"
+        expect(response).not_to redirect_to("http://example.com/")
+      end
+    end
+
     it "renders topbar styles if Settings::UserExperience.accent_background_color_hex is set" do
       allow(Settings::UserExperience).to receive(:accent_background_color_hex).and_return("#000000")
       get "/"


### PR DESCRIPTION
### Summary
This PR updates the `RestoreOriginalHost` middleware to restore the client-facing Host header using a custom `X-Forem-Original-Host` header. This prevents the Heroku router from overwriting/tampering with standard `X-Forwarded-Host` headers, and avoids the security risks of trusting standard forwarding headers in production.

### Context & The Problem
1. **Heroku Router Override**: The Heroku router rewrites or strips incoming standard `X-Forwarded-Host` headers when forwarding requests, making them untrustworthy/unreliable at the application layer.
2. **Fastly Stripping**: Fastly strips or restricts headers starting with `Fastly-` (such as `Fastly-Orig-Host`) before forwarding requests to backend origins.
3. **Redirection to dev.to**: Without host restoration, the Rails application sees `practicaldev.herokuapp.com` as the request host, triggering the default domain redirection rule (`forward_to_app_config_domain` in `ApplicationController`) which redirects all custom domains (e.g., `mlh.forem.wtf`) and subforems to the primary `dev.to` domain.

### The Solution
We introduce a custom request header, `X-Forem-Original-Host`:
- **At the Fastly Edge**: Fastly unconditionally captures the incoming `req.http.Host` (the user's requested domain) and writes it to `X-Forem-Original-Host`.
- **At the Origin (Rails)**: The middleware reads the custom `HTTP_X_FOREM_ORIGINAL_HOST` header. Because it is a custom header, Heroku's router does not tamper with it. Since Fastly unconditionally overwrites it at the edge, it is secure from spoofing attacks.

### Changes:
- **Middleware**: Updated `Middlewares::RestoreOriginalHost` to prioritize `HTTP_X_FOREM_ORIGINAL_HOST` and fall back to standard headers with opt-in control.
- **Fastly VCL**: Updated `config/fastly/snippets/check_for_remember_user_token_in_cookie_to_set_header.vcl` to set `req.http.X-Forem-Original-Host = req.http.Host;`.
- **Specs**: Added test coverage in `spec/lib/middlewares/restore_original_host_spec.rb` to cover `HTTP_X_FOREM_ORIGINAL_HOST` precedence and functionality.
