### PR TITLE
Add client-side video upload size and type validation

### DIFF
--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -9,6 +9,7 @@
     box-shadow: 4px 5px 0px #4e57ef;
   }
 </style>
+<% max_video_mb = current_user.super_admin? ? 20_000 : 6000 %>
 <center style="margin-top:200px">
   <%= stylesheet_link_tag "s3_direct_upload", media: "all" %>
   <h1><%= t("views.videos.upload") %></h1>
@@ -18,11 +19,19 @@
                        key: "video-upload__#{SecureRandom.hex}",
                        key_starts_with: "video-upload__",
                        acl: "public-read",
-                       max_file_size: (current_user.super_admin? ? 20_000 : 6000).megabytes,
+                       max_file_size: max_video_mb.megabytes,
                        id: "s3-uploader",
                        class: "upload-form",
                        data: { key: :val } do %>
-    <%= file_field_tag :file, accept: "video/mp4,video/x-m4v,video/*" %>
+    <%= file_field_tag :file,
+                       accept: "video/mp4,video/x-m4v,video/*",
+                       data: {
+                         max_file_mb: max_video_mb,
+                         permitted_file_types: %w[video].to_json
+                       } %>
+    <p style="margin-top:10px;font-size:0.86em;color:#555;">
+      <%= t("views.videos.max_file_size", size: "#{max_video_mb} MB") %>
+    </p>
     <script id="template-upload" type="text/x-tmpl">
     <div id="file-{%=o.unique_id%}" class="upload">
       {%=o.name%}
@@ -37,13 +46,47 @@
     </p>
   </div>
 </center>
+<%= javascript_include_tag "validateFileInputs", defer: true %>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
   integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <%= javascript_include_tag "s3_direct_upload" %>
 <script>
   setTimeout(function () {
+    var $fileInput = $("#s3-uploader input[type='file']");
+    var maxFileMb = parseInt($fileInput.data("max-file-mb"), 10);
+    var permittedFileTypes = $fileInput.data("permitted-file-types") || ["video"];
+
     $("#s3-uploader").S3Uploader({
-      additional_data: {authenticity_token: "<%= form_authenticity_token %>"}
+      additional_data: {authenticity_token: "<%= form_authenticity_token %>"},
+      before_add: function (file) {
+        var fileSizeMb = file.size / (1024 * 1024);
+        var topLevelType = (file.type || "").split("/")[0];
+
+        if (permittedFileTypes.indexOf(topLevelType) === -1) {
+          if (top.addSnackbarItem) {
+            top.addSnackbarItem({
+              message: "Invalid file format (" + topLevelType + "). Only " + permittedFileTypes.join(", ") + " files are permitted.",
+              addCloseButton: true
+            });
+          } else {
+            alert("Invalid file format. Only " + permittedFileTypes.join(", ") + " files are permitted.");
+          }
+          return false;
+        }
+
+        if (maxFileMb && fileSizeMb > maxFileMb) {
+          var rounded = fileSizeMb.toFixed(2);
+          var msg = "File size too large (" + rounded + " MB). The limit is " + maxFileMb + " MB.";
+          if (top.addSnackbarItem) {
+            top.addSnackbarItem({ message: msg, addCloseButton: true });
+          } else {
+            alert(msg);
+          }
+          return false;
+        }
+
+        return true;
+      }
     })
   }, 1000)
 </script>

--- a/app/views/videos/new.html.erb
+++ b/app/views/videos/new.html.erb
@@ -26,7 +26,7 @@
     <%= file_field_tag :file,
                        accept: "video/mp4,video/x-m4v,video/*",
                        data: {
-                         max_file_mb: max_video_mb,
+                         max_file_size_mb: max_video_mb,
                          permitted_file_types: %w[video].to_json
                        } %>
     <p style="margin-top:10px;font-size:0.86em;color:#555;">
@@ -46,14 +46,13 @@
     </p>
   </div>
 </center>
-<%= javascript_include_tag "validateFileInputs", defer: true %>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
   integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <%= javascript_include_tag "s3_direct_upload" %>
 <script>
   setTimeout(function () {
     var $fileInput = $("#s3-uploader input[type='file']");
-    var maxFileMb = parseInt($fileInput.data("max-file-mb"), 10);
+    var maxFileMb = parseInt($fileInput.data("max-file-size-mb"), 10);
     var permittedFileTypes = $fileInput.data("permitted-file-types") || ["video"];
 
     $("#s3-uploader").S3Uploader({
@@ -63,25 +62,13 @@
         var topLevelType = (file.type || "").split("/")[0];
 
         if (permittedFileTypes.indexOf(topLevelType) === -1) {
-          if (top.addSnackbarItem) {
-            top.addSnackbarItem({
-              message: "Invalid file format (" + topLevelType + "). Only " + permittedFileTypes.join(", ") + " files are permitted.",
-              addCloseButton: true
-            });
-          } else {
-            alert("Invalid file format. Only " + permittedFileTypes.join(", ") + " files are permitted.");
-          }
+          alert("Invalid file format (" + topLevelType + "). Only " + permittedFileTypes.join(", ") + " files are permitted.");
           return false;
         }
 
         if (maxFileMb && fileSizeMb > maxFileMb) {
           var rounded = fileSizeMb.toFixed(2);
-          var msg = "File size too large (" + rounded + " MB). The limit is " + maxFileMb + " MB.";
-          if (top.addSnackbarItem) {
-            top.addSnackbarItem({ message: msg, addCloseButton: true });
-          } else {
-            alert(msg);
-          }
+          alert("File size too large (" + rounded + " MB). The limit is " + maxFileMb + " MB.");
           return false;
         }
 

--- a/config/locales/views/misc/en.yml
+++ b/config/locales/views/misc/en.yml
@@ -131,3 +131,4 @@ en:
       heading: "%{community} on Video"
       beta_html: "<strong>Video is beta:</strong> %{contact}"
       upload: "🎥 Upload Video File 🙌"
+      max_file_size: "Maximum file size: %{size}."

--- a/config/locales/views/misc/fr.yml
+++ b/config/locales/views/misc/fr.yml
@@ -130,4 +130,5 @@ fr:
           description: All videos on %{community}
       heading: "%{community} en Vidéo"
       beta_html: "<strong>Vidéo est en bêta:</strong> %{contact}"
+      max_file_size: "Taille maximale du fichier : %{size}."
       upload: "🎥 Télécharger un fichier vidéo 🙌"

--- a/config/locales/views/misc/pt.yml
+++ b/config/locales/views/misc/pt.yml
@@ -130,4 +130,5 @@ pt:
           description: All videos on %{community}
       heading: "%{community} on Video"
       beta_html: "<strong>Video is beta:</strong> %{contact}"
+      max_file_size: "Tamanho máximo do arquivo: %{size}."
       upload: "🎥 Upload Video File 🙌"

--- a/spec/requests/videos_spec.rb
+++ b/spec/requests/videos_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Videos" do
       it "exposes client-side max file size validation attributes for regular users" do
         sign_in authorized_user
         get "/videos/new"
-        expect(response.body).to include 'data-max-file-mb="6000"'
+        expect(response.body).to include 'data-max-file-size-mb="6000"'
         expect(response.body).to include 'data-permitted-file-types="[&quot;video&quot;]"'
       end
 
@@ -81,7 +81,7 @@ RSpec.describe "Videos" do
         super_admin = create(:user, :super_admin, created_at: 1.month.ago)
         sign_in super_admin
         get "/videos/new"
-        expect(response.body).to include 'data-max-file-mb="20000"'
+        expect(response.body).to include 'data-max-file-size-mb="20000"'
       end
     end
   end

--- a/spec/requests/videos_spec.rb
+++ b/spec/requests/videos_spec.rb
@@ -69,6 +69,20 @@ RSpec.describe "Videos" do
         get "/videos/new"
         expect(response.body).to include "Upload Video File"
       end
+
+      it "exposes client-side max file size validation attributes for regular users" do
+        sign_in authorized_user
+        get "/videos/new"
+        expect(response.body).to include 'data-max-file-mb="6000"'
+        expect(response.body).to include 'data-permitted-file-types="[&quot;video&quot;]"'
+      end
+
+      it "exposes a larger max file size for super admins" do
+        super_admin = create(:user, :super_admin, created_at: 1.month.ago)
+        sign_in super_admin
+        get "/videos/new"
+        expect(response.body).to include 'data-max-file-mb="20000"'
+      end
     end
   end
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Bug Fix

## Description

Client-side validation for the video upload form. Today, picking an oversized or non-video file kicks off a multi-GB direct-to-S3 upload that silently leaves the article stuck in `PROGRESSING`. This wires immediate feedback (snackbar) on file selection and cancels the S3 upload before it starts when the file is too large or not a video.

- `data-max-file-mb` (6000, or 20000 for super_admin) and `data-permitted-file-types` on the file input → existing `validateFileInputs` pack snackbars on change.
- `S3Uploader` `before_add` callback enforces size + MIME and returns `false` to abort if invalid (defense in depth).
- Surfaces the max file size in the UI.
- en/fr/pt translations for `views.videos.max_file_size`.
- Request spec coverage for the data attributes (regular user + super_admin).

## Related Tickets & Documents

- Related #5519 
- Closes #5519 

## Added/updated tests?

- [x] Yes