### PR TITLE
Redirect custom domain 404s to main app domain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -122,6 +122,12 @@ class ApplicationController < ActionController::Base
         redirect_to redirect_rule.destination_url, allow_other_host: true, status: :moved_permanently
         return
       end
+
+      main_app_domain = Settings::General.app_domain
+      if main_app_domain.present? && request.host&.downcase != main_app_domain.downcase
+        redirect_to "#{request.protocol}#{main_app_domain}#{request.fullpath}", allow_other_host: true, status: :moved_permanently
+        return
+      end
     end
 
     raise ActiveRecord::RecordNotFound, "Not Found"

--- a/spec/requests/custom_domain_redirect_spec.rb
+++ b/spec/requests/custom_domain_redirect_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 
 RSpec.describe "Custom Domain Redirects", type: :request do
   let!(:organization) { create(:organization, custom_domain: "blog.example.com") }
+
+  before do
+    allow(Settings::General).to receive(:app_domain).and_return("forem.com")
+  end
   
   context "when the custom domain feature flag is enabled" do
     let!(:base_redirect) do
@@ -47,12 +51,12 @@ RSpec.describe "Custom Domain Redirects", type: :request do
       expect(response).to have_http_status(:moved_permanently)
     end
 
-    it "raises ActiveRecord::RecordNotFound if no redirect exists" do
+    it "redirects to the main app domain if no redirect exists" do
       host! "blog.example.com"
+      get "/non-existent-post"
       
-      expect {
-        get "/non-existent-post"
-      }.to raise_error(ActiveRecord::RecordNotFound)
+      expect(response).to redirect_to("http://forem.com/non-existent-post")
+      expect(response).to have_http_status(:moved_permanently)
     end
 
     it "does not redirect if the domain does not match even if the path exists" do

--- a/spec/requests/org_custom_domain_spec.rb
+++ b/spec/requests/org_custom_domain_spec.rb
@@ -81,11 +81,12 @@ RSpec.describe "Organization Custom Domain Routing", type: :request do
         expect(response.body).to include("Test Article Content")
       end
 
-      it "returns 404 for articles not belonging to the organization" do
+      it "redirects to the main app domain for articles not belonging to the organization" do
         other_article = create(:article)
-        expect {
-          get "http://custom.org/#{other_article.slug}"
-        }.to raise_error(ActiveRecord::RecordNotFound)
+        get "http://custom.org/#{other_article.slug}"
+
+        expect(response).to redirect_to("http://forem.com/#{other_article.slug}")
+        expect(response).to have_http_status(:moved_permanently)
       end
     end
 


### PR DESCRIPTION
When a request on a custom domain results in a 404/not_found and there's no custom RequestRedirect rule matching the URL, this redirects the client to the same path on the main application domain (configured via Settings::General.app_domain) with a 301 (Moved Permanently) status code.