### PR TITLE
feat: Add optional tag association and per-tag trend detection

### DIFF
--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -3,19 +3,30 @@ class TrendsController < ApplicationController
 
   def index
     skip_authorization
-    @trends = Trend.hot_and_recent.limit(20)
-    set_surrogate_key_header Trend.table_key, *@trends.map(&:record_key)
+    @active_trend_tags = Tag.joins(:trends)
+      .merge(Trend.where("trends.last_observed_at >= ?", 7.days.ago))
+      .distinct
+      .order(:name)
+
+    if params[:tag].present?
+      @tag = Tag.find_by(name: params[:tag])
+      @trends = Trend.hot_and_recent.where(tag: @tag).limit(20)
+    else
+      @trends = Trend.hot_and_recent.limit(20)
+    end
+
+    set_surrogate_key_header Trend.table_key, *@trends.map(&:record_key), *@active_trend_tags.map(&:record_key)
   end
 
   def show
     skip_authorization
     @trend = Trend.find_by!(slug: params[:slug])
     @articles = Article.published
-                       .joins(:trend_memberships)
-                       .where(trend_memberships: { trend_id: @trend.id })
-                       .order("trend_memberships.distance ASC, articles.score DESC")
-                       .page(params[:page])
-                       .per(18)
+      .joins(:trend_memberships)
+      .where(trend_memberships: { trend_id: @trend.id })
+      .order("trend_memberships.distance ASC, articles.score DESC")
+      .page(params[:page])
+      .per(18)
     set_surrogate_key_header @trend.record_key, *@articles.map(&:record_key)
   end
 end

--- a/app/controllers/trends_controller.rb
+++ b/app/controllers/trends_controller.rb
@@ -10,9 +10,9 @@ class TrendsController < ApplicationController
 
     if params[:tag].present?
       @tag = Tag.find_by(name: params[:tag])
-      @trends = Trend.hot_and_recent.where(tag: @tag).limit(20)
+      @trends = Trend.hot_and_recent.includes(:tag).where(tag: @tag).limit(20)
     else
-      @trends = Trend.hot_and_recent.limit(20)
+      @trends = Trend.hot_and_recent.includes(:tag).limit(20)
     end
 
     set_surrogate_key_header Trend.table_key, *@trends.map(&:record_key), *@active_trend_tags.map(&:record_key)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -39,6 +39,7 @@ class Tag < ActsAsTaggableOn::Tag
   has_many :articles, through: :taggings, source: :taggable, source_type: "Article"
   has_many :billboards, class_name: "Billboard", through: :taggings, source: :taggable, source_type: "Billboard"
   has_many :subforem_relationships, class_name: "TagSubforemRelationship", dependent: :destroy
+  has_many :trends, dependent: :nullify
 
   mount_uploader :profile_image, ProfileImageUploader
   mount_uploader :social_image, ProfileImageUploader

--- a/app/models/trend.rb
+++ b/app/models/trend.rb
@@ -1,7 +1,9 @@
 class Trend < ApplicationRecord
   has_many :trend_memberships, dependent: :destroy
   has_many :articles, through: :trend_memberships
+  belongs_to :tag, optional: true
 
+  before_validation :generate_slug
   after_commit :purge, on: %i[create update destroy]
   after_commit :purge_all, on: %i[create update destroy]
 
@@ -17,9 +19,11 @@ class Trend < ApplicationRecord
   validates :first_observed_at, presence: true
   validates :last_observed_at, presence: true
 
-  before_validation :generate_slug
-
   scope :hot_and_recent, -> { where("last_observed_at >= ?", 7.days.ago).order(score: :desc, last_observed_at: :desc) }
+
+  def self.purge_all
+    EdgeCache::PurgeByKey.call(table_key)
+  end
 
   def purge
     EdgeCache::PurgeByKey.call(record_key)
@@ -27,10 +31,6 @@ class Trend < ApplicationRecord
 
   def purge_all
     self.class.purge_all
-  end
-
-  def self.purge_all
-    EdgeCache::PurgeByKey.call(table_key)
   end
 
   private

--- a/app/services/ai/trend_detector.rb
+++ b/app/services/ai/trend_detector.rb
@@ -9,13 +9,29 @@ module Ai
     def call(days_lookback: 7, similarity_threshold: 0.90, match_threshold: 0.98, min_articles: 10, min_score: nil)
       min_score ||= Settings::UserExperience.index_minimum_score.to_i
 
-      articles = Article.published
-                        .where("published_at >= ?", days_lookback.days.ago)
-                        .where("score >= ?", min_score)
-                        .where.not(semantic_embedding: nil)
-                        .order(score: :desc)
-                        .limit(1000)
-                        .to_a
+      # Run global trend detection
+      detect_trends_for(tag: nil, days_lookback: days_lookback, similarity_threshold: similarity_threshold,
+                        match_threshold: match_threshold, min_articles: min_articles, min_score: min_score)
+
+      # Run per-tag trend detection for the top 25 hottest tags
+      Tag.direct.order(hotness_score: :desc).limit(25).each do |tag|
+        detect_trends_for(tag: tag, days_lookback: days_lookback, similarity_threshold: similarity_threshold,
+                          match_threshold: match_threshold, min_articles: min_articles, min_score: min_score)
+      end
+    end
+
+    def detect_trends_for(tag: nil, days_lookback: 7, similarity_threshold: 0.90, match_threshold: 0.98,
+                          min_articles: 10, min_score: nil)
+      relation = Article.published
+        .where("published_at >= ?", days_lookback.days.ago)
+        .where("score >= ?", min_score)
+        .where.not(semantic_embedding: nil)
+        .order(score: :desc)
+        .limit(1000)
+
+      relation = relation.cached_tagged_with(tag.name) if tag
+
+      articles = relation.to_a
 
       return if articles.empty?
 
@@ -47,7 +63,7 @@ module Ai
           # Incremental centroid update: (old_centroid * N + new_vector) / (N + 1)
           n = best_cluster[:articles].length
           best_cluster[:centroid] = best_cluster[:centroid].zip(article_vec).map do |c_val, a_val|
-            (c_val * n + a_val) / (n + 1)
+            ((c_val * n) + a_val) / (n + 1)
           end
           best_cluster[:articles] << article
         else
@@ -57,8 +73,8 @@ module Ai
 
       # Filter clusters: must have at least min_articles articles, sorted by size descending, limit to top 5
       valid_clusters = clusters.select { |c| c[:articles].length >= min_articles }
-                               .sort_by { |c| -c[:articles].length }
-                               .first(5)
+        .sort_by { |c| -c[:articles].length }
+        .first(5)
 
       trends_with_centroids = []
 
@@ -68,10 +84,11 @@ module Ai
         cluster[:articles].sort_by! { |a| -a.score }
 
         # Check if this cluster matches an existing active trend in the DB
-        existing_trend = find_matching_trend(cluster[:centroid], 1.0 - match_threshold, days_lookback: days_lookback)
+        existing_trend = find_matching_trend(cluster[:centroid], 1.0 - match_threshold, tag: tag,
+                                                                                        days_lookback: days_lookback)
 
         # Build prompt and call Gemini to get trend metadata (name, description, key questions)
-        metadata = generate_trend_metadata(cluster[:articles].first(5))
+        metadata = generate_trend_metadata(cluster[:articles].first(5), tag: tag)
         next if metadata.blank?
 
         trend = nil
@@ -84,7 +101,7 @@ module Ai
               description: metadata["description"],
               key_questions: metadata["key_questions"],
               centroid_embedding: cluster[:centroid],
-              last_observed_at: Time.current
+              last_observed_at: Time.current,
             )
             trend = existing_trend
           else
@@ -93,8 +110,9 @@ module Ai
               description: metadata["description"],
               key_questions: metadata["key_questions"],
               centroid_embedding: cluster[:centroid],
+              tag_id: tag&.id,
               first_observed_at: Time.current,
-              last_observed_at: Time.current
+              last_observed_at: Time.current,
             )
             new_trend_created = true
           end
@@ -119,26 +137,29 @@ module Ai
         quoted_centroid = Article.connection.quote(centroid_literal)
 
         # Find qualifying articles for this centroid, ordered by distance and capped at 1000 to keep the queries bounded
-        qualifying_articles = Article.published
-                                     .select("articles.*, (semantic_embedding <=> #{quoted_centroid}) AS computed_distance")
-                                     .where("published_at >= ?", days_lookback.days.ago)
-                                     .where("score >= ?", min_score)
-                                     .where.not(semantic_embedding: nil)
-                                     .where("semantic_embedding <=> #{quoted_centroid} <= ?", dist_threshold)
-                                     .order(Arel.sql("semantic_embedding <=> #{quoted_centroid}"))
-                                     .limit(1000)
+        qualifying_relation = Article.published
+          .select("articles.*, (semantic_embedding <=> #{quoted_centroid}) AS computed_distance")
+          .where("published_at >= ?", days_lookback.days.ago)
+          .where("score >= ?", min_score)
+          .where.not(semantic_embedding: nil)
+          .where("semantic_embedding <=> #{quoted_centroid} <= ?", dist_threshold)
+
+        qualifying_relation = qualifying_relation.cached_tagged_with(tag.name) if tag
+
+        qualifying_articles = qualifying_relation.order(Arel.sql("semantic_embedding <=> #{quoted_centroid}"))
+          .limit(1000)
 
         qualifying_articles.each do |article|
           dist = article.computed_distance.to_f
           existing = article_closest_trend[article.id]
 
-          if existing.nil? || dist < existing[:distance]
-            article_closest_trend[article.id] = {
-              trend_id: trend.id,
-              distance: dist,
-              article: article
-            }
-          end
+          next unless existing.nil? || dist < existing[:distance]
+
+          article_closest_trend[article.id] = {
+            trend_id: trend.id,
+            distance: dist,
+            article: article
+          }
         end
       end
 
@@ -203,25 +224,28 @@ module Ai
       sum_vector.map { |val| val / vectors.length }
     end
 
-    def find_matching_trend(centroid, max_distance, days_lookback:)
+    def find_matching_trend(centroid, max_distance, tag:, days_lookback:)
       centroid_literal = "[#{centroid.join(',')}]"
       # Order by pgvector cosine distance operator, filtering to active trends
       trend = Trend.where("last_observed_at >= ?", days_lookback.days.ago)
-                   .order(Arel.sql("centroid_embedding <=> #{Trend.connection.quote(centroid_literal)}"))
-                   .first
-      return nil unless trend
+        .where(tag_id: tag&.id)
+        .order(Arel.sql("centroid_embedding <=> #{Trend.connection.quote(centroid_literal)}"))
+        .first
+      return unless trend
 
       dist = cosine_distance(trend.centroid_embedding.to_a, centroid)
       dist <= max_distance ? trend : nil
     end
 
-    def generate_trend_metadata(articles)
+    def generate_trend_metadata(articles, tag: nil)
       articles_text = articles.map.with_index do |a, idx|
         "#{idx + 1}. Title: #{a.title}\nTags: #{a.cached_tag_list}\nSummary: #{a.body_markdown.truncate(400)}"
       end.join("\n\n")
 
+      prompt_tag_context = tag ? " (focused specifically on the '#{tag.name}' tag)" : ""
+
       prompt = <<~PROMPT
-        You are analyzing a cluster of highly related technical articles published recently on a developer community platform.
+        You are analyzing a cluster of highly related technical articles published recently on a developer community platform#{prompt_tag_context}.
         Your goal is to identify the emergent, specific trend or topic that groups these articles together, and produce structured information about it.
 
         Articles in this cluster:
@@ -241,7 +265,7 @@ module Ai
 
       begin
         response = @ai_client.call(prompt, response_mime_type: "application/json")
-        return nil if response.blank?
+        return if response.blank?
 
         JSON.parse(response.strip)
       rescue StandardError => e
@@ -253,9 +277,9 @@ module Ai
     def recalculate_trend_score(trend, days_lookback:)
       # Score is sum of (article.score * decay) for all articles associated in the lookback window
       recent_memberships = trend.trend_memberships
-                                .joins(:article)
-                                .where("articles.published_at >= ?", days_lookback.days.ago)
-                                .includes(:article)
+        .joins(:article)
+        .where("articles.published_at >= ?", days_lookback.days.ago)
+        .includes(:article)
 
       total_score = 0.0
       recent_memberships.each do |m|

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -19,13 +19,13 @@
     <nav class="crayons-tabs crayons-tabs--scrollable mb-6" aria-label="<%= t("trends.index.tag_filters_nav_label") %>">
       <ul class="crayons-tabs__list">
         <li>
-          <a href="<%= trending_index_path %>" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params[:tag].blank? %>" aria-current="<%= "page" if params[:tag].blank? %>">
+          <a href="<%= trending_index_path %>" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params[:tag].blank? %>" <%= 'aria-current="page"' if params[:tag].blank? %>>
             <%= t("trends.index.all_trends") %>
           </a>
         </li>
         <% @active_trend_tags.each do |tag| %>
           <li>
-            <a href="<%= trending_index_path(tag: tag.name) %>" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params[:tag] == tag.name %>" aria-current="<%= "page" if params[:tag] == tag.name %>">
+            <a href="<%= trending_index_path(tag: tag.name) %>" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params[:tag] == tag.name %>" <%= 'aria-current="page"' if params[:tag] == tag.name %>>
               #<%= tag.name %>
             </a>
           </li>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -15,6 +15,25 @@
     </p>
   </header>
 
+  <% if @active_trend_tags.any? %>
+    <nav class="crayons-tabs crayons-tabs--scrollable mb-6" aria-label="<%= t("trends.index.tag_filters_nav_label") %>">
+      <ul class="crayons-tabs__list">
+        <li>
+          <a href="<%= trending_index_path %>" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params[:tag].blank? %>" aria-current="<%= "page" if params[:tag].blank? %>">
+            <%= t("trends.index.all_trends") %>
+          </a>
+        </li>
+        <% @active_trend_tags.each do |tag| %>
+          <li>
+            <a href="<%= trending_index_path(tag: tag.name) %>" class="crayons-tabs__item <%= "crayons-tabs__item--current" if params[:tag] == tag.name %>" aria-current="<%= "page" if params[:tag] == tag.name %>">
+              #<%= tag.name %>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </nav>
+  <% end %>
+
   <% if @trends.empty? %>
     <div class="articles-list crayons-layout__content" id="articles-list">
       <div class="p-9 align-center crayons-card">
@@ -27,9 +46,14 @@
         <div class="crayons-card trend-card p-5 relative flex flex-col justify-between">
           <div>
             <div class="flex items-center justify-between mb-3">
-              <span class="fs-xs font-semibold uppercase tracking-wider px-2 py-1 bg-brand-10 color-brand rounded">
-                Trend
-              </span>
+              <div class="flex items-center gap-2">
+                <span class="fs-xs font-semibold uppercase tracking-wider px-2 py-1 bg-brand-10 color-brand rounded">
+                  Trend
+                </span>
+                <% if trend.tag.present? %>
+                  <%= render_tag_link(trend.tag, monochrome: true) %>
+                <% end %>
+              </div>
               <span class="fs-xs color-base-60">
                 <%= t("trends.index.posts_count", count: trend.articles_count) %>
               </span>

--- a/config/locales/views/trends/en.yml
+++ b/config/locales/views/trends/en.yml
@@ -9,6 +9,8 @@ en:
       explore_trend: "Explore Trend →"
       active_ago: "Active %{time} ago"
       active_recently: "Active recently"
+      all_trends: "All Trends"
+      tag_filters_nav_label: "Filter trends by tag"
       posts_count:
         one: "1 post in the last 7 days"
         other: "%{count} posts in the last 7 days"

--- a/config/locales/views/trends/fr.yml
+++ b/config/locales/views/trends/fr.yml
@@ -9,6 +9,8 @@ fr:
       explore_trend: "Explorer la tendance →"
       active_ago: "Actif il y a %{time}"
       active_recently: "Actif récemment"
+      all_trends: "Toutes les tendances"
+      tag_filters_nav_label: "Filtrer les tendances par tag"
       posts_count:
         one: "1 publication au cours des 7 derniers jours"
         other: "%{count} publications au cours des 7 derniers jours"

--- a/config/locales/views/trends/pt.yml
+++ b/config/locales/views/trends/pt.yml
@@ -9,6 +9,8 @@ pt:
       explore_trend: "Explorar Tendência →"
       active_ago: "Ativo há %{time}"
       active_recently: "Ativo recentemente"
+      all_trends: "Todas as tendências"
+      tag_filters_nav_label: "Filtrar tendências por tag"
       posts_count:
         one: "1 publicação nos últimos 7 dias"
         other: "%{count} publicações nos últimos 7 dias"

--- a/db/migrate/20260528205800_add_tag_id_to_trends.rb
+++ b/db/migrate/20260528205800_add_tag_id_to_trends.rb
@@ -1,0 +1,6 @@
+class AddTagIdToTrends < ActiveRecord::Migration[7.0]
+  def change
+    add_column :trends, :tag_id, :bigint
+    add_foreign_key :trends, :tags, on_delete: :nullify, validate: false
+  end
+end

--- a/db/migrate/20260528205801_add_index_to_trends_tag_id.rb
+++ b/db/migrate/20260528205801_add_index_to_trends_tag_id.rb
@@ -1,0 +1,15 @@
+class AddIndexToTrendsTagId < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def up
+    return if index_exists?(:trends, :tag_id)
+
+    add_index :trends, :tag_id, algorithm: :concurrently
+  end
+
+  def down
+    return unless index_exists?(:trends, :tag_id)
+
+    remove_index :trends, :tag_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260528205802_validate_add_tag_id_to_trends.rb
+++ b/db/migrate/20260528205802_validate_add_tag_id_to_trends.rb
@@ -1,0 +1,5 @@
+class ValidateAddTagIdToTrends < ActiveRecord::Migration[7.0]
+  def change
+    validate_foreign_key :trends, :tags
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_05_21_163241) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_28_205802) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "ltree"
@@ -1766,9 +1766,11 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_21_163241) do
     t.string "name", null: false
     t.float "score", default: 0.0, null: false
     t.string "slug", null: false
+    t.bigint "tag_id"
     t.datetime "updated_at", null: false
     t.index ["centroid_embedding"], name: "index_trends_on_centroid_embedding", opclass: :vector_cosine_ops, using: :hnsw
     t.index ["slug"], name: "index_trends_on_slug", unique: true
+    t.index ["tag_id"], name: "index_trends_on_tag_id"
   end
 
   create_table "tweets", force: :cascade do |t|
@@ -2202,6 +2204,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_05_21_163241) do
   add_foreign_key "tags", "badges", on_delete: :nullify
   add_foreign_key "trend_memberships", "articles"
   add_foreign_key "trend_memberships", "trends"
+  add_foreign_key "trends", "tags", on_delete: :nullify
   add_foreign_key "tweets", "users", on_delete: :nullify
   add_foreign_key "user_activities", "users"
   add_foreign_key "user_blocks", "users", column: "blocked_id"

--- a/spec/requests/trends_spec.rb
+++ b/spec/requests/trends_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Trends", type: :request do
+RSpec.describe "Trends" do
   describe "GET /trending" do
     it "renders the trends list" do
       allow(Images::Optimizer).to receive(:call).and_call_original
@@ -9,7 +9,7 @@ RSpec.describe "Trends", type: :request do
         .and_return("https://optimized.example.com/ruby34_750.png")
 
       trend1 = create(:trend, name: "Ruby 3.4 release", score: 10, cover_image: "https://example.com/ruby34.png")
-      trend2 = create(:trend, name: "AI Agent Revolution", score: 5)
+      create(:trend, name: "AI Agent Revolution", score: 5)
 
       get trending_index_path
       expect(response).to have_http_status(:ok)
@@ -20,7 +20,36 @@ RSpec.describe "Trends", type: :request do
       # Assert surrogate keys
       expect(response.headers["Surrogate-Key"]).to include("trends")
       expect(response.headers["Surrogate-Key"]).to include(trend1.record_key)
-      expect(response.headers["Surrogate-Key"]).to include(trend2.record_key)
+    end
+  end
+
+  describe "GET /trending with tag filtering" do
+    let(:tag_ruby) { create(:tag, name: "ruby") }
+    let(:tag_python) { create(:tag, name: "python") }
+
+    before do
+      create(:trend, name: "Ruby 3.4 release", tag: tag_ruby, last_observed_at: 1.day.ago)
+      create(:trend, name: "Python 3.13 release", tag: tag_python, last_observed_at: 1.day.ago)
+      create(:trend, name: "AI Agent Revolution", tag: nil, last_observed_at: 1.day.ago)
+    end
+
+    it "renders all trends when no tag filter is specified" do
+      get trending_index_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Ruby 3.4 release", "Python 3.13 release", "AI Agent Revolution")
+      expect(response.body).to include("#ruby", "#python")
+
+      # Assert active trend tag surrogate keys
+      expect(response.headers["Surrogate-Key"]).to include(tag_ruby.record_key)
+      expect(response.headers["Surrogate-Key"]).to include(tag_python.record_key)
+    end
+
+    it "filters trends by tag when tag param is provided" do
+      get trending_index_path, params: { tag: "ruby" }
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Ruby 3.4 release")
+      expect(response.body).not_to include("Python 3.13 release")
+      expect(response.body).not_to include("AI Agent Revolution")
     end
   end
 
@@ -34,7 +63,8 @@ RSpec.describe "Trends", type: :request do
         .with("https://example.com/ruby34_large.png", hash_including(width: 1200))
         .and_return("https://optimized.example.com/ruby34_1200.png")
 
-      trend = create(:trend, name: "Ruby 3.4 release", description: "Awesome discussions about Ruby 3.4 features", cover_image: "https://example.com/ruby34_large.png")
+      trend = create(:trend, name: "Ruby 3.4 release", description: "Awesome discussions about Ruby 3.4 features",
+                             cover_image: "https://example.com/ruby34_large.png")
       article1 = create(:article, published: true, title: "Ruby 3.4 features deep dive")
       article2 = create(:article, published: true, title: "Why I love Ruby 3.4")
 
@@ -48,7 +78,7 @@ RSpec.describe "Trends", type: :request do
       expect(response.body).to include("Ruby 3.4 features deep dive", "Why I love Ruby 3.4")
       expect(response.body).to include("About this trend")
       expect(response.body).to include("This trend groups posts from the last 7 days that discuss similar concepts, technologies, or ideas.")
-      
+
       # Assert cover image and OG/Twitter tags
       expect(response.body).to include("https://optimized.example.com/ruby34_500.png")
       expect(response.body).to include('property="og:image" content="https://optimized.example.com/ruby34_1200.png"')

--- a/spec/services/ai/trend_detector_spec.rb
+++ b/spec/services/ai/trend_detector_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Ai::TrendDetector do
   before do
     allow(Ai::Base).to receive(:new).and_return(ai_client)
     allow(Trends::GenerateCoverImageWorker).to receive(:perform_async)
+    allow(Tag).to receive(:direct).and_return(Tag.none)
   end
 
   describe "#call" do
@@ -34,10 +35,10 @@ RSpec.describe Ai::TrendDetector do
 
     context "when thresholds are satisfied" do
       it "clusters articles and creates a new Trend and TrendMemberships" do
-        expect {
+        expect do
           detector.call(min_articles: 3, min_score: 10)
-        }.to change(Trend, :count).by(1)
-         .and change(TrendMembership, :count).by(3)
+        end.to change(Trend, :count).by(1)
+          .and change(TrendMembership, :count).by(3)
 
         trend = Trend.last
         expect(trend.name).to eq("Emergent Ruby Patterns")
@@ -56,7 +57,7 @@ RSpec.describe Ai::TrendDetector do
           relation = m.call(*args)
           class << relation
             def limit(limit_val)
-              if limit_val == 1000 && !to_sql.include?("computed_distance")
+              if limit_val == 1000 && to_sql.exclude?("computed_distance")
                 super(2)
               else
                 super(limit_val)
@@ -70,10 +71,10 @@ RSpec.describe Ai::TrendDetector do
       it "includes the excluded article in the second pass and marks it as a trend member" do
         # min_articles: 2, so article2 and article3 (score 25, 30) form a cluster of size 2, creating the trend.
         # article1 (score 20) is excluded from the first-pass limit(2) but should be caught by the second pass.
-        expect {
+        expect do
           detector.call(min_articles: 2, min_score: 10)
-        }.to change(Trend, :count).by(1)
-         .and change(TrendMembership, :count).by(3)
+        end.to change(Trend, :count).by(1)
+          .and change(TrendMembership, :count).by(3)
 
         trend = Trend.last
         expect(trend.articles).to contain_exactly(article1, article2, article3)
@@ -85,18 +86,18 @@ RSpec.describe Ai::TrendDetector do
         # If min_score is 22, article1 (score 20) is excluded.
         # This leaves only article2 and article3 (count 2), which is below min_articles (3).
         # Thus, no trend should be created.
-        expect {
+        expect do
           detector.call(min_articles: 3, min_score: 22)
-        }.not_to change(Trend, :count)
+        end.not_to change(Trend, :count)
       end
     end
 
     context "when filtering by cluster size (min_articles)" do
       it "does not create a trend if cluster size is below min_articles" do
         # 3 articles in cluster, min_articles is set to 4
-        expect {
+        expect do
           detector.call(min_articles: 4, min_score: 10)
-        }.not_to change(Trend, :count)
+        end.not_to change(Trend, :count)
       end
     end
 
@@ -112,10 +113,10 @@ RSpec.describe Ai::TrendDetector do
 
       it "updates the existing trend and adds new memberships instead of creating a duplicate" do
         # The new cluster is very close to embedding1 (distance 0.0) which is within match_threshold.
-        expect {
+        # updates existing_trend, doesn't create new
+        expect do
           detector.call(min_articles: 3, min_score: 10, match_threshold: 0.88)
-        }.not_to change(Trend, :count) # updates existing_trend, doesn't create new
-
+        end.not_to change(Trend, :count)
         existing_trend.reload
         expect(existing_trend.name).to eq("Emergent Ruby Patterns")
         expect(existing_trend.description).to eq("A cluster of discussions focused on Ruby patterns and updates.")
@@ -132,7 +133,7 @@ RSpec.describe Ai::TrendDetector do
         emb
       end
 
-      let!(:existing_trend) do
+      before do
         create(:trend,
                name: "Existing Trend",
                description: "Old description",
@@ -142,15 +143,15 @@ RSpec.describe Ai::TrendDetector do
       end
 
       it "updates the existing trend if match_threshold is set to 0.88" do
-        expect {
+        expect do
           detector.call(min_articles: 3, min_score: 10, match_threshold: 0.88)
-        }.not_to change(Trend, :count)
+        end.not_to change(Trend, :count)
       end
 
       it "creates a new trend under the default match_threshold of 0.98" do
-        expect {
+        expect do
           detector.call(min_articles: 3, min_score: 10)
-        }.to change(Trend, :count).by(1)
+        end.to change(Trend, :count).by(1)
       end
     end
 
@@ -164,9 +165,66 @@ RSpec.describe Ai::TrendDetector do
         # Since article1 (20), article2 (25), and article3 (30) all have score >= 5,
         # they are all included. However, default min_articles is 10.
         # Let's verify that under default configurations, 3 articles are not enough to create a trend.
-        expect {
+        expect do
           detector.call
-        }.not_to change(Trend, :count)
+        end.not_to change(Trend, :count)
+      end
+    end
+
+    context "with per-tag trend detection" do
+      before do
+        allow(Tag).to receive(:direct).and_return(Tag.where(name: %w[ruby python]))
+      end
+
+      let!(:tag_ruby) { create(:tag, name: "ruby", hotness_score: 100) }
+      let!(:tag_python) { create(:tag, name: "python", hotness_score: 50) }
+
+      let!(:ruby_article1) do
+        create(:article, published: true, score: 20, semantic_embedding: embedding1, tag_list: "ruby")
+      end
+      let!(:ruby_article2) do
+        create(:article, published: true, score: 25, semantic_embedding: embedding2, tag_list: "ruby")
+      end
+      let!(:ruby_article3) do
+        create(:article, published: true, score: 30, semantic_embedding: embedding3, tag_list: "ruby")
+      end
+
+      let!(:python_article1) do
+        create(:article, published: true, score: 20, semantic_embedding: embedding1, tag_list: "python")
+      end
+      let!(:python_article2) do
+        create(:article, published: true, score: 25, semantic_embedding: embedding2, tag_list: "python")
+      end
+
+      it "detects trends for the hottest tags that satisfy min_articles" do
+        expect do
+          detector.call(min_articles: 3, min_score: 10)
+        end.to change(Trend, :count).by(2) # 1 global trend and 1 ruby trend
+
+        ruby_trend = Trend.find_by(tag: tag_ruby)
+        global_trend = Trend.find_by(tag: nil)
+
+        expect(ruby_trend).to be_present
+        expect(global_trend).to be_present
+        expect(Trend.find_by(tag: tag_python)).to be_nil
+
+        expect(ruby_trend.articles).to contain_exactly(ruby_article1, ruby_article2, ruby_article3)
+        expect(global_trend.articles).to contain_exactly(
+          article1, article2, article3,
+          ruby_article1, ruby_article2, ruby_article3,
+          python_article1, python_article2
+        )
+      end
+
+      it "does not match trends across different tags" do
+        existing_ruby_trend = create(:trend, name: "Old Ruby", centroid_embedding: embedding1, tag: tag_ruby,
+                                             first_observed_at: 2.days.ago, last_observed_at: 2.days.ago)
+
+        expect do
+          detector.call(min_articles: 3, min_score: 10)
+        end.to change(Trend, :count).by(1) # Only creates global trend
+
+        expect(existing_ruby_trend.reload.name).to eq("Emergent Ruby Patterns")
       end
     end
   end


### PR DESCRIPTION
Allows trends to optionally belong to a tag, runs per-tag trend detection for the top 25 hottest tags, and adds tag filtering and pills on the trending page.