### PR TITLE
style: set #topbar z-index to 10000

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,6 +1,10 @@
 @import '../config/import';
 @import './skip-link';
 
+#topbar {
+  z-index: 10000;
+}
+
 .crayons-header {
   height: var(--header-height);
   background: var(--header-bg);


### PR DESCRIPTION
Sets the #topbar z-index to 10000 so it sufficiently has priority over everything else on the page.