### PR TITLE
Change Mod Sidebar position for Visibility

### DIFF
--- a/app/assets/stylesheets/views/mod-actions.scss
+++ b/app/assets/stylesheets/views/mod-actions.scss
@@ -4,7 +4,7 @@
 
 .mod-actions-menu {
   position: fixed;
-  top: 0;
+  top: 56px;
   right: 0;
   height: 100vh;
   z-index: var(--z-drawer);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR fixes the issue where the Navigation Bar overlap the Mod Sidebar by changing the position of the sidebar `top: 56px`. This number came from the height of the Navigation Bar and ensure there is no gap between the Sidebar and the Navigation bar.





## Related Tickets & Documents

- Related Issue #23388
- Closes #23388 





## What gif best describes this PR or how it makes you feel?

<img width="500" height="281" alt="Yugioh" src="https://github.com/user-attachments/assets/976ff807-8e4a-41af-95a5-07fa3bb80bfc" />