### PR TITLE
Emit gated user_created/user_updated events to Customer.io/Segment CDP

### DIFF
--- a/app/lib/constants/settings/general.rb
+++ b/app/lib/constants/settings/general.rb
@@ -8,6 +8,9 @@ module Constants
           ahoy_tracking: {
             description: I18n.t("lib.constants.settings.general.ahoy_tracking.description")
           },
+          customerio_cdp_enabled: {
+            description: I18n.t("lib.constants.settings.general.customerio_cdp_enabled.description")
+          },
           billboard_enabled_countries: {
             description: I18n.t("lib.constants.settings.general.billboard_enabled_countries.description")
           },

--- a/app/models/settings/general.rb
+++ b/app/models/settings/general.rb
@@ -42,6 +42,11 @@ module Settings
     # Ahoy Tracking
     setting :ahoy_tracking, type: :boolean, default: false
 
+    # Master switch for emitting user lifecycle events to the Customer.io CDP
+    # (DEV -> MLH Core sync). Per-account rollout is gated separately by the
+    # :dev_core_user_sync feature flag.
+    setting :customerio_cdp_enabled, type: :boolean, default: false
+
     # Images
     setting :main_social_image,
             type: :string,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   include Images::Profile.for(:profile_image_url)
   include AlgoliaSearchable
+  include Trackable
 
   # NOTE: we are using an inline module to keep profile related things together.
   concerning :Profiles do
@@ -811,6 +812,44 @@ class User < ApplicationRecord
 
     last_followed_at.respond_to?(:rfc3339) ? last_followed_at.rfc3339 : last_followed_at.to_s
   end
+
+  # === Trackable (DEV → MLH Core user sync) ===
+  # Emits user_created / user_updated to the Customer.io CDP so MLH Core can
+  # link the DEV account (SocialProfiles::Dev) and record engagement.
+
+  def trackable_user_ids
+    [id]
+  end
+
+  # Curated payload — do NOT ship the full users row across the boundary.
+  def trackable_payload
+    { id: id, username: username, email: email, name: name }
+  end
+
+  # Emit user_updated only on deliberate profile edits. Forem touches
+  # profile_updated_at on every profile-edit path (Users::Update, users#update),
+  # so unrelated row churn (sign-ins, counters, score recalcs) does not emit.
+  def enqueue_trackable_event_updated
+    return unless previous_changes.key?("profile_updated_at")
+
+    enqueue_trackable_event("user_updated")
+  end
+
+  # Two gates: the global admin master switch, then the per-account rollout flag.
+  def trackable_events_skipped?
+    return true unless Settings::General.customerio_cdp_enabled?
+    return true unless FeatureFlag.enabled_for_user?(:dev_core_user_sync, self)
+
+    super
+  end
+
+  # User deletion / unlink is intentionally out of scope for the DEV → Core sync
+  # (created + updated only), and the Core consumer does not handle deletes, so
+  # suppress the concern's default user_destroyed emission.
+  def enqueue_trackable_event_destroyed(*)
+    nil
+  end
+  private :enqueue_trackable_event_updated, :trackable_events_skipped?, :enqueue_trackable_event_destroyed
 
   protected
 

--- a/app/services/trackable/registry.rb
+++ b/app/services/trackable/registry.rb
@@ -26,10 +26,12 @@ module Trackable
         active_names.map { |name| instance_for(name) }
       end
 
-      # Memoized: TRACKABLE_ADAPTERS and adapter `#enabled?` are both ENV-driven
-      # and effectively static after boot. Cleared by `reset!`.
+      # Recomputed per call: adapter `#enabled?` is now runtime-dynamic (e.g.
+      # Trackers::CustomerioCdp consults the customerio_cdp_enabled admin
+      # setting), so memoizing here would make the toggle require a restart.
+      # Cost is a cached Setting read plus the memoized adapter instance.
       def active_names
-        @active_names ||= configured_adapter_names.select { |name| instance_for(name)&.enabled? }
+        configured_adapter_names.select { |name| instance_for(name)&.enabled? }
       end
 
       def reset!

--- a/app/services/trackers/customerio_cdp.rb
+++ b/app/services/trackers/customerio_cdp.rb
@@ -9,7 +9,8 @@ module Trackers
     DEFAULT_HOST = "cdp.customer.io".freeze
 
     def enabled?
-      ApplicationConfig["CUSTOMERIO_CDP_WRITE_KEY"].present?
+      ApplicationConfig["CUSTOMERIO_CDP_WRITE_KEY"].present? &&
+        Settings::General.customerio_cdp_enabled?
     end
 
     def track(event_name:, user_ids:, properties:, timestamp: nil)

--- a/app/views/admin/settings/forms/_ahoy.html.erb
+++ b/app/views/admin/settings/forms/_ahoy.html.erb
@@ -14,6 +14,11 @@
           <%= admin_config_label :ahoy_tracking %>
         </div>
         <%= admin_config_description Constants::Settings::General.details[:ahoy_tracking][:description] %>
+        <div class="crayons-field crayons-field--checkbox">
+          <%= f.check_box :customerio_cdp_enabled, checked: Settings::General.customerio_cdp_enabled, class: "crayons-checkbox" %>
+          <%= admin_config_label :customerio_cdp_enabled %>
+        </div>
+        <%= admin_config_description Constants::Settings::General.details[:customerio_cdp_enabled][:description] %>
       </fieldset>
       <%= render "update_setting_button", f: f %>
     </div>

--- a/config/locales/lib/en.yml
+++ b/config/locales/lib/en.yml
@@ -107,6 +107,8 @@ en:
         general:
           ahoy_tracking:
             description: Track visits and events - data is stored in your database. A restart is required for changes to this configuration to take effect.
+          customerio_cdp_enabled:
+            description: Master switch for sending user registration and profile-update events to the Customer.io CDP (DEV to MLH Core sync). Per-account rollout is controlled separately by the dev_core_user_sync feature flag.
           billboard_enabled_countries:
             description: Countries that can be geotargeted by billboards. Click on a selected country to toggle targeting on a sub-country level.
           contact_email:

--- a/config/locales/lib/fr.yml
+++ b/config/locales/lib/fr.yml
@@ -107,6 +107,8 @@ fr:
         general:
           ahoy_tracking:
             description: Track visits and events - data is stored in your database. A restart is required for changes to this configuration to take effect.
+          customerio_cdp_enabled:
+            description: Master switch for sending user registration and profile-update events to the Customer.io CDP (DEV to MLH Core sync). Per-account rollout is controlled separately by the dev_core_user_sync feature flag.
           billboard_enabled_countries:
             description: Countries that can be geotargeted by billboards. Click on a selected country to toggle targeting on a sub-country level.
           contact_email:

--- a/config/locales/lib/pt.yml
+++ b/config/locales/lib/pt.yml
@@ -107,6 +107,8 @@ pt:
         general:
           ahoy_tracking:
             description: Enable Ahoy tracking
+          customerio_cdp_enabled:
+            description: Master switch for sending user registration and profile-update events to the Customer.io CDP (DEV to MLH Core sync). Per-account rollout is controlled separately by the dev_core_user_sync feature flag.
           billboard_enabled_countries:
             description: Countries where billboards are enabled
           contact_email:

--- a/spec/models/settings/general_spec.rb
+++ b/spec/models/settings/general_spec.rb
@@ -96,6 +96,17 @@ RSpec.describe Settings::General do
       end
     end
 
+    describe ".customerio_cdp_enabled" do
+      it "defaults to false" do
+        expect(described_class.customerio_cdp_enabled).to be(false)
+      end
+
+      it "can be enabled" do
+        described_class.customerio_cdp_enabled = true
+        expect(described_class.customerio_cdp_enabled?).to be(true)
+      end
+    end
+
     describe "validating algolia settings" do
       it "only accepts strings" do
         expect(described_class.get_setting(:algolia_application_id)[:type]).to eq(:string)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,6 +39,84 @@ RSpec.describe User do
     allow(Settings::Authentication).to receive(:providers).and_return(Authentication::Providers.available)
   end
 
+  describe "Trackable adoption for DEV → Core sync" do
+    before do
+      allow(Trackable::Registry).to receive(:active_names).and_return([:any])
+      allow(Trackable::DispatchWorker).to receive(:perform_async)
+    end
+
+    around { |ex| with_trackable_events { ex.run } }
+
+    after { FeatureFlag.remove(:dev_core_user_sync) }
+
+    def enable_sync(actor: nil)
+      Settings::General.customerio_cdp_enabled = true
+      if actor
+        FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[actor])
+      else
+        FeatureFlag.enable(:dev_core_user_sync)
+      end
+    end
+
+    it "includes the Trackable concern" do
+      expect(described_class.included_modules).to include(Trackable)
+    end
+
+    it "tracks only its own user id" do
+      user = create(:user)
+      expect(user.trackable_user_ids).to eq([user.id])
+    end
+
+    it "ships a curated payload of id, username, email, name" do
+      user = create(:user)
+      expect(user.trackable_payload.keys).to contain_exactly(:id, :username, :email, :name)
+    end
+
+    it "emits user_created on registration when sync is enabled" do
+      enable_sync
+      create(:user)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_created", anything, anything, anything)
+    end
+
+    it "does not emit when the admin setting is off" do
+      Settings::General.customerio_cdp_enabled = false
+      FeatureFlag.enable(:dev_core_user_sync)
+      create(:user)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+    end
+
+    it "does not emit for a user without the feature flag" do
+      Settings::General.customerio_cdp_enabled = true
+      create(:user) # flag not enabled
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+    end
+
+    it "emits user_updated when profile_updated_at is touched" do
+      user = create(:user)
+      enable_sync(actor: user)
+      user.touch(:profile_updated_at)
+      expect(Trackable::DispatchWorker).to have_received(:perform_async)
+        .with(anything, "user_updated", anything, anything, anything)
+    end
+
+    it "does not emit user_updated for non-profile row changes" do
+      user = create(:user)
+      enable_sync(actor: user)
+      user.update!(last_comment_at: 1.day.ago)
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+        .with(anything, "user_updated", anything, anything, anything)
+    end
+
+    it "does not emit user_destroyed when a synced user is deleted (deletes are out of scope)" do
+      user = create(:user)
+      enable_sync(actor: user)
+      user.destroy!
+      expect(Trackable::DispatchWorker).not_to have_received(:perform_async)
+        .with(anything, "user_destroyed", anything, anything, anything)
+    end
+  end
+
   describe "delegations" do
     it { is_expected.to delegate_method(:admin?).to(:authorizer) }
     it { is_expected.to delegate_method(:any_admin?).to(:authorizer) }

--- a/spec/services/trackable/registry_spec.rb
+++ b/spec/services/trackable/registry_spec.rb
@@ -83,6 +83,27 @@ RSpec.describe Trackable::Registry do
     end
   end
 
+  describe ".active_names" do
+    it "reflects adapter enablement changes at runtime (no stale memoization)" do
+      described_class.reset!
+
+      togglable = Class.new(Trackers::Base) do
+        class << self; attr_accessor :on; end
+        def enabled? = self.class.on
+      end
+      described_class.register(:togglable, togglable)
+      allow(described_class).to receive(:configured_adapter_names).and_return([:togglable])
+
+      togglable.on = false
+      expect(described_class.active_names).to eq([])
+
+      togglable.on = true
+      expect(described_class.active_names).to eq([:togglable])
+    ensure
+      described_class.reset!
+    end
+  end
+
   describe ".instance_for" do
     before { described_class.register(:dummy, dummy_adapter_class) }
 

--- a/spec/services/trackers/customerio_cdp_spec.rb
+++ b/spec/services/trackers/customerio_cdp_spec.rb
@@ -3,10 +3,16 @@ require "rails_helper"
 RSpec.describe Trackers::CustomerioCdp do
   subject(:adapter) { described_class.new }
 
+  def stub_write_key(value)
+    allow(ApplicationConfig).to receive(:[]).and_call_original
+    allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_CDP_WRITE_KEY").and_return(value)
+  end
+
   describe "#enabled?" do
-    it "is true when CUSTOMERIO_CDP_WRITE_KEY is present" do
+    it "is true when CUSTOMERIO_CDP_WRITE_KEY is present and the admin setting is on" do
       allow(ApplicationConfig).to receive(:[]).and_call_original
       allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_CDP_WRITE_KEY").and_return("key123")
+      Settings::General.customerio_cdp_enabled = true
 
       expect(adapter.enabled?).to be true
     end
@@ -14,6 +20,7 @@ RSpec.describe Trackers::CustomerioCdp do
     it "is false when CUSTOMERIO_CDP_WRITE_KEY is unset" do
       allow(ApplicationConfig).to receive(:[]).and_call_original
       allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_CDP_WRITE_KEY").and_return(nil)
+      Settings::General.customerio_cdp_enabled = true
 
       expect(adapter.enabled?).to be false
     end
@@ -21,8 +28,30 @@ RSpec.describe Trackers::CustomerioCdp do
     it "is false when CUSTOMERIO_CDP_WRITE_KEY is empty" do
       allow(ApplicationConfig).to receive(:[]).and_call_original
       allow(ApplicationConfig).to receive(:[]).with("CUSTOMERIO_CDP_WRITE_KEY").and_return("")
+      Settings::General.customerio_cdp_enabled = true
 
       expect(adapter.enabled?).to be false
+    end
+
+    it "is false when the admin setting is off, even with a write key" do
+      stub_write_key("wk_test")
+      Settings::General.customerio_cdp_enabled = false
+
+      expect(described_class.new.enabled?).to be(false)
+    end
+
+    it "is true when both the write key and the setting are present" do
+      stub_write_key("wk_test")
+      Settings::General.customerio_cdp_enabled = true
+
+      expect(described_class.new.enabled?).to be(true)
+    end
+
+    it "is false when the write key is missing, even if the setting is on" do
+      stub_write_key(nil)
+      Settings::General.customerio_cdp_enabled = true
+
+      expect(described_class.new.enabled?).to be(false)
     end
   end
 


### PR DESCRIPTION
## Summary

  Second half of the DEV (Forem) _ MLH Core user-sync pipeline: the **emitter**. Forem now emits user lifecycle events to the Customer.io CDP so MLH Core can link the DEV account (`SocialProfiles::Dev`) and
  record engagement. (Companion: the Core consumer PR _ MLH-Engineering/core#2601.)

  - **`User` adopts `Trackable`** with a curated payload `{id, username, email, name}` (not the full row).
  - **`user_created`** fires automatically on registration; **`user_updated`** fires **only on deliberate profile edits** (scoped to `profile_updated_at` changes), so sign-ins / counter / score-recalc churn don't
  emit. `user_destroyed` is explicitly suppressed (deletes are out of scope for v1).
  - **Admin master switch** _ new `Settings::General.customerio_cdp_enabled` (default off), surfaced in admin settings; `Trackers::CustomerioCdp#enabled?` consults it.
  - **Per-account rollout** _ emission is additionally gated by the `:dev_core_user_sync` Flipper feature flag, so it can be enabled for specific test accounts first.
  - **`Trackable::Registry.active_names`** de-memoized so the admin toggle takes effect at runtime (no restart).

  Defense-in-depth gating: emission is blocked unless the master switch is on **AND** the per-user flag is enabled (and the adapter independently re-checks the switch).

  ## Test Plan

  - [x] `User` Trackable adoption spec: includes concern; `trackable_user_ids`; curated payload; `user_created` emits when enabled; no emit when setting off; no emit when flag off; `user_updated` emits on
  `profile_updated_at` touch; no `user_updated` on non-profile change; no `user_destroyed` on delete (9 examples)
  - [x] `CustomerioCdp#enabled?` honors write key **AND** setting
  - [x] `Trackable::Registry.active_names` reflects enablement changes at runtime
  - [x] `Settings::General.customerio_cdp_enabled` default + toggle
  - [x] RuboCop clean on changed lines; full `user_spec` green in isolation (321 examples)

  ## Manual setup (env / rollout) _ required before this emits

  - [ ] Set `CUSTOMERIO_CDP_WRITE_KEY` and include `customerio_cdp` in `TRACKABLE_ADAPTERS`
  - [ ] Configure the consolidated Customer.io workspace + `devto` Segment source forwarding `user_created`/`user_updated` to Core's `POST /v4/webhooks/segment/devto` (see companion Core PR)
  - [ ] Turn on `Settings::General.customerio_cdp_enabled` (admin) when ready to start rollout
  - [ ] Enable `:dev_core_user_sync` for initial test accounts: `FeatureFlag.enable(:dev_core_user_sync, FeatureFlag::Actor[user])`, verify the DEV profile + `engaged_at` appear in Core, then widen (percentage _
  global). The admin setting stays as the global kill switch.

  > Note: running this branch's `settings`/`user` specs combined with unrelated spec files surfaces 2 failures (`feed_pinned_article_id` validation, an `above_average` articles_count test) _ these reproduce
  identically on `main` and are pre-existing cross-file test pollution, unrelated to this branch.