### PR TITLE
Fix DoubleRenderError in custom domain not_found redirects

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,18 @@
 class ApplicationController < ActionController::Base
+  class RedirectRequired < StandardError
+    attr_reader :url, :status, :allow_other_host
+    def initialize(url, status: :moved_permanently, allow_other_host: true)
+      @url = url
+      @status = status
+      @allow_other_host = allow_other_host
+      super("Redirect to #{url} required")
+    end
+  end
+
+  rescue_from RedirectRequired do |exception|
+    redirect_to exception.url, allow_other_host: exception.allow_other_host, status: exception.status
+  end
+
   before_action :redirect_www_and_unregistred_subforems_to_root
   before_action :redirect_all_subforems_to_default
   before_action :configure_permitted_parameters, if: :devise_controller?
@@ -120,14 +134,12 @@ class ApplicationController < ActionController::Base
       )
       
       if redirect_rule
-        redirect_to redirect_rule.destination_url, allow_other_host: true, status: :moved_permanently
-        return
+        raise RedirectRequired.new(redirect_rule.destination_url, status: :moved_permanently)
       end
 
       main_app_domain = Settings::General.app_domain
       if main_app_domain.present? && request.host&.downcase != main_app_domain.downcase
-        redirect_to "#{request.protocol}#{main_app_domain}#{request.fullpath}", allow_other_host: true, status: :moved_permanently
-        return
+        raise RedirectRequired.new("#{request.protocol}#{main_app_domain}#{request.fullpath}", status: :moved_permanently)
       end
     end
 

--- a/spec/requests/custom_domain_redirect_spec.rb
+++ b/spec/requests/custom_domain_redirect_spec.rb
@@ -144,6 +144,15 @@ RSpec.describe "Custom Domain Redirects", type: :request do
       expect(response).to redirect_to("https://dev.to/my-new-post")
       expect(response).to have_http_status(:moved_permanently)
     end
+
+    it "does not raise a DoubleRenderError and redirects successfully when org_slug is mismatched on show path" do
+      host! "blog.example.com"
+      
+      get "/wrong-org/feed"
+      
+      expect(response).to redirect_to("http://forem.com/wrong-org/feed")
+      expect(response).to have_http_status(:moved_permanently)
+    end
   end
 
   context "when the custom domain feature flag is disabled" do


### PR DESCRIPTION
Resolves the DoubleRenderError on custom domain requests where not_found redirects to the main app domain but doesn't halt action execution. We introduce a custom RedirectRequired error to cleanly interrupt execution.