### PR TITLE
Fix ActiveRecord::NotNullViolation in SyncWebpageReferencesWorker when processing URLs with empty/invalid hostnames

### DIFF
--- a/app/models/linked_domain.rb
+++ b/app/models/linked_domain.rb
@@ -15,9 +15,10 @@ class LinkedDomain < ApplicationRecord
   def self.find_or_create_by_url(url)
     uri = URI.parse(url)
     host = uri.host&.downcase
-    return nil unless host
+    return nil if host.blank?
 
-    create_or_find_by(host: host)
+    domain = create_or_find_by(host: host)
+    domain.persisted? ? domain : nil
   rescue URI::Error, ActiveRecord::RecordInvalid
     nil
   rescue ActiveRecord::RecordNotUnique

--- a/spec/models/linked_domain_spec.rb
+++ b/spec/models/linked_domain_spec.rb
@@ -19,6 +19,38 @@ RSpec.describe LinkedDomain, type: :model do
     end
   end
 
+  describe ".find_or_create_by_url" do
+    context "with a valid URL" do
+      it "returns a persisted LinkedDomain" do
+        domain = described_class.find_or_create_by_url("https://example.com/some/page")
+        expect(domain).to be_persisted
+        expect(domain.host).to eq("example.com")
+      end
+
+      it "reuses an existing LinkedDomain if already present" do
+        existing = described_class.create!(host: "example.com")
+        domain = described_class.find_or_create_by_url("https://example.com/other")
+        expect(domain).to eq(existing)
+      end
+    end
+
+    context "with a URL with an empty/blank host" do
+      it "returns nil for 'https://'" do
+        expect(described_class.find_or_create_by_url("https://")).to be_nil
+      end
+
+      it "returns nil for invalid/empty URL" do
+        expect(described_class.find_or_create_by_url("")).to be_nil
+      end
+    end
+
+    context "with an invalid URL" do
+      it "returns nil" do
+        expect(described_class.find_or_create_by_url("http:::/invalid")).to be_nil
+      end
+    end
+  end
+
   describe "manual_setting limits on net_score" do
     let(:domain) { LinkedDomain.create!(host: "example.com") }
 

--- a/spec/workers/sync_webpage_references_worker_spec.rb
+++ b/spec/workers/sync_webpage_references_worker_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe SyncWebpageReferencesWorker do
       expect(LinkedDomains::UpdateScoreWorker).to have_received(:perform_async).with(domain_new2.id)
     end
 
+    it "skips invalid or blank URLs without failing" do
+      allow(WebpageExtractor).to receive(:extract).and_return(["https://", "https://example.com/page"])
+
+      expect {
+        subject.perform("Article", article.id)
+      }.to change(LinkedDomain, :count).by(1)
+       .and change(WebpageReference, :count).by(1)
+
+      expect(LinkedDomain.pluck(:host)).to include("example.com")
+      expect(LinkedDomain.pluck(:host)).not_to include("")
+    end
+
     it "does nothing if the record does not exist" do
       expect {
         subject.perform("Article", -1)


### PR DESCRIPTION

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Forem Contributing Guide: https://developers.forem.com/contributing-guide/forem#create-a-pull-request
     - 📖 Read the Forem Code of Conduct: https://github.com/forem/forem/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.

     NOTE: Pull Requests from forked repositories will need to be reviewed by
     a Forem Team member before any CI builds will run. Once your PR is approved
     with a `/ci` reply to the PR, it will be allowed to run subsequent builds without
     manual approval.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes occasional error