### PR TITLE
Tweak default trend matching and similarity thresholds

### DIFF
--- a/app/services/ai/trend_detector.rb
+++ b/app/services/ai/trend_detector.rb
@@ -6,7 +6,7 @@ module Ai
       @ai_client = Ai::Base.new(wrapper: self)
     end
 
-    def call(days_lookback: 7, similarity_threshold: 0.90, match_threshold: 0.98, min_articles: 10, min_score: nil, min_unique_authors: 4)
+    def call(days_lookback: 7, similarity_threshold: 0.89, match_threshold: 0.97, min_articles: 10, min_score: nil, min_unique_authors: 4)
       min_score ||= Settings::UserExperience.index_minimum_score.to_i
 
       # Run global trend detection
@@ -22,7 +22,7 @@ module Ai
       end
     end
 
-    def detect_trends_for(tag: nil, days_lookback: 7, similarity_threshold: 0.90, match_threshold: 0.98,
+    def detect_trends_for(tag: nil, days_lookback: 7, similarity_threshold: 0.89, match_threshold: 0.97,
                           min_articles: 10, min_score: nil, min_unique_authors: 4)
       relation = Article.published
         .where("published_at >= ?", days_lookback.days.ago)

--- a/spec/services/ai/trend_detector_spec.rb
+++ b/spec/services/ai/trend_detector_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Ai::TrendDetector do
         end.not_to change(Trend, :count)
       end
 
-      it "creates a new trend under the default match_threshold of 0.98" do
+      it "creates a new trend under the default match_threshold of 0.97" do
         # Passing min_unique_authors: 3 to satisfy diversity with 3 test articles
         expect do
           detector.call(min_articles: 3, min_score: 10, min_unique_authors: 3)
@@ -208,6 +208,20 @@ RSpec.describe Ai::TrendDetector do
         expect do
           detector.call
         end.not_to change(Trend, :count)
+      end
+
+      it "uses 0.89 for similarity_threshold and 0.97 for match_threshold by default" do
+        allow(detector).to receive(:detect_trends_for)
+        detector.call
+        expect(detector).to have_received(:detect_trends_for).with(
+          tag: nil,
+          days_lookback: 7,
+          similarity_threshold: 0.89,
+          match_threshold: 0.97,
+          min_articles: 10,
+          min_score: 5,
+          min_unique_authors: 4
+        ).at_least(:once)
       end
     end
 


### PR DESCRIPTION
This PR tweaks default trend detection thresholds to make it slightly more likely to group and match trends:

1. Decreased default `similarity_threshold` from `0.90` to `0.89` in `TrendDetector`.
2. Decreased default `match_threshold` from `0.98` to `0.97` in `TrendDetector`.
3. Updated tests and added a regression test for default threshold options in `trend_detector_spec.rb`.